### PR TITLE
HDDS-9699. Upgrade Hadoop2 to latest 2.10.2

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -43,11 +43,10 @@ export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-for HADOOP_VERSION in 2.7.3 3.1.2 3.2.2 3.3.6; do
+for HADOOP_VERSION in ${hadoop2.version} 3.1.2 3.2.2 ${hadoop3.version}; do
   export HADOOP_VERSION
   export HADOOP_MAJOR_VERSION=${HADOOP_VERSION%%.*}
-  # Check if $HADOOP_VERSION starts with the prefix "3.3."
-  if [[ $HADOOP_VERSION == 3.3.* ]]; then
+  if [[ "${HADOOP_VERSION}" == "${hadoop2.version}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop3.version}" ]]; then
     export HADOOP_IMAGE=apache/hadoop
   else
     export HADOOP_IMAGE=flokkr/hadoop

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -43,10 +43,10 @@ export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-for HADOOP_VERSION in ${hadoop2.version} 3.1.2 ${hadoop3.version}; do
+for HADOOP_VERSION in ${hadoop2.version} 3.1.2 ${hadoop.version}; do
   export HADOOP_VERSION
   export HADOOP_MAJOR_VERSION=${HADOOP_VERSION%%.*}
-  if [[ "${HADOOP_VERSION}" == "${hadoop2.version}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop3.version}" ]]; then
+  if [[ "${HADOOP_VERSION}" == "${hadoop2.version}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop.version}" ]]; then
     export HADOOP_IMAGE=apache/hadoop
   else
     export HADOOP_IMAGE=flokkr/hadoop

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -24,6 +24,7 @@ export COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.yaml}:../common/${extra_compo
 export COMPOSE_FILE
 export HADOOP_MAJOR_VERSION=3
 export HADOOP_VERSION=unused # will be set for each test version below
+export HADOOP2_IMAGE_VERSION=2 # TEMP until tagged with specific version on Docker Hub
 export OZONE_REPLICATION_FACTOR=3
 
 # shellcheck source=/dev/null
@@ -43,10 +44,10 @@ export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-for HADOOP_VERSION in ${hadoop2.version} 3.1.2 ${hadoop.version}; do
+for HADOOP_VERSION in ${HADOOP2_IMAGE_VERSION} 3.1.2 ${hadoop.version}; do
   export HADOOP_VERSION
   export HADOOP_MAJOR_VERSION=${HADOOP_VERSION%%.*}
-  if [[ "${HADOOP_VERSION}" == "${hadoop2.version}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop.version}" ]]; then
+  if [[ "${HADOOP_VERSION}" == "${HADOOP2_IMAGE_VERSION}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop.version}" ]]; then
     export HADOOP_IMAGE=apache/hadoop
   else
     export HADOOP_IMAGE=flokkr/hadoop

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -19,9 +19,8 @@ extra_compose_file=hadoop.yaml
 if [[ ${SECURITY_ENABLED} == "true" ]]; then
   extra_compose_file=hadoop-secure.yaml
 fi
-export COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.yaml}:../common/${extra_compose_file}
+export COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yaml}":../common/${extra_compose_file}
 
-export COMPOSE_FILE
 export HADOOP_MAJOR_VERSION=3
 export HADOOP_VERSION=unused # will be set for each test version below
 export HADOOP2_IMAGE_VERSION=2 # TEMP until tagged with specific version on Docker Hub

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -23,7 +23,6 @@ export COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yaml}":../common/${extra_com
 
 export HADOOP_MAJOR_VERSION=3
 export HADOOP_VERSION=unused # will be set for each test version below
-export HADOOP2_IMAGE_VERSION=2 # TEMP until tagged with specific version on Docker Hub
 export OZONE_REPLICATION_FACTOR=3
 
 # shellcheck source=/dev/null
@@ -43,10 +42,10 @@ export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-for HADOOP_VERSION in ${HADOOP2_IMAGE_VERSION} 3.1.2 ${hadoop.version}; do
+for HADOOP_VERSION in ${hadoop2.version} 3.1.2 ${hadoop.version}; do
   export HADOOP_VERSION
   export HADOOP_MAJOR_VERSION=${HADOOP_VERSION%%.*}
-  if [[ "${HADOOP_VERSION}" == "${HADOOP2_IMAGE_VERSION}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop.version}" ]]; then
+  if [[ "${HADOOP_VERSION}" == "${hadoop2.version}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop.version}" ]]; then
     export HADOOP_IMAGE=apache/hadoop
   else
     export HADOOP_IMAGE=flokkr/hadoop

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -43,7 +43,7 @@ export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-for HADOOP_VERSION in ${hadoop2.version} 3.1.2 3.2.2 ${hadoop3.version}; do
+for HADOOP_VERSION in ${hadoop2.version} 3.1.2 ${hadoop3.version}; do
   export HADOOP_VERSION
   export HADOOP_MAJOR_VERSION=${HADOOP_VERSION%%.*}
   if [[ "${HADOOP_VERSION}" == "${hadoop2.version}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop3.version}" ]]; then

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   </organization>
 
   <properties>
-    <hadoop2.version>2.7.3</hadoop2.version>
+    <hadoop2.version>2.10.2</hadoop2.version>
     <hadoop.version>3.3.6</hadoop.version>
 
     <!-- version for hdds/ozone components -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Upgrade Ozone's Hadoop2 dependency to 2.10.2.
 * Use `apache/hadoop` docker image for testing this version (no `flokkr/hadoop` image available).
 * Drop 3.2.2 from versions being tested.

Related discussion on mailing list:
https://lists.apache.org/thread/q99x4f93yk20z6m8wsqpvwms1vqw030l

https://issues.apache.org/jira/browse/HDDS-9699

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/6878591140/job/18712121667#step:5:151