### PR TITLE
HDDS-9757. Cannot run specific test due to failIfNoSpecifiedTests=true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <release-year>2019</release-year>
 
     <failIfNoTests>false</failIfNoTests>
+    <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <jetty.version>9.4.53.v20231009</jetty.version>
     <java.dev.jna.version>5.2.0</java.dev.jna.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

After HDDS-9741 upgraded Surefire from 3.0.0-M5 to 3.2.2, trying to run specific tests by setting `-Dtest` in the CLI fails with `No tests matching pattern "..." were executed`.

Example:

```
$ mvn -am -pl :hdds-server-scm -Dtest='TestBlockManager' clean test
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project hdds-annotation-processing: No tests matching pattern "TestBlockManager" were executed! (Set -Dsurefire.failIfNoSpecifiedTests=false to ignore this error.) 
```

The problem is that the default value of [`failIfNoSpecifiedTests`](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#failIfNoSpecifiedTests) was changed to `true` in 3.0.0-M6 by [SUREFIRE-1910](https://issues.apache.org/jira/browse/SUREFIRE-1910).

https://issues.apache.org/jira/browse/HDDS-9757

## How was this patch tested?

```
$ mvn -am -pl :hdds-server-scm -Dtest='TestBlockManager' clean test
...
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.494 s -- in org.apache.hadoop.hdds.scm.block.TestBlockManager
```