### PR TITLE
HDDS-9491. Migrate tests in hdds to JUnit5

### DIFF
--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Client</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestContainerClientMetrics.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestContainerClientMetrics.java
@@ -21,21 +21,22 @@ package org.apache.hadoop.hdds.scm;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test ContainerClientMetrics.
  */
 public class TestContainerClientMetrics {
-  @Before
+  @BeforeEach
   public void setup() {
     while (ContainerClientMetrics.referenceCount > 0) {
       ContainerClientMetrics.release();
@@ -81,27 +82,27 @@ public class TestContainerClientMetrics {
         metrics.getWriteChunksCallsByLeaders().get(leaderId2).value());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testReleaseWithoutUse() {
-    ContainerClientMetrics.release();
+    assertThrows(IllegalStateException.class, ContainerClientMetrics::release);
   }
 
   @Test
   public void testAcquireAndRelease() {
-    Assertions.assertNotNull(ContainerClientMetrics.acquire());
-    Assertions.assertEquals(1, ContainerClientMetrics.referenceCount);
+    assertNotNull(ContainerClientMetrics.acquire());
+    assertEquals(1, ContainerClientMetrics.referenceCount);
     ContainerClientMetrics.release();
-    Assertions.assertEquals(0, ContainerClientMetrics.referenceCount);
+    assertEquals(0, ContainerClientMetrics.referenceCount);
 
-    Assertions.assertNotNull(ContainerClientMetrics.acquire());
-    Assertions.assertNotNull(ContainerClientMetrics.acquire());
-    Assertions.assertEquals(2, ContainerClientMetrics.referenceCount);
+    assertNotNull(ContainerClientMetrics.acquire());
+    assertNotNull(ContainerClientMetrics.acquire());
+    assertEquals(2, ContainerClientMetrics.referenceCount);
     ContainerClientMetrics.release();
     ContainerClientMetrics.release();
-    Assertions.assertEquals(0, ContainerClientMetrics.referenceCount);
+    assertEquals(0, ContainerClientMetrics.referenceCount);
 
     ContainerClientMetrics.acquire();
-    Assertions.assertNotNull(ContainerClientMetrics.acquire());
+    assertNotNull(ContainerClientMetrics.acquire());
   }
 
   private Pipeline createPipeline(PipelineID piplineId, UUID leaderId) {

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.ratis.thirdparty.io.grpc.Status;
 import org.apache.ratis.thirdparty.io.grpc.StatusException;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,6 +61,10 @@ import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
 import static org.apache.hadoop.hdds.scm.storage.TestChunkInputStream.generateRandomData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -137,8 +140,8 @@ public class TestBlockInputStream {
 
   private void seekAndVerify(int pos) throws Exception {
     blockStream.seek(pos);
-    Assert.assertEquals("Current position of buffer does not match with the " +
-        "seeked position", pos, blockStream.getPos());
+    assertEquals(pos, blockStream.getPos(),
+        "Current position of buffer does not match with the sought position");
   }
 
   /**
@@ -152,7 +155,7 @@ public class TestBlockInputStream {
   private void matchWithInputData(byte[] readData, int inputDataStartIndex,
       int length) {
     for (int i = inputDataStartIndex; i < inputDataStartIndex + length; i++) {
-      Assert.assertEquals(blockData[i], readData[i - inputDataStartIndex]);
+      assertEquals(blockData[i], readData[i - inputDataStartIndex]);
     }
   }
 
@@ -161,36 +164,27 @@ public class TestBlockInputStream {
     // Seek to position 0
     int pos = 0;
     seekAndVerify(pos);
-    Assert.assertEquals("ChunkIndex is incorrect", 0,
-        blockStream.getChunkIndex());
+    assertEquals(0, blockStream.getChunkIndex(), "ChunkIndex is incorrect");
 
     // Before BlockInputStream is initialized (initialization happens during
     // read operation), seek should update the BlockInputStream#blockPosition
     pos = CHUNK_SIZE;
     seekAndVerify(pos);
-    Assert.assertEquals("ChunkIndex is incorrect", 0,
-        blockStream.getChunkIndex());
-    Assert.assertEquals(pos, blockStream.getBlockPosition());
+    assertEquals(0, blockStream.getChunkIndex(), "ChunkIndex is incorrect");
+    assertEquals(pos, blockStream.getBlockPosition());
 
-    // Initialize the BlockInputStream. After initializtion, the chunkIndex
-    // should be updated to correspond to the seeked position.
+    // Initialize the BlockInputStream. After initialization, the chunkIndex
+    // should be updated to correspond to the sought position.
     blockStream.initialize();
-    Assert.assertEquals("ChunkIndex is incorrect", 1,
-        blockStream.getChunkIndex());
+    assertEquals(1, blockStream.getChunkIndex(), "ChunkIndex is incorrect");
 
     pos = (CHUNK_SIZE * 4) + 5;
     seekAndVerify(pos);
-    Assert.assertEquals("ChunkIndex is incorrect", 4,
-        blockStream.getChunkIndex());
+    assertEquals(4, blockStream.getChunkIndex(), "ChunkIndex is incorrect");
+    pos = blockSize + 10;
 
-    try {
-      // Try seeking beyond the blockSize.
-      pos = blockSize + 10;
-      seekAndVerify(pos);
-      Assert.fail("Seek to position beyond block size should fail.");
-    } catch (EOFException e) {
-      System.out.println(e);
-    }
+    int finalPos = pos;
+    assertThrows(EOFException.class, () -> seekAndVerify(finalPos));
 
     // Seek to random positions between 0 and the block size.
     Random random = new Random();
@@ -212,8 +206,8 @@ public class TestBlockInputStream {
 
     // The new position of the blockInputStream should be the last index read
     // + 1.
-    Assert.assertEquals(250, blockStream.getPos());
-    Assert.assertEquals(2, blockStream.getChunkIndex());
+    assertEquals(250, blockStream.getPos());
+    assertEquals(2, blockStream.getChunkIndex());
   }
 
   @Test
@@ -228,8 +222,8 @@ public class TestBlockInputStream {
 
     // The new position of the blockInputStream should be the last index read
     // + 1.
-    Assert.assertEquals(250, blockStream.getPos());
-    Assert.assertEquals(2, blockStream.getChunkIndex());
+    assertEquals(250, blockStream.getPos());
+    assertEquals(2, blockStream.getChunkIndex());
   }
 
   @Test
@@ -241,13 +235,13 @@ public class TestBlockInputStream {
     ByteBuffer buffer = ByteBuffer.allocateDirect(200);
     blockStream.read(buffer);
     for (int i = 50; i < 50 + 200; i++) {
-      Assert.assertEquals(blockData[i], buffer.get(i - 50));
+      assertEquals(blockData[i], buffer.get(i - 50));
     }
 
     // The new position of the blockInputStream should be the last index read
     // + 1.
-    Assert.assertEquals(250, blockStream.getPos());
-    Assert.assertEquals(2, blockStream.getChunkIndex());
+    assertEquals(250, blockStream.getPos());
+    assertEquals(2, blockStream.getChunkIndex());
   }
 
   @Test
@@ -269,19 +263,16 @@ public class TestBlockInputStream {
     BlockID blockID = new BlockID(new ContainerBlockID(1, 1));
     AtomicBoolean isRefreshed = new AtomicBoolean();
     createChunkList(5);
-    BlockInputStream blockInputStreamWithRetry =
-        new DummyBlockInputStreamWithRetry(blockID, blockSize,
-            MockPipeline.createSingleNodePipeline(), null,
-            false, null, chunks, chunkDataMap, isRefreshed, null);
 
-    try {
-      Assert.assertFalse(isRefreshed.get());
+    try (BlockInputStream blockInputStreamWithRetry =
+             new DummyBlockInputStreamWithRetry(blockID, blockSize,
+                 MockPipeline.createSingleNodePipeline(), null,
+                 false, null, chunks, chunkDataMap, isRefreshed, null)) {
+      assertFalse(isRefreshed.get());
       seekAndVerify(50);
       byte[] b = new byte[200];
       blockInputStreamWithRetry.read(b, 0, 200);
-      Assert.assertTrue(isRefreshed.get());
-    } finally {
-      blockInputStreamWithRetry.close();
+      assertTrue(isRefreshed.get());
     }
   }
 
@@ -329,7 +320,7 @@ public class TestBlockInputStream {
       int bytesRead = subject.read(b, 0, len);
 
       // THEN
-      Assert.assertEquals(len, bytesRead);
+      assertEquals(len, bytesRead);
       verify(this.refreshFunction).apply(blockID);
     } finally {
       reset(this.refreshFunction);
@@ -442,7 +433,7 @@ public class TestBlockInputStream {
       int bytesRead = subject.read(b, 0, len);
 
       // THEN
-      Assert.assertEquals(len, bytesRead);
+      assertEquals(len, bytesRead);
       verify(refreshFunction).apply(blockID);
       verify(clientFactory).acquireClientForReadData(pipeline);
       verify(clientFactory).releaseClientForReadData(client, false);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -22,8 +22,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.client.BlockID;
@@ -45,9 +43,10 @@ import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * UNIT test for BlockOutputStream.
@@ -105,7 +104,7 @@ public class TestBlockOutputStreamCorrectness {
     config.setChecksumType(ChecksumType.NONE);
     config.setBytesPerChecksum(256 * 1024);
 
-    BlockOutputStream outputStream = new RatisBlockOutputStream(
+    return new RatisBlockOutputStream(
         new BlockID(1L, 1L),
         xcm,
         pipeline,
@@ -113,7 +112,6 @@ public class TestBlockOutputStreamCorrectness {
         config,
         null,
         ContainerClientMetrics.acquire());
-    return outputStream;
   }
 
   /**
@@ -123,9 +121,9 @@ public class TestBlockOutputStreamCorrectness {
 
     private final Pipeline pipeline;
 
-    private Random expectedRandomStream = new Random(SEED);
+    private final Random expectedRandomStream = new Random(SEED);
 
-    private AtomicInteger counter = new AtomicInteger();
+    private final AtomicInteger counter = new AtomicInteger();
 
     MockXceiverClientSpi(Pipeline pipeline) {
       super();
@@ -133,12 +131,12 @@ public class TestBlockOutputStreamCorrectness {
     }
 
     @Override
-    public void connect() throws Exception {
+    public void connect() {
 
     }
 
     @Override
-    public void connect(String encodedToken) throws Exception {
+    public void connect(String encodedToken) {
 
     }
 
@@ -155,9 +153,7 @@ public class TestBlockOutputStreamCorrectness {
     @Override
     public XceiverClientReply sendCommandAsync(
         ContainerCommandRequestProto request
-    )
-        throws IOException, ExecutionException, InterruptedException {
-
+    ) {
       final ContainerCommandResponseProto.Builder builder =
           ContainerCommandResponseProto.newBuilder()
               .setResult(Result.SUCCESS)
@@ -178,10 +174,9 @@ public class TestBlockOutputStreamCorrectness {
       case WriteChunk:
         ByteString data = request.getWriteChunk().getData();
         final byte[] writePayload = data.toByteArray();
-        for (int i = 0; i < writePayload.length; i++) {
+        for (byte b : writePayload) {
           byte expectedByte = (byte) expectedRandomStream.nextInt();
-          Assert.assertEquals(expectedByte,
-              writePayload[i]);
+          assertEquals(expectedByte, b);
         }
         break;
       default:
@@ -200,9 +195,7 @@ public class TestBlockOutputStreamCorrectness {
     }
 
     @Override
-    public XceiverClientReply watchForCommit(long index)
-        throws InterruptedException, ExecutionException, TimeoutException,
-        IOException {
+    public XceiverClientReply watchForCommit(long index) {
       final ContainerCommandResponseProto.Builder builder =
           ContainerCommandResponseProto.newBuilder()
               .setCmdType(Type.WriteChunk)
@@ -220,8 +213,7 @@ public class TestBlockOutputStreamCorrectness {
 
     @Override
     public Map<DatanodeDetails, ContainerCommandResponseProto>
-        sendCommandOnAllNodes(ContainerCommandRequestProto request
-    ) throws IOException, InterruptedException {
+        sendCommandOnAllNodes(ContainerCommandRequestProto request) {
       return null;
     }
   }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/ECStreamTestUtil.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/ECStreamTestUtil.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
 import org.apache.ozone.erasurecode.rawcoder.util.CodecUtil;
 import org.apache.ratis.util.Preconditions;
-import org.junit.Assert;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -46,6 +45,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SplittableRandom;
 import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Utility class providing methods useful in EC tests.
@@ -151,8 +152,8 @@ public final class ECStreamTestUtil {
     int i = 0;
     while (b.hasRemaining()) {
       i++;
-      Assert.assertEquals("Failed on iteration " + i,
-          (byte)rand.nextInt(255), b.get());
+      assertEquals((byte) rand.nextInt(255), b.get(),
+          "Failed on iteration " + i);
     }
   }
 

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -28,6 +28,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Common</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/Proto2CodecTestBase.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/Proto2CodecTestBase.java
@@ -18,44 +18,37 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-
-import static org.junit.Assert.fail;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test {@link Proto2Codec} related classes.
  */
 public abstract class Proto2CodecTestBase<T> {
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   public abstract Codec<T> getCodec();
 
   @Test
   public void testInvalidProtocolBuffer() throws Exception {
-    try {
-      getCodec().fromPersistedFormat("random".getBytes(StandardCharsets.UTF_8));
-      fail("testInvalidProtocolBuffer failed");
-    } catch (InvalidProtocolBufferException e) {
-      GenericTestUtils.assertExceptionContains(
-          "the input ended unexpectedly", e);
-    }
+    InvalidProtocolBufferException exception =
+        assertThrows(InvalidProtocolBufferException.class,
+            () -> getCodec().fromPersistedFormat("random".getBytes(UTF_8)));
+    assertThat(exception.getMessage(),
+        containsString("the input ended unexpectedly"));
   }
 
   @Test
-  public void testFromPersistedFormat() throws Exception {
-    thrown.expect(NullPointerException.class);
-    getCodec().fromPersistedFormat(null);
+  public void testFromPersistedFormat() {
+    assertThrows(NullPointerException.class,
+        () -> getCodec().fromPersistedFormat(null));
   }
 
   @Test
   public void testToPersistedFormat() throws Exception {
-    thrown.expect(NullPointerException.class);
-    getCodec().toPersistedFormat(null);
+    assertThrows(NullPointerException.class,
+        () -> getCodec().toPersistedFormat(null));
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
@@ -46,9 +46,11 @@ import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.security.token.Token;
 
 import com.google.common.base.Preconditions;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Helpers for container tests.
@@ -445,8 +447,8 @@ public final class ContainerTestHelper {
    */
   public static void verifyGetBlock(ContainerCommandRequestProto request,
       ContainerCommandResponseProto response, int expectedChunksCount) {
-    Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-    Assert.assertEquals(expectedChunksCount,
+    assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+    assertEquals(expectedChunksCount,
         response.getGetBlock().getBlockData().getChunksCount());
   }
 
@@ -626,7 +628,7 @@ public final class ContainerTestHelper {
       break;
 
     default:
-      Assert.fail("Unhandled request type " + cmdType + " in unit test");
+      fail("Unhandled request type " + cmdType + " in unit test");
     }
 
     return builder.build();

--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -29,7 +29,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <packaging>jar</packaging>
 
   <properties>
-
+    <allow.junit4>false</allow.junit4>
   </properties>
 
   <dependencies>

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileAppender.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileAppender.java
@@ -17,10 +17,12 @@
  */
 package org.apache.hadoop.hdds.conf;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.StringWriter;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test the utility which loads/writes the config file fragments.
@@ -38,11 +40,11 @@ public class TestConfigFileAppender {
 
     StringWriter builder = new StringWriter();
     appender.write(builder);
-
-    Assert.assertTrue("Generated config should contain property key entry",
-        builder.toString().contains("<name>hadoop.scm.enabled</name>"));
-
-    Assert.assertTrue("Generated config should contain tags",
-        builder.toString().contains("<tag>OZONE, SECURITY</tag>"));
+    assertThat("Generated config should contain property key entry",
+        builder.toString(),
+        containsString("<name>hadoop.scm.enabled</name>"));
+    assertThat("Generated config should contain tags",
+        builder.toString(),
+        containsString("<tag>OZONE, SECURITY</tag>"));
   }
 }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileGenerator.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileGenerator.java
@@ -22,14 +22,16 @@ import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test the ConfigFileGenerator.
  * <p>
  * ConfigFileGenerator is an annotation processor and activated for the
- * testCompile. Therefore in the unit test we can check the content of the
+ * testCompile. Therefore, in the unit test we can check the content of the
  * generated ozone-default-generated.xml
  */
 public class TestConfigFileGenerator {
@@ -42,21 +44,22 @@ public class TestConfigFileGenerator {
             .useDelimiter("//Z")
             .next();
 
-    Assert.assertTrue(
-        "Generated config should have entry based on the annotation",
-        generatedXml.contains("<name>ozone.scm.client.bind.host</name>"));
+    assertThat("Generated config should have entry based on the annotation",
+        generatedXml,
+        containsString("<name>ozone.scm.client.bind.host</name>"));
 
-    Assert.assertTrue(
-        "Generated config should have entry based on the annotation from the "
-            + "parent class",
-        generatedXml.contains("<name>ozone.scm.client.secure</name>"));
+    assertThat("Generated config should have entry based on the annotation " +
+            "from the parent class",
+        generatedXml,
+        containsString("<name>ozone.scm.client.secure</name>"));
 
-    Assert.assertTrue(
-        "Generated config should have entry based on the annotation from the "
-            + "grand-parent class.",
-        generatedXml.contains("<name>ozone.scm.client.number</name>"));
+    assertThat("Generated config should have entry based on the annotation " +
+            "from the grand-parent class.",
+        generatedXml,
+        containsString("<name>ozone.scm.client.number</name>"));
 
-    Assert.assertTrue("Generated config should contain tags",
-        generatedXml.contains("<tag>MANAGEMENT</tag>"));
+    assertThat("Generated config should contain tags",
+        generatedXml,
+        containsString("<tag>MANAGEMENT</tag>"));
   }
 }

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Server Framework</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestPemFileBasedKeyStoresFactory.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestPemFileBasedKeyStoresFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -40,9 +40,11 @@ import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.ClientAuth;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.net.ssl.SSLException;
 import java.util.ArrayList;
@@ -50,57 +52,43 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.SUCCESS;
 
 /**
  * Test PemFileBasedKeyStoresFactory.
  */
 public class TestPemFileBasedKeyStoresFactory {
-  private OzoneConfiguration conf;
   private CertificateClientTestImpl caClient;
   private SecurityConfig secConf;
   private static final int RELOAD_INTERVAL = 2000;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
-    conf = new OzoneConfiguration();
+    OzoneConfiguration conf = new OzoneConfiguration();
     caClient = new CertificateClientTestImpl(conf);
     secConf = new SecurityConfig(conf);
   }
-  @Test
-  public void testInit() throws Exception {
-    clientMode(true);
-    clientMode(false);
-    serverMode(true);
-    serverMode(false);
-  }
 
-  private void clientMode(boolean clientAuth) throws Exception {
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest
+  public void testInit(boolean clientAuth) throws Exception {
     KeyStoresFactory keyStoresFactory = new PemFileBasedKeyStoresFactory(
         secConf, caClient);
     try {
       keyStoresFactory.init(KeyStoresFactory.Mode.CLIENT, clientAuth);
-      if (clientAuth) {
-        Assert.assertTrue(keyStoresFactory.getKeyManagers()[0]
-            instanceof ReloadingX509KeyManager);
-      } else {
-        Assert.assertFalse(keyStoresFactory.getKeyManagers()[0]
-            instanceof ReloadingX509KeyManager);
-      }
-      Assert.assertTrue(keyStoresFactory.getTrustManagers()[0]
+      Assertions.assertEquals(clientAuth, keyStoresFactory.getKeyManagers()[0]
+          instanceof ReloadingX509KeyManager);
+      Assertions.assertTrue(keyStoresFactory.getTrustManagers()[0]
           instanceof ReloadingX509TrustManager);
     } finally {
       keyStoresFactory.destroy();
     }
-  }
 
-  private void serverMode(boolean clientAuth) throws Exception {
-    KeyStoresFactory keyStoresFactory = new PemFileBasedKeyStoresFactory(
-        secConf, caClient);
     try {
       keyStoresFactory.init(KeyStoresFactory.Mode.SERVER, clientAuth);
-      Assert.assertTrue(keyStoresFactory.getKeyManagers()[0]
+      Assertions.assertTrue(keyStoresFactory.getKeyManagers()[0]
           instanceof ReloadingX509KeyManager);
-      Assert.assertTrue(keyStoresFactory.getTrustManagers()[0]
+      Assertions.assertTrue(keyStoresFactory.getTrustManagers()[0]
           instanceof ReloadingX509TrustManager);
     } finally {
       keyStoresFactory.destroy();
@@ -129,8 +117,7 @@ public class TestPemFileBasedKeyStoresFactory {
 
       // send command
       ContainerCommandResponseProto responseProto = sendRequest(asyncStub);
-      Assert.assertTrue(responseProto.getResult() ==
-          ContainerProtos.Result.SUCCESS);
+      Assertions.assertEquals(SUCCESS, responseProto.getResult());
 
       // Renew certificate
       caClient.renewKey();
@@ -138,8 +125,7 @@ public class TestPemFileBasedKeyStoresFactory {
 
       // send command again
       responseProto = sendRequest(asyncStub);
-      Assert.assertTrue(responseProto.getResult() ==
-          ContainerProtos.Result.SUCCESS);
+      Assertions.assertEquals(SUCCESS, responseProto.getResult());
     } finally {
       if (channel != null) {
         channel.shutdownNow();
@@ -160,7 +146,7 @@ public class TestPemFileBasedKeyStoresFactory {
       XceiverClientProtocolServiceStub stub) throws Exception {
     DatanodeDetails dn = DatanodeDetails.newBuilder()
         .setUuid(UUID.randomUUID()).build();
-    List<DatanodeDetails> nodes = new ArrayList();
+    List<DatanodeDetails> nodes = new ArrayList<>();
     nodes.add(dn);
     Pipeline pipeline = Pipeline.newBuilder().setId(PipelineID.randomId())
         .setReplicationConfig(RatisReplicationConfig
@@ -189,6 +175,7 @@ public class TestPemFileBasedKeyStoresFactory {
     requestObserver.onCompleted();
     return replyFuture.get();
   }
+
   private ManagedChannel setupClient(KeyStoresFactory factory, int port)
       throws SSLException {
     NettyChannelBuilder channelBuilder =
@@ -217,9 +204,8 @@ public class TestPemFileBasedKeyStoresFactory {
   /**
    * Test Class to provide a server side service.
    */
-  public class GrpcService extends XceiverClientProtocolServiceImplBase {
-    public GrpcService() {
-    }
+  private static class GrpcService
+      extends XceiverClientProtocolServiceImplBase {
 
     @Override
     public StreamObserver<ContainerCommandRequestProto> send(
@@ -231,7 +217,7 @@ public class TestPemFileBasedKeyStoresFactory {
           ContainerCommandResponseProto resp =
               ContainerCommandResponseProto.newBuilder()
                   .setCmdType(ContainerProtos.Type.CreateContainer)
-                  .setResult(ContainerProtos.Result.SUCCESS)
+                  .setResult(SUCCESS)
                   .build();
           responseObserver.onNext(resp);
         }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509KeyManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509KeyManager.java
@@ -21,15 +21,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManager;
 import java.security.PrivateKey;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test ReloadingX509KeyManager.
@@ -40,7 +40,7 @@ public class TestReloadingX509KeyManager {
   private static OzoneConfiguration conf;
   private static CertificateClientTestImpl caClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     conf = new OzoneConfiguration();
     caClient = new CertificateClientTestImpl(conf);
@@ -48,8 +48,7 @@ public class TestReloadingX509KeyManager {
 
   @Test
   public void testReload() throws Exception {
-    KeyManager km =
-        caClient.getServerKeyStoresFactory().getKeyManagers()[0];
+    KeyManager km = caClient.getServerKeyStoresFactory().getKeyManagers()[0];
     PrivateKey privateKey1 = caClient.getPrivateKey();
     assertEquals(privateKey1, ((ReloadingX509KeyManager)km).getPrivateKey(
         caClient.getComponentName() + "_key"));

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
@@ -21,16 +21,17 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.security.cert.X509Certificate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Test ReloadingX509TrustManager.
@@ -38,12 +39,11 @@ import static org.junit.Assert.assertTrue;
 public class TestReloadingX509TrustManager {
   private final LogCapturer reloaderLog =
       LogCapturer.captureLogs(ReloadingX509TrustManager.LOG);
-  private static OzoneConfiguration conf;
   private static CertificateClientTestImpl caClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
-    conf = new OzoneConfiguration();
+    OzoneConfiguration conf = new OzoneConfiguration();
     caClient = new CertificateClientTestImpl(conf);
   }
 
@@ -53,7 +53,7 @@ public class TestReloadingX509TrustManager {
         (ReloadingX509TrustManager) caClient.getServerKeyStoresFactory()
             .getTrustManagers()[0];
     X509Certificate cert1 = caClient.getRootCACertificate();
-    MatcherAssert.assertThat(tm.getAcceptedIssuers(),
+    assertThat(tm.getAcceptedIssuers(),
         Matchers.arrayContaining(cert1));
 
     caClient.renewRootCA();
@@ -61,13 +61,10 @@ public class TestReloadingX509TrustManager {
     X509Certificate cert2 = caClient.getRootCACertificate();
     assertNotEquals(cert1, cert2);
 
-    MatcherAssert.assertThat(tm.getAcceptedIssuers(),
-        Matchers.hasItemInArray(cert1));
-    MatcherAssert.assertThat(tm.getAcceptedIssuers(),
-        Matchers.hasItemInArray(cert2));
-
-    assertTrue(reloaderLog.getOutput().contains(
-        "ReloadingX509TrustManager is reloaded"));
+    assertThat(tm.getAcceptedIssuers(), hasItemInArray(cert1));
+    assertThat(tm.getAcceptedIssuers(), hasItemInArray(cert2));
+    assertThat(reloaderLog.getOutput(),
+        containsString("ReloadingX509TrustManager is reloaded"));
 
     // Make sure there are two reload happened, one for server, one for client
     assertEquals(2, StringUtils.countMatches(reloaderLog.getOutput(),

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
@@ -32,9 +32,8 @@ import org.apache.hadoop.hdds.security.symmetric.SecretKeyTestUtil;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
@@ -50,8 +49,11 @@ import static org.apache.hadoop.ozone.container.ContainerTestHelper.getBlockRequ
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getReadChunkRequest;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.newPutBlockRequestBuilder;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.newWriteChunkRequestBuilder;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -67,12 +69,11 @@ public class TestOzoneBlockTokenSecretManager {
   private OzoneBlockTokenSecretManager secretManager;
   private UUID secretKeyId;
   private SecretKeyVerifierClient secretKeyClient;
-  private SecretKeySignerClient secretKeySignerClient;
   private TokenVerifier tokenVerifier;
   private Pipeline pipeline;
   private ManagedSecretKey secretKey;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     pipeline = MockPipeline.createPipeline(3);
 
@@ -85,7 +86,8 @@ public class TestOzoneBlockTokenSecretManager {
     secretKeyId = secretKey.getId();
 
     secretKeyClient = Mockito.mock(SecretKeyVerifierClient.class);
-    secretKeySignerClient = Mockito.mock(SecretKeySignerClient.class);
+    SecretKeySignerClient secretKeySignerClient =
+        Mockito.mock(SecretKeySignerClient.class);
     when(secretKeySignerClient.getCurrentSecretKey()).thenReturn(secretKey);
     when(secretKeyClient.getSecretKey(secretKeyId)).thenReturn(secretKey);
 
@@ -104,30 +106,30 @@ public class TestOzoneBlockTokenSecretManager {
         OzoneBlockTokenIdentifier.readFieldsProtobuf(new DataInputStream(
             new ByteArrayInputStream(token.getIdentifier())));
     // Check basic details.
-    Assert.assertEquals(OzoneBlockTokenIdentifier.getTokenService(blockID),
+    assertEquals(OzoneBlockTokenIdentifier.getTokenService(blockID),
         identifier.getService());
-    Assert.assertEquals(EnumSet.allOf(AccessModeProto.class),
+    assertEquals(EnumSet.allOf(AccessModeProto.class),
         identifier.getAccessModes());
-    Assert.assertEquals(secretKeyId, identifier.getSecretKeyId());
-
-    validateHash(token.getPassword(), token.getIdentifier());
+    assertEquals(secretKeyId, identifier.getSecretKeyId());
+    assertFalse(secretKey.isValidSignature(token.getPassword(),
+        token.getIdentifier()));
   }
 
   @Test
-  public void testCreateIdentifierSuccess() throws Exception {
+  public void testCreateIdentifierSuccess() {
     BlockID blockID = new BlockID(101, 0);
     OzoneBlockTokenIdentifier btIdentifier = secretManager.createIdentifier(
         "testUser", blockID, EnumSet.allOf(AccessModeProto.class), 100);
 
     // Check basic details.
-    Assert.assertEquals("testUser", btIdentifier.getOwnerId());
-    Assert.assertEquals(BlockTokenVerifier.getTokenService(blockID),
+    assertEquals("testUser", btIdentifier.getOwnerId());
+    assertEquals(BlockTokenVerifier.getTokenService(blockID),
         btIdentifier.getService());
-    Assert.assertEquals(EnumSet.allOf(AccessModeProto.class),
+    assertEquals(EnumSet.allOf(AccessModeProto.class),
         btIdentifier.getAccessModes());
     byte[] hash = secretManager.createPassword(btIdentifier);
-    Assert.assertEquals(secretKeyId, btIdentifier.getSecretKeyId());
-    validateHash(hash, btIdentifier.getBytes());
+    assertEquals(secretKeyId, btIdentifier.getSecretKeyId());
+    assertFalse(secretKey.isValidSignature(hash, btIdentifier.getBytes()));
   }
 
   @Test
@@ -171,15 +173,11 @@ public class TestOzoneBlockTokenSecretManager {
     // THEN
     BlockTokenException e = assertThrows(BlockTokenException.class,
         () -> tokenVerifier.verify("testUser", token, writeChunkRequest));
-    String msg = e.getMessage();
-    assertTrue(msg, msg.contains("Token for ID: " +
+
+    assertThat(e.getMessage(), containsString("Token for ID: " +
         OzoneBlockTokenIdentifier.getTokenService(blockID) +
         " can't be used to access: " +
         OzoneBlockTokenIdentifier.getTokenService(otherBlockID)));
-  }
-
-  private void validateHash(byte[] hash, byte[] identifier) throws Exception {
-    assertTrue(secretKey.isValidSignature(identifier, hash));
   }
 
   @Test
@@ -203,8 +201,9 @@ public class TestOzoneBlockTokenSecretManager {
 
     BlockTokenException e = assertThrows(BlockTokenException.class,
         () -> tokenVerifier.verify(testUser1, token, putBlockCommand));
-    String msg = e.getMessage();
-    assertTrue(msg, msg.contains("doesn't have WRITE permission"));
+
+    assertThat(e.getMessage(),
+        containsString("doesn't have WRITE permission"));
 
     tokenVerifier.verify(testUser1, token, getBlockCommand);
   }
@@ -228,8 +227,8 @@ public class TestOzoneBlockTokenSecretManager {
 
     BlockTokenException e = assertThrows(BlockTokenException.class,
         () -> tokenVerifier.verify(testUser2, token, readChunkRequest));
-    String msg = e.getMessage();
-    assertTrue(msg, msg.contains("doesn't have READ permission"));
+    assertThat(e.getMessage(),
+        containsString("doesn't have READ permission"));
   }
 
   @Test
@@ -252,9 +251,8 @@ public class TestOzoneBlockTokenSecretManager {
 
     BlockTokenException e = assertThrows(BlockTokenException.class,
         () -> tokenVerifier.verify(user, token, writeChunkRequest));
-    String msg = e.getMessage();
-    assertTrue(msg, msg.contains("Token can't be verified due to" +
-        " expired secret key"));
+    assertThat(e.getMessage(),
+        containsString("Token can't be verified due to expired secret key"));
   }
 
   private ManagedSecretKey generateValidSecretKey()

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
@@ -52,8 +52,8 @@ import static org.apache.hadoop.ozone.container.ContainerTestHelper.newWriteChun
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -111,8 +111,8 @@ public class TestOzoneBlockTokenSecretManager {
     assertEquals(EnumSet.allOf(AccessModeProto.class),
         identifier.getAccessModes());
     assertEquals(secretKeyId, identifier.getSecretKeyId());
-    assertFalse(secretKey.isValidSignature(token.getPassword(),
-        token.getIdentifier()));
+    assertTrue(secretKey.isValidSignature(token.getIdentifier(),
+        token.getPassword()));
   }
 
   @Test
@@ -129,7 +129,7 @@ public class TestOzoneBlockTokenSecretManager {
         btIdentifier.getAccessModes());
     byte[] hash = secretManager.createPassword(btIdentifier);
     assertEquals(secretKeyId, btIdentifier.getSecretKeyId());
-    assertFalse(secretKey.isValidSignature(hash, btIdentifier.getBytes()));
+    assertTrue(secretKey.isValidSignature(btIdentifier.getBytes(), hash));
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
@@ -30,19 +30,17 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.recon.ReconConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.test.PathUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -50,8 +48,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class TestServerUtils {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   /**
    * Test case for {@link ServerUtils#getPermissions}.
@@ -84,7 +82,7 @@ public class TestServerUtils {
   public void testGetDirectoryFromConfigWithOctalPermissions()
       throws IOException {
     // Create a temporary directory
-    String filePath = folder.getRoot().getAbsolutePath();
+    String filePath = folder.toAbsolutePath().toString();
 
     // Create an OzoneConfiguration object
     OzoneConfiguration conf = new OzoneConfiguration();
@@ -127,7 +125,7 @@ public class TestServerUtils {
   public void testGetDirectoryFromConfigWithSymbolicPermissions()
       throws IOException {
     // Create a temporary directory
-    String filePath = folder.getRoot().getAbsolutePath();
+    String filePath = folder.toAbsolutePath().toString();
 
     OzoneConfiguration conf = new OzoneConfiguration();
     String key = OzoneConfigKeys.OZONE_METADATA_DIRS;
@@ -162,8 +160,8 @@ public class TestServerUtils {
   public void testGetDirectoryFromConfigWithMultipleDirectories()
       throws IOException {
     // Create temporary directories
-    File dir1 = folder.newFolder("dir1");
-    File dir2 = folder.newFolder("dir2");
+    File dir1 = new File(folder.toFile(), "dir1");
+    File dir2 = new File(folder.toFile(), "dir2");
 
     // Create an OzoneConfiguration object
     OzoneConfiguration conf = new OzoneConfiguration();
@@ -198,9 +196,8 @@ public class TestServerUtils {
    */
   @Test
   public void testGetScmDbDir() {
-    final File testDir = PathUtils.getTestDir(TestServerUtils.class);
-    final File dbDir = new File(testDir, "scmDbDir");
-    final File metaDir = new File(testDir, "metaDir");
+    final File dbDir = new File(folder.toFile(), "scmDbDir");
+    final File metaDir = new File(folder.toFile(), "metaDir");
     final OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.OZONE_SCM_DB_DIRS, dbDir.getPath());
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDir.getPath());
@@ -222,8 +219,7 @@ public class TestServerUtils {
    */
   @Test
   public void testGetScmDbDirWithFallback() {
-    final File testDir = PathUtils.getTestDir(TestServerUtils.class);
-    final File metaDir = new File(testDir, "metaDir");
+    final File metaDir = new File(folder.toFile(), "metaDir");
     final OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDir.getPath());
     try {
@@ -249,8 +245,7 @@ public class TestServerUtils {
 
   @Test
   public void ozoneMetadataDirAcceptsSingleItem() {
-    final File testDir = PathUtils.getTestDir(TestServerUtils.class);
-    final File metaDir = new File(testDir, "metaDir");
+    final File metaDir = new File(folder.toFile(), "metaDir");
     final OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDir.getPath());
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2Metrics.java
@@ -33,8 +33,8 @@ import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Random;
@@ -48,7 +48,7 @@ public class TestHttpServer2Metrics {
   private MetricsCollector metricsCollector;
   private MetricsRecordBuilder recorder;
 
-  @Before
+  @BeforeEach
   public void setup() {
     threadPool = Mockito.mock(QueuedThreadPool.class);
     metricsCollector = Mockito.mock(MetricsCollector.class);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -24,11 +24,9 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.Assert;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -38,6 +36,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests RDBStore creation.
@@ -52,21 +56,21 @@ public class TestDBStoreBuilder {
   @Test
   public void builderWithoutAnyParams() {
     OzoneConfiguration conf = new OzoneConfiguration();
-    Assertions.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> DBStoreBuilder.newBuilder(conf).build());
   }
 
   @Test
   public void builderWithOneParamV1() {
     OzoneConfiguration conf = new OzoneConfiguration();
-    Assertions.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> DBStoreBuilder.newBuilder(conf).setName("Test.db").build());
   }
 
   @Test
   public void builderWithOneParamV2(@TempDir Path tempDir) {
     OzoneConfiguration conf = new OzoneConfiguration();
-    Assertions.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> DBStoreBuilder.newBuilder(conf).setPath(tempDir).build());
   }
 
@@ -102,7 +106,7 @@ public class TestDBStoreBuilder {
           RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
       firstTable.put(key, value);
       byte[] temp = firstTable.get(key);
-      Assertions.assertArrayEquals(value, temp);
+      assertArrayEquals(value, temp);
     }
 
     dbStore.close();
@@ -124,11 +128,11 @@ public class TestDBStoreBuilder {
             RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
         firstTable.put(key, value);
         byte[] temp = firstTable.get(key);
-        Assertions.assertArrayEquals(value, temp);
+        assertArrayEquals(value, temp);
       }
 
       try (Table secondTable = dbStore.getTable("Second")) {
-        Assertions.assertTrue(secondTable.isEmpty());
+        assertTrue(secondTable.isEmpty());
       }
     }
   }
@@ -151,11 +155,11 @@ public class TestDBStoreBuilder {
             RandomStringUtils.random(9).getBytes(StandardCharsets.UTF_8);
         firstTable.put(key, value);
         byte[] temp = firstTable.get(key);
-        Assertions.assertArrayEquals(value, temp);
+        assertArrayEquals(value, temp);
       }
 
       try (Table secondTable = dbStore.getTable("Second")) {
-        Assertions.assertTrue(secondTable.isEmpty());
+        assertTrue(secondTable.isEmpty());
       }
     }
   }
@@ -168,7 +172,7 @@ public class TestDBStoreBuilder {
     File newFolder = new File(tempDir.toString() + "/newFolder");
 
     if (!newFolder.exists()) {
-      Assert.assertTrue(newFolder.mkdirs());
+      assertTrue(newFolder.mkdirs());
     }
 
     String sampleTableName = "sampleTable";
@@ -203,14 +207,14 @@ public class TestDBStoreBuilder {
 
     try (DBStore dbStore = DBStoreBuilder.newBuilder(conf, sampleDB)
         .setName("SampleStore").setPath(newFolder.toPath()).build()) {
-      Assert.assertTrue(dbStore instanceof RDBStore);
+      assertTrue(dbStore instanceof RDBStore);
 
       RDBStore rdbStore = (RDBStore) dbStore;
       Collection<RocksDatabase.ColumnFamily> cfFamilies =
           rdbStore.getColumnFamilies();
 
       // we also have the default column family, so there are 2
-      Assert.assertEquals(2, cfFamilies.size());
+      assertEquals(2, cfFamilies.size());
 
       boolean checked = false;
       for (RocksDatabase.ColumnFamily cfFamily : cfFamilies) {
@@ -221,12 +225,12 @@ public class TestDBStoreBuilder {
               .forceConsistencyChecks();
 
           // the value should be different from the default value
-          Assert.assertNotEquals(cfFamily.getHandle().getDescriptor()
+          assertNotEquals(cfFamily.getHandle().getDescriptor()
               .getOptions().forceConsistencyChecks(), defaultValue);
           checked = true;
         }
       }
-      Assert.assertTrue(checked);
+      assertTrue(checked);
     }
   }
 
@@ -240,7 +244,7 @@ public class TestDBStoreBuilder {
     File newFolder = new File(tempDir.toString(), "newFolder");
 
     if (!newFolder.exists()) {
-      Assert.assertTrue(newFolder.mkdirs());
+      assertTrue(newFolder.mkdirs());
     }
 
     String sampleTableName = "sampleTable";
@@ -269,18 +273,18 @@ public class TestDBStoreBuilder {
             .setName("SampleStore")
             .disableDefaultCFAutoCompaction(disableAutoCompaction)
             .setPath(newFolder.toPath()).build()) {
-      Assert.assertTrue(dbStore instanceof RDBStore);
+      assertTrue(dbStore instanceof RDBStore);
 
       RDBStore rdbStore = (RDBStore) dbStore;
       Collection<RocksDatabase.ColumnFamily> cfFamilies =
               rdbStore.getColumnFamilies();
 
       // we also have the default column family, so there are 2
-      Assert.assertEquals(2, cfFamilies.size());
+      assertEquals(2, cfFamilies.size());
 
       for (RocksDatabase.ColumnFamily cfFamily : cfFamilies) {
         // the value should be different from the default value
-        Assertions.assertEquals(cfFamily.getHandle().getDescriptor()
+        assertEquals(cfFamily.getHandle().getDescriptor()
                 .getOptions().disableAutoCompactions(),
                 disableAutoCompaction);
       }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestFixedLengthStringCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestFixedLengthStringCodec.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.primitives.Longs;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for class {@link FixedLengthStringCodec}.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -35,7 +35,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -738,7 +738,7 @@ public class TestRDBTableStore {
       // check dump file exist
       assertTrue(dumpFile.exists());
       // empty dump file
-      Assertions.assertEquals(0, dumpFile.length());
+      assertEquals(0, dumpFile.length());
     }
 
     // load dump file into another table

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -41,13 +41,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
-import org.junit.Assert;
-import org.junit.Rule;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for RocksDBTable Store.
@@ -70,7 +77,6 @@ public class TestRDBTableStore {
       "PrefixFour", "PrefixFifth"
   );
   private static final int PREFIX_LENGTH = 9;
-  @Rule
   private RDBStore rdbStore = null;
   private ManagedDBOptions options = null;
   private static byte[][] bytesOf;
@@ -90,9 +96,9 @@ public class TestRDBTableStore {
   private static boolean consume(Table.KeyValue keyValue)  {
     count++;
     try {
-      Assertions.assertNotNull(keyValue.getKey());
+      assertNotNull(keyValue.getKey());
     } catch (IOException ex) {
-      Assertions.fail("Unexpected Exception " + ex);
+      fail("Unexpected Exception " + ex);
     }
     return true;
   }
@@ -138,8 +144,8 @@ public class TestRDBTableStore {
   @Test
   public void getHandle() throws Exception {
     try (Table testTable = rdbStore.getTable("First")) {
-      Assertions.assertNotNull(testTable);
-      Assertions.assertNotNull(((RDBTable) testTable).getColumnFamily());
+      assertNotNull(testTable);
+      assertNotNull(((RDBTable) testTable).getColumnFamily());
     }
   }
 
@@ -151,12 +157,12 @@ public class TestRDBTableStore {
       byte[] value =
           RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
       testTable.put(key, value);
-      Assertions.assertFalse(testTable.isEmpty());
+      assertFalse(testTable.isEmpty());
       byte[] readValue = testTable.get(key);
-      Assertions.assertArrayEquals(value, readValue);
+      assertArrayEquals(value, readValue);
     }
     try (Table secondTable = rdbStore.getTable("Second")) {
-      Assertions.assertTrue(secondTable.isEmpty());
+      assertTrue(secondTable.isEmpty());
     }
   }
 
@@ -179,21 +185,21 @@ public class TestRDBTableStore {
     // Write all the keys and delete the keys scheduled for delete.
     // Assert we find only expected keys in the Table.
     try (Table testTable = rdbStore.getTable("Fourth")) {
-      for (int x = 0; x < deletedKeys.size(); x++) {
-        testTable.put(deletedKeys.get(x), value);
-        testTable.delete(deletedKeys.get(x));
+      for (byte[] bytes : deletedKeys) {
+        testTable.put(bytes, value);
+        testTable.delete(bytes);
       }
 
-      for (int x = 0; x < validKeys.size(); x++) {
-        testTable.put(validKeys.get(x), value);
+      for (byte[] key : validKeys) {
+        testTable.put(key, value);
       }
 
-      for (int x = 0; x < validKeys.size(); x++) {
-        Assertions.assertNotNull(testTable.get(validKeys.get(x)));
+      for (byte[] validKey : validKeys) {
+        assertNotNull(testTable.get(validKey));
       }
 
-      for (int x = 0; x < deletedKeys.size(); x++) {
-        Assertions.assertNull(testTable.get(deletedKeys.get(x)));
+      for (byte[] deletedKey : deletedKeys) {
+        assertNull(testTable.get(deletedKey));
       }
     }
   }
@@ -220,7 +226,7 @@ public class TestRDBTableStore {
 
       // All keys should exist at this point
       for (int x = 0; x < keys.size(); x++) {
-        Assertions.assertNotNull(testTable.get(keys.get(x)));
+        assertNotNull(testTable.get(keys.get(x)));
       }
 
       // Delete a range of keys: [10th, 20th), zero-indexed
@@ -232,15 +238,15 @@ public class TestRDBTableStore {
 
       // Keys [10th, 20th) should be gone now
       for (int x = deleteRangeBegin; x < deleteRangeEnd; x++) {
-        Assertions.assertNull(testTable.get(keys.get(x)));
+        assertNull(testTable.get(keys.get(x)));
       }
 
       // While the rest of the keys should be untouched
       for (int x = 0; x < deleteRangeBegin; x++) {
-        Assertions.assertNotNull(testTable.get(keys.get(x)));
+        assertNotNull(testTable.get(keys.get(x)));
       }
       for (int x = deleteRangeEnd; x < 100; x++) {
-        Assertions.assertNotNull(testTable.get(keys.get(x)));
+        assertNotNull(testTable.get(keys.get(x)));
       }
 
       // Delete the rest of the keys
@@ -248,15 +254,15 @@ public class TestRDBTableStore {
 
       // Confirm key deletion
       for (int x = 0; x < 100 - 1; x++) {
-        Assertions.assertNull(testTable.get(keys.get(x)));
+        assertNull(testTable.get(keys.get(x)));
       }
       // The last key is still there because
       // deleteRange() excludes the endKey by design
-      Assertions.assertNotNull(testTable.get(keys.get(100 - 1)));
+      assertNotNull(testTable.get(keys.get(100 - 1)));
 
       // Delete the last key
       testTable.delete(keys.get(100 - 1));
-      Assertions.assertNull(testTable.get(keys.get(100 - 1)));
+      assertNull(testTable.get(keys.get(100 - 1)));
     }
 
   }
@@ -270,14 +276,14 @@ public class TestRDBTableStore {
           RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
       byte[] value =
           RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
-      Assertions.assertNull(testTable.get(key));
+      assertNull(testTable.get(key));
 
       //when
       testTable.putWithBatch(batch, key, value);
       rdbStore.commitBatchOperation(batch);
 
       //then
-      Assertions.assertNotNull(testTable.get(key));
+      assertNotNull(testTable.get(key));
     }
   }
 
@@ -292,7 +298,7 @@ public class TestRDBTableStore {
       byte[] value =
           RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
       testTable.put(key, value);
-      Assertions.assertNotNull(testTable.get(key));
+      assertNotNull(testTable.get(key));
 
 
       //when
@@ -300,7 +306,7 @@ public class TestRDBTableStore {
       rdbStore.commitBatchOperation(batch);
 
       //then
-      Assertions.assertNull(testTable.get(key));
+      assertNull(testTable.get(key));
     }
   }
 
@@ -322,10 +328,10 @@ public class TestRDBTableStore {
           localCount++;
         }
 
-        Assertions.assertEquals(iterCount, localCount);
+        assertEquals(iterCount, localCount);
         iter.seekToFirst();
         iter.forEachRemaining(TestRDBTableStore::consume);
-        Assertions.assertEquals(iterCount, count);
+        assertEquals(iterCount, count);
 
       }
     }
@@ -345,26 +351,26 @@ public class TestRDBTableStore {
       testTable.put(key, value);
 
       // Test if isExist returns true for a key that definitely exists.
-      Assertions.assertTrue(testTable.isExist(key));
+      assertTrue(testTable.isExist(key));
 
       // Test if isExist returns false for a key that has been deleted.
       testTable.delete(key);
-      Assertions.assertFalse(testTable.isExist(key));
+      assertFalse(testTable.isExist(key));
 
       // Test a key with zero size value.
-      Assertions.assertNull(testTable.get(zeroSizeKey));
+      assertNull(testTable.get(zeroSizeKey));
       testTable.put(zeroSizeKey, zeroSizeValue);
-      Assertions.assertEquals(0, testTable.get(zeroSizeKey).length);
+      assertEquals(0, testTable.get(zeroSizeKey).length);
 
       byte[] invalidKey =
           RandomStringUtils.random(5).getBytes(StandardCharsets.UTF_8);
       // Test if isExist returns false for a key that is definitely not present.
-      Assertions.assertFalse(testTable.isExist(invalidKey));
+      assertFalse(testTable.isExist(invalidKey));
 
       RDBMetrics rdbMetrics = rdbStore.getMetrics();
-      Assertions.assertEquals(3, rdbMetrics.getNumDBKeyMayExistChecks());
-      Assertions.assertEquals(0, rdbMetrics.getNumDBKeyMayExistMisses());
-      Assertions.assertEquals(2, rdbMetrics.getNumDBKeyGets());
+      assertEquals(3, rdbMetrics.getNumDBKeyMayExistChecks());
+      assertEquals(0, rdbMetrics.getNumDBKeyMayExistMisses());
+      assertEquals(2, rdbMetrics.getNumDBKeyGets());
 
       // Reinsert key for further testing.
       testTable.put(key, value);
@@ -374,14 +380,14 @@ public class TestRDBTableStore {
     setUp();
     try (Table<byte[], byte[]> testTable = rdbStore.getTable(tableName)) {
       // Verify isExist works with key not in block cache.
-      Assertions.assertTrue(testTable.isExist(key));
-      Assertions.assertEquals(0, testTable.get(zeroSizeKey).length);
-      Assertions.assertTrue(testTable.isExist(zeroSizeKey));
+      assertTrue(testTable.isExist(key));
+      assertEquals(0, testTable.get(zeroSizeKey).length);
+      assertTrue(testTable.isExist(zeroSizeKey));
 
       RDBMetrics rdbMetrics = rdbStore.getMetrics();
-      Assertions.assertEquals(2, rdbMetrics.getNumDBKeyMayExistChecks());
-      Assertions.assertEquals(0, rdbMetrics.getNumDBKeyMayExistMisses());
-      Assertions.assertEquals(2, rdbMetrics.getNumDBKeyGets());
+      assertEquals(2, rdbMetrics.getNumDBKeyMayExistChecks());
+      assertEquals(0, rdbMetrics.getNumDBKeyMayExistMisses());
+      assertEquals(2, rdbMetrics.getNumDBKeyGets());
     }
   }
 
@@ -403,9 +409,9 @@ public class TestRDBTableStore {
 
         testTable.put(keyBytes, valueBytes);
         final byte[] got = testTable.get(keyBytes);
-        Assertions.assertArrayEquals(valueBytes, got);
-        Assertions.assertEquals(value, codec.fromPersistedFormat(got));
-        Assertions.assertEquals(value, typedTable.get(key));
+        assertArrayEquals(valueBytes, got);
+        assertEquals(value, codec.fromPersistedFormat(got));
+        assertEquals(value, typedTable.get(key));
       }
     }
   }
@@ -422,23 +428,23 @@ public class TestRDBTableStore {
       testTable.put(key, value);
 
       // Test if isExist returns value for a key that definitely exists.
-      Assertions.assertNotNull(testTable.getIfExist(key));
+      assertNotNull(testTable.getIfExist(key));
 
       // Test if isExist returns null for a key that has been deleted.
       testTable.delete(key);
-      Assertions.assertNull(testTable.getIfExist(key));
+      assertNull(testTable.getIfExist(key));
 
       byte[] invalidKey =
           RandomStringUtils.random(5).getBytes(StandardCharsets.UTF_8);
       // Test if isExist returns null for a key that is definitely not present.
-      Assertions.assertNull(testTable.getIfExist(invalidKey));
+      assertNull(testTable.getIfExist(invalidKey));
 
       RDBMetrics rdbMetrics = rdbStore.getMetrics();
-      Assertions.assertEquals(3, rdbMetrics.getNumDBKeyGetIfExistChecks());
+      assertEquals(3, rdbMetrics.getNumDBKeyGetIfExistChecks());
 
-      Assertions.assertEquals(0, rdbMetrics.getNumDBKeyGetIfExistMisses());
+      assertEquals(0, rdbMetrics.getNumDBKeyGetIfExistMisses());
 
-      Assertions.assertEquals(0, rdbMetrics.getNumDBKeyGetIfExistGets());
+      assertEquals(0, rdbMetrics.getNumDBKeyGetIfExistGets());
 
       // Reinsert key for further testing.
       testTable.put(key, value);
@@ -448,7 +454,7 @@ public class TestRDBTableStore {
     setUp();
     try (Table<byte[], byte[]> testTable = rdbStore.getTable(tableName)) {
       // Verify getIfExists works with key not in block cache.
-      Assertions.assertNotNull(testTable.getIfExist(key));
+      assertNotNull(testTable.getIfExist(key));
     }
   }
 
@@ -467,7 +473,7 @@ public class TestRDBTableStore {
       }
       long keyCount = testTable.getEstimatedKeyCount();
       // The result should be larger than zero but not exceed(?) numKeys
-      Assertions.assertTrue(keyCount > 0 && keyCount <= numKeys);
+      assertTrue(keyCount > 0 && keyCount <= numKeys);
     }
   }
 
@@ -481,9 +487,9 @@ public class TestRDBTableStore {
           testTable.iterator()) {
         iterator.removeFromDB();
       }
-      Assertions.assertNull(testTable.get(bytesOf[1]));
-      Assertions.assertNotNull(testTable.get(bytesOf[2]));
-      Assertions.assertNotNull(testTable.get(bytesOf[3]));
+      assertNull(testTable.get(bytesOf[1]));
+      assertNotNull(testTable.get(bytesOf[2]));
+      assertNotNull(testTable.get(bytesOf[3]));
     }
 
     // Remove after seekToLast removes lastEntry
@@ -494,9 +500,9 @@ public class TestRDBTableStore {
         iterator.seekToLast();
         iterator.removeFromDB();
       }
-      Assertions.assertNotNull(testTable.get(bytesOf[1]));
-      Assertions.assertNotNull(testTable.get(bytesOf[2]));
-      Assertions.assertNull(testTable.get(bytesOf[3]));
+      assertNotNull(testTable.get(bytesOf[1]));
+      assertNotNull(testTable.get(bytesOf[2]));
+      assertNull(testTable.get(bytesOf[3]));
     }
 
     // Remove after seek deletes that entry.
@@ -507,9 +513,9 @@ public class TestRDBTableStore {
         iterator.seek(bytesOf[3]);
         iterator.removeFromDB();
       }
-      Assertions.assertNotNull(testTable.get(bytesOf[1]));
-      Assertions.assertNotNull(testTable.get(bytesOf[2]));
-      Assertions.assertNull(testTable.get(bytesOf[3]));
+      assertNotNull(testTable.get(bytesOf[1]));
+      assertNotNull(testTable.get(bytesOf[2]));
+      assertNull(testTable.get(bytesOf[3]));
     }
 
     // Remove after next() deletes entry that was returned by next.
@@ -521,9 +527,9 @@ public class TestRDBTableStore {
         iterator.next();
         iterator.removeFromDB();
       }
-      Assertions.assertNotNull(testTable.get(bytesOf[1]));
-      Assertions.assertNull(testTable.get(bytesOf[2]));
-      Assertions.assertNotNull(testTable.get(bytesOf[3]));
+      assertNotNull(testTable.get(bytesOf[1]));
+      assertNull(testTable.get(bytesOf[2]));
+      assertNotNull(testTable.get(bytesOf[3]));
     }
   }
 
@@ -557,21 +563,19 @@ public class TestRDBTableStore {
         int keyCount = 0;
         while (iter.hasNext()) {
           // iterator should only meet keys with samplePrefix
-          Assert.assertTrue(Arrays.equals(
-              Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH),
-              samplePrefix));
+          assertArrayEquals(
+              Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH), samplePrefix);
           keyCount++;
         }
 
         // iterator should end at right pos
-        Assert.assertEquals(blockCount, keyCount);
+        assertEquals(blockCount, keyCount);
 
         // iterator should be able to seekToFirst
         iter.seekToFirst();
-        Assert.assertTrue(iter.hasNext());
-        Assert.assertTrue(Arrays.equals(
-            Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH),
-            samplePrefix));
+        assertTrue(iter.hasNext());
+        assertArrayEquals(Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH),
+            samplePrefix);
       }
     }
   }
@@ -601,17 +605,17 @@ public class TestRDBTableStore {
     try (Table.KeyValueIterator<String, String> i = table.iterator(prefix)) {
       int keyCount = 0;
       for (; i.hasNext(); keyCount++) {
-        Assertions.assertEquals(prefix,
+        assertEquals(prefix,
             i.next().getKey().substring(0, PREFIX_LENGTH));
       }
-      Assertions.assertEquals(expectedCount, keyCount);
+      assertEquals(expectedCount, keyCount);
 
       // test seekToFirst
       i.seekToFirst();
       if (expectedCount > 0) {
         // iterator should be able to seekToFirst
-        Assertions.assertTrue(i.hasNext());
-        Assertions.assertEquals(prefix,
+        assertTrue(i.hasNext());
+        assertEquals(prefix,
             i.next().getKey().substring(0, PREFIX_LENGTH));
       }
     }
@@ -623,12 +627,7 @@ public class TestRDBTableStore {
         "PrefixFirst", String.class, String.class)) {
       // iterator should seek to right pos in the middle
       rdbStore.close();
-      try {
-        testTable.iterator("abc");
-        Assertions.fail();
-      } catch (IOException ioe) {
-        LOG.info("Great!", ioe);
-      }
+      assertThrows(IOException.class, () -> testTable.iterator("abc"));
     }
   }
 
@@ -652,13 +651,13 @@ public class TestRDBTableStore {
       byte[] startKey = samplePrefix;
       List<? extends Table.KeyValue<byte[], byte[]>> rangeKVs = testTable
           .getRangeKVs(startKey, 3, samplePrefix);
-      Assert.assertEquals(3, rangeKVs.size());
+      assertEquals(3, rangeKVs.size());
 
       // test start with a middle key
       startKey = StringUtils.string2Bytes(
           StringUtils.bytes2String(samplePrefix) + "3");
       rangeKVs = testTable.getRangeKVs(startKey, blockCount, samplePrefix);
-      Assert.assertEquals(2, rangeKVs.size());
+      assertEquals(2, rangeKVs.size());
 
       // test with a filter
       MetadataKeyFilters.KeyPrefixFilter filter1 = new MetadataKeyFilters
@@ -668,13 +667,13 @@ public class TestRDBTableStore {
           StringUtils.bytes2String(samplePrefix));
       rangeKVs = testTable.getRangeKVs(startKey, blockCount,
           samplePrefix, filter1);
-      Assert.assertEquals(1, rangeKVs.size());
+      assertEquals(1, rangeKVs.size());
 
       // test start with a non-exist key
       startKey = StringUtils.string2Bytes(
           StringUtils.bytes2String(samplePrefix) + 123);
       rangeKVs = testTable.getRangeKVs(startKey, 10, samplePrefix);
-      Assert.assertEquals(0, rangeKVs.size());
+      assertEquals(0, rangeKVs.size());
     }
   }
 
@@ -695,8 +694,8 @@ public class TestRDBTableStore {
       testTable1.dumpToFileWithPrefix(dumpFile, samplePrefix);
 
       // check dump file exist
-      Assert.assertTrue(dumpFile.exists());
-      Assert.assertTrue(dumpFile.length() != 0);
+      assertTrue(dumpFile.exists());
+      assertTrue(dumpFile.length() != 0);
     }
 
     // load dump file into another table
@@ -710,14 +709,14 @@ public class TestRDBTableStore {
         int keyCount = 0;
         while (iter.hasNext()) {
           // check prefix
-          Assert.assertTrue(Arrays.equals(
+          assertTrue(Arrays.equals(
               Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH),
               samplePrefix));
           keyCount++;
         }
 
         // check block count
-        Assert.assertEquals(blockCount, keyCount);
+        assertEquals(blockCount, keyCount);
       }
     }
   }
@@ -737,9 +736,9 @@ public class TestRDBTableStore {
       testTable1.dumpToFileWithPrefix(dumpFile, samplePrefix);
 
       // check dump file exist
-      Assert.assertTrue(dumpFile.exists());
+      assertTrue(dumpFile.exists());
       // empty dump file
-      Assert.assertTrue(dumpFile.length() == 0);
+      Assertions.assertEquals(0, dumpFile.length());
     }
 
     // load dump file into another table
@@ -753,14 +752,14 @@ public class TestRDBTableStore {
         int keyCount = 0;
         while (iter.hasNext()) {
           // check prefix
-          Assert.assertTrue(Arrays.equals(
+          assertTrue(Arrays.equals(
               Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH),
               samplePrefix));
           keyCount++;
         }
 
         // check block count
-        Assert.assertEquals(0, keyCount);
+        assertEquals(0, keyCount);
       }
     }
   }

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -28,6 +28,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS SCM Server</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
@@ -92,7 +92,7 @@ public class InterSCMGrpcClient implements SCMSnapshotDownloader {
 
   @Override
   public CompletableFuture<Path> download(final Path outputPath) {
-    // By default on every checkpoint, the rocks db will be flushed
+    // By default, on every checkpoint, the rocks db will be flushed
     InterSCMProtocolProtos.CopyDBCheckpointRequestProto request =
         InterSCMProtocolProtos.CopyDBCheckpointRequestProto.newBuilder()
             .setFlush(true)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -46,6 +46,8 @@ import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.DATANODE_COMMAND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -54,7 +56,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -155,7 +156,7 @@ public class TestCloseContainerEventHandler {
     closeHandler.onMessage(container.containerID(), eventPublisher);
     Mockito.verify(mockLeaseManager, atLeastOnce())
         .acquire(any(), anyLong(), any());
-    Assert.assertTrue(leaseList.size() > 0);
+    assertTrue(leaseList.size() > 0);
     // immediate check if event is published
     Mockito.verify(eventPublisher, never())
         .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
@@ -214,14 +215,14 @@ public class TestCloseContainerEventHandler {
         .map(d -> d.getUuid())
         .collect(Collectors.toSet());
     for (CommandForDatanode c : cmds) {
-      Assert.assertTrue(pipelineDNs.contains(c.getDatanodeId()));
+      assertTrue(pipelineDNs.contains(c.getDatanodeId()));
       pipelineDNs.remove(c.getDatanodeId());
       CloseContainerCommand ccc = (CloseContainerCommand)c.getCommand();
-      Assert.assertEquals(container.getContainerID(), ccc.getContainerID());
-      Assert.assertEquals(pipeline.getId(), ccc.getPipelineID());
-      Assert.assertEquals(forceClose, ccc.getProto().getForce());
+      assertEquals(container.getContainerID(), ccc.getContainerID());
+      assertEquals(pipeline.getId(), ccc.getPipelineID());
+      assertEquals(forceClose, ccc.getProto().getForce());
     }
-    Assert.assertEquals(0, pipelineDNs.size());
+    assertEquals(0, pipelineDNs.size());
   }
 
   private Pipeline createPipeline(ReplicationConfig repConfig, int nodes) {
@@ -249,5 +250,4 @@ public class TestCloseContainerEventHandler {
     builder.setState(HddsProtos.LifeCycleState.OPEN);
     return builder.build();
   }
-
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,8 +44,8 @@ import java.util.Set;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -95,7 +94,7 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
                     any(), any(), any(),
                     Mockito.anyInt(), Mockito.anyLong(), Mockito.anyLong()))
             .thenThrow(new IOException("No nodes found"));
-    Assertions.assertThrows(SCMException.class, () -> testMisReplication(
+    assertThrows(SCMException.class, () -> testMisReplication(
             availableReplicas, placementPolicy, Collections.emptyList(),
             0, 2, 0));
   }
@@ -233,7 +232,7 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
   protected void assertReplicaIndex(
       Map<DatanodeDetails, Integer> expectedReplicaIndexes,
       DatanodeDetails sourceDatanode, int actualReplicaIndex) {
-    Assertions.assertEquals(
-        expectedReplicaIndexes.get(sourceDatanode), actualReplicaIndex);
+    assertEquals(expectedReplicaIndexes.get(sourceDatanode),
+        actualReplicaIndex);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,6 +62,9 @@ import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaO
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -267,9 +269,9 @@ public class TestECOverReplicationHandler {
     ecORH.processAndSendCommands(availableReplicas, ImmutableList.of(),
         health, 1);
 
-    Assert.assertEquals(1, commandsSent.size());
+    assertEquals(1, commandsSent.size());
     SCMCommand<?> cmd = commandsSent.iterator().next().getValue();
-    Assert.assertEquals(1, ((DeleteContainerCommand)cmd).getReplicaIndex());
+    assertEquals(1, ((DeleteContainerCommand)cmd).getReplicaIndex());
   }
 
   @Test
@@ -316,7 +318,7 @@ public class TestECOverReplicationHandler {
     } catch (CommandTargetOverloadedException e) {
       // This is expected.
     }
-    Assert.assertEquals(1, commandsSent.size());
+    assertEquals(1, commandsSent.size());
   }
 
   private void testOverReplicationWithIndexes(
@@ -337,10 +339,10 @@ public class TestECOverReplicationHandler {
     // the excess nums
     int totalDeleteCommandNum =
         index2excessNum.values().stream().reduce(0, Integer::sum);
-    Assert.assertEquals(totalDeleteCommandNum, commandsSent.size());
+    assertEquals(totalDeleteCommandNum, commandsSent.size());
 
     // Each command should have a non-zero replica index
-    commandsSent.forEach(pair -> Assert.assertNotEquals(0,
+    commandsSent.forEach(pair -> assertNotEquals(0,
         ((DeleteContainerCommand) pair.getValue()).getReplicaIndex()));
 
     // command num of each index should be equal to the excess num
@@ -355,8 +357,8 @@ public class TestECOverReplicationHandler {
     );
 
     index2commandNum.keySet().forEach(i -> {
-      Assert.assertTrue(index2excessNum.containsKey(i));
-      Assert.assertEquals(index2commandNum.get(i), index2excessNum.get(i));
+      assertTrue(index2excessNum.containsKey(i));
+      assertEquals(index2commandNum.get(i), index2excessNum.get(i));
     });
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.OverReplicatedHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -44,7 +44,7 @@ public class TestOverReplicatedProcessor {
   private OverReplicatedProcessor overReplicatedProcessor;
   private ReplicationQueue queue;
 
-  @Before
+  @BeforeEach
   public void setup() {
     ConfigurationSource conf = new OzoneConfiguration();
     ReplicationManagerConfiguration rmConf =
@@ -60,7 +60,7 @@ public class TestOverReplicatedProcessor {
 
     // Even through the limit has been exceeded, it should not stop over-rep
     // processing, as the over-rep handler ignores the limit as it only does
-    // deletes.
+    // delete.
     Mockito.when(replicationManager.getReplicationInFlightLimit())
         .thenReturn(1L);
     Mockito.when(replicationManager.getInflightReplicationCount())
@@ -82,7 +82,7 @@ public class TestOverReplicatedProcessor {
   }
 
   @Test
-  public void testMessageRequeuedOnException() throws IOException {
+  public void testMessageReQueuedOnException() throws IOException {
     ContainerInfo container = ReplicationTestUtil
         .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
     OverReplicatedHealthResult result = new OverReplicatedHealthResult(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisContainerReplicaCount.java
@@ -21,10 +21,10 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,8 +40,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
-import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSING;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.OPEN;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED;
@@ -99,7 +98,7 @@ class TestRatisContainerReplicaCount {
   /**
    * This does not schedule a container to be removed, as the inFlight add may
    * fail and then the delete would make things under-replicated. Once the add
-   * completes there will be 4 healthy and it will get taken care of then.
+   * completes there will be 4 healthy, and it will get taken care of then.
    */
   @Test
   void testThreeHealthyAndInflightAdd() {
@@ -434,10 +433,10 @@ class TestRatisContainerReplicaCount {
   void testSufficientReplicationWithMismatchedReplicaState() {
     ContainerInfo container =
         createContainerInfo(RatisReplicationConfig.getInstance(
-            HddsProtos.ReplicationFactor.THREE), 1L,
+            THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED);
     Set<ContainerReplica> replicas =
-        createReplicas(ContainerID.valueOf(1L), CLOSED, 0, 0);
+        createReplicas(ContainerID.valueOf(1L), State.CLOSED, 0, 0);
     replicas.add(createContainerReplica(ContainerID.valueOf(1L), 0,
         IN_SERVICE, CLOSING));
 
@@ -451,10 +450,10 @@ class TestRatisContainerReplicaCount {
   void testReplicaCounts() {
     ContainerInfo container =
         createContainerInfo(RatisReplicationConfig.getInstance(
-                HddsProtos.ReplicationFactor.THREE), 1L,
+                THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED);
     Set<ContainerReplica> replicas =
-        createReplicas(ContainerID.valueOf(1L), CLOSED, 0, 0);
+        createReplicas(ContainerID.valueOf(1L), State.CLOSED, 0, 0);
     replicas.add(createContainerReplica(ContainerID.valueOf(1L), 0,
         IN_SERVICE, CLOSING));
     replicas.add(createContainerReplica(ContainerID.valueOf(1L), 0,
@@ -498,10 +497,10 @@ class TestRatisContainerReplicaCount {
   void testUnhealthyReplicaOnDecommissionedNodeWithPendingDelete() {
     ContainerInfo container =
         createContainerInfo(RatisReplicationConfig.getInstance(
-                HddsProtos.ReplicationFactor.THREE), 1L,
+                THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED);
     Set<ContainerReplica> replicas =
-        createReplicas(ContainerID.valueOf(1L), CLOSED, 0, 0);
+        createReplicas(ContainerID.valueOf(1L), State.CLOSED, 0, 0);
     replicas.add(createContainerReplica(ContainerID.valueOf(1L), 0,
         IN_SERVICE, CLOSING));
     ContainerReplica unhealthyReplica =
@@ -561,10 +560,10 @@ class TestRatisContainerReplicaCount {
   void testSufficientReplicationWithPendingDeleteOnUnhealthyReplica() {
     ContainerInfo container =
         createContainerInfo(RatisReplicationConfig.getInstance(
-            HddsProtos.ReplicationFactor.THREE), 1L,
+            THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED);
     Set<ContainerReplica> replicas =
-        createReplicas(container.containerID(), CLOSED, 0, 0, 0);
+        createReplicas(container.containerID(), State.CLOSED, 0, 0, 0);
     ContainerReplica unhealthyReplica = createContainerReplica(
         ContainerID.valueOf(1L), 0, IN_SERVICE, UNHEALTHY);
     replicas.add(unhealthyReplica);
@@ -590,10 +589,10 @@ class TestRatisContainerReplicaCount {
   public void testUnderReplicationBecauseOfUnhealthyReplica() {
     ContainerInfo container =
         createContainerInfo(RatisReplicationConfig.getInstance(
-                HddsProtos.ReplicationFactor.THREE), 1L,
+                THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED);
     Set<ContainerReplica> replicas =
-        createReplicas(container.containerID(), CLOSED, 0, 0);
+        createReplicas(container.containerID(), State.CLOSED, 0, 0);
     ContainerReplica unhealthyReplica = createContainerReplica(
         ContainerID.valueOf(1L), 0, IN_SERVICE, UNHEALTHY);
     replicas.add(unhealthyReplica);
@@ -652,10 +651,10 @@ class TestRatisContainerReplicaCount {
      */
     ContainerInfo container =
         createContainerInfo(RatisReplicationConfig.getInstance(
-                HddsProtos.ReplicationFactor.THREE), 1L,
+                THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED);
     Set<ContainerReplica> replicas =
-        createReplicas(container.containerID(), CLOSED, 0, 0, 0);
+        createReplicas(container.containerID(), State.CLOSED, 0, 0, 0);
     Set<ContainerReplica> unhealthyReplicas =
         createReplicas(container.containerID(), UNHEALTHY, 0, 0);
     replicas.addAll(unhealthyReplicas);
@@ -677,9 +676,9 @@ class TestRatisContainerReplicaCount {
     Second case: 2 CLOSED, 1 CLOSING, 1 UNHEALTHY
      */
     container = createContainerInfo(RatisReplicationConfig.getInstance(
-                HddsProtos.ReplicationFactor.THREE), 1L,
-            HddsProtos.LifeCycleState.CLOSED);
-    replicas = createReplicas(container.containerID(), CLOSED, 0, 0);
+                THREE), 1L,
+        HddsProtos.LifeCycleState.CLOSED);
+    replicas = createReplicas(container.containerID(), State.CLOSED, 0, 0);
     ContainerReplica unhealthyReplica =
         createContainerReplica(container.containerID(), 0, IN_SERVICE,
             UNHEALTHY);
@@ -704,11 +703,9 @@ class TestRatisContainerReplicaCount {
     assertFalse(withUnhealthy.isSafelyOverReplicated());
     // now check by adding a CLOSED replica
     replicas.add(createContainerReplica(container.containerID(), 0,
-        IN_SERVICE, CLOSED));
-    withUnhealthy =
-        new RatisContainerReplicaCount(container, replicas,
-            Collections.emptyList(), 2,
-            true);
+        IN_SERVICE, State.CLOSED));
+    withUnhealthy = new RatisContainerReplicaCount(container, replicas,
+        Collections.emptyList(), 2, true);
     validate(withUnhealthy, true, -2, true, false);
     assertTrue(withUnhealthy.isSafelyOverReplicated());
   }
@@ -720,14 +717,12 @@ class TestRatisContainerReplicaCount {
     ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
     RatisContainerReplicaCount rcnt =
         new RatisContainerReplicaCount(container, replica, 0, 1, 3, 2);
-    Assert.assertEquals(2, rcnt.getRemainingRedundancy());
+    assertEquals(2, rcnt.getRemainingRedundancy());
     replica = registerNodes(IN_SERVICE);
-    rcnt =
-        new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
-    Assert.assertEquals(0, rcnt.getRemainingRedundancy());
-    rcnt =
-        new RatisContainerReplicaCount(container, replica, 0, 1, 3, 2);
-    Assert.assertEquals(0, rcnt.getRemainingRedundancy());
+    rcnt = new RatisContainerReplicaCount(container, replica, 0, 0, 3, 2);
+    assertEquals(0, rcnt.getRemainingRedundancy());
+    rcnt = new RatisContainerReplicaCount(container, replica, 0, 1, 3, 2);
+    assertEquals(0, rcnt.getRemainingRedundancy());
   }
 
   @Test
@@ -739,8 +734,7 @@ class TestRatisContainerReplicaCount {
     assertFalse(rcnt.isSufficientlyReplicated(true));
     assertFalse(rcnt.isSufficientlyReplicated(false));
 
-    rcnt =
-        new RatisContainerReplicaCount(container, replica, 1, 0, 3, 2);
+    rcnt = new RatisContainerReplicaCount(container, replica, 1, 0, 3, 2);
     assertTrue(rcnt.isSufficientlyReplicated(true));
     assertFalse(rcnt.isSufficientlyReplicated(false));
 
@@ -759,11 +753,10 @@ class TestRatisContainerReplicaCount {
   @Test
   void testQuasiClosedReplicaWithCorrectSequenceID() {
     final ContainerInfo container =
-        createContainerInfo(RatisReplicationConfig.getInstance(
-                HddsProtos.ReplicationFactor.THREE), 1L,
+        createContainerInfo(RatisReplicationConfig.getInstance(THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED);
     final Set<ContainerReplica> replicas =
-        createReplicas(container.containerID(), CLOSED, 0, 0);
+        createReplicas(container.containerID(), State.CLOSED, 0, 0);
     final Set<ContainerReplica> quasiClosedReplica =
         createReplicas(container.containerID(), QUASI_CLOSED, 0);
     replicas.addAll(quasiClosedReplica);
@@ -776,7 +769,6 @@ class TestRatisContainerReplicaCount {
     assertEquals(0, crc.getUnhealthyReplicaCount());
 
     // With additional unhealthy replica
-
     final Set<ContainerReplica> unhealthyReplica =
         createReplicas(container.containerID(), UNHEALTHY, 0);
     replicas.addAll(unhealthyReplica);
@@ -791,11 +783,9 @@ class TestRatisContainerReplicaCount {
 
   @Test
   void testQuasiClosedReplicaWithInCorrectSequenceID() {
-
     final long sequenceID = 101;
     final ContainerInfo container =
-        createContainerInfo(RatisReplicationConfig.getInstance(
-                HddsProtos.ReplicationFactor.THREE), 1L,
+        createContainerInfo(RatisReplicationConfig.getInstance(THREE), 1L,
             HddsProtos.LifeCycleState.CLOSED, sequenceID);
     final ContainerID containerID = container.containerID();
 
@@ -851,7 +841,7 @@ class TestRatisContainerReplicaCount {
       dn.setPersistedOpState(s);
       replica.add(new ContainerReplica.ContainerReplicaBuilder()
           .setContainerID(ContainerID.valueOf(1))
-          .setContainerState(CLOSED)
+          .setContainerState(State.CLOSED)
           .setDatanodeDetails(dn)
           .setOriginNodeId(dn.getUuid())
           .setSequenceId(1)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -45,7 +45,6 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -186,7 +185,7 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
         .createReplicas(Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0),
             Pair.of(IN_SERVICE, 0));
-    assertThrows(CommandTargetOverloadedException.class,
+    Assertions.assertThrows(CommandTargetOverloadedException.class,
         () -> testMisReplication(availableReplicas, mockPlacementPolicy(),
             Collections.emptyList(), 0, 1, 1, 0));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -36,9 +36,8 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.slf4j.event.Level;
@@ -56,6 +55,10 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicasWithSameOrigin;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -75,7 +78,7 @@ public class TestRatisOverReplicationHandler {
   private ReplicationManager replicationManager;
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
 
-  @Before
+  @BeforeEach
   public void setup() throws NodeNotFoundException, NotLeaderException,
       CommandTargetOverloadedException {
     container = createContainer(HddsProtos.LifeCycleState.CLOSED,
@@ -233,8 +236,7 @@ public class TestRatisOverReplicationHandler {
         replicas, Collections.emptyList(), getOverReplicatedHealthResult(), 2);
     Set<DatanodeDetails> datanodes =
         commands.stream().map(Pair::getKey).collect(Collectors.toSet());
-    Assert.assertTrue(
-        datanodes.contains(quasiClosedReplica.getDatanodeDetails()));
+    assertTrue(datanodes.contains(quasiClosedReplica.getDatanodeDetails()));
   }
 
   @Test
@@ -257,9 +259,9 @@ public class TestRatisOverReplicationHandler {
         replicas, Collections.emptyList(), getOverReplicatedHealthResult(), 1);
     Set<DatanodeDetails> datanodes =
         commands.stream().map(Pair::getKey).collect(Collectors.toSet());
-    Assert.assertFalse(
+    assertFalse(
         datanodes.contains(decommissioningReplica.getDatanodeDetails()));
-    Assert.assertFalse(
+    assertFalse(
         datanodes.contains(maintenanceReplica.getDatanodeDetails()));
   }
 
@@ -344,9 +346,9 @@ public class TestRatisOverReplicationHandler {
     } catch (CommandTargetOverloadedException e) {
       // Expected
     }
-    Assert.assertEquals(1, commandsSent.size());
+    assertEquals(1, commandsSent.size());
     Pair<DatanodeDetails, SCMCommand<?>> cmd = commandsSent.iterator().next();
-    Assert.assertNotEquals(quasiClosedReplica.getDatanodeDetails(),
+    assertNotEquals(quasiClosedReplica.getDatanodeDetails(),
         cmd.getKey());
   }
 
@@ -380,7 +382,7 @@ public class TestRatisOverReplicationHandler {
 
     handler.processAndSendCommands(closedReplicas, Collections.emptyList(),
         getOverReplicatedHealthResult(), 2);
-    Assert.assertEquals(2, commandsSent.size());
+    assertEquals(2, commandsSent.size());
   }
 
   /**
@@ -404,7 +406,7 @@ public class TestRatisOverReplicationHandler {
 
     handler.processAndSendCommands(replicas, pendingOps,
             healthResult, 2);
-    Assert.assertEquals(expectNumCommands, commandsSent.size());
+    assertEquals(expectNumCommands, commandsSent.size());
 
     return commandsSent;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -39,10 +39,8 @@ import org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -63,6 +61,10 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -82,7 +84,7 @@ public class TestRatisUnderReplicationHandler {
   private Set<Pair<DatanodeDetails, SCMCommand<?>>> commandsSent;
   private ReplicationManagerMetrics metrics;
 
-  @Before
+  @BeforeEach
   public void setup() throws NodeNotFoundException,
       CommandTargetOverloadedException, NotLeaderException {
     container = ReplicationTestUtil.createContainer(
@@ -226,11 +228,11 @@ public class TestRatisUnderReplicationHandler {
     Set<ContainerReplica> replicas
         = createReplicas(container.containerID(), State.CLOSED, 0, 0);
 
-    Assert.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
             Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
-    Assert.assertEquals(0, commandsSent.size());
-    Assert.assertEquals(0, metrics.getPartialReplicationTotal());
+    assertEquals(0, commandsSent.size());
+    assertEquals(0, metrics.getPartialReplicationTotal());
   }
 
   @Test
@@ -244,13 +246,13 @@ public class TestRatisUnderReplicationHandler {
     Set<ContainerReplica> replicas
         = createReplicas(container.containerID(), State.CLOSED, 0);
 
-    Assert.assertThrows(InsufficientDatanodesException.class,
+    assertThrows(InsufficientDatanodesException.class,
         () -> handler.processAndSendCommands(replicas,
             Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
     // One command should be sent to the replication manager as we could only
     // fine one node rather than two.
-    Assert.assertEquals(1, commandsSent.size());
-    Assert.assertEquals(1, metrics.getPartialReplicationTotal());
+    assertEquals(1, commandsSent.size());
+    assertEquals(1, metrics.getPartialReplicationTotal());
   }
 
   @Test
@@ -267,11 +269,11 @@ public class TestRatisUnderReplicationHandler {
         container.containerID(), 0, IN_SERVICE, State.UNHEALTHY);
     replicas.add(shouldDelete);
 
-    Assert.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
             Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
     // No commands send, as there are only 2 replicas available.
-    Assert.assertEquals(0, commandsSent.size());
+    assertEquals(0, commandsSent.size());
   }
 
   @Test
@@ -285,11 +287,11 @@ public class TestRatisUnderReplicationHandler {
     Set<ContainerReplica> replicas
         = createReplicas(container.containerID(), State.UNHEALTHY, 0, 0);
 
-    Assert.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
             Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
     // No commands send, as no CLOSED replicas available.
-    Assert.assertEquals(0, commandsSent.size());
+    assertEquals(0, commandsSent.size());
   }
 
   @Test
@@ -306,13 +308,13 @@ public class TestRatisUnderReplicationHandler {
         container.containerID(), 0, IN_SERVICE, State.UNHEALTHY);
     replicas.add(shouldDelete);
 
-    Assert.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
             Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
-    Assert.assertEquals(1, commandsSent.size());
+    assertEquals(1, commandsSent.size());
     Pair<DatanodeDetails, SCMCommand<?>> cmd = commandsSent.iterator().next();
-    Assert.assertEquals(shouldDelete.getDatanodeDetails(), cmd.getKey());
-    Assert.assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
+    assertEquals(shouldDelete.getDatanodeDetails(), cmd.getKey());
+    assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
         .Type.deleteContainerCommand, cmd.getValue().getType());
   }
 
@@ -334,11 +336,11 @@ public class TestRatisUnderReplicationHandler {
         ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.DELETE,
         shouldDelete.getDatanodeDetails(), 0));
 
-    Assert.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
             pending, getUnderReplicatedHealthResult(), 2));
     // No commands sent as we have a pending delete.
-    Assert.assertEquals(0, commandsSent.size());
+    assertEquals(0, commandsSent.size());
   }
 
   @Test
@@ -366,13 +368,13 @@ public class TestRatisUnderReplicationHandler {
         container.containerID(), 0, IN_SERVICE, State.UNHEALTHY);
     replicas.add(shouldDelete);
 
-    Assert.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> handler.processAndSendCommands(replicas,
             Collections.emptyList(), getUnderReplicatedHealthResult(), 2));
-    Assert.assertEquals(1, commandsSent.size());
+    assertEquals(1, commandsSent.size());
     Pair<DatanodeDetails, SCMCommand<?>> cmd = commandsSent.iterator().next();
-    Assert.assertEquals(shouldDelete.getDatanodeDetails(), cmd.getKey());
-    Assert.assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
+    assertEquals(shouldDelete.getDatanodeDetails(), cmd.getKey());
+    assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
         .Type.deleteContainerCommand, cmd.getValue().getType());
   }
 
@@ -414,7 +416,7 @@ public class TestRatisUnderReplicationHandler {
         testProcessing(replicas, Collections.emptyList(),
             getUnderReplicatedHealthResult(), 2, 2);
     commands.forEach(
-        command -> Assert.assertEquals(closedReplica.getDatanodeDetails(),
+        command -> assertEquals(closedReplica.getDatanodeDetails(),
             command.getKey()));
   }
 
@@ -437,7 +439,7 @@ public class TestRatisUnderReplicationHandler {
         testProcessing(replicas, Collections.emptyList(),
             getUnderReplicatedHealthResult(), 2, 1);
     commands.forEach(
-        command -> Assert.assertNotEquals(unhealthyReplica.getDatanodeDetails(),
+        command -> assertNotEquals(unhealthyReplica.getDatanodeDetails(),
             command.getKey()));
   }
 
@@ -515,15 +517,12 @@ public class TestRatisUnderReplicationHandler {
     List<DatanodeDetails> usedNodes = usedNodesCaptor.getValue();
     List<DatanodeDetails> excludedNodes = excludedNodesCaptor.getValue();
 
-    Assertions.assertTrue(usedNodes.contains(good.getDatanodeDetails()));
-    Assertions.assertTrue(usedNodes.contains(maintenance.getDatanodeDetails()));
-    Assertions.assertTrue(usedNodes.contains(pendingAdd));
-
-    Assertions.assertTrue(excludedNodes.contains(
-        unhealthy.getDatanodeDetails()));
-    Assertions.assertTrue(excludedNodes.contains(
-        decommissioning.getDatanodeDetails()));
-    Assertions.assertTrue(excludedNodes.contains(pendingRemove));
+    assertTrue(usedNodes.contains(good.getDatanodeDetails()));
+    assertTrue(usedNodes.contains(maintenance.getDatanodeDetails()));
+    assertTrue(usedNodes.contains(pendingAdd));
+    assertTrue(excludedNodes.contains(unhealthy.getDatanodeDetails()));
+    assertTrue(excludedNodes.contains(decommissioning.getDatanodeDetails()));
+    assertTrue(excludedNodes.contains(pendingRemove));
   }
 
   @Test
@@ -547,7 +546,7 @@ public class TestRatisUnderReplicationHandler {
         testProcessing(replicas, Collections.emptyList(),
             getUnderReplicatedHealthResult(), 2, 2);
     commands.forEach(
-        command -> Assert.assertNotEquals(
+        command -> assertNotEquals(
             quasiClosedReplica.getDatanodeDetails(),
             command.getKey()));
   }
@@ -569,7 +568,7 @@ public class TestRatisUnderReplicationHandler {
         testProcessing(replicas, Collections.emptyList(),
             getUnderReplicatedHealthResult(), 2, 2);
     commands.forEach(
-        command -> Assert.assertEquals(
+        command -> assertEquals(
             quasiClosedReplica.getDatanodeDetails(),
             command.getKey()));
   }
@@ -592,7 +591,7 @@ public class TestRatisUnderReplicationHandler {
         testProcessing(replicas, Collections.emptyList(),
             getUnderReplicatedHealthResult(), 2, 1);
     commands.forEach(
-        command -> Assert.assertEquals(closedReplica.getDatanodeDetails(),
+        command -> assertEquals(closedReplica.getDatanodeDetails(),
             command.getKey()));
   }
 
@@ -643,7 +642,7 @@ public class TestRatisUnderReplicationHandler {
 
     handler.processAndSendCommands(replicas, pendingOps,
             healthResult, minHealthyForMaintenance);
-    Assert.assertEquals(expectNumCommands, commandsSent.size());
+    assertEquals(expectNumCommands, commandsSent.size());
     return commandsSent;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -50,8 +50,6 @@ import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.util.Lists;
 import org.apache.ozone.test.TestClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,8 +83,11 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicasWithSameOrigin;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.getNoNodesTestPlacementPolicy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -364,7 +365,7 @@ public class TestReplicationManager {
         .thenReturn(NodeStatus.inServiceHealthy());
     handler.processAndSendCommands(replicas, Collections.emptyList(),
             repQueue.dequeueOverReplicatedContainer(), 2);
-    Assert.assertTrue(commandsSent.iterator().hasNext());
+    assertTrue(commandsSent.iterator().hasNext());
     assertEquals(unhealthy.getDatanodeDetails().getUuid(),
         commandsSent.iterator().next().getKey());
     assertEquals(SCMCommandProto.Type.deleteContainerCommand,
@@ -403,10 +404,10 @@ public class TestReplicationManager {
         .thenReturn(NodeStatus.inServiceHealthy());
     handler.processAndSendCommands(replicas, Collections.emptyList(),
         repQueue.dequeueOverReplicatedContainer(), 2);
-    Assert.assertTrue(commandsSent.iterator().hasNext());
+    assertTrue(commandsSent.iterator().hasNext());
 
     // unhealthy replica can't be deleted because it has a unique origin DN
-    Assert.assertNotEquals(unhealthy.getDatanodeDetails().getUuid(),
+    assertNotEquals(unhealthy.getDatanodeDetails().getUuid(),
         commandsSent.iterator().next().getKey());
     assertEquals(SCMCommandProto.Type.deleteContainerCommand,
         commandsSent.iterator().next().getValue().getType());
@@ -788,7 +789,7 @@ public class TestReplicationManager {
     // index 1
     assertEquals(1, commandsSent.size());
     Pair<UUID, SCMCommand<?>> command = commandsSent.iterator().next();
-    Assertions.assertEquals(SCMCommandProto.Type.deleteContainerCommand,
+    assertEquals(SCMCommandProto.Type.deleteContainerCommand,
         command.getValue().getType());
     DeleteContainerCommand deleteCommand =
         (DeleteContainerCommand) command.getValue();
@@ -896,15 +897,15 @@ public class TestReplicationManager {
     List<ContainerReplicaOp> ops =
         containerReplicaPendingOps.getPendingOps(container.containerID());
     Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
-    Assertions.assertEquals(1, ops.size());
-    Assertions.assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
+    assertEquals(1, ops.size());
+    assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
         ops.get(0).getOpType());
-    Assertions.assertEquals(unhealthyReplica.getDatanodeDetails(),
+    assertEquals(unhealthyReplica.getDatanodeDetails(),
         ops.get(0).getTarget());
-    Assertions.assertEquals(1, ops.get(0).getReplicaIndex());
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(1, ops.get(0).getReplicaIndex());
+    assertEquals(1, replicationManager.getMetrics()
         .getEcDeletionCmdsSentTotal());
-    Assertions.assertEquals(0, replicationManager.getMetrics()
+    assertEquals(0, replicationManager.getMetrics()
         .getDeletionCmdsSentTotal());
 
     /*
@@ -1000,7 +1001,7 @@ public class TestReplicationManager {
     assertEquals(misRep, res.getContainerInfo());
 
     res = queue.dequeueUnderReplicatedContainer();
-    Assert.assertNull(res);
+    assertNull(res);
   }
 
   @Test
@@ -1021,14 +1022,14 @@ public class TestReplicationManager {
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
     Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
-    Assertions.assertEquals(1, ops.size());
-    Assertions.assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
+    assertEquals(1, ops.size());
+    assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
         ops.get(0).getOpType());
-    Assertions.assertEquals(target, ops.get(0).getTarget());
-    Assertions.assertEquals(1, ops.get(0).getReplicaIndex());
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(target, ops.get(0).getTarget());
+    assertEquals(1, ops.get(0).getReplicaIndex());
+    assertEquals(1, replicationManager.getMetrics()
             .getEcDeletionCmdsSentTotal());
-    Assertions.assertEquals(0, replicationManager.getMetrics()
+    assertEquals(0, replicationManager.getMetrics()
         .getDeletionCmdsSentTotal());
 
     // Repeat with Ratis container, as different metrics should be incremented
@@ -1045,16 +1046,16 @@ public class TestReplicationManager {
 
     ops = containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
     Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
-    Assertions.assertEquals(1, ops.size());
-    Assertions.assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
+    assertEquals(1, ops.size());
+    assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
         ops.get(0).getOpType());
-    Assertions.assertEquals(target, ops.get(0).getTarget());
-    Assertions.assertEquals(0, ops.get(0).getReplicaIndex());
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(target, ops.get(0).getTarget());
+    assertEquals(0, ops.get(0).getReplicaIndex());
+    assertEquals(1, replicationManager.getMetrics()
         .getEcDeletionCmdsSentTotal());
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(1, replicationManager.getMetrics()
         .getDeletionCmdsSentTotal());
-    Assertions.assertEquals(20, replicationManager.getMetrics()
+    assertEquals(20, replicationManager.getMetrics()
         .getDeletionBytesTotal());
   }
 
@@ -1088,24 +1089,24 @@ public class TestReplicationManager {
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
     Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
-    Assertions.assertEquals(2, ops.size());
+    assertEquals(2, ops.size());
     Set<DatanodeDetails> cmdTargets = new HashSet<>();
     Set<Integer> cmdIndexes = new HashSet<>();
     for (ContainerReplicaOp op : ops) {
-      Assertions.assertEquals(ADD, op.getOpType());
+      assertEquals(ADD, op.getOpType());
       cmdTargets.add(op.getTarget());
       cmdIndexes.add(op.getReplicaIndex());
     }
-    Assertions.assertEquals(2, cmdTargets.size());
+    assertEquals(2, cmdTargets.size());
     for (DatanodeDetails dn : targetNodes) {
-      Assertions.assertTrue(cmdTargets.contains(dn));
+      assertTrue(cmdTargets.contains(dn));
     }
 
-    Assertions.assertEquals(2, cmdIndexes.size());
+    assertEquals(2, cmdIndexes.size());
     for (int i : missingIndexes) {
-      Assertions.assertTrue(cmdIndexes.contains(i));
+      assertTrue(cmdIndexes.contains(i));
     }
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(1, replicationManager.getMetrics()
         .getEcReconstructionCmdsSentTotal());
   }
 
@@ -1139,14 +1140,14 @@ public class TestReplicationManager {
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
     Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
-    Assertions.assertEquals(1, ops.size());
-    Assertions.assertEquals(ContainerReplicaOp.PendingOpType.ADD,
+    assertEquals(1, ops.size());
+    assertEquals(ContainerReplicaOp.PendingOpType.ADD,
         ops.get(0).getOpType());
-    Assertions.assertEquals(target, ops.get(0).getTarget());
-    Assertions.assertEquals(1, ops.get(0).getReplicaIndex());
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(target, ops.get(0).getTarget());
+    assertEquals(1, ops.get(0).getReplicaIndex());
+    assertEquals(1, replicationManager.getMetrics()
         .getEcReplicationCmdsSentTotal());
-    Assertions.assertEquals(0, replicationManager.getMetrics()
+    assertEquals(0, replicationManager.getMetrics()
         .getReplicationCmdsSentTotal());
 
     // Repeat with Ratis container, as different metrics should be incremented
@@ -1162,14 +1163,14 @@ public class TestReplicationManager {
 
     ops = containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
     Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
-    Assertions.assertEquals(1, ops.size());
-    Assertions.assertEquals(ContainerReplicaOp.PendingOpType.ADD,
+    assertEquals(1, ops.size());
+    assertEquals(ContainerReplicaOp.PendingOpType.ADD,
         ops.get(0).getOpType());
-    Assertions.assertEquals(target, ops.get(0).getTarget());
-    Assertions.assertEquals(0, ops.get(0).getReplicaIndex());
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(target, ops.get(0).getTarget());
+    assertEquals(0, ops.get(0).getReplicaIndex());
+    assertEquals(1, replicationManager.getMetrics()
         .getEcReplicationCmdsSentTotal());
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(1, replicationManager.getMetrics()
         .getReplicationCmdsSentTotal());
   }
 
@@ -1205,14 +1206,14 @@ public class TestReplicationManager {
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
     Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
-    Assertions.assertEquals(1, ops.size());
-    Assertions.assertEquals(ContainerReplicaOp.PendingOpType.ADD,
+    assertEquals(1, ops.size());
+    assertEquals(ContainerReplicaOp.PendingOpType.ADD,
         ops.get(0).getOpType());
-    Assertions.assertEquals(target, ops.get(0).getTarget());
-    Assertions.assertEquals(1, ops.get(0).getReplicaIndex());
-    Assertions.assertEquals(1, replicationManager.getMetrics()
+    assertEquals(target, ops.get(0).getTarget());
+    assertEquals(1, ops.get(0).getReplicaIndex());
+    assertEquals(1, replicationManager.getMetrics()
         .getEcReplicationCmdsSentTotal());
-    Assertions.assertEquals(0, replicationManager.getMetrics()
+    assertEquals(0, replicationManager.getMetrics()
         .getReplicationCmdsSentTotal());
   }
 
@@ -1242,10 +1243,10 @@ public class TestReplicationManager {
 
     ReplicateContainerCommand sentCommand =
         (ReplicateContainerCommand)command.getValue();
-    Assertions.assertEquals(datanodeDeadline, sentCommand.getDeadline());
-    Assertions.assertEquals(LOW, sentCommand.getPriority());
-    Assertions.assertEquals(src.getUuid(), targetUUID.getValue());
-    Assertions.assertEquals(target, sentCommand.getTargetDatanode());
+    assertEquals(datanodeDeadline, sentCommand.getDeadline());
+    assertEquals(LOW, sentCommand.getPriority());
+    assertEquals(src.getUuid(), targetUUID.getValue());
+    assertEquals(target, sentCommand.getTargetDatanode());
   }
 
   @Test
@@ -1298,15 +1299,15 @@ public class TestReplicationManager {
     replicationManager.sendThrottledReplicationCommand(
         container, new ArrayList<>(sourceNodes), destination, replicaIndex);
 
-    Assertions.assertEquals(1, commandsSent.size());
+    assertEquals(1, commandsSent.size());
     Pair<UUID, SCMCommand<?>> cmdWithTarget = commandsSent.iterator().next();
-    Assertions.assertEquals(expectedTarget.getUuid(), cmdWithTarget.getLeft());
-    Assertions.assertEquals(ReplicateContainerCommand.class,
+    assertEquals(expectedTarget.getUuid(), cmdWithTarget.getLeft());
+    assertEquals(ReplicateContainerCommand.class,
         cmdWithTarget.getRight().getClass());
     ReplicateContainerCommand cmd =
         (ReplicateContainerCommand) cmdWithTarget.getRight();
-    Assertions.assertEquals(destination, cmd.getTargetDatanode());
-    Assertions.assertEquals(replicaIndex, cmd.getReplicaIndex());
+    assertEquals(destination, cmd.getTargetDatanode());
+    assertEquals(replicaIndex, cmd.getReplicaIndex());
   }
 
   @Test
@@ -1360,9 +1361,9 @@ public class TestReplicationManager {
 
     replicationManager.sendThrottledReconstructionCommand(container, command);
 
-    Assertions.assertEquals(1, commandsSent.size());
+    assertEquals(1, commandsSent.size());
     Pair<UUID, SCMCommand<?>> cmd = commandsSent.iterator().next();
-    Assertions.assertEquals(cmdTarget.getUuid(), cmd.getLeft());
+    assertEquals(cmdTarget.getUuid(), cmd.getLeft());
     assertEquals(0, replicationManager.getMetrics()
         .getEcReconstructionCmdsDeferredTotal());
   }
@@ -1478,7 +1479,7 @@ public class TestReplicationManager {
     assertEquals(1, excluded.size());
     // dn 3 was at the limit already, so should be added when filtering the
     // nodes
-    Assert.assertTrue(excluded.contains(dn3));
+    assertTrue(excluded.contains(dn3));
 
     // Trigger an update for dn3, but it should stay in the excluded list as its
     // count is still at the limit.
@@ -1500,7 +1501,7 @@ public class TestReplicationManager {
     excluded = replicationManager.getExcludedNodes();
     assertEquals(1, excluded.size());
     // dn 2 reached the limit from the reconstruction command
-    Assert.assertTrue(excluded.contains(dn2));
+    assertTrue(excluded.contains(dn2));
 
     // Update received for DN2, it should be cleared from the excluded list.
     replicationManager.datanodeCommandCountUpdated(dn2);
@@ -1525,19 +1526,19 @@ public class TestReplicationManager {
     config.setInflightReplicationLimitFactor(0.0);
     configuration.setFromObject(config);
     ReplicationManager rm = createReplicationManager();
-    Assertions.assertEquals(0, rm.getReplicationInFlightLimit());
+    assertEquals(0, rm.getReplicationInFlightLimit());
 
     config.setInflightReplicationLimitFactor(1);
     configuration.setFromObject(config);
     rm = createReplicationManager();
-    Assertions.assertEquals(
+    assertEquals(
         healthyNodes * config.getDatanodeReplicationLimit(),
         rm.getReplicationInFlightLimit());
 
     config.setInflightReplicationLimitFactor(0.75);
     configuration.setFromObject(config);
     rm = createReplicationManager();
-    Assertions.assertEquals(
+    assertEquals(
         (int) Math.ceil(healthyNodes
             * config.getDatanodeReplicationLimit() * 0.75),
         rm.getReplicationInFlightLimit());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -25,9 +25,8 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -39,6 +38,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for ReplicationManagerUtil.
@@ -47,7 +48,7 @@ public class TestReplicationManagerUtil {
 
   private ReplicationManager replicationManager;
 
-  @Before
+  @BeforeEach
   public void setup() {
     replicationManager = Mockito.mock(ReplicationManager.class);
   }
@@ -111,22 +112,22 @@ public class TestReplicationManagerUtil {
             new ArrayList<>(replicas), toBeRemoved, pending,
             replicationManager);
 
-    Assertions.assertEquals(3, excludedAndUsedNodes.getUsedNodes().size());
-    Assertions.assertTrue(excludedAndUsedNodes.getUsedNodes()
+    assertEquals(3, excludedAndUsedNodes.getUsedNodes().size());
+    assertTrue(excludedAndUsedNodes.getUsedNodes()
         .contains(good.getDatanodeDetails()));
-    Assertions.assertTrue(excludedAndUsedNodes.getUsedNodes()
+    assertTrue(excludedAndUsedNodes.getUsedNodes()
         .contains(maintenance.getDatanodeDetails()));
-    Assertions.assertTrue(excludedAndUsedNodes.getUsedNodes()
+    assertTrue(excludedAndUsedNodes.getUsedNodes()
         .contains(pendingAdd));
 
-    Assertions.assertEquals(4, excludedAndUsedNodes.getExcludedNodes().size());
-    Assertions.assertTrue(excludedAndUsedNodes.getExcludedNodes()
+    assertEquals(4, excludedAndUsedNodes.getExcludedNodes().size());
+    assertTrue(excludedAndUsedNodes.getExcludedNodes()
         .contains(unhealthy.getDatanodeDetails()));
-    Assertions.assertTrue(excludedAndUsedNodes.getExcludedNodes()
+    assertTrue(excludedAndUsedNodes.getExcludedNodes()
         .contains(decommissioning.getDatanodeDetails()));
-    Assertions.assertTrue(excludedAndUsedNodes.getExcludedNodes()
+    assertTrue(excludedAndUsedNodes.getExcludedNodes()
         .contains(remove.getDatanodeDetails()));
-    Assertions.assertTrue(excludedAndUsedNodes.getExcludedNodes()
+    assertTrue(excludedAndUsedNodes.getExcludedNodes()
         .contains(pendingDelete));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.UnderReplicatedHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -46,7 +46,7 @@ public class TestUnderReplicatedProcessor {
   private ReplicationQueue queue;
   private ReplicationManagerMetrics rmMetrics;
 
-  @Before
+  @BeforeEach
   public void setup() {
     ConfigurationSource conf = new OzoneConfiguration();
     ReplicationManagerConfiguration rmConf =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECMisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECMisReplicationCheckHandler.java
@@ -34,9 +34,8 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -45,13 +44,14 @@ import java.util.List;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.HealthState.MIS_REPLICATED;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.ADD;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.DELETE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -63,12 +63,11 @@ public class TestECMisReplicationCheckHandler {
   private ECMisReplicationCheckHandler handler;
   private ECReplicationConfig repConfig;
   private ReplicationQueue repQueue;
-  private int maintenanceRedundancy = 2;
   private ContainerCheckRequest.Builder requestBuilder;
   private ReplicationManagerReport report;
   private PlacementPolicy placementPolicy;
 
-  @Before
+  @BeforeEach
   public void setup() {
     placementPolicy = Mockito.mock(PlacementPolicy.class);
     Mockito.when(placementPolicy.validateContainerPlacement(
@@ -78,6 +77,7 @@ public class TestECMisReplicationCheckHandler {
     repConfig = new ECReplicationConfig(3, 2);
     repQueue = new ReplicationQueue();
     report = new ReplicationManagerReport();
+    int maintenanceRedundancy = 2;
     requestBuilder = new ContainerCheckRequest.Builder()
         .setReplicationQueue(repQueue)
         .setMaintenanceRedundancy(maintenanceRedundancy)
@@ -142,8 +142,7 @@ public class TestECMisReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = handler.checkMisReplication(request);
-    Assertions.assertEquals(ContainerHealthResult.HealthState.MIS_REPLICATED,
-        result.getHealthState());
+    assertEquals(MIS_REPLICATED, result.getHealthState());
 
     assertTrue(handler.handle(request));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -192,8 +191,7 @@ public class TestECMisReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = handler.checkMisReplication(request);
-    Assertions.assertEquals(ContainerHealthResult.HealthState.MIS_REPLICATED,
-        result.getHealthState());
+    assertEquals(MIS_REPLICATED, result.getHealthState());
 
     assertTrue(handler.handle(request));
     assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -248,8 +246,7 @@ public class TestECMisReplicationCheckHandler {
         .build();
 
     ContainerHealthResult result = handler.checkMisReplication(request);
-    Assertions.assertEquals(ContainerHealthResult.HealthState.MIS_REPLICATED,
-        result.getHealthState());
+    assertEquals(MIS_REPLICATED, result.getHealthState());
 
     assertTrue(handler.handle(request));
     assertEquals(0, repQueue.underReplicatedQueueSize());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcProtocolService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcProtocolService.java
@@ -31,9 +31,8 @@ import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
 import javax.net.ssl.KeyManager;
@@ -86,8 +85,8 @@ public class TestInterSCMGrpcProtocolService {
   private X509KeyManager clientKeyManager;
   private X509TrustManager clientTrustManager;
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  private Path temp;
 
   @Test
   public void testMTLSOnInterScmGrpcProtocolServiceAccess() throws Exception {
@@ -101,7 +100,8 @@ public class TestInterSCMGrpcProtocolService {
 
     InterSCMGrpcClient client =
         new InterSCMGrpcClient("localhost", port, conf, scmCertClient);
-    CompletableFuture<Path> res = client.download(temp.newFile().toPath());
+    Path tempFile = Files.createTempFile(temp, CP_FILE_NAME, "");
+    CompletableFuture<Path> res = client.download(tempFile);
     Path downloaded = res.get();
 
     verifyServiceUsedItsCertAndValidatedClientCert();
@@ -182,7 +182,7 @@ public class TestInterSCMGrpcProtocolService {
   }
 
   private DBCheckpoint checkPoint() throws IOException {
-    Path checkPointLocation = temp.newFolder().toPath();
+    Path checkPointLocation = Files.createTempDirectory(temp, "cpDir");
     Path cpFile = Paths.get(checkPointLocation.toString(), CP_FILE_NAME);
     Files.write(cpFile, CP_CONTENTS.getBytes(UTF_8));
     DBCheckpoint checkpoint = mock(DBCheckpoint.class);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -33,7 +33,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.TimeDuration;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -66,7 +65,9 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVIC
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for SCM HA-related configuration.
@@ -302,21 +303,21 @@ class TestSCMHAConfiguration {
 
   @Test
   public void testRatisEnabledDefaultConfigWithoutInitializedSCM()
-      throws IOException, NoSuchFieldException, IllegalAccessException {
+      throws IOException {
     SCMStorageConfig scmStorageConfig = Mockito.mock(SCMStorageConfig.class);
     Mockito.when(scmStorageConfig.getState())
         .thenReturn(Storage.StorageState.NOT_INITIALIZED);
     SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
-    Assert.assertEquals(SCMHAUtils.isSCMHAEnabled(conf),
+    assertEquals(SCMHAUtils.isSCMHAEnabled(conf),
         ScmConfigKeys.OZONE_SCM_HA_ENABLE_DEFAULT);
     DefaultConfigManager.clearDefaultConfigs();
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, false);
     SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
-    Assert.assertEquals(SCMHAUtils.isSCMHAEnabled(conf), false);
+    assertFalse(SCMHAUtils.isSCMHAEnabled(conf));
     DefaultConfigManager.clearDefaultConfigs();
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
-    Assert.assertEquals(SCMHAUtils.isSCMHAEnabled(conf), true);
+    assertTrue(SCMHAUtils.isSCMHAEnabled(conf));
   }
 
   @Test
@@ -328,11 +329,11 @@ class TestSCMHAConfiguration {
     Mockito.when(scmStorageConfig.isSCMHAEnabled()).thenReturn(false);
     DefaultConfigManager.clearDefaultConfigs();
     SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
-    Assert.assertEquals(SCMHAUtils.isSCMHAEnabled(conf),
+    assertEquals(SCMHAUtils.isSCMHAEnabled(conf),
         scmStorageConfig.isSCMHAEnabled());
     Mockito.when(scmStorageConfig.isSCMHAEnabled()).thenReturn(false);
     DefaultConfigManager.clearDefaultConfigs();
-    Assert.assertEquals(SCMHAUtils.isSCMHAEnabled(conf), true);
+    assertTrue(SCMHAUtils.isSCMHAEnabled(conf));
   }
 
   @ParameterizedTest

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueue.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueue.java
@@ -26,13 +26,14 @@ import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.CreatePipelineCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for the CommandQueue class.
@@ -74,56 +75,56 @@ public class TestCommandQueue {
     commandQueue.addCommand(datanode2UUID, createPipelineCommand);
 
     // Check zero returned for unknown DN
-    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+    assertEquals(0, commandQueue.getDatanodeCommandCount(
         UUID.randomUUID(), SCMCommandProto.Type.closeContainerCommand));
 
-    Assert.assertEquals(2, commandQueue.getDatanodeCommandCount(
+    assertEquals(2, commandQueue.getDatanodeCommandCount(
         datanode1UUID, SCMCommandProto.Type.closeContainerCommand));
-    Assert.assertEquals(1, commandQueue.getDatanodeCommandCount(
+    assertEquals(1, commandQueue.getDatanodeCommandCount(
         datanode1UUID, SCMCommandProto.Type.createPipelineCommand));
-    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+    assertEquals(0, commandQueue.getDatanodeCommandCount(
         datanode1UUID, SCMCommandProto.Type.closePipelineCommand));
-    Assert.assertEquals(1, commandQueue.getDatanodeCommandCount(
+    assertEquals(1, commandQueue.getDatanodeCommandCount(
         datanode1UUID, SCMCommandProto.Type.replicateContainerCommand));
 
     Map<SCMCommandProto.Type, Integer> commandSummary =
         commandQueue.getDatanodeCommandSummary(datanode1UUID);
-    Assert.assertEquals(3, commandSummary.size());
-    Assert.assertEquals(Integer.valueOf(2),
+    assertEquals(3, commandSummary.size());
+    assertEquals(Integer.valueOf(2),
         commandSummary.get(SCMCommandProto.Type.closeContainerCommand));
-    Assert.assertEquals(Integer.valueOf(1),
+    assertEquals(Integer.valueOf(1),
         commandSummary.get(SCMCommandProto.Type.createPipelineCommand));
-    Assert.assertEquals(Integer.valueOf(1),
+    assertEquals(Integer.valueOf(1),
         commandSummary.get(SCMCommandProto.Type.replicateContainerCommand));
 
-    Assert.assertEquals(1, commandQueue.getDatanodeCommandCount(
+    assertEquals(1, commandQueue.getDatanodeCommandCount(
         datanode2UUID, SCMCommandProto.Type.closeContainerCommand));
-    Assert.assertEquals(2, commandQueue.getDatanodeCommandCount(
+    assertEquals(2, commandQueue.getDatanodeCommandCount(
         datanode2UUID, SCMCommandProto.Type.createPipelineCommand));
 
     // Ensure the counts are cleared when the commands are retrieved
     List<SCMCommand> cmds = commandQueue.getCommand(datanode1UUID);
-    Assert.assertEquals(5, cmds.size());
+    assertEquals(5, cmds.size());
 
-    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+    assertEquals(0, commandQueue.getDatanodeCommandCount(
         datanode1UUID, SCMCommandProto.Type.closeContainerCommand));
-    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+    assertEquals(0, commandQueue.getDatanodeCommandCount(
         datanode1UUID, SCMCommandProto.Type.createPipelineCommand));
-    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+    assertEquals(0, commandQueue.getDatanodeCommandCount(
         datanode1UUID, SCMCommandProto.Type.closePipelineCommand));
-    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+    assertEquals(0, commandQueue.getDatanodeCommandCount(
         datanode1UUID, SCMCommandProto.Type.replicateContainerCommand));
 
-    Assert.assertEquals(1, commandQueue.getDatanodeCommandCount(
+    assertEquals(1, commandQueue.getDatanodeCommandCount(
         datanode2UUID, SCMCommandProto.Type.closeContainerCommand));
-    Assert.assertEquals(2, commandQueue.getDatanodeCommandCount(
+    assertEquals(2, commandQueue.getDatanodeCommandCount(
         datanode2UUID, SCMCommandProto.Type.createPipelineCommand));
 
     // Ensure the commands are zeroed when the queue is cleared
     commandQueue.clear();
-    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+    assertEquals(0, commandQueue.getDatanodeCommandCount(
         datanode2UUID, SCMCommandProto.Type.closeContainerCommand));
-    Assert.assertEquals(0, commandQueue.getDatanodeCommandCount(
+    assertEquals(0, commandQueue.getDatanodeCommandCount(
         datanode2UUID, SCMCommandProto.Type.createPipelineCommand));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,13 +40,15 @@ import java.util.UUID;
 import java.util.Arrays;
 import java.util.ArrayList;
 
+import static java.util.Collections.singletonList;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.assertj.core.api.Fail.fail;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit tests for the decommision manager.
+ * Unit tests for the decommission manager.
  */
 
 public class TestNodeDecommissionManager {
@@ -87,11 +88,8 @@ public class TestNodeDecommissionManager {
     assertEquals("foobar.mycompany.com", def.getHostname());
     assertEquals(1234, def.getPort());
 
-    try {
-      new NodeDecommissionManager.HostDefinition("foobar:abcd");
-      fail("InvalidHostStringException should have been thrown");
-    } catch (InvalidHostStringException e) {
-    }
+    assertThrows(InvalidHostStringException.class,
+        () -> new NodeDecommissionManager.HostDefinition("foobar:abcd"));
   }
 
   @Test
@@ -101,47 +99,41 @@ public class TestNodeDecommissionManager {
     // Try to decommission a host that does exist, but give incorrect port
     List<DatanodeAdminError> error =
         decom.decommissionNodes(
-            Arrays.asList(dns.get(1).getIpAddress() + ":10"));
-    Assert.assertTrue(error.size() == 1);
-    Assert.assertTrue(
-        error.get(0).getHostname().contains(dns.get(1).getIpAddress()));
+            singletonList(dns.get(1).getIpAddress() + ":10"));
+    assertEquals(1, error.size());
+    assertTrue(error.get(0).getHostname().contains(dns.get(1).getIpAddress()));
 
     // Try to decommission a host that does not exist
-    error = decom.decommissionNodes(Arrays.asList("123.123.123.123"));
-    Assert.assertTrue(error.size() == 1);
-    Assert.assertTrue(
-        error.get(0).getHostname().contains("123.123.123.123"));
+    error = decom.decommissionNodes(singletonList("123.123.123.123"));
+    assertEquals(1, error.size());
+    assertTrue(error.get(0).getHostname().contains("123.123.123.123"));
 
     // Try to decommission a host that does exist and a host that does not
-    error  = decom.decommissionNodes(Arrays.asList(
-          dns.get(1).getIpAddress(), "123,123,123,123"));
-    Assert.assertTrue(error.size() == 1);
-    Assert.assertTrue(
-        error.get(0).getHostname().contains("123,123,123,123"));
+    error  = decom.decommissionNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        "123,123,123,123"));
+    assertEquals(1, error.size());
+    assertTrue(error.get(0).getHostname().contains("123,123,123,123"));
 
     // Try to decommission a host with many DNs on the address with no port
-    error = decom.decommissionNodes(Arrays.asList(
-          dns.get(0).getIpAddress()));
-    Assert.assertTrue(error.size() == 1);
-    Assert.assertTrue(
-        error.get(0).getHostname().contains(dns.get(0).getIpAddress()));
+    error = decom.decommissionNodes(singletonList(dns.get(0).getIpAddress()));
+    assertEquals(1, error.size());
+    assertTrue(error.get(0).getHostname().contains(dns.get(0).getIpAddress()));
 
     // Try to decommission a host with many DNs on the address with a port
     // that does not exist
-    error = decom.decommissionNodes(Arrays.asList(
-          dns.get(0).getIpAddress() + ":10"));
-    Assert.assertTrue(error.size() == 1);
-    Assert.assertTrue(
-        error.get(0).getHostname().contains(dns.get(0).getIpAddress() + ":10"));
+    error = decom.decommissionNodes(singletonList(dns.get(0).getIpAddress()
+        + ":10"));
+    assertEquals(1, error.size());
+    assertTrue(error.get(0).getHostname().contains(dns.get(0).getIpAddress()
+        + ":10"));
 
     // Try to decommission 2 hosts with address that does not exist
     // Both should return error
     error  = decom.decommissionNodes(Arrays.asList(
         "123.123.123.123", "234.234.234.234"));
-    Assert.assertTrue(error.size() == 2);
-    Assert.assertTrue(
-        error.get(0).getHostname().contains("123.123.123.123") &&
-            error.get(1).getHostname().contains("234.234.234.234"));
+    assertEquals(2, error.size());
+    assertTrue(error.get(0).getHostname().contains("123.123.123.123") &&
+        error.get(1).getHostname().contains("234.234.234.234"));
   }
 
   @Test
@@ -167,7 +159,7 @@ public class TestNodeDecommissionManager {
     DatanodeDetails multiDn = dns.get(10);
     String multiAddr =
         multiDn.getIpAddress() + ":" + multiDn.getPorts().get(0).getValue();
-    decom.decommissionNodes(Arrays.asList(multiAddr));
+    decom.decommissionNodes(singletonList(multiAddr));
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
         nodeManager.getNodeStatus(multiDn).getOperationalState());
 
@@ -175,7 +167,7 @@ public class TestNodeDecommissionManager {
     // dn(11) with identical ports.
     nodeManager.processHeartbeat(dns.get(9), defaultLayoutVersionProto());
     DatanodeDetails duplicatePorts = dns.get(9);
-    decom.decommissionNodes(Arrays.asList(duplicatePorts.getIpAddress()));
+    decom.decommissionNodes(singletonList(duplicatePorts.getIpAddress()));
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
         nodeManager.getNodeStatus(duplicatePorts).getOperationalState());
 
@@ -226,20 +218,19 @@ public class TestNodeDecommissionManager {
 
     // Attempt to decommission with just the IP, which should fail.
     List<DatanodeAdminError> error =
-        decom.decommissionNodes(Arrays.asList(extraDN.getIpAddress()));
-    Assert.assertTrue(error.size() == 1);
-    Assert.assertTrue(
-        error.get(0).getHostname().contains(extraDN.getIpAddress()));
+        decom.decommissionNodes(singletonList(extraDN.getIpAddress()));
+    assertEquals(1, error.size());
+    assertTrue(error.get(0).getHostname().contains(extraDN.getIpAddress()));
 
     // Now try the one with the unique port
-    decom.decommissionNodes(Arrays.asList(
-        extraDN.getIpAddress() + ":" + ratisPort + 1));
+    decom.decommissionNodes(
+        singletonList(extraDN.getIpAddress() + ":" + ratisPort + 1));
 
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
         nodeManager.getNodeStatus(extraDN).getOperationalState());
 
-    decom.recommissionNodes(Arrays.asList(
-        extraDN.getIpAddress() + ":" + ratisPort + 1));
+    decom.recommissionNodes(
+        singletonList(extraDN.getIpAddress() + ":" + ratisPort + 1));
     decom.getMonitor().run();
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(extraDN).getOperationalState());
@@ -248,7 +239,7 @@ public class TestNodeDecommissionManager {
     DatanodeDetails expectedDN = dns.get(9);
     nodeManager.processHeartbeat(expectedDN, defaultLayoutVersionProto());
 
-    decom.decommissionNodes(Arrays.asList(
+    decom.decommissionNodes(singletonList(
         expectedDN.getIpAddress() + ":" + ratisPort));
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
         nodeManager.getNodeStatus(expectedDN).getOperationalState());
@@ -256,7 +247,7 @@ public class TestNodeDecommissionManager {
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(11)).getOperationalState());
 
-    decom.recommissionNodes(Arrays.asList(
+    decom.recommissionNodes(singletonList(
         expectedDN.getIpAddress() + ":" + ratisPort));
     decom.getMonitor().run();
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
@@ -290,7 +281,7 @@ public class TestNodeDecommissionManager {
     DatanodeDetails multiDn = dns.get(10);
     String multiAddr =
         multiDn.getIpAddress() + ":" + multiDn.getPorts().get(0).getValue();
-    decom.startMaintenanceNodes(Arrays.asList(multiAddr), 100);
+    decom.startMaintenanceNodes(singletonList(multiAddr), 100);
     assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
         nodeManager.getNodeStatus(multiDn).getOperationalState());
 
@@ -298,7 +289,7 @@ public class TestNodeDecommissionManager {
     // dn(11) with identical ports.
     nodeManager.processHeartbeat(dns.get(9), defaultLayoutVersionProto());
     DatanodeDetails duplicatePorts = dns.get(9);
-    decom.startMaintenanceNodes(Arrays.asList(duplicatePorts.getIpAddress()),
+    decom.startMaintenanceNodes(singletonList(duplicatePorts.getIpAddress()),
         100);
     assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
         nodeManager.getNodeStatus(duplicatePorts).getOperationalState());
@@ -444,5 +435,4 @@ public class TestNodeDecommissionManager {
 
     return dns;
   }
-
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -250,7 +250,7 @@ public class TestRatisPipelineProvider {
     List<DatanodeDetails> healthyNodes =
         nodeManager.getNodes(NodeStatus.inServiceHealthy());
 
-    Assume.assumeTrue(healthyNodes.size() == 8);
+    Assumptions.assumeTrue(healthyNodes.size() == 8);
 
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -39,8 +39,6 @@ import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoo
 import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -62,6 +60,8 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.CLOSED;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -311,12 +311,10 @@ public class TestWritableECContainerProvider {
     };
     provider = createSubject(policy);
 
-    try {
-      provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-      Assert.fail();
-    } catch (IOException ex) {
-      GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
-    }
+    IOException ioException = assertThrows(IOException.class,
+        () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
+    assertThat(ioException.getMessage(),
+        containsString("Cannot create pipelines"));
   }
 
   @ParameterizedTest
@@ -342,20 +340,16 @@ public class TestWritableECContainerProvider {
     };
     provider = createSubject(policy);
 
-    try {
-      provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-      Assert.fail();
-    } catch (IOException ex) {
-      GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
-    }
+    IOException ioException = assertThrows(IOException.class,
+        () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
+    assertThat(ioException.getMessage(),
+        containsString("Cannot create pipelines"));
 
     for (int i = 0; i < 5; i++) {
-      try {
-        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-        Assert.fail();
-      } catch (IOException ex) {
-        GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
-      }
+      ioException = assertThrows(IOException.class,
+          () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
+      assertThat(ioException.getMessage(),
+          containsString("Cannot create pipelines"));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
@@ -65,7 +65,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICAT
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdds.scm.server;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionScmResponseProto;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
@@ -28,17 +28,17 @@ import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
-
-import org.junit.Assert;
-import org.junit.jupiter.api.Test;
-
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests to validate the SCMClientProtocolServer
@@ -92,8 +92,7 @@ public class TestSCMClientProtocolServer {
 
     // should have optional error message set in response
     assertTrue(resp.hasErrorMsg());
-    assertTrue(resp.getErrorMsg()
-        .equals(err));
+    assertEquals(err, resp.getErrorMsg());
   }
 
   @Test
@@ -105,7 +104,7 @@ public class TestSCMClientProtocolServer {
       // read operator
       server.getScm().checkAdminAccess(testUser, true);
       // write operator
-      Assert.assertThrows(AccessControlException.class,
+      assertThrows(AccessControlException.class,
           () -> server.getScm().checkAdminAccess(testUser, false));
     } finally {
       UserGroupInformation.reset();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
@@ -27,9 +27,9 @@ import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
+import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationCheckpoint;
 import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationManager;
 import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationStateManager;
-import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationCheckpoint;
 import org.apache.hadoop.hdds.scm.server.upgrade.SCMUpgradeFinalizationContext;
 import org.apache.hadoop.hdds.scm.server.upgrade.SCMUpgradeFinalizer;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
@@ -38,11 +38,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
-import org.junit.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatchers;
@@ -54,6 +50,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests SCM finalization operations on mocked upgrade state.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -79,7 +79,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/hadoop-hdds/tools/pom.xml
+++ b/hadoop-hdds/tools/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Tools</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/TestUpgradeManager.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/TestUpgradeManager.java
@@ -46,9 +46,9 @@ import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.metadata.DatanodeSchemaThreeDBDefinition;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -65,8 +65,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.COMMIT_STAGE;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.WRITE_STAGE;
 import static org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask.LOG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -75,19 +75,19 @@ import static org.mockito.Mockito.mock;
  * Tests for UpgradeManager class.
  */
 public class TestUpgradeManager {
+  private static final String SCM_ID = UUID.randomUUID().toString();
+  private static final OzoneConfiguration CONF = new OzoneConfiguration();
 
   private File testRoot;
-  private String scmId = UUID.randomUUID().toString();
   private MutableVolumeSet volumeSet;
   private UUID datanodeId;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
-  private static final OzoneConfiguration CONF = new OzoneConfiguration();
 
   private BlockManager blockManager;
   private FilePerBlockStrategy chunkManager;
   private ContainerSet containerSet;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     DatanodeConfiguration dc = CONF.getObject(DatanodeConfiguration.class);
     dc.setContainerSchemaV3Enabled(true);
@@ -112,14 +112,15 @@ public class TestUpgradeManager {
         volume1Path.getAbsolutePath() + "," + volume2Path.getAbsolutePath());
     CONF.set(OZONE_METADATA_DIRS, metadataPath.getAbsolutePath());
     datanodeId = UUID.randomUUID();
-    volumeSet = new MutableVolumeSet(datanodeId.toString(), scmId, CONF,
+    volumeSet = new MutableVolumeSet(datanodeId.toString(), SCM_ID, CONF,
         null, StorageVolume.VolumeType.DATA_VOLUME, null);
 
     // create rocksdb instance in volume dir
     final List<HddsVolume> volumes = new ArrayList<>();
     for (StorageVolume storageVolume : volumeSet.getVolumesList()) {
       HddsVolume hddsVolume = (HddsVolume) storageVolume;
-      StorageVolumeUtil.checkVolume(hddsVolume, scmId, scmId, CONF, null, null);
+      StorageVolumeUtil.checkVolume(hddsVolume, SCM_ID, SCM_ID, CONF, null,
+          null);
       volumes.add(hddsVolume);
     }
 
@@ -142,7 +143,7 @@ public class TestUpgradeManager {
     chunkManager = new FilePerBlockStrategy(true, blockManager, null);
   }
 
-  @After
+  @AfterEach
   public void after() throws IOException {
     FileUtils.deleteDirectory(testRoot);
   }
@@ -242,7 +243,7 @@ public class TestUpgradeManager {
       data.setSchemaVersion(OzoneConsts.SCHEMA_V2);
 
       KeyValueContainer container = new KeyValueContainer(data, CONF);
-      container.create(volumeSet, volumeChoosingPolicy, scmId);
+      container.create(volumeSet, volumeChoosingPolicy, SCM_ID);
 
       containerSet.addContainer(container);
       data = (KeyValueContainerData) containerSet.getContainer(containerId)


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to migrate tests in hdds to JUnit5. Tests migrated, are listed below.
```
hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestContainerClientMetrics.java
hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/Proto2CodecTestBase.java
hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileAppender.java
hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileGenerator.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestPemFileBasedKeyStoresFactory.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509KeyManager.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestServerUtils.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2MetricsTest.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestFixedLengthStringCodec.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestMoveManager.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECMisReplicationCheckHandler.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcProtocolService.java
hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/upgrade/TestUpgradeManager.java
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9491

## How was this patch tested?
CD/CI run on the fork: https://github.com/hemantk-12/ozone/actions/runs/6961062933
