### PR TITLE
Revert "HDDS-9078. Set ratis.thirdparty.io.netty.native.workdir as OZONE home temp directory"

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -79,7 +79,6 @@ function ozonecmd_case
   # This parameter significantly reduces GC pressure for Datanode.
   # Corresponding Ratis issue https://issues.apache.org/jira/browse/RATIS-534.
   RATIS_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false ${RATIS_OPTS}"
-  OZONE_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.native.workdir=${OZONE_HOME}/temp ${OZONE_OPTS}"
   # Add JVM parameter for Java 17
   OZONE_MODULE_ACCESS_ARGS=""
 


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Reverting the change for now.

**What is the link to the Apache JIRA**
https://issues.apache.org/jira/browse/HDDS-9078
