### PR TITLE
HDDS-9729. Provide API to check a container via Replication Manager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerCheckRequest.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerCheckRequest.java
@@ -36,7 +36,7 @@ public final class ContainerCheckRequest {
   private final int maintenanceRedundancy;
   private final ReplicationManagerReport report;
   private final ReplicationQueue replicationQueue;
-
+  private final boolean readOnly;
 
   private ContainerCheckRequest(Builder builder) {
     this.containerInfo = builder.containerInfo;
@@ -46,6 +46,7 @@ public final class ContainerCheckRequest {
     this.maintenanceRedundancy = builder.maintenanceRedundancy;
     this.report = builder.report;
     this.replicationQueue = builder.replicationQueue;
+    this.readOnly = builder.readOnly;
   }
 
   public List<ContainerReplicaOp> getPendingOps() {
@@ -72,6 +73,10 @@ public final class ContainerCheckRequest {
     return replicationQueue;
   }
 
+  public boolean isReadOnly() {
+    return readOnly;
+  }
+
   /**
    * Builder class for ContainerCheckRequest.
    */
@@ -83,6 +88,7 @@ public final class ContainerCheckRequest {
     private int maintenanceRedundancy;
     private ReplicationManagerReport report;
     private ReplicationQueue replicationQueue;
+    private boolean readOnly = false;
 
     public Builder setContainerInfo(ContainerInfo containerInfo) {
       this.containerInfo = containerInfo;
@@ -112,6 +118,11 @@ public final class ContainerCheckRequest {
 
     public Builder setReport(ReplicationManagerReport report) {
       this.report = report;
+      return this;
+    }
+
+    public Builder setReadOnly(boolean readOnly) {
+      this.readOnly = readOnly;
       return this;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/NullReplicationQueue.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/NullReplicationQueue.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+/**
+ * A class which extents ReplicationQueue and does nothing. This is used when
+ * checking containers in a read-only mode, where we don't want to queue them
+ * for replication.
+ */
+
+public class NullReplicationQueue extends ReplicationQueue {
+
+  @Override
+  public void enqueue(ContainerHealthResult.UnderReplicatedHealthResult
+                          underReplicatedHealthResult) {
+    // Do nothing
+  }
+
+  @Override
+  public void enqueue(ContainerHealthResult.OverReplicatedHealthResult
+                          overReplicatedHealthResult) {
+    // Do nothing
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosedWithUnhealthyReplicasHandler.java
@@ -102,11 +102,13 @@ public class ClosedWithUnhealthyReplicasHandler extends AbstractCheck {
         }
 
         foundUnhealthy = true;
-        sendDeleteCommand(containerInfo, replica);
+        if (!request.isReadOnly()) {
+          sendDeleteCommand(containerInfo, replica);
+        }
       }
     }
 
-    // some unhealthy replicas were found so the container must be over
+    // some unhealthy replicas were found so the container must be
     // over replicated due to unhealthy replicas.
     if (foundUnhealthy) {
       request.getReport().incrementAndSample(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ClosingContainerHandler.java
@@ -70,10 +70,17 @@ public class ClosingContainerHandler extends AbstractCheck {
     boolean forceClose = containerInfo.getReplicationConfig()
         .getReplicationType() != ReplicationType.RATIS;
 
+    // TODO - review this logic - may need an empty check here
     if (request.getContainerReplicas().isEmpty()) {
       request.getReport().incrementAndSample(
           ReplicationManagerReport.HealthState.MISSING,
           containerInfo.containerID());
+    }
+
+    if (request.isReadOnly()) {
+      // The reset of this method modifies container state, so we just return
+      // here if the request is read only.
+      return true;
     }
 
     boolean allUnhealthy = true;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/DeletingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/DeletingContainerHandler.java
@@ -70,6 +70,12 @@ public class DeletingContainerHandler extends AbstractCheck {
     LOG.debug("Checking container {} in DeletingContainerHandler",
         containerInfo);
 
+    if (request.isReadOnly()) {
+      // The reset of this method modifies state, so we just return true if
+      // the request is read only
+      return true;
+    }
+
     if (request.getContainerReplicas().size() == 0) {
       LOG.debug("Deleting Container {} has no replicas so marking for cleanup" +
           " and returning true", containerInfo);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -131,7 +131,7 @@ public class ECReplicationCheckHandler extends AbstractCheck {
         // via an EC reconstruction command. Note that it may also have some
         // replicas in decommission / maintenance states, but as the under
         // replication is not caused only by decommission, we say it is not
-        // due to decommission/
+        // due to decommission
         dueToOutOfService = false;
         remainingRedundancy = repConfig.getParity() - missingIndexes.size();
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/EmptyContainerHandler.java
@@ -60,14 +60,16 @@ public class EmptyContainerHandler extends AbstractCheck {
       request.getReport()
           .incrementAndSample(ReplicationManagerReport.HealthState.EMPTY,
               containerInfo.containerID());
-      LOG.debug("Container {} is empty and closed, marking as DELETING",
-          containerInfo);
-      // delete replicas if they are closed and empty
-      deleteContainerReplicas(containerInfo, replicas);
+      if (!request.isReadOnly()) {
+        LOG.debug("Container {} is empty and closed, marking as DELETING",
+            containerInfo);
+        // delete replicas if they are closed and empty
+        deleteContainerReplicas(containerInfo, replicas);
 
-      // Update the container's state
-      replicationManager.updateContainerState(
-          containerInfo.containerID(), HddsProtos.LifeCycleEvent.DELETE);
+        // Update the container's state
+        replicationManager.updateContainerState(
+            containerInfo.containerID(), HddsProtos.LifeCycleEvent.DELETE);
+      }
       return true;
     } else if (containerInfo.getState() == HddsProtos.LifeCycleState.CLOSED
         && containerInfo.getNumberOfKeys() == 0 && replicas.isEmpty()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/MismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/MismatchedReplicasHandler.java
@@ -68,6 +68,9 @@ public class MismatchedReplicasHandler extends AbstractCheck {
     LOG.debug("Checking container {} in MismatchedReplicasHandler",
         containerInfo);
 
+    if (request.isReadOnly()) {
+      return false;
+    }
     // close replica if needed
     for (ContainerReplica replica : replicas) {
       if (shouldBeClosed(containerInfo, replica)) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/OpenContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/OpenContainerHandler.java
@@ -62,7 +62,10 @@ public class OpenContainerHandler extends AbstractCheck {
         request.getReport().incrementAndSample(
             ReplicationManagerReport.HealthState.OPEN_UNHEALTHY,
             containerInfo.containerID());
-        replicationManager.sendCloseContainerEvent(containerInfo.containerID());
+        if (!request.isReadOnly()) {
+          replicationManager
+              .sendCloseContainerEvent(containerInfo.containerID());
+        }
         return true;
       }
       // For open containers we do not want to do any further processing in RM

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/QuasiClosedContainerHandler.java
@@ -69,7 +69,9 @@ public class QuasiClosedContainerHandler extends AbstractCheck {
 
     Set<ContainerReplica> replicas = request.getContainerReplicas();
     if (canForceCloseContainer(containerInfo, replicas)) {
-      forceCloseContainer(containerInfo, replicas);
+      if (!request.isReadOnly()) {
+        forceCloseContainer(containerInfo, replicas);
+      }
       return true;
     } else {
       LOG.debug("Container {} cannot be force closed and is stuck in " +

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -480,6 +480,17 @@ public class TestReplicationManager {
   }
 
   @Test
+  public void testHealthyContainerStatus() throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4, 5);
+
+    boolean result = replicationManager.checkContainerStatus(
+        container, repReport);
+    assertEquals(false, result);
+  }
+
+  @Test
   public void testUnderReplicatedContainer() throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
@@ -491,6 +502,20 @@ public class TestReplicationManager {
     assertEquals(0, repQueue.overReplicatedQueueSize());
     assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+  }
+
+  @Test
+  public void testUnderReplicatedContainerStatus()
+      throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
+
+    boolean result = replicationManager.checkContainerStatus(
+        container, repReport);
+    assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(true, result);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
@@ -137,10 +137,23 @@ public class TestClosedWithUnhealthyReplicasHandler {
         .setContainerInfo(container)
         .build();
 
+    ContainerCheckRequest readRequest = requestBuilder
+        .setContainerReplicas(containerReplicas)
+        .setContainerInfo(container)
+        .setReadOnly(true)
+        .build();
+
     assertTrue(handler.handle(request));
     assertEquals(1, request.getReport().getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
 
+    assertTrue(handler.handle(readRequest));
+    // Same report object is incremented again
+    assertEquals(2, request.getReport().getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+
+    // Only a single delete should be sent, as the read request should not have
+    // triggered one.
     ArgumentCaptor<Integer> replicaIndexCaptor =
         ArgumentCaptor.forClass(Integer.class);
     Mockito.verify(replicationManager, Mockito.times(2))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -191,13 +191,17 @@ public class TestClosingContainerHandler {
 
     ReplicationManagerReport report = new ReplicationManagerReport();
 
-    ContainerCheckRequest request = new ContainerCheckRequest.Builder()
+    ContainerCheckRequest.Builder builder = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.emptyList())
         .setReport(report)
         .setContainerInfo(containerInfo)
-        .setContainerReplicas(containerReplicas)
-        .build();
+        .setContainerReplicas(containerReplicas);
+    ContainerCheckRequest request = builder.build();
 
+    builder.setReadOnly(true);
+    ContainerCheckRequest readRequest = builder.build();
+
+    assertAndVerify(readRequest, true, 0);
     assertAndVerify(request, true, 3);
     report.getStats().forEach((k, v) -> Assertions.assertEquals(0L, v));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
@@ -87,6 +87,15 @@ public class TestEmptyContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
+
+    assertAndVerify(readRequest, true, 0, 1);
     assertAndVerify(request, true, 5, 1);
   }
 
@@ -109,6 +118,15 @@ public class TestEmptyContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
+
+    assertAndVerify(readRequest, true, 0, 1);
     assertAndVerify(request, true, 3, 1);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
@@ -128,9 +128,18 @@ public class TestMismatchedReplicasHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
+
     // this handler always returns false so other handlers can fix issues
     // such as under replication
     Assertions.assertFalse(handler.handle(request));
+    Assertions.assertFalse(handler.handle(readRequest));
 
     Mockito.verify(replicationManager, times(1))
         .sendCloseContainerReplicaCommand(
@@ -207,10 +216,18 @@ public class TestMismatchedReplicasHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
 
     // this handler always returns false so other handlers can fix issues
     // such as under replication
     Assertions.assertFalse(handler.handle(request));
+    Assertions.assertFalse(handler.handle(readRequest));
 
     Mockito.verify(replicationManager, times(1))
         .sendCloseContainerReplicaCommand(
@@ -254,10 +271,18 @@ public class TestMismatchedReplicasHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
 
     // this handler always returns false so other handlers can fix issues
     // such as under replication
     Assertions.assertFalse(handler.handle(request));
+    Assertions.assertFalse(handler.handle(readRequest));
 
     Mockito.verify(replicationManager, times(1))
         .sendCloseContainerReplicaCommand(
@@ -296,10 +321,18 @@ public class TestMismatchedReplicasHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
 
     // this handler always returns false so other handlers can fix issues
     // such as under replication
     Assertions.assertFalse(handler.handle(request));
+    Assertions.assertFalse(handler.handle(readRequest));
 
     Mockito.verify(replicationManager, times(1))
         .sendCloseContainerReplicaCommand(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
@@ -107,7 +107,15 @@ public class TestOpenContainerHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
     Assertions.assertTrue(openContainerHandler.handle(request));
+    Assertions.assertTrue(openContainerHandler.handle(readRequest));
     Mockito.verify(replicationManager, times(1))
         .sendCloseContainerEvent(containerInfo.containerID());
   }
@@ -161,7 +169,15 @@ public class TestOpenContainerHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
     Assertions.assertTrue(openContainerHandler.handle(request));
+    Assertions.assertTrue(openContainerHandler.handle(readRequest));
     Mockito.verify(replicationManager, times(1))
         .sendCloseContainerEvent(Mockito.any());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedContainerHandler.java
@@ -128,8 +128,16 @@ public class TestQuasiClosedContainerHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
 
     Assertions.assertTrue(quasiClosedContainerHandler.handle(request));
+    Assertions.assertTrue(quasiClosedContainerHandler.handle(readRequest));
     Mockito.verify(replicationManager, times(2))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
   }
@@ -224,8 +232,16 @@ public class TestQuasiClosedContainerHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
+    ContainerCheckRequest readRequest = new ContainerCheckRequest.Builder()
+        .setPendingOps(Collections.emptyList())
+        .setReport(new ReplicationManagerReport())
+        .setContainerInfo(containerInfo)
+        .setContainerReplicas(containerReplicas)
+        .setReadOnly(true)
+        .build();
 
     Assertions.assertTrue(quasiClosedContainerHandler.handle(request));
+    Assertions.assertTrue(quasiClosedContainerHandler.handle(readRequest));
     // verify close command was sent for replicas with sequence ID 1001, that
     // is dnTwo and dnThree
     Mockito.verify(replicationManager, times(1))


### PR DESCRIPTION
## What changes were proposed in this pull request?


Replication Manager has increasingly complex logic used to check if a container is under or over replicated, unhealthy etc.

Other parts of the system, such as Decommission and Recon also need to know if a set of containers are healthy or not, but they currently have their own logic to do this, which can result in a mis-match in health states between RM and Recon or decommission.

This PR exposes the container check chain used by RM to check containers, and allows it to be called in a read-only way, avoiding any commands being sent.

The results of the call populate a ReplicationManagerReport instance passed into the command, which allows the call to check the state of containers checked.

In a later PR, we plan to integrate the Decommission Monitor with this API so it does not have any of its own logic to determine if a container is under-replicated or not.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9729

## How was this patch tested?

Various tests modified to confirm the readonly operation and some new tests to validate the new API works correctly.