### PR TITLE
HDDS-9750. [hsync] Make Putblock performance acceptable - Skeleton code

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -143,6 +143,10 @@ public final class ScmConfigKeys {
   public static final String OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_DEFAULT =
       "64KB";
 
+  public static final String OZONE_CHUNK_LIST_INCREMENTAL =
+      "ozone.chunk.list.incremental";
+  public static final boolean OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT = false;
+
   public static final String OZONE_SCM_CONTAINER_LAYOUT_KEY =
       "ozone.scm.container.layout";
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/upgrade/HDDSLayoutFeature.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/upgrade/HDDSLayoutFeature.java
@@ -42,8 +42,8 @@ public enum HDDSLayoutFeature implements LayoutFeature {
       "to DatanodeDetails."),
   HADOOP_PRC_PORTS_IN_DATANODEDETAILS(7, "Adding Hadoop RPC ports " +
                                      "to DatanodeDetails."),
-  LAST_CHUNK_TABLE(8, "Datanode RocksDB Schema Version 3 has an extra table " +
-          "for the last chunk of blocks)");
+  HBASE_SUPPORT(8, "Datanode RocksDB Schema Version 3 has an extra table " +
+          "for the last chunk of blocks to support HBase.)");
 
   //////////////////////////////  //////////////////////////////
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/upgrade/HDDSLayoutFeature.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/upgrade/HDDSLayoutFeature.java
@@ -41,7 +41,9 @@ public enum HDDSLayoutFeature implements LayoutFeature {
   WEBUI_PORTS_IN_DATANODEDETAILS(6, "Adding HTTP and HTTPS ports " +
       "to DatanodeDetails."),
   HADOOP_PRC_PORTS_IN_DATANODEDETAILS(7, "Adding Hadoop RPC ports " +
-                                     "to DatanodeDetails.");
+                                     "to DatanodeDetails."),
+  LAST_CHUNK_TABLE(8, "Datanode RocksDB Schema Version 3 has an extra table " +
+          "for the last chunk of blocks)");
 
   //////////////////////////////  //////////////////////////////
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -841,6 +841,17 @@
     </description>
   </property>
   <property>
+    <name>ozone.chunk.list.incremental</name>
+    <value>false</value>
+    <tag>OZONE, CLIENT, DATANODE, PERFORMANCE</tag>
+    <description>
+      By default, a writer client sends full chunk list of a block when it
+      sends PutBlock requests. Changing this configuration to true will send
+      only incremental chunk list which reduces metadata overhead and improves
+      hsync performance.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.container.layout</name>
     <value>FILE_PER_BLOCK</value>
     <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -146,7 +146,7 @@ public class HddsVolume extends StorageVolume {
 
     // Create DB store for a newly formatted volume
     if (VersionedDatanodeFeatures.isFinalized(
-        HDDSLayoutFeature.LAST_CHUNK_TABLE)) {
+        HDDSLayoutFeature.DATANODE_SCHEMA_V3)) {
       createDbStore(dbVolumeSet);
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -146,7 +146,7 @@ public class HddsVolume extends StorageVolume {
 
     // Create DB store for a newly formatted volume
     if (VersionedDatanodeFeatures.isFinalized(
-        HDDSLayoutFeature.DATANODE_SCHEMA_V3)) {
+        HDDSLayoutFeature.LAST_CHUNK_TABLE)) {
       createDbStore(dbVolumeSet);
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -112,7 +112,7 @@ public class BlockManagerImpl implements BlockManager {
             config.getBoolean(OZONE_CHUNK_LIST_INCREMENTAL,
                     OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT);
     if (incrementalEnabled && !VersionedDatanodeFeatures.isFinalized(
-            HDDSLayoutFeature.LAST_CHUNK_TABLE)) {
+            HDDSLayoutFeature.HBASE_SUPPORT)) {
       throw new StorageContainerException("DataNode has not finalized " +
         "upgrading to a version that supports incremental chunk list.",
         UNSUPPORTED_REQUEST);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
@@ -77,4 +77,6 @@ public abstract class AbstractDatanodeDBDefinition implements DBDefinition {
   public DBColumnFamilyDefinition<String, Long> getFinalizeBlocksColumnFamily() {
     return null;
   }
+  public abstract DBColumnFamilyDefinition<String, BlockData>
+      getLastChunkInfoColumnFamily();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -63,6 +63,8 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
   private Table<String, BlockData> blockDataTable;
 
+  private Table<String, BlockData> lastChunkInfoTable;
+
   private Table<String, BlockData> blockDataTableWithIterator;
 
   private Table<String, ChunkInfoList> deletedBlocksTable;
@@ -186,6 +188,12 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
             finalizeBlocksTableWithIterator);
         checkTableStatus(finalizeBlocksTable, finalizeBlocksTable.getName());
       }
+
+      if (dbDef.getLastChunkInfoColumnFamily() != null) {
+        lastChunkInfoTable = new DatanodeTable<>(
+            dbDef.getLastChunkInfoColumnFamily().getTable(this.store));
+        checkTableStatus(lastChunkInfoTable, lastChunkInfoTable.getName());
+      }
     }
   }
 
@@ -215,6 +223,11 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   @Override
   public Table<String, BlockData> getBlockDataTable() {
     return blockDataTable;
+  }
+
+  @Override
+  public Table<String, BlockData> getLastChunkInfoTable() {
+    return lastChunkInfoTable;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -103,6 +103,12 @@ public class DatanodeSchemaOneDBDefinition
   }
 
   @Override
+  public DBColumnFamilyDefinition<String, BlockData>
+      getLastChunkInfoColumnFamily() {
+    return null;
+  }
+
+  @Override
   public List<DBColumnFamilyDefinition<?, ?>> getColumnFamilies(String name) {
     return COLUMN_FAMILIES.get(name);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
@@ -101,6 +101,15 @@ public class DatanodeSchemaThreeDBDefinition
           Long.class,
           LongCodec.get());
 
+  public static final DBColumnFamilyDefinition<String, BlockData>
+      LAST_CHUNK_INFO =
+      new DBColumnFamilyDefinition<>(
+          "last_chunk_info",
+          String.class,
+          FixedLengthStringCodec.get(),
+          BlockData.class,
+          BlockData.getCodec());
+
   private static String separator = "";
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>
@@ -109,8 +118,8 @@ public class DatanodeSchemaThreeDBDefinition
          METADATA,
          DELETED_BLOCKS,
          DELETE_TRANSACTION,
-         FINALIZE_BLOCKS);
-
+         FINALIZE_BLOCKS,
+         LAST_CHUNK_INFO);
 
   public DatanodeSchemaThreeDBDefinition(String dbPath,
       ConfigurationSource config) {
@@ -134,6 +143,7 @@ public class DatanodeSchemaThreeDBDefinition
     DELETED_BLOCKS.setCfOptions(cfOptions);
     DELETE_TRANSACTION.setCfOptions(cfOptions);
     FINALIZE_BLOCKS.setCfOptions(cfOptions);
+    LAST_CHUNK_INFO.setCfOptions(cfOptions);
   }
 
   @Override
@@ -156,6 +166,12 @@ public class DatanodeSchemaThreeDBDefinition
   public DBColumnFamilyDefinition<String, ChunkInfoList>
       getDeletedBlocksColumnFamily() {
     return DELETED_BLOCKS;
+  }
+
+  @Override
+  public DBColumnFamilyDefinition<String, BlockData>
+      getLastChunkInfoColumnFamily() {
+    return LAST_CHUNK_INFO;
   }
 
   public DBColumnFamilyDefinition<String, DeletedBlocksTransaction>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -86,6 +86,15 @@ public class DatanodeSchemaTwoDBDefinition
           Long.class,
           LongCodec.get());
 
+  public static final DBColumnFamilyDefinition<String, BlockData>
+      LAST_CHUNK_INFO =
+      new DBColumnFamilyDefinition<>(
+          "last_chunk_info",
+          String.class,
+          FixedLengthStringCodec.get(),
+          BlockData.class,
+          BlockData.getCodec());
+
   public DatanodeSchemaTwoDBDefinition(String dbPath,
       ConfigurationSource config) {
     super(dbPath, config);
@@ -97,7 +106,8 @@ public class DatanodeSchemaTwoDBDefinition
           METADATA,
           DELETED_BLOCKS,
           DELETE_TRANSACTION,
-          FINALIZE_BLOCKS);
+          FINALIZE_BLOCKS,
+          LAST_CHUNK_INFO);
 
   @Override
   public Map<String, DBColumnFamilyDefinition<?, ?>> getMap() {
@@ -124,7 +134,7 @@ public class DatanodeSchemaTwoDBDefinition
   @Override
   public DBColumnFamilyDefinition<String, BlockData>
       getLastChunkInfoColumnFamily() {
-    return null;
+    return LAST_CHUNK_INFO;
   }
 
   public DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -121,6 +121,12 @@ public class DatanodeSchemaTwoDBDefinition
     return DELETED_BLOCKS;
   }
 
+  @Override
+  public DBColumnFamilyDefinition<String, BlockData>
+      getLastChunkInfoColumnFamily() {
+    return null;
+  }
+
   public DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
       getDeleteTransactionsColumnFamily() {
     return DELETE_TRANSACTION;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStore.java
@@ -18,22 +18,31 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
 import java.io.Closeable;
 import java.io.IOException;
+
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 
 /**
  * Interface for interacting with datanode databases.
  */
 public interface DatanodeStore extends Closeable {
+  String NO_SUCH_BLOCK_ERR_MSG =
+          "Unable to find the block.";
 
   /**
    * Start datanode manager.
@@ -85,6 +94,13 @@ public interface DatanodeStore extends Closeable {
   Table<String, Long> getFinalizeBlocksTable();
 
   /**
+   * A Table that keeps the metadata of the last chunk of blocks.
+   *
+   * @return Table
+   */
+  Table<String, BlockData> getLastChunkInfoTable();
+
+  /**
    * Helper to create and write batch transactions.
    */
   BatchOperationHandler getBatchHandler();
@@ -111,5 +127,29 @@ public interface DatanodeStore extends Closeable {
   boolean isClosed();
 
   default void compactionIfNeeded() throws Exception {
+  }
+
+  default BlockData getBlockByID(BlockID blockID,
+      KeyValueContainerData containerData) throws IOException {
+    String blockKey = containerData.getBlockKey(blockID.getLocalID());
+
+    // check block data table
+    BlockData blockData = getBlockDataTable().get(blockKey);
+
+    if (blockData == null) {
+      throw new StorageContainerException(
+            NO_SUCH_BLOCK_ERR_MSG + " BlockID : " + blockID, NO_SUCH_BLOCK);
+    }
+
+    return blockData;
+  }
+
+  default void putBlockByID(BatchOperation batch, boolean incremental,
+      long localID, BlockData data, KeyValueContainerData containerData,
+      boolean endOfBlock)
+      throws IOException {
+    // old client: override chunk list.
+    getBlockDataTable().putWithBatch(
+        batch, containerData.getBlockKey(localID), data);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Skeleton code for supporting incremental chunk list in PutBlock. See HDDS-8047 for the problem description and design doc.

Please describe your PR in detail:
* Add a new rocksdb table lastChunkInfoTable to store the last, in-progress, partial chunk of blocks. (Question: does adding a new table require a new schema version v4? do we need additional code to support upgrade?)
* Add a Client configuration switch incremental.chunk.list for clients to send incremental chunk list in PutBlock.
* Add a new client version INCREMENTAL_CHUNK_LIST_SUPPORT (this version change may not be required)


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9750

## How was this patch tested?
Skeleton code. No functional change.
