### PR TITLE
HDDS-9502. Migrate tests in ozonefs-common to JUnit5

### DIFF
--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -95,6 +95,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <version>${powermock1.version}</version>

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -28,6 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
+    <allow.junit4>false</allow.junit4>
   </properties>
 
   <build>

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -22,10 +22,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageSize;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -35,18 +34,13 @@ import java.util.Collection;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.any;
 
 /**
  * Unit test for Basic*OzoneFileSystem.
  */
-@RunWith(Parameterized.class)
 public class TestBasicOzoneFileSystems {
-
-  private final FileSystem subject;
-
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[]{new BasicOzoneFileSystem()},
@@ -54,44 +48,45 @@ public class TestBasicOzoneFileSystems {
     );
   }
 
-  public TestBasicOzoneFileSystems(FileSystem subject) {
-    this.subject = subject;
-  }
-
-  @Test
-  public void defaultBlockSize() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void defaultBlockSize(FileSystem subject) {
     Configuration conf = new OzoneConfiguration();
     subject.setConf(conf);
 
     long expected = toBytes(OZONE_SCM_BLOCK_SIZE_DEFAULT);
-    assertDefaultBlockSize(expected);
+    assertDefaultBlockSize(expected, subject);
   }
 
-  @Test
-  public void defaultBlockSizeCustomized() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void defaultBlockSizeCustomized(FileSystem subject) {
     String customValue = "128MB";
     Configuration conf = new OzoneConfiguration();
     conf.set(OZONE_SCM_BLOCK_SIZE, customValue);
     subject.setConf(conf);
 
-    assertDefaultBlockSize(toBytes(customValue));
+    assertDefaultBlockSize(toBytes(customValue), subject);
   }
 
   // test for filesystem pseduo-posix symlink support
-  @Test
-  public void testFileSystemPosixSymlinkSupport() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testFileSystemPosixSymlinkSupport(FileSystem subject) {
     if (subject instanceof BasicRootedOzoneFileSystem) {
-      Assert.assertTrue(subject.supportsSymlinks());
+      Assertions.assertTrue(subject.supportsSymlinks());
     } else if (subject instanceof BasicOzoneFileSystem) {
-      Assert.assertFalse(subject.supportsSymlinks());
+      Assertions.assertFalse(subject.supportsSymlinks());
     } else {
-      Assert.fail("Test case not implemented for FileSystem: " +
+      Assertions.fail("Test case not implemented for FileSystem: " +
           subject.getClass().getSimpleName());
     }
   }
 
-  @Test
-  public void testCreateSnapshotReturnPath() throws IOException {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testCreateSnapshotReturnPath(
+      FileSystem subject) throws IOException {
     final String snapshotName = "snap1";
 
     if (subject instanceof BasicRootedOzoneFileSystem) {
@@ -112,7 +107,7 @@ public class TestBasicOzoneFileSystems {
 
       // Return value path should be "ofs://om/vol1/buck1/.snapshot/snap1"
       // without the subdirectory "dir1" in the Path.
-      Assert.assertEquals(expectedSnapshotPath, res);
+      Assertions.assertEquals(expectedSnapshotPath, res);
     } else if (subject instanceof BasicOzoneFileSystem) {
       BasicOzoneClientAdapterImpl adapter =
           Mockito.mock(BasicOzoneClientAdapterImpl.class);
@@ -131,14 +126,14 @@ public class TestBasicOzoneFileSystems {
 
       // Return value path should be "o3fs://buck1.vol1.om/.snapshot/snap1"
       // without the subdirectory "dir1" in the Path.
-      Assert.assertEquals(expectedSnapshotPath, res);
+      Assertions.assertEquals(expectedSnapshotPath, res);
     } else {
-      Assert.fail("Test case not implemented for FileSystem: " +
+      Assertions.fail("Test case not implemented for FileSystem: " +
           subject.getClass().getSimpleName());
     }
   }
 
-  private void assertDefaultBlockSize(long expected) {
+  private void assertDefaultBlockSize(long expected, FileSystem subject) {
     assertEquals(expected, subject.getDefaultBlockSize());
 
     Path anyPath = new Path("/");

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -48,7 +48,7 @@ public class TestBasicOzoneFileSystems {
     );
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("data")
   public void defaultBlockSize(FileSystem subject) {
     Configuration conf = new OzoneConfiguration();
@@ -58,7 +58,7 @@ public class TestBasicOzoneFileSystems {
     assertDefaultBlockSize(expected, subject);
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("data")
   public void defaultBlockSizeCustomized(FileSystem subject) {
     String customValue = "128MB";
@@ -70,7 +70,7 @@ public class TestBasicOzoneFileSystems {
   }
 
   // test for filesystem pseduo-posix symlink support
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("data")
   public void testFileSystemPosixSymlinkSupport(FileSystem subject) {
     if (subject instanceof BasicRootedOzoneFileSystem) {
@@ -83,7 +83,7 @@ public class TestBasicOzoneFileSystems {
     }
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(autoCloseArguments = false)
   @MethodSource("data")
   public void testCreateSnapshotReturnPath(
       FileSystem subject) throws IOException {

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -41,10 +41,10 @@ import static org.mockito.Matchers.any;
  * Unit test for Basic*OzoneFileSystem.
  */
 public class TestBasicOzoneFileSystems {
-  public static Collection<Object[]> data() {
+  public static Collection<FileSystem> data() {
     return Arrays.asList(
-        new Object[]{new BasicOzoneFileSystem()},
-        new Object[]{new BasicRootedOzoneFileSystem()}
+        new BasicOzoneFileSystem(),
+        new BasicRootedOzoneFileSystem()
     );
   }
 

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OFSPath;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -35,116 +35,117 @@ public class TestOFSPath {
   public void testParsingPathWithSpace() {
     // Two most common cases: file key and dir key inside a bucket
     OFSPath ofsPath = new OFSPath("/volume1/bucket2/dir3/key4 space", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals("volume1", ofsPath.getVolumeName());
-    Assert.assertEquals("bucket2", ofsPath.getBucketName());
-    Assert.assertEquals("dir3/key4 space", ofsPath.getKeyName());
-    Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("/volume1/bucket2/dir3/key4 space", ofsPath.toString());
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
+    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
+    Assertions.assertEquals("dir3/key4 space", ofsPath.getKeyName());
+    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("/volume1/bucket2/dir3/key4 space",
+        ofsPath.toString());
   }
 
   @Test
   public void testParsingVolumeBucketWithKey() {
     // Two most common cases: file key and dir key inside a bucket
     OFSPath ofsPath = new OFSPath("/volume1/bucket2/dir3/key4", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals("volume1", ofsPath.getVolumeName());
-    Assert.assertEquals("bucket2", ofsPath.getBucketName());
-    Assert.assertEquals("dir3/key4", ofsPath.getKeyName());
-    Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("/volume1/bucket2/dir3/key4", ofsPath.toString());
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
+    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
+    Assertions.assertEquals("dir3/key4", ofsPath.getKeyName());
+    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("/volume1/bucket2/dir3/key4", ofsPath.toString());
 
     // The ending '/' matters for key inside a bucket, indicating directory
     ofsPath = new OFSPath("/volume1/bucket2/dir3/dir5/", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals("volume1", ofsPath.getVolumeName());
-    Assert.assertEquals("bucket2", ofsPath.getBucketName());
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
+    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
     // Check the key must end with '/' (dir5 is a directory)
-    Assert.assertEquals("dir3/dir5/", ofsPath.getKeyName());
-    Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("/volume1/bucket2/dir3/dir5/", ofsPath.toString());
+    Assertions.assertEquals("dir3/dir5/", ofsPath.getKeyName());
+    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("/volume1/bucket2/dir3/dir5/", ofsPath.toString());
   }
 
   @Test
   public void testParsingVolumeBucketOnly() {
     // Volume and bucket only
     OFSPath ofsPath = new OFSPath("/volume1/bucket2/", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals("volume1", ofsPath.getVolumeName());
-    Assert.assertEquals("bucket2", ofsPath.getBucketName());
-    Assert.assertEquals("", ofsPath.getMountName());
-    Assert.assertEquals("", ofsPath.getKeyName());
-    Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("/volume1/bucket2/", ofsPath.toString());
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
+    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
+    Assertions.assertEquals("", ofsPath.getMountName());
+    Assertions.assertEquals("", ofsPath.getKeyName());
+    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("/volume1/bucket2/", ofsPath.toString());
 
     // The trailing '/' doesn't matter when parsing a bucket path
     ofsPath = new OFSPath("/volume1/bucket2", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals("volume1", ofsPath.getVolumeName());
-    Assert.assertEquals("bucket2", ofsPath.getBucketName());
-    Assert.assertEquals("", ofsPath.getMountName());
-    Assert.assertEquals("", ofsPath.getKeyName());
-    Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("/volume1/bucket2/", ofsPath.toString());
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
+    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
+    Assertions.assertEquals("", ofsPath.getMountName());
+    Assertions.assertEquals("", ofsPath.getKeyName());
+    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("/volume1/bucket2/", ofsPath.toString());
   }
 
   @Test
   public void testParsingVolumeOnly() {
     // Volume only
     OFSPath ofsPath = new OFSPath("/volume1/", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals("volume1", ofsPath.getVolumeName());
-    Assert.assertEquals("", ofsPath.getBucketName());
-    Assert.assertEquals("", ofsPath.getMountName());
-    Assert.assertEquals("", ofsPath.getKeyName());
-    Assert.assertEquals("/volume1/", ofsPath.getNonKeyPath());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("/volume1/", ofsPath.toString());
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
+    Assertions.assertEquals("", ofsPath.getBucketName());
+    Assertions.assertEquals("", ofsPath.getMountName());
+    Assertions.assertEquals("", ofsPath.getKeyName());
+    Assertions.assertEquals("/volume1/", ofsPath.getNonKeyPath());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("/volume1/", ofsPath.toString());
 
     // The trailing '/' doesn't matter when parsing a volume path
     ofsPath = new OFSPath("/volume1", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals("volume1", ofsPath.getVolumeName());
-    Assert.assertEquals("", ofsPath.getBucketName());
-    Assert.assertEquals("", ofsPath.getMountName());
-    Assert.assertEquals("", ofsPath.getKeyName());
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
+    Assertions.assertEquals("", ofsPath.getBucketName());
+    Assertions.assertEquals("", ofsPath.getMountName());
+    Assertions.assertEquals("", ofsPath.getKeyName());
     // Note: currently getNonKeyPath() returns with '/' if input is volume only.
     //  There is no use case for this for now.
     //  The behavior might change in the future.
-    Assert.assertEquals("/volume1/", ofsPath.getNonKeyPath());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("/volume1/", ofsPath.toString());
+    Assertions.assertEquals("/volume1/", ofsPath.getNonKeyPath());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("/volume1/", ofsPath.toString());
   }
 
   @Test
   public void testParsingEmptyInput() {
     OFSPath ofsPath = new OFSPath("", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals("", ofsPath.getVolumeName());
-    Assert.assertEquals("", ofsPath.getBucketName());
-    Assert.assertEquals("", ofsPath.getKeyName());
-    Assert.assertEquals("", ofsPath.getNonKeyPath());
-    Assert.assertEquals("", ofsPath.getNonKeyPathNoPrefixDelim());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("", ofsPath.toString());
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals("", ofsPath.getVolumeName());
+    Assertions.assertEquals("", ofsPath.getBucketName());
+    Assertions.assertEquals("", ofsPath.getKeyName());
+    Assertions.assertEquals("", ofsPath.getNonKeyPath());
+    Assertions.assertEquals("", ofsPath.getNonKeyPathNoPrefixDelim());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("", ofsPath.toString());
   }
 
   @Test
   public void testParsingWithAuthority() {
     OFSPath ofsPath = new OFSPath("ofs://svc1:9876/volume1/bucket2/dir3/",
         conf);
-    Assert.assertEquals("svc1:9876", ofsPath.getAuthority());
-    Assert.assertEquals("volume1", ofsPath.getVolumeName());
-    Assert.assertEquals("bucket2", ofsPath.getBucketName());
-    Assert.assertEquals("dir3/", ofsPath.getKeyName());
-    Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("ofs://svc1:9876/volume1/bucket2/dir3/",
+    Assertions.assertEquals("svc1:9876", ofsPath.getAuthority());
+    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
+    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
+    Assertions.assertEquals("dir3/", ofsPath.getKeyName());
+    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    Assertions.assertFalse(ofsPath.isMount());
+    Assertions.assertEquals("ofs://svc1:9876/volume1/bucket2/dir3/",
         ofsPath.toString());
   }
 
@@ -154,32 +155,32 @@ public class TestOFSPath {
     try {
       bucketName = OFSPath.getTempMountBucketNameOfCurrentUser();
     } catch (IOException ex) {
-      Assert.fail("Failed to get the current user name, "
+      Assertions.fail("Failed to get the current user name, "
           + "thus failed to get temp bucket name.");
       bucketName = "";  // Make javac happy
     }
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals(
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
-    Assert.assertEquals(bucketName, ofsPath.getBucketName());
-    Assert.assertEquals("tmp", ofsPath.getMountName());
-    Assert.assertEquals("", ofsPath.getKeyName());
-    Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());
-    Assert.assertTrue(ofsPath.isMount());
-    Assert.assertEquals("/tmp/", ofsPath.toString());
+    Assertions.assertEquals(bucketName, ofsPath.getBucketName());
+    Assertions.assertEquals("tmp", ofsPath.getMountName());
+    Assertions.assertEquals("", ofsPath.getKeyName());
+    Assertions.assertEquals("/tmp", ofsPath.getNonKeyPath());
+    Assertions.assertTrue(ofsPath.isMount());
+    Assertions.assertEquals("/tmp/", ofsPath.toString());
 
     // Mount with key
     ofsPath = new OFSPath("/tmp/key1", conf);
-    Assert.assertEquals("", ofsPath.getAuthority());
-    Assert.assertEquals(
+    Assertions.assertEquals("", ofsPath.getAuthority());
+    Assertions.assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
-    Assert.assertEquals(bucketName, ofsPath.getBucketName());
-    Assert.assertEquals("tmp", ofsPath.getMountName());
-    Assert.assertEquals("key1", ofsPath.getKeyName());
-    Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());
-    Assert.assertTrue(ofsPath.isMount());
-    Assert.assertEquals("/tmp/key1", ofsPath.toString());
+    Assertions.assertEquals(bucketName, ofsPath.getBucketName());
+    Assertions.assertEquals("tmp", ofsPath.getMountName());
+    Assertions.assertEquals("key1", ofsPath.getKeyName());
+    Assertions.assertEquals("/tmp", ofsPath.getNonKeyPath());
+    Assertions.assertTrue(ofsPath.isMount());
+    Assertions.assertEquals("/tmp/key1", ofsPath.toString());
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
@@ -28,12 +28,12 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -47,15 +47,16 @@ public class TestOzoneClientUtils {
   private ReplicationConfig ratis1ReplicationConfig =
       RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE);
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test()
   public void testNegativeLength() throws IOException {
     OzoneVolume volume = mock(OzoneVolume.class);
     OzoneBucket bucket = mock(OzoneBucket.class);
     String keyName = "dummy";
     ClientProtocol clientProtocol = mock(ClientProtocol.class);
-    OzoneClientUtils.getFileChecksumWithCombineMode(volume, bucket, keyName,
-        -1, OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC, clientProtocol);
-
+    Assertions.assertThrows(IllegalArgumentException.class, () ->
+        OzoneClientUtils.getFileChecksumWithCombineMode(volume, bucket, keyName,
+        -1, OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC,
+        clientProtocol));
   }
 
   @Test
@@ -79,7 +80,7 @@ public class TestOzoneClientUtils {
             (short) 3, null,
             ecReplicationConfig, new OzoneConfiguration());
     // Bucket default is EC.
-    Assert.assertEquals(ecReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ecReplicationConfig, replicationConfig);
   }
 
   /**
@@ -92,7 +93,7 @@ public class TestOzoneClientUtils {
             (short) 3, null, null,
             new OzoneConfiguration());
     // Passed replication is 3 - Ozone mapped replication is ratis THREE
-    Assert.assertEquals(ratis3ReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ratis3ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -107,7 +108,7 @@ public class TestOzoneClientUtils {
             new OzoneConfiguration());
     // client configured value also null.
     // This API caller should leave the decision to server.
-    Assert.assertNull(replicationConfig);
+    Assertions.assertNull(replicationConfig);
   }
 
   /**
@@ -121,7 +122,7 @@ public class TestOzoneClientUtils {
             (short) -1, null, ratis3ReplicationConfig,
             new OzoneConfiguration());
     // Configured client config also null.
-    Assert.assertNull(replicationConfig);
+    Assertions.assertNull(replicationConfig);
   }
 
   /**
@@ -135,7 +136,7 @@ public class TestOzoneClientUtils {
             (short) 1, null, ratis3ReplicationConfig,
             new OzoneConfiguration());
     // Passed value is replication one - Ozone mapped value is ratis ONE
-    Assert.assertEquals(ratis1ReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ratis1ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -149,7 +150,7 @@ public class TestOzoneClientUtils {
             (short) 3, ratis3ReplicationConfig,
             ecReplicationConfig, new OzoneConfiguration());
     // Bucket default is EC
-    Assert.assertEquals(ecReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ecReplicationConfig, replicationConfig);
   }
 
   /**
@@ -163,7 +164,7 @@ public class TestOzoneClientUtils {
             (short) -1, ratis3ReplicationConfig, ratis1ReplicationConfig,
             new OzoneConfiguration());
     // Configured value is ratis THREE
-    Assert.assertEquals(ratis3ReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ratis3ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -176,7 +177,7 @@ public class TestOzoneClientUtils {
         .validateAndGetClientReplicationConfig(ReplicationType.RATIS, "1",
             new OzoneConfiguration());
     // Configured value is ratis ONE
-    Assert.assertEquals(ratis1ReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ratis1ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -187,7 +188,7 @@ public class TestOzoneClientUtils {
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, null,
             new OzoneConfiguration());
-    Assert.assertNull(replicationConfig);
+    Assertions.assertNull(replicationConfig);
   }
 
   /**
@@ -201,7 +202,7 @@ public class TestOzoneClientUtils {
     clientSideConfig.set(OzoneConfigKeys.OZONE_REPLICATION, "rs-3-2-1024K");
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, null, clientSideConfig);
-    Assert.assertEquals(ecReplicationConfig, replicationConfig);
+    Assertions.assertEquals(ecReplicationConfig, replicationConfig);
   }
 
   /**
@@ -213,7 +214,7 @@ public class TestOzoneClientUtils {
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, "3",
             new OzoneConfiguration());
-    Assert.assertNull(replicationConfig);
+    Assertions.assertNull(replicationConfig);
   }
 
   /**
@@ -225,7 +226,7 @@ public class TestOzoneClientUtils {
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(ReplicationType.EC, null,
             new OzoneConfiguration());
-    Assert.assertNull(replicationConfig);
+    Assertions.assertNull(replicationConfig);
   }
 
   /**
@@ -240,7 +241,7 @@ public class TestOzoneClientUtils {
     // null.
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, null, clientSideConfig);
-    Assert.assertNull(replicationConfig);
+    Assertions.assertNull(replicationConfig);
   }
 
   /**
@@ -255,7 +256,7 @@ public class TestOzoneClientUtils {
     // as null.
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, null, clientSideConfig);
-    Assert.assertNull(replicationConfig);
+    Assertions.assertNull(replicationConfig);
   }
 
 }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -39,9 +39,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.IntFunction;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsShell.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsShell.java
@@ -28,8 +28,8 @@ import java.util.Arrays;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -55,12 +55,12 @@ public class TestOzoneFsShell {
     } finally {
       // test command bindings for "rm" command handled by OzoneDelete class
       CommandFactory factory = shell.getCommandFactory();
-      Assert.assertEquals(1, Arrays.stream(factory.getNames())
+      Assertions.assertEquals(1, Arrays.stream(factory.getNames())
           .filter(c -> c.equals(rmCmd)).count());
       Command instance = factory.getInstance(rmCmd);
-      Assert.assertNotNull(instance);
-      Assert.assertEquals(OzoneFsDelete.Rm.class, instance.getClass());
-      Assert.assertEquals(rmCmdName, instance.getCommandName());
+      Assertions.assertNotNull(instance);
+      Assertions.assertEquals(OzoneFsDelete.Rm.class, instance.getClass());
+      Assertions.assertEquals(rmCmdName, instance.getCommandName());
       shell.close();
       System.setErr(oldErr);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9502. Migrate tests in ozonefs-common to JUnit5

Migrating all the tests under ozonefs-common to Junit5 and making sure that Junit4 is not used in any of the tests. This PR also migrates the parametrized tests under ozonefs-common to junit5.
Tested that using grep -rlE "org.junit.[A-Z]" . --include '*.java' command in hadoop-ozone/ozonefs-common folder

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9502

## How was this patch tested?

This PR was tested by running the full CI - https://github.com/VarshaRaviCV/ozone/actions/runs/6942165040 
