### PR TITLE
HDDS-9722. Add some logging when KeyDeletingService is running

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -103,6 +103,11 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
 
     long startTime = Time.monotonicNow();
     int delCount = 0;
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Keys sent to SCM: {}, size: {}.",
+          keyBlocksList, keyBlocksList.size());
+    }
     List<DeleteBlockGroupResult> blockDeletionResults =
         scmClient.deleteKeyBlocks(keyBlocksList);
     if (blockDeletionResults != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -103,10 +103,16 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
 
     long startTime = Time.monotonicNow();
     int delCount = 0;
-
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Keys sent to SCM: {}, size: {}.",
-          keyBlocksList, keyBlocksList.size());
+      LOG.debug("Send {} key(s) to SCM: {}",
+          keyBlocksList.size(), keyBlocksList);
+    } else if (LOG.isInfoEnabled()) {
+      int logSize = 10;
+      if (keyBlocksList.size() < logSize) {
+        logSize = keyBlocksList.size();
+      }
+      LOG.info("Send {} key(s) to SCM, first {} keys: {}",
+          keyBlocksList.size(), logSize, keyBlocksList.subList(0, logSize));
     }
     List<DeleteBlockGroupResult> blockDeletionResults =
         scmClient.deleteKeyBlocks(keyBlocksList);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -83,7 +83,7 @@ import org.slf4j.LoggerFactory;
  * keys.
  */
 public class KeyDeletingService extends AbstractKeyDeletingService {
-  private static final Logger LOG =
+  public static final Logger LOG =
       LoggerFactory.getLogger(KeyDeletingService.class);
 
   // Use only a single thread for KeyDeletion. Multiple threads would read
@@ -186,6 +186,9 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
       // Check if this is the Leader OM. If not leader, no need to execute this
       // task.
       if (shouldRun()) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Running KeyDeletingService");
+        }
         getRunCount().incrementAndGet();
 
         // Acquire active DB deletedTable write lock because of the

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -83,7 +83,7 @@ import org.slf4j.LoggerFactory;
  * keys.
  */
 public class KeyDeletingService extends AbstractKeyDeletingService {
-  public static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(KeyDeletingService.class);
 
   // Use only a single thread for KeyDeletion. Multiple threads would read

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -186,10 +186,8 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
       // Check if this is the Leader OM. If not leader, no need to execute this
       // task.
       if (shouldRun()) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Running KeyDeletingService");
-        }
-        getRunCount().incrementAndGet();
+        final long run = getRunCount().incrementAndGet();
+        LOG.debug("Running KeyDeletingService {}", run);
 
         // Acquire active DB deletedTable write lock because of the
         // deletedTable read-write here to avoid interleaving with

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -570,45 +570,6 @@ t
   }
 
   @Test
-  public void testLogContent() throws IOException, AuthenticationException,
-      InterruptedException, TimeoutException {
-    OzoneConfiguration conf = createConfAndInitValues();
-    OmTestManagers omTestManagers = new OmTestManagers(conf);
-    KeyManager keyManager = omTestManagers.getKeyManager();
-    writeClient = omTestManagers.getWriteClient();
-    om = omTestManagers.getOzoneManager();
-
-    GenericTestUtils.LogCapturer keyDeleteLogCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(KeyDeletingService.LOG);
-    GenericTestUtils.setLogLevel(KeyDeletingService.LOG, Level.DEBUG);
-
-    GenericTestUtils.LogCapturer backgroundLogCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(BackgroundService.LOG);
-    GenericTestUtils.setLogLevel(BackgroundService.LOG, Level.DEBUG);
-
-    final int keyCount = 100;
-    createAndDeleteKeys(keyManager, keyCount, 1);
-
-    StringBuffer keyDeleteLogContent = new StringBuffer();
-    GenericTestUtils.waitFor(() -> {
-      keyDeleteLogContent.append(keyDeleteLogCapturer.getOutput());
-      return true;
-    }, 100, 1000);
-    keyDeleteLogCapturer.stopCapturing();
-    Assertions.assertTrue(
-        keyDeleteLogContent.toString().contains("Running KeyDeletingService"));
-
-    StringBuffer backgroundLogContent = new StringBuffer();
-    GenericTestUtils.waitFor(() -> {
-      backgroundLogContent.append(backgroundLogCapturer.getOutput());
-      return true;
-    }, 100, 1000);
-    backgroundLogCapturer.stopCapturing();
-    Assertions.assertTrue(
-        backgroundLogContent.toString().contains("Keys sent to SCM"));
-  }
-
-  @Test
   public void testSnapshotExclusiveSize() throws Exception {
     OzoneConfiguration conf = createConfAndInitValues();
     OmTestManagers omTestManagers

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
-import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.IOmMetadataReader;
@@ -87,7 +86,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.event.Level;
 
 /**
  * Test Key Deleting Service.


### PR DESCRIPTION
## What changes were proposed in this pull request?
When KeyDeletingService is running, the logs recorded are not enough. The purpose of this PR is to be as complete as possible. This is useful for understanding what happened when the key/file was deleted, and can provide some clues as to when the failure occurred.
Here are some logs from the run:
`
2023-11-18 23:26:35,908 [om1-KeyDeletingService#0] DEBUG utils.BackgroundService (AbstractKeyDeletingService.java:processKeyDeletes(108)) - Keys sent to SCM: [BlockGroup[groupID='/volume91iZP/bucketNsfJE/keyy3kmt/-9223372036854772480', blockIDs=[conID: 638262276 locID: 638262276 bcsId: 0]], BlockGroup[groupID='/volumeDK8cR/bucketE4OTF/keyzb2Ty/-9223372036854763264', blockIDs=[conID: 638262316 locID: 638262316 bcsId: 0]], BlockGroup[groupID='/volumeWCaz8/bucketSAWVY/keyrUoAc/-9223372036854764800', blockIDs=[conID: 638262309 locID: 638262309 bcsId: 0]], BlockGroup[groupID='/volumeZ6Zcy/bucketE37By/keyvCfcY/-9223372036854761728', blockIDs=[conID: 638262322 locID: 638262322 bcsId: 0]], BlockGroup[groupID='/volumec6hhl/bucketbYWdT/keyPfwQl/-9223372036854766336', blockIDs=[conID: 638262304 locID: 638262304 bcsId: 0]], BlockGroup[groupID='/volumehOlj0/bucketnZ2Xg/keyqshQW/-9223372036854760192', blockIDs=[conID: 638262328 locID: 638262328 bcsId: 0]], BlockGroup[groupID='/volumeoZXVG/bucketwoMl5/keyog0iG/-9223372036854775552', blockIDs=[conID: 638262198 locID: 638262198 bcsId: 0]], BlockGroup[groupID='/volumephBqw/buckethX2vx/keyVaImy/-9223372036854774016', blockIDs=[conID: 638262269 locID: 638262269 bcsId: 0]], BlockGroup[groupID='/volumet4mZz/bucketcixLB/keyHf8w6/-9223372036854769408', blockIDs=[conID: 638262289 locID: 638262289 bcsId: 0]], BlockGroup[groupID='/volumewcLLQ/bucketVkB5r/key6P34z/-9223372036854767872', blockIDs=[conID: 638262296 locID: 638262296 bcsId: 0]], BlockGroup[groupID='/volumezZQ1M/bucketarT3x/key1rzt7/-9223372036854770944', blockIDs=[conID: 638262282 locID: 638262282 bcsId: 0]]], size: 11.
`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9722

## How was this patch tested?
We need to ensure that the unit tests pass.
