### PR TITLE
HDDS-9732. SCM WebUI incorrectly renders DN links

### DIFF
--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -56,7 +56,14 @@
     </thead>
     <tbody>
         <tr ng-repeat="typestat in nodeStatus|filter:search|orderBy:columnName:reverse">
-            <td><a href="{{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}}" target="_blank">{{typestat.hostname}}</a></td>
+            <td ng-switch="typestat.port > 0">
+                <span ng-switch-when="true">
+                    <a href="{{typestat.protocol}}://{{typestat.hostname}}:{{typestat.port}}" target="_blank">{{typestat.hostname}}</a>
+                </span>
+                <span ng-switch-when="false">
+                    {{typestat.hostname}}
+                </span>
+            </td>
             <td>{{typestat.opstate}}</td>
             <td>{{typestat.comstate}}</td>
        </tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

If there are both HTTP and HTTPS port present in the NodeStatusInfo object in the JMX of SCM, then the JS code should select the port that belongs the protocol via which the SCM webUI is being rendered. Currently the selection relies on the order of the keys in a structure that most likely contains both ports, and is completely ad-hoc.

So in order to provide a functionality with the least astonishment, the new logic follows these guidelines:
- if SCM webUI is rendered over https, then it should display http links to DNs, while if it is rendered over https it should display https links to DNs.
- if SCM webUID is rendered http, but DN has only https port defined or vice versa then fallback to the available protocol.
- In case the DN does not expose neither HTTP nor HTTPS port (which would possibly be a bug), then no links should be displayed.

To achieve this, I extracted a method in scm.js, that checks the ports, sets up and return the proper set of values, which can then be provided to the UI rendering code.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9732

## How was this patch tested?

I deployed this in a real cluster, and tested the following setups:
- http.policy is uniformly HTTPS_ONLY, HTTP_ONLY, and HTTP_AND_HTTPS in 3 separate tests
- http.policy is HTTP_AND_HTTPS for SCM, while Datanodes have mixed policies, some has HTTP_ONLY, some has HTTPS_ONLY, some has HTTP_AND_HTTPS, all DN links were rendered as expected.

I did not tested the no port case, as it seems to be proven that it works if links are properly display in the presence of ports, while it seem to require a code change that makes it too complex compared to the importance of the UI to work correctly in case of a bug.
