### PR TITLE
HDDS-9706. Intermittent failure in TestOzoneManagerHAWithStoppedNodes#testOMRatisSnapshot.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -1014,4 +1014,86 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     Assertions.assertTrue(removeAcl);
   }
 
+  @Test
+  void testOMRatisSnapshot() throws Exception {
+    String userName = "user" + RandomStringUtils.randomNumeric(5);
+    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+
+    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
+        .setOwner(userName)
+        .setAdmin(adminName)
+        .build();
+
+    ObjectStore objectStore = getObjectStore();
+    objectStore.createVolume(volumeName, createVolumeArgs);
+    OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
+
+    retVolumeinfo.createBucket(bucketName);
+    OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
+
+    String leaderOMNodeId = OmFailoverProxyUtil
+        .getFailoverProxyProvider(objectStore.getClientProxy())
+        .getCurrentProxyOMNodeId();
+
+    OzoneManager ozoneManager = getCluster().getOzoneManager(leaderOMNodeId);
+
+    // Send commands to ratis to increase the log index so that ratis
+    // triggers a snapshot on the state machine.
+
+    long appliedLogIndex = 0;
+    while (appliedLogIndex <= getSnapshotThreshold()) {
+      createKey(ozoneBucket);
+      appliedLogIndex = ozoneManager.getOmRatisServer()
+          .getLastAppliedTermIndex().getIndex();
+    }
+
+    GenericTestUtils.waitFor(() -> {
+      try {
+        if (ozoneManager.getRatisSnapshotIndex() > 0) {
+          return true;
+        }
+      } catch (IOException ex) {
+        Assertions.fail("test failed during transactionInfo read");
+      }
+      return false;
+    }, 1000, 100000);
+
+    ozoneManager.awaitDoubleBufferFlush();
+    // The current lastAppliedLogIndex on the state machine should be greater
+    // than or equal to the saved snapshot index.
+    long smLastAppliedIndex =
+        ozoneManager.getOmRatisServer().getLastAppliedTermIndex().getIndex();
+    long ratisSnapshotIndex = ozoneManager.getRatisSnapshotIndex();
+    assertTrue(smLastAppliedIndex >= ratisSnapshotIndex,
+        "LastAppliedIndex on OM State Machine ("
+            + smLastAppliedIndex + ") is less than the saved snapshot index("
+            + ratisSnapshotIndex + ").");
+
+    // Add more transactions to Ratis to trigger another snapshot
+    while (appliedLogIndex <= (smLastAppliedIndex + getSnapshotThreshold())) {
+      createKey(ozoneBucket);
+      appliedLogIndex = ozoneManager.getOmRatisServer()
+          .getLastAppliedTermIndex().getIndex();
+    }
+
+    GenericTestUtils.waitFor(() -> {
+      try {
+        if (ozoneManager.getRatisSnapshotIndex() > 0) {
+          return true;
+        }
+      } catch (IOException ex) {
+        Assertions.fail("test failed during transactionInfo read");
+      }
+      return false;
+    }, 1000, 100000);
+
+    // The new snapshot index must be greater than the previous snapshot index
+    long ratisSnapshotIndexNew = ozoneManager.getRatisSnapshotIndex();
+    assertTrue(ratisSnapshotIndexNew > ratisSnapshotIndex,
+        "Latest snapshot index must be greater than previous " +
+            "snapshot indices");
+
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -282,7 +282,8 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
       }
       return false;
     }, 1000, 100000);
-
+    
+    ozoneManager.awaitDoubleBufferFlush();
     // The current lastAppliedLogIndex on the state machine should be greater
     // than or equal to the saved snapshot index.
     long smLastAppliedIndex =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import java.io.IOException;
 import java.net.ConnectException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -235,89 +234,6 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
     // Verify that a failover occurred. the new proxy nodeId should be
     // different from the old proxy nodeId.
     assertNotEquals(firstProxyNodeId, newProxyNodeId);
-  }
-
-  @Test
-  void testOMRatisSnapshot() throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-
-    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
-        .setOwner(userName)
-        .setAdmin(adminName)
-        .build();
-
-    ObjectStore objectStore = getObjectStore();
-    objectStore.createVolume(volumeName, createVolumeArgs);
-    OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
-
-    retVolumeinfo.createBucket(bucketName);
-    OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
-
-    String leaderOMNodeId = OmFailoverProxyUtil
-        .getFailoverProxyProvider(objectStore.getClientProxy())
-        .getCurrentProxyOMNodeId();
-
-    OzoneManager ozoneManager = getCluster().getOzoneManager(leaderOMNodeId);
-
-    // Send commands to ratis to increase the log index so that ratis
-    // triggers a snapshot on the state machine.
-
-    long appliedLogIndex = 0;
-    while (appliedLogIndex <= getSnapshotThreshold()) {
-      createKey(ozoneBucket);
-      appliedLogIndex = ozoneManager.getOmRatisServer()
-          .getLastAppliedTermIndex().getIndex();
-    }
-
-    GenericTestUtils.waitFor(() -> {
-      try {
-        if (ozoneManager.getRatisSnapshotIndex() > 0) {
-          return true;
-        }
-      } catch (IOException ex) {
-        Assertions.fail("test failed during transactionInfo read");
-      }
-      return false;
-    }, 1000, 100000);
-    
-    ozoneManager.awaitDoubleBufferFlush();
-    // The current lastAppliedLogIndex on the state machine should be greater
-    // than or equal to the saved snapshot index.
-    long smLastAppliedIndex =
-        ozoneManager.getOmRatisServer().getLastAppliedTermIndex().getIndex();
-    long ratisSnapshotIndex = ozoneManager.getRatisSnapshotIndex();
-    assertTrue(smLastAppliedIndex >= ratisSnapshotIndex,
-        "LastAppliedIndex on OM State Machine ("
-        + smLastAppliedIndex + ") is less than the saved snapshot index("
-        + ratisSnapshotIndex + ").");
-
-    // Add more transactions to Ratis to trigger another snapshot
-    while (appliedLogIndex <= (smLastAppliedIndex + getSnapshotThreshold())) {
-      createKey(ozoneBucket);
-      appliedLogIndex = ozoneManager.getOmRatisServer()
-          .getLastAppliedTermIndex().getIndex();
-    }
-
-    GenericTestUtils.waitFor(() -> {
-      try {
-        if (ozoneManager.getRatisSnapshotIndex() > 0) {
-          return true;
-        }
-      } catch (IOException ex) {
-        Assertions.fail("test failed during transactionInfo read");
-      }
-      return false;
-    }, 1000, 100000);
-
-    // The new snapshot index must be greater than the previous snapshot index
-    long ratisSnapshotIndexNew = ozoneManager.getRatisSnapshotIndex();
-    assertTrue(ratisSnapshotIndexNew > ratisSnapshotIndex,
-        "Latest snapshot index must be greater than previous " +
-            "snapshot indices");
-
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR addresses the timing/sync issue between two separate indexes:
```
lastAppliedTermIndex -- committed index where apply transaction is completed
Ratis snapshot index for OM -  its from DB which represent last index present in DB, and when snapshot is taken, it takes this DB one
```
Both indexes are mostly same however due to DoubleBuffer, these 2 indexes may give different values sometimes with fraction of time difference when these two called upon.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9706

## How was this patch tested?

This patch is tested by running multiple splits and iterations. Here is the green CI [link](https://github.com/devmadhuu/ozone/actions/runs/6931437125/job/18876158682) with 3 job runs repeatedly on the patch in different test branch. 
