### PR TITLE
HDDS-9749. Infinite loop in ReconUtils.nextClosestPowerIndexOfTwo().

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
 
+import com.google.common.base.Preconditions;
 import com.google.inject.Singleton;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
@@ -314,6 +315,8 @@ public class ReconUtils {
 
 
   public static int getFileSizeBinIndex(long fileSize) {
+    Preconditions.checkArgument(fileSize >= 0,
+        "fileSize = %s < 0", fileSize);
     // if the file size is larger than our track scope,
     // we map it to the last bin
     if (fileSize >= ReconConstants.MAX_FILE_SIZE_UPPER_BOUND) {
@@ -326,6 +329,8 @@ public class ReconUtils {
   }
 
   public static int getContainerSizeBinIndex(long containerSize) {
+    Preconditions.checkArgument(containerSize >= 0,
+        "containerSize = %s < 0", containerSize);
     // if the container size is larger than our track scope,
     // we map it to the last bin
     if (containerSize >= ReconConstants.MAX_CONTAINER_SIZE_UPPER_BOUND) {
@@ -337,13 +342,11 @@ public class ReconUtils {
     return index < 29 ? 0 : index - 29;
   }
 
-  private static int nextClosestPowerIndexOfTwo(long dataSize) {
-    int index = 0;
-    while (dataSize != 0) {
-      dataSize >>= 1;
-      index += 1;
-    }
-    return index;
+  static int nextClosestPowerIndexOfTwo(long n) {
+    return n > 0 ? 64 - Long.numberOfLeadingZeros(n - 1)
+        : n == 0 ? 0
+        : n == Long.MIN_VALUE ? -63
+        : -nextClosestPowerIndexOfTwo(-n);
   }
 
   public SCMNodeDetails getReconNodeDetails(OzoneConfiguration conf) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -169,7 +169,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
           process(container, containerSizeCountMap);
         } catch (Exception e) {
           // FIXME: it is a bug if there is an exception.
-          LOG.error("FIXME: Unexpected failure when processing " + container, e);
+          LOG.error("FIXME: Failed to process " + container, e);
         }
       }
 
@@ -313,7 +313,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
       Map<ContainerSizeCountKey, Long> containerSizeCountMap) {
     ContainerSizeCountKey key = getContainerSizeCountKey(containerSize);
     containerSizeCountMap.compute(key,
-        (k, previous) -> previous != null? previous + delta: delta);
+        (k, previous) -> previous != null ? previous + delta : delta);
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -121,13 +121,12 @@ public class ContainerSizeCountTask extends ReconScmTask {
   private void process(ContainerInfo container,
       Map<ContainerSizeCountKey, Long> map) {
     final ContainerID id = container.containerID();
-    final Long currentSize = container.getUsedBytes();
+    final long currentSize = container.getUsedBytes();
     final Long previousSize = processedContainers.put(id, currentSize);
-    incrementContainerSizeCount(currentSize, map);
-    if (currentSize.equals(previousSize)) {
-      // Container Size is changed
+    if (previousSize != null) {
       decrementContainerSizeCount(previousSize, map);
     }
+    incrementContainerSizeCount(currentSize, map);
   }
 
   /**
@@ -283,7 +282,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
    *
    * @param containerSize to calculate the upperSizeBound
    */
-  private void incrementContainerSizeCount(long containerSize,
+  private static void incrementContainerSizeCount(long containerSize,
                    Map<ContainerSizeCountKey, Long> containerSizeCountMap) {
     updateContainerSizeCount(containerSize, 1, containerSizeCountMap);
   }
@@ -304,12 +303,12 @@ public class ContainerSizeCountTask extends ReconScmTask {
    *
    * @param containerSize to calculate the upperSizeBound
    */
-  private void decrementContainerSizeCount(long containerSize,
+  private static void decrementContainerSizeCount(long containerSize,
                    Map<ContainerSizeCountKey, Long> containerSizeCountMap) {
     updateContainerSizeCount(containerSize, -1, containerSizeCountMap);
   }
 
-  private void updateContainerSizeCount(long containerSize, int delta,
+  private static void updateContainerSizeCount(long containerSize, int delta,
       Map<ContainerSizeCountKey, Long> containerSizeCountMap) {
     ContainerSizeCountKey key = getContainerSizeCountKey(containerSize);
     containerSizeCountMap.compute(key,
@@ -328,7 +327,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
    *
    * @param containerSize to calculate the upperSizeBound
    */
-  private ContainerSizeCountKey getContainerSizeCountKey(
+  private static ContainerSizeCountKey getContainerSizeCountKey(
       long containerSize) {
     return new ContainerSizeCountKey(
         ReconUtils.getContainerSizeUpperBound(containerSize));

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -206,14 +206,14 @@ public class TestReconUtils {
     assertNextClosestPowerIndexOfTwo(Long.MAX_VALUE);
     assertNextClosestPowerIndexOfTwo(Long.MIN_VALUE);
 
-    for(long n = 1; n != 0; n <<= 1) {
+    for (long n = 1; n != 0; n <<= 1) {
       assertNextClosestPowerIndexOfTwo(n);
       assertNextClosestPowerIndexOfTwo(n + 1);
       assertNextClosestPowerIndexOfTwo(n - 1);
     }
 
     final Random random = new Random();
-    for(int i = 0; i < 10; i++) {
+    for (int i = 0; i < 10; i++) {
       assertNextClosestPowerIndexOfTwo(random.nextLong());
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -38,6 +38,7 @@ import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
 import java.net.URL;
+import java.util.Random;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -195,5 +196,49 @@ public class TestReconUtils {
     ReconUtils reconUtils = new ReconUtils();
     File latestValidFile = reconUtils.getLastKnownDB(newDir, "valid");
     assertTrue(latestValidFile.getName().equals("valid_2"));
+  }
+
+  @Test
+  public void testNextClosestPowerIndexOfTwo() {
+    assertNextClosestPowerIndexOfTwo(0);
+    assertNextClosestPowerIndexOfTwo(1);
+    assertNextClosestPowerIndexOfTwo(-1);
+    assertNextClosestPowerIndexOfTwo(Long.MAX_VALUE);
+    assertNextClosestPowerIndexOfTwo(Long.MIN_VALUE);
+
+    for(long n = 1; n != 0; n <<= 1) {
+      assertNextClosestPowerIndexOfTwo(n);
+      assertNextClosestPowerIndexOfTwo(n + 1);
+      assertNextClosestPowerIndexOfTwo(n - 1);
+    }
+
+    final Random random = new Random();
+    for(int i = 0; i < 10; i++) {
+      assertNextClosestPowerIndexOfTwo(random.nextLong());
+    }
+  }
+
+  static void assertNextClosestPowerIndexOfTwo(long n) {
+    final int expected = oldNextClosestPowerIndexOfTwoFixed(n);
+    final int computed = ReconUtils.nextClosestPowerIndexOfTwo(n);
+    Assert.assertEquals("n=" + n, expected, computed);
+  }
+
+  private static int oldNextClosestPowerIndexOfTwoFixed(long n) {
+    return n == 0 ? 0
+        : n == Long.MIN_VALUE ? -63
+        : n == Long.highestOneBit(n) ? 63 - Long.numberOfLeadingZeros(n)
+        : n > 0 ? oldNextClosestPowerIndexOfTwo(n)
+        : -oldNextClosestPowerIndexOfTwoFixed(-n);
+  }
+
+  /** The old buggy method works only for n >= 0 with n not a power of 2. */
+  private static int oldNextClosestPowerIndexOfTwo(long dataSize) {
+    int index = 0;
+    while (dataSize != 0) {
+      dataSize >>= 1;
+      index += 1;
+    }
+    return index;
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
@@ -79,6 +79,11 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
 
   @Test
   public void testProcess() {
+    // mock a container with invalid used bytes
+    final ContainerInfo omContainerInfo0 = mock(ContainerInfo.class);
+    given(omContainerInfo0.containerID()).willReturn(new ContainerID(3));
+    given(omContainerInfo0.getUsedBytes()).willReturn(-1L);
+
     // Write 2 keys
     ContainerInfo omContainerInfo1 = mock(ContainerInfo.class);
     given(omContainerInfo1.containerID()).willReturn(new ContainerID(1));
@@ -90,6 +95,7 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
 
     // mock getContainers method to return a list of containers
     List<ContainerInfo> containers = new ArrayList<>();
+    containers.add(omContainerInfo0);
     containers.add(omContainerInfo1);
     containers.add(omContainerInfo2);
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
@@ -81,7 +81,7 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
   public void testProcess() {
     // mock a container with invalid used bytes
     final ContainerInfo omContainerInfo0 = mock(ContainerInfo.class);
-    given(omContainerInfo0.containerID()).willReturn(new ContainerID(3));
+    given(omContainerInfo0.containerID()).willReturn(new ContainerID(0));
     given(omContainerInfo0.getUsedBytes()).willReturn(-1L);
 
     // Write 2 keys


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the following method which does not work for 
- negative number (infinite loop), and
- positive power of two (incorrect value).
```java
//ReconUtils
  private static int nextClosestPowerIndexOfTwo(long dataSize) {
    int index = 0;
    while (dataSize != 0) {
      dataSize >>= 1;
      index += 1;
    }
    return index;
  }
```

## What is the link to the Apache JIRA

HDDS-9749

## How was this patch tested?

Added a new test.