### PR TITLE
HDDS-9737. Legacy Replication Manager should consider that UNHEALTHY replicas might be decommissioning

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyRatisContainerReplicaCount.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
@@ -48,6 +49,13 @@ public class LegacyRatisContainerReplicaCount extends
                                     int minHealthyForMaintenance) {
     super(container, replicas, inFlightAdd, inFlightDelete, replicationFactor,
         minHealthyForMaintenance);
+  }
+
+  public LegacyRatisContainerReplicaCount(ContainerInfo container,
+      Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps,
+      int minHealthyForMaintenance, boolean considerUnhealthy) {
+    super(container, replicas, pendingOps, minHealthyForMaintenance,
+        considerUnhealthy);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
The initial problem was that `LegacyReplicationManager` was not considering that `UNHEALTHY` replicas could be decommissioning or entering maintenance. So, its logic for determining whether a container with all `UNHEALTHY` replicas is under replicated was flawed. This was fixed in [HDDS-9652](https://issues.apache.org/jira/browse/HDDS-9652). The fix simply used existing logic in `RatisContainerReplicaCount` that is able to account for decommissioning `UNHEALTHY` replicas. However this didn't completely fix the problem because `DatanodeAdminMonitorImpl` also needs to be updated. The reason it needs to be updated is that `RatisContainerReplicaCount` (extended by `LegacyRatisContainerReplicaCount`, exclusively used by the legacy replication manager) is the interface between the replication manager and the decommissioning flow. It's used by both to determine whether a container is under replicated. This Jira should make it so that when a container has all `UNHEALTHY` replicas, `DatanodeAdminMonitor` receives the `LegacyRatisContainerReplicaCount` object which can handle decommissioning `UNHEALTHY` containers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9737

## How was this patch tested?

Added unit tests.