### PR TITLE
HDDS-9745. Change IllegalStateException to IOException in SnapshotChainManager

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -69,14 +69,15 @@ public class SnapshotChainManager {
   /**
    * Add snapshot to global snapshot chain.
    */
-  private void addSnapshotGlobal(UUID snapshotID, UUID prevGlobalID) {
+  private void addSnapshotGlobal(UUID snapshotID, UUID prevGlobalID)
+      throws IOException {
     if (globalSnapshotChain.containsKey(snapshotID)) {
-      throw new IllegalStateException(String.format(
+      throw new IOException(String.format(
           "Global Snapshot chain corruption. Snapshot with snapshotId: %s is " +
               "already present in the chain.", snapshotID));
     }
     if (globalSnapshotChain.size() > 0 && prevGlobalID == null) {
-      throw new IllegalStateException(String.format("Snapshot chain " +
+      throw new IOException(String.format("Snapshot chain " +
           "corruption. Adding snapshot %s as head node while there are %d " +
               "snapshots in the global snapshot chain.", snapshotID,
           globalSnapshotChain.size()));
@@ -84,7 +85,7 @@ public class SnapshotChainManager {
 
     if (prevGlobalID != null &&
         !globalSnapshotChain.containsKey(prevGlobalID)) {
-      throw new IllegalStateException(String.format(
+      throw new IOException(String.format(
           "Global Snapshot chain corruption. Previous snapshotId: %s is " +
               "set for snapshotId: %s but no associated snapshot found in " +
               "snapshot chain.", prevGlobalID, snapshotID));
@@ -92,7 +93,7 @@ public class SnapshotChainManager {
 
     if (prevGlobalID != null) {
       if (globalSnapshotChain.get(prevGlobalID).hasNextSnapshotId()) {
-        throw new IllegalStateException(String.format(
+        throw new IOException(String.format(
             "Global Snapshot chain corruption. Snapshot with snapshotId: %s " +
                 "already has the next snapshotId: %s. Adding snapshot %s " +
                 "with prevSnapshotId: %s will make the chain non linear.",
@@ -116,12 +117,12 @@ public class SnapshotChainManager {
    * Add snapshot to bucket snapshot chain(path based).
    */
   private void addSnapshotPath(String snapshotPath, UUID snapshotID,
-                               UUID prevPathID) {
+                               UUID prevPathID) throws IOException {
     // On add snapshot, set previous snapshot entry nextSnapshotId = snapshotId
     if (prevPathID != null &&
         ((!snapshotChainByPath.containsKey(snapshotPath)) ||
             (!snapshotChainByPath.get(snapshotPath).containsKey(prevPathID)))) {
-      throw new IllegalStateException(String.format(
+      throw new IOException(String.format(
           "Path Snapshot chain corruption. Previous snapshotId: %s is set " +
               "for snapshotId: %s but no associated snapshot found in " +
               "snapshot chain.", prevPathID, snapshotID));
@@ -129,7 +130,7 @@ public class SnapshotChainManager {
 
     if (prevPathID == null && snapshotChainByPath.containsKey(snapshotPath) &&
         !snapshotChainByPath.get(snapshotPath).isEmpty()) {
-      throw new IllegalStateException(String.format(
+      throw new IOException(String.format(
           "Path Snapshot chain corruption. Error while adding snapshot with " +
               "snapshotId %s with as the first snapshot in snapshot path: " +
               "%s which already has %d snapshots.", snapshotID, snapshotPath,
@@ -139,7 +140,7 @@ public class SnapshotChainManager {
     if (prevPathID != null && snapshotChainByPath.containsKey(snapshotPath)) {
       if (snapshotChainByPath.get(snapshotPath).get(prevPathID)
           .hasNextSnapshotId()) {
-        throw new IllegalStateException(String.format(
+        throw new IOException(String.format(
             "Path Snapshot chain corruption. Next snapshotId: %s is already " +
                 "set for snapshotId: %s. Adding snapshotId: %s with " +
                 "prevSnapshotId: %s will make the chain non linear.",
@@ -164,7 +165,7 @@ public class SnapshotChainManager {
     latestSnapshotIdByPath.put(snapshotPath, snapshotID);
   }
 
-  private boolean deleteSnapshotGlobal(UUID snapshotID) {
+  private boolean deleteSnapshotGlobal(UUID snapshotID) throws IOException {
     if (globalSnapshotChain.containsKey(snapshotID)) {
       // reset prev and next snapshot entries in chain ordered list
       // for node removal
@@ -172,14 +173,14 @@ public class SnapshotChainManager {
       UUID prev = globalSnapshotChain.get(snapshotID).getPreviousSnapshotId();
 
       if (prev != null && !globalSnapshotChain.containsKey(prev)) {
-        throw new IllegalStateException(String.format(
+        throw new IOException(String.format(
             "Global snapshot chain corruption. " +
                 "SnapshotId: %s to be deleted has previous snapshotId: %s " +
                 "but associated snapshot is not found in snapshot chain.",
             snapshotID, prev));
       }
       if (next != null && !globalSnapshotChain.containsKey(next)) {
-        throw new IllegalStateException(String.format(
+        throw new IOException(String.format(
             "Global snapshot chain corruption. " +
                 "SnapshotId: {%s} to be deleted has next snapshotId: %s " +
                 "but associated snapshot is not found in snapshot chain.",
@@ -206,7 +207,7 @@ public class SnapshotChainManager {
   }
 
   private boolean deleteSnapshotPath(String snapshotPath,
-                                     UUID snapshotId) {
+                                     UUID snapshotId) throws IOException {
     if (snapshotChainByPath.containsKey(snapshotPath) &&
         snapshotChainByPath.get(snapshotPath).containsKey(snapshotId)) {
       // reset prev and next snapshot entries in chain ordered list
@@ -223,7 +224,7 @@ public class SnapshotChainManager {
       if (previousSnapshotId != null &&
           !snapshotChainByPath.get(snapshotPath)
               .containsKey(previousSnapshotId)) {
-        throw new IllegalStateException(String.format(
+        throw new IOException(String.format(
             "Path snapshot chain corruption. " +
                 "SnapshotId: %s at snapshotPath: %s to be deleted has " +
                 "previous snapshotId: %s but associated snapshot is not " +
@@ -232,7 +233,7 @@ public class SnapshotChainManager {
       }
       if (nextSnapshotId != null && !snapshotChainByPath.get(snapshotPath)
           .containsKey(nextSnapshotId)) {
-        throw new IllegalStateException(String.format(
+        throw new IOException(String.format(
             "Path snapshot chain corruption. " +
                 "SnapshotId: %s at snapshotPath: %s to be deleted has next " +
                 "snapshotId: %s but associated snapshot is not found in " +
@@ -320,11 +321,11 @@ public class SnapshotChainManager {
         head = snapshotToNextSnapshotMap.get(head);
       }
       if (size != snaps.size()) {
-        throw new IllegalStateException(String.format("Snapshot chain " +
+        throw new IOException(String.format("Snapshot chain " +
             "corruption. All snapshots have not been added to the " +
             "snapshot chain. Last snapshot added to chain : %s", prev));
       }
-    } catch (IOException | IllegalStateException exception) {
+    } catch (IOException exception) {
       LOG.error("Failure while loading snapshot chain.", exception);
       return false;
     }
@@ -334,7 +335,8 @@ public class SnapshotChainManager {
   /**
    * Add snapshot to snapshot chain.
    */
-  public synchronized void addSnapshot(SnapshotInfo snapshotInfo) {
+  public synchronized void addSnapshot(SnapshotInfo snapshotInfo)
+      throws IOException {
     validateSnapshotChain();
     addSnapshotGlobal(snapshotInfo.getSnapshotId(),
         snapshotInfo.getGlobalPreviousSnapshotId());
@@ -349,7 +351,8 @@ public class SnapshotChainManager {
   /**
    * Delete snapshot from snapshot chain.
    */
-  public synchronized boolean deleteSnapshot(SnapshotInfo snapshotInfo) {
+  public synchronized boolean deleteSnapshot(SnapshotInfo snapshotInfo)
+      throws IOException {
     validateSnapshotChain();
     boolean status = deleteSnapshotGlobal(snapshotInfo.getSnapshotId()) &&
         deleteSnapshotPath(snapshotInfo.getSnapshotPath(),
@@ -363,7 +366,7 @@ public class SnapshotChainManager {
   /**
    * Get latest global snapshot in snapshot chain.
    */
-  public UUID getLatestGlobalSnapshotId() {
+  public UUID getLatestGlobalSnapshotId() throws IOException {
     validateSnapshotChain();
     return latestGlobalSnapshotId;
   }
@@ -371,7 +374,7 @@ public class SnapshotChainManager {
   /**
    * Get latest path snapshot in snapshot chain.
    */
-  public UUID getLatestPathSnapshotId(String snapshotPath) {
+  public UUID getLatestPathSnapshotId(String snapshotPath) throws IOException {
     validateSnapshotChain();
     return latestSnapshotIdByPath.get(snapshotPath);
   }
@@ -380,7 +383,7 @@ public class SnapshotChainManager {
    * Returns true if snapshot from given snapshotId has a next snapshot entry
    * in the global snapshot chain.
    */
-  public boolean hasNextGlobalSnapshot(UUID snapshotId) {
+  public boolean hasNextGlobalSnapshot(UUID snapshotId) throws IOException {
     validateSnapshotChain();
     if (!globalSnapshotChain.containsKey(snapshotId)) {
       LOG.error("No snapshot for provided snapshotId: {}", snapshotId);
@@ -393,7 +396,7 @@ public class SnapshotChainManager {
   /**
    * Get next global snapshot in snapshot chain from given snapshot.
    */
-  public UUID nextGlobalSnapshot(UUID snapshotId) {
+  public UUID nextGlobalSnapshot(UUID snapshotId) throws IOException {
     validateSnapshotChain();
     if (!hasNextGlobalSnapshot(snapshotId)) {
       LOG.error("No snapshot for provided snapshotId: {}", snapshotId);
@@ -407,7 +410,7 @@ public class SnapshotChainManager {
    * Returns true if snapshot from given snapshotId has a previous snapshot
    * entry in the global snapshot chain.
    */
-  public boolean hasPreviousGlobalSnapshot(UUID snapshotId) {
+  public boolean hasPreviousGlobalSnapshot(UUID snapshotId) throws IOException {
     validateSnapshotChain();
     if (!globalSnapshotChain.containsKey(snapshotId)) {
       LOG.error("No snapshot found in snapshot chain for provided " +
@@ -422,7 +425,7 @@ public class SnapshotChainManager {
   /**
    * Get previous global snapshot in snapshot chain from given snapshot.
    */
-  public UUID previousGlobalSnapshot(UUID snapshotId) {
+  public UUID previousGlobalSnapshot(UUID snapshotId) throws IOException {
     validateSnapshotChain();
     if (!hasPreviousGlobalSnapshot(snapshotId)) {
       LOG.error("No preceding snapshot found in snapshot chain for provided " +
@@ -437,7 +440,8 @@ public class SnapshotChainManager {
    * Returns true if snapshot path from given snapshotId has a next snapshot
    * entry in the path snapshot chain.
    */
-  public boolean hasNextPathSnapshot(String snapshotPath, UUID snapshotId) {
+  public boolean hasNextPathSnapshot(String snapshotPath, UUID snapshotId)
+      throws IOException {
     validateSnapshotChain();
     if (!snapshotChainByPath.containsKey(snapshotPath) ||
         !snapshotChainByPath.get(snapshotPath).containsKey(snapshotId)) {
@@ -457,7 +461,8 @@ public class SnapshotChainManager {
   /**
    * Get next path snapshot in snapshot chain from given snapshot.
    */
-  public UUID nextPathSnapshot(String snapshotPath, UUID snapshotId) {
+  public UUID nextPathSnapshot(String snapshotPath, UUID snapshotId)
+      throws IOException {
     validateSnapshotChain();
     if (!hasNextPathSnapshot(snapshotPath, snapshotId)) {
       LOG.error("No following snapshot for provided snapshotId {} and " +
@@ -476,7 +481,7 @@ public class SnapshotChainManager {
    * previous snapshot entry in the path snapshot chain.
    */
   public boolean hasPreviousPathSnapshot(String snapshotPath,
-                                         UUID snapshotId) {
+                                         UUID snapshotId) throws IOException {
     validateSnapshotChain();
     if (!snapshotChainByPath.containsKey(snapshotPath) ||
         !snapshotChainByPath.get(snapshotPath).containsKey(snapshotId)) {
@@ -495,7 +500,7 @@ public class SnapshotChainManager {
    * Get previous path snapshot in snapshot chain from given snapshot.
    */
   public UUID previousPathSnapshot(String snapshotPath,
-                                   UUID snapshotId) {
+                                   UUID snapshotId) throws IOException {
     validateSnapshotChain();
     if (!hasPreviousPathSnapshot(snapshotPath, snapshotId)) {
       LOG.error("No preceding snapshot for provided snapshotId: {} and " +
@@ -515,32 +520,34 @@ public class SnapshotChainManager {
   }
 
   public LinkedHashMap<UUID, SnapshotChainInfo> getSnapshotChainPath(
-      String path) {
+      String path) throws IOException {
     validateSnapshotChain();
     return snapshotChainByPath.get(path);
   }
 
   @VisibleForTesting
-  public Map<UUID, SnapshotChainInfo> getGlobalSnapshotChain() {
+  public Map<UUID, SnapshotChainInfo> getGlobalSnapshotChain()
+      throws IOException {
     validateSnapshotChain();
     return globalSnapshotChain;
   }
 
   @VisibleForTesting
   public Map<String,
-      LinkedHashMap<UUID, SnapshotChainInfo>> getSnapshotChainByPath() {
+      LinkedHashMap<UUID, SnapshotChainInfo>> getSnapshotChainByPath()
+      throws IOException {
     validateSnapshotChain();
     return snapshotChainByPath;
   }
 
   /**
    * Validate if snapshot chain is loaded without any error and throw
-   * IllegalStateException in case there was an issue while loading snapshot
+   * IOException in case there was an issue while loading snapshot
    * chain on OM start up.
    */
-  private void validateSnapshotChain() {
+  private void validateSnapshotChain() throws IOException {
     if (snapshotChainCorrupted) {
-      throw new IllegalStateException("Snapshot chain is corrupted.");
+      throw new IOException("Snapshot chain is corrupted.");
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -267,7 +267,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
         omMetadataManager.getSnapshotInfoTable()
             .addCacheEntry(new CacheKey<>(snapshotInfo.getTableKey()),
                 CacheValue.get(transactionLogIndex, snapshotInfo));
-      } catch (Exception exception) {
+      } catch (IOException exception) {
         // Remove snapshot from the SnapshotChainManager in case of any failure.
         // It is possible that createSnapshot request fails after snapshot gets
         // added to snapshot chain manager because couldn't add it to cache/DB.
@@ -300,7 +300,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
   ) {
     try {
       snapshotChainManager.deleteSnapshot(info);
-    } catch (IllegalStateException exception) {
+    } catch (IOException exception) {
       LOG.error("Failed to remove snapshot: {} from SnapshotChainManager.",
           info, exception);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -191,7 +191,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
           .setSnapshotInfo(snapshotInfo.getProtobuf()));
       omClientResponse = new OMSnapshotCreateResponse(
           omResponse.build(), snapshotInfo);
-    } catch (IOException | InvalidPathException | IllegalStateException ex) {
+    } catch (IOException | InvalidPathException ex) {
       exception = ex;
       omClientResponse = new OMSnapshotCreateResponse(
           createErrorOMResponse(omResponse, exception));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotChain.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotChain.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -92,7 +93,7 @@ public class TestSnapshotChain {
         .build();
   }
 
-  private void deleteSnapshot(UUID snapshotID) {
+  private void deleteSnapshot(UUID snapshotID) throws IOException {
     SnapshotInfo sinfo = null;
     final String snapshotPath = "vol1/bucket1";
     // reset the next snapshotInfo.globalPreviousSnapshotID
@@ -352,13 +353,12 @@ public class TestSnapshotChain {
         UUID.randomUUID(),
         UUID.randomUUID(),
         System.currentTimeMillis());
-    IllegalStateException createException =
-        assertThrows(IllegalStateException.class,
+    IOException createException = assertThrows(IOException.class,
             () -> chainManager.addSnapshot(snapInfo));
     assertEquals("Snapshot chain is corrupted.", createException.getMessage());
     if (!snapshotIDs.isEmpty()) {
-      IllegalStateException deleteException =
-          assertThrows(IllegalStateException.class,
+      IOException deleteException =
+          assertThrows(IOException.class,
               () -> chainManager.deleteSnapshot(
                   snapshotInfo.get(snapshotIDs.get(0).toString())));
       assertEquals("Snapshot chain is corrupted.",
@@ -386,13 +386,12 @@ public class TestSnapshotChain {
         UUID.randomUUID(),
         UUID.randomUUID(),
         System.currentTimeMillis());
-    IllegalStateException createException =
-        assertThrows(IllegalStateException.class,
+    IOException createException = assertThrows(IOException.class,
             () -> chainManager.addSnapshot(snapInfo));
     assertEquals("Snapshot chain is corrupted.", createException.getMessage());
     if (!snapshotIDs.isEmpty()) {
-      IllegalStateException deleteException =
-          assertThrows(IllegalStateException.class,
+      IOException deleteException =
+          assertThrows(IOException.class,
               () -> chainManager.deleteSnapshot(
                   snapshotInfo.get(snapshotIDs.get(0).toString())));
       assertEquals("Snapshot chain is corrupted.",

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
@@ -452,7 +452,7 @@ public class TestOMSnapshotPurgeRequestAndResponse {
 
   private void validateSnapshotOrderInSnapshotInfoTableAndSnapshotChain(
       List<SnapshotInfo> snapshotInfoList
-  ) {
+  ) throws IOException {
     if (snapshotInfoList.isEmpty()) {
       return;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
As fix of HDDS-9199, exceptions in snapshot chain creation were changed IllegalStateException. We have seen couple of issues with this as in HDDS-9685 and HDDS-9745.
This change is to change unchecked `IllegalStateException` to checked `IOException` so that OM state machine can handle the exception properly and doesn't crash the system.

## What is the link to the Apache JIRA
[HDDS-9745](https://issues.apache.org/jira/browse/HDDS-9745)

## How was this patch tested?
Updated unit and integration tests.
