### PR TITLE
HDDS-9726. Add page jump function and entity count display to the Node Status section of the SCM UI.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -71,7 +71,7 @@
         </select>
         <span>of {{lastIndex}}. </span>
         <span ng-if="nodeStatus && nodeStatus.length > 0">
-            Showing {{getCurrentPageFirstItemIndex()}} to {{getCurrentPageLastItemIndex()}} of {{totalItems}} entries.
+            Showing {{getCurrentPageFirstItemIndex()}} to {{getCurrentPageLastItemIndex()}} of the total {{totalItems}} entries.
         </span>
     </div>
     <div class="col-md-6 text-right">

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -62,22 +62,35 @@
        </tr>
     </tbody>
 </table>
-<div>
-    <nav aria-label="...">
-        <ul class="pagination">
-            <li class="page-item" ng-class="{disabled:currentPage==1}"
-                ng-click="handlePagination(currentPage-1,(currentPage==1))">
-                <span class="page-link" tabindex="-1">Previous</span>
-            </li>
-            <li class="page-item active">
-                <span class="page-link">{{currentPage}} </span>
-            </li>
-            <li class="page-item" ng-class="{disabled:lastIndex==currentPage}"
-                ng-click="handlePagination(currentPage+1, (lastIndex==currentPage))">
-                <span class="page-link" tabindex="-1">Next</span>
-            </li>
-        </ul>
-    </nav>
+
+<div class="row">
+    <div class="col-md-6 text-left">
+        <label>Page:</label>
+        <select class="form-select" ng-model="currentPage" ng-change="handlePagination(currentPage, false)">
+            <option ng-repeat="page in getPagesArray()" ng-value="page">{{page}}</option>
+        </select>
+        <span>of {{lastIndex}}. </span>
+        <span ng-if="nodeStatus && nodeStatus.length > 0">
+            Showing {{getCurrentPageFirstItemIndex()}} to {{getCurrentPageLastItemIndex()}} of {{totalItems}} entries.
+        </span>
+    </div>
+    <div class="col-md-6 text-right">
+        <nav aria-label="..." ng-show="RecordsToDisplay !== 'All'">
+            <ul class="pagination" style="margin: 0; padding: 0">
+                <li class="page-item" ng-class="{disabled:currentPage==1}"
+                    ng-click="handlePagination(currentPage-1,(currentPage==1))">
+                    <span class="page-link" tabindex="-1">Previous</span>
+                </li>
+                <li class="page-item active">
+                    <span class="page-link">{{currentPage}} </span>
+                </li>
+                <li class="page-item" ng-class="{disabled:lastIndex==currentPage}"
+                    ng-click="handlePagination(currentPage+1, (lastIndex==currentPage))">
+                    <span class="page-link" tabindex="-1">Next</span>
+                </li>
+            </ul>
+        </nav>
+    </div>
 </div>
 
 <h2>Status</h2>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -64,6 +64,7 @@
                             });
 
                     nodeStatusCopy = [...$scope.nodeStatus];
+                    $scope.totalItems = nodeStatusCopy.length;
                     $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
                     $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
                 });
@@ -80,10 +81,11 @@
             }
             /* Page Slicing  logic */
             $scope.handlePagination = (pageIndex, isDisabled) => {
-                if(!isDisabled) {
+                if(!isDisabled && $scope.RecordsToDisplay != 'All') {
+                    pageIndex = parseInt(pageIndex);
                     let startIndex = 0, endIndex = 0;
                     $scope.currentPage = pageIndex;
-                    startIndex = (pageIndex * $scope.RecordsToDisplay) - $scope.RecordsToDisplay;
+                    startIndex = ($scope.currentPage - 1) * parseInt($scope.RecordsToDisplay);
                     endIndex = startIndex + parseInt($scope.RecordsToDisplay);
                     $scope.nodeStatus = nodeStatusCopy.slice(startIndex, endIndex);
                 }
@@ -93,6 +95,27 @@
                 $scope.columnName = colName;
                 $scope.reverse = !$scope.reverse;
             }
+            /*show page*/
+            $scope.getPagesArray = function () {
+                return Array.from({ length: $scope.lastIndex }, (_, index) => index + 1);
+            };
+            /*show last item index*/
+            $scope.getCurrentPageLastItemIndex = ()  => {
+                if ($scope.RecordsToDisplay == 'All') {
+                    return $scope.totalItems;
+                }
+
+                let endIndex = $scope.currentPage * parseInt($scope.RecordsToDisplay);
+                return Math.min(endIndex, $scope.totalItems);
+            }
+            /*show first item index*/
+            $scope.getCurrentPageFirstItemIndex = () => {
+                if ($scope.RecordsToDisplay == 'All') {
+                    return 1;
+                }
+                return ($scope.currentPage - 1) * $scope.RecordsToDisplay + 1;
+            }
+
             const nodeOpStateSortOrder = {
                 "IN_SERVICE": "a",
                 "DECOMMISSIONING": "b",


### PR DESCRIPTION
## What changes were proposed in this pull request?
If there are hundreds of Datanodes, it is difficult to browse the situation and view the number of Datanodes.
In the SCM UI, I need to check how many datanodes there are, so here I need to display the number of records of the datanodes and be able to jump to the specified page during pagination.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9726

## How was this patch tested?
Only all unit test.
https://github.com/aierate/ozone/actions/runs/6938742317

Here is UI screenshot.

![image](https://github.com/apache/ozone/assets/56783384/8e9a1c94-74df-423f-8543-c254e22da16e)
