### PR TITLE
HDDS-9691. Migrate remaining tests in ozone-recon to JUnit5

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -25,6 +25,7 @@
   <artifactId>ozone-recon</artifactId>
   <properties>
     <pnpm.version>7.33.6</pnpm.version>
+    <allow.junit4>false</allow.junit4>
   </properties>
   <build>
     <resources>
@@ -298,11 +299,6 @@
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-common</artifactId>
       <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
@@ -27,7 +27,7 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DIRECTORY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -68,7 +68,8 @@ public class TestReconUtils {
   }
 
   @Test
-  public void testCreateTarFile(@TempDir File tempSnapshotDir) throws Exception {
+  public void testCreateTarFile(@TempDir File tempSnapshotDir)
+      throws Exception {
 
     FileInputStream fis = null;
     FileOutputStream fos = null;
@@ -103,7 +104,8 @@ public class TestReconUtils {
   @Test
   public void testUntarCheckpointFile() throws Exception {
 
-    File newDir = Files.createDirectory(temporaryFolder.resolve("NewDir")).toFile();
+    File newDir = Files.createDirectory(
+        temporaryFolder.resolve("NewDir")).toFile();
     File file1 = Paths.get(newDir.getAbsolutePath(), "file1")
         .toFile();
     String str = "File1 Contents";
@@ -122,7 +124,8 @@ public class TestReconUtils {
 
     //Create test tar file.
     File tarFile = createTarFile(newDir.toPath());
-    File outputDir = Files.createDirectory(temporaryFolder.resolve("OutputDir")).toFile();
+    File outputDir = Files.createDirectory(
+        temporaryFolder.resolve("OutputDir")).toFile();
     new ReconUtils().untarCheckpointFile(tarFile, outputDir.toPath());
 
     assertTrue(outputDir.isDirectory());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/common/CommonUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/common/CommonUtils.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.recon.api.types.ResponseStatus;
 import org.apache.hadoop.ozone.recon.api.types.VolumeObjectDBInfo;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.junit.Assert;
 
 import javax.ws.rs.core.Response;
 
@@ -43,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This is a utility class for common code for test cases.
@@ -84,21 +84,20 @@ public class CommonUtils {
     Response rootResponse = nsSummaryEndpoint.getBasicInfo(ROOT_PATH);
     NamespaceSummaryResponse rootResponseObj =
         (NamespaceSummaryResponse) rootResponse.getEntity();
-    Assert.assertEquals(EntityType.ROOT, rootResponseObj.getEntityType());
-    Assert.assertEquals(2, rootResponseObj.getCountStats().getNumVolume());
-    Assert.assertEquals(4, rootResponseObj.getCountStats().getNumBucket());
-    Assert.assertEquals(5, rootResponseObj.getCountStats().getNumTotalDir());
-    Assert.assertEquals(10, rootResponseObj.getCountStats().getNumTotalKey());
-    Assert.assertEquals("USER",
+    assertEquals(EntityType.ROOT, rootResponseObj.getEntityType());
+    assertEquals(2, rootResponseObj.getCountStats().getNumVolume());
+    assertEquals(4, rootResponseObj.getCountStats().getNumBucket());
+    assertEquals(5, rootResponseObj.getCountStats().getNumTotalDir());
+    assertEquals(10, rootResponseObj.getCountStats().getNumTotalKey());
+    assertEquals("USER",
         rootResponseObj.getObjectDBInfo().getAcls().get(0).getType());
-    Assert.assertEquals("WRITE",
-        rootResponseObj.getObjectDBInfo().getAcls().get(0)
+    assertEquals("WRITE", rootResponseObj.getObjectDBInfo().getAcls().get(0)
             .getAclList().get(0));
-    Assert.assertEquals(username,
+    assertEquals(username,
         rootResponseObj.getObjectDBInfo().getAcls().get(0).getName());
-    Assert.assertEquals("value",
+    assertEquals("value",
         rootResponseObj.getObjectDBInfo().getMetadata().get("key"));
-    Assert.assertEquals("ACCESS",
+    assertEquals("ACCESS",
         rootResponseObj.getObjectDBInfo().getAcls().get(0).getScope());
   }
 
@@ -107,26 +106,18 @@ public class CommonUtils {
     Response volResponse = nsSummaryEndpoint.getBasicInfo(VOL_PATH);
     NamespaceSummaryResponse volResponseObj =
         (NamespaceSummaryResponse) volResponse.getEntity();
-    Assert.assertEquals(EntityType.VOLUME,
+    assertEquals(EntityType.VOLUME,
         volResponseObj.getEntityType());
-    Assert.assertEquals(2,
-        volResponseObj.getCountStats().getNumBucket());
-    Assert.assertEquals(4,
-        volResponseObj.getCountStats().getNumTotalDir());
-    Assert.assertEquals(6,
-        volResponseObj.getCountStats().getNumTotalKey());
-    Assert.assertEquals("TestUser",
-        ((VolumeObjectDBInfo) volResponseObj.
+    assertEquals(2, volResponseObj.getCountStats().getNumBucket());
+    assertEquals(4, volResponseObj.getCountStats().getNumTotalDir());
+    assertEquals(6, volResponseObj.getCountStats().getNumTotalKey());
+    assertEquals("TestUser", ((VolumeObjectDBInfo) volResponseObj.
             getObjectDBInfo()).getAdmin());
-    Assert.assertEquals("TestUser",
-        ((VolumeObjectDBInfo) volResponseObj.
+    assertEquals("TestUser", ((VolumeObjectDBInfo) volResponseObj.
             getObjectDBInfo()).getOwner());
-    Assert.assertEquals("vol",
-        volResponseObj.getObjectDBInfo().getName());
-    Assert.assertEquals(2097152,
-        volResponseObj.getObjectDBInfo().getQuotaInBytes());
-    Assert.assertEquals(-1,
-        volResponseObj.getObjectDBInfo().getQuotaInNamespace());
+    assertEquals("vol", volResponseObj.getObjectDBInfo().getName());
+    assertEquals(2097152, volResponseObj.getObjectDBInfo().getQuotaInBytes());
+    assertEquals(-1, volResponseObj.getObjectDBInfo().getQuotaInNamespace());
   }
 
   public void testNSSummaryBasicInfoBucketOne(BucketLayout bucketLayout,
@@ -135,18 +126,18 @@ public class CommonUtils {
         nsSummaryEndpoint.getBasicInfo(BUCKET_ONE_PATH);
     NamespaceSummaryResponse bucketOneObj =
         (NamespaceSummaryResponse) bucketOneResponse.getEntity();
-    Assert.assertEquals(EntityType.BUCKET, bucketOneObj.getEntityType());
-    Assert.assertEquals(4, bucketOneObj.getCountStats().getNumTotalDir());
-    Assert.assertEquals(4, bucketOneObj.getCountStats().getNumTotalKey());
-    Assert.assertEquals("vol",
+    assertEquals(EntityType.BUCKET, bucketOneObj.getEntityType());
+    assertEquals(4, bucketOneObj.getCountStats().getNumTotalDir());
+    assertEquals(4, bucketOneObj.getCountStats().getNumTotalKey());
+    assertEquals("vol",
         ((BucketObjectDBInfo) bucketOneObj.getObjectDBInfo()).getVolumeName());
-    Assert.assertEquals(StorageType.DISK,
+    assertEquals(StorageType.DISK,
         ((BucketObjectDBInfo)
             bucketOneObj.getObjectDBInfo()).getStorageType());
-    Assert.assertEquals(bucketLayout,
+    assertEquals(bucketLayout,
         ((BucketObjectDBInfo)
             bucketOneObj.getObjectDBInfo()).getBucketLayout());
-    Assert.assertEquals("bucket1",
+    assertEquals("bucket1",
         ((BucketObjectDBInfo) bucketOneObj.getObjectDBInfo()).getName());
   }
 
@@ -157,18 +148,18 @@ public class CommonUtils {
         nsSummaryEndpoint.getBasicInfo(BUCKET_TWO_PATH);
     NamespaceSummaryResponse bucketTwoObj =
         (NamespaceSummaryResponse) bucketTwoResponse.getEntity();
-    Assert.assertEquals(EntityType.BUCKET, bucketTwoObj.getEntityType());
-    Assert.assertEquals(0, bucketTwoObj.getCountStats().getNumTotalDir());
-    Assert.assertEquals(2, bucketTwoObj.getCountStats().getNumTotalKey());
-    Assert.assertEquals("vol",
+    assertEquals(EntityType.BUCKET, bucketTwoObj.getEntityType());
+    assertEquals(0, bucketTwoObj.getCountStats().getNumTotalDir());
+    assertEquals(2, bucketTwoObj.getCountStats().getNumTotalKey());
+    assertEquals("vol",
         ((BucketObjectDBInfo) bucketTwoObj.getObjectDBInfo()).getVolumeName());
-    Assert.assertEquals(StorageType.DISK,
+    assertEquals(StorageType.DISK,
         ((BucketObjectDBInfo)
             bucketTwoObj.getObjectDBInfo()).getStorageType());
-    Assert.assertEquals(bucketLayout,
+    assertEquals(bucketLayout,
         ((BucketObjectDBInfo)
             bucketTwoObj.getObjectDBInfo()).getBucketLayout());
-    Assert.assertEquals("bucket2",
+    assertEquals("bucket2",
         ((BucketObjectDBInfo) bucketTwoObj.getObjectDBInfo()).getName());
   }
 
@@ -177,21 +168,14 @@ public class CommonUtils {
     Response dirOneResponse = nsSummaryEndpoint.getBasicInfo(DIR_ONE_PATH);
     NamespaceSummaryResponse dirOneObj =
         (NamespaceSummaryResponse) dirOneResponse.getEntity();
-    Assert.assertEquals(EntityType.DIRECTORY, dirOneObj.getEntityType());
-    Assert.assertEquals(3,
-        dirOneObj.getCountStats().getNumTotalDir());
-    Assert.assertEquals(3,
-        dirOneObj.getCountStats().getNumTotalKey());
-    Assert.assertEquals("dir1",
-        dirOneObj.getObjectDBInfo().getName());
-    Assert.assertEquals(0,
-        dirOneObj.getObjectDBInfo().getMetadata().size());
-    Assert.assertEquals(0,
-        dirOneObj.getObjectDBInfo().getQuotaInBytes());
-    Assert.assertEquals(0,
-        dirOneObj.getObjectDBInfo().getQuotaInNamespace());
-    Assert.assertEquals(0,
-        dirOneObj.getObjectDBInfo().getUsedNamespace());
+    assertEquals(EntityType.DIRECTORY, dirOneObj.getEntityType());
+    assertEquals(3, dirOneObj.getCountStats().getNumTotalDir());
+    assertEquals(3, dirOneObj.getCountStats().getNumTotalKey());
+    assertEquals("dir1", dirOneObj.getObjectDBInfo().getName());
+    assertEquals(0, dirOneObj.getObjectDBInfo().getMetadata().size());
+    assertEquals(0, dirOneObj.getObjectDBInfo().getQuotaInBytes());
+    assertEquals(0, dirOneObj.getObjectDBInfo().getQuotaInNamespace());
+    assertEquals(0, dirOneObj.getObjectDBInfo().getUsedNamespace());
   }
 
   public void testNSSummaryBasicInfoNoPath(
@@ -200,10 +184,9 @@ public class CommonUtils {
         .getBasicInfo(INVALID_PATH);
     NamespaceSummaryResponse invalidObj =
         (NamespaceSummaryResponse) invalidResponse.getEntity();
-    Assert.assertEquals(ResponseStatus.PATH_NOT_FOUND,
-        invalidObj.getStatus());
-    Assert.assertEquals(null, invalidObj.getCountStats());
-    Assert.assertEquals(null, invalidObj.getObjectDBInfo());
+    assertEquals(ResponseStatus.PATH_NOT_FOUND, invalidObj.getStatus());
+    assertEquals(null, invalidObj.getCountStats());
+    assertEquals(null, invalidObj.getObjectDBInfo());
   }
 
   public void testNSSummaryBasicInfoKey(
@@ -211,16 +194,16 @@ public class CommonUtils {
     Response keyResponse = nsSummaryEndpoint.getBasicInfo(KEY_PATH);
     NamespaceSummaryResponse keyResObj =
         (NamespaceSummaryResponse) keyResponse.getEntity();
-    Assert.assertEquals(EntityType.KEY, keyResObj.getEntityType());
-    Assert.assertEquals("vol",
+    assertEquals(EntityType.KEY, keyResObj.getEntityType());
+    assertEquals("vol",
         ((KeyObjectDBInfo) keyResObj.getObjectDBInfo()).getVolumeName());
-    Assert.assertEquals("bucket2",
+    assertEquals("bucket2",
         ((KeyObjectDBInfo) keyResObj.getObjectDBInfo()).getBucketName());
-    Assert.assertEquals("file4",
+    assertEquals("file4",
         ((KeyObjectDBInfo) keyResObj.getObjectDBInfo()).getKeyName());
-    Assert.assertEquals(2049,
+    assertEquals(2049,
         ((KeyObjectDBInfo) keyResObj.getObjectDBInfo()).getDataSize());
-    Assert.assertEquals(HddsProtos.ReplicationType.STAND_ALONE,
+    assertEquals(HddsProtos.ReplicationType.STAND_ALONE,
         ((KeyObjectDBInfo) keyResObj.getObjectDBInfo()).
             getReplicationConfig().getReplicationType());
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestReconWithDifferentSqlDBs.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestReconWithDifferentSqlDBs.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.recon.persistence;
 import static org.apache.hadoop.ozone.recon.ReconControllerModule.ReconDaoBindingModule.RECON_DAO_LIST;
 import static org.hadoop.ozone.recon.codegen.SqlDbUtils.SQLITE_DRIVER_CLASS;
 import static org.hadoop.ozone.recon.schema.Tables.RECON_TASK_STATUS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
@@ -24,10 +24,10 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -30,10 +30,11 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA
 import static org.apache.hadoop.ozone.recon.ReconUtils.createTarFile;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmDeltaRequest;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmSnapshotRequest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -75,11 +76,9 @@ import org.apache.hadoop.ozone.recon.tasks.ReconTaskController;
 
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.ReconTaskStatus;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.rocksdb.TransactionLogIterator.BatchResult;
 import org.rocksdb.WriteBatch;
@@ -89,33 +88,30 @@ import org.rocksdb.WriteBatch;
  */
 public class TestOzoneManagerServiceProviderImpl {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
   private OzoneConfiguration configuration;
   private OzoneManagerProtocol ozoneManagerProtocol;
   private CommonUtils commonUtils;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  public void setUp(@TempDir File dirReconSnapDB, @TempDir File dirReconDB) throws Exception {
     configuration = new OzoneConfiguration();
     configuration.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR,
-        temporaryFolder.newFolder().getAbsolutePath());
+        dirReconSnapDB.getAbsolutePath());
     configuration.set(OZONE_RECON_DB_DIR,
-        temporaryFolder.newFolder().getAbsolutePath());
+        dirReconSnapDB.getAbsolutePath());
     configuration.set("ozone.om.address", "localhost:9862");
     ozoneManagerProtocol = getMockOzoneManagerClient(new DBUpdates());
     commonUtils = new CommonUtils();
   }
 
   @Test
-  public void testUpdateReconOmDBWithNewSnapshot() throws Exception {
+  public void testUpdateReconOmDBWithNewSnapshot(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
 
     OMMetadataManager omMetadataManager =
-        initializeNewOmMetadataManager(temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(dirOmMetadata);
     ReconOMMetadataManager reconOMMetadataManager =
         getTestReconOmMetadataManager(omMetadataManager,
-            temporaryFolder.newFolder());
+            dirReconMetadata);
 
     writeDataToOm(omMetadataManager, "key_one");
     writeDataToOm(omMetadataManager, "key_two");
@@ -139,9 +135,9 @@ public class TestOzoneManagerServiceProviderImpl {
             reconOMMetadataManager, reconTaskController, reconUtilsMock,
             ozoneManagerProtocol);
 
-    Assert.assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+    assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_one"));
-    Assert.assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+    assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_two"));
 
     assertTrue(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
@@ -153,12 +149,11 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testReconOmDBCloseAndOpenNewSnapshotDb() throws Exception {
+  public void testReconOmDBCloseAndOpenNewSnapshotDb(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
     OMMetadataManager omMetadataManager =
-        initializeNewOmMetadataManager(temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(dirOmMetadata);
     ReconOMMetadataManager reconOMMetadataManager =
-        getTestReconOmMetadataManager(omMetadataManager,
-            temporaryFolder.newFolder());
+        getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata);
 
     writeDataToOm(omMetadataManager, "key_one");
     writeDataToOm(omMetadataManager, "key_two");
@@ -197,37 +192,27 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testGetOzoneManagerDBSnapshot() throws Exception {
+  public void testGetOzoneManagerDBSnapshot(@TempDir File dirReconMetadata) throws Exception {
 
-    File reconOmSnapshotDbDir = temporaryFolder.newFolder();
-
-    File checkpointDir = Paths.get(reconOmSnapshotDbDir.getAbsolutePath(),
+    File checkpointDir = Paths.get(dirReconMetadata.getAbsolutePath(),
         "testGetOzoneManagerDBSnapshot").toFile();
     checkpointDir.mkdir();
 
     File file1 = Paths.get(checkpointDir.getAbsolutePath(), "file1")
         .toFile();
     String str = "File1 Contents";
-    BufferedWriter writer = null;
-    try {
-      writer = new BufferedWriter(new OutputStreamWriter(
-          new FileOutputStream(file1), UTF_8));
-      writer.write(str);
-    } finally {
-      if (writer != null) {
-        writer.close();
-      }
+
+    try(BufferedWriter writer1 = new BufferedWriter(new OutputStreamWriter(
+        new FileOutputStream(file1), UTF_8))) {
+      writer1.write(str);
     }
 
     File file2 = Paths.get(checkpointDir.getAbsolutePath(), "file2")
         .toFile();
     str = "File2 Contents";
-    try {
-      writer = new BufferedWriter(new OutputStreamWriter(
-          new FileOutputStream(file2), UTF_8));
+    try(BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
+        new FileOutputStream(file2), UTF_8))) {
       writer.write(str);
-    } finally {
-      writer.close();
     }
 
     //Create test tar file.
@@ -265,12 +250,12 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testGetAndApplyDeltaUpdatesFromOM() throws Exception {
+  public void testGetAndApplyDeltaUpdatesFromOM(@TempDir File dirSrcOmMetadata, @TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
 
     // Writing 2 Keys into a source OM DB and collecting it in a
     // DBUpdatesWrapper.
     OMMetadataManager sourceOMMetadataMgr =
-        initializeNewOmMetadataManager(temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(dirSrcOmMetadata);
     writeDataToOm(sourceOMMetadataMgr, "key_one");
     writeDataToOm(sourceOMMetadataMgr, "key_two");
 
@@ -288,12 +273,11 @@ public class TestOzoneManagerServiceProviderImpl {
 
     // OM Service Provider's Metadata Manager.
     OMMetadataManager omMetadataManager =
-        initializeNewOmMetadataManager(temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(dirOmMetadata);
 
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new OzoneManagerServiceProviderImpl(configuration,
-            getTestReconOmMetadataManager(omMetadataManager,
-                temporaryFolder.newFolder()),
+            getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata),
             getMockTaskController(), new ReconUtils(),
             getMockOzoneManagerClient(dbUpdatesWrapper));
 
@@ -326,12 +310,12 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testGetAndApplyDeltaUpdatesFromOMWithLimit() throws Exception {
+  public void testGetAndApplyDeltaUpdatesFromOMWithLimit(@TempDir File dirSrcOmMetadata, @TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
 
     // Writing 2 Keys into a source OM DB and collecting it in a
     // DBUpdatesWrapper.
     OMMetadataManager sourceOMMetadataMgr =
-        initializeNewOmMetadataManager(temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(dirSrcOmMetadata);
     writeDataToOm(sourceOMMetadataMgr, "key_one");
     writeDataToOm(sourceOMMetadataMgr, "key_two");
 
@@ -352,7 +336,7 @@ public class TestOzoneManagerServiceProviderImpl {
 
     // OM Service Provider's Metadata Manager.
     OMMetadataManager omMetadataManager =
-        initializeNewOmMetadataManager(temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(dirOmMetadata);
 
     OzoneConfiguration withLimitConfiguration =
         new OzoneConfiguration(configuration);
@@ -360,16 +344,15 @@ public class TestOzoneManagerServiceProviderImpl {
     withLimitConfiguration.setLong(RECON_OM_DELTA_UPDATE_LOOP_LIMIT, 3);
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new OzoneManagerServiceProviderImpl(withLimitConfiguration,
-            getTestReconOmMetadataManager(omMetadataManager,
-                temporaryFolder.newFolder()),
+            getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata),
             getMockTaskController(), new ReconUtils(),
             getMockOzoneManagerClientWith4Updates(dbUpdatesWrapper[0],
                 dbUpdatesWrapper[1], dbUpdatesWrapper[2], dbUpdatesWrapper[3]));
 
-    assertEquals(true, dbUpdatesWrapper[0].isDBUpdateSuccess());
-    assertEquals(true, dbUpdatesWrapper[1].isDBUpdateSuccess());
-    assertEquals(true, dbUpdatesWrapper[2].isDBUpdateSuccess());
-    assertEquals(true, dbUpdatesWrapper[3].isDBUpdateSuccess());
+    assertTrue(dbUpdatesWrapper[0].isDBUpdateSuccess());
+    assertTrue(dbUpdatesWrapper[1].isDBUpdateSuccess());
+    assertTrue(dbUpdatesWrapper[2].isDBUpdateSuccess());
+    assertTrue(dbUpdatesWrapper[3].isDBUpdateSuccess());
 
     OMDBUpdatesHandler updatesHandler =
         new OMDBUpdatesHandler(omMetadataManager);
@@ -400,12 +383,11 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testSyncDataFromOMFullSnapshot() throws Exception {
+  public void testSyncDataFromOMFullSnapshot(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
 
     // Empty OM DB to start with.
     ReconOMMetadataManager omMetadataManager = getTestReconOmMetadataManager(
-        initializeEmptyOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeEmptyOmMetadataManager(dirOmMetadata), dirReconMetadata);
     ReconTaskStatusDao reconTaskStatusDaoMock =
         mock(ReconTaskStatusDao.class);
     doNothing().when(reconTaskStatusDaoMock)
@@ -438,12 +420,11 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testSyncDataFromOMDeltaUpdates() throws Exception {
+  public void testSyncDataFromOMDeltaUpdates(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
 
     // Non-Empty OM DB to start with.
     ReconOMMetadataManager omMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(dirOmMetadata), dirReconMetadata);
     ReconTaskStatusDao reconTaskStatusDaoMock =
         mock(ReconTaskStatusDao.class);
     doNothing().when(reconTaskStatusDaoMock)
@@ -478,12 +459,11 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testSyncDataFromOMFullSnapshotForSNNFE() throws Exception {
+  public void testSyncDataFromOMFullSnapshotForSNNFE(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
 
     // Non-Empty OM DB to start with.
     ReconOMMetadataManager omMetadataManager = getTestReconOmMetadataManager(
-        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
-        temporaryFolder.newFolder());
+        initializeNewOmMetadataManager(dirOmMetadata), dirReconMetadata);
     ReconTaskStatusDao reconTaskStatusDaoMock =
         mock(ReconTaskStatusDao.class);
     doNothing().when(reconTaskStatusDaoMock)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -93,7 +93,8 @@ public class TestOzoneManagerServiceProviderImpl {
   private CommonUtils commonUtils;
 
   @BeforeEach
-  public void setUp(@TempDir File dirReconSnapDB, @TempDir File dirReconDB) throws Exception {
+  public void setUp(@TempDir File dirReconSnapDB, @TempDir File dirReconDB)
+      throws Exception {
     configuration = new OzoneConfiguration();
     configuration.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR,
         dirReconSnapDB.getAbsolutePath());
@@ -105,7 +106,9 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testUpdateReconOmDBWithNewSnapshot(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+  public void testUpdateReconOmDBWithNewSnapshot(
+      @TempDir File dirOmMetadata, @TempDir File dirReconMetadata)
+      throws Exception {
 
     OMMetadataManager omMetadataManager =
         initializeNewOmMetadataManager(dirOmMetadata);
@@ -149,7 +152,9 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testReconOmDBCloseAndOpenNewSnapshotDb(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+  public void testReconOmDBCloseAndOpenNewSnapshotDb(
+      @TempDir File dirOmMetadata, @TempDir File dirReconMetadata)
+      throws Exception {
     OMMetadataManager omMetadataManager =
         initializeNewOmMetadataManager(dirOmMetadata);
     ReconOMMetadataManager reconOMMetadataManager =
@@ -192,7 +197,8 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testGetOzoneManagerDBSnapshot(@TempDir File dirReconMetadata) throws Exception {
+  public void testGetOzoneManagerDBSnapshot(@TempDir File dirReconMetadata)
+      throws Exception {
 
     File checkpointDir = Paths.get(dirReconMetadata.getAbsolutePath(),
         "testGetOzoneManagerDBSnapshot").toFile();
@@ -202,7 +208,7 @@ public class TestOzoneManagerServiceProviderImpl {
         .toFile();
     String str = "File1 Contents";
 
-    try(BufferedWriter writer1 = new BufferedWriter(new OutputStreamWriter(
+    try (BufferedWriter writer1 = new BufferedWriter(new OutputStreamWriter(
         new FileOutputStream(file1), UTF_8))) {
       writer1.write(str);
     }
@@ -210,7 +216,7 @@ public class TestOzoneManagerServiceProviderImpl {
     File file2 = Paths.get(checkpointDir.getAbsolutePath(), "file2")
         .toFile();
     str = "File2 Contents";
-    try(BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
+    try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
         new FileOutputStream(file2), UTF_8))) {
       writer.write(str);
     }
@@ -250,7 +256,9 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testGetAndApplyDeltaUpdatesFromOM(@TempDir File dirSrcOmMetadata, @TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+  public void testGetAndApplyDeltaUpdatesFromOM(
+      @TempDir File dirSrcOmMetadata, @TempDir File dirOmMetadata,
+      @TempDir File dirReconMetadata) throws Exception {
 
     // Writing 2 Keys into a source OM DB and collecting it in a
     // DBUpdatesWrapper.
@@ -310,7 +318,9 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testGetAndApplyDeltaUpdatesFromOMWithLimit(@TempDir File dirSrcOmMetadata, @TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+  public void testGetAndApplyDeltaUpdatesFromOMWithLimit(
+      @TempDir File dirSrcOmMetadata, @TempDir File dirOmMetadata,
+      @TempDir File dirReconMetadata) throws Exception {
 
     // Writing 2 Keys into a source OM DB and collecting it in a
     // DBUpdatesWrapper.
@@ -383,7 +393,9 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testSyncDataFromOMFullSnapshot(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+  public void testSyncDataFromOMFullSnapshot(
+      @TempDir File dirOmMetadata, @TempDir File dirReconMetadata)
+      throws Exception {
 
     // Empty OM DB to start with.
     ReconOMMetadataManager omMetadataManager = getTestReconOmMetadataManager(
@@ -420,7 +432,9 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testSyncDataFromOMDeltaUpdates(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+  public void testSyncDataFromOMDeltaUpdates(
+      @TempDir File dirOmMetadata, @TempDir File dirReconMetadata)
+      throws Exception {
 
     // Non-Empty OM DB to start with.
     ReconOMMetadataManager omMetadataManager = getTestReconOmMetadataManager(
@@ -459,7 +473,9 @@ public class TestOzoneManagerServiceProviderImpl {
   }
 
   @Test
-  public void testSyncDataFromOMFullSnapshotForSNNFE(@TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+  public void testSyncDataFromOMFullSnapshotForSNNFE(
+      @TempDir File dirOmMetadata, @TempDir File dirReconMetadata)
+      throws Exception {
 
     // Non-Empty OM DB to start with.
     ReconOMMetadataManager omMetadataManager = getTestReconOmMetadataManager(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -223,31 +223,32 @@ public class TestOzoneManagerServiceProviderImpl {
 
     //Create test tar file.
     File tarFile = createTarFile(checkpointDir.toPath());
-    InputStream fileInputStream = new FileInputStream(tarFile);
-    ReconUtils reconUtilsMock = getMockReconUtils();
-    HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
-    when(httpURLConnectionMock.getInputStream()).thenReturn(fileInputStream);
-    when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
-        .thenReturn(httpURLConnectionMock);
-    when(reconUtilsMock.getReconNodeDetails(
-        any(OzoneConfiguration.class))).thenReturn(
-        commonUtils.getReconNodeDetails());
-    ReconOMMetadataManager reconOMMetadataManager =
-        mock(ReconOMMetadataManager.class);
-    ReconTaskController reconTaskController = getMockTaskController();
-    OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
-        new OzoneManagerServiceProviderImpl(configuration,
-            reconOMMetadataManager, reconTaskController, reconUtilsMock,
-            ozoneManagerProtocol);
+    try (InputStream fileInputStream = new FileInputStream(tarFile)) {
+      ReconUtils reconUtilsMock = getMockReconUtils();
+      HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
+      when(httpURLConnectionMock.getInputStream()).thenReturn(fileInputStream);
+      when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
+          .thenReturn(httpURLConnectionMock);
+      when(reconUtilsMock.getReconNodeDetails(
+          any(OzoneConfiguration.class))).thenReturn(
+          commonUtils.getReconNodeDetails());
+      ReconOMMetadataManager reconOMMetadataManager =
+          mock(ReconOMMetadataManager.class);
+      ReconTaskController reconTaskController = getMockTaskController();
+      OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
+          new OzoneManagerServiceProviderImpl(configuration,
+              reconOMMetadataManager, reconTaskController, reconUtilsMock,
+              ozoneManagerProtocol);
 
-    DBCheckpoint checkpoint = ozoneManagerServiceProvider
-        .getOzoneManagerDBSnapshot();
-    assertNotNull(checkpoint);
-    assertTrue(checkpoint.getCheckpointLocation().toFile().isDirectory());
+      DBCheckpoint checkpoint = ozoneManagerServiceProvider
+          .getOzoneManagerDBSnapshot();
+      assertNotNull(checkpoint);
+      assertTrue(checkpoint.getCheckpointLocation().toFile().isDirectory());
 
-    File[] files = checkpoint.getCheckpointLocation().toFile().listFiles();
-    assertNotNull(files);
-    assertEquals(2, files.length);
+      File[] files = checkpoint.getCheckpointLocation().toFile().listFiles();
+      assertNotNull(files);
+      assertEquals(2, files.length);
+    }
   }
 
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.Assert;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
@@ -52,6 +51,9 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getMockOzoneManagerServiceProvider;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test for NSSummaryTask. Create one bucket of each layout
@@ -122,7 +124,7 @@ public final class TestNSSummaryTask {
 
     NSSummary nonExistentSummary =
         reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
-    Assert.assertNull(nonExistentSummary);
+    assertNull(nonExistentSummary);
 
     populateOMDB();
 
@@ -151,10 +153,10 @@ public final class TestNSSummaryTask {
       reconNamespaceSummaryManager.commitBatchOperation(rdbBatchOperation);
 
       // Verify commit
-      Assert.assertNotNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNotNull(reconNamespaceSummaryManager.getNSSummary(-1L));
 
       nSSummaryTask.reprocess(reconOMMetadataManager);
-      Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
 
       nsSummaryForBucket1 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
@@ -162,44 +164,44 @@ public final class TestNSSummaryTask {
           reconNamespaceSummaryManager.getNSSummary(BUCKET_TWO_OBJECT_ID);
       nsSummaryForBucket3 =
       reconNamespaceSummaryManager.getNSSummary(BUCKET_THREE_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForBucket1);
-      Assert.assertNotNull(nsSummaryForBucket2);
-      Assert.assertNull(nsSummaryForBucket3);
+      assertNotNull(nsSummaryForBucket1);
+      assertNotNull(nsSummaryForBucket2);
+      assertNull(nsSummaryForBucket3);
     }
 
     @Test
     public void testReprocessNSSummaryNull() throws IOException {
-      Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
     }
 
     @Test
     public void testReprocessGetFiles() {
-      Assert.assertEquals(1, nsSummaryForBucket1.getNumOfFiles());
-      Assert.assertEquals(1, nsSummaryForBucket2.getNumOfFiles());
+      assertEquals(1, nsSummaryForBucket1.getNumOfFiles());
+      assertEquals(1, nsSummaryForBucket2.getNumOfFiles());
 
-      Assert.assertEquals(KEY_ONE_SIZE, nsSummaryForBucket1.getSizeOfFiles());
-      Assert.assertEquals(KEY_TWO_SIZE, nsSummaryForBucket2.getSizeOfFiles());
+      assertEquals(KEY_ONE_SIZE, nsSummaryForBucket1.getSizeOfFiles());
+      assertEquals(KEY_TWO_SIZE, nsSummaryForBucket2.getSizeOfFiles());
     }
 
     @Test
     public void testReprocessFileBucketSize() {
       int[] fileDistBucket1 = nsSummaryForBucket1.getFileSizeBucket();
       int[] fileDistBucket2 = nsSummaryForBucket2.getFileSizeBucket();
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileDistBucket1.length);
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileDistBucket2.length);
 
-      Assert.assertEquals(1, fileDistBucket1[0]);
+      assertEquals(1, fileDistBucket1[0]);
       for (int i = 1; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
-        Assert.assertEquals(0, fileDistBucket1[i]);
+        assertEquals(0, fileDistBucket1[i]);
       }
-      Assert.assertEquals(1, fileDistBucket2[1]);
+      assertEquals(1, fileDistBucket2[1]);
       for (int i = 0; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
         if (i == 1) {
           continue;
         }
-        Assert.assertEquals(0, fileDistBucket2[i]);
+        assertEquals(0, fileDistBucket2[i]);
       }
     }
 
@@ -225,13 +227,13 @@ public final class TestNSSummaryTask {
 
       nsSummaryForBucket1 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForBucket1);
+      assertNotNull(nsSummaryForBucket1);
       nsSummaryForBucket2 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_TWO_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForBucket2);
+      assertNotNull(nsSummaryForBucket2);
       nsSummaryForBucket3 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_THREE_OBJECT_ID);
-      Assert.assertNull(nsSummaryForBucket3);
+      assertNull(nsSummaryForBucket3);
     }
 
     private OMUpdateEventBatch processEventBatch() throws IOException {
@@ -271,31 +273,31 @@ public final class TestNSSummaryTask {
     @Test
     public void testProcessUpdateFileSize() throws IOException {
       // file 1 is gone, so bucket 1 is empty now
-      Assert.assertNotNull(nsSummaryForBucket1);
-      Assert.assertEquals(0, nsSummaryForBucket1.getNumOfFiles());
+      assertNotNull(nsSummaryForBucket1);
+      assertEquals(0, nsSummaryForBucket1.getNumOfFiles());
 
       Set<Long> childDirBucket1 = nsSummaryForBucket1.getChildDir();
-      Assert.assertEquals(0, childDirBucket1.size());
+      assertEquals(0, childDirBucket1.size());
     }
 
     @Test
     public void testProcessBucket() throws IOException {
       // file 5 is added under bucket 2, so bucket 2 has 2 keys now
-      Assert.assertNotNull(nsSummaryForBucket2);
-      Assert.assertEquals(2, nsSummaryForBucket2.getNumOfFiles());
+      assertNotNull(nsSummaryForBucket2);
+      assertEquals(2, nsSummaryForBucket2.getNumOfFiles());
       // key 2 + key 5
-      Assert.assertEquals(KEY_TWO_SIZE + KEY_FIVE_SIZE,
+      assertEquals(KEY_TWO_SIZE + KEY_FIVE_SIZE,
           nsSummaryForBucket2.getSizeOfFiles());
 
       int[] fileSizeDist = nsSummaryForBucket2.getFileSizeBucket();
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileSizeDist.length);
       // 1025L
-      Assert.assertEquals(1, fileSizeDist[0]);
+      assertEquals(1, fileSizeDist[0]);
       // 2050L
-      Assert.assertEquals(1, fileSizeDist[1]);
+      assertEquals(1, fileSizeDist[1]);
       for (int i = 2; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
-        Assert.assertEquals(0, fileSizeDist[i]);
+        assertEquals(0, fileSizeDist[i]);
       }
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.Assert;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
@@ -52,6 +51,9 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializ
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDirToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyToOm;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_NSSUMMARY_FLUSH_TO_DB_MAX_THRESHOLD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test for NSSummaryTaskWithFSO.
@@ -138,7 +140,7 @@ public final class TestNSSummaryTaskWithFSO {
 
     NSSummary nonExistentSummary =
             reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
-    Assert.assertNull(nonExistentSummary);
+    assertNull(nonExistentSummary);
 
     populateOMDB();
 
@@ -167,34 +169,34 @@ public final class TestNSSummaryTaskWithFSO {
       reconNamespaceSummaryManager.commitBatchOperation(rdbBatchOperation);
 
       // Verify commit
-      Assert.assertNotNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNotNull(reconNamespaceSummaryManager.getNSSummary(-1L));
 
       // reinit Recon RocksDB's namespace CF.
       reconNamespaceSummaryManager.clearNSSummaryTable();
 
       nSSummaryTaskWithFso.reprocessWithFSO(reconOMMetadataManager);
-      Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
 
       nsSummaryForBucket1 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
       nsSummaryForBucket2 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_TWO_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForBucket1);
-      Assert.assertNotNull(nsSummaryForBucket2);
+      assertNotNull(nsSummaryForBucket1);
+      assertNotNull(nsSummaryForBucket2);
     }
 
     @Test
     public void testReprocessNSSummaryNull() throws IOException {
-      Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
     }
 
     @Test
     public void testReprocessGetFiles() {
-      Assert.assertEquals(1, nsSummaryForBucket1.getNumOfFiles());
-      Assert.assertEquals(2, nsSummaryForBucket2.getNumOfFiles());
+      assertEquals(1, nsSummaryForBucket1.getNumOfFiles());
+      assertEquals(2, nsSummaryForBucket2.getNumOfFiles());
 
-      Assert.assertEquals(KEY_ONE_SIZE, nsSummaryForBucket1.getSizeOfFiles());
-      Assert.assertEquals(KEY_TWO_OLD_SIZE + KEY_FOUR_SIZE,
+      assertEquals(KEY_ONE_SIZE, nsSummaryForBucket1.getSizeOfFiles());
+      assertEquals(KEY_TWO_OLD_SIZE + KEY_FOUR_SIZE,
           nsSummaryForBucket2.getSizeOfFiles());
     } 
 
@@ -202,22 +204,22 @@ public final class TestNSSummaryTaskWithFSO {
     public void testReprocessFileBucketSize() {
       int[] fileDistBucket1 = nsSummaryForBucket1.getFileSizeBucket();
       int[] fileDistBucket2 = nsSummaryForBucket2.getFileSizeBucket();
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileDistBucket1.length);
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileDistBucket2.length);
 
-      Assert.assertEquals(1, fileDistBucket1[0]);
+      assertEquals(1, fileDistBucket1[0]);
       for (int i = 1; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
-        Assert.assertEquals(0, fileDistBucket1[i]);
+        assertEquals(0, fileDistBucket1[i]);
       }
-      Assert.assertEquals(1, fileDistBucket2[1]);
-      Assert.assertEquals(1, fileDistBucket2[2]);
+      assertEquals(1, fileDistBucket2[1]);
+      assertEquals(1, fileDistBucket2[2]);
       for (int i = 0; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
         if (i == 1 || i == 2) {
           continue;
         }
-        Assert.assertEquals(0, fileDistBucket2[i]);
+        assertEquals(0, fileDistBucket2[i]);
       }
     }
 
@@ -226,11 +228,11 @@ public final class TestNSSummaryTaskWithFSO {
       // Bucket one has one dir, bucket two has none.
       Set<Long> childDirBucketOne = nsSummaryForBucket1.getChildDir();
       Set<Long> childDirBucketTwo = nsSummaryForBucket2.getChildDir();
-      Assert.assertEquals(1, childDirBucketOne.size());
+      assertEquals(1, childDirBucketOne.size());
       bucketOneAns.clear();
       bucketOneAns.add(DIR_ONE_OBJECT_ID);
-      Assert.assertEquals(bucketOneAns, childDirBucketOne);
-      Assert.assertEquals(0, childDirBucketTwo.size());
+      assertEquals(bucketOneAns, childDirBucketOne);
+      assertEquals(0, childDirBucketTwo.size());
     }
 
     @Test
@@ -239,34 +241,34 @@ public final class TestNSSummaryTaskWithFSO {
       // Dir 1 has two dir: dir2 and dir3.
       NSSummary nsSummaryInDir1 = reconNamespaceSummaryManager
           .getNSSummary(DIR_ONE_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryInDir1);
+      assertNotNull(nsSummaryInDir1);
       Set<Long> childDirForDirOne = nsSummaryInDir1.getChildDir();
-      Assert.assertEquals(2, childDirForDirOne.size());
+      assertEquals(2, childDirForDirOne.size());
       dirOneAns.clear();
       dirOneAns.add(DIR_TWO_OBJECT_ID);
       dirOneAns.add(DIR_THREE_OBJECT_ID);
-      Assert.assertEquals(dirOneAns, childDirForDirOne);
+      assertEquals(dirOneAns, childDirForDirOne);
 
       NSSummary nsSummaryInDir2 = reconNamespaceSummaryManager
           .getNSSummary(DIR_TWO_OBJECT_ID);
-      Assert.assertEquals(1, nsSummaryInDir2.getNumOfFiles());
-      Assert.assertEquals(KEY_THREE_SIZE, nsSummaryInDir2.getSizeOfFiles());
+      assertEquals(1, nsSummaryInDir2.getNumOfFiles());
+      assertEquals(KEY_THREE_SIZE, nsSummaryInDir2.getSizeOfFiles());
 
       int[] fileDistForDir2 = nsSummaryInDir2.getFileSizeBucket();
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileDistForDir2.length);
-      Assert.assertEquals(1, fileDistForDir2[fileDistForDir2.length - 1]);
+      assertEquals(1, fileDistForDir2[fileDistForDir2.length - 1]);
       for (int i = 0; i < ReconConstants.NUM_OF_FILE_SIZE_BINS - 1; ++i) {
-        Assert.assertEquals(0, fileDistForDir2[i]);
+        assertEquals(0, fileDistForDir2[i]);
       }
-      Assert.assertEquals(0, nsSummaryInDir2.getChildDir().size());
+      assertEquals(0, nsSummaryInDir2.getChildDir().size());
 
       // bucket should have empty dirName
-      Assert.assertEquals(0, nsSummaryForBucket1.getDirName().length());
-      Assert.assertEquals(0, nsSummaryForBucket2.getDirName().length());
+      assertEquals(0, nsSummaryForBucket1.getDirName().length());
+      assertEquals(0, nsSummaryForBucket2.getDirName().length());
       // check dirName is correctly written
-      Assert.assertEquals(DIR_ONE, nsSummaryInDir1.getDirName());
-      Assert.assertEquals(DIR_TWO, nsSummaryInDir2.getDirName());
+      assertEquals(DIR_ONE, nsSummaryInDir1.getDirName());
+      assertEquals(DIR_TWO, nsSummaryInDir2.getDirName());
     }
   }
 
@@ -399,16 +401,16 @@ public final class TestNSSummaryTaskWithFSO {
       NSSummary nsSummaryForBucket1 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
       // file 1 is gone, so bucket 1 is empty now
-      Assert.assertNotNull(nsSummaryForBucket1);
-      Assert.assertEquals(0, nsSummaryForBucket1.getNumOfFiles());
+      assertNotNull(nsSummaryForBucket1);
+      assertEquals(0, nsSummaryForBucket1.getNumOfFiles());
 
       Set<Long> childDirBucket1 = nsSummaryForBucket1.getChildDir();
       // after put dir4, bucket1 now has two child dirs: dir1 and dir4
-      Assert.assertEquals(2, childDirBucket1.size());
+      assertEquals(2, childDirBucket1.size());
       bucketOneAns.clear();
       bucketOneAns.add(DIR_ONE_OBJECT_ID);
       bucketOneAns.add(DIR_FOUR_OBJECT_ID);
-      Assert.assertEquals(bucketOneAns, childDirBucket1);
+      assertEquals(bucketOneAns, childDirBucket1);
     }
 
     @Test
@@ -418,31 +420,31 @@ public final class TestNSSummaryTaskWithFSO {
       // file 5 is added under bucket 2, so bucket 2 has 3 keys now
       // file 2 is updated with new datasize,
       // so file size dist for bucket 2 should be updated
-      Assert.assertNotNull(nsSummaryForBucket2);
-      Assert.assertEquals(3, nsSummaryForBucket2.getNumOfFiles());
+      assertNotNull(nsSummaryForBucket2);
+      assertEquals(3, nsSummaryForBucket2.getNumOfFiles());
       // key 4 + key 5 + updated key 2
-      Assert.assertEquals(KEY_FOUR_SIZE + KEY_FIVE_SIZE
+      assertEquals(KEY_FOUR_SIZE + KEY_FIVE_SIZE
           + KEY_TWO_UPDATE_SIZE, nsSummaryForBucket2.getSizeOfFiles());
 
       int[] fileSizeDist = nsSummaryForBucket2.getFileSizeBucket();
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileSizeDist.length);
       // 1023L and 100L
-      Assert.assertEquals(2, fileSizeDist[0]);
+      assertEquals(2, fileSizeDist[0]);
       // 2050L
-      Assert.assertEquals(1, fileSizeDist[2]);
+      assertEquals(1, fileSizeDist[2]);
       for (int i = 0; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
         if (i == 0 || i == 2) {
           continue;
         }
-        Assert.assertEquals(0, fileSizeDist[i]);
+        assertEquals(0, fileSizeDist[i]);
       }
 
       // after put dir5, bucket 2 now has one dir
       Set<Long> childDirBucket2 = nsSummaryForBucket2.getChildDir();
-      Assert.assertEquals(1, childDirBucket2.size());
+      assertEquals(1, childDirBucket2.size());
       bucketTwoAns.add(DIR_FIVE_OBJECT_ID);
-      Assert.assertEquals(bucketTwoAns, childDirBucket2);
+      assertEquals(bucketTwoAns, childDirBucket2);
     }
 
     @Test
@@ -450,15 +452,15 @@ public final class TestNSSummaryTaskWithFSO {
       // after delete dir 3, dir 1 now has only one dir: dir2
       NSSummary nsSummaryForDir1 = reconNamespaceSummaryManager
           .getNSSummary(DIR_ONE_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForDir1);
+      assertNotNull(nsSummaryForDir1);
       Set<Long> childDirForDir1 = nsSummaryForDir1.getChildDir();
-      Assert.assertEquals(1, childDirForDir1.size());
+      assertEquals(1, childDirForDir1.size());
       dirOneAns.clear();
       dirOneAns.add(DIR_TWO_OBJECT_ID);
-      Assert.assertEquals(dirOneAns, childDirForDir1);
+      assertEquals(dirOneAns, childDirForDir1);
 
       // after renaming dir1, check its new name
-      Assert.assertEquals(DIR_ONE_RENAME, nsSummaryForDir1.getDirName());
+      assertEquals(DIR_ONE_RENAME, nsSummaryForDir1.getDirName());
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithLegacy.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.Assert;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
@@ -54,6 +53,9 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyT
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDirToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getMockOzoneManagerServiceProvider;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test for NSSummaryTaskWithLegacy.
@@ -139,7 +141,7 @@ public final class TestNSSummaryTaskWithLegacy {
 
     NSSummary nonExistentSummary =
         reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
-    Assert.assertNull(nonExistentSummary);
+    assertNull(nonExistentSummary);
 
     populateOMDB();
 
@@ -168,34 +170,34 @@ public final class TestNSSummaryTaskWithLegacy {
       reconNamespaceSummaryManager.commitBatchOperation(rdbBatchOperation);
 
       // Verify commit
-      Assert.assertNotNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNotNull(reconNamespaceSummaryManager.getNSSummary(-1L));
 
       // reinit Recon RocksDB's namespace CF.
       reconNamespaceSummaryManager.clearNSSummaryTable();
 
       nSSummaryTaskWithLegacy.reprocessWithLegacy(reconOMMetadataManager);
-      Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
 
       nsSummaryForBucket1 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
       nsSummaryForBucket2 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_TWO_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForBucket1);
-      Assert.assertNotNull(nsSummaryForBucket2);
+      assertNotNull(nsSummaryForBucket1);
+      assertNotNull(nsSummaryForBucket2);
     }
 
     @Test
     public void testReprocessNSSummaryNull() throws IOException {
-      Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
+      assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
     }
 
     @Test
     public void testReprocessGetFiles() {
-      Assert.assertEquals(1, nsSummaryForBucket1.getNumOfFiles());
-      Assert.assertEquals(2, nsSummaryForBucket2.getNumOfFiles());
+      assertEquals(1, nsSummaryForBucket1.getNumOfFiles());
+      assertEquals(2, nsSummaryForBucket2.getNumOfFiles());
 
-      Assert.assertEquals(KEY_ONE_SIZE, nsSummaryForBucket1.getSizeOfFiles());
-      Assert.assertEquals(KEY_TWO_OLD_SIZE + KEY_FOUR_SIZE,
+      assertEquals(KEY_ONE_SIZE, nsSummaryForBucket1.getSizeOfFiles());
+      assertEquals(KEY_TWO_OLD_SIZE + KEY_FOUR_SIZE,
           nsSummaryForBucket2.getSizeOfFiles());
     }
 
@@ -203,22 +205,22 @@ public final class TestNSSummaryTaskWithLegacy {
     public void testReprocessFileBucketSize() {
       int[] fileDistBucket1 = nsSummaryForBucket1.getFileSizeBucket();
       int[] fileDistBucket2 = nsSummaryForBucket2.getFileSizeBucket();
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileDistBucket1.length);
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileDistBucket2.length);
 
-      Assert.assertEquals(1, fileDistBucket1[0]);
+      assertEquals(1, fileDistBucket1[0]);
       for (int i = 1; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
-        Assert.assertEquals(0, fileDistBucket1[i]);
+        assertEquals(0, fileDistBucket1[i]);
       }
-      Assert.assertEquals(1, fileDistBucket2[1]);
-      Assert.assertEquals(1, fileDistBucket2[2]);
+      assertEquals(1, fileDistBucket2[1]);
+      assertEquals(1, fileDistBucket2[2]);
       for (int i = 0; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
         if (i == 1 || i == 2) {
           continue;
         }
-        Assert.assertEquals(0, fileDistBucket2[i]);
+        assertEquals(0, fileDistBucket2[i]);
       }
     }
 
@@ -227,11 +229,11 @@ public final class TestNSSummaryTaskWithLegacy {
       // Bucket one has one dir, bucket two has none.
       Set<Long> childDirBucketOne = nsSummaryForBucket1.getChildDir();
       Set<Long> childDirBucketTwo = nsSummaryForBucket2.getChildDir();
-      Assert.assertEquals(1, childDirBucketOne.size());
+      assertEquals(1, childDirBucketOne.size());
       bucketOneAns.clear();
       bucketOneAns.add(DIR_ONE_OBJECT_ID);
-      Assert.assertEquals(bucketOneAns, childDirBucketOne);
-      Assert.assertEquals(0, childDirBucketTwo.size());
+      assertEquals(bucketOneAns, childDirBucketOne);
+      assertEquals(0, childDirBucketTwo.size());
     }
 
     @Test
@@ -240,35 +242,35 @@ public final class TestNSSummaryTaskWithLegacy {
       // Dir 1 has two dir: dir2 and dir3.
       NSSummary nsSummaryInDir1 = reconNamespaceSummaryManager
           .getNSSummary(DIR_ONE_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryInDir1);
+      assertNotNull(nsSummaryInDir1);
       Set<Long> childDirForDirOne = nsSummaryInDir1.getChildDir();
-      Assert.assertEquals(2, childDirForDirOne.size());
+      assertEquals(2, childDirForDirOne.size());
       dirOneAns.clear();
       dirOneAns.add(DIR_TWO_OBJECT_ID);
       dirOneAns.add(DIR_THREE_OBJECT_ID);
-      Assert.assertEquals(dirOneAns, childDirForDirOne);
+      assertEquals(dirOneAns, childDirForDirOne);
 
       NSSummary nsSummaryInDir2 = reconNamespaceSummaryManager
           .getNSSummary(DIR_TWO_OBJECT_ID);
-      Assert.assertEquals(1, nsSummaryInDir2.getNumOfFiles());
-      Assert.assertEquals(KEY_THREE_SIZE, nsSummaryInDir2.getSizeOfFiles());
+      assertEquals(1, nsSummaryInDir2.getNumOfFiles());
+      assertEquals(KEY_THREE_SIZE, nsSummaryInDir2.getSizeOfFiles());
 
       int[] fileDistForDir2 = nsSummaryInDir2.getFileSizeBucket();
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileDistForDir2.length);
-      Assert.assertEquals(1,
+      assertEquals(1,
           fileDistForDir2[fileDistForDir2.length - 1]);
       for (int i = 0; i < ReconConstants.NUM_OF_FILE_SIZE_BINS - 1; ++i) {
-        Assert.assertEquals(0, fileDistForDir2[i]);
+        assertEquals(0, fileDistForDir2[i]);
       }
-      Assert.assertEquals(0, nsSummaryInDir2.getChildDir().size());
+      assertEquals(0, nsSummaryInDir2.getChildDir().size());
 
       // bucket should have empty dirName
-      Assert.assertEquals(0, nsSummaryForBucket1.getDirName().length());
-      Assert.assertEquals(0, nsSummaryForBucket2.getDirName().length());
+      assertEquals(0, nsSummaryForBucket1.getDirName().length());
+      assertEquals(0, nsSummaryForBucket2.getDirName().length());
       // check dirName is correctly written
-      Assert.assertEquals(DIR_ONE, nsSummaryInDir1.getDirName());
-      Assert.assertEquals(DIR_ONE + OM_KEY_PREFIX + DIR_TWO,
+      assertEquals(DIR_ONE, nsSummaryInDir1.getDirName());
+      assertEquals(DIR_ONE + OM_KEY_PREFIX + DIR_TWO,
           nsSummaryInDir2.getDirName());
     }
   }
@@ -297,10 +299,10 @@ public final class TestNSSummaryTaskWithLegacy {
 
       nsSummaryForBucket1 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForBucket1);
+      assertNotNull(nsSummaryForBucket1);
       nsSummaryForBucket2 =
           reconNamespaceSummaryManager.getNSSummary(BUCKET_TWO_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForBucket2);
+      assertNotNull(nsSummaryForBucket2);
     }
 
     private OMUpdateEventBatch processEventBatch() throws IOException {
@@ -436,16 +438,16 @@ public final class TestNSSummaryTaskWithLegacy {
     @Test
     public void testProcessUpdateFileSize() throws IOException {
       // file 1 is gone, so bucket 1 is empty now
-      Assert.assertNotNull(nsSummaryForBucket1);
-      Assert.assertEquals(0, nsSummaryForBucket1.getNumOfFiles());
+      assertNotNull(nsSummaryForBucket1);
+      assertEquals(0, nsSummaryForBucket1.getNumOfFiles());
 
       Set<Long> childDirBucket1 = nsSummaryForBucket1.getChildDir();
       // after put dir4, bucket1 now has two child dirs: dir1 and dir4
-      Assert.assertEquals(2, childDirBucket1.size());
+      assertEquals(2, childDirBucket1.size());
       bucketOneAns.clear();
       bucketOneAns.add(DIR_ONE_OBJECT_ID);
       bucketOneAns.add(DIR_FOUR_OBJECT_ID);
-      Assert.assertEquals(bucketOneAns, childDirBucket1);
+      assertEquals(bucketOneAns, childDirBucket1);
     }
 
     @Test
@@ -453,31 +455,31 @@ public final class TestNSSummaryTaskWithLegacy {
       // file 5 is added under bucket 2, so bucket 2 has 3 keys now
       // file 2 is updated with new datasize,
       // so file size dist for bucket 2 should be updated
-      Assert.assertNotNull(nsSummaryForBucket2);
-      Assert.assertEquals(3, nsSummaryForBucket2.getNumOfFiles());
+      assertNotNull(nsSummaryForBucket2);
+      assertEquals(3, nsSummaryForBucket2.getNumOfFiles());
       // key 4 + key 5 + updated key 2
-      Assert.assertEquals(KEY_FOUR_SIZE + KEY_FIVE_SIZE
+      assertEquals(KEY_FOUR_SIZE + KEY_FIVE_SIZE
           + KEY_TWO_UPDATE_SIZE, nsSummaryForBucket2.getSizeOfFiles());
 
       int[] fileSizeDist = nsSummaryForBucket2.getFileSizeBucket();
-      Assert.assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
+      assertEquals(ReconConstants.NUM_OF_FILE_SIZE_BINS,
           fileSizeDist.length);
       // 1023L and 100L
-      Assert.assertEquals(2, fileSizeDist[0]);
+      assertEquals(2, fileSizeDist[0]);
       // 2050L
-      Assert.assertEquals(1, fileSizeDist[2]);
+      assertEquals(1, fileSizeDist[2]);
       for (int i = 0; i < ReconConstants.NUM_OF_FILE_SIZE_BINS; ++i) {
         if (i == 0 || i == 2) {
           continue;
         }
-        Assert.assertEquals(0, fileSizeDist[i]);
+        assertEquals(0, fileSizeDist[i]);
       }
 
       // after put dir5, bucket 2 now has one dir
       Set<Long> childDirBucket2 = nsSummaryForBucket2.getChildDir();
-      Assert.assertEquals(1, childDirBucket2.size());
+      assertEquals(1, childDirBucket2.size());
       bucketTwoAns.add(DIR_FIVE_OBJECT_ID);
-      Assert.assertEquals(bucketTwoAns, childDirBucket2);
+      assertEquals(bucketTwoAns, childDirBucket2);
     }
 
     @Test
@@ -485,15 +487,15 @@ public final class TestNSSummaryTaskWithLegacy {
       // after delete dir 3, dir 1 now has only one dir: dir2
       NSSummary nsSummaryForDir1 = reconNamespaceSummaryManager
           .getNSSummary(DIR_ONE_OBJECT_ID);
-      Assert.assertNotNull(nsSummaryForDir1);
+      assertNotNull(nsSummaryForDir1);
       Set<Long> childDirForDir1 = nsSummaryForDir1.getChildDir();
-      Assert.assertEquals(1, childDirForDir1.size());
+      assertEquals(1, childDirForDir1.size());
       dirOneAns.clear();
       dirOneAns.add(DIR_TWO_OBJECT_ID);
-      Assert.assertEquals(dirOneAns, childDirForDir1);
+      assertEquals(dirOneAns, childDirForDir1);
 
       // after renaming dir1, check its new name
-      Assert.assertEquals(DIR_ONE_RENAME, nsSummaryForDir1.getDirName());
+      assertEquals(DIR_ONE_RENAME, nsSummaryForDir1.getDirName());
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
**Migrate the following test classes to JUnit5.**

Please describe your PR in detail:
Migrate the following test classes to JUnit5.
`
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/common/CommonUtils.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestReconWithDifferentSqlDBs.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithFSO.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTaskWithLegacy.java
`
Covered two more files which were not in scope.
`hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconDBProvider.java`

Also covered to close the Closable using try () block at three places. where it was been closed in catch at two places and was missed to close at one place.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9691

## How was this patch tested?
Tested each test cases manually.
