### PR TITLE
HDDS-9512. Datanode in ozone share a same port with datanode in HDFS.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -362,7 +362,7 @@ public final class HddsConfigKeys {
       "0.0.0.0";
   public static final String HDDS_DATANODE_CLIENT_PORT_KEY =
       "hdds.datanode.client.port";
-  public static final int HDDS_DATANODE_CLIENT_PORT_DEFAULT = 9864;
+  public static final int HDDS_DATANODE_CLIENT_PORT_DEFAULT = 19864;
   public static final String HDDS_DATANODE_HANDLER_COUNT_KEY =
       "hdds.datanode.handler.count";
   public static final int HDDS_DATANODE_HANDLER_COUNT_DEFAULT = 1;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2811,7 +2811,7 @@
   </property>
   <property>
     <name>hdds.datanode.client.port</name>
-    <value>9864</value>
+    <value>19864</value>
     <tag>OZONE, HDDS, MANAGEMENT</tag>
     <description>
       The port number of the Ozone Datanode client service.

--- a/hadoop-hdds/docs/content/feature/Reconfigurability.md
+++ b/hadoop-hdds/docs/content/feature/Reconfigurability.md
@@ -84,17 +84,17 @@ ozone.administrators
 ## Datanode Reconfigurability
 >For example, modify `ozone.example.config` in ozone-site.xml and execute:
 >
-> $ `ozone admin reconfig --address=hadoop1:9864 start`<br>
-Datanode: Started reconfiguration task on node [hadoop1:9864].
+> $ `ozone admin reconfig --address=hadoop1:19864 start`<br>
+Datanode: Started reconfiguration task on node [hadoop1:19864].
 >
->$ `ozone admin reconfig --address=hadoop1:9864 status`<br>
-Datanode: Reconfiguring status for node [hadoop1:9864]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
+>$ `ozone admin reconfig --address=hadoop1:19864 status`<br>
+Datanode: Reconfiguring status for node [hadoop1:19864]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
 SUCCESS: Changed property ozone.example.config<br>
 From: "old"<br>
 To: "new"
 >
-> $ `ozone admin reconfig -address=hadoop1:9864 properties`<br>
-Datanode: Node [hadoop1:9864] Reconfigurable properties:<br>
+> $ `ozone admin reconfig -address=hadoop1:19864 properties`<br>
+Datanode: Node [hadoop1:19864] Reconfigurable properties:<br>
 ozone.example.config
 
 ### Batch operation
@@ -105,10 +105,10 @@ Currently, only Datanode supports batch operations<br>
 
 >For example, to list the reconfigurable properties of all Datanodes:<br>
 > $ `ozone admin reconfig --in-service-datanodes properties`<br>
-Datanode: Node [hadoop1:9864] Reconfigurable properties:<br>
+Datanode: Node [hadoop1:19864] Reconfigurable properties:<br>
 ozone.example.config<br>
-Datanode: Node [hadoop2:9864] Reconfigurable properties:<br>
+Datanode: Node [hadoop2:19864] Reconfigurable properties:<br>
 ozone.example.config<br>
-Datanode: Node [hadoop3:9864] Reconfigurable properties:<br>
+Datanode: Node [hadoop3:19864] Reconfigurable properties:<br>
 ozone.example.config<br>
 Reconfig successfully 3 nodes, failure 0 nodes.<br>

--- a/hadoop-hdds/docs/content/feature/Reconfigurability.zh.md
+++ b/hadoop-hdds/docs/content/feature/Reconfigurability.zh.md
@@ -83,17 +83,17 @@ ozone.administrators
 ## Datanode 动态配置
 >例如, 在`ozone-site.xml`文件中修改`ozone.example.config`的值并执行:
 >
-> $ `ozone admin reconfig --address=hadoop1:9864 start`<br>
-Datanode: Started reconfiguration task on node [hadoop1:9864].
+> $ `ozone admin reconfig --address=hadoop1:19864 start`<br>
+Datanode: Started reconfiguration task on node [hadoop1:19864].
 >
->$ `ozone admin reconfig --address=hadoop1:9864 status`<br>
-Datanode: Reconfiguring status for node [hadoop1:9864]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
+>$ `ozone admin reconfig --address=hadoop1:19864 status`<br>
+Datanode: Reconfiguring status for node [hadoop1:19864]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
 SUCCESS: Changed property ozone.example.config<br>
 From: "old"<br>
 To: "new"
 >
-> $ `ozone admin reconfig --address=hadoop1:9864 properties`<br>
-Datanode: Node [hadoop1:9864] Reconfigurable properties:<br>
+> $ `ozone admin reconfig --address=hadoop1:19864 properties`<br>
+Datanode: Node [hadoop1:19864] Reconfigurable properties:<br>
 ozone.example.config
 
 
@@ -105,10 +105,10 @@ ozone.example.config
 
 >例如, 列出 Datanode 所有可配置的属性:<br>
 > $ `ozone admin reconfig --in-service-datanodes properties`<br>
-Datanode: Node [hadoop1:9864] Reconfigurable properties:<br>
+Datanode: Node [hadoop1:19864] Reconfigurable properties:<br>
 ozone.example.config<br>
-Datanode: Node [hadoop2:9864] Reconfigurable properties:<br>
+Datanode: Node [hadoop2:19864] Reconfigurable properties:<br>
 ozone.example.config<br>
-Datanode: Node [hadoop3:9864] Reconfigurable properties:<br>
+Datanode: Node [hadoop3:19864] Reconfigurable properties:<br>
 ozone.example.config<br>
 Reconfig successfully 3 nodes, failure 0 nodes.<br>

--- a/hadoop-ozone/dist/src/main/compose/compatibility/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
   datanode:
     <<: *common-config
     ports:
-      - 9864
+      - 19864
       - 9882
     environment:
       <<: *replication

--- a/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     environment:
       OZONE_OPTS:
     ports:
-      - 9864
+      - 19864
       - 9882
     command: ["ozone","datanode"]
   om:

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
   datanode:
     <<: *common-config
     ports:
-      - 9864
+      - 19864
       - 9882
     environment:
       <<: *replication

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       volumes:
         - ../..:/opt/hadoop
       ports:
-        - 9864
+        - 19864
       command: sh -c "sudo /usr/sbin/sshd -E /tmp/sshd.log && /opt/hadoop/bin/ozone datanode"
       env_file:
         - ./docker-config

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
@@ -34,7 +34,7 @@ x-datanode:
   environment:
     <<: *replication
   ports:
-    - 9864
+    - 19864
     - 9882
 
 x-om:

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       volumes:
         - ../..:/opt/hadoop
       ports:
-        - 9864
+        - 19864
         - 9882
       command: ["/opt/hadoop/bin/ozone","datanode"]
       env_file:
@@ -38,7 +38,7 @@ services:
       volumes:
         - ../..:/opt/hadoop
       ports:
-        - 9864
+        - 19864
         - 9882
       command: ["/opt/hadoop/bin/ozone","datanode"]
       env_file:
@@ -54,7 +54,7 @@ services:
       volumes:
         - ../..:/opt/hadoop
       ports:
-        - 9864
+        - 19864
         - 9882
       command: ["/opt/hadoop/bin/ozone","datanode"]
       env_file:
@@ -70,7 +70,7 @@ services:
       volumes:
         - ../..:/opt/hadoop
       ports:
-        - 9864
+        - 19864
         - 9882
       command: ["/opt/hadoop/bin/ozone","datanode"]
       env_file:
@@ -86,7 +86,7 @@ services:
      volumes:
        - ../..:/opt/hadoop
      ports:
-       - 9864
+       - 19864
        - 9882
      command: ["/opt/hadoop/bin/ozone","datanode"]
      env_file:
@@ -102,7 +102,7 @@ services:
      volumes:
        - ../..:/opt/hadoop
      ports:
-       - 9864
+       - 19864
        - 9882
      command: ["/opt/hadoop/bin/ozone","datanode"]
      env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
   datanode:
     <<: *common-config
     ports:
-      - 9864
+      - 19864
       - 9882
     environment:
       <<: *replication

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       volumes:
         - ../..:/opt/hadoop
       ports:
-        - 9864
+        - 19864
       command: ["/opt/hadoop/bin/ozone","datanode"]
       env_file:
         - ./docker-config

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       volumes:
         - ../..:/opt/hadoop
       ports:
-        - 9864
+        - 19864
       env_file:
         - ./docker-config
    om:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - ../_keytabs:/etc/security/keytabs
       - ./krb5.conf:/etc/krb5.conf
     ports:
-      - 9864:9999
+      - 19864:9999
     command: ["/opt/hadoop/bin/ozone","datanode"]
     extra_hosts:
       - "scm1.org: 172.25.0.116"

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - ../_keytabs:/etc/security/keytabs
       - ./krb5.conf:/etc/krb5.conf
     ports:
-      - 9864
+      - 19864
     command: ["/opt/hadoop/bin/ozone","datanode"]
     env_file:
       - docker-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - ../_keytabs:/etc/security/keytabs
       - ./krb5.conf:/etc/krb5.conf
     ports:
-      - 9864
+      - 19864
     command: ["/opt/hadoop/bin/ozone","datanode"]
     env_file:
       - docker-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/public-key-cert-recovery-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/public-key-cert-recovery-test.sh
@@ -26,10 +26,10 @@ wait_for_port recon 9888 120
 wait_for_execute_command recon 60 "find /data/metadata/recon/keys/public.pem && find /data/metadata/recon/certs/ROOTCA*.crt"
 
 #test DN
-wait_for_port datanode 9864 120
+wait_for_port datanode 19864 120
 wait_for_execute_command datanode 60 "find /data/metadata/dn/keys/public.pem -delete && find /data/metadata/dn/certs/*.crt -delete"
 docker-compose stop datanode
 docker-compose start datanode
-wait_for_port datanode 9864 120
+wait_for_port datanode 19864 120
 wait_for_execute_command datanode 60 "find /data/metadata/dn/keys/public.pem && find /data/metadata/dn/certs/ROOTCA*.crt"
 

--- a/hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml
@@ -34,7 +34,7 @@ x-datanode:
   environment:
     <<: *replication
   ports:
-    - 9864
+    - 19864
     - 9882
 
 services:

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
@@ -37,7 +37,7 @@ x-datanode:
   environment:
     <<: *environment
   ports:
-    - 9864
+    - 19864
     - 9882
 
 x-scm:

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-compose.yaml
@@ -36,7 +36,7 @@ x-datanode:
   environment:
     <<: *environment
   ports:
-    - 9864
+    - 19864
     - 9882
 
 x-volumes:

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/om-ha/docker-compose.yaml
@@ -36,7 +36,7 @@ x-datanode:
   environment:
     <<: *environment
   ports:
-    - 9864
+    - 19864
     - 9882
 
 x-om:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
@@ -29,7 +29,7 @@ services:
   datanode:
     <<: *new-config
     ports:
-      - 9864
+      - 19864
       - 9882
     environment:
       OZONE_OPTS:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/old-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/old-cluster.yaml
@@ -29,7 +29,7 @@ services:
   datanode:
     <<: *old-config
     ports:
-      - 9864
+      - 19864
       - 9882
     environment:
       HADOOP_OPTS:

--- a/hadoop-ozone/fault-injection-test/network-tests/src/test/compose/docker-compose.yaml
+++ b/hadoop-ozone/fault-injection-test/network-tests/src/test/compose/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
    datanode:
       image: ${docker.image}
       ports:
-        - 9864
+        - 19864
       command: ["/opt/hadoop/bin/ozone","datanode"]
       env_file:
         - ./docker-config


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change Ozone Datanode client port default value from 9864 to 19864.  This port was added since the last release (1.3.0) to support dynamic reconfiguration protocol, but it conflicts with HDFS Datanode web port.  Thus it makes sense to change it before the conflicting port gets into any Ozone release.

https://issues.apache.org/jira/browse/HDDS-9512

## How was this patch tested?

Tested the port in `ozone` compose environment:

```
$ ozone admin reconfig --address 192.168.80.9:19864 properties
DN: Node [192.168.80.9:19864] Reconfigurable properties:
hdds.datanode.block.delete.threads.max
hdds.datanode.block.deleting.limit.per.interval
ozone.block.deleting.service.workers
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/6934881675