### PR TITLE
HDDS-9505. Migrated integration tests with TemporaryFolder to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
@@ -27,6 +27,8 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_F
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.base.Strings;
 import java.io.File;
@@ -42,7 +44,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
@@ -55,15 +56,11 @@ import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTrans
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,15 +68,13 @@ import org.slf4j.LoggerFactory;
  * Test OzoneManager list volume operation under combinations of configs
  * in secure mode.
  */
+@Timeout(1200)
 public class TestOzoneManagerListVolumesSecure {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestOzoneManagerListVolumesSecure.class);
 
-  private static final Logger LOG = LoggerFactory
-      .getLogger(TestOzoneManagerListVolumesSecure.class);
-
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(1200));
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private String realm;
   private OzoneConfiguration conf;
@@ -105,14 +100,14 @@ public class TestOzoneManagerListVolumesSecure {
   private UserGroupInformation userUGI1;
   private UserGroupInformation userUGI2;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     this.conf = new OzoneConfiguration();
     conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, "localhost");
     conf.set(OZONE_SECURITY_ENABLED_KEY, "true");
     conf.set("hadoop.security.authentication", "kerberos");
 
-    this.workDir = folder.newFolder();
+    this.workDir = folder.toFile();
 
     startMiniKdc();
     this.realm = miniKdc.getRealm();
@@ -144,8 +139,8 @@ public class TestOzoneManagerListVolumesSecure {
   }
 
   private void createPrincipals() throws Exception {
-    String host = InetAddress.getLocalHost().getCanonicalHostName().
-        toLowerCase();
+    String host = InetAddress.getLocalHost()
+        .getCanonicalHostName().toLowerCase();
     String hostAndRealm = host + "@" + this.realm;
     this.adminPrincipal = adminUser + "/" + hostAndRealm;
     this.adminPrincipalInOtherHost = adminUser + "/otherhost@" + this.realm;
@@ -168,21 +163,12 @@ public class TestOzoneManagerListVolumesSecure {
     miniKdc.createPrincipal(keytab, principal);
   }
 
-  @After
+  @AfterEach
   public void stop() {
-    try {
-      stopMiniKdc();
-
-      if (om != null) {
-        om.stop();
-        om.join();
-      }
-
-      if (workDir != null) {
-        FileUtils.deleteDirectory(workDir);
-      }
-    } catch (Exception e) {
-      LOG.error("Failed to stop TestSecureOzoneCluster", e);
+    stopMiniKdc();
+    if (om != null) {
+      om.stop();
+      om.join();
     }
   }
 
@@ -190,7 +176,7 @@ public class TestOzoneManagerListVolumesSecure {
    * Setup test environment.
    */
   private void setupEnvironment(boolean aclEnabled,
-      boolean volListAllAllowed) throws Exception {
+                                boolean volListAllAllowed) throws Exception {
     Path omPath = Paths.get(workDir.getPath(), "om-meta");
     conf.set(OZONE_METADATA_DIRS, omPath.toString());
 
@@ -249,7 +235,7 @@ public class TestOzoneManagerListVolumesSecure {
     if (!Strings.isNullOrEmpty(aclString)) {
       OzoneObj obj = OzoneObjInfo.Builder.newBuilder().setVolumeName(volumeName)
           .setResType(OzoneObj.ResourceType.VOLUME).setStoreType(OZONE).build();
-      Assert.assertTrue(client.setAcl(obj, OzoneAcl.parseAcls(aclString)));
+      assertTrue(client.setAcl(obj, OzoneAcl.parseAcls(aclString)));
     }
   }
 
@@ -258,7 +244,7 @@ public class TestOzoneManagerListVolumesSecure {
    * under different config combination.
    */
   private void checkUser(String userName, List<String> expectVol,
-      boolean expectListAllSuccess) throws IOException {
+                         boolean expectListAllSuccess) throws IOException {
 
     OzoneManagerProtocolClientSideTranslatorPB client =
         new OzoneManagerProtocolClientSideTranslatorPB(
@@ -275,7 +261,7 @@ public class TestOzoneManagerListVolumesSecure {
         String volumeName = v.getVolume();
         accessibleVolumes.add(volumeName);
       }
-      Assert.assertEquals(new HashSet<>(expectVol), accessibleVolumes);
+      assertEquals(new HashSet<>(expectVol), accessibleVolumes);
     } catch (OMException e) {
       if (!expectListAllSuccess &&
           e.getResult() == OMException.ResultCodes.PERMISSION_DENIED) {
@@ -291,8 +277,8 @@ public class TestOzoneManagerListVolumesSecure {
     //  disallowed).
     try {
       volumeList = client.listAllVolumes("volume", "", 100);
-      Assert.assertEquals(6, volumeList.size());
-      Assert.assertTrue(expectListAllSuccess);
+      assertEquals(6, volumeList.size());
+      assertTrue(expectListAllSuccess);
     } catch (OMException ex) {
       if (!expectListAllSuccess &&
           ex.getResult() == OMException.ResultCodes.PERMISSION_DENIED) {
@@ -305,10 +291,10 @@ public class TestOzoneManagerListVolumesSecure {
   }
 
   private static void doAs(UserGroupInformation ugi,
-      Callable<Boolean> callable) {
+                           Callable<Boolean> callable) {
     // Some thread (eg: HeartbeatEndpointTask) will use the login ugi,
     // so we could not use loginUserFromKeytabAndReturnUGI to switch user.
-    Assert.assertEquals(true, ugi.doAs((PrivilegedAction) () -> {
+    assertEquals(true, ugi.doAs((PrivilegedAction<Boolean>) () -> {
       try {
         return callable.call();
       } catch (Throwable ex) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
@@ -33,43 +33,39 @@ import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
-import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.INVALID_REQUEST;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 /**
  * Test OM Ratis request handling.
  */
+@Timeout(300)
 public class TestOzoneManagerRatisRequest {
-  @Rule public TemporaryFolder folder = new TemporaryFolder();
-
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
+  @TempDir
+  private Path folder;
 
   private OzoneManager ozoneManager;
-  private OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+  private final OzoneConfiguration ozoneConfiguration =
+      new OzoneConfiguration();
   private OMMetadataManager omMetadataManager;
 
   @Test
-  public void testRequestWithNonExistentBucket()
-      throws Exception {
-    // Test: Creating a client request for a bucket which doesn't exist.
+  public void testRequestWithNonExistentBucket() throws Exception {
     ozoneManager = Mockito.mock(OzoneManager.class);
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        Files.createTempDirectory(folder, "om").toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
@@ -91,21 +87,16 @@ public class TestOzoneManagerRatisRequest {
         .createCompleteMPURequest(volumeName, bucketName, "mpuKey", "mpuKeyID",
             new ArrayList<>());
 
-    try {
-      // Request creation flow should throw exception if the bucket associated
-      // with the request doesn't exist.
-      OzoneManagerRatisUtils.createClientRequest(omRequest, ozoneManager);
-      fail("Expected OMException: Bucket not found");
-    } catch (OMException oe) {
-      // Expected exception.
-      Assert.assertEquals(OMException.ResultCodes.BUCKET_NOT_FOUND,
-          oe.getResult());
-    }
+    OMException omException = assertThrows(OMException.class,
+        () -> OzoneManagerRatisUtils.createClientRequest(omRequest,
+            ozoneManager));
+    assertEquals(OMException.ResultCodes.BUCKET_NOT_FOUND,
+        omException.getResult());
   }
 
   @Test
-  public void testUnknownRequestHandling() throws IOException,
-      ServiceException {
+  public void testUnknownRequestHandling()
+      throws IOException, ServiceException {
     // Create an instance of OMRequest with an unknown command type.
     OzoneManagerProtocolProtos.OMRequest omRequest =
         OzoneManagerProtocolProtos.OMRequest.newBuilder()
@@ -115,7 +106,7 @@ public class TestOzoneManagerRatisRequest {
 
     ozoneManager = Mockito.mock(OzoneManager.class);
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        Files.createTempDirectory(folder, "om").toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
@@ -147,7 +138,7 @@ public class TestOzoneManagerRatisRequest {
       OzoneManagerProtocolProtos.OMResponse actualResponse =
           serverSideTranslatorPB.processRequest(omRequest);
 
-      Assertions.assertEquals(expectedResponse, actualResponse);
+      assertEquals(expectedResponse, actualResponse);
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
@@ -16,32 +16,6 @@
  */
 package org.apache.hadoop.ozone.om.service;
 
-import static org.apache.hadoop.hdds.scm.HddsTestUtils.mockRemoteUser;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RANGER_HTTPS_ADMIN_API_PASSWD;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RANGER_HTTPS_ADMIN_API_USER;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_RANGER_HTTPS_ADDRESS_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_RANGER_SERVICE;
-import static org.apache.hadoop.ozone.om.OMMultiTenantManager.OZONE_TENANT_RANGER_ROLE_DESCRIPTION;
-import static org.apache.hadoop.security.authentication.util.KerberosName.DEFAULT_MECHANISM;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.framework;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -68,43 +42,61 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.util.KerberosName;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.UnhealthyTest;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.apache.ranger.RangerServiceException;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeerId;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.slf4j.event.Level;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hadoop.hdds.scm.HddsTestUtils.mockRemoteUser;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RANGER_HTTPS_ADMIN_API_PASSWD;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RANGER_HTTPS_ADMIN_API_USER;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_RANGER_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_RANGER_SERVICE;
+import static org.apache.hadoop.ozone.om.OMMultiTenantManager.OZONE_TENANT_RANGER_ROLE_DESCRIPTION;
+import static org.apache.hadoop.security.authentication.util.KerberosName.DEFAULT_MECHANISM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.framework;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests Ozone Manager Multi-Tenancy feature Background Sync with Apache Ranger.
  * Marking it as Ignore because it needs Ranger access point.
  */
-@Category(UnhealthyTest.class) @Unhealthy("Requires a Ranger endpoint")
+@Unhealthy("Requires a Ranger endpoint")
+@Timeout(180)
 public class TestRangerBGSyncService {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestRangerBGSyncService.class);
-
-  /**
-   * Timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(180));
 
   private static final long TEST_SYNC_INTERVAL_SEC = 1L;
   private static final long TEST_SYNC_TIMEOUT_SEC = 3L;
@@ -112,7 +104,8 @@ public class TestRangerBGSyncService {
   private static final int CHECK_SYNC_MILLIS = 1000;
   private static final int WAIT_SYNC_TIMEOUT_MILLIS = 60000;
 
-  private TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path folder;
 
   private MultiTenantAccessController accessController;
   private OMRangerBGSyncService bgSync;
@@ -121,7 +114,7 @@ public class TestRangerBGSyncService {
   private final List<String> policiesCreated = new ArrayList<>();
   // List of role names created in Ranger for the test
   private final List<String> rolesCreated = new ArrayList<>();
-  // List of user names created in Ranger for the test
+  // List of usernames created in Ranger for the test
   private final List<String> usersCreated = new ArrayList<>();
 
   private static OzoneConfiguration conf;
@@ -157,7 +150,7 @@ public class TestRangerBGSyncService {
         System.getProperty(OZONE_OM_RANGER_HTTPS_ADMIN_API_PASSWD));
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     conf = new OzoneConfiguration();
     simulateOzoneSiteXmlConfig();
@@ -168,11 +161,11 @@ public class TestRangerBGSyncService {
         Level.INFO);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
 
     KerberosName.setRuleMechanism(DEFAULT_MECHANISM);
@@ -181,7 +174,7 @@ public class TestRangerBGSyncService {
             "RULE:[1:$1@$0](.*@EXAMPLE.COM)s/@.*//\n" +
             "DEFAULT");
     ugiAlice = UserGroupInformation.createRemoteUser(USER_ALICE);
-    Assert.assertEquals(USER_ALICE_SHORT, ugiAlice.getShortUserName());
+    assertEquals(USER_ALICE_SHORT, ugiAlice.getShortUserName());
 
     ozoneManager = mock(OzoneManager.class);
 
@@ -194,10 +187,8 @@ public class TestRangerBGSyncService {
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDirPath.toString());
 
     omMetrics = OMMetrics.create();
-    folder = new TemporaryFolder(new File("/tmp"));
-    folder.create();
     conf.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.newFolder().getAbsolutePath());
+        Files.createTempDirectory(folder.toAbsolutePath(), "om").toString());
     // No need to conf.set(OzoneConfigKeys.OZONE_ADMINISTRATORS, ...) here
     //  as we did the trick earlier with mockito.
     omMetadataManager = new OmMetadataManagerImpl(conf, ozoneManager);
@@ -265,7 +256,7 @@ public class TestRangerBGSyncService {
     accessController = new RangerClientMultiTenantAccessController(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     bgSync.shutdown();
     cleanupPoliciesRolesUsers();
@@ -283,7 +274,7 @@ public class TestRangerBGSyncService {
   private void createRoleHelper(Role role) throws IOException {
     Role roleCreated = accessController.createRole(role);
     // Confirm role creation
-    Assert.assertEquals(role.getName(), roleCreated.getName());
+    assertEquals(role.getName(), roleCreated.getName());
     // Add to created roles list
     rolesCreated.add(0, role.getName());
   }
@@ -337,7 +328,7 @@ public class TestRangerBGSyncService {
                 .setIsDelegatedAdmin(false)
                 .build());
       } catch (IOException e) {
-        Assert.fail(e.getMessage());
+        fail(e.getMessage());
       }
     }
 
@@ -346,7 +337,7 @@ public class TestRangerBGSyncService {
       rangerUserRequest.createUser(USER_ALICE_SHORT, "Password12");
       usersCreated.add(USER_ALICE_SHORT);
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     try {
@@ -354,7 +345,7 @@ public class TestRangerBGSyncService {
       rangerUserRequest.createUser(USER_BOB_SHORT, "Password12");
       usersCreated.add(USER_BOB_SHORT);
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     try {
@@ -366,7 +357,7 @@ public class TestRangerBGSyncService {
           .build();
       createRoleHelper(adminRole);
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     try {
@@ -380,7 +371,7 @@ public class TestRangerBGSyncService {
           .build();
       createRoleHelper(userRole);
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     try {
@@ -392,7 +383,7 @@ public class TestRangerBGSyncService {
       accessController.createPolicy(tenant1VolumeAccessPolicy);
       policiesCreated.add(tenant1VolumeAccessPolicy.getName());
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
 
     try {
@@ -404,7 +395,7 @@ public class TestRangerBGSyncService {
       accessController.createPolicy(tenant1BucketCreatePolicy);
       policiesCreated.add(tenant1BucketCreatePolicy.getName());
     } catch (IOException e) {
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
   }
 
@@ -477,7 +468,7 @@ public class TestRangerBGSyncService {
 
     final long rangerSvcVersionBefore =
         bgSync.getRangerOzoneServicePolicyVersion();
-    Assert.assertTrue(rangerSvcVersionBefore >= startingRangerVersion);
+    assertTrue(rangerSvcVersionBefore >= startingRangerVersion);
 
     // Note: DB Service Version will be -1 if the test starts with an empty DB
     final long dbSvcVersionBefore = bgSync.getOMDBRangerServiceVersion();
@@ -490,9 +481,9 @@ public class TestRangerBGSyncService {
     final long dbSvcVersionAfter = bgSync.getOMDBRangerServiceVersion();
     final long rangerSvcVersionAfter =
         bgSync.getRangerOzoneServicePolicyVersion();
-    Assert.assertEquals(rangerSvcVersionAfter, dbSvcVersionAfter);
-    Assert.assertTrue(dbSvcVersionAfter > dbSvcVersionBefore);
-    Assert.assertTrue(rangerSvcVersionAfter > rangerSvcVersionBefore);
+    assertEquals(rangerSvcVersionAfter, dbSvcVersionAfter);
+    assertTrue(dbSvcVersionAfter > dbSvcVersionBefore);
+    assertTrue(rangerSvcVersionAfter > rangerSvcVersionBefore);
 
     // Verify that the Ranger policies and roles not backed up
     // by OzoneManager Multi-Tenancy tables are cleaned up by sync thread
@@ -500,28 +491,28 @@ public class TestRangerBGSyncService {
     for (String policy : policiesCreated) {
       try {
         final Policy policyRead = accessController.getPolicy(policy);
-        Assert.fail("The policy should have been deleted: " + policyRead);
+        fail("The policy should have been deleted: " + policyRead);
       } catch (IOException ex) {
         if (!(ex.getCause() instanceof RangerServiceException)) {
-          Assert.fail("Expected RangerServiceException, got " +
+          fail("Expected RangerServiceException, got " +
               ex.getCause().getClass().getSimpleName());
         }
         RangerServiceException rse = (RangerServiceException) ex.getCause();
-        Assert.assertEquals(404, rse.getStatus().getStatusCode());
+        assertEquals(404, rse.getStatus().getStatusCode());
       }
     }
 
     for (String roleName : rolesCreated) {
       try {
         final Role role = accessController.getRole(roleName);
-        Assert.fail("This role should have been deleted from Ranger: " + role);
+        fail("This role should have been deleted from Ranger: " + role);
       } catch (IOException ex) {
         if (!(ex.getCause() instanceof RangerServiceException)) {
-          Assert.fail("Expected RangerServiceException, got " +
+          fail("Expected RangerServiceException, got " +
               ex.getCause().getClass().getSimpleName());
         }
         RangerServiceException rse = (RangerServiceException) ex.getCause();
-        Assert.assertEquals(400, rse.getStatus().getStatusCode());
+        assertEquals(400, rse.getStatus().getStatusCode());
       }
     }
   }
@@ -540,7 +531,7 @@ public class TestRangerBGSyncService {
     createRolesAndPoliciesInRanger(true);
 
     long rangerSvcVersionBefore = bgSync.getRangerOzoneServicePolicyVersion();
-    Assert.assertTrue(rangerSvcVersionBefore >= startingRangerVersion);
+    assertTrue(rangerSvcVersionBefore >= startingRangerVersion);
 
     // Note: DB Service Version will be -1 if the test starts with an empty DB
     final long dbSvcVersionBefore = bgSync.getOMDBRangerServiceVersion();
@@ -553,29 +544,29 @@ public class TestRangerBGSyncService {
     final long dbSvcVersionAfter = bgSync.getOMDBRangerServiceVersion();
     final long rangerSvcVersionAfter =
         bgSync.getRangerOzoneServicePolicyVersion();
-    Assert.assertEquals(rangerSvcVersionAfter, dbSvcVersionAfter);
-    Assert.assertEquals(rangerSvcVersionAfter, rangerSvcVersionBefore);
+    assertEquals(rangerSvcVersionAfter, dbSvcVersionAfter);
+    assertEquals(rangerSvcVersionAfter, rangerSvcVersionBefore);
     if (dbSvcVersionBefore != -1L) {
-      Assert.assertEquals(dbSvcVersionBefore, dbSvcVersionAfter);
+      assertEquals(dbSvcVersionBefore, dbSvcVersionAfter);
     }
 
     for (String policyName : policiesCreated) {
       try {
         final Policy policyRead = accessController.getPolicy(policyName);
-        Assert.assertEquals(policyName, policyRead.getName());
+        assertEquals(policyName, policyRead.getName());
       } catch (Exception e) {
         e.printStackTrace();
-        Assert.fail(e.getMessage());
+        fail(e.getMessage());
       }
     }
 
     for (String roleName : rolesCreated) {
       try {
         final Role roleResponse = accessController.getRole(roleName);
-        Assert.assertEquals(roleName, roleResponse.getName());
+        assertEquals(roleName, roleResponse.getName());
       } catch (Exception e) {
         e.printStackTrace();
-        Assert.fail(e.getMessage());
+        fail(e.getMessage());
       }
     }
   }
@@ -593,11 +584,11 @@ public class TestRangerBGSyncService {
 
     long rangerVersionAfterCreation =
         bgSync.getRangerOzoneServicePolicyVersion();
-    Assert.assertTrue(rangerVersionAfterCreation >= startingRangerVersion);
+    assertTrue(rangerVersionAfterCreation >= startingRangerVersion);
 
     // Delete user bob from user role, expect Ranger sync thread to update it
     String userRoleName = rolesCreated.get(0);
-    Assert.assertEquals(
+    assertEquals(
         OMMultiTenantManager.getDefaultUserRoleName(TENANT_ID), userRoleName);
 
     Role userRole = accessController.getRole(userRoleName);
@@ -626,15 +617,14 @@ public class TestRangerBGSyncService {
     final long dbSvcVersionAfter = bgSync.getOMDBRangerServiceVersion();
     final long rangerSvcVersionAfter =
         bgSync.getRangerOzoneServicePolicyVersion();
-    Assert.assertEquals(rangerSvcVersionAfter, dbSvcVersionAfter);
-    Assert.assertTrue(dbSvcVersionAfter > dbSvcVersionBefore);
-    Assert.assertTrue(rangerSvcVersionAfter > rangerSvcVersionBefore);
+    assertEquals(rangerSvcVersionAfter, dbSvcVersionAfter);
+    assertTrue(dbSvcVersionAfter > dbSvcVersionBefore);
+    assertTrue(rangerSvcVersionAfter > rangerSvcVersionBefore);
 
     for (String policyName : policiesCreated) {
       final Policy policy = accessController.getPolicy(policyName);
-      Assert.assertNotNull("Policy should exist in Ranger: " + policyName,
-          policy);
-      Assert.assertEquals(policyName, policy.getName());
+      assertNotNull(policy, "Policy should exist in Ranger: " + policyName);
+      assertEquals(policyName, policy.getName());
     }
 
     for (String roleName : rolesCreated) {
@@ -643,7 +633,7 @@ public class TestRangerBGSyncService {
       }
       final Role roleRead = accessController.getRole(roleName);
       final Set<String> usersGot = roleRead.getUsersMap().keySet();
-      Assert.assertEquals(userSet, usersGot);
+      assertEquals(userSet, usersGot);
       break;
     }
   }
@@ -662,7 +652,7 @@ public class TestRangerBGSyncService {
 
     long rangerVersionAfterCreation =
         bgSync.getRangerOzoneServicePolicyVersion();
-    Assert.assertTrue(rangerVersionAfterCreation >= startingRangerVersion);
+    assertTrue(rangerVersionAfterCreation >= startingRangerVersion);
 
     // Delete both policies, expect Ranger sync thread to recover both
     accessController.deletePolicy(
@@ -683,27 +673,27 @@ public class TestRangerBGSyncService {
     long dbSvcVersionAfter = bgSync.getOMDBRangerServiceVersion();
     final long rangerSvcVersionAfter =
         bgSync.getRangerOzoneServicePolicyVersion();
-    Assert.assertEquals(rangerSvcVersionAfter, dbSvcVersionAfter);
-    Assert.assertTrue(dbSvcVersionAfter > dbSvcVersionBefore);
-    Assert.assertTrue(rangerSvcVersionAfter > rangerSvcVersionBefore);
+    assertEquals(rangerSvcVersionAfter, dbSvcVersionAfter);
+    assertTrue(dbSvcVersionAfter > dbSvcVersionBefore);
+    assertTrue(rangerSvcVersionAfter > rangerSvcVersionBefore);
 
     for (String policyName : policiesCreated) {
       try {
         final Policy policyRead = accessController.getPolicy(policyName);
-        Assert.assertEquals(policyName, policyRead.getName());
+        assertEquals(policyName, policyRead.getName());
       } catch (Exception e) {
         e.printStackTrace();
-        Assert.fail(e.getMessage());
+        fail(e.getMessage());
       }
     }
 
     for (String roleName : rolesCreated) {
       try {
         final Role roleRead = accessController.getRole(roleName);
-        Assert.assertEquals(roleName, roleRead.getName());
+        assertEquals(roleName, roleRead.getName());
       } catch (Exception e) {
         e.printStackTrace();
-        Assert.fail(e.getMessage());
+        fail(e.getMessage());
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -36,15 +36,10 @@ import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
@@ -52,30 +47,23 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVA
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CLOSE_CONTAINER;
 import static org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer.runTestOzoneContainerViaDataNode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Recon's passive SCM integration tests.
  */
+@Timeout(180)
 public class TestReconAsPassiveScm {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
-  private MiniOzoneCluster cluster = null;
+  private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(HDDS_CONTAINER_REPORT_INTERVAL, "5s");
@@ -86,7 +74,7 @@ public class TestReconAsPassiveScm {
     GenericTestUtils.setLogLevel(ReconNodeManager.LOG, Level.DEBUG);
   }
 
-  @After
+  @AfterEach
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -110,7 +98,7 @@ public class TestReconAsPassiveScm {
       try {
         assertNotNull(reconPipelineManager.getPipeline(p.getId()));
       } catch (PipelineNotFoundException e) {
-        Assert.fail();
+        fail();
       }
     });
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
@@ -36,39 +36,27 @@ import org.apache.hadoop.ozone.recon.tasks.ReconTaskConfig;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer.runTestOzoneContainerViaDataNode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Integration Tests for Recon's tasks.
  */
+@Timeout(300)
 public class TestReconTasks {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
   private MiniOzoneCluster cluster = null;
   private OzoneConfiguration conf;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(HDDS_CONTAINER_REPORT_INTERVAL, "5s");
@@ -85,7 +73,7 @@ public class TestReconTasks {
     cluster.waitForClusterToBeReady();
   }
 
-  @After
+  @AfterEach
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -120,11 +108,11 @@ public class TestReconTasks {
     int scmContainersCount = scmContainerManager.getContainers().size();
     int reconContainersCount = reconContainerManager
         .getContainers().size();
-    Assert.assertNotEquals(scmContainersCount, reconContainersCount);
+    assertNotEquals(scmContainersCount, reconContainersCount);
     reconScm.syncWithSCMContainerInfo();
     reconContainersCount = reconContainerManager
         .getContainers().size();
-    Assert.assertEquals(scmContainersCount, reconContainersCount);
+    assertEquals(scmContainersCount, reconContainersCount);
   }
 
   @Test
@@ -153,7 +141,7 @@ public class TestReconTasks {
     runTestOzoneContainerViaDataNode(containerID, client);
 
     // Make sure Recon got the container report with new container.
-    Assert.assertEquals(scmContainerManager.getContainers(),
+    assertEquals(scmContainerManager.getContainers(),
         reconContainerManager.getContainers());
 
     // Bring down the Datanode that had the container replica.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrated following integration tests with TemporaryFolder to JUnit5.

```
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmStartupSlvLessThanMlv.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9505

## How was this patch tested?
CI/CD run on fork: https://github.com/hemantk-12/ozone/actions/runs/6954241843