### PR TITLE
HDDS-9504. Migrate some parameterized integration tests to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -27,19 +26,19 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.Assert;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,8 +46,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -56,63 +56,50 @@ import java.util.Collection;
 /**
  * Ozone file system tests to validate default bucket layout configuration
  * and behaviour.
- * TODO: Refactor this and TestOzoneFileSystem to reduce duplication.
+ * TODO: merge with some other test
  */
-@RunWith(Parameterized.class)
-public class TestOzoneFSBucketLayout {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOzoneFSBucketLayout {
 
-  private static String defaultBucketLayout;
-  private static MiniOzoneCluster cluster = null;
-  private static ObjectStore objectStore;
-  private static OzoneClient client;
-  private BasicRootedOzoneClientAdapterImpl adapter;
-  private static String rootPath;
-  private static String volumeName;
-  private static Path volumePath;
+  private MiniOzoneCluster cluster;
+  private ObjectStore objectStore;
+  private OzoneClient client;
+  private String rootPath;
+  private String volumeName;
 
-  private static final String INVALID_CONFIG = "INVALID";
+  private static final String UNKNOWN_LAYOUT = "INVALID";
   private static final Map<String, String> ERROR_MAP = new HashMap<>();
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestOzoneFSBucketLayout.class);
 
   // Initialize error map.
   static {
     ERROR_MAP.put(BucketLayout.OBJECT_STORE.name(),
         "Buckets created with OBJECT_STORE layout do not support file " +
             "system semantics.");
-    ERROR_MAP.put(INVALID_CONFIG, "Unsupported value provided for " +
+    ERROR_MAP.put(UNKNOWN_LAYOUT, "Unsupported value provided for " +
         OzoneConfigKeys.OZONE_CLIENT_FS_DEFAULT_BUCKET_LAYOUT);
   }
 
-  @Parameterized.Parameters
-  public static Collection<String> data() {
+  static Collection<String> validDefaultBucketLayouts() {
     return Arrays.asList(
         // Empty Config
         "",
-        // Invalid Config
-        INVALID_CONFIG,
-        // Unsupported Bucket Layout for OFS
-        BucketLayout.OBJECT_STORE.name(),
         // Supported bucket layouts.
         BucketLayout.FILE_SYSTEM_OPTIMIZED.name(),
         BucketLayout.LEGACY.name()
     );
   }
 
-  public TestOzoneFSBucketLayout(String bucketLayout) {
-    // Ignored. Actual init done in initParam().
-    // This empty constructor is still required to avoid argument exception.
+  static Collection<String> invalidDefaultBucketLayouts() {
+    return Arrays.asList(
+        // Invalid Config
+        UNKNOWN_LAYOUT,
+        // Unsupported Bucket Layout for OFS
+        BucketLayout.OBJECT_STORE.name()
+    );
   }
 
-  @Parameterized.BeforeParam
-  public static void initDefaultLayout(String bucketLayout) {
-    defaultBucketLayout = bucketLayout;
-    LOG.info("Default bucket layout: {}", defaultBucketLayout);
-  }
-
-  @BeforeClass
-  public static void initCluster() throws Exception {
+  @BeforeAll
+  void initCluster() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
@@ -122,89 +109,64 @@ public class TestOzoneFSBucketLayout {
     objectStore = client.getObjectStore();
     rootPath = String.format("%s://%s/",
         OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
-
-    // create a volume and a bucket to be used by RootedOzoneFileSystem (OFS)
-    volumeName =
-        TestDataUtil.createVolumeAndBucket(client)
-            .getVolumeName();
-    volumePath = new Path(OZONE_URI_DELIMITER, volumeName);
+    volumeName = TestDataUtil.createVolumeAndBucket(client).getVolumeName();
   }
 
-  @AfterClass
-  public static void teardown() throws IOException {
+  @AfterAll
+  void teardown() throws IOException {
     IOUtils.closeQuietly(client);
-    // Tear down the cluster after EACH set of parameters
     if (cluster != null) {
       cluster.shutdown();
     }
   }
 
-  @Test
-  public void testFileSystemBucketLayoutConfiguration() throws IOException {
-    OzoneConfiguration conf = new OzoneConfiguration();
+  @ParameterizedTest
+  @MethodSource("invalidDefaultBucketLayouts")
+  void fileSystemWithUnsupportedDefaultBucketLayout(String layout) {
+    OzoneConfiguration conf = configWithDefaultBucketLayout(layout);
 
-    OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
-    clientConfig.setFsDefaultBucketLayout(defaultBucketLayout);
+    OMException e = assertThrows(OMException.class,
+        () -> FileSystem.newInstance(conf));
+    assertThat(e.getMessage(),
+        containsString(ERROR_MAP.get(layout)));
+  }
+  @ParameterizedTest
+  @MethodSource("validDefaultBucketLayouts")
+  void fileSystemWithValidBucketLayout(String layout) throws IOException {
+    OzoneConfiguration conf = configWithDefaultBucketLayout(layout);
 
-    conf.setFromObject(clientConfig);
+    try (FileSystem fs = FileSystem.newInstance(conf)) {
+      // Create a new directory, which in turn creates a new bucket.
+      String bucketName = getBucketName(layout);
+      fs.mkdirs(new Path(new Path(OZONE_ROOT, volumeName), bucketName));
 
-    // Set the fs.defaultFS and start the filesystem
-    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+      // Make sure the bucket layout of created bucket matches the config.
+      OzoneBucket bucketInfo =
+          objectStore.getClientProxy().getBucketDetails(volumeName, bucketName);
 
-    // In case OZONE_CLIENT_FS_DEFAULT_BUCKET_LAYOUT is set to OBS,
-    // FS initialization should fail.
-
-    if (ERROR_MAP.containsKey(defaultBucketLayout)) {
-      try {
-        FileSystem.newInstance(conf);
-        Assert.fail("File System initialization should fail in case " +
-            " of invalid configuration of " +
-            OzoneConfigKeys.OZONE_CLIENT_FS_DEFAULT_BUCKET_LAYOUT);
-      } catch (OMException oe) {
-        Assert.assertTrue(
-            oe.getMessage().contains(ERROR_MAP.get(defaultBucketLayout)));
-        return;
-      }
+      String expectedLayout = layout.isEmpty()
+          ? OzoneConfigKeys.OZONE_CLIENT_FS_BUCKET_LAYOUT_DEFAULT
+          : layout;
+      assertEquals(expectedLayout, bucketInfo.getBucketLayout().name());
     }
-
-    // initialize FS and adapter.
-    FileSystem fs = FileSystem.newInstance(conf);
-    RootedOzoneFileSystem ofs = (RootedOzoneFileSystem) fs;
-    adapter = (BasicRootedOzoneClientAdapterImpl) ofs.getAdapter();
-
-    // Create a new directory, which in turn creates a new bucket.
-    Path root = new Path("/" + volumeName);
-
-    String bucketName = getBucketName();
-    Path dir1 = new Path(root, bucketName);
-
-    adapter.createDirectory(dir1.toString());
-
-    // Make sure the bucket layout of created bucket matches the config.
-    OzoneBucket bucketInfo =
-        objectStore.getClientProxy().getBucketDetails(volumeName, bucketName);
-    if (StringUtils.isNotBlank(defaultBucketLayout)) {
-      Assert.assertEquals(defaultBucketLayout,
-          bucketInfo.getBucketLayout().name());
-    } else {
-      Assert.assertEquals(OzoneConfigKeys.OZONE_CLIENT_FS_BUCKET_LAYOUT_DEFAULT,
-          bucketInfo.getBucketLayout().name());
-    }
-
-    // cleanup
-    IOUtils.closeQuietly(fs);
   }
 
-  private String getBucketName() {
-    String bucketSuffix;
-    if (StringUtils.isNotBlank(defaultBucketLayout)) {
-      bucketSuffix = defaultBucketLayout
-          .toLowerCase()
-          .replaceAll("_", "-");
-    } else {
-      bucketSuffix = "empty";
-    }
+  private String getBucketName(String layout) {
+    String bucketSuffix = layout.isEmpty()
+        ? "empty"
+        : layout.toLowerCase().replaceAll("_", "-");
 
     return "bucket-" + bucketSuffix;
   }
+
+  private OzoneConfiguration configWithDefaultBucketLayout(String layout) {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
+    clientConfig.setFsDefaultBucketLayout(layout);
+    conf.setFromObject(clientConfig);
+    return conf;
+  }
+
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -45,7 +45,7 @@ import org.apache.ratis.util.ExitUtils;
 /**
  * Interface used for MiniOzoneClusters.
  */
-public interface MiniOzoneCluster {
+public interface MiniOzoneCluster extends AutoCloseable {
 
   /**
    * Returns the Builder to construct MiniOzoneCluster.
@@ -259,6 +259,10 @@ public interface MiniOzoneCluster {
    * Shutdown the MiniOzoneCluster and delete the storage dirs.
    */
   void shutdown();
+
+  default void close() {
+    shutdown();
+  }
 
   /**
    * Stop the MiniOzoneCluster without any cleanup.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -18,9 +18,11 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -28,183 +30,126 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.io.OzoneInputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 /**
  * Main purpose of this test is with OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION
  * set/unset key create/read works properly or not for buckets
- * with/with out versioning.
+ * with/without versioning.
+ * TODO: can be merged with other test class
  */
-@RunWith(Parameterized.class)
-public class TestOzoneRpcClientWithKeyLatestVersion {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOzoneRpcClientWithKeyLatestVersion {
 
-  private static MiniOzoneCluster cluster;
+  private MiniOzoneCluster cluster;
 
-  private ObjectStore objectStore;
-
-  private OzoneClient ozClient;
-
-  private final boolean getLatestVersion;
-
-  @Parameterized.Parameters
-  public static Collection<Object> data() {
-    return Arrays.asList(true, false);
-  }
-
-  public TestOzoneRpcClientWithKeyLatestVersion(boolean latestVersion) {
-    getLatestVersion = latestVersion;
-  }
-
-  @BeforeClass
-  public static void setup() throws Exception {
+  @BeforeAll
+  void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(3)
-        .setScmId(UUID.randomUUID().toString())
-        .setClusterId(UUID.randomUUID().toString())
         .build();
     cluster.waitForClusterToBeReady();
   }
 
-  @AfterClass
-  public static void tearDown() throws Exception {
+  @AfterAll
+  void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
     }
   }
 
-  @Before
-  public void setupClient() throws Exception {
-    OzoneConfiguration conf = cluster.getConf();
-    conf.setBoolean(OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION, getLatestVersion);
-    ozClient = OzoneClientFactory.getRpcClient(conf);
-    objectStore = ozClient.getObjectStore();
-  }
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testWithGetLatestVersion(boolean getLatestVersionOnly) throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration(cluster.getConf());
+    conf.setBoolean(OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION,
+        getLatestVersionOnly);
 
-  @After
-  public void closeClient() throws Exception {
-    if (ozClient != null) {
-      ozClient.close();
+    try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
+      String volumeName = UUID.randomUUID().toString();
+      ObjectStore objectStore = client.getObjectStore();
+      objectStore.createVolume(volumeName);
+      OzoneVolume volume = objectStore.getVolume(volumeName);
+
+      for (boolean versioning : new boolean[] {false, true}) {
+        String bucketName = UUID.randomUUID().toString();
+        volume.createBucket(bucketName,
+            BucketArgs.newBuilder()
+                .setVersioning(versioning)
+                .build());
+
+        OzoneBucket bucket = volume.getBucket(bucketName);
+        String keyName = UUID.randomUUID().toString();
+        byte[] content = RandomUtils.nextBytes(128);
+        int versions = RandomUtils.nextInt(2, 5);
+
+        createAndOverwriteKey(bucket, keyName, versions, content);
+
+        assertKeyContent(bucket, keyName, content);
+
+        int expectedVersionCount =
+            versioning && !getLatestVersionOnly ? versions : 1;
+        assertListStatus(bucket, keyName, expectedVersionCount);
+      }
     }
   }
 
-
-  @Test
-  public void testWithGetLatestVersion() throws Exception {
-    testOverrideAndReadKey();
-  }
-
-
-
-  public void testOverrideAndReadKey() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
-    String keyName = UUID.randomUUID().toString();
-
-    // Test checks key override and read are working with
-    // bucket versioning false.
-    String value = "sample value";
-    createRequiredForVersioningTest(volumeName, bucketName, keyName,
-        false, value);
-
-    // read key and test
-    testReadKey(volumeName, bucketName, keyName, value);
-
-    testListStatus(volumeName, bucketName, keyName, false);
-
-
-    // Bucket versioning turned on
-    volumeName = UUID.randomUUID().toString();
-    bucketName = UUID.randomUUID().toString();
-    keyName = UUID.randomUUID().toString();
-
-    // Test checks key override and read are working with
-    // bucket versioning true.
-    createRequiredForVersioningTest(volumeName, bucketName, keyName,
-        true, value);
-
-    // read key and test
-    testReadKey(volumeName, bucketName, keyName, value);
-
-
-    testListStatus(volumeName, bucketName, keyName, true);
-  }
-
-  private void createRequiredForVersioningTest(String volumeName,
-      String bucketName, String keyName, boolean versioning,
-      String value) throws Exception {
-
-    ReplicationConfig replicationConfig = ReplicationConfig
-        .fromProtoTypeAndFactor(RATIS, HddsProtos.ReplicationFactor.THREE);
-
-    objectStore.createVolume(volumeName);
-    OzoneVolume volume = objectStore.getVolume(volumeName);
-
-    // Bucket created with versioning false.
-    volume.createBucket(bucketName,
-        BucketArgs.newBuilder().setVersioning(versioning).build());
-    OzoneBucket bucket = volume.getBucket(bucketName);
-
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, replicationConfig, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
-
-    // Override key
-    out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, replicationConfig, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
-  }
-
-  private void testReadKey(String volumeName, String bucketName,
-      String keyName, String value) throws Exception {
-    OzoneVolume volume = objectStore.getVolume(volumeName);
-    OzoneBucket ozoneBucket = volume.getBucket(bucketName);
-    byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-    try (OzoneInputStream is = ozoneBucket.readKey(keyName)) {
-      is.read(fileContent);
+  /** Repeatedly write {@code key}, first some random data, then
+   * {@code content}. */
+  private void createAndOverwriteKey(OzoneBucket bucket, String key,
+      int versions, byte[] content) throws IOException {
+    ReplicationConfig replication = RatisReplicationConfig.getInstance(THREE);
+    for (int i = 1; i < versions; i++) {
+      writeKey(bucket, key, RandomUtils.nextBytes(content.length), replication);
     }
-    Assert.assertEquals(value, new String(fileContent, UTF_8));
+    // overwrite it
+    writeKey(bucket, key, content, replication);
   }
 
-  private void testListStatus(String volumeName, String bucketName,
-      String keyName, boolean versioning) throws Exception {
-    OzoneVolume volume = objectStore.getVolume(volumeName);
-    OzoneBucket ozoneBucket = volume.getBucket(bucketName);
-    List<OzoneFileStatus> ozoneFileStatusList = ozoneBucket.listStatus(keyName,
-        false, "", 1);
-    Assert.assertNotNull(ozoneFileStatusList);
-    Assert.assertEquals(1, ozoneFileStatusList.size());
-    if (!getLatestVersion && versioning) {
-      Assert.assertEquals(2, ozoneFileStatusList.get(0).getKeyInfo()
-          .getKeyLocationVersions().size());
-    } else {
-      Assert.assertEquals(1, ozoneFileStatusList.get(0).getKeyInfo()
-          .getKeyLocationVersions().size());
+  private static void writeKey(OzoneBucket bucket, String key, byte[] content,
+      ReplicationConfig replication) throws IOException {
+    try (OutputStream out = bucket.createKey(key, content.length, replication,
+        new HashMap<>())) {
+      out.write(content);
     }
+  }
+
+  private void assertKeyContent(OzoneBucket bucket, String key, byte[] expected)
+      throws Exception {
+    try (InputStream in = bucket.readKey(key)) {
+      assertArrayEquals(expected, IOUtils.readFully(in, expected.length));
+    }
+  }
+
+  private void assertListStatus(OzoneBucket bucket, String keyName,
+      int expectedVersionCount) throws Exception {
+    List<OzoneFileStatus> files = bucket.listStatus(keyName, false, "", 1);
+
+    assertNotNull(files);
+    assertEquals(1, files.size());
+
+    List<?> versions = files.get(0).getKeyInfo().getKeyLocationVersions();
+    assertEquals(expectedVersionCount, versions.size());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -135,8 +135,8 @@ class TestOzoneRpcClientWithKeyLatestVersion {
     }
   }
 
-  private void assertKeyContent(OzoneBucket bucket, String key, byte[] expected)
-      throws Exception {
+  public static void assertKeyContent(OzoneBucket bucket, String key,
+      byte[] expected) throws Exception {
     try (InputStream in = bucket.readKey(key)) {
       assertArrayEquals(expected, IOUtils.readFully(in, expected.length));
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -18,243 +18,139 @@
 package org.apache.hadoop.ozone.client.rpc;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.XceiverClientFactory;
-import org.apache.hadoop.hdds.scm.XceiverClientRatis;
-import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
-import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneKeyLocation;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.io.KeyOutputStream;
-import org.apache.hadoop.ozone.client.io.OzoneInputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
-import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 
-import org.junit.After;
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.fail;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientWithKeyLatestVersion.assertKeyContent;
+import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.configureFSOptimizedPaths;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
-import org.junit.rules.ExpectedException;
-
-/**
- * Test read retries from multiple nodes in the pipeline.
- */
-@RunWith(Parameterized.class)
-public class TestReadRetries {
+@Timeout(300)
+class TestReadRetries {
 
   /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
-  private MiniOzoneCluster cluster = null;
-  private OzoneClient ozClient = null;
-  private ObjectStore store = null;
-  private OzoneManager ozoneManager;
-  private StorageContainerLocationProtocolClientSideTranslatorPB
-      storageContainerLocationClient;
-
-  private static final String SCM_ID = UUID.randomUUID().toString();
-  private String bucketLayout;
-
-  public TestReadRetries(String bucketLayout) {
-    this.bucketLayout = bucketLayout;
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[]{OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT},
-        new Object[]{OMConfigKeys.
-              OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED});
-  }
-
-  /**
-   * Create a MiniOzoneCluster for testing.
-   * @throws Exception
+   * Test read retries from multiple nodes in the pipeline.
    */
-  @Before
-  public void init() throws Exception {
+  @Test
+  void testPutKeyAndGetKeyThreeNodes() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
-    OMRequestTestUtils.configureFSOptimizedPaths(conf,
-            true, BucketLayout.fromString(bucketLayout));
-    cluster = MiniOzoneCluster.newBuilder(conf)
+    configureFSOptimizedPaths(conf, true, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+    try (MiniOzoneCluster cluster = newCluster(conf)) {
+      cluster.waitForClusterToBeReady();
+      cluster.waitForPipelineTobeReady(THREE, 180000);
+
+      try (OzoneClient client = cluster.newClient()) {
+        ObjectStore store = client.getObjectStore();
+
+        String volumeName = UUID.randomUUID().toString();
+        store.createVolume(volumeName);
+        OzoneVolume volume = store.getVolume(volumeName);
+
+        String bucketName = UUID.randomUUID().toString();
+        volume.createBucket(bucketName);
+        OzoneBucket bucket = volume.getBucket(bucketName);
+
+        String keyName = "a/b/c/" + UUID.randomUUID();
+        byte[] content = RandomUtils.nextBytes(128);
+        try (OutputStream out = bucket.createKey(keyName, content.length,
+            RatisReplicationConfig.getInstance(THREE), new HashMap<>())) {
+          out.write(content);
+        }
+
+        // First, confirm the key info from the client matches the info in OM.
+        OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setKeyName(keyName)
+            .build();
+        OmKeyLocationInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs)
+            .getKeyLocationVersions().get(0)
+            .getBlocksLatestVersionOnly().get(0);
+        long containerID = keyInfo.getContainerID();
+
+        OzoneKeyDetails keyDetails = bucket.getKey(keyName);
+        assertEquals(keyName, keyDetails.getName());
+
+        List<OzoneKeyLocation> keyLocations = keyDetails.getOzoneKeyLocations();
+        assertEquals(1, keyLocations.size());
+        assertEquals(containerID, keyLocations.get(0).getContainerID());
+        assertEquals(keyInfo.getLocalID(), keyLocations.get(0).getLocalID());
+
+        // Make sure that the data size matched.
+        assertEquals(content.length, keyLocations.get(0).getLength());
+
+        StorageContainerManager scm = cluster.getStorageContainerManager();
+        ContainerInfo container = scm.getContainerManager()
+            .getContainer(ContainerID.valueOf(containerID));
+        Pipeline pipeline = scm.getPipelineManager()
+            .getPipeline(container.getPipelineID());
+        List<DatanodeDetails> datanodes = pipeline.getNodes();
+        assertEquals(3, datanodes.size());
+
+        // shutdown the datanode
+        cluster.shutdownHddsDatanode(datanodes.get(0));
+        // try to read, this should be successful
+        assertKeyContent(bucket, keyName, content);
+
+        // shutdown the second datanode
+        cluster.shutdownHddsDatanode(datanodes.get(1));
+        // we still should be able to read
+        assertKeyContent(bucket, keyName, content);
+
+        // shutdown the 3rd datanode
+        cluster.shutdownHddsDatanode(datanodes.get(2));
+        // no longer can read it
+        assertThrows(IOException.class,
+            () -> assertKeyContent(bucket, keyName, content));
+
+        // read intermediate directory
+        verifyIntermediateDir(bucket, "a/b/c");
+      }
+    }
+  }
+
+  private static MiniOzoneCluster newCluster(OzoneConfiguration conf)
+      throws IOException {
+    return MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
-        .setScmId(SCM_ID)
         .build();
-    cluster.waitForClusterToBeReady();
-    cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE,
-            180000);
-    ozClient = OzoneClientFactory.getRpcClient(conf);
-    store = ozClient.getObjectStore();
-    storageContainerLocationClient =
-        cluster.getStorageContainerLocationClient();
-    ozoneManager = cluster.getOzoneManager();
   }
 
-
-  /**
-   * Close OzoneClient and shutdown MiniOzoneCluster.
-   */
-  @After
-  public void shutdown() throws IOException {
-    if (ozClient != null) {
-      ozClient.close();
-    }
-
-    if (storageContainerLocationClient != null) {
-      storageContainerLocationClient.close();
-    }
-
-    if (cluster != null) {
-      cluster.shutdown();
-    }
-  }
-
-
-  @Test
-  public void testPutKeyAndGetKeyThreeNodes()
-      throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
-
-    String value = "sample value";
-    store.createVolume(volumeName);
-    OzoneVolume volume = store.getVolume(volumeName);
-    volume.createBucket(bucketName);
-    OzoneBucket bucket = volume.getBucket(bucketName);
-
-    String keyName = "a/b/c/" + UUID.randomUUID().toString();
-
-    OzoneOutputStream out = bucket
-        .createKey(keyName, value.getBytes(UTF_8).length, ReplicationType.RATIS,
-            ReplicationFactor.THREE, new HashMap<>());
-    KeyOutputStream groupOutputStream =
-        (KeyOutputStream) out.getOutputStream();
-    XceiverClientFactory factory = groupOutputStream.getXceiverClientFactory();
-    out.write(value.getBytes(UTF_8));
-    out.close();
-    // First, confirm the key info from the client matches the info in OM.
-    OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
-    builder.setVolumeName(volumeName).setBucketName(bucketName)
-        .setKeyName(keyName);
-    OmKeyLocationInfo keyInfo = ozoneManager.lookupKey(builder.build()).
-        getKeyLocationVersions().get(0).getBlocksLatestVersionOnly().get(0);
-    long containerID = keyInfo.getContainerID();
-    long localID = keyInfo.getLocalID();
-    OzoneKeyDetails keyDetails = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, keyDetails.getName());
-
-    List<OzoneKeyLocation> keyLocations = keyDetails.getOzoneKeyLocations();
-    Assert.assertEquals(1, keyLocations.size());
-    Assert.assertEquals(containerID, keyLocations.get(0).getContainerID());
-    Assert.assertEquals(localID, keyLocations.get(0).getLocalID());
-
-    // Make sure that the data size matched.
-    Assert.assertEquals(value.getBytes(UTF_8).length,
-        keyLocations.get(0).getLength());
-
-    ContainerInfo container = cluster.getStorageContainerManager()
-        .getContainerManager().getContainer(ContainerID.valueOf(containerID));
-    Pipeline pipeline = cluster.getStorageContainerManager()
-        .getPipelineManager().getPipeline(container.getPipelineID());
-    List<DatanodeDetails> datanodes = pipeline.getNodes();
-
-    DatanodeDetails datanodeDetails = datanodes.get(0);
-    Assert.assertNotNull(datanodeDetails);
-
-    XceiverClientSpi clientSpi = factory.acquireClient(pipeline);
-    Assert.assertTrue(clientSpi instanceof XceiverClientRatis);
-    XceiverClientRatis ratisClient = (XceiverClientRatis)clientSpi;
-
-    ratisClient.watchForCommit(keyInfo.getBlockCommitSequenceId());
-    // shutdown the datanode
-    cluster.shutdownHddsDatanode(datanodeDetails);
-    // try to read, this should be successful
-    readKey(bucket, keyName, value);
-
-    // read intermediate directory
-    verifyIntermediateDir(bucket, "a/b/c");
-
-    // shutdown the second datanode
-    datanodeDetails = datanodes.get(1);
-    cluster.shutdownHddsDatanode(datanodeDetails);
-
-    // we still should be able to read via Standalone protocol
-    // try to read
-    readKey(bucket, keyName, value);
-
-    // shutdown the 3rd datanode
-    datanodeDetails = datanodes.get(2);
-    cluster.shutdownHddsDatanode(datanodeDetails);
-    try {
-      // try to read
-      readKey(bucket, keyName, value);
-      fail("Expected exception not thrown");
-    } catch (IOException e) {
-      // it should throw an ioException as none of the servers
-      // are available
-    }
-    factory.releaseClient(clientSpi, false);
-  }
-
-  private void verifyIntermediateDir(OzoneBucket bucket, String dir)
+  private static void verifyIntermediateDir(OzoneBucket bucket, String dir)
       throws IOException {
     OzoneFileStatus fileStatus = bucket.getFileStatus(dir);
-    Assert.assertTrue(fileStatus.isDirectory());
-    Assert.assertEquals(dir, fileStatus.getTrimmedName());
-  }
-
-  private void readKey(OzoneBucket bucket, String keyName, String data)
-      throws IOException {
-    OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
-    OzoneInputStream is = bucket.readKey(keyName);
-    byte[] fileContent = new byte[data.getBytes(UTF_8).length];
-    is.read(fileContent);
-    is.close();
+    assertTrue(fileStatus.isDirectory());
+    assertEquals(dir, fileStatus.getTrimmedName());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -19,32 +19,50 @@ package org.apache.hadoop.ozone.client.rpc.read;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
-import org.junit.Assert;
-import org.junit.Test;
+import org.apache.hadoop.ozone.om.TestBucket;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests {@link ChunkInputStream}.
  */
-public class TestChunkInputStream extends TestInputStreamBase {
+class TestChunkInputStream extends TestInputStreamBase {
 
-  public TestChunkInputStream(ContainerLayoutVersion layout) {
-    super(layout);
+  private static List<ContainerLayoutVersion> layouts() {
+    return ContainerLayoutVersion.getAllVersions();
   }
 
   /**
    * Run the tests as a single test method to avoid needing a new mini-cluster
    * for each test.
    */
-  @Test
-  public void testAll() throws Exception {
-    testChunkReadBuffers();
-    testBufferRelease();
-    testCloseReleasesBuffers();
+  @ParameterizedTest
+  @MethodSource("layouts")
+  void testAll(ContainerLayoutVersion layout) throws Exception {
+    try (MiniOzoneCluster cluster = newCluster(layout)) {
+      cluster.waitForClusterToBeReady();
+
+      try (OzoneClient client = cluster.newClient()) {
+        TestBucket bucket = TestBucket.newBuilder(client).build();
+
+        testChunkReadBuffers(bucket);
+        testBufferRelease(bucket);
+        testCloseReleasesBuffers(bucket);
+      }
+    }
   }
 
 
@@ -52,12 +70,12 @@ public class TestChunkInputStream extends TestInputStreamBase {
    * Test to verify that data read from chunks is stored in a list of buffers
    * with max capacity equal to the bytes per checksum.
    */
-  public void testChunkReadBuffers() throws Exception {
+  private void testChunkReadBuffers(TestBucket bucket) throws Exception {
     String keyName = getNewKeyName();
     int dataLength = (2 * BLOCK_SIZE) + (CHUNK_SIZE);
-    byte[] inputData = writeRandomBytes(keyName, dataLength);
+    byte[] inputData = bucket.writeRandomBytes(keyName, dataLength);
 
-    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
+    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
 
       BlockInputStream block0Stream =
           (BlockInputStream)keyInputStream.getPartStreams().get(0);
@@ -74,7 +92,7 @@ public class TestChunkInputStream extends TestInputStreamBase {
       // Read > checksum boundary of data from chunk0
       int readDataLen = BYTES_PER_CHECKSUM + (BYTES_PER_CHECKSUM / 2);
       byte[] readData = readDataFromChunk(chunk0Stream, 0, readDataLen);
-      validateData(inputData, 0, readData);
+      bucket.validateData(inputData, 0, readData);
 
       // The first checksum boundary size of data was already existing in the
       // ChunkStream buffers. Once that data is read, the next checksum
@@ -93,7 +111,7 @@ public class TestChunkInputStream extends TestInputStreamBase {
       readDataLen = BYTES_PER_CHECKSUM + (BYTES_PER_CHECKSUM / 2);
       int offset = 2 * BYTES_PER_CHECKSUM + 1;
       readData = readDataFromChunk(chunk0Stream, offset, readDataLen);
-      validateData(inputData, offset, readData);
+      bucket.validateData(inputData, offset, readData);
       checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 2, 1,
           BYTES_PER_CHECKSUM);
 
@@ -102,34 +120,34 @@ public class TestChunkInputStream extends TestInputStreamBase {
       // buffers. We read CHUNK_SIZE - 1 as otherwise all the buffers will be
       // released once all chunk data is read.
       readData = readDataFromChunk(chunk0Stream, 0, CHUNK_SIZE - 1);
-      validateData(inputData, 0, readData);
+      bucket.validateData(inputData, 0, readData);
       int expectedNumBuffers = CHUNK_SIZE / BYTES_PER_CHECKSUM;
       checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(),
           expectedNumBuffers, expectedNumBuffers - 1, BYTES_PER_CHECKSUM);
 
       // Read the last byte of chunk and verify that the buffers are released.
       chunk0Stream.read(new byte[1]);
-      Assert.assertNull("ChunkInputStream did not release buffers after " +
-          "reaching EOF.", chunk0Stream.getCachedBuffers());
+      assertNull(chunk0Stream.getCachedBuffers(),
+          "ChunkInputStream did not release buffers after reaching EOF.");
     }
   }
 
-  private void testCloseReleasesBuffers() throws Exception {
+  private void testCloseReleasesBuffers(TestBucket bucket) throws Exception {
     String keyName = getNewKeyName();
-    writeRandomBytes(keyName, CHUNK_SIZE);
+    bucket.writeRandomBytes(keyName, CHUNK_SIZE);
 
-    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
+    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
       BlockInputStream block0Stream =
           (BlockInputStream) keyInputStream.getPartStreams().get(0);
       block0Stream.initialize();
 
       ChunkInputStream chunk0Stream = block0Stream.getChunkStreams().get(0);
       readDataFromChunk(chunk0Stream, 0, 1);
-      Assert.assertNotNull(chunk0Stream.getCachedBuffers());
+      assertNotNull(chunk0Stream.getCachedBuffers());
 
       chunk0Stream.close();
 
-      Assert.assertNull(chunk0Stream.getCachedBuffers());
+      assertNull(chunk0Stream.getCachedBuffers());
     }
   }
 
@@ -137,12 +155,11 @@ public class TestChunkInputStream extends TestInputStreamBase {
    * Test that ChunkInputStream buffers are released as soon as the last byte
    * of the buffer is read.
    */
-  public void testBufferRelease() throws Exception {
+  private void testBufferRelease(TestBucket bucket) throws Exception {
     String keyName = getNewKeyName();
-    int dataLength = CHUNK_SIZE;
-    byte[] inputData = writeRandomBytes(keyName, dataLength);
+    byte[] inputData = bucket.writeRandomBytes(keyName, CHUNK_SIZE);
 
-    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
+    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
 
       BlockInputStream block0Stream =
           (BlockInputStream)keyInputStream.getPartStreams().get(0);
@@ -153,21 +170,20 @@ public class TestChunkInputStream extends TestInputStreamBase {
       // Read checksum boundary - 1 bytes of data
       int readDataLen = BYTES_PER_CHECKSUM - 1;
       byte[] readData = readDataFromChunk(chunk0Stream, 0, readDataLen);
-      validateData(inputData, 0, readData);
+      bucket.validateData(inputData, 0, readData);
 
       // There should be 1 byte of data remaining in the buffer which is not
       // yet read. Hence, the buffer should not be released.
       checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(),
           1, 0, BYTES_PER_CHECKSUM);
-      Assert.assertEquals(1, chunk0Stream.getCachedBuffers()[0].remaining());
+      assertEquals(1, chunk0Stream.getCachedBuffers()[0].remaining());
 
       // Reading the last byte in the buffer should result in all the buffers
       // being released.
       readData = readDataFromChunk(chunk0Stream, 1);
-      validateData(inputData, readDataLen, readData);
-      Assert
-          .assertNull("Chunk stream buffers not released after last byte is " +
-              "read", chunk0Stream.getCachedBuffers());
+      bucket.validateData(inputData, readDataLen, readData);
+      assertNull(chunk0Stream.getCachedBuffers(),
+          "Chunk stream buffers not released after last byte is read");
 
       // Read more data to get the data till the next checksum boundary.
       readDataLen = BYTES_PER_CHECKSUM / 2;
@@ -177,7 +193,7 @@ public class TestChunkInputStream extends TestInputStreamBase {
       checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1, 0,
           BYTES_PER_CHECKSUM);
       ByteBuffer lastCachedBuffer = chunk0Stream.getCachedBuffers()[0];
-      Assert.assertEquals(BYTES_PER_CHECKSUM - readDataLen,
+      assertEquals(BYTES_PER_CHECKSUM - readDataLen,
           lastCachedBuffer.remaining());
 
       // Read more than the remaining data in buffer (but less than the next
@@ -185,14 +201,14 @@ public class TestChunkInputStream extends TestInputStreamBase {
       int position = (int) chunk0Stream.getPos();
       readDataLen = lastCachedBuffer.remaining() + BYTES_PER_CHECKSUM / 2;
       readData = readDataFromChunk(chunk0Stream, readDataLen);
-      validateData(inputData, position, readData);
+      bucket.validateData(inputData, position, readData);
       // After reading the remaining data in the buffer, the buffer should be
       // released and next checksum size of data must be read into the buffers
       checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1, 0,
           BYTES_PER_CHECKSUM);
       // Verify that the previously cached buffer is released by comparing it
       // with the current cached buffer
-      Assert.assertNotEquals(lastCachedBuffer,
+      assertNotEquals(lastCachedBuffer,
           chunk0Stream.getCachedBuffers()[0]);
     }
   }
@@ -224,16 +240,17 @@ public class TestChunkInputStream extends TestInputStreamBase {
   private void checkBufferSizeAndCapacity(ByteBuffer[] buffers,
       int expectedNumBuffers, int numReleasedBuffers,
       long expectedBufferCapacity) {
-    Assert.assertEquals("ChunkInputStream does not have expected number of " +
-        "ByteBuffers", expectedNumBuffers, buffers.length);
+    assertEquals(expectedNumBuffers, buffers.length,
+        "ChunkInputStream does not have expected number of " +
+        "ByteBuffers");
     for (int i = 0; i < buffers.length; i++) {
       if (i <= numReleasedBuffers - 1) {
         // This buffer should have been released and hence null
-        Assert.assertNull("ChunkInputStream Buffer not released after being " +
-            "read", buffers[i]);
+        assertNull(buffers[i],
+            "ChunkInputStream Buffer not released after being read");
       } else {
-        Assert.assertEquals("ChunkInputStream ByteBuffer capacity is wrong",
-            expectedBufferCapacity, buffers[i].capacity());
+        assertEquals(expectedBufferCapacity, buffers[i].capacity(),
+            "ChunkInputStream ByteBuffer capacity is wrong");
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -24,76 +24,70 @@ import java.util.Arrays;
 
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.apache.hadoop.ozone.om.TestBucket;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.ozone.container.TestHelper.countReplicas;
-import static org.junit.Assert.fail;
+import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_BLOCK;
+import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_CHUNK;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests {@link KeyInputStream}.
  */
-public class TestKeyInputStream extends TestInputStreamBase {
+class TestKeyInputStream extends TestInputStreamBase {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestKeyInputStream.class);
-
-  public TestKeyInputStream(ContainerLayoutVersion layout) {
-    super(layout);
+  private static List<ContainerLayoutVersion> layouts() {
+    return ContainerLayoutVersion.getAllVersions();
   }
 
   /**
    * This method does random seeks and reads and validates the reads are
    * correct or not.
-   * @param dataLength
-   * @param keyInputStream
-   * @param inputData
-   * @throws Exception
    */
-  private void randomSeek(int dataLength, KeyInputStream keyInputStream,
-      byte[] inputData) throws Exception {
+  private void randomSeek(TestBucket bucket, int dataLength,
+      KeyInputStream keyInputStream, byte[] inputData) throws Exception {
     // Do random seek.
     for (int i = 0; i < dataLength - 300; i += 20) {
-      validate(keyInputStream, inputData, i, 200);
+      validate(bucket, keyInputStream, inputData, i, 200);
     }
 
     // Seek to end and read in reverse order. And also this is partial chunks
     // as readLength is 20, chunk length is 100.
     for (int i = dataLength - 100; i >= 100; i -= 20) {
-      validate(keyInputStream, inputData, i, 20);
+      validate(bucket, keyInputStream, inputData, i, 20);
     }
 
     // Start from begin and seek such that we read partially chunks.
     for (int i = 0; i < dataLength - 300; i += 20) {
-      validate(keyInputStream, inputData, i, 90);
+      validate(bucket, keyInputStream, inputData, i, 90);
     }
 
   }
@@ -101,87 +95,87 @@ public class TestKeyInputStream extends TestInputStreamBase {
   /**
    * This method does random seeks and reads and validates the reads are
    * correct or not.
-   * @param dataLength
-   * @param keyInputStream
-   * @param inputData
-   * @param readSize
-   * @throws Exception
    */
-  private void randomPositionSeek(int dataLength, KeyInputStream keyInputStream,
+  private void randomPositionSeek(TestBucket bucket, int dataLength,
+      KeyInputStream keyInputStream,
       byte[] inputData, int readSize) throws Exception {
     Random rand = new Random();
     for (int i = 0; i < 100; i++) {
       int position = rand.nextInt(dataLength - readSize);
-      validate(keyInputStream, inputData, position, readSize);
+      validate(bucket, keyInputStream, inputData, position, readSize);
     }
   }
 
   /**
    * This method seeks to specified seek value and read the data specified by
    * readLength and validate the read is correct or not.
-   * @param keyInputStream
-   * @param inputData
-   * @param seek
-   * @param readLength
-   * @throws Exception
    */
-  private void validate(KeyInputStream keyInputStream, byte[] inputData,
-      long seek, int readLength) throws Exception {
+  private void validate(TestBucket bucket, KeyInputStream keyInputStream,
+      byte[] inputData, long seek, int readLength) throws Exception {
     keyInputStream.seek(seek);
 
     byte[] readData = new byte[readLength];
     keyInputStream.read(readData, 0, readLength);
 
-    validateData(inputData, (int) seek, readData);
+    bucket.validateData(inputData, (int) seek, readData);
   }
 
   /**
    * This test runs the others as a single test, so to avoid creating a new
    * mini-cluster for each test.
    */
-  @Test
-  public void testNonReplicationReads() throws Exception {
-    testInputStreams();
-    testSeekRandomly();
-    testSeek();
-    testReadChunkWithByteArray();
-    testReadChunkWithByteBuffer();
-    testSkip();
-    testECSeek();
+  @ParameterizedTest
+  @MethodSource("layouts")
+  void testNonReplicationReads(ContainerLayoutVersion layout) throws Exception {
+    try (MiniOzoneCluster cluster = newCluster(layout)) {
+      cluster.waitForClusterToBeReady();
+
+      try (OzoneClient client = cluster.newClient()) {
+        TestBucket bucket = TestBucket.newBuilder(client).build();
+
+        testInputStreams(bucket);
+        testSeekRandomly(bucket);
+        testSeek(bucket);
+        testReadChunkWithByteArray(bucket);
+        testReadChunkWithByteBuffer(bucket);
+        testSkip(bucket);
+        testECSeek(bucket);
+      }
+    }
   }
 
-  public void testInputStreams() throws Exception {
+  private void testInputStreams(TestBucket bucket) throws Exception {
     String keyName = getNewKeyName();
     int dataLength = (2 * BLOCK_SIZE) + (CHUNK_SIZE) + 1;
-    writeRandomBytes(keyName, dataLength);
+    bucket.writeRandomBytes(keyName, dataLength);
 
-    KeyInputStream keyInputStream = getKeyInputStream(keyName);
+    KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName);
 
     // Verify BlockStreams and ChunkStreams
     int expectedNumBlockStreams = BufferUtils.getNumberOfBins(
         dataLength, BLOCK_SIZE);
     List<BlockExtendedInputStream> blockStreams =
         keyInputStream.getPartStreams();
-    Assert.assertEquals(expectedNumBlockStreams, blockStreams.size());
+    assertEquals(expectedNumBlockStreams, blockStreams.size());
 
     int readBlockLength = 0;
     for (BlockExtendedInputStream stream : blockStreams) {
       BlockInputStream blockStream = (BlockInputStream) stream;
       int blockStreamLength = Math.min(BLOCK_SIZE,
           dataLength - readBlockLength);
-      Assert.assertEquals(blockStreamLength, blockStream.getLength());
+      assertEquals(blockStreamLength, blockStream.getLength());
 
       int expectedNumChunkStreams =
           BufferUtils.getNumberOfBins(blockStreamLength, CHUNK_SIZE);
       blockStream.initialize();
       List<ChunkInputStream> chunkStreams = blockStream.getChunkStreams();
-      Assert.assertEquals(expectedNumChunkStreams, chunkStreams.size());
+      assertEquals(expectedNumChunkStreams, chunkStreams.size());
 
       int readChunkLength = 0;
       for (ChunkInputStream chunkStream : chunkStreams) {
         int chunkStreamLength = Math.min(CHUNK_SIZE,
             blockStreamLength - readChunkLength);
-        Assert.assertEquals(chunkStreamLength, chunkStream.getRemaining());
+        assertEquals(chunkStreamLength, chunkStream.getRemaining());
 
         readChunkLength += chunkStreamLength;
       }
@@ -190,37 +184,37 @@ public class TestKeyInputStream extends TestInputStreamBase {
     }
   }
 
-  public void testSeekRandomly() throws Exception {
+  private void testSeekRandomly(TestBucket bucket) throws Exception {
     String keyName = getNewKeyName();
     int dataLength = (2 * BLOCK_SIZE) + (CHUNK_SIZE);
-    byte[] inputData = writeRandomBytes(keyName, dataLength);
+    byte[] inputData = bucket.writeRandomBytes(keyName, dataLength);
 
-    KeyInputStream keyInputStream = getKeyInputStream(keyName);
+    KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName);
 
     // Seek to some where end.
-    validate(keyInputStream, inputData, dataLength - 200, 100);
+    validate(bucket, keyInputStream, inputData, dataLength - 200, 100);
 
     // Now seek to start.
-    validate(keyInputStream, inputData, 0, 140);
+    validate(bucket, keyInputStream, inputData, 0, 140);
 
-    validate(keyInputStream, inputData, 200, 300);
+    validate(bucket, keyInputStream, inputData, 200, 300);
 
-    validate(keyInputStream, inputData, 30, 500);
+    validate(bucket, keyInputStream, inputData, 30, 500);
 
-    randomSeek(dataLength, keyInputStream, inputData);
+    randomSeek(bucket, dataLength, keyInputStream, inputData);
 
     // Read entire key.
-    validate(keyInputStream, inputData, 0, dataLength);
+    validate(bucket, keyInputStream, inputData, 0, dataLength);
 
     // Repeat again and check.
-    randomSeek(dataLength, keyInputStream, inputData);
+    randomSeek(bucket, dataLength, keyInputStream, inputData);
 
-    validate(keyInputStream, inputData, 0, dataLength);
+    validate(bucket, keyInputStream, inputData, 0, dataLength);
 
     keyInputStream.close();
   }
 
-  public void testECSeek() throws Exception {
+  public void testECSeek(TestBucket bucket) throws Exception {
     int ecChunkSize = 1024 * 1024;
     ECReplicationConfig repConfig = new ECReplicationConfig(3, 2, RS,
         ecChunkSize);
@@ -228,29 +222,30 @@ public class TestKeyInputStream extends TestInputStreamBase {
     // 3 full EC blocks plus one chunk
     int dataLength = (9 * BLOCK_SIZE + ecChunkSize);
 
-    byte[] inputData = writeRandomBytes(keyName, repConfig, dataLength);
-    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
+    byte[] inputData = bucket.writeRandomBytes(keyName, repConfig, dataLength);
+    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
 
-      validate(keyInputStream, inputData, 0, ecChunkSize + 1234);
+      validate(bucket, keyInputStream, inputData, 0, ecChunkSize + 1234);
 
-      validate(keyInputStream, inputData, 200, ecChunkSize);
+      validate(bucket, keyInputStream, inputData, 200, ecChunkSize);
 
-      validate(keyInputStream, inputData, BLOCK_SIZE * 4, ecChunkSize);
+      validate(bucket, keyInputStream, inputData, BLOCK_SIZE * 4, ecChunkSize);
 
-      validate(keyInputStream, inputData, BLOCK_SIZE * 4 + 200, ecChunkSize);
+      validate(bucket, keyInputStream, inputData,
+          BLOCK_SIZE * 4 + 200, ecChunkSize);
 
-      validate(keyInputStream, inputData, dataLength - ecChunkSize - 100,
-          ecChunkSize + 50);
+      validate(bucket, keyInputStream, inputData,
+          dataLength - ecChunkSize - 100, ecChunkSize + 50);
 
-      randomPositionSeek(dataLength, keyInputStream, inputData,
+      randomPositionSeek(bucket, dataLength, keyInputStream, inputData,
           ecChunkSize + 200);
 
       // Read entire key.
-      validate(keyInputStream, inputData, 0, dataLength);
+      validate(bucket, keyInputStream, inputData, 0, dataLength);
     }
   }
 
-  public void testSeek() throws Exception {
+  public void testSeek(TestBucket bucket) throws Exception {
     XceiverClientManager.resetXceiverClientMetrics();
     XceiverClientMetrics metrics = XceiverClientManager
         .getXceiverClientMetrics();
@@ -262,28 +257,28 @@ public class TestKeyInputStream extends TestInputStreamBase {
     String keyName = getNewKeyName();
     // write data spanning 3 chunks
     int dataLength = (2 * CHUNK_SIZE) + (CHUNK_SIZE / 2);
-    byte[] inputData = writeKey(keyName, dataLength);
+    byte[] inputData = bucket.writeKey(keyName, dataLength);
 
-    Assert.assertEquals(writeChunkCount + 3,
+    assertEquals(writeChunkCount + 3,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
 
-    KeyInputStream keyInputStream = getKeyInputStream(keyName);
+    KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName);
 
     // Seek to position 150
     keyInputStream.seek(150);
 
-    Assert.assertEquals(150, keyInputStream.getPos());
+    assertEquals(150, keyInputStream.getPos());
 
     // Seek operation should not result in any readChunk operation.
-    Assert.assertEquals(readChunkCount, metrics
+    assertEquals(readChunkCount, metrics
         .getContainerOpCountMetrics(ContainerProtos.Type.ReadChunk));
 
     byte[] readData = new byte[CHUNK_SIZE];
     keyInputStream.read(readData, 0, CHUNK_SIZE);
 
-    // Since we reading data from index 150 to 250 and the chunk boundary is
+    // Since we read data from index 150 to 250 and the chunk boundary is
     // 100 bytes, we need to read 2 chunks.
-    Assert.assertEquals(readChunkCount + 2,
+    assertEquals(readChunkCount + 2,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.ReadChunk));
 
     keyInputStream.close();
@@ -291,19 +286,19 @@ public class TestKeyInputStream extends TestInputStreamBase {
     // Verify that the data read matches with the input data at corresponding
     // indices.
     for (int i = 0; i < CHUNK_SIZE; i++) {
-      Assert.assertEquals(inputData[CHUNK_SIZE + 50 + i], readData[i]);
+      assertEquals(inputData[CHUNK_SIZE + 50 + i], readData[i]);
     }
   }
 
-  public void testReadChunkWithByteArray() throws Exception {
+  private void testReadChunkWithByteArray(TestBucket bucket) throws Exception {
     String keyName = getNewKeyName();
 
     // write data spanning multiple blocks/chunks
     int dataLength = 2 * BLOCK_SIZE + (BLOCK_SIZE / 2);
-    byte[] data = writeRandomBytes(keyName, dataLength);
+    byte[] data = bucket.writeRandomBytes(keyName, dataLength);
 
     // read chunk data using Byte Array
-    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
+    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
 
       int[] bufferSizeList = {BYTES_PER_CHECKSUM + 1, CHUNK_SIZE / 4,
           CHUNK_SIZE / 2, CHUNK_SIZE - 1, CHUNK_SIZE, CHUNK_SIZE + 1,
@@ -315,15 +310,15 @@ public class TestKeyInputStream extends TestInputStreamBase {
     }
   }
 
-  public void testReadChunkWithByteBuffer() throws Exception {
+  public void testReadChunkWithByteBuffer(TestBucket bucket) throws Exception {
     String keyName = getNewKeyName();
 
     // write data spanning multiple blocks/chunks
     int dataLength = 2 * BLOCK_SIZE + (BLOCK_SIZE / 2);
-    byte[] data = writeRandomBytes(keyName, dataLength);
+    byte[] data = bucket.writeRandomBytes(keyName, dataLength);
 
     // read chunk data using ByteBuffer
-    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
+    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
 
       int[] bufferSizeList = {BYTES_PER_CHECKSUM + 1, CHUNK_SIZE / 4,
           CHUNK_SIZE / 2, CHUNK_SIZE - 1, CHUNK_SIZE, CHUNK_SIZE + 1,
@@ -335,7 +330,7 @@ public class TestKeyInputStream extends TestInputStreamBase {
     }
   }
 
-  public void testSkip() throws Exception {
+  private void testSkip(TestBucket bucket) throws Exception {
     XceiverClientManager.resetXceiverClientMetrics();
     XceiverClientMetrics metrics = XceiverClientManager
         .getXceiverClientMetrics();
@@ -347,28 +342,28 @@ public class TestKeyInputStream extends TestInputStreamBase {
     String keyName = getNewKeyName();
     // write data spanning 3 chunks
     int dataLength = (2 * CHUNK_SIZE) + (CHUNK_SIZE / 2);
-    byte[] inputData = writeKey(keyName, dataLength);
+    byte[] inputData = bucket.writeKey(keyName, dataLength);
 
-    Assert.assertEquals(writeChunkCount + 3,
+    assertEquals(writeChunkCount + 3,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
 
-    KeyInputStream keyInputStream = getKeyInputStream(keyName);
+    KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName);
 
     // skip 150
     long skipped = keyInputStream.skip(70);
-    Assert.assertEquals(70, skipped);
-    Assert.assertEquals(70, keyInputStream.getPos());
+    assertEquals(70, skipped);
+    assertEquals(70, keyInputStream.getPos());
 
     skipped = keyInputStream.skip(0);
-    Assert.assertEquals(0, skipped);
-    Assert.assertEquals(70, keyInputStream.getPos());
+    assertEquals(0, skipped);
+    assertEquals(70, keyInputStream.getPos());
 
     skipped = keyInputStream.skip(80);
-    Assert.assertEquals(80, skipped);
-    Assert.assertEquals(150, keyInputStream.getPos());
+    assertEquals(80, skipped);
+    assertEquals(150, keyInputStream.getPos());
 
     // Skip operation should not result in any readChunk operation.
-    Assert.assertEquals(readChunkCount, metrics
+    assertEquals(readChunkCount, metrics
         .getContainerOpCountMetrics(ContainerProtos.Type.ReadChunk));
 
     byte[] readData = new byte[CHUNK_SIZE];
@@ -376,7 +371,7 @@ public class TestKeyInputStream extends TestInputStreamBase {
 
     // Since we reading data from index 150 to 250 and the chunk boundary is
     // 100 bytes, we need to read 2 chunks.
-    Assert.assertEquals(readChunkCount + 2,
+    assertEquals(readChunkCount + 2,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.ReadChunk));
 
     keyInputStream.close();
@@ -384,92 +379,85 @@ public class TestKeyInputStream extends TestInputStreamBase {
     // Verify that the data read matches with the input data at corresponding
     // indices.
     for (int i = 0; i < CHUNK_SIZE; i++) {
-      Assert.assertEquals(inputData[CHUNK_SIZE + 50 + i], readData[i]);
+      assertEquals(inputData[CHUNK_SIZE + 50 + i], readData[i]);
     }
   }
 
-  @Test
-  public void readAfterReplication() throws Exception {
-    testReadAfterReplication(false);
+  private static List<Arguments> readAfterReplicationArgs() {
+    return Arrays.asList(
+        Arguments.arguments(FILE_PER_BLOCK, false),
+        Arguments.arguments(FILE_PER_BLOCK, true),
+        Arguments.arguments(FILE_PER_CHUNK, false),
+        Arguments.arguments(FILE_PER_CHUNK, true)
+    );
   }
 
-  @Test
-  public void readAfterReplicationWithUnbuffering() throws Exception {
-    testReadAfterReplication(true);
+  @ParameterizedTest
+  @MethodSource("readAfterReplicationArgs")
+  void readAfterReplication(ContainerLayoutVersion layout,
+      boolean doUnbuffer) throws Exception {
+    try (MiniOzoneCluster cluster = newCluster(layout)) {
+      cluster.waitForClusterToBeReady();
+
+      try (OzoneClient client = cluster.newClient()) {
+        TestBucket bucket = TestBucket.newBuilder(client).build();
+
+        testReadAfterReplication(cluster, bucket, doUnbuffer);
+      }
+    }
   }
 
-  private void testReadAfterReplication(boolean doUnbuffer) throws Exception {
-    Assume.assumeTrue(getCluster().getHddsDatanodes().size() > 3);
-
+  private void testReadAfterReplication(MiniOzoneCluster cluster,
+      TestBucket bucket, boolean doUnbuffer) throws Exception {
     int dataLength = 2 * CHUNK_SIZE;
     String keyName = getNewKeyName();
-    byte[] data = writeRandomBytes(keyName, dataLength);
+    byte[] data = bucket.writeRandomBytes(keyName, dataLength);
 
-    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(getVolumeName())
-        .setBucketName(getBucketName())
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(bucket.delegate().getVolumeName())
+        .setBucketName(bucket.delegate().getName())
         .setKeyName(keyName)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .build();
-    OmKeyInfo keyInfo = getCluster().getOzoneManager()
+    OmKeyInfo keyInfo = cluster.getOzoneManager()
         .getKeyInfo(keyArgs, false)
         .getKeyInfo();
 
     OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
-    Assert.assertNotNull(locations);
+    assertNotNull(locations);
     List<OmKeyLocationInfo> locationInfoList = locations.getLocationList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo loc = locationInfoList.get(0);
     long containerID = loc.getContainerID();
-    Assert.assertEquals(3, countReplicas(containerID, getCluster()));
+    assertEquals(3, countReplicas(containerID, cluster));
 
-    TestHelper.waitForContainerClose(getCluster(), containerID);
+    TestHelper.waitForContainerClose(cluster, containerID);
 
     List<DatanodeDetails> pipelineNodes = loc.getPipeline().getNodes();
 
     // read chunk data
-    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
+    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
       int b = keyInputStream.read();
-      Assert.assertNotEquals(-1, b);
+      assertNotEquals(-1, b);
       if (doUnbuffer) {
         keyInputStream.unbuffer();
       }
-      getCluster().shutdownHddsDatanode(pipelineNodes.get(0));
+      cluster.shutdownHddsDatanode(pipelineNodes.get(0));
       // check that we can still read it
       assertReadFully(data, keyInputStream, dataLength - 1, 1);
     }
 
     // read chunk data with ByteBuffer
-    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
+    try (KeyInputStream keyInputStream = bucket.getKeyInputStream(keyName)) {
       int b = keyInputStream.read();
-      Assert.assertNotEquals(-1, b);
+      assertNotEquals(-1, b);
       if (doUnbuffer) {
         keyInputStream.unbuffer();
       }
-      getCluster().shutdownHddsDatanode(pipelineNodes.get(0));
+      cluster.shutdownHddsDatanode(pipelineNodes.get(0));
       // check that we can still read it
       assertReadFullyUsingByteBuffer(data, keyInputStream, dataLength - 1, 1);
     }
-  }
-
-  private void waitForNodeToBecomeDead(
-      DatanodeDetails datanode) throws TimeoutException, InterruptedException {
-    GenericTestUtils.waitFor(() ->
-        HddsProtos.NodeState.DEAD == getNodeHealth(datanode),
-        100, 30000);
-    LOG.info("Node {} is {}", datanode.getUuidString(),
-        getNodeHealth(datanode));
-  }
-
-  private HddsProtos.NodeState getNodeHealth(DatanodeDetails dn) {
-    HddsProtos.NodeState health = null;
-    try {
-      NodeManager nodeManager =
-          getCluster().getStorageContainerManager().getScmNodeManager();
-      health = nodeManager.getNodeStatus(dn).getHealth();
-    } catch (NodeNotFoundException e) {
-      fail("Unexpected NodeNotFound exception");
-    }
-    return health;
   }
 
   private void assertReadFully(byte[] data, InputStream in,
@@ -485,10 +473,10 @@ public class TestKeyInputStream extends TestInputStreamBase {
           Arrays.copyOfRange(data, totalRead, totalRead + numBytesRead);
       byte[] tmp2 =
           Arrays.copyOfRange(buffer, 0, numBytesRead);
-      Assert.assertArrayEquals(tmp1, tmp2);
+      assertArrayEquals(tmp1, tmp2);
       totalRead += numBytesRead;
     }
-    Assert.assertEquals(data.length, totalRead);
+    assertEquals(data.length, totalRead);
   }
 
   private void assertReadFullyUsingByteBuffer(byte[] data, KeyInputStream in,
@@ -505,10 +493,10 @@ public class TestKeyInputStream extends TestInputStreamBase {
       byte[] tmp2 = new byte[numBytesRead];
       buffer.flip();
       buffer.get(tmp2, 0, numBytesRead);
-      Assert.assertArrayEquals(tmp1, tmp2);
+      assertArrayEquals(tmp1, tmp2);
       totalRead += numBytesRead;
       buffer.clear();
     }
-    Assert.assertEquals(data.length, totalRead);
+    assertEquals(data.length, totalRead);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -19,177 +19,142 @@
 package org.apache.hadoop.ozone.container;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
 import static org.apache.hadoop.ozone.container.TestHelper.waitForReplicaCount;
-import static org.junit.Assert.assertFalse;
+import static org.apache.ozone.test.GenericTestUtils.setLogLevel;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Duration;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementCapacity;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRandom;
-import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 
-import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.event.Level;
 
 /**
  * Tests ozone containers replication.
  */
-@RunWith(Parameterized.class)
-public class TestContainerReplication {
-  /**
-   * Set the timeout for every test.
-   */
-  @Rule
-  public TestRule testTimeout = new JUnit5AwareTimeout(Timeout.seconds(300));
+@Timeout(300)
+class TestContainerReplication {
 
   private static final String VOLUME = "vol1";
   private static final String BUCKET = "bucket1";
   private static final String KEY = "key1";
 
-  private MiniOzoneCluster cluster;
-  private OzoneClient client;
-  private String placementPolicyClass;
+  private static final List<Class<? extends PlacementPolicy>> POLICIES = asList(
+      SCMContainerPlacementCapacity.class,
+      SCMContainerPlacementRackAware.class,
+      SCMContainerPlacementRandom.class
+  );
 
-  @Parameterized.Parameters
-  public static List<String> parameters() {
-    List<String> classes = new ArrayList<>();
-    classes.add(SCMContainerPlacementRackAware.class.getCanonicalName());
-    classes.add(SCMContainerPlacementCapacity.class.getCanonicalName());
-    classes.add(SCMContainerPlacementRandom.class.getCanonicalName());
-    return classes;
+  static List<Arguments> containerReplicationArguments() {
+    List<Arguments> arguments = new LinkedList<>();
+    for (Class<? extends PlacementPolicy> policyClass : POLICIES) {
+      String canonicalName = policyClass.getCanonicalName();
+      arguments.add(Arguments.arguments(canonicalName, true));
+      arguments.add(Arguments.arguments(canonicalName, false));
+    }
+    return arguments;
   }
 
-  public TestContainerReplication(String placementPolicy) {
-    this.placementPolicyClass = placementPolicy;
+  @BeforeAll
+  static void setUp() {
+    setLogLevel(SCMContainerPlacementCapacity.LOG, Level.DEBUG);
+    setLogLevel(SCMContainerPlacementRackAware.LOG, Level.DEBUG);
+    setLogLevel(SCMContainerPlacementRandom.LOG, Level.DEBUG);
   }
 
-  @Before
-  public void setUp() throws Exception {
-    GenericTestUtils.setLogLevel(SCMContainerPlacementRandom.LOG, Level.DEBUG);
-    GenericTestUtils.setLogLevel(SCMContainerPlacementCapacity.LOG,
-        Level.DEBUG);
-    GenericTestUtils.setLogLevel(SCMContainerPlacementRackAware.LOG,
-        Level.DEBUG);
-  }
+  @ParameterizedTest
+  @MethodSource("containerReplicationArguments")
+  void testContainerReplication(
+      String placementPolicyClass, boolean legacyEnabled) throws Exception {
 
-  @After
-  public void tearDown() {
-    IOUtils.closeQuietly(client);
-    if (cluster != null) {
-      cluster.shutdown();
+    OzoneConfiguration conf = createConfiguration(legacyEnabled);
+    conf.set(OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY, placementPolicyClass);
+    try (MiniOzoneCluster cluster = newCluster(conf)) {
+      cluster.waitForClusterToBeReady();
+      try (OzoneClient client = cluster.newClient()) {
+        createTestData(client);
+
+        List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
+        assertFalse(keyLocations.isEmpty());
+
+        OmKeyLocationInfo keyLocation = keyLocations.get(0);
+        long containerID = keyLocation.getContainerID();
+        waitForContainerClose(cluster, containerID);
+
+        cluster.shutdownHddsDatanode(keyLocation.getPipeline().getFirstNode());
+        waitForReplicaCount(containerID, 2, cluster);
+
+        waitForReplicaCount(containerID, 3, cluster);
+      }
     }
   }
 
-  @Test
-  public void testContainerReplication() throws Exception {
-    OzoneConfiguration conf = createConfiguration();
-    conf.set(OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY, placementPolicyClass);
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
-    cluster.waitForClusterToBeReady();
-    client = OzoneClientFactory.getRpcClient(conf);
-    createTestData();
-
-    List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
-    assertFalse(keyLocations.isEmpty());
-
-    OmKeyLocationInfo keyLocation = keyLocations.get(0);
-    long containerID = keyLocation.getContainerID();
-    waitForContainerClose(cluster, containerID);
-
-    cluster.shutdownHddsDatanode(keyLocation.getPipeline().getFirstNode());
-    waitForReplicaCount(containerID, 2, cluster);
-
-    waitForReplicaCount(containerID, 3, cluster);
+  private static MiniOzoneCluster newCluster(OzoneConfiguration conf)
+      throws IOException {
+    return MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(5)
+        .build();
   }
 
-  @Test
-  public void testContainerReplicationWithLegacyReplicationManagerDisabled()
-      throws Exception {
-    OzoneConfiguration conf = createConfiguration();
-
-    /*
-    Disable LegacyReplicationManager so that ReplicationManager handles Ratis
-     containers.
-     */
-    ReplicationManagerConfiguration repConf =
-        conf.getObject(ReplicationManagerConfiguration.class);
-    repConf.setEnableLegacy(false);
-    repConf.setUnderReplicatedInterval(Duration.ofSeconds(1));
-    conf.setFromObject(repConf);
-
-    conf.set(OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY, placementPolicyClass);
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
-    cluster.waitForClusterToBeReady();
-    client = OzoneClientFactory.getRpcClient(conf);
-    createTestData();
-
-    List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
-    assertFalse(keyLocations.isEmpty());
-
-    OmKeyLocationInfo keyLocation = keyLocations.get(0);
-    long containerID = keyLocation.getContainerID();
-    waitForContainerClose(cluster, containerID);
-
-    cluster.shutdownHddsDatanode(keyLocation.getPipeline().getFirstNode());
-    waitForReplicaCount(containerID, 2, cluster);
-
-    waitForReplicaCount(containerID, 3, cluster);
-  }
-
-  private static OzoneConfiguration createConfiguration() {
+  private static OzoneConfiguration createConfiguration(boolean enableLegacy) {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
 
     ReplicationManagerConfiguration repConf =
         conf.getObject(ReplicationManagerConfiguration.class);
+    repConf.setEnableLegacy(enableLegacy);
     repConf.setInterval(Duration.ofSeconds(1));
+    repConf.setUnderReplicatedInterval(Duration.ofSeconds(1));
     conf.setFromObject(repConf);
+
     return conf;
   }
 
-  private void createTestData() throws IOException {
+  // TODO use common helper to create test data
+  private void createTestData(OzoneClient client) throws IOException {
     ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume(VOLUME);
     OzoneVolume volume = objectStore.getVolume(VOLUME);
     volume.createBucket(BUCKET);
 
     OzoneBucket bucket = volume.getBucket(BUCKET);
-    try (OutputStream out = bucket.createKey(KEY, 0)) {
+
+    try (OutputStream out = bucket.createKey(KEY, 0,
+        RatisReplicationConfig.getInstance(THREE), emptyMap())) {
       out.write("Hello".getBytes(UTF_8));
     }
   }
@@ -200,11 +165,10 @@ public class TestContainerReplication {
         .setVolumeName(VOLUME)
         .setBucketName(BUCKET)
         .setKeyName(KEY)
-        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
-    Assert.assertNotNull(locations);
+    assertNotNull(locations);
     return locations.getLocationList();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
@@ -20,40 +20,33 @@
 package org.apache.hadoop.ozone.dn.scanner;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.utils.ContainerLogger;
 import org.apache.hadoop.ozone.container.ozoneimpl.BackgroundContainerDataScanner;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.Collection;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Integration tests for the background container data scanner. This scanner
  * checks all data and metadata in the container.
  */
-@RunWith(Parameterized.class)
-public class TestBackgroundContainerDataScannerIntegration
+class TestBackgroundContainerDataScannerIntegration
     extends TestContainerScannerIntegrationAbstract {
 
-  private final ContainerCorruptions corruption;
-  private final LogCapturer logCapturer;
+  private final LogCapturer logCapturer =
+      LogCapturer.log4j2(ContainerLogger.LOG_NAME);
 
-  @Parameterized.Parameters(name = "{0}")
-  public static Collection<Object[]> supportedCorruptionTypes() {
-    // Background container data scanner should be able to detect all errors.
-    return ContainerCorruptions.getAllParamsExcept();
-  }
-
-  @BeforeClass
-  public static void init() throws Exception {
+  @BeforeAll
+  static void init() throws Exception {
     OzoneConfiguration ozoneConfig = new OzoneConfiguration();
     ozoneConfig.setBoolean(
         ContainerScannerConfiguration.HDDS_CONTAINER_SCRUB_ENABLED, true);
@@ -69,28 +62,25 @@ public class TestBackgroundContainerDataScannerIntegration
     buildCluster(ozoneConfig);
   }
 
-  public TestBackgroundContainerDataScannerIntegration(
-      ContainerCorruptions corruption) {
-    this.corruption = corruption;
-    logCapturer = GenericTestUtils.LogCapturer.log4j2(ContainerLogger.LOG_NAME);
-  }
-
   /**
    * {@link BackgroundContainerDataScanner} should detect corrupted blocks
    * in a closed container without client interaction.
    */
-  @Test
-  public void testCorruptionDetected() throws Exception {
+  @ParameterizedTest
+  // Background container data scanner should be able to detect all errors.
+  @EnumSource
+  void testCorruptionDetected(ContainerCorruptions corruption)
+      throws Exception {
     long containerID = writeDataThenCloseContainer();
     // Container corruption has not yet been introduced.
-    Assert.assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
-        getDnContainer(containerID).getContainerState());
+    Container<?> container = getDnContainer(containerID);
+    assertEquals(State.CLOSED, container.getContainerState());
 
-    corruption.applyTo(getDnContainer(containerID));
+    corruption.applyTo(container);
+
     // Wait for the scanner to detect corruption.
-    GenericTestUtils.waitFor(() ->
-            getDnContainer(containerID).getContainerState() ==
-                ContainerProtos.ContainerDataProto.State.UNHEALTHY,
+    GenericTestUtils.waitFor(
+        () -> container.getContainerState() == State.UNHEALTHY,
         500, 5000);
 
     // Wait for SCM to get a report of the unhealthy replica.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
@@ -45,7 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class TestBackgroundContainerMetadataScannerIntegration
     extends TestContainerScannerIntegrationAbstract {
 
-  private final GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.log4j2(ContainerLogger.LOG_NAME);
+  private final GenericTestUtils.LogCapturer logCapturer =
+      GenericTestUtils.LogCapturer.log4j2(ContainerLogger.LOG_NAME);
 
   static Collection<ContainerCorruptions> supportedCorruptionTypes() {
     return ContainerCorruptions.getAllParamsExcept(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
@@ -20,44 +20,42 @@
 package org.apache.hadoop.ozone.dn.scanner;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.utils.ContainerLogger;
 import org.apache.hadoop.ozone.container.ozoneimpl.BackgroundContainerMetadataScanner;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Integration tests for the background container metadata scanner. This
  * scanner does a quick check of container metadata to find obvious failures
  * faster than a full data scan.
  */
-@RunWith(Parameterized.class)
-public class TestBackgroundContainerMetadataScannerIntegration
+class TestBackgroundContainerMetadataScannerIntegration
     extends TestContainerScannerIntegrationAbstract {
 
-  private final ContainerCorruptions corruption;
-  private final GenericTestUtils.LogCapturer logCapturer;
+  private final GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer.log4j2(ContainerLogger.LOG_NAME);
 
-  @Parameterized.Parameters(name = "{0}")
-  public static Collection<Object[]> supportedCorruptionTypes() {
+  static Collection<ContainerCorruptions> supportedCorruptionTypes() {
     return ContainerCorruptions.getAllParamsExcept(
         ContainerCorruptions.MISSING_BLOCK,
         ContainerCorruptions.CORRUPT_BLOCK,
         ContainerCorruptions.TRUNCATED_BLOCK);
   }
 
-  @BeforeClass
-  public static void init() throws Exception {
+  @BeforeAll
+  static void init() throws Exception {
     OzoneConfiguration ozoneConfig = new OzoneConfiguration();
     // Speed up SCM closing of open container when an unhealthy replica is
     // reported.
@@ -80,42 +78,39 @@ public class TestBackgroundContainerMetadataScannerIntegration
     buildCluster(ozoneConfig);
   }
 
-  public TestBackgroundContainerMetadataScannerIntegration(
-      ContainerCorruptions corruption) {
-    this.corruption = corruption;
-    logCapturer = GenericTestUtils.LogCapturer.log4j2(ContainerLogger.LOG_NAME);
-  }
-
   /**
    * {@link BackgroundContainerMetadataScanner} should detect corrupted metadata
    * in open or closed containers without client interaction.
    */
-  @Test
-  public void testCorruptionDetected() throws Exception {
+  @ParameterizedTest
+  @MethodSource("supportedCorruptionTypes")
+  void testCorruptionDetected(ContainerCorruptions corruption)
+      throws Exception {
     // Write data to an open and closed container.
     long closedContainerID = writeDataThenCloseContainer();
-    Assert.assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
-        getDnContainer(closedContainerID).getContainerState());
+    Container<?> closedContainer = getDnContainer(closedContainerID);
+    assertEquals(State.CLOSED, closedContainer.getContainerState());
+
     long openContainerID = writeDataToOpenContainer();
-    Assert.assertEquals(ContainerProtos.ContainerDataProto.State.OPEN,
-        getDnContainer(openContainerID).getContainerState());
+    Container<?> openContainer = getDnContainer(openContainerID);
+    assertEquals(State.OPEN, openContainer.getContainerState());
 
     // Corrupt both containers.
-    corruption.applyTo(getDnContainer(closedContainerID));
-    corruption.applyTo(getDnContainer(openContainerID));
+    corruption.applyTo(closedContainer);
+    corruption.applyTo(openContainer);
+
     // Wait for the scanner to detect corruption.
-    GenericTestUtils.waitFor(() ->
-            getDnContainer(closedContainerID).getContainerState() ==
-                ContainerProtos.ContainerDataProto.State.UNHEALTHY,
+    GenericTestUtils.waitFor(
+        () -> closedContainer.getContainerState() == State.UNHEALTHY,
         500, 5000);
-    GenericTestUtils.waitFor(() ->
-            getDnContainer(openContainerID).getContainerState() ==
-                ContainerProtos.ContainerDataProto.State.UNHEALTHY,
+    GenericTestUtils.waitFor(
+        () -> openContainer.getContainerState() == State.UNHEALTHY,
         500, 5000);
 
     // Wait for SCM to get reports of the unhealthy replicas.
     waitForScmToSeeUnhealthyReplica(closedContainerID);
     waitForScmToSeeUnhealthyReplica(openContainerID);
+
     // Once the unhealthy replica is reported, the open container's lifecycle
     // state in SCM should move to closed.
     waitForScmToCloseContainer(openContainerID);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -19,25 +19,23 @@
  */
 package org.apache.hadoop.ozone.dn.volume;
 
-import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
-import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
-import org.apache.hadoop.ozone.client.OzoneKey;
-import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.io.OzoneInputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
@@ -49,73 +47,218 @@ import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.dn.DatanodeTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
 import java.util.UUID;
 
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Timeout;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
-import static org.apache.hadoop.hdds.client.ReplicationType.RATIS;
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.io.IOUtils.readFully;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This class tests datanode can detect failed volumes.
  */
-@RunWith(Parameterized.class)
-public class TestDatanodeHddsVolumeFailureDetection {
-  private boolean schemaV3;
-  public TestDatanodeHddsVolumeFailureDetection(boolean enableV3) {
-    this.schemaV3 = enableV3;
+@Timeout(300)
+class TestDatanodeHddsVolumeFailureDetection {
+
+  private static final int KEY_SIZE = 128;
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void corruptChunkFile(boolean schemaV3) throws Exception {
+    try (MiniOzoneCluster cluster = newCluster(schemaV3)) {
+      try (OzoneClient client = cluster.newClient()) {
+        OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
+
+        // write a file
+        String keyName = UUID.randomUUID().toString();
+        long containerId = createKey(bucket, keyName);
+
+        // corrupt chunk file by rename file->dir
+        HddsDatanodeService dn = cluster.getHddsDatanodes().get(0);
+        OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
+        MutableVolumeSet volSet = oc.getVolumeSet();
+        StorageVolume vol0 = volSet.getVolumesList().get(0);
+        HddsVolume volume = assertInstanceOf(HddsVolume.class, vol0);
+        Path chunksPath = Paths.get(
+            volume.getStorageDir().getPath(),
+            volume.getClusterID(),
+            Storage.STORAGE_DIR_CURRENT,
+            Storage.CONTAINER_DIR + "0",
+            String.valueOf(containerId),
+            OzoneConsts.STORAGE_DIR_CHUNKS
+        );
+        File[] chunkFiles = chunksPath.toFile().listFiles();
+        assertNotNull(chunkFiles);
+
+        try {
+          for (File chunkFile : chunkFiles) {
+            DatanodeTestUtils.injectDataFileFailure(chunkFile);
+          }
+
+          // simulate bad volume by removing write permission on root dir
+          // refer to HddsVolume.check()
+          DatanodeTestUtils.simulateBadVolume(vol0);
+
+          // read written file to trigger checkVolumeAsync
+          readKeyToTriggerCheckVolumeAsync(bucket, keyName);
+
+          // should trigger checkVolumeAsync and
+          // a failed volume should be detected
+          DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
+          DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
+        } finally {
+          // restore for cleanup
+          DatanodeTestUtils.restoreBadVolume(vol0);
+          for (File chunkFile : chunkFiles) {
+            DatanodeTestUtils.restoreDataFileFromFailure(chunkFile);
+          }
+        }
+      }
+    }
   }
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[]{false},
-        new Object[]{true});
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void corruptContainerFile(boolean schemaV3) throws Exception {
+    try (MiniOzoneCluster cluster = newCluster(schemaV3)) {
+      // create a container
+      ContainerWithPipeline container;
+      OzoneConfiguration conf = cluster.getConf();
+      try (ScmClient scmClient = new ContainerOperationClient(conf)) {
+        container = scmClient.createContainer(ReplicationType.STAND_ALONE,
+            ReplicationFactor.ONE, OzoneConsts.OZONE);
+      }
+
+      // corrupt container file by removing write permission on
+      // container metadata dir, since container update operation
+      // use a create temp & rename way, so we can't just rename
+      // container file to simulate corruption
+      HddsDatanodeService dn = cluster.getHddsDatanodes().get(0);
+      OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
+      MutableVolumeSet volSet = oc.getVolumeSet();
+      StorageVolume vol0 = volSet.getVolumesList().get(0);
+      Container<?> c1 = oc.getContainerSet().getContainer(
+          container.getContainerInfo().getContainerID());
+      File metadataDir = new File(c1.getContainerFile().getParent());
+      try {
+        DatanodeTestUtils.injectContainerMetaDirFailure(metadataDir);
+
+        // simulate bad volume by removing write permission on root dir
+        // refer to HddsVolume.check()
+        DatanodeTestUtils.simulateBadVolume(vol0);
+
+        // close container to trigger checkVolumeAsync
+        assertThrows(IOException.class, c1::close);
+
+        // should trigger CheckVolumeAsync and
+        // a failed volume should be detected
+        DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
+        DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
+      } finally {
+        // restore for cleanup
+        DatanodeTestUtils.restoreBadVolume(vol0);
+        DatanodeTestUtils.restoreContainerMetaDirFromFailure(metadataDir);
+      }
+    }
   }
 
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-  private MiniOzoneCluster cluster;
-  private OzoneConfiguration ozoneConfig;
-  private OzoneClient ozClient = null;
-  private ScmClient scmClient;
-  private ObjectStore store = null;
-  private OzoneVolume volume;
-  private OzoneBucket bucket;
-  private List<HddsDatanodeService> datanodes;
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void corruptDbFile(boolean schemaV3) throws Exception {
+    try (MiniOzoneCluster cluster = newCluster(schemaV3)) {
+      try (OzoneClient client = cluster.newClient()) {
+        OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 
-  @Before
-  public void init() throws Exception {
-    ozoneConfig = new OzoneConfiguration();
+        // write a file, will create container1
+        String keyName = UUID.randomUUID().toString();
+        long containerId = createKey(bucket, keyName);
+
+        // close container1
+        HddsDatanodeService dn = cluster.getHddsDatanodes().get(0);
+        OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
+        Container<?> c1 = oc.getContainerSet().getContainer(containerId);
+        c1.close();
+
+        // create container2, and container1 is kicked out of cache
+        OzoneConfiguration conf = cluster.getConf();
+        try (ScmClient scmClient = new ContainerOperationClient(conf)) {
+          ContainerWithPipeline c2 = scmClient.createContainer(
+              ReplicationType.STAND_ALONE, ReplicationFactor.ONE,
+              OzoneConsts.OZONE);
+          assertEquals(c2.getContainerInfo().getState(), LifeCycleState.OPEN);
+        }
+
+        // corrupt db by rename dir->file
+        File dbDir;
+        if (schemaV3) {
+          dbDir = new File(((KeyValueContainerData) (c1.getContainerData()))
+              .getDbFile().getAbsolutePath());
+        } else {
+          File metadataDir = new File(c1.getContainerFile().getParent());
+          dbDir = new File(metadataDir, "1" + OzoneConsts.DN_CONTAINER_DB);
+        }
+
+        MutableVolumeSet volSet = oc.getVolumeSet();
+        StorageVolume vol0 = volSet.getVolumesList().get(0);
+
+        try {
+          DatanodeTestUtils.injectDataDirFailure(dbDir);
+          if (schemaV3) {
+            // remove rocksDB from cache
+            DatanodeStoreCache.getInstance().removeDB(dbDir.getAbsolutePath());
+          }
+
+          // simulate bad volume by removing write permission on root dir
+          // refer to HddsVolume.check()
+          DatanodeTestUtils.simulateBadVolume(vol0);
+
+          readKeyToTriggerCheckVolumeAsync(bucket, keyName);
+
+          // should trigger CheckVolumeAsync and
+          // a failed volume should be detected
+          DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
+          DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
+        } finally {
+          // restore all
+          DatanodeTestUtils.restoreBadVolume(vol0);
+          DatanodeTestUtils.restoreDataDirFromFailure(dbDir);
+        }
+      }
+    }
+  }
+
+  private static void readKeyToTriggerCheckVolumeAsync(OzoneBucket bucket,
+      String key) throws IOException {
+    try (InputStream is = bucket.readKey(key)) {
+      assertThrows(IOException.class, () -> readFully(is, new byte[KEY_SIZE]));
+    }
+  }
+
+  private static MiniOzoneCluster newCluster(boolean schemaV3)
+      throws Exception {
+    OzoneConfiguration ozoneConfig = new OzoneConfiguration();
     ozoneConfig.set(OZONE_SCM_CONTAINER_SIZE, "1GB");
     ozoneConfig.setStorageSize(OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN,
         0, StorageUnit.MB);
-    ozoneConfig.setInt(OZONE_REPLICATION, ReplicationFactor.ONE.getValue());
+    ozoneConfig.setInt(OZONE_REPLICATION, 1);
     // keep the cache size = 1, so we could trigger io exception on
     // reading on-disk db instance
     ozoneConfig.setInt(OZONE_CONTAINER_CACHE_SIZE, 1);
@@ -129,208 +272,28 @@ public class TestDatanodeHddsVolumeFailureDetection {
     dnConf.setFailedDataVolumesTolerated(1);
     dnConf.setDiskCheckMinGap(Duration.ofSeconds(5));
     ozoneConfig.setFromObject(dnConf);
-    cluster = MiniOzoneCluster.newBuilder(ozoneConfig)
+    MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(ozoneConfig)
         .setNumDatanodes(1)
         .setNumDataVolumes(1)
         .build();
     cluster.waitForClusterToBeReady();
-    cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 30000);
+    cluster.waitForPipelineTobeReady(ReplicationFactor.ONE, 30000);
 
-    ozClient = OzoneClientFactory.getRpcClient(ozoneConfig);
-    store = ozClient.getObjectStore();
-    scmClient = new ContainerOperationClient(ozoneConfig);
-
-    String volumeName = UUID.randomUUID().toString();
-    store.createVolume(volumeName);
-    volume = store.getVolume(volumeName);
-
-    String bucketName = UUID.randomUUID().toString();
-    volume.createBucket(bucketName);
-    bucket = volume.getBucket(bucketName);
-
-    datanodes = cluster.getHddsDatanodes();
+    return cluster;
   }
 
-  @After
-  public void shutdown() throws IOException {
-    IOUtils.closeQuietly(scmClient);
-    if (ozClient != null) {
-      ozClient.close();
+  private static long createKey(OzoneBucket bucket, String key)
+      throws IOException {
+    byte[] bytes = RandomUtils.nextBytes(KEY_SIZE);
+    RatisReplicationConfig replication =
+        RatisReplicationConfig.getInstance(ReplicationFactor.ONE);
+    try (OutputStream out = bucket.createKey(key, bytes.length, replication,
+        emptyMap())) {
+      out.write(bytes);
     }
-    if (cluster != null) {
-      cluster.shutdown();
-    }
+    OzoneKeyDetails keyDetails = bucket.getKey(key);
+    assertEquals(key, keyDetails.getName());
+    return keyDetails.getOzoneKeyLocations().get(0).getContainerID();
   }
 
-  @Test
-  public void testHddsVolumeFailureOnChunkFileCorrupt() throws Exception {
-    // write a file
-    String keyName = UUID.randomUUID().toString();
-    String value = "sample value";
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, RATIS,
-        ONE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
-    OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
-
-    // corrupt chunk file by rename file->dir
-    HddsDatanodeService dn = datanodes.get(0);
-    OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
-    MutableVolumeSet volSet = oc.getVolumeSet();
-    StorageVolume vol0 = volSet.getVolumesList().get(0);
-    Assert.assertTrue(vol0 instanceof HddsVolume);
-    File clusterDir = DatanodeTestUtils.getHddsVolumeClusterDir(
-        (HddsVolume) vol0);
-    File currentDir = new File(clusterDir, Storage.STORAGE_DIR_CURRENT);
-    File containerTopDir = new File(currentDir, Storage.CONTAINER_DIR + "0");
-    File containerDir = new File(containerTopDir, "1");
-    File chunksDir = new File(containerDir, OzoneConsts.STORAGE_DIR_CHUNKS);
-    File[] chunkFiles = chunksDir.listFiles();
-    Assert.assertNotNull(chunkFiles);
-    for (File chunkFile : chunkFiles) {
-      DatanodeTestUtils.injectDataFileFailure(chunkFile);
-    }
-
-    // simulate bad volume by removing write permission on root dir
-    // refer to HddsVolume.check()
-    DatanodeTestUtils.simulateBadVolume(vol0);
-
-    // read written file to trigger checkVolumeAsync
-    OzoneInputStream is = bucket.readKey(keyName);
-    byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-
-    try {
-      is.read(fileContent);
-      Assert.fail();
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof IOException);
-    } finally {
-      is.close();
-    }
-
-    // should trigger checkVolumeAsync and
-    // a failed volume should be detected
-    DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
-    DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
-
-    // restore for cleanup
-    DatanodeTestUtils.restoreBadVolume(vol0);
-    for (File chunkFile : chunkFiles) {
-      DatanodeTestUtils.restoreDataFileFromFailure(chunkFile);
-    }
-  }
-
-  @Test
-  public void testHddsVolumeFailureOnContainerFileCorrupt() throws Exception {
-    // create a container
-    ContainerWithPipeline container = scmClient.createContainer(HddsProtos
-        .ReplicationType.STAND_ALONE, HddsProtos.ReplicationFactor
-        .ONE, OzoneConsts.OZONE);
-
-    // corrupt container file by removing write permission on
-    // container metadata dir, since container update operation
-    // use a create temp & rename way, so we can't just rename
-    // container file to simulate corruption
-    HddsDatanodeService dn = datanodes.get(0);
-    OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
-    MutableVolumeSet volSet = oc.getVolumeSet();
-    StorageVolume vol0 = volSet.getVolumesList().get(0);
-    Container c1 = oc.getContainerSet().getContainer(container.
-        getContainerInfo().getContainerID());
-    File metadataDir = new File(c1.getContainerFile().getParent());
-    DatanodeTestUtils.injectContainerMetaDirFailure(metadataDir);
-
-    // simulate bad volume by removing write permission on root dir
-    // refer to HddsVolume.check()
-    DatanodeTestUtils.simulateBadVolume(vol0);
-
-    // close container to trigger checkVolumeAsync
-    try {
-      c1.close();
-      Assert.fail();
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof IOException);
-    }
-
-    // should trigger CheckVolumeAsync and
-    // a failed volume should be detected
-    DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
-    DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
-
-    // restore for cleanup
-    DatanodeTestUtils.restoreBadVolume(vol0);
-    DatanodeTestUtils.restoreContainerMetaDirFromFailure(metadataDir);
-  }
-
-  @Test
-  public void testHddsVolumeFailureOnDbFileCorrupt() throws Exception {
-    // write a file, will create container1
-    String keyName = UUID.randomUUID().toString();
-    String value = "sample value";
-    OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, RATIS,
-        ONE, new HashMap<>());
-    out.write(value.getBytes(UTF_8));
-    out.close();
-    OzoneKey key = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, key.getName());
-
-    // close container1
-    HddsDatanodeService dn = datanodes.get(0);
-    OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
-    Container c1 = oc.getContainerSet().getContainer(1);
-    c1.close();
-
-    // create container2, and container1 is kicked out of cache
-    ContainerWithPipeline c2 = scmClient.createContainer(HddsProtos
-        .ReplicationType.STAND_ALONE, HddsProtos.ReplicationFactor
-        .ONE, OzoneConsts.OZONE);
-    Assert.assertTrue(c2.getContainerInfo().getState()
-        .equals(HddsProtos.LifeCycleState.OPEN));
-
-    // corrupt db by rename dir->file
-    File dbDir;
-    if (schemaV3) {
-      dbDir = new File(((KeyValueContainerData)(c1.getContainerData()))
-          .getDbFile().getAbsolutePath());
-    } else {
-      File metadataDir = new File(c1.getContainerFile().getParent());
-      dbDir = new File(metadataDir, "1" + OzoneConsts.DN_CONTAINER_DB);
-    }
-    DatanodeTestUtils.injectDataDirFailure(dbDir);
-    if (schemaV3) {
-      // remove rocksDB from cache
-      DatanodeStoreCache.getInstance().removeDB(dbDir.getAbsolutePath());
-    }
-
-    // simulate bad volume by removing write permission on root dir
-    // refer to HddsVolume.check()
-    MutableVolumeSet volSet = oc.getVolumeSet();
-    StorageVolume vol0 = volSet.getVolumesList().get(0);
-    DatanodeTestUtils.simulateBadVolume(vol0);
-
-    // read written file to trigger checkVolumeAsync
-    OzoneInputStream is = bucket.readKey(keyName);
-    byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-
-    try {
-      is.read(fileContent);
-      Assert.fail();
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof IOException);
-    } finally {
-      is.close();
-    }
-
-    // should trigger CheckVolumeAsync and
-    // a failed volume should be detected
-    DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
-    DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
-
-    // restore all
-    DatanodeTestUtils.restoreBadVolume(vol0);
-    DatanodeTestUtils.restoreDataDirFromFailure(dbDir);
-  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucket.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucket.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.io.KeyInputStream;
+import org.apache.hadoop.ozone.container.ContainerTestHelper;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * Wrapper for {@code OzoneBucket} for testing.  Can create random keys,
+ * verify content, etc.
+ */
+public final class TestBucket {
+
+  private final OzoneBucket bucket;
+
+  private TestBucket(OzoneBucket bucket) {
+    this.bucket = bucket;
+  }
+
+  public static Builder newBuilder(OzoneClient client) {
+    return new Builder(client);
+  }
+
+  public OzoneBucket delegate() {
+    return bucket;
+  }
+
+  public KeyInputStream getKeyInputStream(String keyName) throws IOException {
+    return (KeyInputStream) bucket
+        .readKey(keyName).getInputStream();
+  }
+
+  public byte[] writeKey(String keyName, int dataLength) throws Exception {
+    ReplicationConfig repConfig = RatisReplicationConfig.getInstance(THREE);
+    return writeKey(keyName, repConfig, dataLength);
+  }
+
+  public byte[] writeKey(String key, ReplicationConfig repConfig, int len)
+      throws Exception {
+    byte[] inputData = ContainerTestHelper
+        .getFixedLengthString(UUID.randomUUID().toString(), len)
+        .getBytes(UTF_8);
+
+    writeKey(key, repConfig, inputData);
+
+    return inputData;
+  }
+
+  public void writeKey(String key, ReplicationConfig repConfig,
+      byte[] inputData) throws IOException {
+    try (OutputStream out = bucket.createKey(key, 0, repConfig, emptyMap())) {
+      out.write(inputData);
+    }
+  }
+
+  public byte[] writeRandomBytes(String keyName, int dataLength)
+      throws Exception {
+    ReplicationConfig repConfig = RatisReplicationConfig.getInstance(THREE);
+    return writeRandomBytes(keyName, repConfig, dataLength);
+  }
+
+  public byte[] writeRandomBytes(String key, ReplicationConfig repConfig,
+      int len) throws Exception {
+    byte[] inputData = new byte[len];
+    ThreadLocalRandom.current().nextBytes(inputData);
+
+    writeKey(key, repConfig, inputData);
+    return inputData;
+  }
+
+  public void validateData(byte[] inputData, int offset, byte[] readData) {
+    int readDataLen = readData.length;
+    byte[] expectedData = new byte[readDataLen];
+    System.arraycopy(inputData, offset, expectedData, 0, readDataLen);
+
+    assertArrayEquals(expectedData, readData);
+  }
+
+  /**
+   * Builder for {@code TestBucket}.
+   */
+  public static class Builder {
+    private final OzoneClient client;
+    private OzoneVolume volume;
+    private String volumeName;
+    private String bucketName;
+
+    Builder(OzoneClient client) {
+      this.client = client;
+    }
+
+    public TestBucket build() throws IOException {
+      ObjectStore objectStore = client.getObjectStore();
+      if (volume == null) { // TODO add setVolume
+        if (volumeName == null) { // TODO add setVolumeName
+          volumeName = "vol" + randomNumeric(10);
+        }
+        objectStore.createVolume(volumeName);
+        volume = objectStore.getVolume(volumeName);
+      }
+      if (bucketName == null) { // TODO add setBucketName
+        bucketName = "bucket" + randomNumeric(10);
+      }
+      volume.createBucket(bucketName);
+      return new TestBucket(volume.getBucket(bucketName));
+    }
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
@@ -23,41 +23,39 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
-import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
-import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Test;
-import org.junit.Before;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.OzoneConsts.LAYOUT_VERSION_KEY;
 import static org.apache.hadoop.ozone.om.OMUpgradeTestUtils.waitForFinalization;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.INITIAL_VERSION;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager.maxLayoutVersion;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Upgrade testing for Bucket Layout Feature.
@@ -68,50 +66,30 @@ import static org.junit.Assert.assertEquals;
  * <p>
  * 2. Post-Finalize: OM should allow creation of buckets with new bucket
  * layouts.
+ *
+ * Test cases are run on the same single cluster.  Order is important,
+ * because "upgrade" changes its state.  Test cases are therefore assigned to
+ * 3 groups: before, during and after upgrade.
  */
-@RunWith(Parameterized.class)
-public class TestOMBucketLayoutUpgrade {
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(new Timeout(300000));
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Timeout(300)
+class TestOMBucketLayoutUpgrade {
+
+  private static final int PRE_UPGRADE = 100;
+  private static final int DURING_UPGRADE = 200;
+  private static final int POST_UPGRADE = 300;
+
   private MiniOzoneHAClusterImpl cluster;
   private OzoneManager ozoneManager;
-  private ClientProtocol clientProtocol;
   private static final String VOLUME_NAME = "vol-" + UUID.randomUUID();
-  private int fromLayoutVersion;
+  private final int fromLayoutVersion = INITIAL_VERSION.layoutVersion();
   private OzoneManagerProtocol omClient;
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestOMBucketLayoutUpgrade.class);
   private OzoneClient client;
 
-  /**
-   * Defines a "from" layout version to finalize from.
-   *
-   * @return
-   */
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][]{
-        {INITIAL_VERSION}
-    });
-  }
-
-
-  public TestOMBucketLayoutUpgrade(OMLayoutFeature fromVersion) {
-    this.fromLayoutVersion = fromVersion.layoutVersion();
-  }
-
-  /**
-   * Create a MiniDFSCluster for testing.
-   */
-  @Before
-  public void setup() throws Exception {
-    org.junit.Assume.assumeTrue("Check if there is need to finalize.",
-        maxLayoutVersion() > fromLayoutVersion);
-
+  @BeforeAll
+  void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     String omServiceId = UUID.randomUUID().toString();
     cluster = (MiniOzoneHAClusterImpl) MiniOzoneCluster.newOMHABuilder(conf)
@@ -125,10 +103,8 @@ public class TestOMBucketLayoutUpgrade {
 
     cluster.waitForClusterToBeReady();
     ozoneManager = cluster.getOzoneManager();
-    client = OzoneClientFactory.getRpcClient(omServiceId, conf);
-    ObjectStore objectStore = client.getObjectStore();
-    clientProtocol = objectStore.getClientProxy();
-    omClient = clientProtocol.getOzoneManagerClient();
+    client = cluster.newClient();
+    omClient = client.getObjectStore().getClientProxy().getOzoneManagerClient();
 
     // create sample volume.
     omClient.createVolume(
@@ -139,102 +115,78 @@ public class TestOMBucketLayoutUpgrade {
             .build());
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
-  @After
-  public void shutdown() {
+  @AfterAll
+  void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
     }
   }
 
-  /**
-   * Tests that OM blocks all requests to create any buckets with a new bucket
-   * layout.
-   *
-   * @throws Exception
-   */
   @Test
-  public void testCreateBucketWithBucketLayoutsDuringUpgrade()
-      throws Exception {
-    // Assert OM layout version is 'fromLayoutVersion' on deploy.
+  @Order(PRE_UPGRADE)
+  void omLayoutBeforeUpgrade() throws IOException {
     assertEquals(fromLayoutVersion,
         ozoneManager.getVersionManager().getMetadataLayoutVersion());
     assertNull(ozoneManager.getMetadataManager().getMetaTable()
         .get(LAYOUT_VERSION_KEY));
-
-    // Test bucket creation with new bucket layouts.
-    // FSO and OBS bucket creation should fail.
-    verifyBucketCreationBlockedWithNewLayouts();
-
-    // Bucket creation with LEGACY layout should succeed in Pre-Finalized state.
-    LOG.info("Creating legacy bucket during Pre-Finalize");
-    verifyBucketCreationWithLayout(new BucketLayout[]{BucketLayout.LEGACY});
-
-    // Finalize the cluster upgrade.
-    finalizeUpgrade();
-
-    // Cluster upgrade is now complete,
-    // Bucket creation should now succeed with all layouts.
-    verifyBucketCreationWithLayout(new BucketLayout[]{
-        BucketLayout.LEGACY,
-        BucketLayout.FILE_SYSTEM_OPTIMIZED,
-        BucketLayout.OBJECT_STORE
-    });
-  }
-
-
-  /**
-   * Tests that OM allows bucket creation with given bucket layouts.
-   *
-   * @param bucketLayouts bucket layouts to test
-   * @throws Exception if any
-   */
-  private void verifyBucketCreationWithLayout(BucketLayout[] bucketLayouts)
-      throws Exception {
-    String bucketName;
-    for (BucketLayout layout : bucketLayouts) {
-      LOG.info("Creating bucket with layout {} after OM finalization", layout);
-
-      bucketName = createBucketWithLayout(layout);
-
-      // Make sure the bucket exists in the bucket table with the
-      // expected layout.
-      assertEquals(
-          omClient.getBucketInfo(VOLUME_NAME, bucketName).getBucketName(),
-          bucketName);
-      assertEquals(
-          omClient.getBucketInfo(VOLUME_NAME, bucketName).getBucketLayout(),
-          layout);
-    }
   }
 
   /**
    * Tests that OM blocks all requests to create any buckets with a new bucket
    * layout.
-   *
-   * @throws Exception if any
    */
-  private void verifyBucketCreationBlockedWithNewLayouts() throws Exception {
-    BucketLayout[] bucketLayouts = new BucketLayout[]{
-        BucketLayout.OBJECT_STORE,
-        BucketLayout.FILE_SYSTEM_OPTIMIZED,
-    };
+  @Order(PRE_UPGRADE)
+  @ParameterizedTest
+  @MethodSource("layoutsNotAllowedBeforeUpgrade")
+  void blocksNewLayoutBeforeUpgrade(BucketLayout layout) {
+    OMException e = assertThrows(OMException.class,
+        () -> createBucketWithLayout(layout));
+    assertEquals(NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION, e.getResult());
+  }
 
-    for (BucketLayout layout : bucketLayouts) {
-      try {
-        LOG.info("Creating bucket with layout {} during Pre-Finalize", layout);
-        createBucketWithLayout(layout);
-        fail("Expected to fail creating bucket with layout " + layout);
-      } catch (OMException e) {
-        // Expected exception.
-        assertEquals(
-            OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION,
-            e.getResult());
-      }
-    }
+  @Order(PRE_UPGRADE)
+  @Test
+  void allowsLegacyBucketBeforeUpgrade() throws Exception {
+    assertCreateBucketWithLayout(BucketLayout.LEGACY);
+  }
+
+  /**
+   * Complete the cluster upgrade.
+   */
+  @Test
+  @Order(DURING_UPGRADE)
+  void finalizeUpgrade() throws Exception {
+    UpgradeFinalizer.StatusAndMessages response =
+        omClient.finalizeUpgrade("finalize-test");
+    System.out.println("Finalization Messages : " + response.msgs());
+
+    waitForFinalization(omClient);
+
+    final String expectedVersion = String.valueOf(maxLayoutVersion());
+    LambdaTestUtils.await(30000, 3000,
+        () -> expectedVersion.equals(
+            ozoneManager.getMetadataManager().getMetaTable()
+                .get(LAYOUT_VERSION_KEY)));
+  }
+
+  @Order(POST_UPGRADE)
+  @ParameterizedTest
+  @EnumSource
+  void allowsBucketCreationWithAnyLayoutAfterUpgrade(BucketLayout layout)
+      throws Exception {
+    assertCreateBucketWithLayout(layout);
+  }
+
+  private void assertCreateBucketWithLayout(BucketLayout layout)
+      throws Exception {
+    String bucketName = createBucketWithLayout(layout);
+
+    // Make sure the bucket exists in the bucket table with the
+    // expected layout.
+    OmBucketInfo bucketInfo = omClient.getBucketInfo(VOLUME_NAME, bucketName);
+    assertEquals(bucketName, bucketInfo.getBucketName());
+    assertEquals(layout, bucketInfo.getBucketLayout());
   }
 
   /**
@@ -257,22 +209,7 @@ public class TestOMBucketLayoutUpgrade {
     return bucketName;
   }
 
-  /**
-   * Complete the cluster upgrade.
-   *
-   * @throws Exception if upgrade fails.
-   */
-  private void finalizeUpgrade() throws Exception {
-    UpgradeFinalizer.StatusAndMessages response =
-        omClient.finalizeUpgrade("finalize-test");
-    System.out.println("Finalization Messages : " + response.msgs());
-
-    waitForFinalization(omClient);
-
-    LambdaTestUtils.await(30000, 3000, () -> {
-      String lvString = ozoneManager.getMetadataManager().getMetaTable()
-          .get(LAYOUT_VERSION_KEY);
-      return maxLayoutVersion() == Integer.parseInt(lvString);
-    });
+  private static Set<BucketLayout> layoutsNotAllowedBeforeUpgrade() {
+    return EnumSet.complementOf(EnumSet.of(BucketLayout.LEGACY));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate the following test classes to JUnit5.

```
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestSecureOzoneContainer.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerMetadataScannerIntegration.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestOnDemandContainerDataScannerIntegration.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMBucketLayoutUpgrade.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
```

 * Let `MiniOzoneCluster` be `AutoCloseable` so it can be used in `try-with-resources` or close via `IOUtils.closeQuietly`
 * Removed one test case from `TestOMUpgradeFinalization`, because `TestOMBucketLayoutUpgrade` tests the same and more
 * Split the only test in `TestOMBucketLayoutUpgrade` into several smaller ones, executed on the same cluster
 * `TestOzoneContainerWithTLS#testCertificateLifetime` does not need to be parameterized (hence one less test run in that class)
 * `TestReadRetries` has been running twice with the same parameter value, since `OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT` is FSO

Before:

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.501 s - in org.apache.hadoop.fs.ozone.TestOzoneFSBucketLayout
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 24.47 s -- in org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientWithKeyLatestVersion
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 52.92 s -- in org.apache.hadoop.ozone.client.rpc.TestReadRetries
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 42.82 s -- in org.apache.hadoop.ozone.client.rpc.read.TestChunkInputStream
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 188.5 s -- in org.apache.hadoop.ozone.client.rpc.read.TestKeyInputStream
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 218.542 s - in org.apache.hadoop.ozone.container.TestContainerReplication
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 43.821 s - in org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainerWithTLS
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.952 s - in org.apache.hadoop.ozone.container.ozoneimpl.TestSecureOzoneContainer
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 71.799 s - in org.apache.hadoop.ozone.dn.scanner.TestBackgroundContainerDataScannerIntegration
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 42.873 s - in org.apache.hadoop.ozone.dn.scanner.TestOnDemandContainerDataScannerIntegration
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 50.591 s - in org.apache.hadoop.ozone.dn.scanner.TestBackgroundContainerMetadataScannerIntegration
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 132.022 s - in org.apache.hadoop.ozone.dn.volume.TestDatanodeHddsVolumeFailureDetection
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.451 s - in org.apache.hadoop.ozone.om.TestOMBucketLayoutUpgrade
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 107.155 s - in org.apache.hadoop.ozone.om.TestOMUpgradeFinalization
```

After:

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.38 s -- in org.apache.hadoop.fs.ozone.TestOzoneFSBucketLayout
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.77 s -- in org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientWithKeyLatestVersion
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 28.75 s -- in org.apache.hadoop.ozone.client.rpc.TestReadRetries
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.53 s -- in org.apache.hadoop.ozone.client.rpc.read.TestChunkInputStream
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 150.7 s -- in org.apache.hadoop.ozone.client.rpc.read.TestKeyInputStream
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 188.7 s -- in org.apache.hadoop.ozone.container.TestContainerReplication
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 46.04 s -- in org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainerWithTLS
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 16.00 s -- in org.apache.hadoop.ozone.container.ozoneimpl.TestSecureOzoneContainer
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 70.75 s -- in org.apache.hadoop.ozone.dn.scanner.TestBackgroundContainerDataScannerIntegration
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.23 s -- in org.apache.hadoop.ozone.dn.scanner.TestOnDemandContainerDataScannerIntegration
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 49.96 s -- in org.apache.hadoop.ozone.dn.scanner.TestBackgroundContainerMetadataScannerIntegration
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 122.1 s -- in org.apache.hadoop.ozone.dn.volume.TestDatanodeHddsVolumeFailureDetection
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.12 s -- in org.apache.hadoop.ozone.om.TestOMBucketLayoutUpgrade
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.24 s -- in org.apache.hadoop.ozone.om.TestOMUpgradeFinalization
```

https://issues.apache.org/jira/browse/HDDS-9504

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7004821430