### PR TITLE
HDDS-9694. Delete redundant symbols in the datanode heartbeat report log

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -178,9 +178,7 @@ public class HeartbeatEndpointTask
       addPipelineActions(requestBuilder);
       addQueuedCommandCounts(requestBuilder);
       SCMHeartbeatRequestProto request = requestBuilder.build();
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Sending heartbeat message :: {}", request.toString());
-      }
+      LOG.debug("Sending heartbeat message : {}", request);
       SCMHeartbeatResponseProto response = rpcEndpoint.getEndPoint()
           .sendHeartbeat(request);
       processResponse(response, datanodeDetailsProto);


### PR DESCRIPTION
## What changes were proposed in this pull request?
When a heartbeat request occurs on the datanode, some redundant symbols are found in the log. The purpose of this PR is to optimize it.
`
2023-11-15 12:57:37,450 [EndpointStateMachine task thread for xxxx.xxxx.xxxx.xxxx/xxx.xxx.xxx.xxx:9861 - 0 ] DEBUG org.apache.hadoop.ozone.container.common.states.endpoint.HeartbeatEndpointTask: Sending heartbeat message :: datanodeDetails {
`
Details: HDDS-9694

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9694

## How was this patch tested?
Just make sure that the existing unit tests are normal.
