### PR TITLE
HDDS-9713. Replace Thread.sleep in TestPipelineClose.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -46,7 +46,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.Test;
@@ -60,6 +59,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for Pipeline Closing.
@@ -185,23 +186,20 @@ public class TestPipelineClose {
     final HddsProtos.PipelineID pid = pipelineID.getProtobuf();
 
     // ensure the pipeline is not reported by the dn
-    GenericTestUtils
-        .waitFor(() -> {
-          final List<PipelineReport> pipelineReports = ozoneContainer
-              .getPipelineReport().getPipelineReportList();
-          for (PipelineReport pipelineReport : pipelineReports) {
-            if (pipelineReport.getPipelineID().equals(pid)) {
-              return false;
-            }
-          }
-          return true;
-        }, 500, 5000);
+    GenericTestUtils.waitFor(() -> {
+      final List<PipelineReport> pipelineReports = ozoneContainer
+          .getPipelineReport().getPipelineReportList();
+      for (PipelineReport pipelineReport : pipelineReports) {
+        if (pipelineReport.getPipelineID().equals(pid)) {
+          return false;
+        }
+      }
+      return true;
+    }, 500, 5000);
 
-    try {
-      pipelineManager.getPipeline(ratisContainer.getPipeline().getId());
-      Assertions.fail("Pipeline should not exist in SCM");
-    } catch (PipelineNotFoundException ignored) {
-    }
+    assertThrows(PipelineNotFoundException.class, () ->
+            pipelineManager.getPipeline(pipelineID),
+        "Pipeline should not exist in SCM");
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replace Thread.sleep in TestPipelineClose#testPipelineCloseWithPipelineAction with a conditional wait.

## What is the link to the Apache JIRA
HDDS-9713

## How was this patch tested?
This is a unit test change