### PR TITLE
HDDS-9720. XceiverServerRatis.triggerPipelineClose throws NPE.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -856,7 +856,7 @@ public class ContainerStateMachine extends BaseStateMachine {
 
   private CompletableFuture<ContainerCommandResponseProto> submitTask(
       ContainerCommandRequestProto request, DispatcherContext.Builder context,
-      Consumer<Exception> exceptionHandler) {
+      Consumer<Throwable> exceptionHandler) {
     final long containerId = request.getContainerID();
     final CheckedSupplier<ContainerCommandResponseProto, Exception> task
         = () -> {
@@ -928,9 +928,9 @@ public class ContainerStateMachine extends BaseStateMachine {
       }
       CompletableFuture<Message> applyTransactionFuture =
           new CompletableFuture<>();
-      final Consumer<Exception> exceptionHandler = e -> {
-        LOG.error("gid {} : ApplyTransaction failed. cmd {} logIndex "
-            + "{} exception {}", gid, requestProto.getCmdType(), index, e);
+      final Consumer<Throwable> exceptionHandler = e -> {
+        LOG.error(gid + ": failed to applyTransaction at logIndex " + index
+            + " for " + requestProto.getCmdType(), e);
         stateMachineHealthy.compareAndSet(true, false);
         metrics.incNumApplyTransactionsFails();
         applyTransactionFuture.completeExceptionally(e);
@@ -991,9 +991,7 @@ public class ContainerStateMachine extends BaseStateMachine {
         return applyTransactionFuture;
       }).whenComplete((r, t) -> {
         if (t != null) {
-          stateMachineHealthy.set(false);
-          LOG.error("gid {} : ApplyTransaction failed. cmd {} logIndex "
-              + "{} exception {}", gid, requestProto.getCmdType(), index, t);
+          exceptionHandler.accept(t);
         }
         applyTransactionSemaphore.release();
         metrics.recordApplyTransactionCompletionNs(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -712,10 +712,12 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         .setClosePipeline(closePipelineInfo)
         .setAction(PipelineAction.Action.CLOSE)
         .build();
-    context.addPipelineActionIfAbsent(action);
-    // wait for the next HB timeout or right away?
-    if (triggerHB) {
-      context.getParent().triggerHeartbeat();
+    if (context != null) {
+      context.addPipelineActionIfAbsent(action);
+      // wait for the next HB timeout or right away?
+      if (triggerHB) {
+        context.getParent().triggerHeartbeat();
+      }
     }
     LOG.error("pipeline Action {} on pipeline {}.Reason : {}",
             action.getAction(), pipelineID,


### PR DESCRIPTION
## What changes were proposed in this pull request?

To reproduce, run `TestSecureContainerServer.testClientServerRatisGrpc()` (although it will pass) and then search NPE in the log.
```java
Caused by: java.lang.NullPointerException
	at org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis.triggerPipelineClose(XceiverServerRatis.java:715)
	at org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis.handleApplyTransactionFailure(XceiverServerRatis.java:842)
	at org.apache.hadoop.ozone.container.common.transport.server.ratis.ContainerStateMachine.lambda$applyTransaction$11(ContainerStateMachine.java:968)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:616)
```

## What is the link to the Apache JIRA

HDDS-9720

## How was this patch tested?

Run `TestSecureContainerServer.testClientServerRatisGrpc()` and search NPE.