### PR TITLE
HDDS-8047. [hsync] Make Putblock performance acceptable

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -222,6 +222,15 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private String fsDefaultBucketLayout = "FILE_SYSTEM_OPTIMIZED";
 
+  @Config(key = "incremental.chunk.list",
+      defaultValue = "false",
+      type = ConfigType.BOOLEAN,
+      description = "Client PutBlock request can choose incremental chunk " +
+          "list rather than full chunk list to optimize performance. " +
+          "Critical to HBase.",
+      tags = ConfigTag.CLIENT)
+  private boolean incrementalChunkList = false;
+
   @PostConstruct
   private void validate() {
     Preconditions.checkState(streamBufferSize > 0);
@@ -398,5 +407,13 @@ public class OzoneClientConfig {
 
   public void setDatastreamPipelineMode(boolean datastreamPipelineMode) {
     this.datastreamPipelineMode = datastreamPipelineMode;
+  }
+
+  public void setIncrementalChunkList(boolean enable) {
+    this.incrementalChunkList = enable;
+  }
+
+  public boolean getIncrementalChunkList() {
+    return this.incrementalChunkList;
   }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -872,7 +872,6 @@ public class BlockOutputStream extends OutputStream {
               " pos=" + lastChunkBuffer.position() +
               " limit=" + lastChunkBuffer.limit() +
               " capacity=" + lastChunkBuffer.capacity());
-          //LOG.error("ddd");
           throw e;
         }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -483,7 +483,7 @@ public class BlockOutputStream extends OutputStream {
         ContainerCommandResponseProto> flushFuture = null;
     try {
       BlockData blockData = containerBlockData.build();
-      LOG.debug("sending PutBlock " + blockData);
+      LOG.debug("sending PutBlock {}", blockData);
 
       if (config.getIncrementalChunkList()) {
         // remove any chunks in the containerBlockData list.
@@ -803,16 +803,15 @@ public class BlockOutputStream extends OutputStream {
 
     // the last partial chunk in containerBlockData will be replaced.
     // So remove it.
-    removeLastPartialchunk();
+    removeLastPartialChunk();
     LOG.debug("lastChunkOffset = {}", lastChunkOffset);
 
     chunk.rewind();
-    LOG.debug("adding chunk pos " + chunk.position() +
-        " limit " + chunk.limit() +
-        " remaining " + chunk.remaining());
-    LOG.debug("adding lastChunkBuffer pos " + lastChunkBuffer.position() +
-        " limit " + lastChunkBuffer.limit() +
-        " remaining " + lastChunkBuffer.remaining());
+    LOG.debug("adding chunk pos {} limit {} remaining {}",
+        chunk.position(), chunk.limit(), chunk.remaining());
+    LOG.debug("adding lastChunkBuffer pos {} limit {} remaining {}",
+        lastChunkBuffer.position(), lastChunkBuffer.limit(),
+        lastChunkBuffer.remaining());
 
     // Append the chunk to the last chunk buffer.
     // if the resulting size could exceed limit (4MB),
@@ -821,7 +820,7 @@ public class BlockOutputStream extends OutputStream {
         lastChunkBuffer.capacity()) {
       LOG.debug("containerBlockData one block");
       appendLastChunkBuffer(chunk, 0, chunk.remaining());
-      LOG.debug("after append, lastChunkBuffer=" + lastChunkBuffer);
+      LOG.debug("after append, lastChunkBuffer={}", lastChunkBuffer);
     } else {
       LOG.debug("containerBlockData two blocks");
       int remainingBufferSize =
@@ -830,7 +829,7 @@ public class BlockOutputStream extends OutputStream {
 
       // create chunk info for lastChunkBuffer, which is full
       ChunkInfo lastChunkInfo = createChunkInfo(lastChunkOffset);
-      LOG.debug("lastChunkInfo = " + lastChunkInfo);
+      LOG.debug("lastChunkInfo = {}", lastChunkInfo);
       //long lastChunkSize = lastChunkInfo.getLen();
       addToBlockData(lastChunkInfo);
 
@@ -838,11 +837,11 @@ public class BlockOutputStream extends OutputStream {
       appendLastChunkBuffer(chunk, remainingBufferSize,
           chunk.remaining() - remainingBufferSize);
       lastChunkOffset += config.getStreamBufferSize();
-      LOG.debug("Updates lastChunkOffset to " + lastChunkOffset);
+      LOG.debug("Updates lastChunkOffset to {}", lastChunkOffset);
     }
     // create chunk info for lastChunkBuffer, which is partial
     ChunkInfo lastChunkInfo2 = createChunkInfo(lastChunkOffset);
-    LOG.debug("lastChunkInfo2 = " + lastChunkInfo2);
+    LOG.debug("lastChunkInfo2 = {}", lastChunkInfo2);
     long lastChunkSize = lastChunkInfo2.getLen();
     if (lastChunkSize > 0) {
       addToBlockData(lastChunkInfo2);
@@ -888,10 +887,9 @@ public class BlockOutputStream extends OutputStream {
     }
   }
 
-  private long removeLastPartialchunk() {
-    //assert containerBlockData.getChunksList().isEmpty();
+  private void removeLastPartialChunk() {
     if (containerBlockData.getChunksList().isEmpty()) {
-      return 0;
+      return;
     }
     int lastChunkIndex = containerBlockData.getChunksCount() - 1;
     ChunkInfo lastChunkInBlockData = containerBlockData.getChunks(
@@ -899,7 +897,6 @@ public class BlockOutputStream extends OutputStream {
     if (!isFullChunk(lastChunkInBlockData)) {
       containerBlockData.removeChunks(lastChunkIndex);
     }
-    return lastChunkInBlockData.getOffset();
   }
 
   private ChunkInfo createChunkInfo(long lastPartialChunkOffset)
@@ -932,12 +929,10 @@ public class BlockOutputStream extends OutputStream {
   }
 
   private void addToBlockData(ChunkInfo revisedChunkInfo) {
-    for (ChunkInfo info : containerBlockData.getChunksList()) {
-      LOG.debug("containerBlockData chunk: {}", info);
-    }
+    LOG.debug("containerBlockData chunk: {}", containerBlockData);
     if (containerBlockData.getChunksCount() > 0) {
-      ChunkInfo lastChunk =
-          containerBlockData.getChunks(containerBlockData.getChunksCount() - 1);
+      ChunkInfo lastChunk = containerBlockData.getChunks(
+          containerBlockData.getChunksCount() - 1);
       LOG.debug("revisedChunkInfo chunk: {}", revisedChunkInfo);
       if (lastChunk.getOffset() + lastChunk.getLen() !=
           revisedChunkInfo.getOffset()) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -98,6 +98,9 @@ public class BufferPool {
 
   void releaseBuffer(ChunkBuffer chunkBuffer) {
     Preconditions.assertTrue(!bufferList.isEmpty(), "empty buffer list");
+    if (bufferList.get(0) != chunkBuffer) {
+      return;
+    }
     Preconditions.assertSame(bufferList.get(0), chunkBuffer,
         "only the first buffer can be released");
     Preconditions.assertTrue(currentBufferIndex >= 0,

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -98,9 +98,6 @@ public class BufferPool {
 
   void releaseBuffer(ChunkBuffer chunkBuffer) {
     Preconditions.assertTrue(!bufferList.isEmpty(), "empty buffer list");
-    /*if (bufferList.get(0) != chunkBuffer) {
-      return;
-    }*/
     Preconditions.assertSame(bufferList.get(0), chunkBuffer,
         "only the first buffer can be released");
     Preconditions.assertTrue(currentBufferIndex >= 0,

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -98,9 +98,9 @@ public class BufferPool {
 
   void releaseBuffer(ChunkBuffer chunkBuffer) {
     Preconditions.assertTrue(!bufferList.isEmpty(), "empty buffer list");
-    if (bufferList.get(0) != chunkBuffer) {
+    /*if (bufferList.get(0) != chunkBuffer) {
       return;
-    }
+    }*/
     Preconditions.assertSame(bufferList.get(0), chunkBuffer,
         "only the first buffer can be released");
     Preconditions.assertTrue(currentBufferIndex >= 0,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -41,6 +41,8 @@ public enum ClientVersion implements ComponentVersion {
   BUCKET_LAYOUT_SUPPORT(3,
       "This client version has support for Object Store and File " +
           "System Optimized Bucket Layouts."),
+  INCREMENTAL_CHUNK_LIST_SUPPORT(4,
+      "This client version has support for incremental chunk list."),
 
   FUTURE_VERSION(-1, "Used internally when the server side is older and an"
       + " unknown client version has arrived from the client.");

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
@@ -106,6 +106,22 @@ public interface ChunkBuffer {
     return put(b.asReadOnlyByteBuffer());
   }
 
+  default ChunkBuffer put(ChunkBuffer b, int offset, int length) {
+    int pos = 0;
+    for (ByteBuffer bb : b.asByteBufferList()) {
+      if (pos + bb.limit() < offset) {
+      } else if (pos + bb.limit() < offset + length) {
+        put(bb);
+      } else if (pos > offset + length) {
+        return this;
+      } else {
+        put(bb.array(), 0, length - pos);
+      }
+      pos += bb.limit();
+    }
+    return this;
+  }
+
   /**
    * Duplicate and then set the position and limit on the duplicated buffer.
    * The new limit cannot be larger than the limit of this buffer.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
@@ -106,22 +106,6 @@ public interface ChunkBuffer {
     return put(b.asReadOnlyByteBuffer());
   }
 
-  default ChunkBuffer put(ChunkBuffer b, int offset, int length) {
-    int pos = 0;
-    for (ByteBuffer bb : b.asByteBufferList()) {
-      if (pos + bb.limit() < offset) {
-      } else if (pos + bb.limit() < offset + length) {
-        put(bb);
-      } else if (pos > offset + length) {
-        return this;
-      } else {
-        put(bb.array(), 0, length - pos);
-      }
-      pos += bb.limit();
-    }
-    return this;
-  }
-
   /**
    * Duplicate and then set the position and limit on the duplicated buffer.
    * The new limit cannot be larger than the limit of this buffer.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfo.java
@@ -24,6 +24,10 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
+
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
+import org.apache.hadoop.hdds.utils.db.Proto3Codec;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -44,6 +48,12 @@ public class ChunkInfo {
   // reside in one buffer). This variable should be set to true for older
   // clients to maintain backward wire compatibility.
   private boolean readDataIntoSingleBuffer = false;
+
+  private static final Codec<ChunkInfo>
+      CODEC = new DelegatedCodec<>(
+      Proto3Codec.get(ContainerProtos.ChunkInfo.class),
+      ChunkInfo::getFromProtoBuf,
+      ChunkInfo::getProtoBufMessage);
 
   /**
    * Constructs a ChunkInfo.
@@ -207,5 +217,9 @@ public class ChunkInfo {
 
   public boolean isReadDataIntoSingleBuffer() {
     return readDataIntoSingleBuffer;
+  }
+
+  public static Codec<ChunkInfo> getCodec() {
+    return CODEC;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfo.java
@@ -25,9 +25,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.hadoop.hdds.utils.db.Codec;
-import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
-import org.apache.hadoop.hdds.utils.db.Proto3Codec;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -48,12 +45,6 @@ public class ChunkInfo {
   // reside in one buffer). This variable should be set to true for older
   // clients to maintain backward wire compatibility.
   private boolean readDataIntoSingleBuffer = false;
-
-  private static final Codec<ChunkInfo>
-      CODEC = new DelegatedCodec<>(
-      Proto3Codec.get(ContainerProtos.ChunkInfo.class),
-      ChunkInfo::getFromProtoBuf,
-      ChunkInfo::getProtoBufMessage);
 
   /**
    * Constructs a ChunkInfo.
@@ -217,9 +208,5 @@ public class ChunkInfo {
 
   public boolean isReadDataIntoSingleBuffer() {
     return readDataIntoSingleBuffer;
-  }
-
-  public static Codec<ChunkInfo> getCodec() {
-    return CODEC;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerInspector;
+import org.apache.hadoop.ozone.container.metadata.AbstractDatanodeStore;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
@@ -548,6 +549,7 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
     for (long id : localIDs) {
       try {
         final String blockKey = containerData.getBlockKey(id);
+        //// TODO: use store.getBlockByID() instead
         final BlockData blockData = blockDataTable.get(blockKey);
         if (blockData != null) {
           pendingDeleteBytes += blockData.getSize();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerInspector;
-import org.apache.hadoop.ozone.container.metadata.AbstractDatanodeStore;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -548,8 +548,10 @@ public class KeyValueHandler extends Handler {
           dispatcherContext == null ? 0 : dispatcherContext.getLogIndex();
       blockData.setBlockCommitSequenceId(bcsId);
       boolean incrementalChunkList =
-          request.getVersion() >= ClientVersion.INCREMENTAL_CHUNK_LIST_SUPPORT.toProtoValue();
-      blockManager.putBlock(kvContainer, blockData, endOfBlock, incrementalChunkList);
+          request.getVersion() >=
+              ClientVersion.INCREMENTAL_CHUNK_LIST_SUPPORT.toProtoValue();
+      blockManager.putBlock(kvContainer, blockData, endOfBlock,
+          incrementalChunkList);
 
       blockDataProto = blockData.getProtoBufMessage();
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
@@ -546,7 +547,9 @@ public class KeyValueHandler extends Handler {
       long bcsId =
           dispatcherContext == null ? 0 : dispatcherContext.getLogIndex();
       blockData.setBlockCommitSequenceId(bcsId);
-      blockManager.putBlock(kvContainer, blockData, endOfBlock);
+      boolean incrementalChunkList =
+          request.getVersion() >= ClientVersion.INCREMENTAL_CHUNK_LIST_SUPPORT.toProtoValue();
+      blockManager.putBlock(kvContainer, blockData, endOfBlock, incrementalChunkList);
 
       blockDataProto = blockData.getProtoBufMessage();
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -173,8 +173,12 @@ public class BlockManagerImpl implements BlockManager {
       // update the blockData as well as BlockCommitSequenceId here
       try (BatchOperation batch = db.getStore().getBatchHandler()
           .initBatchOperation()) {
-        Preconditions.checkState(!data.getChunks().isEmpty(),
-            "empty chunk list unexpected");
+        //Preconditions.checkState(!data.getChunks().isEmpty(),
+        //    "empty chunk list unexpected");
+        /*if (data.getChunks().isEmpty()) {
+          //LOG.error("unexpected empty chunk");
+          assert endOfBlock;
+        }*/
 
         // If the block does not exist in the pendingPutBlockCache of the
         // container, then check the DB to ascertain if it exists or not.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -58,7 +58,7 @@ public class BlockManagerImpl implements BlockManager {
   private ConfigurationSource config;
 
   private static final String DB_NULL_ERR_MSG = "DB cannot be null here";
-  private static final String NO_SUCH_BLOCK_ERR_MSG =
+  public static final String NO_SUCH_BLOCK_ERR_MSG =
       "Unable to find the block.";
 
   // Default Read Buffer capacity when Checksum is not present
@@ -438,36 +438,6 @@ public class BlockManagerImpl implements BlockManager {
 
   private BlockData getBlockByID(DBHandle db, BlockID blockID,
       KeyValueContainerData containerData) throws IOException {
-    String blockKey = containerData.getBlockKey(blockID.getLocalID());
-
-    // check last chunk table
-    BlockData lastChunk = db.getStore().getLastChunkInfoTable().
-        get(blockKey);
-
-    // check block data table
-    BlockData blockData = db.getStore().getBlockDataTable().get(blockKey);
-
-    if (blockData == null) {
-      if (lastChunk == null) {
-        throw new StorageContainerException(
-            NO_SUCH_BLOCK_ERR_MSG + " BlockID : " + blockID, NO_SUCH_BLOCK);
-      } else {
-        return lastChunk;
-      }
-    } else {
-      // append last partial chunk to the block data
-      if (lastChunk != null) {
-        Preconditions.checkState(lastChunk.getChunks().size() == 1);
-        ContainerProtos.ChunkInfo lastChunkInBlockData =
-            blockData.getChunks().get(blockData.getChunks().size() - 1);
-        Preconditions.checkState(
-            lastChunkInBlockData.getOffset() + lastChunkInBlockData.getLen()
-          == lastChunk.getChunks().get(0).getOffset(), "chunk offset does not match");
-          blockData.addChunk(lastChunk.getChunks().get(0));
-          blockData.setBlockCommitSequenceId(lastChunk.getBlockCommitSequenceId());
-      }
-    }
-
-    return blockData;
+    return db.getStore().getBlockByID(blockID, containerData);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -53,6 +53,19 @@ public interface BlockManager {
       throws IOException;
 
   /**
+   * Puts or overwrites a block.
+   *
+   * @param container - Container for which block need to be added.
+   * @param data     - Block Data.
+   * @param incrKeyCount - Whether to increase container key count.
+   * @param incremental - chunk list is incremental.
+   * @return length of the Block.
+   * @throws IOException
+   */
+  long putBlock(Container container, BlockData data, boolean incrKeyCount,
+      boolean incremental) throws IOException;
+
+  /**
    * Gets an existing block.
    *
    * @param container - Container from which block need to be get.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
@@ -434,6 +434,7 @@ public class BlockDeletingTask implements BackgroundTask {
       for (Long blkLong : entry.getLocalIDList()) {
         String blk = containerData.getBlockKey(blkLong);
         BlockData blkInfo = blockDataTable.get(blk);
+        //// TODO: deal with the last chunk table
         LOG.debug("Deleting block {}", blkLong);
         if (blkInfo == null) {
           try {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
@@ -18,14 +18,9 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
-import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
-import org.apache.hadoop.hdds.utils.db.Proto3Codec;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 
 import java.io.File;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
@@ -18,9 +18,14 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
+import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
+import org.apache.hadoop.hdds.utils.db.Proto3Codec;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 
 import java.io.File;
@@ -73,4 +78,7 @@ public abstract class AbstractDatanodeDBDefinition implements DBDefinition {
 
   public abstract DBColumnFamilyDefinition<String, ChunkInfoList>
       getDeletedBlocksColumnFamily();
+
+  public abstract DBColumnFamilyDefinition<String, ChunkInfo>
+      getLastChunkInfoColumnFamily();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
@@ -79,6 +79,6 @@ public abstract class AbstractDatanodeDBDefinition implements DBDefinition {
   public abstract DBColumnFamilyDefinition<String, ChunkInfoList>
       getDeletedBlocksColumnFamily();
 
-  public abstract DBColumnFamilyDefinition<String, ChunkInfo>
+  public abstract DBColumnFamilyDefinition<String, BlockData>
       getLastChunkInfoColumnFamily();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -21,7 +21,9 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
@@ -45,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
@@ -62,6 +65,8 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   private Table<String, Long> metadataTable;
 
   private Table<String, BlockData> blockDataTable;
+
+  private Table<BlockID, List<ContainerProtos.ChunkInfo>> lastChunkInfoTable;
 
   private Table<String, BlockData> blockDataTableWithIterator;
 
@@ -202,6 +207,11 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   @Override
   public Table<String, BlockData> getBlockDataTable() {
     return blockDataTable;
+  }
+
+  @Override
+  public Table<BlockID, List<ContainerProtos.ChunkInfo>> getLastChunkInfoTable() {
+    return lastChunkInfoTable;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -180,9 +180,11 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
               dbDef.getDeletedBlocksColumnFamily().getTable(this.store));
       checkTableStatus(deletedBlocksTable, deletedBlocksTable.getName());
 
-      lastChunkInfoTable = new DatanodeTable<>(
-          dbDef.getLastChunkInfoColumnFamily().getTable(this.store));
-      checkTableStatus(lastChunkInfoTable, lastChunkInfoTable.getName());
+      if (dbDef.getLastChunkInfoColumnFamily() != null) {
+        lastChunkInfoTable = new DatanodeTable<>(
+            dbDef.getLastChunkInfoColumnFamily().getTable(this.store));
+        checkTableStatus(lastChunkInfoTable, lastChunkInfoTable.getName());
+      }
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -21,9 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
-import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
@@ -36,7 +34,6 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedStatistics;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
@@ -48,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -67,7 +67,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
   private Table<String, BlockData> blockDataTable;
 
-  private Table<String, ChunkInfo> lastChunkInfoTable;
+  private Table<String, BlockData> lastChunkInfoTable;
 
   private Table<String, BlockData> blockDataTableWithIterator;
 
@@ -182,7 +182,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
       lastChunkInfoTable = new DatanodeTable<>(
           dbDef.getLastChunkInfoColumnFamily().getTable(this.store));
-      checkTableStatus(blockDataTable, blockDataTable.getName());
+      checkTableStatus(lastChunkInfoTable, lastChunkInfoTable.getName());
     }
   }
 
@@ -215,7 +215,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   }
 
   @Override
-  public Table<String, ChunkInfo> getLastChunkInfoTable() {
+  public Table<String, BlockData> getLastChunkInfoTable() {
     return lastChunkInfoTable;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedStatistics;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
@@ -66,7 +67,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
   private Table<String, BlockData> blockDataTable;
 
-  private Table<BlockID, List<ContainerProtos.ChunkInfo>> lastChunkInfoTable;
+  private Table<String, ChunkInfo> lastChunkInfoTable;
 
   private Table<String, BlockData> blockDataTableWithIterator;
 
@@ -178,6 +179,10 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
       deletedBlocksTable = new DatanodeTable<>(
               dbDef.getDeletedBlocksColumnFamily().getTable(this.store));
       checkTableStatus(deletedBlocksTable, deletedBlocksTable.getName());
+
+      lastChunkInfoTable = new DatanodeTable<>(
+          dbDef.getLastChunkInfoColumnFamily().getTable(this.store));
+      checkTableStatus(blockDataTable, blockDataTable.getName());
     }
   }
 
@@ -210,7 +215,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   }
 
   @Override
-  public Table<BlockID, List<ContainerProtos.ChunkInfo>> getLastChunkInfoTable() {
+  public Table<String, ChunkInfo> getLastChunkInfoTable() {
     return lastChunkInfoTable;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.CollectionUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 
 import java.util.List;
@@ -100,6 +101,11 @@ public class DatanodeSchemaOneDBDefinition
   public DBColumnFamilyDefinition<String, ChunkInfoList>
       getDeletedBlocksColumnFamily() {
     return DELETED_BLOCKS;
+  }
+
+  @Override
+  public DBColumnFamilyDefinition<String, ChunkInfo> getLastChunkInfoColumnFamily() {
+    return null;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -104,7 +104,7 @@ public class DatanodeSchemaOneDBDefinition
   }
 
   @Override
-  public DBColumnFamilyDefinition<String, ChunkInfo> getLastChunkInfoColumnFamily() {
+  public DBColumnFamilyDefinition<String, BlockData> getLastChunkInfoColumnFamily() {
     return null;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.CollectionUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 
 import java.util.List;
@@ -104,7 +103,8 @@ public class DatanodeSchemaOneDBDefinition
   }
 
   @Override
-  public DBColumnFamilyDefinition<String, BlockData> getLastChunkInfoColumnFamily() {
+  public DBColumnFamilyDefinition<String, BlockData>
+      getLastChunkInfoColumnFamily() {
     return null;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.metadata;
 
 import com.google.common.primitives.Longs;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
@@ -27,6 +28,7 @@ import org.apache.hadoop.hdds.utils.db.FixedLengthStringCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.utils.db.DatanodeDBProfile;
@@ -92,6 +94,15 @@ public class DatanodeSchemaThreeDBDefinition
           DeletedBlocksTransaction.class,
           Proto2Codec.get(DeletedBlocksTransaction.class));
 
+  public static final DBColumnFamilyDefinition<String, ChunkInfo>
+      LAST_CHUNK_INFO =
+      new DBColumnFamilyDefinition<>(
+          "last_chunk_info",
+          String.class,
+          FixedLengthStringCodec.get(),
+          ChunkInfo.class,
+          ChunkInfo.getCodec());
+
   private static String separator = "";
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>
@@ -99,7 +110,8 @@ public class DatanodeSchemaThreeDBDefinition
          BLOCK_DATA,
          METADATA,
          DELETED_BLOCKS,
-         DELETE_TRANSACTION);
+         DELETE_TRANSACTION,
+         LAST_CHUNK_INFO);
 
   public DatanodeSchemaThreeDBDefinition(String dbPath,
       ConfigurationSource config) {
@@ -122,6 +134,7 @@ public class DatanodeSchemaThreeDBDefinition
     METADATA.setCfOptions(cfOptions);
     DELETED_BLOCKS.setCfOptions(cfOptions);
     DELETE_TRANSACTION.setCfOptions(cfOptions);
+    LAST_CHUNK_INFO.setCfOptions(cfOptions);
   }
 
   @Override
@@ -144,6 +157,12 @@ public class DatanodeSchemaThreeDBDefinition
   public DBColumnFamilyDefinition<String, ChunkInfoList>
       getDeletedBlocksColumnFamily() {
     return DELETED_BLOCKS;
+  }
+
+  @Override
+  public DBColumnFamilyDefinition<String, ChunkInfo>
+  getLastChunkInfoColumnFamily() {
+    return LAST_CHUNK_INFO;
   }
 
   public DBColumnFamilyDefinition<String, DeletedBlocksTransaction>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.container.metadata;
 
 import com.google.common.primitives.Longs;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
@@ -28,7 +27,6 @@ import org.apache.hadoop.hdds.utils.db.FixedLengthStringCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.utils.db.DatanodeDBProfile;
@@ -161,7 +159,7 @@ public class DatanodeSchemaThreeDBDefinition
 
   @Override
   public DBColumnFamilyDefinition<String, BlockData>
-  getLastChunkInfoColumnFamily() {
+      getLastChunkInfoColumnFamily() {
     return LAST_CHUNK_INFO;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
@@ -94,14 +94,14 @@ public class DatanodeSchemaThreeDBDefinition
           DeletedBlocksTransaction.class,
           Proto2Codec.get(DeletedBlocksTransaction.class));
 
-  public static final DBColumnFamilyDefinition<String, ChunkInfo>
+  public static final DBColumnFamilyDefinition<String, BlockData>
       LAST_CHUNK_INFO =
       new DBColumnFamilyDefinition<>(
           "last_chunk_info",
           String.class,
           FixedLengthStringCodec.get(),
-          ChunkInfo.class,
-          ChunkInfo.getCodec());
+          BlockData.class,
+          BlockData.getCodec());
 
   private static String separator = "";
 
@@ -160,7 +160,7 @@ public class DatanodeSchemaThreeDBDefinition
   }
 
   @Override
-  public DBColumnFamilyDefinition<String, ChunkInfo>
+  public DBColumnFamilyDefinition<String, BlockData>
   getLastChunkInfoColumnFamily() {
     return LAST_CHUNK_INFO;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
@@ -112,7 +111,8 @@ public class DatanodeSchemaTwoDBDefinition
   }
 
   @Override
-  public DBColumnFamilyDefinition<String, BlockData> getLastChunkInfoColumnFamily() {
+  public DBColumnFamilyDefinition<String, BlockData>
+      getLastChunkInfoColumnFamily() {
     return null;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
@@ -108,6 +109,11 @@ public class DatanodeSchemaTwoDBDefinition
   public DBColumnFamilyDefinition<String, ChunkInfoList>
       getDeletedBlocksColumnFamily() {
     return DELETED_BLOCKS;
+  }
+
+  @Override
+  public DBColumnFamilyDefinition<String, ChunkInfo> getLastChunkInfoColumnFamily() {
+    return null;
   }
 
   public DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -112,7 +112,7 @@ public class DatanodeSchemaTwoDBDefinition
   }
 
   @Override
-  public DBColumnFamilyDefinition<String, ChunkInfo> getLastChunkInfoColumnFamily() {
+  public DBColumnFamilyDefinition<String, BlockData> getLastChunkInfoColumnFamily() {
     return null;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
@@ -18,7 +18,10 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
@@ -29,6 +32,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Interface for interacting with datanode databases.
@@ -76,6 +80,13 @@ public interface DatanodeStore extends Closeable {
    * @return Table
    */
   Table<String, ChunkInfoList> getDeletedBlocksTable();
+
+  /**
+   * A Table that keeps the metadata of the lsast chunk of blocks.
+   *
+   * @return Table
+   */
+  Table<BlockID, List<ContainerProtos.ChunkInfo>> getLastChunkInfoTable();
 
   /**
    * Helper to create and write batch transactions.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -135,5 +136,14 @@ public interface DatanodeStore extends Closeable {
     }
 
     return blockData;
+  }
+
+  default void putBlockByID(BatchOperation batch, boolean incremental,
+      long localID, BlockData data, KeyValueContainerData containerData,
+      boolean endOfBlock)
+      throws IOException {
+    // old client: override chunk list.
+    getBlockDataTable().putWithBatch(
+        batch, containerData.getBlockKey(localID), data);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
@@ -18,11 +18,9 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -30,15 +28,12 @@ import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
-import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.ozone.container.keyvalue.impl.BlockManagerImpl.NO_SUCH_BLOCK_ERR_MSG;
@@ -131,7 +126,7 @@ public interface DatanodeStore extends Closeable {
     BlockData blockData = getBlockDataTable().get(blockKey);
 
     if (blockData == null) {
-        throw new StorageContainerException(
+      throw new StorageContainerException(
             NO_SUCH_BLOCK_ERR_MSG + " BlockID : " + blockID, NO_SUCH_BLOCK);
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
@@ -83,11 +83,11 @@ public interface DatanodeStore extends Closeable {
   Table<String, ChunkInfoList> getDeletedBlocksTable();
 
   /**
-   * A Table that keeps the metadata of the lsast chunk of blocks.
+   * A Table that keeps the metadata of the last chunk of blocks.
    *
    * @return Table
    */
-  Table<String, ChunkInfo> getLastChunkInfoTable();
+  Table<String, BlockData> getLastChunkInfoTable();
 
   /**
    * Helper to create and write batch transactions.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
@@ -18,10 +18,12 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
@@ -30,10 +32,15 @@ import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
+import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
+import static org.apache.hadoop.ozone.container.keyvalue.impl.BlockManagerImpl.NO_SUCH_BLOCK_ERR_MSG;
 
 /**
  * Interface for interacting with datanode databases.
@@ -113,5 +120,20 @@ public interface DatanodeStore extends Closeable {
   boolean isClosed();
 
   default void compactionIfNeeded() throws Exception {
+  }
+
+  default BlockData getBlockByID(BlockID blockID,
+      KeyValueContainerData containerData) throws IOException {
+    String blockKey = containerData.getBlockKey(blockID.getLocalID());
+
+    // check block data table
+    BlockData blockData = getBlockDataTable().get(blockKey);
+
+    if (blockData == null) {
+        throw new StorageContainerException(
+            NO_SUCH_BLOCK_ERR_MSG + " BlockID : " + blockID, NO_SUCH_BLOCK);
+    }
+
+    return blockData;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 
@@ -86,7 +87,7 @@ public interface DatanodeStore extends Closeable {
    *
    * @return Table
    */
-  Table<BlockID, List<ContainerProtos.ChunkInfo>> getLastChunkInfoTable();
+  Table<String, ChunkInfo> getLastChunkInfoTable();
 
   /**
    * Helper to create and write batch transactions.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
@@ -286,7 +286,9 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
     if (endOfBlock) {
       return true;
     }
-    Preconditions.checkState(data.getChunks().size() > 0);
+    if (data.getChunks().isEmpty()) {
+      return true;
+    }
     if (isFullChunk(data.getChunks().get(data.getChunks().size() - 1))) {
       return true;
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
@@ -237,7 +237,6 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
 
     // check last chunk table
     BlockData lastChunk = getLastChunkInfoTable().get(blockKey);
-
     // check block data table
     BlockData blockData = getBlockDataTable().get(blockKey);
 
@@ -250,7 +249,6 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
         return lastChunk;
       }
     } else {
-      // append last partial chunk to the block data
       if (lastChunk != null) {
         reconcilePartialChunks(lastChunk, blockData);
       } else {
@@ -273,6 +271,7 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
             == lastChunk.getChunks().get(0).getOffset(),
         "chunk offset does not match");
 
+    // append last partial chunk to the block data
     List<ContainerProtos.ChunkInfo> chunkInfos =
         new ArrayList<>(blockData.getChunks());
     chunkInfos.add(lastChunk.getChunks().get(0));
@@ -304,10 +303,7 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
     if (data.getChunks().isEmpty()) {
       return true;
     }
-    if (isFullChunk(data.getChunks().get(data.getChunks().size() - 1))) {
-      return true;
-    }
-    return false;
+    return isFullChunk(data.getChunks().get(data.getChunks().size() - 1));
   }
 
   public void putBlockByID(BatchOperation batch, boolean incremental,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
@@ -246,13 +246,13 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
         throw new StorageContainerException(
             NO_SUCH_BLOCK_ERR_MSG + " BlockID : " + blockID, NO_SUCH_BLOCK);
       } else {
-        LOG.info("blockData=(null)" + ", lastChunk=" + lastChunk.getChunks());
+        LOG.debug("blockData=(null)" + ", lastChunk=" + lastChunk.getChunks());
         return lastChunk;
       }
     } else {
       // append last partial chunk to the block data
       if (lastChunk != null) {
-        LOG.info("blockData=" + blockData.getChunks() + ", lastChunk=" + lastChunk.getChunks());
+        LOG.debug("blockData=" + blockData.getChunks() + ", lastChunk=" + lastChunk.getChunks());
         Preconditions.checkState(lastChunk.getChunks().size() == 1);
         ContainerProtos.ChunkInfo lastChunkInBlockData =
             blockData.getChunks().get(blockData.getChunks().size() - 1);
@@ -266,11 +266,10 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
         chunkInfos.add(lastChunk.getChunks().get(0));
         blockData.setChunks(chunkInfos);
 
-        //blockData.addChunk(lastChunk.getChunks().get(0));
         blockData.setBlockCommitSequenceId(
             lastChunk.getBlockCommitSequenceId());
       } else {
-        LOG.info("blockData=" + blockData.getChunks() + ", lastChunk=(null)");
+        LOG.debug("blockData=" + blockData.getChunks() + ", lastChunk=(null)");
       }
     }
 
@@ -375,13 +374,14 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
             assert info.getOffset() == next;
             next += info.getLen();
           }
+          LOG.debug("block " + localID + " does not have full chunks yet. Adding the chunks to it " + blockData);
         } else {
           // if the block exists in the block data table,
           // append chunks till except the last one (supposedly partial)
           List<ContainerProtos.ChunkInfo> chunkInfos = new ArrayList<>(blockData.getChunks());
 
-          LOG.info("blockData.getChunks()=" + chunkInfos);
-          LOG.info("data.getChunks()=" + data.getChunks());
+          LOG.debug("blockData.getChunks()=" + chunkInfos);
+          LOG.debug("data.getChunks()=" + data.getChunks());
 
           for (int i = 0; i < lastChunkIndex; i++) {
             chunkInfos.add(data.getChunks().get(i));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -49,9 +49,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -285,6 +287,7 @@ public class TestBlockManagerImpl {
 
   @Test
   public void testFlush1() throws Exception {
+    assumeTrue(isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3));
     // simulates writing 1024 bytes, hsync,
     // write another 1024 bytes, hsync
     // write another 1024 bytes, hsync
@@ -322,6 +325,7 @@ public class TestBlockManagerImpl {
 
   @Test
   public void testFlush2() throws Exception {
+    assumeTrue(isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3));
     // simulates writing a full chunk + 1024 bytes, hsync,
     // write another 1024 bytes, hsync
     // write another 1024 bytes, hsync
@@ -354,6 +358,7 @@ public class TestBlockManagerImpl {
 
   @Test
   public void testFlush3() throws Exception {
+    assumeTrue(isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3));
     // simulates writing 1024 bytes, hsync,
     // and then write till 4 chunks are full
     long containerID = 1;

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.scm.storage.BlockOutputStream.FULL_CHUNK_KV;
 import static org.apache.hadoop.hdds.scm.storage.BlockOutputStream.INCREMENTAL_CHUNK_LIST;
 
 /**
@@ -83,13 +84,8 @@ public class MockDatanodeStorage {
     }
   }
 
-  private static final ContainerProtos.KeyValue FULL_CHUNK =
-      ContainerProtos.KeyValue.newBuilder()
-          .setKey(BlockOutputStream.FULL_CHUNK)
-          .build();
-
   private boolean isFullChunk(ChunkInfo chunkInfo) {
-    return (chunkInfo.getMetadataList().contains(FULL_CHUNK));
+    return (chunkInfo.getMetadataList().contains(FULL_CHUNK_KV));
   }
 
   public void putBlockIncremental(

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
@@ -75,10 +75,10 @@ public class MockDatanodeStorage {
 
   public void putBlock(DatanodeBlockID blockID, BlockData blockData) {
     if (isIncrementalChunkList(blockData)) {
-      LOG.info("incremental chunk list");
+      LOG.debug("incremental chunk list");
       putBlockIncremental(blockID, blockData);
     } else {
-      LOG.info("full chunk list");
+      LOG.debug("full chunk list");
       putBlockFull(blockID, blockData);
     }
   }
@@ -190,7 +190,7 @@ public class MockDatanodeStorage {
       DatanodeBlockID blockID,
       ChunkInfo chunkInfo) {
     //return data.get(createKey(blockID, chunkInfo));
-    LOG.info("readChunkData: blockID=" + createKey(blockID) +
+    LOG.debug("readChunkData: blockID=" + createKey(blockID) +
         " chunkInfo offset=" + chunkInfo.getOffset() +
         " chunkInfo len=" + chunkInfo.getLen());
     ByteString str = data.get(createKey(blockID)).substring(

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
@@ -115,9 +115,9 @@ public class MockXceiverClientSpi extends XceiverClientSpi {
 
   private ReadChunkResponseProto readChunk(ReadChunkRequestProto readChunk) {
     return ReadChunkResponseProto.newBuilder()
-        .setChunkData(datanodeStorage
-            .readChunkInfo(readChunk.getBlockID(), readChunk.getChunkData()))
-        //.setChunkData(readChunk.getChunkData())
+        //.setChunkData(datanodeStorage
+        //    .readChunkInfo(readChunk.getBlockID(), readChunk.getChunkData()))
+        .setChunkData(readChunk.getChunkData())
         .setData(datanodeStorage
             .readChunkData(readChunk.getBlockID(), readChunk.getChunkData()))
         .setBlockID(readChunk.getBlockID())

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
@@ -117,6 +117,7 @@ public class MockXceiverClientSpi extends XceiverClientSpi {
     return ReadChunkResponseProto.newBuilder()
         .setChunkData(datanodeStorage
             .readChunkInfo(readChunk.getBlockID(), readChunk.getChunkData()))
+        //.setChunkData(readChunk.getChunkData())
         .setData(datanodeStorage
             .readChunkData(readChunk.getBlockID(), readChunk.getChunkData()))
         .setBlockID(readChunk.getBlockID())

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -1,0 +1,139 @@
+package org.apache.hadoop.ozone.client;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.InMemoryConfiguration;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.XceiverClientFactory;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.client.rpc.RpcClient;
+import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class TestBlockOutputStreamIncrementalPutBlock {
+  private OzoneClient client;
+  private ObjectStore store;
+  private OzoneVolume volume;
+  private RpcClient rpcClient;
+
+  private String keyName = UUID.randomUUID().toString();
+  private String volumeName = UUID.randomUUID().toString();
+  private String bucketName = UUID.randomUUID().toString();
+  private ConfigurationSource config = new InMemoryConfiguration();
+  private boolean enableIncrementalChunkList;
+
+
+  @Parameterized.Parameters
+  public static Iterable<Boolean> parameters() {
+    return Arrays.asList(true, false);
+  }
+
+  public TestBlockOutputStreamIncrementalPutBlock(Boolean enableIncrementalChunkList) {
+    this.enableIncrementalChunkList = enableIncrementalChunkList;
+  }
+
+  @Before
+  public void init() throws IOException {
+    OzoneClientConfig clientConfig = config.getObject(OzoneClientConfig.class);
+
+    clientConfig.setIncrementalChunkList(this.enableIncrementalChunkList);
+    clientConfig.setChecksumType(ContainerProtos.ChecksumType.CRC32C);
+
+    ((InMemoryConfiguration)config).setFromObject(clientConfig);
+
+    rpcClient = new RpcClient(config, null) {
+
+      @Override
+      protected OmTransport createOmTransport(
+          String omServiceId)
+          throws IOException {
+        return new MockOmTransport();
+      }
+
+      @NotNull
+      @Override
+      protected XceiverClientFactory createXceiverClientFactory(
+          List<X509Certificate> x509Certificates)
+          throws IOException {
+        return new MockXceiverClientFactory();
+      }
+    };
+
+    client = new OzoneClient(config, rpcClient);
+    store = client.getObjectStore();
+  }
+
+  @After
+  public void close() throws IOException {
+    client.close();
+  }
+
+  @Test
+  public void writeSmallKey() throws IOException {
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    int size = 1024;
+    ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    try (OzoneOutputStream out = bucket.createKey(keyName, size,
+        ReplicationConfig.getDefault(config), new HashMap<>())) {
+      out.write(byteBuffer);
+      out.hsync();
+    }
+
+    try (OzoneInputStream is = bucket.readKey(keyName)) {
+      ByteBuffer readBuffer = ByteBuffer.allocate(size);
+      is.read(readBuffer);
+      assertEquals(0, readBuffer.compareTo(byteBuffer));
+    }
+  }
+
+  @Test
+  public void writeLargeKey() throws IOException {
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    int size = 1024 * 1024 + 1;
+    ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    try (OzoneOutputStream out = bucket.createKey(keyName, size,
+        ReplicationConfig.getDefault(config), new HashMap<>())) {
+      out.write(byteBuffer);
+      out.hsync();
+    }
+
+    try (OzoneInputStream is = bucket.readKey(keyName)) {
+      ByteBuffer readBuffer = ByteBuffer.allocate(size);
+      is.read(readBuffer);
+      assertEquals(0, readBuffer.compareTo(byteBuffer));
+    }
+  }
+}

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -3,7 +3,6 @@ package org.apache.hadoop.ozone.client;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -11,7 +10,6 @@ import java.util.UUID;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,17 +24,14 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
-import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 
 @RunWith(Parameterized.class)
 public class TestBlockOutputStreamIncrementalPutBlock {
   private OzoneClient client;
   private ObjectStore store;
-  private OzoneVolume volume;
   private RpcClient rpcClient;
 
   private String keyName = UUID.randomUUID().toString();
@@ -110,7 +105,7 @@ public class TestBlockOutputStreamIncrementalPutBlock {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       ByteBuffer readBuffer = ByteBuffer.allocate(size);
       is.read(readBuffer);
-      assertEquals(0, readBuffer.compareTo(byteBuffer));
+      assertArrayEquals(readBuffer.array(), byteBuffer.array());
     }
   }
 
@@ -133,7 +128,7 @@ public class TestBlockOutputStreamIncrementalPutBlock {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       ByteBuffer readBuffer = ByteBuffer.allocate(size);
       is.read(readBuffer);
-      assertEquals(0, readBuffer.compareTo(byteBuffer));
+      assertArrayEquals(readBuffer.array(), byteBuffer.array());
     }
   }
 }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.client;
 
 import java.io.IOException;
@@ -28,6 +46,10 @@ import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 
 import static org.junit.Assert.assertArrayEquals;
 
+/**
+ * Verify BlockOutputStream with incremental PutBlock feature.
+ * (incremental.chunk.list = true)
+ */
 @RunWith(Parameterized.class)
 public class TestBlockOutputStreamIncrementalPutBlock {
   private OzoneClient client;
@@ -46,7 +68,8 @@ public class TestBlockOutputStreamIncrementalPutBlock {
     return Arrays.asList(true, false);
   }
 
-  public TestBlockOutputStreamIncrementalPutBlock(Boolean enableIncrementalChunkList) {
+  public TestBlockOutputStreamIncrementalPutBlock(
+      Boolean enableIncrementalChunkList) {
     this.enableIncrementalChunkList = enableIncrementalChunkList;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -116,6 +116,7 @@ public class TestHSync {
     CONF.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
     CONF.set(OZONE_DEFAULT_BUCKET_LAYOUT, layout.name());
     CONF.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
+    CONF.setBoolean("ozone.client.incremental.chunk.list", true);
     cluster = MiniOzoneCluster.newBuilder(CONF)
         .setNumDatanodes(5)
         .setTotalPipelineNumLimit(10)
@@ -135,9 +136,9 @@ public class TestHSync {
     bucket = TestDataUtil.createVolumeAndBucket(client, layout);
 
     // Enable DEBUG level logging for relevant classes
-    GenericTestUtils.setLogLevel(OMKeyRequest.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(OMKeyCommitRequest.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.LOG, Level.DEBUG);
+    //GenericTestUtils.setLogLevel(OMKeyRequest.LOG, Level.DEBUG);
+    //GenericTestUtils.setLogLevel(OMKeyCommitRequest.LOG, Level.DEBUG);
+    //GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.LOG, Level.DEBUG);
   }
 
   @AfterAll

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -61,12 +61,8 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequest;
-import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequestWithFSO;
-import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -74,7 +70,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -286,7 +286,7 @@ public class GeneratorDatanode extends BaseGenerator {
           writtenBytes += currentChunkSize;
         }
 
-        BlockManagerImpl.persistPutBlock(container, blockData, config, true);
+        BlockManagerImpl.persistPutBlock(container, blockData, config, true, false);
 
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -286,7 +286,8 @@ public class GeneratorDatanode extends BaseGenerator {
           writtenBytes += currentChunkSize;
         }
 
-        BlockManagerImpl.persistPutBlock(container, blockData, config, true, false);
+        BlockManagerImpl.persistPutBlock(container, blockData, config, true,
+            false);
 
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-8047. [hsync] Make Putblock performance acceptable

Please describe your PR in detail:
Merge small, incomplete chunks in order to reduce metadata overhead.
Preliminary write-only ycsb benchmarks shows it improves HBase throughput by 3-4x.
This is a draft. I'll split it up into several smaller ones. Will also attach the design doc for review later.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8047

## How was this patch tested?

Additional unit tests, ran freon test and ycsb tests.