### PR TITLE
HDDS-3438. Fix and enable TestContainerServer#testClientServerWithContainerDispatcher

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
@@ -77,14 +77,12 @@ import org.apache.ratis.util.function.CheckedBiFunction;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.apache.ozone.test.tag.Slow;
 import org.junit.jupiter.api.Test;
 
 
 /**
  * Test Containers.
  */
-@Slow
 public class TestContainerServer {
   static final String TEST_DIR = GenericTestUtils.getTestDir("dfs")
       .getAbsolutePath() + File.separator;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
@@ -20,11 +20,13 @@ package org.apache.hadoop.ozone.container.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -56,15 +58,19 @@ import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSp
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.ozone.test.GenericTestUtils;
 
 import com.google.common.collect.Maps;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 
-import org.apache.ozone.test.tag.Unhealthy;
 import org.apache.ratis.rpc.RpcType;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
 import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.apache.ratis.util.function.CheckedBiFunction;
@@ -74,7 +80,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.apache.ozone.test.tag.Slow;
 import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.mock;
 
 /**
  * Test Containers.
@@ -182,61 +187,47 @@ public class TestContainerServer {
     }
   }
 
-  @Unhealthy("Fails with StatusRuntimeException: UNKNOWN")
+  private static HddsDispatcher createDispatcher(DatanodeDetails dd, UUID scmId,
+                                                 OzoneConfiguration conf)
+      throws IOException {
+    ContainerSet containerSet = new ContainerSet(1000);
+    conf.set(HDDS_DATANODE_DIR_KEY,
+        Paths.get(TEST_DIR, "dfs", "data", "hdds",
+            RandomStringUtils.randomAlphabetic(4)).toString());
+    conf.set(OZONE_METADATA_DIRS, TEST_DIR);
+    VolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
+    StateContext context = ContainerTestUtils.getMockContext(dd, conf);
+    ContainerMetrics metrics = ContainerMetrics.create(conf);
+    Map<ContainerProtos.ContainerType, Handler> handlers = Maps.newHashMap();
+    for (ContainerProtos.ContainerType containerType :
+        ContainerProtos.ContainerType.values()) {
+      handlers.put(containerType,
+          Handler.getHandlerForContainerType(containerType, conf,
+              dd.getUuid().toString(),
+              containerSet, volumeSet, metrics,
+              c -> {
+              }));
+    }
+    HddsDispatcher hddsDispatcher = new HddsDispatcher(
+        conf, containerSet, volumeSet, handlers, context, metrics, null);
+    hddsDispatcher.setClusterId(scmId.toString());
+    return hddsDispatcher;
+  }
+
   @Test
   public void testClientServerWithContainerDispatcher() throws Exception {
-    XceiverServerGrpc server = null;
-    XceiverClientGrpc client = null;
-    UUID scmId = UUID.randomUUID();
-    try {
-      Pipeline pipeline = MockPipeline.createSingleNodePipeline();
-      OzoneConfiguration conf = new OzoneConfiguration();
-      conf.setInt(OzoneConfigKeys.DFS_CONTAINER_IPC_PORT,
-          pipeline.getFirstNode()
-              .getPort(DatanodeDetails.Port.Name.STANDALONE).getValue());
-
-      ContainerSet containerSet = new ContainerSet(1000);
-      VolumeSet volumeSet = mock(MutableVolumeSet.class);
-      ContainerMetrics metrics = ContainerMetrics.create(conf);
-      Map<ContainerProtos.ContainerType, Handler> handlers = Maps.newHashMap();
-      DatanodeDetails datanodeDetails = randomDatanodeDetails();
-      StateContext context = ContainerTestUtils.getMockContext(
-          datanodeDetails, conf);
-
-
-      for (ContainerProtos.ContainerType containerType :
-          ContainerProtos.ContainerType.values()) {
-        handlers.put(containerType,
-            Handler.getHandlerForContainerType(containerType, conf,
-                context.getParent().getDatanodeDetails().getUuidString(),
-                containerSet, volumeSet, metrics,
-                c -> { }));
-      }
-      HddsDispatcher dispatcher = new HddsDispatcher(
-          conf, containerSet, volumeSet, handlers, context, metrics, null);
-      dispatcher.setClusterId(scmId.toString());
-      dispatcher.init();
-
-      server = new XceiverServerGrpc(datanodeDetails, conf, dispatcher,
-          caClient);
-      client = new XceiverClientGrpc(pipeline, conf);
-
-      server.start();
-      client.connect();
-
-      ContainerCommandRequestProto request =
-          ContainerTestHelper.getCreateContainerRequest(
-              ContainerTestHelper.getTestContainerID(), pipeline);
-      ContainerCommandResponseProto response = client.sendCommand(request);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-    } finally {
-      if (client != null) {
-        client.close();
-      }
-      if (server != null) {
-        server.stop();
-      }
-    }
+    DatanodeDetails dd = MockDatanodeDetails.randomDatanodeDetails();
+    HddsDispatcher hddsDispatcher = createDispatcher(dd,
+        UUID.randomUUID(), CONF);
+    runTestClientServer(1, (pipeline, conf) -> conf
+            .setInt(OzoneConfigKeys.DFS_CONTAINER_IPC_PORT,
+                pipeline.getFirstNode()
+                    .getPort(DatanodeDetails.Port.Name.STANDALONE).getValue()),
+        XceiverClientGrpc::new,
+        (dn, conf) -> new XceiverServerGrpc(dd, conf,
+            hddsDispatcher, caClient), (dn, p) -> {
+        });
   }
 
   private static class TestContainerDispatcher implements ContainerDispatcher {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to allow running test cases of `TestContainerServer` class, as they were marked `slow` and some `unhealthy`.  In earlier written test case, some of the inputs to `testClientServerWithContainerDispatcher` like volumeSet and config like `hdds.datanode.dir` were not set correctly due to which the test was failing and it was failing after running and retrying for more than 2 mins. This PR has improved that corrected the test case.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3438

## How was this patch tested?

Since this PR is to allow and enable running of test cases of `TestContainerServer` class, the test class has been tested using running multiple times and it passed successfully without any significant delay.
