### PR TITLE
HDDS-9769. SCM's FinalizationStateManager#finalizeLayoutFeature Ratis call should be idempotent.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/AbstractLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/AbstractLayoutVersionManager.java
@@ -129,20 +129,18 @@ public abstract class AbstractLayoutVersionManager<T extends LayoutFeature>
           LOG.info("Finalization is complete.");
         }
       } else {
-        String msgStart = "";
-        if (layoutFeature.layoutVersion() <= metadataLayoutVersion) {
-          msgStart = "Finalize attempt on a layoutFeature which has already "
-              + "been finalized.";
-        } else {
-          msgStart =
-              "Finalize attempt on a layoutFeature that is newer than the " +
-                  "next feature to be finalized.";
-        }
+        String versionMsg = "Software layout version: " + softwareLayoutVersion
+            + " Metadata layout version: " + metadataLayoutVersion
+            + " Feature Layout version: " + layoutFeature.layoutVersion();
 
-        throw new IllegalArgumentException(
-            msgStart + " Software layout version: " + softwareLayoutVersion
-                + " Metadata layout version: " + metadataLayoutVersion
-                + " Feature Layout version: " + layoutFeature.layoutVersion());
+        if (layoutFeature.layoutVersion() <= metadataLayoutVersion) {
+          LOG.warn("Finalize attempt on a layoutFeature which has already "
+              + "been finalized. " + versionMsg);
+        } else {
+          throw new IllegalArgumentException(
+              "Finalize attempt on a layoutFeature that is newer than the " +
+                  "next feature to be finalized. " + versionMsg);
+        }
       }
     } finally {
       lock.writeLock().unlock();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/AbstractLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/AbstractLayoutVersionManager.java
@@ -130,12 +130,14 @@ public abstract class AbstractLayoutVersionManager<T extends LayoutFeature>
         }
       } else {
         String versionMsg = "Software layout version: " + softwareLayoutVersion
-            + " Metadata layout version: " + metadataLayoutVersion
-            + " Feature Layout version: " + layoutFeature.layoutVersion();
+            + ", Metadata layout version: " + metadataLayoutVersion
+            + ", Feature Layout version: " + layoutFeature.layoutVersion()
+            + ".";
 
         if (layoutFeature.layoutVersion() <= metadataLayoutVersion) {
-          LOG.warn("Finalize attempt on a layoutFeature which has already "
-              + "been finalized. " + versionMsg);
+          LOG.info("Finalize attempt on a layoutFeature which has already "
+              + "been finalized. " + versionMsg + " This can happen when " +
+              "Raft Log is replayed during service restart.");
         } else {
           throw new IllegalArgumentException(
               "Finalize attempt on a layoutFeature that is newer than the " +

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
@@ -122,13 +122,19 @@ public class TestAbstractLayoutVersionManager {
   }
 
   @Test
-  public void testFeatureFinalizationFailsIfFeatureIsAlreadyFinalized()
+  public void testFeatureFinalizationIfFeatureIsAlreadyFinalized()
       throws IOException {
+    /*
+     * Feature finalization call is idempotent, it should not have any
+     * side effects even if it's executed again.
+     */
     LayoutFeature[] lfs = getTestLayoutFeatures(3);
-    versionManager.init(1, lfs);
-
-    assertThrows(IllegalArgumentException.class,
-        () -> versionManager.finalized(lfs[0]));
+    versionManager.init(2, lfs);
+    assertEquals(2, versionManager.getMetadataLayoutVersion());
+    versionManager.finalized(lfs[0]);
+    assertEquals(2, versionManager.getMetadataLayoutVersion());
+    versionManager.finalized(lfs[1]);
+    assertEquals(2, versionManager.getMetadataLayoutVersion());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
If there is a restart during or immediately after SCM upgrade finalization, the `FinalizationStateManager#finalizeLayoutFeature` Ratis call will be re-executed while Raft log is re-applied during restart.
This will cause the SCM to crash if `FinalizationStateManager#finalizeLayoutFeature` call is not idempotent.

This PR modifies the behaviour of `AbstractLayoutVersionManager` to make `finalizeLayoutFeature` call idempotent.

## What is the link to the Apache JIRA
HDDS-9769

## How was this patch tested?
Modified the existing unit test to verify the new behavior.
