### PR TITLE
HDDS-9710. Missing snapshot entries list Snapshot under a bucket API

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1432,6 +1432,10 @@ public class KeyManagerImpl implements KeyManager {
         && omKeyInfoCacheValue.getCacheValue() == null;
   }
 
+  public static boolean isKeyInCache(String key, Table keyTable) {
+    return keyTable.getCacheValue(new CacheKey(key)) != null;
+  }
+
   /**
    * Helper function for listStatus to find key in TableCache.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.utils.db.CopyObject;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.PriorityQueue;
+import java.util.TreeMap;
+
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+
+/**
+ * Common class to do listing of resources after merging
+ * rocksDB table cache & actual table.
+ */
+public class ListIterator {
+
+  /**
+   * Interface for iteration of Heap Entries.
+   */
+  public interface ClosableIterator extends Iterator<HeapEntry>, Closeable {
+
+  }
+
+  /**
+   * Entry to be added to the heap.
+   */
+  public static class HeapEntry implements Comparable<HeapEntry> {
+    private final int entryInteratorId;
+    private final String tableName;
+    private final String key;
+    private final Object value;
+
+    HeapEntry(int entryInteratorId, String tableName, String key,
+              Object value) {
+      this.entryInteratorId = entryInteratorId;
+      this.tableName = tableName;
+      this.key = key;
+      this.value = value;
+    }
+
+    public String getKey() {
+      return this.key;
+    }
+
+    private int getEntryInteratorId() {
+      return this.entryInteratorId;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    public Object getValue() {
+      return value;
+    }
+
+    public int compareTo(HeapEntry other) {
+      return Comparator.comparing(HeapEntry::getKey)
+          .thenComparing(HeapEntry::getEntryInteratorId).compare(this, other);
+    }
+
+    public boolean equals(Object other) {
+      if (other == null) {
+        return false;
+      }
+
+      if (!(other instanceof HeapEntry)) {
+        return false;
+      }
+
+
+      HeapEntry that = (HeapEntry) other;
+      return this.compareTo(that) == 0;
+    }
+
+    public int hashCode() {
+      return key.hashCode();
+    }
+  }
+
+  /**
+   * Iterator for DB entries in a Dir and File Table.
+   */
+  public static class RawIter<Value> implements
+      ClosableIterator {
+    private final int entryInteratorId;
+    private final String prefixKey;
+    private final TableIterator<String,
+        ? extends Table.KeyValue<String, Value>> tableIterator;
+
+    private final Table<String, Value> table;
+    private HeapEntry currentKey;
+
+    RawIter(int entryInteratorId, Table<String, Value> table,
+            String prefixKey, String startKey) throws IOException {
+      this.entryInteratorId = entryInteratorId;
+      this.table = table;
+      this.tableIterator = table.iterator(prefixKey);
+      this.prefixKey = prefixKey;
+      this.currentKey = null;
+
+      // only seek for the start key if the start key is lexicographically
+      // after the prefix key. For example
+      // Prefix key = 1024/c, Start key = 1024/a
+      // then do not seek for the start key
+      //
+      // on the other hand,
+      // Prefix key = 1024/a, Start key = 1024/c
+      // then seek for the start key
+      if (!StringUtils.isBlank(startKey) &&
+          startKey.compareTo(prefixKey) > 0) {
+        tableIterator.seek(startKey);
+      }
+
+      getNextKey();
+    }
+
+    private void getNextKey() throws IOException {
+      while (tableIterator.hasNext() && currentKey == null) {
+        Table.KeyValue<String, Value> entry = tableIterator.next();
+        String entryKey = entry.getKey();
+        if (entryKey.startsWith(prefixKey)) {
+          if (!KeyManagerImpl.isKeyDeleted(entryKey, table)) {
+            currentKey = new HeapEntry(entryInteratorId,
+                table.getName(), entryKey, entry.getValue());
+          }
+        } else {
+          // if the prefix key does not match, then break
+          // as the iterator is beyond the prefix.
+          break;
+        }
+      }
+    }
+
+    public boolean hasNext() {
+      try {
+        getNextKey();
+      } catch (Throwable t) {
+        throw new NoSuchElementException();
+      }
+      return currentKey != null;
+    }
+
+    public HeapEntry next() {
+      try {
+        getNextKey();
+      } catch (Throwable t) {
+        throw new NoSuchElementException();
+      }
+      HeapEntry ret = currentKey;
+      currentKey = null;
+
+      return ret;
+    }
+
+    public void close() throws IOException {
+      tableIterator.close();
+    }
+  }
+
+  /**
+   * Iterator for Cache entries in a Dir and File Table.
+   */
+  public static class CacheIter<Value>
+      implements ClosableIterator {
+    private final Map<String, Value> cacheKeyMap;
+
+    private final Iterator<Map.Entry<String, Value>>
+        cacheCreatedKeyIter;
+    private final Iterator<Map.Entry<CacheKey<String>, CacheValue<Value>>>
+        cacheIter;
+    private final String prefixKey;
+    private final String startKey;
+    private final String tableName;
+
+    private final int entryInteratorId;
+
+    CacheIter(int entryInteratorId, String tableName,
+              Iterator<Map.Entry<CacheKey<String>,
+                  CacheValue<Value>>> cacheIter, String startKey,
+              String prefixKey) {
+      this.cacheKeyMap = new TreeMap<>();
+
+      this.cacheIter = cacheIter;
+      this.startKey = startKey;
+      this.prefixKey = prefixKey;
+      this.tableName = tableName;
+      this.entryInteratorId = entryInteratorId;
+
+      getCacheValues();
+
+      cacheCreatedKeyIter = cacheKeyMap.entrySet().iterator();
+    }
+
+    private void getCacheValues() {
+      while (cacheIter.hasNext()) {
+        Map.Entry<CacheKey<String>, CacheValue<Value>> entry =
+            cacheIter.next();
+        String cacheKey = entry.getKey().getCacheKey();
+        Value cacheOmInfo = entry.getValue().getCacheValue();
+
+        // Copy cache value to local copy and work on it
+        if (cacheOmInfo instanceof CopyObject) {
+          cacheOmInfo = ((CopyObject<Value>) cacheOmInfo).copyObject();
+        }
+        if (StringUtils.isBlank(startKey)) {
+          // startKey is null or empty, then the seekKeyInDB="1024/"
+          if (cacheKey.startsWith(prefixKey)) {
+            cacheKeyMap.put(cacheKey, cacheOmInfo);
+          }
+        } else {
+          // startKey not empty, then the seekKeyInDB="1024/b" and
+          // seekKeyInDBWithOnlyParentID = "1024/". This is to avoid case of
+          // parentID with "102444" cache entries.
+          // Here, it has to list all the keys after "1024/b" and requires >=0
+          // string comparison.
+          if (cacheKey.startsWith(prefixKey) &&
+              cacheKey.compareTo(startKey) >= 0) {
+            cacheKeyMap.put(cacheKey, cacheOmInfo);
+          }
+        }
+      }
+    }
+
+    public boolean hasNext() {
+      return cacheCreatedKeyIter.hasNext();
+    }
+
+    public HeapEntry next() {
+      Map.Entry<String, Value> entry = cacheCreatedKeyIter.next();
+      return new HeapEntry(this.entryInteratorId, this.tableName,
+          entry.getKey(), entry.getValue());
+    }
+
+    public void close() {
+      // Nothing to close here
+    }
+  }
+
+  /**
+   * Implement lexicographical sorting of the file status by sorting file status
+   * across multiple lists. Each of these lists are sorted internally.
+   *
+   * This class implements sorted output by implementing a min heap based
+   * iterator where the initial element from each of sorted list is inserted.
+   *
+   * The least entry is removed and the next entry from the same list from
+   * which the entry is removed is added into the list.
+   *
+   * For example
+   * RawDir   - a1, a3, a5, a7
+   * RawFile  - a2, a4, a6, a8
+   *
+   * Min Heap is initially composed of {(a1, RawDir), (a2, RawFile)}
+   * THe least element is removed i.e a1 and then next entry from RawDir
+   * is inserted into minheap resulting in {(a2, RawFile), (a3, RawDir)}
+   *
+   * This process is repeated till both the lists are exhausted.
+   */
+  public static class MinHeapIterator implements ClosableIterator {
+    private final PriorityQueue<HeapEntry> minHeap = new PriorityQueue<>();
+    private final ArrayList<ClosableIterator> iterators = new ArrayList<>();
+
+    MinHeapIterator(OMMetadataManager omMetadataManager, String prefixKey,
+                    BucketLayout bucketLayout, String startKey,
+                    String volumeName, String bucketName) throws IOException {
+
+      this(omMetadataManager, prefixKey, startKey, volumeName,
+          bucketName, omMetadataManager.getDirectoryTable(),
+          omMetadataManager.getKeyTable(bucketLayout));
+    }
+
+    MinHeapIterator(OMMetadataManager omMetadataManager, String prefixKey,
+                    String startKey, String volumeName, String bucketName,
+                    Table... tables) throws IOException {
+      omMetadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
+          bucketName);
+      try {
+        int iteratorId = 0;
+        for (Table table : tables) {
+          iterators.add(new CacheIter<>(iteratorId, table.getName(),
+                  table.cacheIterator(), startKey, prefixKey));
+          iteratorId++;
+          iterators.add(new RawIter<>(iteratorId,
+                  omMetadataManager.getDirectoryTable(),
+                  prefixKey, startKey));
+          iteratorId++;
+        }
+      } finally {
+        omMetadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+            bucketName);
+      }
+
+      // Insert the element from each of the iterator
+      for (Iterator<HeapEntry> iter : iterators) {
+        if (iter.hasNext()) {
+          minHeap.add(iter.next());
+        }
+      }
+
+    }
+
+    public boolean hasNext() {
+      return !minHeap.isEmpty();
+    }
+
+    public HeapEntry next() {
+      HeapEntry heapEntry = minHeap.remove();
+      // remove the least element and
+      // reinsert the next element from the same iterator
+      Iterator<HeapEntry> iter = iterators.get(heapEntry.getEntryInteratorId());
+      if (iter.hasNext()) {
+        minHeap.add(iter.next());
+      }
+
+      return heapEntry;
+    }
+
+    public void close() throws IOException {
+      for (ClosableIterator iterator : iterators) {
+        iterator.close();
+      }
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -112,7 +112,7 @@ public class ListIterator {
   /**
    * Iterator for DB entries from a given rocksDB table.
    */
-  public static class RawIter<Value> implements
+  public static class DbTableIter<Value> implements
       ClosableIterator {
     private final int entryIteratorId;
     private final String prefixKey;
@@ -122,8 +122,8 @@ public class ListIterator {
     private final Table<String, Value> table;
     private HeapEntry currentKey;
 
-    RawIter(int entryIteratorId, Table<String, Value> table,
-            String prefixKey, String startKey) throws IOException {
+    DbTableIter(int entryIteratorId, Table<String, Value> table,
+                String prefixKey, String startKey) throws IOException {
       this.entryIteratorId = entryIteratorId;
       this.table = table;
       this.tableIterator = table.iterator(prefixKey);
@@ -312,7 +312,7 @@ public class ListIterator {
           iterators.add(new CacheIter<>(iteratorId, table.getName(),
                   table.cacheIterator(), startKey, prefixKey));
           iteratorId++;
-          iterators.add(new RawIter<>(iteratorId, table, prefixKey, startKey));
+          iterators.add(new DbTableIter<>(iteratorId, table, prefixKey, startKey));
           iteratorId++;
         }
       } finally {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -312,7 +312,8 @@ public class ListIterator {
           iterators.add(new CacheIter<>(iteratorId, table.getName(),
                   table.cacheIterator(), startKey, prefixKey));
           iteratorId++;
-          iterators.add(new DbTableIter<>(iteratorId, table, prefixKey, startKey));
+          iterators.add(new DbTableIter<>(iteratorId, table, prefixKey,
+              startKey));
           iteratorId++;
         }
       } finally {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -163,15 +163,12 @@ public class ListIterator {
     }
 
     public HeapEntry next() {
-      try {
-        getNextKey();
-      } catch (Throwable t) {
-        throw new NoSuchElementException();
+      if (hasNext()) {
+        HeapEntry ret = currentKey;
+        currentKey = null;
+        return ret;
       }
-      HeapEntry ret = currentKey;
-      currentKey = null;
-
-      return ret;
+      throw new NoSuchElementException();
     }
 
     public void close() throws IOException {
@@ -273,7 +270,7 @@ public class ListIterator {
    * RawFile  - a2, a4, a6, a8
    *
    * Min Heap is initially composed of {(a1, RawDir), (a2, RawFile)}
-   * THe least element is removed i.e a1 and then next entry from RawDir
+   * The least element is removed i.e a1 and then next entry from RawDir
    * is inserted into minheap resulting in {(a2, RawFile), (a3, RawDir)}
    *
    * This process is repeated till both the lists are exhausted.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -115,7 +115,6 @@ public class ListIterator {
   public static class DbTableIter<Value> implements
       ClosableIterator {
     private final int entryIteratorId;
-    private final String prefixKey;
     private final TableIterator<String,
         ? extends Table.KeyValue<String, Value>> tableIterator;
 
@@ -127,7 +126,6 @@ public class ListIterator {
       this.entryIteratorId = entryIteratorId;
       this.table = table;
       this.tableIterator = table.iterator(prefixKey);
-      this.prefixKey = prefixKey;
       this.currentKey = null;
 
       // only seek for the start key if the start key is lexicographically
@@ -142,23 +140,15 @@ public class ListIterator {
           startKey.compareTo(prefixKey) > 0) {
         tableIterator.seek(startKey);
       }
-
-      getNextKey();
     }
 
     private void getNextKey() throws IOException {
       while (tableIterator.hasNext() && currentKey == null) {
         Table.KeyValue<String, Value> entry = tableIterator.next();
         String entryKey = entry.getKey();
-        if (entryKey.startsWith(prefixKey)) {
-          if (!KeyManagerImpl.isKeyInCache(entryKey, table)) {
-            currentKey = new HeapEntry(entryIteratorId,
-                table.getName(), entryKey, entry.getValue());
-          }
-        } else {
-          // if the prefix key does not match, then break
-          // as the iterator is beyond the prefix.
-          break;
+        if (!KeyManagerImpl.isKeyInCache(entryKey, table)) {
+          currentKey = new HeapEntry(entryIteratorId,
+              table.getName(), entryKey, entry.getValue());
         }
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -183,8 +183,6 @@ public class ListIterator {
 
     private final Iterator<Map.Entry<String, Value>>
         cacheCreatedKeyIter;
-    private final Iterator<Map.Entry<CacheKey<String>, CacheValue<Value>>>
-        cacheIter;
     private final String prefixKey;
     private final String startKey;
     private final String tableName;
@@ -197,18 +195,18 @@ public class ListIterator {
               String prefixKey) {
       this.cacheKeyMap = new TreeMap<>();
 
-      this.cacheIter = cacheIter;
       this.startKey = startKey;
       this.prefixKey = prefixKey;
       this.tableName = tableName;
       this.entryIteratorId = entryIteratorId;
 
-      getCacheValues();
+      populateCacheMap(cacheIter);
 
       cacheCreatedKeyIter = cacheKeyMap.entrySet().iterator();
     }
 
-    private void getCacheValues() {
+    private void populateCacheMap(Iterator<Map.Entry<CacheKey<String>,
+        CacheValue<Value>>> cacheIter) {
       while (cacheIter.hasNext()) {
         Map.Entry<CacheKey<String>, CacheValue<Value>> entry =
             cacheIter.next();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1370,7 +1370,12 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         new ListIterator.MinHeapIterator(this, prefix, seek, volumeName,
             bucketName, snapshotInfoTable)) {
       while (snapshotIterator.hasNext() && maxListResult > 0) {
-        snapshotInfos.add((SnapshotInfo) snapshotIterator.next().getValue());
+        SnapshotInfo snapshotInfo = (SnapshotInfo) snapshotIterator.next()
+            .getValue();
+        if (!snapshotInfo.getName().equals(prevSnapshot)) {
+          snapshotInfos.add(snapshotInfo);
+          maxListResult--;
+        }
       }
     }
     return snapshotInfos;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -119,7 +119,6 @@ import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.checkSnapshotDir
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.compaction.log.CompactionLogEntry;
 import org.apache.ratis.util.ExitUtils;
-import org.eclipse.jetty.io.RuntimeIOException;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -21,34 +21,23 @@ import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
-import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
-import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
-import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.hdds.utils.db.CopyObject;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
-import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.NoSuchElementException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -56,8 +45,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.
     ResultCodes.FILE_NOT_FOUND;
-import static org.apache.hadoop.ozone.om.lock.
-    OzoneManagerLock.Resource.BUCKET_LOCK;
 
 /**
  * Helper class for fetching List Status for a path.
@@ -70,13 +57,6 @@ public class OzoneListStatusHelper {
   public interface GetFileStatusHelper {
     OzoneFileStatus apply(OmKeyArgs args, String clientAddress,
                           boolean skipFileNotFoundError) throws IOException;
-  }
-
-  /**
-   * Interface for iteration of Heap Entries.
-   */
-  public interface ClosableIterator extends Iterator<HeapEntry>, Closeable {
-
   }
 
   private static final Logger LOG =
@@ -208,23 +188,54 @@ public class OzoneListStatusHelper {
 
     // fetch the sorted output using a min heap iterator where
     // every remove from the heap will give the smallest entry.
-    try (MinHeapIterator heapIterator = new MinHeapIterator(metadataManager,
-        dbPrefixKey, bucketLayout, startKeyPrefix, volumeName, bucketName)) {
+    try (ListIterator.MinHeapIterator heapIterator =
+             new ListIterator.MinHeapIterator(metadataManager, dbPrefixKey,
+                 bucketLayout, startKeyPrefix, volumeName, bucketName)) {
 
       while (map.size() < numEntries && heapIterator.hasNext()) {
-        HeapEntry entry = heapIterator.next();
-        OzoneFileStatus status = entry.getStatus(prefixKey,
-            scmBlockSize, volumeName, bucketName, replication);
+        ListIterator.HeapEntry entry = heapIterator.next();
+        OzoneFileStatus status = getStatus(prefixKey,
+            scmBlockSize, volumeName, bucketName, replication, entry);
         // Caution: DO NOT use putIfAbsent. putIfAbsent undesirably overwrites
         // the value with `status` when the existing value in the map is null.
-        if (!map.containsKey(entry.key)) {
-          map.put(entry.key, status);
+        if (!map.containsKey(entry.getKey())) {
+          map.put(entry.getKey(), status);
         }
       }
     }
 
     return map.values().stream().filter(e -> e != null).collect(
         Collectors.toList());
+  }
+
+  private OzoneFileStatus getStatus(String prefixPath, long scmBlockSz,
+                                   String volumeName, String bucketName,
+                                   ReplicationConfig bucketReplication,
+                                   ListIterator.HeapEntry entry) {
+    if (entry == null || entry.getValue() == null) {
+      return null;
+    }
+    Object value = entry.getValue();
+    boolean isDir =
+        OmMetadataManagerImpl.DIRECTORY_TABLE.equals(entry.getTableName());
+    OmKeyInfo keyInfo;
+    if (isDir) {
+      Preconditions.checkArgument(value instanceof OmDirectoryInfo);
+      OmDirectoryInfo dirInfo = (OmDirectoryInfo) value;
+      String dirName = OMFileRequest.getAbsolutePath(prefixPath,
+          dirInfo.getName());
+      keyInfo = OMFileRequest.getOmKeyInfo(volumeName,
+          bucketName, dirInfo, dirName);
+      keyInfo.setReplicationConfig(bucketReplication); // always overwrite
+    } else {
+      Preconditions.checkArgument(value instanceof OmKeyInfo);
+      keyInfo = (OmKeyInfo) value;
+      keyInfo.setFileName(keyInfo.getKeyName());
+      String fullKeyPath = OMFileRequest.getAbsolutePath(prefixPath,
+          keyInfo.getKeyName());
+      keyInfo.setKeyName(fullKeyPath);
+    }
+    return new OzoneFileStatus(keyInfo, scmBlockSz, isDir);
   }
 
   private String getDbKey(String key, OmKeyArgs args,
@@ -259,334 +270,4 @@ public class OzoneListStatusHelper {
     }
   }
 
-  /**
-   * Enum of types of entries in the heap.
-   */
-  public enum EntryType {
-    DIR_CACHE,
-    FILE_CACHE,
-    RAW_DIR_DB,
-    RAW_FILE_DB;
-
-    public boolean isDir() {
-      switch (this) {
-      case DIR_CACHE:
-      case RAW_DIR_DB:
-        return true;
-      case FILE_CACHE:
-      case RAW_FILE_DB:
-        return false;
-      default:
-        throw new IllegalArgumentException();
-      }
-    }
-  }
-
-  /**
-   * Entry to be added to the heap.
-   */
-  private static class HeapEntry implements Comparable<HeapEntry> {
-    private final EntryType entryType;
-    private final String key;
-    private final Object value;
-
-    HeapEntry(EntryType entryType, String key, Object value) {
-      Preconditions.checkArgument(value == null ||
-          value instanceof OmDirectoryInfo ||
-              value instanceof OmKeyInfo);
-      this.entryType = entryType;
-      this.key = key;
-      this.value = value;
-    }
-
-    public int compareTo(HeapEntry other) {
-      return this.key.compareTo(other.key);
-    }
-
-    public boolean equals(Object other) {
-      if (other == null) {
-        return false;
-      }
-
-      if (!(other instanceof HeapEntry)) {
-        return false;
-      }
-
-
-      HeapEntry that = (HeapEntry) other;
-      return this.key.equals(that.key);
-    }
-
-    public int hashCode() {
-      return key.hashCode();
-    }
-
-    public OzoneFileStatus getStatus(
-        String prefixPath,
-        long scmBlockSize,
-        String volumeName,
-        String bucketName,
-        ReplicationConfig bucketReplication
-    ) {
-      if (value == null) {
-        return null;
-      }
-      OmKeyInfo keyInfo;
-      if (entryType.isDir()) {
-        Preconditions.checkArgument(value instanceof OmDirectoryInfo);
-        OmDirectoryInfo dirInfo = (OmDirectoryInfo) value;
-        String dirName = OMFileRequest.getAbsolutePath(prefixPath,
-            dirInfo.getName());
-        keyInfo = OMFileRequest.getOmKeyInfo(volumeName,
-            bucketName, dirInfo, dirName);
-        keyInfo.setReplicationConfig(bucketReplication); // always overwrite
-      } else {
-        Preconditions.checkArgument(value instanceof OmKeyInfo);
-        keyInfo = (OmKeyInfo) value;
-        keyInfo.setFileName(keyInfo.getKeyName());
-        String fullKeyPath = OMFileRequest.getAbsolutePath(prefixPath,
-            keyInfo.getKeyName());
-        keyInfo.setKeyName(fullKeyPath);
-      }
-      return new OzoneFileStatus(keyInfo, scmBlockSize, entryType.isDir());
-    }
-  }
-
-  /**
-   * Iterator for DB entries in a Dir and File Table.
-   */
-  private static class RawIter<Value> implements ClosableIterator {
-    private final EntryType iterType;
-    private final String prefixKey;
-    private final TableIterator<String,
-        ? extends Table.KeyValue<String, Value>> tableIterator;
-
-    private final Table<String, Value> table;
-    private HeapEntry currentKey;
-
-    RawIter(EntryType iterType, Table<String, Value> table,
-            String prefixKey, String startKey) throws IOException {
-      this.iterType = iterType;
-      this.table = table;
-      this.tableIterator = table.iterator(prefixKey);
-      this.prefixKey = prefixKey;
-      this.currentKey = null;
-
-      // only seek for the start key if the start key is lexicographically
-      // after the prefix key. For example
-      // Prefix key = 1024/c, Start key = 1024/a
-      // then do not seek for the start key
-      //
-      // on the other hand,
-      // Prefix key = 1024/a, Start key = 1024/c
-      // then seek for the start key
-      if (!StringUtils.isBlank(startKey) &&
-          startKey.compareTo(prefixKey) > 0) {
-        tableIterator.seek(startKey);
-      }
-
-      getNextKey();
-    }
-
-    private void getNextKey() throws IOException {
-      while (tableIterator.hasNext() && currentKey == null) {
-        Table.KeyValue<String, Value> entry = tableIterator.next();
-        String entryKey = entry.getKey();
-        if (entryKey.startsWith(prefixKey)) {
-          if (!KeyManagerImpl.isKeyDeleted(entryKey, table)) {
-            currentKey = new HeapEntry(iterType, entryKey, entry.getValue());
-          }
-        } else {
-          // if the prefix key does not match, then break
-          // as the iterator is beyond the prefix.
-          break;
-        }
-      }
-    }
-
-    public boolean hasNext() {
-      try {
-        getNextKey();
-      } catch (Throwable t) {
-        throw new NoSuchElementException();
-      }
-      return currentKey != null;
-    }
-
-    public HeapEntry next() {
-      try {
-        getNextKey();
-      } catch (Throwable t) {
-        throw new NoSuchElementException();
-      }
-      HeapEntry ret = currentKey;
-      currentKey = null;
-
-      return ret;
-    }
-
-    public void close() throws IOException {
-      tableIterator.close();
-    }
-  }
-
-  /**
-   * Iterator for Cache entries in a Dir and File Table.
-   */
-  private static class CacheIter<Value extends WithParentObjectId>
-      implements ClosableIterator {
-    private final Map<String, Value> cacheKeyMap;
-    private final Iterator<Map.Entry<String, Value>>
-        cacheCreatedKeyIter;
-    private final Iterator<Map.Entry<CacheKey<String>, CacheValue<Value>>>
-        cacheIter;
-    private final String prefixKey;
-    private final String startKey;
-    private final EntryType entryType;
-
-    CacheIter(EntryType entryType, Iterator<Map.Entry<CacheKey<String>,
-        CacheValue<Value>>> cacheIter, String startKey, String prefixKey) {
-      this.cacheKeyMap = new TreeMap<>();
-
-      this.cacheIter = cacheIter;
-      this.startKey = startKey;
-      this.prefixKey = prefixKey;
-      this.entryType = entryType;
-
-      getCacheValues();
-
-      cacheCreatedKeyIter = cacheKeyMap.entrySet().iterator();
-    }
-
-    private void getCacheValues() {
-      while (cacheIter.hasNext()) {
-        Map.Entry<CacheKey<String>, CacheValue<Value>> entry =
-            cacheIter.next();
-        String cacheKey = entry.getKey().getCacheKey();
-        Value cacheOmInfo = entry.getValue().getCacheValue();
-
-        // Copy cache value to local copy and work on it
-        if (cacheOmInfo instanceof CopyObject) {
-          cacheOmInfo = ((CopyObject<Value>) cacheOmInfo).copyObject();
-        }
-        if (StringUtils.isBlank(startKey)) {
-          // startKey is null or empty, then the seekKeyInDB="1024/"
-          if (cacheKey.startsWith(prefixKey)) {
-            cacheKeyMap.put(cacheKey, cacheOmInfo);
-          }
-        } else {
-          // startKey not empty, then the seekKeyInDB="1024/b" and
-          // seekKeyInDBWithOnlyParentID = "1024/". This is to avoid case of
-          // parentID with "102444" cache entries.
-          // Here, it has to list all the keys after "1024/b" and requires >=0
-          // string comparison.
-          if (cacheKey.startsWith(prefixKey) &&
-              cacheKey.compareTo(startKey) >= 0) {
-            cacheKeyMap.put(cacheKey, cacheOmInfo);
-          }
-        }
-      }
-    }
-
-    public boolean hasNext() {
-      return cacheCreatedKeyIter.hasNext();
-    }
-
-    public HeapEntry next() {
-      Map.Entry<String, Value> entry = cacheCreatedKeyIter.next();
-      return new HeapEntry(entryType, entry.getKey(), entry.getValue());
-    }
-
-    public void close() {
-      // Nothing to close here
-    }
-  }
-
-  /**
-   * Implement lexicographical sorting of the file status by sorting file status
-   * across multiple lists. Each of these lists are sorted internally.
-   *
-   * This class implements sorted output by implementing a min heap based
-   * iterator where the initial element from each of sorted list is inserted.
-   *
-   * The least entry is removed and the next entry from the same list from
-   * which the entry is removed is added into the list.
-   *
-   * For example
-   * RawDir   - a1, a3, a5, a7
-   * RawFile  - a2, a4, a6, a8
-   *
-   * Min Heap is initially composed of {(a1, RawDir), (a2, RawFile)}
-   * THe least element is removed i.e a1 and then next entry from RawDir
-   * is inserted into minheap resulting in {(a2, RawFile), (a3, RawDir)}
-   *
-   * This process is repeated till both the lists are exhausted.
-   */
-  private static class MinHeapIterator implements ClosableIterator {
-    private final PriorityQueue<HeapEntry> minHeap = new PriorityQueue<>();
-    private final ArrayList<ClosableIterator> iterators = new ArrayList<>();
-
-    MinHeapIterator(OMMetadataManager omMetadataManager, String prefixKey,
-                    BucketLayout bucketLayout, String startKey,
-                    String volumeName, String bucketName) throws IOException {
-
-      omMetadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-          bucketName);
-      try {
-        // Initialize all the iterators
-        iterators.add(EntryType.DIR_CACHE.ordinal(),
-            new CacheIter<>(EntryType.DIR_CACHE,
-                omMetadataManager.getDirectoryTable().cacheIterator(),
-                startKey, prefixKey));
-
-        iterators.add(EntryType.FILE_CACHE.ordinal(),
-            new CacheIter<>(EntryType.FILE_CACHE,
-                omMetadataManager.getKeyTable(bucketLayout).cacheIterator(),
-                startKey, prefixKey));
-
-        iterators.add(EntryType.RAW_DIR_DB.ordinal(),
-            new RawIter<>(EntryType.RAW_DIR_DB,
-                omMetadataManager.getDirectoryTable(),
-                prefixKey, startKey));
-
-        iterators.add(EntryType.RAW_FILE_DB.ordinal(),
-            new RawIter<>(EntryType.RAW_FILE_DB,
-                omMetadataManager.getKeyTable(bucketLayout),
-                prefixKey, startKey));
-      } finally {
-        omMetadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-            bucketName);
-      }
-
-      // Insert the element from each of the iterator
-      for (Iterator<HeapEntry> iter : iterators) {
-        if (iter.hasNext()) {
-          minHeap.add(iter.next());
-        }
-      }
-    }
-
-
-    public boolean hasNext() {
-      return !minHeap.isEmpty();
-    }
-
-    public HeapEntry next() {
-      HeapEntry heapEntry = minHeap.remove();
-      // remove the least element and
-      // reinsert the next element from the same iterator
-      Iterator<HeapEntry> iter = iterators.get(heapEntry.entryType.ordinal());
-      if (iter.hasNext()) {
-        minHeap.add(iter.next());
-      }
-
-      return heapEntry;
-    }
-
-    public void close() throws IOException {
-      for (ClosableIterator iterator : iterators) {
-        iterator.close();
-      }
-    }
-  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -217,9 +217,9 @@ public class OzoneListStatusHelper {
   }
 
   private OzoneFileStatus getStatus(String prefixPath, long scmBlockSz,
-                                   String volumeName, String bucketName,
-                                   ReplicationConfig bucketReplication,
-                                   ListIterator.HeapEntry entry) {
+                                    String volumeName, String bucketName,
+                                    ReplicationConfig bucketReplication,
+                                    ListIterator.HeapEntry entry) {
     if (entry == null || entry.getValue() == null) {
       return null;
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -503,23 +503,25 @@ public final class OMRequestTestUtils {
   /**
    * Add snapshot entry to DB.
    */
-  public static void addSnapshotToTable(
+  public static SnapshotInfo addSnapshotToTable(
       String volumeName, String bucketName, String snapshotName,
       OMMetadataManager omMetadataManager) throws IOException {
     SnapshotInfo snapshotInfo = SnapshotInfo.newInstance(volumeName,
         bucketName, snapshotName, UUID.randomUUID(), Time.now());
     addSnapshotToTable(false, 0L, snapshotInfo, omMetadataManager);
+    return snapshotInfo;
   }
 
   /**
    * Add snapshot entry to snapshot table cache.
    */
-  public static void addSnapshotToTableCache(
+  public static SnapshotInfo addSnapshotToTableCache(
       String volumeName, String bucketName, String snapshotName,
       OMMetadataManager omMetadataManager) throws IOException {
     SnapshotInfo snapshotInfo = SnapshotInfo.newInstance(volumeName, bucketName,
         snapshotName, UUID.randomUUID(), Time.now());
     addSnapshotToTable(true, 0L, snapshotInfo, omMetadataManager);
+    return snapshotInfo;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Snapshot list might be missing entries in the return list. Currently the list happens in a paginated fashion getting few snapshots at a time. Thus every page updates the previous value as the last entry in the previous page, helping the api to seek to the next snapshot directly. The problem is we form the listing by getting the first few entries from the cache and then the remaining entries from the table and return the concatenated list.

Consider the case:

TableCache has snap100...snap125

RocksDB Table has snap0...snap99

Now we want to list all snapshots from snap50 with maxPageSize of 30:

The expected list should be:

snap50 to snap80

But the current output is snap50 to snap54 ... snap100 to snap125 which is wrong. The next page would start from snap125, thus missing the snapshot 55 to snap100 altogether. The ideal approach would be to merge these two streams and get the snapshots in a sorted order.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9710

## How was this patch tested?
Existing UT. Will be adding a few more.
