### PR TITLE
HDDS-9731. Fix false positive findbugs warnings in CodecBuffer

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecBuffer.java
@@ -379,7 +379,8 @@ public class CodecBuffer implements AutoCloseable {
    */
   public CodecBuffer putShort(short n) {
     assertRefCnt(1);
-    buf.writeShort(n);
+    final ByteBuf returned = buf.writeShort(n);
+    Preconditions.assertSame(buf, returned, "buf");
     return this;
   }
 
@@ -390,7 +391,8 @@ public class CodecBuffer implements AutoCloseable {
    */
   public CodecBuffer putInt(int n) {
     assertRefCnt(1);
-    buf.writeInt(n);
+    final ByteBuf returned = buf.writeInt(n);
+    Preconditions.assertSame(buf, returned, "buf");
     return this;
   }
 
@@ -401,7 +403,8 @@ public class CodecBuffer implements AutoCloseable {
    */
   public CodecBuffer putLong(long n) {
     assertRefCnt(1);
-    buf.writeLong(n);
+    final ByteBuf returned = buf.writeLong(n);
+    Preconditions.assertSame(buf, returned, "buf");
     return this;
   }
 
@@ -412,7 +415,8 @@ public class CodecBuffer implements AutoCloseable {
    */
   public CodecBuffer put(byte val) {
     assertRefCnt(1);
-    buf.writeByte(val);
+    final ByteBuf returned = buf.writeByte(val);
+    Preconditions.assertSame(buf, returned, "buf");
     return this;
   }
 
@@ -449,7 +453,8 @@ public class CodecBuffer implements AutoCloseable {
     final int w = buf.writerIndex();
     final ByteBuffer buffer = buf.nioBuffer(w, buf.writableBytes());
     final int size = source.applyAsInt(buffer);
-    buf.setIndex(buf.readerIndex(), w + size);
+    final ByteBuf returned = buf.setIndex(buf.readerIndex(), w + size);
+    Preconditions.assertSame(buf, returned, "buf");
     return this;
   }
 
@@ -470,7 +475,8 @@ public class CodecBuffer implements AutoCloseable {
     try (ByteBufOutputStream out = new ByteBufOutputStream(buf)) {
       size = source.apply(out);
     }
-    buf.setIndex(buf.readerIndex(), w + size);
+    final ByteBuf returned = buf.setIndex(buf.readerIndex(), w + size);
+    Preconditions.assertSame(buf, returned, "buf");
     return this;
   }
 
@@ -497,7 +503,8 @@ public class CodecBuffer implements AutoCloseable {
     if (size != null) {
       Preconditions.assertTrue(size >= 0, () -> "size = " + size + " < 0");
       if (size > 0 && size <= writable) {
-        buf.setIndex(buf.readerIndex(), i + size);
+        final ByteBuf returned = buf.setIndex(buf.readerIndex(), i + size);
+        Preconditions.assertSame(buf, returned, "buf");
       }
     }
     return size;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `Return value of ... ignored, but method has no side effect` warnings in `CodecBuffer`.

Examples:
https://github.com/vtutrinov/ozone/actions/runs/6655766005/job/18086771096#step:7:11
https://github.com/xichen01/ozone/actions/runs/6925852588/job/18837148517#step:7:11

The methods being called do have side effects, they return the same buffer only for convenience.  `CodecBuffer.buf` is `final`, we cannot update it to the buffer returned even if it's another instance.

`assertSame` call is added to make use of the return value, and also to alert if the implementation is changed to return any other instance.

https://issues.apache.org/jira/browse/HDDS-9731

## How was this patch tested?

 * Checked out https://github.com/xichen01/ozone/commit/1589e17d0ab64d12064050c73a75bfba52b62132
 * Ran `findbugs.sh` locally to reproduce the problem
 * Applied this patch
 * Ran `findbugs.sh` again to verify the warnings were no longer reported

CI:
https://github.com/adoroszlai/ozone/actions/runs/6935777427