### PR TITLE
HDDS-9752. [hsync] Make Putblock performance acceptable - Client side

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -223,6 +223,15 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private String fsDefaultBucketLayout = "FILE_SYSTEM_OPTIMIZED";
 
+  @Config(key = "incremental.chunk.list",
+      defaultValue = "false",
+      type = ConfigType.BOOLEAN,
+      description = "Client PutBlock request can choose incremental chunk " +
+          "list rather than full chunk list to optimize performance. " +
+          "Critical to HBase.",
+      tags = ConfigTag.CLIENT)
+  private boolean incrementalChunkList = false;
+
   @PostConstruct
   private void validate() {
     Preconditions.checkState(streamBufferSize > 0);
@@ -403,5 +412,13 @@ public class OzoneClientConfig {
 
   public void setDatastreamPipelineMode(boolean datastreamPipelineMode) {
     this.datastreamPipelineMode = datastreamPipelineMode;
+  }
+
+  public void setIncrementalChunkList(boolean enable) {
+    this.incrementalChunkList = enable;
+  }
+
+  public boolean getIncrementalChunkList() {
+    return this.incrementalChunkList;
   }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -63,7 +63,7 @@ import static org.apache.hadoop.hdds.client.ReplicationConfig.getLegacyFactor;
  */
 public class BlockInputStream extends BlockExtendedInputStream {
 
-  private static final Logger LOG =
+  public static final Logger LOG =
       LoggerFactory.getLogger(BlockInputStream.class);
 
   private final BlockID blockID;
@@ -256,8 +256,8 @@ public class BlockInputStream extends BlockExtendedInputStream {
     final Pipeline pipeline = xceiverClient.getPipeline();
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Initializing BlockInputStream for get key to access {}",
-          blockID.getContainerID());
+      LOG.debug("Initializing BlockInputStream for get key to access block {}",
+          blockID);
     }
 
     DatanodeBlockID.Builder blkIDBuilder =

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -179,6 +179,9 @@ public class BlockOutputStream extends OutputStream {
     // tell DataNode I will send incremental chunk list
     if (config.getIncrementalChunkList()) {
       this.containerBlockData.addMetadata(INCREMENTAL_CHUNK_LIST_KV);
+      this.lastChunkBuffer =
+          ByteBuffer.allocate(config.getStreamBufferSize());
+      this.lastChunkOffset = 0;
     }
     this.xceiverClient = xceiverClientManager.acquireClient(pipeline);
     this.bufferPool = bufferPool;
@@ -208,9 +211,6 @@ public class BlockOutputStream extends OutputStream {
     this.clientMetrics = clientMetrics;
     this.pipeline = pipeline;
     this.streamBufferArgs = streamBufferArgs;
-    this.lastChunkBuffer =
-        ByteBuffer.allocate(config.getStreamBufferSize());
-    this.lastChunkOffset = 0;
   }
 
   void refreshCurrentBuffer() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -857,7 +857,7 @@ public class BlockOutputStream extends OutputStream {
     int pos = 0;
     int uncopied = length;
     for (ByteBuffer bb : chunkBuffer.asByteBufferList()) {
-      if (pos + bb.remaining() > offset) {
+      if (pos + bb.remaining() >= offset) {
         int copyStart = offset < pos ? 0 : offset - pos;
         int copyLen = Math.min(uncopied, bb.remaining());
         try {
@@ -877,7 +877,7 @@ public class BlockOutputStream extends OutputStream {
       }
 
       pos += bb.remaining();
-      if (pos > offset + length) {
+      if (pos >= offset + length) {
         return;
       }
       if (uncopied == 0) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreWithIncrementalChunkList.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreWithIncrementalChunkList.java
@@ -94,13 +94,15 @@ public class DatanodeStoreWithIncrementalChunkList extends AbstractDatanodeStore
     LOG.debug("blockData={}, lastChunk={}",
         blockData.getChunks(), lastChunk.getChunks());
     Preconditions.checkState(lastChunk.getChunks().size() == 1);
-    ContainerProtos.ChunkInfo lastChunkInBlockData = blockData.getChunks().size() > 0 ?
-        blockData.getChunks().get(blockData.getChunks().size() - 1) : null;
-    if (lastChunkInBlockData != null) {
-      Preconditions.checkState(
-          lastChunkInBlockData.getOffset() + lastChunkInBlockData.getLen()
-              == lastChunk.getChunks().get(0).getOffset(),
-          "chunk offset does not match");
+    if (!blockData.getChunks().isEmpty()) {
+      ContainerProtos.ChunkInfo lastChunkInBlockData =
+              blockData.getChunks().get(blockData.getChunks().size() - 1);
+      if (lastChunkInBlockData != null) {
+        Preconditions.checkState(
+            lastChunkInBlockData.getOffset() + lastChunkInBlockData.getLen()
+                == lastChunk.getChunks().get(0).getOffset(),
+            "chunk offset does not match");
+      }
     }
 
     // append last partial chunk to the block data
@@ -156,7 +158,7 @@ public class DatanodeStoreWithIncrementalChunkList extends AbstractDatanodeStore
     // if data has no chunks, fetch the last chunk info from lastChunkInfoTable
     if (data.getChunks().isEmpty()) {
       BlockData lastChunk = getLastChunkInfoTable().get(containerData.getBlockKey(localID));
-      if(lastChunk != null ) {
+      if (lastChunk != null) {
         reconcilePartialChunks(lastChunk, data);
       }
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
@@ -83,6 +84,7 @@ public class TestBlockManagerImpl {
     this.schemaVersion = versionInfo.getSchemaVersion();
     this.config = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, config);
+    config.setBoolean(OZONE_CHUNK_LIST_INCREMENTAL, true);
     initilaze();
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.client;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.UUID;
+
+import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.jetbrains.annotations.NotNull;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.InMemoryConfiguration;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.XceiverClientFactory;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.client.rpc.RpcClient;
+import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+
+/**
+ * Verify BlockOutputStream with incremental PutBlock feature.
+ * (incremental.chunk.list = true)
+ */
+public class TestBlockOutputStreamIncrementalPutBlock {
+  private OzoneClient client;
+  private ObjectStore store;
+  private RpcClient rpcClient;
+
+  private String keyName = UUID.randomUUID().toString();
+  private String volumeName = UUID.randomUUID().toString();
+  private String bucketName = UUID.randomUUID().toString();
+  private ConfigurationSource config = new InMemoryConfiguration();
+  private boolean enableIncrementalChunkList;
+
+  public static Iterable<Boolean> parameters() {
+    return Arrays.asList(true, false);
+  }
+
+  public void init() throws IOException {
+    OzoneClientConfig clientConfig = config.getObject(OzoneClientConfig.class);
+
+    clientConfig.setIncrementalChunkList(enableIncrementalChunkList);
+    clientConfig.setChecksumType(ContainerProtos.ChecksumType.CRC32C);
+
+    ((InMemoryConfiguration)config).setFromObject(clientConfig);
+
+    rpcClient = new RpcClient(config, null) {
+
+      @Override
+      protected OmTransport createOmTransport(
+          String omServiceId)
+          throws IOException {
+        return new MockOmTransport();
+      }
+
+      @NotNull
+      @Override
+      protected XceiverClientFactory createXceiverClientFactory(
+          ServiceInfoEx serviceInfo) throws IOException {
+        return new MockXceiverClientFactory();
+      }
+    };
+
+    client = new OzoneClient(config, rpcClient);
+    store = client.getObjectStore();
+  }
+
+  @AfterEach
+  public void close() throws IOException {
+    client.close();
+  }
+
+  @ParameterizedTest
+  @MethodSource("parameters")
+  public void writeSmallKey(boolean incrementalChunkList)
+      throws IOException {
+    this.enableIncrementalChunkList = incrementalChunkList;
+    init();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    int size = 1024;
+    String s = RandomStringUtils.randomAlphabetic(1024);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    try (OzoneOutputStream out = bucket.createKey(keyName, size,
+        ReplicationConfig.getDefault(config), new HashMap<>())) {
+      for (int i = 0; i < 4097; i++) {
+        out.write(byteBuffer);
+        out.hsync();
+      }
+    }
+
+    try (OzoneInputStream is = bucket.readKey(keyName)) {
+      ByteBuffer readBuffer = ByteBuffer.allocate(size);
+      for (int i = 0; i < 4097; i++) {
+        is.read(readBuffer);
+        assertArrayEquals(readBuffer.array(), byteBuffer.array());
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("parameters")
+  public void writeLargeKey(boolean incrementalChunkList)
+      throws IOException {
+    this.enableIncrementalChunkList = incrementalChunkList;
+    init();
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    int size = 1024 * 1024 + 1;
+    ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    try (OzoneOutputStream out = bucket.createKey(keyName, size,
+        ReplicationConfig.getDefault(config), new HashMap<>())) {
+      for (int i = 0; i < 4; i++) {
+        out.write(byteBuffer);
+        out.hsync();
+      }
+    }
+
+    try (OzoneInputStream is = bucket.readKey(keyName)) {
+      ByteBuffer readBuffer = ByteBuffer.allocate(size);
+      for (int i = 0; i < 4; i++) {
+        is.read(readBuffer);
+        assertArrayEquals(readBuffer.array(), byteBuffer.array());
+      }
+    }
+  }
+}

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 
@@ -69,6 +71,11 @@ public class TestBlockOutputStreamIncrementalPutBlock {
     clientConfig.setChecksumType(ContainerProtos.ChecksumType.CRC32C);
 
     ((InMemoryConfiguration)config).setFromObject(clientConfig);
+
+    ((InMemoryConfiguration) config).setBoolean(
+        OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
+    ((InMemoryConfiguration) config).setBoolean(
+        OZONE_CHUNK_LIST_INCREMENTAL, true);
 
     RpcClient rpcClient = new RpcClient(config, null) {
 
@@ -103,7 +110,7 @@ public class TestBlockOutputStreamIncrementalPutBlock {
 
   @ParameterizedTest
   @MethodSource("parameters")
-  public void writeSmallKey(boolean incrementalChunkList)
+  public void writeSmallChunk(boolean incrementalChunkList)
       throws IOException {
     init(incrementalChunkList);
 
@@ -130,7 +137,7 @@ public class TestBlockOutputStreamIncrementalPutBlock {
 
   @ParameterizedTest
   @MethodSource("parameters")
-  public void writeLargeKey(boolean incrementalChunkList)
+  public void writeLargeChunk(boolean incrementalChunkList)
       throws IOException {
     init(incrementalChunkList);
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -64,7 +64,7 @@ public class TestBlockOutputStreamIncrementalPutBlock {
     return Arrays.asList(true, false);
   }
 
-  public void init(boolean incrementalChunkList) throws IOException {
+  private void init(boolean incrementalChunkList) throws IOException {
     OzoneClientConfig clientConfig = config.getObject(OzoneClientConfig.class);
 
     clientConfig.setIncrementalChunkList(incrementalChunkList);
@@ -75,7 +75,7 @@ public class TestBlockOutputStreamIncrementalPutBlock {
     ((InMemoryConfiguration) config).setBoolean(
         OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     ((InMemoryConfiguration) config).setBoolean(
-        OZONE_CHUNK_LIST_INCREMENTAL, true);
+        OZONE_CHUNK_LIST_INCREMENTAL, incrementalChunkList);
 
     RpcClient rpcClient = new RpcClient(config, null) {
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.fs.ozone;
 import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
@@ -28,12 +30,18 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.conf.StorageUnit;
@@ -59,8 +67,10 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -83,6 +93,10 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -98,11 +112,13 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOU
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -122,12 +138,13 @@ public class TestHSync {
   private static OzoneClient client;
   private static final BucketLayout BUCKET_LAYOUT = BucketLayout.FILE_SYSTEM_OPTIMIZED;
 
+  private static final int chunkSize = 4 << 12;
+  private static final int flushSize = 2 * chunkSize;
+  private static final int maxFlushSize = 2 * flushSize;
+  private static final int blockSize = 2 * maxFlushSize;
+
   @BeforeAll
   public static void init() throws Exception {
-    final int chunkSize = 4 << 10;
-    final int flushSize = 2 * chunkSize;
-    final int maxFlushSize = 2 * flushSize;
-    final int blockSize = 2 * maxFlushSize;
     final BucketLayout layout = BUCKET_LAYOUT;
 
     CONF.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
@@ -160,6 +177,7 @@ public class TestHSync {
     GenericTestUtils.setLogLevel(OMKeyCommitRequest.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(BlockOutputStream.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BlockInputStream.LOG, Level.DEBUG);
   }
 
   @AfterAll
@@ -292,13 +310,15 @@ public class TestHSync {
     }
   }
 
-  @Test
-  public void testO3fsHSync() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testO3fsHSync(boolean incrementalChunkList) throws Exception {
     // Set the fs.defaultFS
     final String rootPath = String.format("%s://%s.%s/",
         OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
     CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
 
+    init(incrementalChunkList);
     try (FileSystem fs = FileSystem.get(CONF)) {
       for (int i = 0; i < 10; i++) {
         final Path file = new Path("/file" + i);
@@ -307,8 +327,10 @@ public class TestHSync {
     }
   }
 
-  @Test
-  public void testOfsHSync() throws Exception {
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testOfsHSync(boolean incrementalChunkList) throws Exception {
     // Set the fs.defaultFS
     final String rootPath = String.format("%s://%s/",
         OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
@@ -317,6 +339,7 @@ public class TestHSync {
     final String dir = OZONE_ROOT + bucket.getVolumeName()
         + OZONE_URI_DELIMITER + bucket.getName();
 
+    init(incrementalChunkList);
     try (FileSystem fs = FileSystem.get(CONF)) {
       for (int i = 0; i < 10; i++) {
         final Path file = new Path(dir, "file" + i);
@@ -434,9 +457,7 @@ public class TestHSync {
     ThreadLocalRandom.current().nextBytes(data);
 
     final Path file = new Path(dir, "file-hsync-then-close");
-    long blockSize;
     try (FileSystem fs = FileSystem.get(CONF)) {
-      blockSize = fs.getDefaultBlockSize(file);
       long fileSize = 0;
       try (FSDataOutputStream outputStream = fs.create(file, true)) {
         // make sure at least writing 2 blocks data
@@ -737,5 +758,117 @@ public class TestHSync {
         new CapableOzoneFSOutputStream(ofso, false)) {
       assertFalse(cofsos.hasCapability(StreamCapabilities.HFLUSH));
     }
+  }
+
+  public void init(boolean incrementalChunkList) throws IOException {
+    OzoneClientConfig clientConfig = CONF.getObject(OzoneClientConfig.class);
+    clientConfig.setIncrementalChunkList(incrementalChunkList);
+    clientConfig.setChecksumType(ContainerProtos.ChecksumType.CRC32C);
+    CONF.setFromObject(clientConfig);
+  }
+
+  public static Stream<Arguments> parameters1() {
+    return Stream.of(
+        arguments(true, 512),
+        arguments(true, 511),
+        arguments(true, 513),
+        arguments(false, 512),
+        arguments(false, 511),
+        arguments(false, 513)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("parameters1")
+  public void writeWithSmallBuffer(boolean incrementalChunkList, int bufferSize)
+      throws IOException {
+    init(incrementalChunkList);
+
+    final String keyName = UUID.randomUUID().toString();
+    int fileSize = 16 << 11 ;
+    String s = RandomStringUtils.randomAlphabetic(bufferSize);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+
+    int writtenSize = 0;
+    try (OzoneOutputStream out = bucket.createKey(keyName, fileSize,
+        ReplicationConfig.getDefault(CONF), new HashMap<>())) {
+      while (writtenSize < fileSize) {
+        int len = Math.min(bufferSize, fileSize - writtenSize);
+        out.write(byteBuffer, 0, len);
+        out.hsync();
+        writtenSize += bufferSize;
+      }
+    }
+
+    OzoneKeyDetails keyInfo = bucket.getKey(keyName);
+    assertEquals(fileSize, keyInfo.getDataSize());
+
+    int readSize = 0;
+    try (OzoneInputStream is = bucket.readKey(keyName)) {
+      while (readSize < fileSize) {
+        int len = Math.min(bufferSize, fileSize - readSize);
+        ByteBuffer readBuffer = ByteBuffer.allocate(len);
+        int readLen = is.read(readBuffer);
+        assertEquals(len, readLen);
+        if (len < bufferSize) {
+          for (int i = 0; i < len; i++) {
+            assertEquals(readBuffer.array()[i], byteBuffer.array()[i]);
+          }
+        } else {
+          assertArrayEquals(readBuffer.array(), byteBuffer.array());
+        }
+        readSize += readLen;
+      }
+    }
+    bucket.deleteKey(keyName);
+  }
+
+  public static Stream<Arguments> parameters2() {
+    return Stream.of(
+        arguments(true, 1024 * 1024 + 1),
+        arguments(true, 1024 * 1024 + 1 + chunkSize),
+        arguments(true, 1024 * 1024 - 1 + chunkSize),
+        arguments(false, 1024 * 1024 + 1),
+        arguments(false, 1024 * 1024 + 1 + chunkSize),
+        arguments(false, 1024 * 1024 - 1 + chunkSize)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("parameters2")
+  public void writeWithBigBuffer(boolean incrementalChunkList, int bufferSize)
+      throws IOException {
+    init(incrementalChunkList);
+
+    final String keyName = UUID.randomUUID().toString();
+    int count = 2;
+    int fileSize = bufferSize * count;
+    ByteBuffer byteBuffer = ByteBuffer.allocate(bufferSize);
+
+    try (OzoneOutputStream out = bucket.createKey(keyName, fileSize,
+        ReplicationConfig.getDefault(CONF), new HashMap<>())) {
+      for (int i = 0; i < count; i++) {
+        out.write(byteBuffer);
+        out.hsync();
+      }
+    }
+
+    OzoneKeyDetails keyInfo = bucket.getKey(keyName);
+    assertEquals(fileSize, keyInfo.getDataSize());
+    int totalReadLen = 0;
+    try (OzoneInputStream is = bucket.readKey(keyName)) {
+
+      for (int i = 0; i < count; i++) {
+        ByteBuffer readBuffer = ByteBuffer.allocate(bufferSize);
+        int readLen = is.read(readBuffer);
+        if (bufferSize != readLen) {
+          throw new IOException("failed to read " + bufferSize + " from offset " + totalReadLen +
+              ", actually read " + readLen + ", block " + totalReadLen/blockSize);
+        }
+        assertArrayEquals(byteBuffer.array(), readBuffer.array());
+        totalReadLen += readLen;
+      }
+    }
+    bucket.deleteKey(keyName);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -69,9 +69,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequest;
-import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequestWithFSO;
-import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
@@ -84,9 +81,10 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
@@ -133,6 +131,9 @@ public class TestHSync {
     CONF.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     // Reduce KeyDeletingService interval
     CONF.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
+    CONF.setBoolean("ozone.client.incremental.chunk.list", true);
+    CONF.setBoolean(OZONE_CHUNK_LIST_INCREMENTAL,
+        OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT);
     cluster = MiniOzoneCluster.newBuilder(CONF)
         .setNumDatanodes(5)
         .setTotalPipelineNumLimit(10)
@@ -152,9 +153,9 @@ public class TestHSync {
     bucket = TestDataUtil.createVolumeAndBucket(client, layout);
 
     // Enable DEBUG level logging for relevant classes
-    GenericTestUtils.setLogLevel(OMKeyRequest.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(OMKeyCommitRequest.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.LOG, Level.DEBUG);
+    //GenericTestUtils.setLogLevel(OMKeyRequest.LOG, Level.DEBUG);
+    //GenericTestUtils.setLogLevel(OMKeyCommitRequest.LOG, Level.DEBUG);
+    //GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.LOG, Level.DEBUG);
   }
 
   @AfterAll

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -89,7 +89,6 @@ import org.slf4j.event.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
@@ -137,8 +136,7 @@ public class TestHSync {
     // Reduce KeyDeletingService interval
     CONF.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
     CONF.setBoolean("ozone.client.incremental.chunk.list", true);
-    CONF.setBoolean(OZONE_CHUNK_LIST_INCREMENTAL,
-        OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT);
+    CONF.setBoolean(OZONE_CHUNK_LIST_INCREMENTAL, true);
     cluster = MiniOzoneCluster.newBuilder(CONF)
         .setNumDatanodes(5)
         .setTotalPipelineNumLimit(10)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.CipherSuite;
@@ -69,6 +70,9 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequestWithFSO;
+import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
@@ -81,6 +85,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
@@ -153,9 +158,10 @@ public class TestHSync {
     bucket = TestDataUtil.createVolumeAndBucket(client, layout);
 
     // Enable DEBUG level logging for relevant classes
-    //GenericTestUtils.setLogLevel(OMKeyRequest.LOG, Level.DEBUG);
-    //GenericTestUtils.setLogLevel(OMKeyCommitRequest.LOG, Level.DEBUG);
-    //GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(OMKeyRequest.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(OMKeyCommitRequest.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(OMKeyCommitRequestWithFSO.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(BlockOutputStream.LOG, Level.DEBUG);
   }
 
   @AfterAll


### PR DESCRIPTION
## What changes were proposed in this pull request?
Implement Client side change for HDDS-8047 incremental chunk list for PutBlock. See HDDS-8047 for the problem description and design doc.

Please describe your PR in detail:
* This PR depends on HDDS-9750 / #5661 and HDDS-9751 / #5662
* Updates BlockOutputStream WriteChunk and PutBlock to product the incremental chunk list. See 
[PutBlock metadata optimization.pdf](https://github.com/apache/ozone/files/13444017/PutBlock.metadata.optimization.pdf) for implementation details.
* New test cases TestBlockOutputStreamIncrementalPutBlock


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9752

## How was this patch tested?
* New unit tests TestBlockOutputStreamIncrementalPutBlock
* Full cluster HBase ycsb workload test