### PR TITLE
HDDS-9783. Unregister MBean after test execution in TestAbstractLayoutVersionManager.

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.Iterator;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -48,6 +49,11 @@ public class TestAbstractLayoutVersionManager {
   @BeforeEach
   public void setup() {
     MockitoAnnotations.initMocks(this);
+  }
+
+  @AfterEach
+  public void close() {
+    versionManager.close();
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
We should unregister MBean after test execution in `TestAbstractLayoutVersionManager`.
Not unregistering causes exception in the next test execution
```
2023-11-28 12:09:32,486 [main] INFO  upgrade.AbstractLayoutVersionManager (AbstractLayoutVersionManager.java:init(83)) - Initializing Layout version manager with metadata layout = org.apache.hadoop.ozone.upgrade.TestAbstractLayoutVersionManager$1@1e097d59 (version = 2), software layout = org.apache.hadoop.ozone.upgrade.TestAbstractLayoutVersionManager$1@1e097d59 (version = 2)
2023-11-28 12:09:32,487 [main] WARN  util.MBeans (MBeans.java:getMBeanName(167)) - Error creating MBean object name: Hadoop:service=LayoutVersionManager,name=AbstractLayoutVersionManager$MockitoMock$718765086
org.apache.hadoop.metrics2.MetricsException: org.apache.hadoop.metrics2.MetricsException: Hadoop:service=LayoutVersionManager,name=AbstractLayoutVersionManager$MockitoMock$718765086 already exists!
    at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.newObjectName(DefaultMetricsSystem.java:135)
    at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.newMBeanName(DefaultMetricsSystem.java:110)
    at org.apache.hadoop.metrics2.util.MBeans.getMBeanName(MBeans.java:165)
    at org.apache.hadoop.metrics2.util.MBeans.register(MBeans.java:97)
    at org.apache.hadoop.metrics2.util.MBeans.register(MBeans.java:73)
    at org.apache.hadoop.ozone.upgrade.AbstractLayoutVersionManager.init(AbstractLayoutVersionManager.java:88)
    ... 
    at org.mockito.Answers.answer(Answers.java:98)
    ...
    at org.apache.hadoop.ozone.upgrade.AbstractLayoutVersionManager$MockitoMock$718765086.init(Unknown Source)
    at org.apache.hadoop.ozone.upgrade.TestAbstractLayoutVersionManager.testInitializationWithUpToDateMetadataVersion(TestAbstractLayoutVersionManager.java:73)
    ...
    at java.util.ArrayList.forEach(ArrayList.java:1257)
    ...
    at java.util.ArrayList.forEach(ArrayList.java:1257)
    ...
Caused by: org.apache.hadoop.metrics2.MetricsException: Hadoop:service=LayoutVersionManager,name=AbstractLayoutVersionManager$MockitoMock$718765086 already exists!
    at org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.newObjectName(DefaultMetricsSystem.java:131)
    ... 
89 more
```

This PR adds `close` call at the end to the tests where MBean is initialized.


## What is the link to the Apache JIRA
HDDS-9783

## How was this patch tested?
Ran the unit test locally to make sure that the exception trace is not getting printed.
