### PR TITLE
HDDS-3506. Enable TestOzoneFileInterfaces#testOzoneManagerLocatedFileStatusBlockOffsetsWithMultiBlockFile

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -518,7 +518,6 @@ public class TestOzoneFileInterfaces {
   }
 
   @Test
-  @Category(UnhealthyTest.class) @Unhealthy("HDDS-3506")
   public void testOzoneManagerLocatedFileStatusBlockOffsetsWithMultiBlockFile()
       throws Exception {
     // naive assumption: MiniOzoneCluster will not have larger than ~1GB

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -63,8 +63,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 
-import org.apache.ozone.test.UnhealthyTest;
-import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -78,7 +76,6 @@ import static org.junit.Assume.assumeFalse;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.apache.ozone.test.JUnit5AwareTimeout;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is just to enable `TestOzoneFileInterfaces.testOzoneManagerLocatedFileStatusBlockOffsetsWithMultiBlockFile`  by removing `@Unhealthy` annotation, as this is not reproducible and would like to see if it fails in recent master branch code. This flaky test JIRA is quite old and may have been fixed already.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3506

## How was this patch tested?
This patch was tested by running repeated CI run for `TestOzoneFileInterfaces.testOzoneManagerLocatedFileStatusBlockOffsetsWithMultiBlockFile` using flaky workflow. Here is the green CI [link](https://github.com/devmadhuu/ozone/actions/runs/7000915449)
