### PR TITLE
HDDS-9696. Add configuration for wait time after checking queue in DeleteCmdWorker

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -129,8 +129,8 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
 
   public static final String BLOCK_DELETE_COMMAND_WORKER_INTERVAL =
       "hdds.datanode.block.delete.command.worker.interval";
-  public static final long BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT =
-      2000;
+  public static final Duration BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT =
+      Duration.ofSeconds(2);
 
   /**
    * The maximum number of threads used to delete containers on a datanode
@@ -190,13 +190,13 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   private int blockDeleteQueueLimit = 5;
 
   @Config(key = "block.delete.command.worker.interval",
-      type = ConfigType.LONG,
-      defaultValue = "2000",
+      type = ConfigType.TIME,
+      defaultValue = "2s",
       tags = {DATANODE},
       description = "The interval between DeleteCmdWorker execution of " +
           "delete commands."
   )
-  private long blockDeleteCommandWorkerInterval =
+  private Duration blockDeleteCommandWorkerInterval =
       BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
 
   /**
@@ -649,6 +649,15 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
       diskCheckTimeout = DISK_CHECK_TIMEOUT_DEFAULT;
     }
 
+    if (blockDeleteCommandWorkerInterval.isNegative()) {
+      LOG.warn(BLOCK_DELETE_COMMAND_WORKER_INTERVAL +
+          " must be greater than zero and was set to {}. Defaulting to {}",
+          blockDeleteCommandWorkerInterval,
+          BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT);
+      blockDeleteCommandWorkerInterval =
+          BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
+    }
+
     if (rocksdbLogMaxFileSize < 0) {
       LOG.warn(ROCKSDB_LOG_MAX_FILE_SIZE_BYTES_KEY +
               " must be no less than zero and was set to {}. Defaulting to {}",
@@ -670,15 +679,6 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
           ROCKSDB_DELETE_OBSOLETE_FILES_PERIOD_MICRO_SECONDS_DEFAULT);
       rocksdbDeleteObsoleteFilesPeriod =
           ROCKSDB_DELETE_OBSOLETE_FILES_PERIOD_MICRO_SECONDS_DEFAULT;
-    }
-
-    if (blockDeleteCommandWorkerInterval <= 0) {
-      LOG.warn(BLOCK_DELETE_COMMAND_WORKER_INTERVAL +
-          " must be greater than zero and was set to {}. Defaulting to {}",
-          blockDeleteCommandWorkerInterval,
-          BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT);
-      blockDeleteCommandWorkerInterval =
-          BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
     }
   }
 
@@ -795,12 +795,12 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
     this.blockDeleteQueueLimit = queueLimit;
   }
 
-  public long getBlockDeleteCommandWorkerInterval() {
+  public Duration getBlockDeleteCommandWorkerInterval() {
     return blockDeleteCommandWorkerInterval;
   }
 
   public void setBlockDeleteCommandWorkerInterval(
-      long blockDeleteCommandWorkerInterval) {
+      Duration blockDeleteCommandWorkerInterval) {
     this.blockDeleteCommandWorkerInterval = blockDeleteCommandWorkerInterval;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -127,6 +127,11 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   static final int CONTAINER_CLOSE_THREADS_DEFAULT = 3;
   static final int BLOCK_DELETE_THREADS_DEFAULT = 5;
 
+  public static final String BLOCK_DELETE_COMMAND_WORKER_INTERVAL =
+      "hdds.datanode.block.delete.command.worker.interval";
+  public static final long BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT =
+      2000;
+
   /**
    * The maximum number of threads used to delete containers on a datanode
    * simultaneously.
@@ -183,6 +188,16 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
           " a datanode"
   )
   private int blockDeleteQueueLimit = 5;
+
+  @Config(key = "block.delete.command.worker.interval",
+      type = ConfigType.LONG,
+      defaultValue = "2000",
+      tags = {DATANODE},
+      description = "The interval between DeleteCmdWorker execution of " +
+          "delete commands."
+  )
+  private long blockDeleteCommandWorkerInterval =
+      BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
 
   /**
    * The maximum number of commands in queued list.
@@ -656,6 +671,15 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
       rocksdbDeleteObsoleteFilesPeriod =
           ROCKSDB_DELETE_OBSOLETE_FILES_PERIOD_MICRO_SECONDS_DEFAULT;
     }
+
+    if (blockDeleteCommandWorkerInterval <= 0) {
+      LOG.warn(BLOCK_DELETE_COMMAND_WORKER_INTERVAL +
+          " must be greater than zero and was set to {}. Defaulting to {}",
+          blockDeleteCommandWorkerInterval,
+          BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT);
+      blockDeleteCommandWorkerInterval =
+          BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
+    }
   }
 
   public void setContainerDeleteThreads(int containerDeleteThreads) {
@@ -769,6 +793,15 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
 
   public void setBlockDeleteQueueLimit(int queueLimit) {
     this.blockDeleteQueueLimit = queueLimit;
+  }
+
+  public long getBlockDeleteCommandWorkerInterval() {
+    return blockDeleteCommandWorkerInterval;
+  }
+
+  public void setBlockDeleteCommandWorkerInterval(
+      long blockDeleteCommandWorkerInterval) {
+    this.blockDeleteCommandWorkerInterval = blockDeleteCommandWorkerInterval;
   }
 
   public int getCommandQueueLimit() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -79,8 +79,6 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V1;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V2;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V3;
-import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETE_COMMAND_WORKER_INTERVAL;
-import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
 
 /**
  * Handle block deletion commands.
@@ -123,8 +121,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         dnConf.getBlockDeleteThreads(), threadFactory);
     this.deleteCommandQueues =
         new LinkedBlockingQueue<>(dnConf.getBlockDeleteQueueLimit());
-    long interval = this.conf.getLong(BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
-        BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT);
+    long interval = dnConf.getBlockDeleteCommandWorkerInterval().toMillis();
     handlerThread = new Daemon(new DeleteCmdWorker(interval));
     handlerThread.start();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -222,15 +222,15 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
    */
   public final class DeleteCmdWorker implements Runnable {
 
-    private long interval;
+    private long intervalInMs;
 
     public DeleteCmdWorker(long interval) {
-      this.interval = interval;
+      this.intervalInMs = interval;
     }
 
     @VisibleForTesting
     public long getInterval() {
-      return this.interval;
+      return this.intervalInMs;
     }
 
     @Override
@@ -246,7 +246,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         }
 
         try {
-          Thread.sleep(this.interval);
+          Thread.sleep(this.intervalInMs);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           break;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -61,7 +61,7 @@ public class TestDatanodeConfiguration {
     int validFailedVolumesTolerated = 10;
     long validDiskCheckMinGap = 2;
     long validDiskCheckTimeout = 1;
-    long validBlockDeleteCommandWorkerInterval = 1000;
+    long validBlockDeleteCommandWorkerInterval = 1;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, validDeleteThreads);
     conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
@@ -76,8 +76,8 @@ public class TestDatanodeConfiguration {
         validDiskCheckMinGap, TimeUnit.MINUTES);
     conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
         validDiskCheckTimeout, TimeUnit.MINUTES);
-    conf.setLong(BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
-        validBlockDeleteCommandWorkerInterval);
+    conf.setTimeDuration(BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
+        validBlockDeleteCommandWorkerInterval, TimeUnit.SECONDS);
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
@@ -97,7 +97,7 @@ public class TestDatanodeConfiguration {
     assertEquals(validDiskCheckTimeout,
         subject.getDiskCheckTimeout().toMinutes());
     assertEquals(validBlockDeleteCommandWorkerInterval,
-        subject.getBlockDeleteCommandWorkerInterval());
+        subject.getBlockDeleteCommandWorkerInterval().getSeconds());
   }
 
   @Test
@@ -108,6 +108,7 @@ public class TestDatanodeConfiguration {
     int invalidFailedVolumesTolerated = -2;
     long invalidDiskCheckMinGap = -1;
     long invalidDiskCheckTimeout = -1;
+    long invalidBlockDeleteCommandWorkerInterval = -1;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, invalidDeleteThreads);
     conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
@@ -122,7 +123,8 @@ public class TestDatanodeConfiguration {
         invalidDiskCheckMinGap, TimeUnit.MINUTES);
     conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
         invalidDiskCheckTimeout, TimeUnit.MINUTES);
-    conf.setLong(BLOCK_DELETE_COMMAND_WORKER_INTERVAL, -1000);
+    conf.setTimeDuration (BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
+        invalidBlockDeleteCommandWorkerInterval, TimeUnit.SECONDS);
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -43,6 +43,8 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_DATA_VOLUMES_TOLERATED_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_METADATA_VOLUMES_TOLERATED_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_VOLUMES_TOLERATED_DEFAULT;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETE_COMMAND_WORKER_INTERVAL;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -59,6 +61,7 @@ public class TestDatanodeConfiguration {
     int validFailedVolumesTolerated = 10;
     long validDiskCheckMinGap = 2;
     long validDiskCheckTimeout = 1;
+    long validBlockDeleteCommandWorkerInterval = 1000;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, validDeleteThreads);
     conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
@@ -73,6 +76,8 @@ public class TestDatanodeConfiguration {
         validDiskCheckMinGap, TimeUnit.MINUTES);
     conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
         validDiskCheckTimeout, TimeUnit.MINUTES);
+    conf.setLong(BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
+        validBlockDeleteCommandWorkerInterval);
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
@@ -91,6 +96,8 @@ public class TestDatanodeConfiguration {
         subject.getDiskCheckMinGap().toMinutes());
     assertEquals(validDiskCheckTimeout,
         subject.getDiskCheckTimeout().toMinutes());
+    assertEquals(validBlockDeleteCommandWorkerInterval,
+        subject.getBlockDeleteCommandWorkerInterval());
   }
 
   @Test
@@ -115,6 +122,7 @@ public class TestDatanodeConfiguration {
         invalidDiskCheckMinGap, TimeUnit.MINUTES);
     conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
         invalidDiskCheckTimeout, TimeUnit.MINUTES);
+    conf.setLong(BLOCK_DELETE_COMMAND_WORKER_INTERVAL, -1000);
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
@@ -134,6 +142,8 @@ public class TestDatanodeConfiguration {
         subject.getDiskCheckMinGap());
     assertEquals(DISK_CHECK_TIMEOUT_DEFAULT,
         subject.getDiskCheckTimeout());
+    assertEquals(BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT,
+        subject.getBlockDeleteCommandWorkerInterval());
   }
 
   @Test
@@ -159,6 +169,8 @@ public class TestDatanodeConfiguration {
         subject.getDiskCheckMinGap());
     assertEquals(DISK_CHECK_TIMEOUT_DEFAULT,
         subject.getDiskCheckTimeout());
+    assertEquals(BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT,
+        subject.getBlockDeleteCommandWorkerInterval());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -123,7 +123,7 @@ public class TestDatanodeConfiguration {
         invalidDiskCheckMinGap, TimeUnit.MINUTES);
     conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
         invalidDiskCheckTimeout, TimeUnit.MINUTES);
-    conf.setTimeDuration (BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
+    conf.setTimeDuration(BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
         invalidBlockDeleteCommandWorkerInterval, TimeUnit.SECONDS);
 
     // WHEN

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -56,8 +56,10 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETE_COMMAND_WORKER_INTERVAL;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler.DeleteBlockTransactionExecutionResult;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V1;
 import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V2;
@@ -266,7 +268,8 @@ public class TestDeleteBlocksCommandHandler {
   @Test
   public void testDeleteCmdWorkerInterval() {
     OzoneConfiguration tmpConf = new OzoneConfiguration();
-    tmpConf.setLong(BLOCK_DELETE_COMMAND_WORKER_INTERVAL, 3000);
+    tmpConf.setTimeDuration(BLOCK_DELETE_COMMAND_WORKER_INTERVAL, 3,
+        TimeUnit.SECONDS);
     OzoneContainer container = Mockito.mock(OzoneContainer.class);
     DatanodeConfiguration dnConf =
         tmpConf.getObject(DatanodeConfiguration.class);
@@ -274,8 +277,10 @@ public class TestDeleteBlocksCommandHandler {
         spy(new DeleteBlocksCommandHandler(
         container, tmpConf, dnConf, "test"));
 
-    Assert.assertEquals(Long.parseLong(tmpConf.get(
-        BLOCK_DELETE_COMMAND_WORKER_INTERVAL)), 3000);
+    Assert.assertEquals(tmpConf.getTimeDuration(
+        BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
+        BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT.getSeconds(),
+        TimeUnit.SECONDS), 3);
     DeleteBlocksCommandHandler.DeleteCmdWorker deleteCmdWorker =
         commandHandler.new DeleteCmdWorker(4000);
     Assert.assertEquals(deleteCmdWorker.getInterval(), 4000);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;


### PR DESCRIPTION
## What changes were proposed in this pull request?
When DeleteCmdWorker is running, it will execute the delete command every 2 seconds. Currently, this time is fixed. The interval here should be changeable, which is good for system scalability.
Details: HDDS-9696

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9696

## How was this patch tested?
If you specify a new interval, it must take effect.
