### PR TITLE
HDDS-9479. Pipeline close doesn't wait for containers to be closed.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -416,8 +416,12 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_PIPELINE_DESTROY_TIMEOUT =
       "ozone.scm.pipeline.destroy.timeout";
 
+  // We wait for 150s before closing containers
+  // OzoneConfigKeys#OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION.
+  // So, we are waiting for another 150s before deleting the pipeline
+  // (150 + 150) = 300s
   public static final String OZONE_SCM_PIPELINE_DESTROY_TIMEOUT_DEFAULT =
-      "120s";
+      "300s";
 
   public static final String OZONE_SCM_PIPELINE_CREATION_INTERVAL =
       "ozone.scm.pipeline.creation.interval";
@@ -427,7 +431,7 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_PIPELINE_SCRUB_INTERVAL =
       "ozone.scm.pipeline.scrub.interval";
   public static final String OZONE_SCM_PIPELINE_SCRUB_INTERVAL_DEFAULT =
-      "60s";
+      "150s";
 
 
   // Allow SCM to auto create factor ONE ratis pipeline.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -417,7 +417,7 @@ public final class ScmConfigKeys {
       "ozone.scm.pipeline.destroy.timeout";
 
   public static final String OZONE_SCM_PIPELINE_DESTROY_TIMEOUT_DEFAULT =
-      "66s";
+      "120s";
 
   public static final String OZONE_SCM_PIPELINE_CREATION_INTERVAL =
       "ozone.scm.pipeline.creation.interval";
@@ -427,7 +427,7 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_PIPELINE_SCRUB_INTERVAL =
       "ozone.scm.pipeline.scrub.interval";
   public static final String OZONE_SCM_PIPELINE_SCRUB_INTERVAL_DEFAULT =
-      "5m";
+      "60s";
 
 
   // Allow SCM to auto create factor ONE ratis pipeline.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -87,6 +87,8 @@ public final class Pipeline {
   // suggested leader id with high priority
   private final UUID suggestedLeaderId;
 
+  private final Instant stateEnterTime;
+
   /**
    * The immutable properties of pipeline object is used in
    * ContainerStateManager#getMatchingContainerByPipeline to take a lock on
@@ -102,6 +104,7 @@ public final class Pipeline {
     this.creationTimestamp = Instant.now();
     this.suggestedLeaderId = suggestedLeaderId;
     this.replicaIndexes = new HashMap<>();
+    this.stateEnterTime = Instant.now();
   }
 
   /**
@@ -138,6 +141,10 @@ public final class Pipeline {
    */
   public Instant getCreationTimestamp() {
     return creationTimestamp;
+  }
+
+  public Instant getStateEnterTime() {
+    return stateEnterTime;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -93,6 +93,15 @@ public final class Pipeline {
    * The immutable properties of pipeline object is used in
    * ContainerStateManager#getMatchingContainerByPipeline to take a lock on
    * the container allocations for a particular pipeline.
+   * <br><br>
+   * Since the Pipeline class is immutable, if we want to change the state of
+   * the Pipeline we should create a new Pipeline object with the new state.
+   * Make sure that you set the value of <i>creationTimestamp</i> properly while
+   * creating the new Pipeline object.
+   * <br><br>
+   * There is no need to worry about the value of <i>stateEnterTime</i> as it's
+   * set to <i>Instant.now</i> when you crate the Pipeline object as part of
+   * state change.
    */
   private Pipeline(PipelineID id,
       ReplicationConfig replicationConfig, PipelineState state,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -122,8 +122,8 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
         .ifPresent(pipelines ->
             pipelines.forEach(id -> {
               try {
-                pipelineManager.closePipeline(
-                    pipelineManager.getPipeline(id), false);
+                pipelineManager.closePipeline(id);
+                pipelineManager.deletePipeline(id);
               } catch (PipelineNotFoundException ignore) {
                 // Pipeline is not there in pipeline manager,
                 // should we care?

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -80,8 +80,8 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
        * action.
        */
       LOG.info("A dead datanode is detected. {}", datanodeDetails);
-      destroyPipelines(datanodeDetails);
       closeContainers(datanodeDetails, publisher);
+      destroyPipelines(datanodeDetails);
 
       // Remove the container replicas associated with the dead node unless it
       // is IN_MAINTENANCE

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/HealthyReadOnlyNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/HealthyReadOnlyNodeHandler.java
@@ -90,7 +90,7 @@ public class HealthyReadOnlyNodeHandler
             pipelineID, pipeline.getPipelineState(),
             HddsProtos.NodeState.HEALTHY_READONLY,
             datanodeDetails.getUuidString());
-        pipelineManager.closePipeline(pipeline, true);
+        pipelineManager.closePipeline(pipelineID);
       } catch (IOException ex) {
         LOG.error("Failed to close pipeline {} which uses HEALTHY READONLY " +
             "datanode {}: ", pipelineID, datanodeDetails, ex);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/StaleNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/StaleNodeHandler.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.scm.node;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.server.events.EventHandler;
@@ -59,8 +58,7 @@ public class StaleNodeHandler implements EventHandler<DatanodeDetails> {
         datanodeDetails, pipelineIds);
     for (PipelineID pipelineID : pipelineIds) {
       try {
-        Pipeline pipeline = pipelineManager.getPipeline(pipelineID);
-        pipelineManager.closePipeline(pipeline, true);
+        pipelineManager.closePipeline(pipelineID);
       } catch (IOException e) {
         LOG.info("Could not finalize pipeline={} for dn={}", pipelineID,
             datanodeDetails);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/StartDatanodeAdminHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/StartDatanodeAdminHandler.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hdds.scm.node;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.server.events.EventHandler;
@@ -57,8 +56,7 @@ public class StartDatanodeAdminHandler
         datanodeDetails, pipelineIds);
     for (PipelineID pipelineID : pipelineIds) {
       try {
-        Pipeline pipeline = pipelineManager.getPipeline(pipelineID);
-        pipelineManager.closePipeline(pipeline, false);
+        pipelineManager.closePipeline(pipelineID);
       } catch (IOException e) {
         LOG.info("Could not finalize pipeline={} for dn={}", pipelineID,
             datanodeDetails);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
@@ -84,8 +84,7 @@ public class PipelineActionHandler
           info.getDetailedReason());
 
       if (action == PipelineAction.Action.CLOSE) {
-        pipelineManager.closePipeline(
-            pipelineManager.getPipeline(pid), false);
+        pipelineManager.closePipeline(pid);
       } else {
         LOG.error("unknown pipeline action:{}", action);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -115,8 +115,13 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
 
   void openPipeline(PipelineID pipelineId) throws IOException;
 
+  @Deprecated
   void closePipeline(Pipeline pipeline, boolean onTimeout)
       throws IOException;
+
+  void closePipeline(PipelineID pipelineID) throws IOException;
+
+  void deletePipeline(PipelineID pipelineID) throws IOException;
 
   void closeStalePipelines(DatanodeDetails datanodeDetails);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -489,17 +489,25 @@ public class PipelineManagerImpl implements PipelineManager {
    * put pipeline in CLOSED state.
    * @param pipeline - ID of the pipeline.
    * @param onTimeout - whether to remove pipeline after some time.
-   * @throws IOException
+   * @throws IOException throws exception in case of failure
+   * @deprecated Do not use this method, onTimeout is not honored.
    */
-  @Override
+  @Deprecated
   public void closePipeline(Pipeline pipeline, boolean onTimeout)
-      throws IOException {
-    PipelineID pipelineID = pipeline.getId();
+          throws IOException {
+    closePipeline(pipeline.getId());
+  }
+
+  /**
+   * Move the Pipeline to CLOSED state.
+   * @param pipelineID ID of the Pipeline to be closed
+   * @throws IOException In case of exception while closing the Pipeline
+   */
+  public void closePipeline(PipelineID pipelineID) throws IOException {
     HddsProtos.PipelineID pipelineIDProtobuf = pipelineID.getProtobuf();
     // close containers.
     closeContainersForPipeline(pipelineID);
-
-    if (!pipeline.isClosed()) {
+    if (!getPipeline(pipelineID).isClosed()) {
       acquireWriteLock();
       try {
         stateManager.updatePipelineState(pipelineIDProtobuf,
@@ -507,15 +515,20 @@ public class PipelineManagerImpl implements PipelineManager {
       } finally {
         releaseWriteLock();
       }
-      LOG.info("Pipeline {} moved to CLOSED state", pipeline);
+      LOG.info("Pipeline {} moved to CLOSED state", pipelineID);
     }
 
     metrics.removePipelineMetrics(pipelineID);
 
-    if (!onTimeout) {
-      // close pipeline right away.
-      removePipeline(pipeline);
-    }
+  }
+
+  /**
+   * Deletes the Pipeline for the given PipelineID.
+   * @param pipelineID ID of the Pipeline to be deleted
+   * @throws IOException In case of exception while deleting the Pipeline
+   */
+  public void deletePipeline(PipelineID pipelineID) throws IOException {
+    removePipeline(getPipeline(pipelineID));
   }
 
   /** close the pipelines whose nodes' IPs are stale.
@@ -535,9 +548,11 @@ public class PipelineManagerImpl implements PipelineManager {
             pipelinesWithStaleIpOrHostname.size());
     pipelinesWithStaleIpOrHostname.forEach(p -> {
       try {
-        LOG.info("Closing the stale pipeline: {}", p.getId());
-        closePipeline(p, false);
-        LOG.info("Closed the stale pipeline: {}", p.getId());
+        final PipelineID id = p.getId();
+        LOG.info("Closing the stale pipeline: {}", id);
+        closePipeline(id);
+        deletePipeline(id);
+        LOG.info("Closed the stale pipeline: {}", id);
       } catch (IOException e) {
         LOG.error("Closing the stale pipeline failed: {}", p, e);
       }
@@ -568,26 +583,34 @@ public class PipelineManagerImpl implements PipelineManager {
         ScmConfigKeys.OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT,
         ScmConfigKeys.OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT_DEFAULT,
         TimeUnit.MILLISECONDS);
+    long pipelineDeleteTimoutInMills = conf.getTimeDuration(
+            ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT,
+            ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT_DEFAULT,
+            TimeUnit.MILLISECONDS);
 
     List<Pipeline> candidates = stateManager.getPipelines();
 
     for (Pipeline p : candidates) {
+      final PipelineID id = p.getId();
       // scrub pipelines who stay ALLOCATED for too long.
       if (p.getPipelineState() == Pipeline.PipelineState.ALLOCATED &&
           (currentTime.toEpochMilli() - p.getCreationTimestamp()
               .toEpochMilli() >= pipelineScrubTimeoutInMills)) {
+
         LOG.info("Scrubbing pipeline: id: {} since it stays at ALLOCATED " +
-            "stage for {} mins.", p.getId(),
+            "stage for {} mins.", id,
             Duration.between(currentTime, p.getCreationTimestamp())
                 .toMinutes());
-        closePipeline(p, false);
+        closePipeline(id);
+        deletePipeline(id);
       }
       // scrub pipelines who stay CLOSED for too long.
-      if (p.getPipelineState() == Pipeline.PipelineState.CLOSED) {
+      if (p.getPipelineState() == Pipeline.PipelineState.CLOSED &&
+          (currentTime.toEpochMilli() - p.getStateEnterTime().toEpochMilli())
+              >= pipelineDeleteTimoutInMills) {
         LOG.info("Scrubbing pipeline: id: {} since it stays at CLOSED stage.",
             p.getId());
-        closeContainersForPipeline(p.getId());
-        removePipeline(p);
+        deletePipeline(id);
       }
       // If a datanode is stopped and then SCM is restarted, a pipeline can get
       // stuck in an open state. For Ratis, provided some other DNs that were
@@ -599,8 +622,7 @@ public class PipelineManagerImpl implements PipelineManager {
       if (isOpenWithUnregisteredNodes(p)) {
         LOG.info("Scrubbing pipeline: id: {} as it has unregistered nodes",
             p.getId());
-        closeContainersForPipeline(p.getId());
-        closePipeline(p, true);
+        closePipeline(id);
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -552,7 +552,6 @@ public class PipelineManagerImpl implements PipelineManager {
         LOG.info("Closing the stale pipeline: {}", id);
         closePipeline(id);
         deletePipeline(id);
-        LOG.info("Closed the stale pipeline: {}", id);
       } catch (IOException e) {
         LOG.error("Closing the stale pipeline failed: {}", p, e);
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -244,6 +244,16 @@ public class MockPipelineManager implements PipelineManager {
   }
 
   @Override
+  public void closePipeline(PipelineID pipelineID) throws IOException {
+
+  }
+
+  @Override
+  public void deletePipeline(PipelineID pipelineID) throws IOException {
+
+  }
+
+  @Override
   public void closeStalePipelines(DatanodeDetails datanodeDetails) {
 
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineActionHandler.java
@@ -26,10 +26,10 @@ import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.PipelineActionsFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
-import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.UUID;
 
 /**
@@ -39,12 +39,12 @@ public class TestPipelineActionHandler {
 
   @Test
   public void testCloseActionForMissingPipeline()
-      throws PipelineNotFoundException, NotLeaderException {
+      throws IOException {
     final PipelineManager manager = Mockito.mock(PipelineManager.class);
     final EventQueue queue = Mockito.mock(EventQueue.class);
 
-    Mockito.when(manager.getPipeline(Mockito.any(PipelineID.class)))
-        .thenThrow(new PipelineNotFoundException());
+    Mockito.doThrow(new PipelineNotFoundException())
+        .when(manager).closePipeline(Mockito.any(PipelineID.class));
 
     final PipelineActionHandler actionHandler =
         new PipelineActionHandler(manager, SCMContext.emptyContext(), null);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -116,8 +116,8 @@ public class TestNode2PipelineMap {
         ratisContainer.getPipeline().getId());
     Assertions.assertEquals(0, set2.size());
 
-    pipelineManager
-        .closePipeline(ratisContainer.getPipeline(), false);
+    pipelineManager.closePipeline(ratisContainer.getPipeline().getId());
+    pipelineManager.deletePipeline(ratisContainer.getPipeline().getId());
     pipelines = scm.getScmNodeManager()
         .getPipelines(dns.get(0));
     Assertions.assertFalse(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
@@ -107,6 +107,9 @@ public class TestContainerStateMachine {
     conf.setQuietMode(false);
     OzoneManager.setTestSecureOmFlag(true);
     conf.setLong(OzoneConfigKeys.DFS_RATIS_SNAPSHOT_THRESHOLD_KEY, 1);
+    conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_SCRUB_INTERVAL, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, "5s");
 
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
     clientConfig.setStreamBufferFlushDelay(false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
@@ -84,7 +85,6 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERV
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.QUASI_CLOSED;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 
 import org.apache.ratis.protocol.RaftGroupId;
@@ -136,8 +136,9 @@ public class TestContainerStateMachineFailures {
     conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 200,
         TimeUnit.MILLISECONDS);
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 30, TimeUnit.SECONDS);
-    conf.setTimeDuration(OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, 1,
-        TimeUnit.SECONDS);
+    conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_SCRUB_INTERVAL, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, "5s");
 
     RatisClientConfig ratisClientConfig =
         conf.getObject(RatisClientConfig.class);
@@ -480,7 +481,7 @@ public class TestContainerStateMachineFailures {
     }
     
     // when remove pipeline, group dir including snapshot will be deleted
-    LambdaTestUtils.await(5000, 500,
+    LambdaTestUtils.await(10000, 500,
         () -> (!snapshot.getPath().toFile().exists()));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -111,6 +112,9 @@ public class TestContainerStateMachineFlushDelay {
     OzoneManager.setTestSecureOmFlag(true);
     conf.setLong(OzoneConfigKeys.DFS_RATIS_SNAPSHOT_THRESHOLD_KEY, 1);
     //  conf.set(HADOOP_SECURITY_AUTHENTICATION, KERBEROS.toString());
+    conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_SCRUB_INTERVAL, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, "5s");
     cluster =
         MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1)
             .setBlockSize(blockSize)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptionFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptionFlushDelay.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -100,6 +101,9 @@ public class TestOzoneClientRetriesOnExceptionFlushDelay {
     conf.setFromObject(config);
 
     conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 3);
+    conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_SCRUB_INTERVAL, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, "5s");
     conf.setQuietMode(false);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(7)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -107,6 +108,9 @@ public class TestOzoneClientRetriesOnExceptions {
     conf.setFromObject(clientConfig);
 
     conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 3);
+    conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_SCRUB_INTERVAL, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, "5s");
     conf.setQuietMode(false);
 
     cluster = MiniOzoneCluster.newBuilder(conf)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hdds.scm.storage.RatisBlockOutputStream;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.RatisTestHelper;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -63,7 +64,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import org.apache.ratis.protocol.exceptions.GroupMismatchException;
 import org.junit.Assert;
@@ -109,9 +109,10 @@ public class TestWatchForCommit {
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
     clientConfig.setStreamBufferFlushDelay(false);
     conf.setFromObject(clientConfig);
-    
-    conf.setTimeDuration(OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, 10,
-            TimeUnit.SECONDS);
+
+    conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_SCRUB_INTERVAL, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, "5s");
     conf.setQuietMode(false);
     conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 1);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -192,7 +192,8 @@ public class TestReconAsPassiveScm {
         .filter(p -> !p.getId().equals(containerInfo.getPipelineID()))
         .findFirst();
     assertTrue(pipelineToClose.isPresent());
-    scmPipelineManager.closePipeline(pipelineToClose.get(), false);
+    scmPipelineManager.closePipeline(pipelineToClose.get().getId());
+    scmPipelineManager.deletePipeline(pipelineToClose.get().getId());
 
     // Start Recon
     cluster.startRecon();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneClusterProvider;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -134,6 +135,9 @@ public class TestDecommissionAndMaintenance {
         1, SECONDS);
     conf.setTimeDuration(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
         0, SECONDS);
+    conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_SCRUB_INTERVAL, "2s");
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, "5s");
 
     ReplicationManagerConfiguration replicationConf =
         conf.getObject(ReplicationManagerConfiguration.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -86,10 +86,12 @@ public class TestSCMPipelineMetrics {
     Optional<Pipeline> pipeline = pipelineManager
         .getPipelines().stream().findFirst();
     Assertions.assertTrue(pipeline.isPresent());
-    Assertions.assertDoesNotThrow(() ->
-        cluster.getStorageContainerManager()
-            .getPipelineManager()
-            .closePipeline(pipeline.get(), false));
+    Assertions.assertDoesNotThrow(() -> {
+      PipelineManager pm = cluster.getStorageContainerManager()
+          .getPipelineManager();
+      pm.closePipeline(pipeline.get().getId());
+      pm.deletePipeline(pipeline.get().getId());
+    });
     MetricsRecordBuilder metrics = getMetrics(
         SCMPipelineMetrics.class.getSimpleName());
     assertCounter("NumPipelineDestroyed", 1L, metrics);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
@@ -149,7 +149,8 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
         }
         try {
           LOG.info("Removing invalid pipeline {} from Recon.", pipelineID);
-          closePipeline(p, false);
+          closePipeline(p.getId());
+          deletePipeline(p.getId());
         } catch (IOException e) {
           LOG.warn("Unable to remove pipeline {}", pipelineID, e);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Whenever we close a pipeline, we have an option to give some grace time for the container to get closed, the grace time is configured using `ozone.scm.pipeline.destroy.timeout`.
We wait for the timeout to happen before we go ahead and delete the pipeline. This will give enough time for the datanodes to close the container gracefully.
It will prevent the containers from moving to the `QUASI_CLOSED` state.

This functionality is broken and we don't wait for the timeout to happen before we delete the Pipeline. This creates a lot of `QUASI_CLOSED` containers in the cluster when a node goes stale or when a datanode is getting decommissioned.

This has to be fixed and we should wait for the configured amount of time before we delete the Pipeline, this will give datanodes enough time to `CLOSE` the containers on that pipeline.

## What is the link to the Apache JIRA
HDDS-9479

## How was this patch tested?
Unit test modified to test the behaviour.
