### PR TITLE
HDDS-9698. Skip push build for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
-  OZONE_WITH_COVERAGE: ${{ github.repository == 'apache/ozone' && github.event_name != 'pull_request' && !startsWith(github.ref_name, 'dependabot') }}
+  OZONE_WITH_COVERAGE: ${{ github.repository == 'apache/ozone' && github.event_name != 'pull_request' }}
 jobs:
   build-info:
     runs-on: ubuntu-20.04
@@ -474,7 +474,7 @@ jobs:
   coverage:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
-    if: github.repository == 'apache/ozone' && github.event_name != 'pull_request' && !startsWith(github.ref_name, 'dependabot')
+    if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
     needs:
       - unit
       - acceptance

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -22,5 +22,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   CI:
+    if: github.event_name == 'pull_request' || !startsWith(github.ref_name, 'dependabot')
     uses: ./.github/workflows/ci.yml
     secrets: inherit


### PR DESCRIPTION
## What changes were proposed in this pull request?

dependabot pushes dependency version bumps to the main repo instead of its own fork.  It then creates a pull request without waiting for the `push` workflow to succeed.  Thus both workflows test the same state of code, which is unnecessary.

I propose completely skipping `push` build for dependabot's changes to save CI resources.

https://issues.apache.org/jira/browse/HDDS-9698

## How was this patch tested?

Build skipped in branch `dependabot-HDDS-9698` in my fork:
https://github.com/adoroszlai/ozone/actions/runs/6876171772

but ran normally in branch `HDDS-9698`:
https://github.com/adoroszlai/ozone/actions/runs/6876180867

as well as for PR created from branch `dependabot-HDDS-9698`:
https://github.com/adoroszlai/ozone/actions/runs/6876212003