### PR TITLE
HDDS-9748. When the command status is reported, the command set sent to the datanode is updated

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -189,6 +189,11 @@ public class SCMDatanodeProtocolServer implements
     HddsServerUtil.addSuppressedLoggingExceptions(datanodeRpcServer);
   }
 
+  @VisibleForTesting
+  public SCMDatanodeHeartbeatDispatcher getHeartbeatDispatcher() {
+    return heartbeatDispatcher;
+  }
+
   public void start() {
     LOG.info(
         StorageContainerManager.buildRpcServerStartMessage(


### PR DESCRIPTION
## What changes were proposed in this pull request?
When SCM repeatedly issues deletion commands, the datanode will execute these commands repeatedly, which is unnecessary.
There is a situation that will cause this problem, that is, SCMBlockDeletingService created the DeleteBlocksCommand in advance, but did not update it.
Details: HDDS-9748

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9748

## How was this patch tested?
Unit tests need to pass validation.
