### PR TITLE
HDDS-9495. Migrate TestCreatePipelineCommandHandler to JUnit5

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
@@ -124,7 +124,7 @@ public final class ContainerTestUtils {
       OzoneConfiguration conf) {
     DatanodeStateMachine stateMachine = Mockito.mock(
         DatanodeStateMachine.class);
-    Mockito.when(stateMachine.getReconfigurationHandler())
+    Mockito.lenient().when(stateMachine.getReconfigurationHandler())
         .thenReturn(new ReconfigurationHandler("DN", conf, op -> { }));
     StateContext context = Mockito.mock(StateContext.class);
     Mockito.when(stateMachine.getDatanodeDetails()).thenReturn(datanodeDetails);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCreatePipelineCommandHandler.java
@@ -35,13 +35,11 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.api.GroupManagementApi;
 import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftPeerId;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,8 +50,7 @@ import java.util.List;
 /**
  * Test cases to verify CreatePipelineCommandHandler.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(RaftClient.class)
+@ExtendWith(MockitoExtension.class)
 public class TestCreatePipelineCommandHandler {
 
   private OzoneContainer ozoneContainer;
@@ -63,16 +60,15 @@ public class TestCreatePipelineCommandHandler {
   private GroupManagementApi raftClientGroupManager;
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
     ozoneContainer = Mockito.mock(OzoneContainer.class);
     connectionManager = Mockito.mock(SCMConnectionManager.class);
     raftClient = Mockito.mock(RaftClient.class);
     raftClientGroupManager = Mockito.mock(GroupManagementApi.class);
-    Mockito.when(raftClient.getGroupManagementApi(
+    Mockito.lenient().when(raftClient.getGroupManagementApi(
         Mockito.any(RaftPeerId.class))).thenReturn(raftClientGroupManager);
-    PowerMockito.mockStatic(RaftClient.class);
   }
 
   @Test


### PR DESCRIPTION
## HDDS-9495. Migrate TestCreatePipelineCommandHandler to JUnit5

* This test used `PowerMockRunner` from junit4 making it harder to migrate.
* As part of a larger effort to migrate tests to JUnit5, and due to some test cases being harder than other this pr aims at migrating one such test case from the container-service module to JUnit5. 

## What is the link to the Apache JIRA

[HDDS-9495. Migrate TestCreatePipelineCommandHandler to JUnit5](https://issues.apache.org/jira/browse/HDDS-9495)

## How was this patch tested?

Run locally and there is a green CI run here:
https://github.com/Galsza/ozone/actions/runs/6866136015
