### PR TITLE
HDDS-9697. ContainerStateMachine.applyTransaction(..) should not validate token again.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -489,6 +489,15 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   @Override
   public void validateContainerCommand(
       ContainerCommandRequestProto msg) throws StorageContainerException {
+    try {
+      validateToken(msg);
+    } catch (IOException ioe) {
+      throw new StorageContainerException(
+          ContainerProtos.Result.BLOCK_TOKEN_VERIFICATION_FAILED
+          + ": " + ioe.getMessage(), ioe,
+          ContainerProtos.Result.BLOCK_TOKEN_VERIFICATION_FAILED);
+    }
+
     long containerID = msg.getContainerID();
     Container container = getContainer(containerID);
     if (container == null) {
@@ -532,14 +541,6 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
           "Container " + containerID + " in " + containerState + " state");
       audit(action, eventType, params, AuditEventStatus.FAILURE, iex);
       throw iex;
-    }
-
-    try {
-      validateToken(msg);
-    } catch (IOException ioe) {
-      throw new StorageContainerException(
-          "Block token verification failed. " + ioe.getMessage(), ioe,
-          ContainerProtos.Result.BLOCK_TOKEN_VERIFICATION_FAILED);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -215,11 +215,14 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
             == DispatcherContext.WriteChunkStage.COMMIT_DATA);
 
     try {
-      validateToken(msg);
+      if (DispatcherContext.op(dispatcherContext).validateToken()) {
+        validateToken(msg);
+      }
     } catch (IOException ioe) {
-      StorageContainerException sce = new StorageContainerException(
-          "Block token verification failed. " + ioe.getMessage(), ioe,
-          ContainerProtos.Result.BLOCK_TOKEN_VERIFICATION_FAILED);
+      final String s = ContainerProtos.Result.BLOCK_TOKEN_VERIFICATION_FAILED
+          + " for " + dispatcherContext + ": " + ioe.getMessage();
+      final StorageContainerException sce = new StorageContainerException(
+          s, ioe, ContainerProtos.Result.BLOCK_TOKEN_VERIFICATION_FAILED);
       return ContainerUtils.logAndReturnError(LOG, sce, msg);
     }
     // if the command gets executed other than Ratis, the default write stage

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
@@ -120,7 +120,8 @@ public final class DispatcherContext {
     this.container2BCSIDMap = b.container2BCSIDMap;
   }
 
-  public Op getOp() {
+  /** Use {@link DispatcherContext#op(DispatcherContext)} for handling null. */
+  private Op getOp() {
     return op;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
@@ -93,13 +93,13 @@ public final class DispatcherContext {
 
     public boolean validateToken() {
       switch (this) {
-        case APPLY_TRANSACTION:
-        case WRITE_STATE_MACHINE_DATA:
-        case READ_STATE_MACHINE_DATA:
-        case STREAM_LINK:
-          return false;
-        default:
-          return true;
+      case APPLY_TRANSACTION:
+      case WRITE_STATE_MACHINE_DATA:
+      case READ_STATE_MACHINE_DATA:
+      case STREAM_LINK:
+        return false;
+      default:
+        return true;
       }
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
@@ -65,6 +65,10 @@ public final class DispatcherContext {
     public boolean isWrite() {
       return this != COMMIT_DATA;
     }
+
+    public boolean isCommit() {
+      return this != WRITE_DATA;
+    }
   }
 
   /** Operation types. */
@@ -101,7 +105,6 @@ public final class DispatcherContext {
   private final Op op;
   // whether the chunk data needs to be written or committed or both
   private final WriteChunkStage stage;
-  // indicates whether the read from tmp chunk files is allowed
   // which term the request is being served in Ratis
   private final long term;
   // the log index in Ratis log to which the request belongs to

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
@@ -82,8 +82,6 @@ public final class DispatcherContext {
 
     READ_STATE_MACHINE_DATA,
     WRITE_STATE_MACHINE_DATA,
-
-    START_TRANSACTION,
     APPLY_TRANSACTION,
 
     STREAM_INIT,
@@ -94,7 +92,15 @@ public final class DispatcherContext {
     }
 
     public boolean validateToken() {
-      return this != APPLY_TRANSACTION;
+      switch (this) {
+        case APPLY_TRANSACTION:
+        case WRITE_STATE_MACHINE_DATA:
+        case READ_STATE_MACHINE_DATA:
+        case STREAM_LINK:
+          return false;
+        default:
+          return true;
+      }
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
@@ -19,8 +19,10 @@ package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.ratis.server.protocol.TermIndex;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * DispatcherContext class holds transport protocol specific context info
@@ -29,17 +31,77 @@ import java.util.Map;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public final class DispatcherContext {
+  private static final DispatcherContext HANDLE_READ_CHUNK
+      = newBuilder(Op.HANDLE_READ_CHUNK).build();
+  private static final DispatcherContext HANDLE_WRITE_CHUNK
+      = newBuilder(Op.HANDLE_WRITE_CHUNK).build();
+  private static final DispatcherContext HANDLE_GET_SMALL_FILE
+      = newBuilder(Op.HANDLE_GET_SMALL_FILE).build();
+  private static final DispatcherContext HANDLE_PUT_SMALL_FILE
+      = newBuilder(Op.HANDLE_PUT_SMALL_FILE).build();
+
+  public static DispatcherContext getHandleReadChunk() {
+    return HANDLE_READ_CHUNK;
+  }
+
+  public static DispatcherContext getHandleWriteChunk() {
+    return HANDLE_WRITE_CHUNK;
+  }
+
+  public static DispatcherContext getHandleGetSmallFile() {
+    return HANDLE_GET_SMALL_FILE;
+  }
+
+  public static DispatcherContext getHandlePutSmallFile() {
+    return HANDLE_PUT_SMALL_FILE;
+  }
+
   /**
    * Determines which stage of writeChunk a write chunk request is for.
    */
   public enum WriteChunkStage {
-    WRITE_DATA, COMMIT_DATA, COMBINED
+    WRITE_DATA, COMMIT_DATA, COMBINED;
+
+    public boolean isWrite() {
+      return this != COMMIT_DATA;
+    }
   }
 
+  /** Operation types. */
+  public enum Op {
+    NULL,
+
+    HANDLE_READ_CHUNK,
+    HANDLE_WRITE_CHUNK,
+    HANDLE_GET_SMALL_FILE,
+    HANDLE_PUT_SMALL_FILE,
+
+    READ_STATE_MACHINE_DATA,
+    WRITE_STATE_MACHINE_DATA,
+
+    START_TRANSACTION,
+    APPLY_TRANSACTION,
+
+    STREAM_INIT,
+    STREAM_LINK;
+
+    public boolean readFromTmpFile() {
+      return this == READ_STATE_MACHINE_DATA;
+    }
+
+    public boolean validateToken() {
+      return this != APPLY_TRANSACTION;
+    }
+  }
+
+  public static Op op(DispatcherContext context) {
+    return context == null ? Op.NULL : context.getOp();
+  }
+
+  private final Op op;
   // whether the chunk data needs to be written or committed or both
   private final WriteChunkStage stage;
   // indicates whether the read from tmp chunk files is allowed
-  private final boolean readFromTmpFile;
   // which term the request is being served in Ratis
   private final long term;
   // the log index in Ratis log to which the request belongs to
@@ -47,21 +109,20 @@ public final class DispatcherContext {
 
   private final Map<Long, Long> container2BCSIDMap;
 
-  private DispatcherContext(long term, long index, WriteChunkStage stage,
-      boolean readFromTmpFile, Map<Long, Long> container2BCSIDMap) {
-    this.term = term;
-    this.logIndex = index;
-    this.stage = stage;
-    this.readFromTmpFile = readFromTmpFile;
-    this.container2BCSIDMap = container2BCSIDMap;
+  private DispatcherContext(Builder b) {
+    this.op = Objects.requireNonNull(b.op, "op == null");
+    this.term = b.term;
+    this.logIndex = b.logIndex;
+    this.stage = b.stage;
+    this.container2BCSIDMap = b.container2BCSIDMap;
+  }
+
+  public Op getOp() {
+    return op;
   }
 
   public long getLogIndex() {
     return logIndex;
-  }
-
-  public boolean isReadFromTmpFile() {
-    return readFromTmpFile;
   }
 
   public long getTerm() {
@@ -76,15 +137,28 @@ public final class DispatcherContext {
     return container2BCSIDMap;
   }
 
+  @Override
+  public String toString() {
+    return op + "-" + stage + TermIndex.valueOf(term, logIndex);
+  }
+
+  public static Builder newBuilder(Op op) {
+    return new Builder(Objects.requireNonNull(op, "op == null"));
+  }
+
   /**
    * Builder class for building DispatcherContext.
    */
   public static final class Builder {
+    private final Op op;
     private WriteChunkStage stage = WriteChunkStage.COMBINED;
-    private boolean readFromTmpFile = false;
     private long term;
     private long logIndex;
     private Map<Long, Long> container2BCSIDMap;
+
+    private Builder(Op op) {
+      this.op = op;
+    }
 
     /**
      * Sets the WriteChunkStage.
@@ -94,17 +168,6 @@ public final class DispatcherContext {
      */
     public Builder setStage(WriteChunkStage writeChunkStage) {
       this.stage = writeChunkStage;
-      return this;
-    }
-
-    /**
-     * Sets the flag for reading from tmp chunk files.
-     *
-     * @param setReadFromTmpFile whether to read from tmp chunk file or not
-     * @return DispatcherContext.Builder
-     */
-    public Builder setReadFromTmpFile(boolean setReadFromTmpFile) {
-      this.readFromTmpFile = setReadFromTmpFile;
       return this;
     }
 
@@ -146,8 +209,7 @@ public final class DispatcherContext {
      * @return DispatcherContext
      */
     public DispatcherContext build() {
-      return new DispatcherContext(term, logIndex, stage, readFromTmpFile,
-          container2BCSIDMap);
+      return new DispatcherContext(this);
     }
 
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -74,7 +74,6 @@ import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.report.IncrementalReportSender;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
-import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext.WriteChunkStage;
 import org.apache.hadoop.ozone.container.common.utils.ContainerLogger;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -707,7 +706,7 @@ public class KeyValueHandler extends Handler {
       checkContainerIsHealthy(kvContainer, blockID, Type.ReadChunk);
       BlockUtils.verifyBCSId(kvContainer, blockID);
       if (dispatcherContext == null) {
-        dispatcherContext = new DispatcherContext.Builder().build();
+        dispatcherContext = DispatcherContext.getHandleReadChunk();
       }
 
       boolean isReadChunkV0 = getReadChunkVersion(request.getReadChunk())
@@ -725,7 +724,7 @@ public class KeyValueHandler extends Handler {
       // Validate data only if the read chunk is issued by Ratis for its
       // internal logic.
       //  For client reads, the client is expected to validate.
-      if (dispatcherContext.isReadFromTmpFile()) {
+      if (DispatcherContext.op(dispatcherContext).readFromTmpFile()) {
         validateChunkChecksumData(data, chunkInfo);
       }
       metrics.incContainerBytesStats(Type.ReadChunk, chunkInfo.getLen());
@@ -811,11 +810,10 @@ public class KeyValueHandler extends Handler {
 
       ChunkBuffer data = null;
       if (dispatcherContext == null) {
-        dispatcherContext = new DispatcherContext.Builder().build();
+        dispatcherContext = DispatcherContext.getHandleWriteChunk();
       }
-      WriteChunkStage stage = dispatcherContext.getStage();
-      if (stage == WriteChunkStage.WRITE_DATA ||
-          stage == WriteChunkStage.COMBINED) {
+      final boolean isWrite = dispatcherContext.getStage().isWrite();
+      if (isWrite) {
         data =
             ChunkBuffer.wrap(writeChunk.getData().asReadOnlyByteBufferList());
         validateChunkChecksumData(data, chunkInfo);
@@ -824,8 +822,7 @@ public class KeyValueHandler extends Handler {
           .writeChunk(kvContainer, blockID, chunkInfo, data, dispatcherContext);
 
       // We should increment stats after writeChunk
-      if (stage == WriteChunkStage.WRITE_DATA ||
-          stage == WriteChunkStage.COMBINED) {
+      if (isWrite) {
         metrics.incContainerBytesStats(Type.WriteChunk, writeChunk
             .getChunkData().getLen());
       }
@@ -873,7 +870,7 @@ public class KeyValueHandler extends Handler {
       ChunkBuffer data = ChunkBuffer.wrap(
           putSmallFileReq.getData().asReadOnlyByteBufferList());
       if (dispatcherContext == null) {
-        dispatcherContext = new DispatcherContext.Builder().build();
+        dispatcherContext = DispatcherContext.getHandlePutSmallFile();
       }
 
       BlockID blockID = blockData.getBlockID();
@@ -931,8 +928,8 @@ public class KeyValueHandler extends Handler {
 
       ContainerProtos.ChunkInfo chunkInfoProto = null;
       List<ByteString> dataBuffers = new ArrayList<>();
-      DispatcherContext dispatcherContext =
-          new DispatcherContext.Builder().build();
+      final DispatcherContext dispatcherContext
+          = DispatcherContext.getHandleGetSmallFile();
       for (ContainerProtos.ChunkInfo chunk : responseData.getChunks()) {
         // if the block is committed, all chunks must have been committed.
         // Tmp chunk files won't exist here.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
@@ -48,13 +48,11 @@ public class ChunkManagerDummyImpl implements ChunkManager {
       throws StorageContainerException {
 
     Preconditions.checkNotNull(dispatcherContext);
-    DispatcherContext.WriteChunkStage stage = dispatcherContext.getStage();
+    final boolean isWrite = dispatcherContext.getStage().isWrite();
 
     ContainerData containerData = container.getContainerData();
 
-    if (stage == DispatcherContext.WriteChunkStage.WRITE_DATA
-        || stage == DispatcherContext.WriteChunkStage.COMBINED) {
-
+    if (isWrite) {
       ChunkUtils.validateBufferSize(info.getLen(), data.remaining());
 
       HddsVolume volume = containerData.getVolume();
@@ -63,8 +61,7 @@ public class ChunkManagerDummyImpl implements ChunkManager {
       volumeIOStats.incWriteBytes(info.getLen());
     }
 
-    if (stage == DispatcherContext.WriteChunkStage.COMMIT_DATA
-        || stage == DispatcherContext.WriteChunkStage.COMBINED) {
+    if (isWrite) {
       containerData.updateWriteStats(info.getLen(), false);
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
@@ -48,11 +48,11 @@ public class ChunkManagerDummyImpl implements ChunkManager {
       throws StorageContainerException {
 
     Preconditions.checkNotNull(dispatcherContext);
-    final boolean isWrite = dispatcherContext.getStage().isWrite();
+    DispatcherContext.WriteChunkStage stage = dispatcherContext.getStage();
 
     ContainerData containerData = container.getContainerData();
 
-    if (isWrite) {
+    if (stage.isWrite()) {
       ChunkUtils.validateBufferSize(info.getLen(), data.remaining());
 
       HddsVolume volume = containerData.getVolume();
@@ -61,7 +61,7 @@ public class ChunkManagerDummyImpl implements ChunkManager {
       volumeIOStats.incWriteBytes(info.getLen());
     }
 
-    if (isWrite) {
+    if (stage.isCommit()) {
       containerData.updateWriteStats(info.getLen(), false);
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -222,7 +222,7 @@ public class FilePerChunkStrategy implements ChunkManager {
 
     List<File> possibleFiles = new ArrayList<>();
     possibleFiles.add(finalChunkFile);
-    if (dispatcherContext != null && dispatcherContext.isReadFromTmpFile()) {
+    if (DispatcherContext.op(dispatcherContext).readFromTmpFile()) {
       possibleFiles.add(getTmpChunkFile(finalChunkFile, dispatcherContext));
       // HDDS-2372. Read finalChunkFile after tmpChunkFile to solve race
       // condition between read and commit.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
@@ -85,21 +85,19 @@ public final class ContainerTestUtils {
   private ContainerTestUtils() {
   }
 
-  public static final DispatcherContext WRITE_STAGE
-      = new DispatcherContext.Builder()
+  public static final DispatcherContext WRITE_STAGE = DispatcherContext
+      .newBuilder(DispatcherContext.Op.WRITE_STATE_MACHINE_DATA)
       .setStage(DispatcherContext.WriteChunkStage.WRITE_DATA)
       .build();
 
-  public static final DispatcherContext COMMIT_STAGE
-      = new DispatcherContext.Builder()
+  public static final DispatcherContext COMMIT_STAGE = DispatcherContext
+      .newBuilder(DispatcherContext.Op.APPLY_TRANSACTION)
       .setStage(DispatcherContext.WriteChunkStage.COMMIT_DATA)
       .setContainer2BCSIDMap(Collections.emptyMap())
       .build();
 
   public static final DispatcherContext COMBINED_STAGE
-      = new DispatcherContext.Builder()
-      .setStage(DispatcherContext.WriteChunkStage.COMBINED)
-      .build();
+      = DispatcherContext.getHandleWriteChunk();
 
   /**
    * Creates an Endpoint class for testing purpose.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -203,10 +203,6 @@ public class TestContainerPersistence {
     return ContainerTestHelper.getTestContainerID();
   }
 
-  private DispatcherContext getDispatcherContext() {
-    return new DispatcherContext.Builder().build();
-  }
-
   private KeyValueContainer addContainer(ContainerSet cSet, long cID)
       throws IOException {
     long commitBytesBefore = 0;
@@ -609,7 +605,7 @@ public class TestContainerPersistence {
     commitBytesBefore = container.getContainerData()
         .getVolume().getCommittedBytes();
     chunkManager.writeChunk(container, blockID, info, data,
-        getDispatcherContext());
+        DispatcherContext.getHandleWriteChunk());
     commitBytesAfter = container.getContainerData()
         .getVolume().getCommittedBytes();
     commitDecrement = commitBytesBefore - commitBytesAfter;
@@ -656,7 +652,7 @@ public class TestContainerPersistence {
       ChunkBuffer data = getData(datalen);
       setDataChecksum(info, data);
       chunkManager.writeChunk(container, blockID, info, data,
-          getDispatcherContext());
+          DispatcherContext.getHandleWriteChunk());
       chunks.add(info);
       blockData.addChunk(info.getProtoBufMessage());
     }
@@ -673,8 +669,8 @@ public class TestContainerPersistence {
     // Read chunk via ReadChunk call.
     for (int x = 0; x < chunkCount; x++) {
       ChunkInfo info = chunks.get(x);
-      ChunkBuffer data = chunkManager
-          .readChunk(container, blockID, info, getDispatcherContext());
+      final ChunkBuffer data = chunkManager.readChunk(container, blockID, info,
+          DispatcherContext.getHandleReadChunk());
       ChecksumData checksumData = checksum.computeChecksum(data);
       Assert.assertEquals(info.getChecksumData(), checksumData);
     }
@@ -701,15 +697,15 @@ public class TestContainerPersistence {
     ChunkBuffer data = getData(datalen);
     setDataChecksum(info, data);
     chunkManager.writeChunk(container, blockID, info, data,
-        getDispatcherContext());
+        DispatcherContext.getHandleWriteChunk());
     data.rewind();
     chunkManager.writeChunk(container, blockID, info, data,
-        getDispatcherContext());
+        DispatcherContext.getHandleWriteChunk());
     data.rewind();
     // With the overwrite flag it should work now.
     info.addMetadata(OzoneConsts.CHUNK_OVERWRITE, "true");
     chunkManager.writeChunk(container, blockID, info, data,
-        getDispatcherContext());
+        DispatcherContext.getHandleWriteChunk());
     long bytesUsed = container.getContainerData().getBytesUsed();
     Assert.assertEquals(datalen, bytesUsed);
 
@@ -736,10 +732,11 @@ public class TestContainerPersistence {
     ChunkBuffer data = getData(datalen);
     setDataChecksum(info, data);
     chunkManager.writeChunk(container, blockID, info, data,
-        getDispatcherContext());
+        DispatcherContext.getHandleWriteChunk());
     chunkManager.deleteChunk(container, blockID, info);
     exception.expect(StorageContainerException.class);
-    chunkManager.readChunk(container, blockID, info, getDispatcherContext());
+    chunkManager.readChunk(container, blockID, info,
+        DispatcherContext.getHandleReadChunk());
   }
 
   /**
@@ -847,7 +844,7 @@ public class TestContainerPersistence {
       ChunkBuffer data = getData(datalen);
       setDataChecksum(info, data);
       chunkManager.writeChunk(container, blockID, info, data,
-          getDispatcherContext());
+          DispatcherContext.getHandleWriteChunk());
       totalSize += datalen;
       chunkList.add(info);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -76,6 +76,7 @@ import org.apache.ozone.test.GenericTestUtils;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.HddsUtils.isReadOnly;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.BLOCK_TOKEN_VERIFICATION_FAILED;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.SUCCESS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
@@ -317,11 +318,11 @@ public class TestSecureContainerServer {
       ContainerCommandResponseProto response = client.sendCommand(request);
       assertNotEquals(response.getResult(), ContainerProtos.Result.SUCCESS);
       String msg = response.getMessage();
-      assertTrue(msg, msg.contains("token verification failed"));
+      assertTrue(msg, msg.contains(BLOCK_TOKEN_VERIFICATION_FAILED.name()));
     } else {
-      assertRootCauseMessage("token verification failed",
-          Assert.assertThrows(IOException.class, () ->
-              client.sendCommand(request)));
+      final Throwable t = Assert.assertThrows(Throwable.class,
+          () -> client.sendCommand(request));
+      assertRootCauseMessage(BLOCK_TOKEN_VERIFICATION_FAILED.name(), t);
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
@@ -170,13 +170,12 @@ public class ChunkManagerDiskWrite extends BaseFreonGenerator implements
     ChunkInfo chunkInfo = new ChunkInfo(chunkName, offset, chunkSize);
     LOG.debug("Writing chunk {}: containerID:{} localID:{} offset:{} " +
             "bytesWritten:{}", l, containerID, localID, offset, bytesWritten);
-    DispatcherContext context =
-        new DispatcherContext.Builder()
-            .setStage(WriteChunkStage.WRITE_DATA)
-            .setTerm(1L)
-            .setLogIndex(l)
-            .setReadFromTmpFile(false)
-            .build();
+    final DispatcherContext context = DispatcherContext
+        .newBuilder(DispatcherContext.Op.WRITE_STATE_MACHINE_DATA)
+        .setStage(WriteChunkStage.WRITE_DATA)
+        .setTerm(1L)
+        .setLogIndex(l)
+        .build();
     ByteBuffer buffer = ByteBuffer.wrap(data);
 
     timer.time(() -> {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -341,11 +341,11 @@ public class GeneratorDatanode extends BaseGenerator {
   ) throws IOException {
 
     DispatcherContext context =
-        new DispatcherContext.Builder()
+        DispatcherContext
+            .newBuilder(DispatcherContext.Op.WRITE_STATE_MACHINE_DATA)
             .setStage(WriteChunkStage.WRITE_DATA)
             .setTerm(1L)
             .setLogIndex(logCounter)
-            .setReadFromTmpFile(false)
             .build();
     chunkManager
         .writeChunk(container, blockId, chunkInfo,
@@ -353,11 +353,11 @@ public class GeneratorDatanode extends BaseGenerator {
             context);
 
     context =
-        new DispatcherContext.Builder()
+        DispatcherContext
+            .newBuilder(DispatcherContext.Op.APPLY_TRANSACTION)
             .setStage(WriteChunkStage.COMMIT_DATA)
             .setTerm(1L)
             .setLogIndex(logCounter)
-            .setReadFromTmpFile(false)
             .build();
     chunkManager
         .writeChunk(container, blockId, chunkInfo,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In ContainerStateMachine, the startTransaction(..) method has already validated the token. The applyTransaction(..) should not validate the same token again.

A problem is that the token may expire later on. Then, a server may not be able to re-apply the same transaction when replaying the RaftLog after server restart.
 
## What is the link to the Apache JIRA

HDDS-9697

## How was this patch tested?

New unit test.