### PR TITLE
HDDS-9353. ReplicationManager: Ignore any Datanodes that are not in-service and healthy when finding unique origins

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.container.replication;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -34,11 +33,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -165,13 +161,6 @@ public class RatisOverReplicationHandler
         sortReplicas(replicaCount.getReplicas(),
             replicaCount.getHealthyReplicaCount() == 0);
 
-    // retain one replica per unique origin datanode if the container is not
-    // closed
-    if (replicaCount.getContainer().getState() !=
-        HddsProtos.LifeCycleState.CLOSED) {
-      saveReplicasWithUniqueOrigins(eligibleReplicas);
-    }
-
     Set<DatanodeDetails> pendingDeletion = new HashSet<>();
     // collect the DNs that are going to have their container replica deleted
     for (ContainerReplicaOp op : pendingOps) {
@@ -187,6 +176,14 @@ public class RatisOverReplicationHandler
             HddsProtos.NodeOperationalState.IN_SERVICE ||
             pendingDeletion.contains(replica.getDatanodeDetails()));
 
+    // retain one replica per unique origin datanode if the container is not
+    // closed
+    if (replicaCount.getContainer().getState() !=
+        HddsProtos.LifeCycleState.CLOSED) {
+      saveReplicasWithUniqueOrigins(replicaCount.getContainer(),
+          eligibleReplicas);
+    }
+
     return eligibleReplicas;
   }
 
@@ -199,29 +196,26 @@ public class RatisOverReplicationHandler
    * @param eligibleReplicas List of replicas that are eligible to be deleted
    * and from which replicas with unique origin node ID need to be saved
    */
-  private void saveReplicasWithUniqueOrigins(
+  private void saveReplicasWithUniqueOrigins(ContainerInfo container,
       List<ContainerReplica> eligibleReplicas) {
-    final Map<UUID, ContainerReplica> uniqueOrigins = new LinkedHashMap<>();
-    eligibleReplicas.stream()
-        // get unique origin nodes of healthy replicas
-        .filter(r -> r.getState() != ContainerReplicaProto.State.UNHEALTHY)
-        .forEach(r -> uniqueOrigins.putIfAbsent(r.getOriginDatanodeId(), r));
-
-    /*
-     Now that we've checked healthy replicas, see if some unhealthy replicas
-     need to be saved. For example, in the case of {QUASI_CLOSED,
-     QUASI_CLOSED, QUASI_CLOSED, UNHEALTHY}, if both the first and last
-     replicas have the same origin node ID (and no other replicas have it), we
-     prefer saving the QUASI_CLOSED replica and deleting the UNHEALTHY one.
-     */
-    for (ContainerReplica replica : eligibleReplicas) {
-      if (replica.getState() == ContainerReplicaProto.State.UNHEALTHY) {
-        uniqueOrigins.putIfAbsent(replica.getOriginDatanodeId(), replica);
-      }
-    }
+    List<ContainerReplica> nonUniqueDeleteCandidates =
+        ReplicationManagerUtil.findNonUniqueDeleteCandidates(
+            new HashSet<>(eligibleReplicas),
+            eligibleReplicas, (dnd) -> {
+              try {
+                return replicationManager.getNodeStatus(dnd);
+              } catch (NodeNotFoundException e) {
+                LOG.warn(
+                    "Exception while finding excess unhealthy replicas to " +
+                        "delete for container {} with eligible replicas {}.",
+                    container, eligibleReplicas, e);
+                return null;
+              }
+            });
 
     // note that this preserves order of the List
-    eligibleReplicas.removeAll(uniqueOrigins.values());
+    eligibleReplicas.removeIf(
+        replica -> !nonUniqueDeleteCandidates.contains(replica));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -154,6 +154,9 @@ public class RatisUnderReplicationHandler
   private void removeUnhealthyReplicaIfPossible(ContainerInfo containerInfo,
       Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps)
       throws NotLeaderException {
+    LOG.info("Finding an unhealthy replica to delete for container {} with " +
+        "replicas {} to unblock under replication handling.", containerInfo,
+        replicas);
     int pendingDeletes = 0;
     for (ContainerReplicaOp op : pendingOps) {
       if (op.getOpType() == ContainerReplicaOp.PendingOpType.DELETE) {
@@ -167,6 +170,9 @@ public class RatisUnderReplicationHandler
               try {
                 return replicationManager.getNodeStatus(dnd);
               } catch (NodeNotFoundException e) {
+                LOG.warn("Exception while finding an unhealthy replica to " +
+                    "delete for container {} with replicas {}.", containerInfo,
+                    replicas, e);
                 return null;
               }
             });

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -941,7 +941,8 @@ public class TestLegacyReplicationManager {
       final ContainerReplica replica5 = getReplicas(
           id, UNHEALTHY, 1000L, replica4.getOriginDatanodeId(),
           randomDatanodeDetails());
-      replica5.getDatanodeDetails().setPersistedOpState(DECOMMISSIONING);
+      nodeManager.register(replica5.getDatanodeDetails(),
+          new NodeStatus(DECOMMISSIONING, HEALTHY));
       DatanodeDetails deadNode = randomDatanodeDetails();
       nodeManager.register(deadNode, NodeStatus.inServiceDead());
       final ContainerReplica replica6 = getReplicas(
@@ -1006,6 +1007,8 @@ public class TestLegacyReplicationManager {
       DatanodeDetails decommissioning =
           MockDatanodeDetails.randomDatanodeDetails();
       decommissioning.setPersistedOpState(DECOMMISSIONING);
+      nodeManager.register(decommissioning,
+          new NodeStatus(DECOMMISSIONING, HEALTHY));
       final ContainerReplica replica4 = getReplicas(
           id, UNHEALTHY, sequenceID, decommissioning.getUuid(),
           decommissioning);


### PR DESCRIPTION
## What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/HDDS-9352 makes changes in the algorithm used for saving `UNHEALTHY` replicas with unique origins for a `QUASI_CLOSED` container in Legacy Replication Manager. This PR makes similar changes to `RatisOverReplicationHandler` for the new RM. Basically, any Datanodes not in-service, healthy should not be considered when finding replicas with unique origin datanode id, because these datanodes are likely going away soon or gone already. 

Also refactored duplicated logic to one place and added some logs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9353

## How was this patch tested?
Modified unit tests.