### PR TITLE
HDDS-9659. Intermittent failure in TestOzoneECClient#testPartialStripeWithPartialChunkRetry

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntry.java
@@ -91,16 +91,17 @@ public class ECBlockOutputStreamEntry extends BlockOutputStreamEntry {
   @Override
   void checkStream() throws IOException {
     if (!isInitialized()) {
-      blockOutputStreams =
+      final ECBlockOutputStream[] streams =
           new ECBlockOutputStream[replicationConfig.getRequiredNodes()];
       for (int i = currentStreamIdx; i < replicationConfig
           .getRequiredNodes(); i++) {
         List<DatanodeDetails> nodes = getPipeline().getNodes();
-        blockOutputStreams[i] =
+        streams[i] =
             new ECBlockOutputStream(getBlockID(), getXceiverClientManager(),
                 createSingleECBlockPipeline(getPipeline(), nodes.get(i), i + 1),
                 getBufferPool(), getConf(), getToken(), getClientMetrics());
       }
+      blockOutputStreams = streams;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failures in `testPartialStripeWithPartialChunkRetry`:

```
IndexOutOfBoundsException: Index: -1
	at java.util.Collections$EmptyList.get(Collections.java:4456)
	at java.util.Collections$UnmodifiableList.get(Collections.java:1311)
	at org.apache.hadoop.ozone.client.io.ECBlockOutputStreamEntry.calculateChecksum(ECBlockOutputStreamEntry.java:416)
	at org.apache.hadoop.ozone.client.io.ECKeyOutputStream.commitStripeWrite(ECKeyOutputStream.java:266)
	at org.apache.hadoop.ozone.client.io.ECKeyOutputStream.flushStripeToDatanodes(ECKeyOutputStream.java:585)
	at org.apache.hadoop.ozone.client.io.ECKeyOutputStream.flushStripeFromQueue(ECKeyOutputStream.java:567)
```

and

```
NullPointerException
	at org.apache.hadoop.ozone.client.io.ECBlockOutputStreamEntry.calculateChecksum(ECBlockOutputStreamEntry.java:412)
	at org.apache.hadoop.ozone.client.io.ECKeyOutputStream.commitStripeWrite(ECKeyOutputStream.java:266)
	at org.apache.hadoop.ozone.client.io.ECKeyOutputStream.flushStripeToDatanodes(ECKeyOutputStream.java:585)
	at org.apache.hadoop.ozone.client.io.ECKeyOutputStream.flushStripeFromQueue(ECKeyOutputStream.java:567)
```

and

```
ConcurrentModificationException
	at java.util.HashMap$HashIterator.remove(HashMap.java:1483)
	at org.apache.hadoop.ozone.client.MockXceiverClientFactory.mockStorageFailure(MockXceiverClientFactory.java:71)
	at org.apache.hadoop.ozone.client.MockXceiverClientFactory.mockStorageFailure(MockXceiverClientFactory.java:57)
	at org.apache.hadoop.ozone.client.MockXceiverClientFactory.setFailedStorages(MockXceiverClientFactory.java:47)
	at org.apache.hadoop.ozone.client.TestOzoneECClient.testPartialStripeWithPartialChunkRetry(TestOzoneECClient.java:1037)
```

1. Completely initialize array of `ECBlockOutputStream` before exposing it via `blockOutputStream` member variable.
2. Fix `ConcurrentModificationException` in `MockXceiverClientFactory` by changing to concurrent set/map.

https://issues.apache.org/jira/browse/HDDS-9659

## How was this patch tested?

Passed 100x:
https://github.com/adoroszlai/ozone/actions/runs/6862777705

and 250x:
https://github.com/adoroszlai/ozone/actions/runs/6863403759

For reference, failed 2/100 without the fix:
https://github.com/adoroszlai/ozone/actions/runs/6873776049/job/18695127972