### PR TITLE
HDDS-9763. Over Replication Check of all UNHEALTHY replicas is broken

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisContainerReplicaCount.java
@@ -566,8 +566,7 @@ public class RatisContainerReplicaCount implements ContainerReplicaCount {
       return false;
     }
 
-    return getMatchingReplicaCount() >= repFactor &&
-        getMatchingReplicaCount() - repFactor >= inFlightDel;
+    return getMatchingReplicaCount() >= repFactor;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisReplicationCheckHandler.java
@@ -42,6 +42,15 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.R
  * and current replica details, along with replicas pending add and delete,
  * this class will return a ContainerHealthResult indicating if the container
  * is healthy, or under / over replicated etc.
+ * <p>
+ * For example, this class handles:
+ * <ul>
+ *   <li>A CLOSED container with 4 CLOSED replicas.</li>
+ *   <li>A CLOSED container with 1 CLOSED replica.</li>
+ *   <li>A CLOSED container with 3 CLOSED and 1 UNHEALTHY replica. Or 3
+ *   CLOSED and 1 QUASI_CLOSED replica with incorrect sequence ID.</li>
+ *   <li>etc.</li>
+ * </ul>
  */
 public class RatisReplicationCheckHandler extends AbstractCheck {
   public static final Logger LOG =
@@ -126,7 +135,8 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
       ContainerHealthResult.OverReplicatedHealthResult overHealth
           = ((ContainerHealthResult.OverReplicatedHealthResult) health);
       if (!overHealth.isReplicatedOkAfterPending() &&
-          !overHealth.hasMismatchedReplicas()) {
+          !overHealth.hasMismatchedReplicas() &&
+          overHealth.isSafelyOverReplicated()) {
         /*
         A mis matched replica is one whose state does not match the
         container's state and the state is not UNHEALTHY.
@@ -138,9 +148,12 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
         request.getReplicationQueue().enqueue(overHealth);
       }
       LOG.debug("Container {} is Over Replicated. isReplicatedOkAfterPending" +
-              " is [{}]. hasMismatchedReplicas is [{}]", container,
+              " is [{}]. hasMismatchedReplicas is [{}]. " +
+              "isSafelyOverReplicated is [{}].",
+          container,
           overHealth.isReplicatedOkAfterPending(),
-          overHealth.hasMismatchedReplicas());
+          overHealth.hasMismatchedReplicas(),
+          overHealth.isSafelyOverReplicated());
       return true;
     }
 
@@ -195,7 +208,8 @@ public class RatisReplicationCheckHandler extends AbstractCheck {
     that other than checking over replication of healthy replicas (such as 4
     CLOSED replicas of a CLOSED container), we're also checking for an excess
     of UNHEALTHY replicas (such as 3 CLOSED and 1 UNHEALTHY replicas of a
-    CLOSED container).
+    CLOSED container, or 3 CLOSED and 1 QUASI_CLOSED with incorrect sequence
+    ID for a CLOSED container).
      */
     RatisContainerReplicaCount consideringUnhealthy =
         new RatisContainerReplicaCount(container, replicas, replicaPendingOps,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/RatisUnhealthyReplicationCheckHandler.java
@@ -31,18 +31,16 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 
 /**
- * This class handles UNHEALTHY RATIS replicas. Its responsibilities include:
- * <ul>
- *   <li>If only unhealthy replicas exist, check if there are replication
- *   factor number of replicas and queue them for under/over replication if
- *   needed.
- *   </li>
- *   <li>If there is a mixture of unhealthy and healthy containers this
- *   handler will only be called if there is no under or over replication after
- *   excluding the empty containers. If there is under or over replication the
- *   ECReplicationCheckHandler will take care of it first.
- *   </li>
- * </ul>
+ * This class handles RATIS containers which only have replicas in UNHEALTHY
+ * state, or CLOSED containers with replicas in QUASI_CLOSED state having
+ * less sequence ID. There are no other replicas. This class ensures that
+ * such containers have replication factor number of UNHEALTHY/QUASI_CLOSED
+ * replicas.
+ * <p>
+ * For example, if a CLOSED container with replication factor 3 has 4 UNHEALTHY
+ * replicas, then it's called over replicated and 1 UNHEALTHY replica must be
+ * deleted. On the other hand, if it has only 2 UNHEALTHY replicas, it's
+ * under replicated and 1 more replica should be created.
  */
 public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
   public static final Logger LOG = LoggerFactory.getLogger(
@@ -57,24 +55,15 @@ public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
     ReplicationManagerReport report = request.getReport();
     ContainerInfo container = request.getContainerInfo();
 
-    /*
-    First, verify there's perfect replication without considering UNHEALTHY
-    replicas. If not, we return false. Replication issues without UNHEALTHY
-    replicas should be solved first.
-     */
-    if (!verifyPerfectReplication(request)) {
-      return false;
-    }
-
-    // Now, consider UNHEALTHY replicas when calculating replication status
     RatisContainerReplicaCount replicaCount = getReplicaCount(request);
-    if (replicaCount.getUnhealthyReplicaCount() == 0) {
-      LOG.debug("No UNHEALTHY replicas are present for container {} with " +
-          "replicas [{}].", container, request.getContainerReplicas());
+    if (replicaCount.getHealthyReplicaCount() > 0 ||
+        replicaCount.getUnhealthyReplicaCount() == 0) {
+      LOG.debug("Not handling container {} with replicas [{}].", container,
+          request.getContainerReplicas());
       return false;
     } else {
-      LOG.debug("Container {} has UNHEALTHY replicas. Checking its " +
-          "replication status.", container);
+      LOG.info("Container {} has unhealthy replicas [{}]. Checking its " +
+          "replication status.", container, replicaCount.getReplicas());
       report.incrementAndSample(ReplicationManagerReport.HealthState.UNHEALTHY,
           container.containerID());
     }
@@ -114,43 +103,13 @@ public class RatisUnhealthyReplicationCheckHandler extends AbstractCheck {
           overHealth.isReplicatedOkAfterPending(),
           overHealth.hasMismatchedReplicas());
 
-      if (!overHealth.isReplicatedOkAfterPending() &&
-          overHealth.isSafelyOverReplicated()) {
+      if (!overHealth.isReplicatedOkAfterPending()) {
         request.getReplicationQueue().enqueue(overHealth);
       }
       return true;
     }
 
     return false;
-  }
-
-  /**
-   * Verify there's no under or over replication if only healthy replicas are
-   * considered, or that there are no healthy replicas.
-   * @return true if there's no under/over replication considering healthy
-   * replicas
-   */
-  private boolean verifyPerfectReplication(ContainerCheckRequest request) {
-    RatisContainerReplicaCount replicaCountWithoutUnhealthy =
-        new RatisContainerReplicaCount(request.getContainerInfo(),
-            request.getContainerReplicas(), request.getPendingOps(),
-            request.getMaintenanceRedundancy(), false);
-
-    if (replicaCountWithoutUnhealthy.getHealthyReplicaCount() == 0) {
-      return true;
-    }
-    if (replicaCountWithoutUnhealthy.isUnderReplicated() ||
-        replicaCountWithoutUnhealthy.isOverReplicated()) {
-      LOG.debug("Checking replication for container {} without considering " +
-              "UNHEALTHY replicas. isUnderReplicated is [{}]. " +
-              "isOverReplicated is [{}]. Returning false because there should" +
-              " be perfect replication for this handler to work.",
-          request.getContainerInfo(),
-          replicaCountWithoutUnhealthy.isUnderReplicated(),
-          replicaCountWithoutUnhealthy.isOverReplicated());
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -183,6 +183,39 @@ public class TestRatisOverReplicationHandler {
         getOverReplicatedHealthResult(), 0);
   }
 
+  @Test
+  public void testClosedOverReplicatedWithAllUnhealthyReplicas()
+      throws IOException {
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(),
+        State.UNHEALTHY, 0, 0, 0, 0, 0);
+    List<ContainerReplicaOp> pendingOps = ImmutableList.of(
+        ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.DELETE,
+            MockDatanodeDetails.randomDatanodeDetails(), 0));
+
+    // 1 replica is already pending delete, so only 1 new command should be
+    // created
+    testProcessing(replicas, pendingOps, getOverReplicatedHealthResult(),
+        1);
+  }
+
+  @Test
+  public void testClosedOverReplicatedWithExcessUnhealthy() throws IOException {
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(),
+        State.CLOSED, 0, 0, 0);
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            State.UNHEALTHY);
+    replicas.add(unhealthyReplica);
+
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
+        testProcessing(replicas, Collections.emptyList(),
+            getOverReplicatedHealthResult(),
+            1);
+    Pair<DatanodeDetails, SCMCommand<?>> command = commands.iterator().next();
+    Assert.assertEquals(unhealthyReplica.getDatanodeDetails(),
+        command.getKey());
+  }
+
   /**
    * Handler should not create any delete commands if removing a replica
    * makes the container mis replicated.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -490,6 +491,43 @@ public class TestRatisReplicationCheckHandler {
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
+  @Test
+  public void shouldQueueForOverReplicationOnlyWhenSafe() {
+    ContainerInfo container =
+        createContainerInfo(repConfig, 1L, HddsProtos.LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(),
+        StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED, 0, 0);
+    ContainerReplica unhealthyReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.UNHEALTHY);
+    ContainerReplica mismatchedReplica =
+        createContainerReplica(container.containerID(), 0, IN_SERVICE,
+            StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.QUASI_CLOSED);
+    replicas.add(mismatchedReplica);
+    replicas.add(unhealthyReplica);
+
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+
+    ContainerHealthResult.OverReplicatedHealthResult
+        result = (ContainerHealthResult.OverReplicatedHealthResult)
+        healthCheck.checkHealth(requestBuilder.build());
+
+    assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+        result.getHealthState());
+    assertEquals(1, result.getExcessRedundancy());
+    assertFalse(result.isReplicatedOkAfterPending());
+
+    // not safe for over replication because we don't have 3 matching replicas
+    assertFalse(result.isSafelyOverReplicated());
+
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+  }
+
   /**
    * Scenario: CLOSED container with 2 CLOSED, 1 CLOSING and 3 UNHEALTHY
    * replicas.
@@ -528,6 +566,44 @@ public class TestRatisReplicationCheckHandler {
     // it should not be queued for over replication because there's a mis
     // matched replica
     assertEquals(0, repQueue.overReplicatedQueueSize());
+    assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+  }
+
+  /**
+   * There is a CLOSED container with 3 CLOSED replicas and 1 QUASI_CLOSED
+   * replica with incorrect sequence ID. This container is over replicated
+   * because of the QUASI_CLOSED replica and should be queued for over
+   * replication.
+   */
+  @Test
+  public void testExcessQuasiClosedWithIncorrectSequenceID() {
+    ContainerInfo container = createContainerInfo(repConfig);
+    Set<ContainerReplica> replicas
+        = createReplicas(container.containerID(), State.CLOSED, 0, 0, 0);
+    ContainerReplica quasiClosed =
+        createContainerReplica(container.containerID(), 0,
+            IN_SERVICE, State.QUASI_CLOSED, container.getSequenceId() - 1);
+    replicas.add(quasiClosed);
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container);
+    ContainerHealthResult result =
+        healthCheck.checkHealth(requestBuilder.build());
+
+    // there's an excess QUASI_CLOSED replica with incorrect sequence ID, so
+    // it's over replicated
+    assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    OverReplicatedHealthResult overRepResult =
+        (OverReplicatedHealthResult) result;
+    assertEquals(1, overRepResult.getExcessRedundancy());
+    assertFalse(overRepResult.hasMismatchedReplicas());
+    assertFalse(overRepResult.isReplicatedOkAfterPending());
+
+    assertTrue(healthCheck.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(1, repQueue.overReplicatedQueueSize());
     assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
     assertEquals(0, report.getStat(


### PR DESCRIPTION
## What changes were proposed in this pull request?
When all replicas of a `CLOSED` container are `UNHEALTHY` and more than replication factor, the container is reported as over replicated but not queued to the over replication queue. This jira will fix this and also define clear and separate responsibilities for `RatisReplicationCheckHandler` and `RatisUnhealthyReplicationCheckHandler` to avoid confusion.

`RatisReplicationCheckHandler`: Checks replication for typical over replicated cases, such as 4 `CLOSED` replicas. And also for an excess of unhealthy replicas when we have enough matching replicas, such as 3 `CLOSED` and 1 `UNHEALTHY` or 3 `CLOSED` and 1 `QUASI_CLOSED` with incorrect sequence ID.

`RatisUnhealthyReplicationCheckHandler`: Checks replication when only `UNHEALTHY` replicas are present or when the container is closed and only `QUASI_CLOSED` replicas with incorrect sequence IDs are present.

This problem only affects the new `ReplicationManager`. The majority of changes and additions are in tests.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9763

## How was this patch tested?
Added unit tests.