### PR TITLE
HDDS-9773. Fix to run TestOmSnapshotFileSystem in CI workflow

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
@@ -271,7 +271,7 @@ public abstract class TestOmSnapshotFileSystem {
     deleteSnapshot(snapshotName);
     String expectedMessage = String.format("Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName);
+        VOLUME_NAME, bucketName, snapshotName);
     OMException exception = assertThrows(OMException.class,
         () -> ozoneBucket.listKeys(keyPrefix + "a/", null));
     assertEquals(expectedMessage, exception.getMessage());
@@ -491,21 +491,21 @@ public abstract class TestOmSnapshotFileSystem {
         () -> fs.listStatus(snapshotRoot1));
     assertEquals(String.format("Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName1), exception1.getMessage());
+        VOLUME_NAME, bucketName, snapshotName1), exception1.getMessage());
 
     deleteSnapshot(snapshotName2);
     FileNotFoundException exception2 = assertThrows(FileNotFoundException.class,
         () -> fs.listStatus(snapshotRoot2));
     assertEquals(String.format("Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName2), exception2.getMessage());
+        VOLUME_NAME, bucketName, snapshotName2), exception2.getMessage());
 
     deleteSnapshot(snapshotName3);
     FileNotFoundException exception3 = assertThrows(FileNotFoundException.class,
         () -> fs.listStatus(snapshotParent3));
     assertEquals(String.format("Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName3), exception3.getMessage());
+        VOLUME_NAME, bucketName, snapshotName3), exception3.getMessage());
   }
 
   @Test
@@ -540,7 +540,7 @@ public abstract class TestOmSnapshotFileSystem {
         () -> fs.listStatus(snapshotParent));
     assertEquals(String.format("Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName), exception.getMessage());
+        VOLUME_NAME, bucketName, snapshotName), exception.getMessage());
   }
 
   @Test
@@ -576,7 +576,7 @@ public abstract class TestOmSnapshotFileSystem {
         () -> fs.listStatus(snapshotParent));
     assertEquals(String.format("Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName), exception.getMessage());
+        VOLUME_NAME, bucketName, snapshotName), exception.getMessage());
   }
 
   @Test
@@ -619,7 +619,7 @@ public abstract class TestOmSnapshotFileSystem {
         () -> fs.open(fileInSnapshot));
     assertEquals(String.format("FILE_NOT_FOUND: Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName), exception.getMessage());
+        VOLUME_NAME, bucketName, snapshotName), exception.getMessage());
   }
 
   private void createAndCommitKey(String keyName) throws IOException {
@@ -668,7 +668,7 @@ public abstract class TestOmSnapshotFileSystem {
         () -> fs.listStatus(snapshotRoot));
     assertEquals(String.format("Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName), exception.getMessage());
+        VOLUME_NAME, bucketName, snapshotName), exception.getMessage());
   }
 
   /**
@@ -725,7 +725,7 @@ public abstract class TestOmSnapshotFileSystem {
         () -> fs.listStatus(snapshotRoot));
     assertEquals(String.format("Unable to load snapshot. " +
             "Snapshot with table key '/%s/%s/%s' is no longer active",
-        volumeName, bucketName, snapshotName), exception.getMessage());
+        VOLUME_NAME, bucketName, snapshotName), exception.getMessage());
   }
 
   private String createSnapshot(String snapshotName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystem.java
@@ -90,10 +90,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * OmSnapshot file system tests.
+ * Abstract class for OmSnapshot file system tests.
  */
 @Timeout(120)
 public abstract class TestOmSnapshotFileSystem {
+  protected static final String VOLUME_NAME =
+      "volume" + RandomStringUtils.randomNumeric(5);
+  protected static final String BUCKET_NAME_FSO =
+      "bucket-fso-" + RandomStringUtils.randomNumeric(5);
+  protected static final String BUCKET_NAME_LEGACY =
+      "bucket-legacy-" + RandomStringUtils.randomNumeric(5);
+
   private static MiniOzoneCluster cluster = null;
   private static OzoneClient client;
   private static ObjectStore objectStore;
@@ -101,9 +108,6 @@ public abstract class TestOmSnapshotFileSystem {
   private static OzoneManagerProtocol writeClient;
   private static OzoneManager ozoneManager;
   private static String keyPrefix;
-  private static String volumeName;
-  private static String bucketNameFso;
-  private static String bucketNameLegacy;
   private final String bucketName;
   private FileSystem fs;
   private OzoneFileSystem o3fs;
@@ -113,26 +117,6 @@ public abstract class TestOmSnapshotFileSystem {
 
   public TestOmSnapshotFileSystem(String bucketName) {
     this.bucketName = bucketName;
-  }
-
-  /**
-   * OmSnapshot file system tests for FSO.
-   */
-  public static class TestOmSnapshotFileSystemFso
-      extends TestOmSnapshotFileSystem {
-    TestOmSnapshotFileSystemFso() {
-      super(bucketNameFso);
-    }
-  }
-
-  /**
-   * OmSnapshot file system tests for Legacy.
-   */
-  public static class TestOmSnapshotFileSystemLegacy
-      extends TestOmSnapshotFileSystem {
-    TestOmSnapshotFileSystemLegacy() {
-      super(bucketNameLegacy);
-    }
   }
 
   @BeforeAll
@@ -151,17 +135,13 @@ public abstract class TestOmSnapshotFileSystem {
     writeClient = objectStore.getClientProxy().getOzoneManagerClient();
     ozoneManager = cluster.getOzoneManager();
 
-    volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    bucketNameFso = "bucket-fso-" + RandomStringUtils.randomNumeric(5);
-    bucketNameLegacy = "bucket-legacy-" + RandomStringUtils.randomNumeric(5);
-
-    TestDataUtil.createVolume(client, volumeName);
-    TestDataUtil.createBucket(client, volumeName,
+    TestDataUtil.createVolume(client, VOLUME_NAME);
+    TestDataUtil.createBucket(client, VOLUME_NAME,
         new BucketArgs.Builder().setBucketLayout(FILE_SYSTEM_OPTIMIZED).build(),
-        bucketNameFso);
-    TestDataUtil.createBucket(client, volumeName,
+        BUCKET_NAME_FSO);
+    TestDataUtil.createBucket(client, VOLUME_NAME,
         new BucketArgs.Builder().setBucketLayout(LEGACY).build(),
-        bucketNameLegacy);
+        BUCKET_NAME_LEGACY);
 
     // stop the deletion services so that keys can still be read
     KeyManagerImpl keyManager = (KeyManagerImpl) ozoneManager.getKeyManager();
@@ -171,7 +151,7 @@ public abstract class TestOmSnapshotFileSystem {
   @BeforeEach
   public void setupFsClient() throws IOException {
     String rootPath = String.format("%s://%s.%s/",
-        OzoneConsts.OZONE_URI_SCHEME, bucketName, volumeName);
+        OzoneConsts.OZONE_URI_SCHEME, bucketName, VOLUME_NAME);
     // Set the fs.defaultFS and start the filesystem
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
     // Set the number of keys to be processed during batch operate.
@@ -223,8 +203,8 @@ public abstract class TestOmSnapshotFileSystem {
   @Test
   // based on TestObjectStoreWithFSO:testListKeysAtDifferentLevels
   public void testListKeysAtDifferentLevels() throws Exception {
-    OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertEquals(ozoneVolume.getName(), volumeName);
+    OzoneVolume ozoneVolume = objectStore.getVolume(VOLUME_NAME);
+    assertEquals(ozoneVolume.getName(), VOLUME_NAME);
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
     assertEquals(ozoneBucket.getName(), bucketName);
 
@@ -383,7 +363,7 @@ public abstract class TestOmSnapshotFileSystem {
 
     // Read using filesystem.
     String rootPath = String.format("%s://%s.%s/", OZONE_URI_SCHEME,
-        bucketName, volumeName);
+        bucketName, VOLUME_NAME);
     OzoneFileSystem o3fsNew = (OzoneFileSystem) FileSystem
         .get(new URI(rootPath), conf);
     FSDataInputStream fsDataInputStream = o3fsNew.open(new Path(key));
@@ -643,7 +623,7 @@ public abstract class TestOmSnapshotFileSystem {
   }
 
   private void createAndCommitKey(String keyName) throws IOException {
-    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(VOLUME_NAME)
         .setBucketName(bucketName).setKeyName(keyName)
         .setAcls(Collections.emptyList())
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
@@ -752,12 +732,12 @@ public abstract class TestOmSnapshotFileSystem {
       throws IOException, InterruptedException, TimeoutException {
 
     // create snapshot
-    writeClient.createSnapshot(volumeName, bucketName, snapshotName);
+    writeClient.createSnapshot(VOLUME_NAME, bucketName, snapshotName);
 
     // wait till the snapshot directory exists
     SnapshotInfo snapshotInfo = ozoneManager.getMetadataManager()
         .getSnapshotInfoTable()
-        .get(SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName));
+        .get(SnapshotInfo.getTableKey(VOLUME_NAME, bucketName, snapshotName));
     String snapshotDirName = getSnapshotPath(conf, snapshotInfo) +
         OM_KEY_PREFIX + "CURRENT";
     GenericTestUtils.waitFor(() -> new File(snapshotDirName).exists(),
@@ -767,6 +747,6 @@ public abstract class TestOmSnapshotFileSystem {
   }
 
   private void deleteSnapshot(String snapshotName) throws IOException {
-    writeClient.deleteSnapshot(volumeName, bucketName, snapshotName);
+    writeClient.deleteSnapshot(VOLUME_NAME, bucketName, snapshotName);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystemFso.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystemFso.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * OmSnapshot file system tests for FSO.
+ */
+@Timeout(120)
+public class TestOmSnapshotFileSystemFso extends TestOmSnapshotFileSystem {
+  TestOmSnapshotFileSystemFso() {
+    super(BUCKET_NAME_FSO);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystemLegacy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotFileSystemLegacy.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * OmSnapshot file system tests for Legacy.
+ */
+@Timeout(120)
+public class TestOmSnapshotFileSystemLegacy extends TestOmSnapshotFileSystem {
+  TestOmSnapshotFileSystemLegacy() {
+    super(BUCKET_NAME_LEGACY);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
[HDDS-8201](https://issues.apache.org/jira/browse/HDDS-8201) migrated parameterized JUnit4 TestOmSnapshotFileSystem to JUnit5 by creating two subclasses. These are not executed, unless explicitly specified by -Dtest.

This change is to convert the nested subclasses TestOmSnapshotFileSystemFso and TestOmSnapshotFileSystemLegacy to top-level so that they run in CI workflow.

Note: I thought about creating buckets in @BeforeAll but FileSystem is setup based on bucket name. If create bucket in @BeforeAll we have to create and clean up two FileSystem clients. I think having subclasses is cleaner approach so implemented that.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9773

## How was this patch tested?
Verified that TestOmSnapshotFileSystemFso and TestOmSnapshotFileSystemLegacy ran in forkCI run: https://github.com/hemantk-12/ozone/actions/runs/7009458897/job/19068867657
