### PR TITLE
HDDS-9747. Incorrect sorting order for all unhealthy replicas in RatisOverReplicationHandler

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
@@ -231,7 +231,7 @@ public class RatisOverReplicationHandler
       // prefer deleting replicas with lower sequence IDs
       return replicas.stream()
           .sorted(Comparator.comparingLong(ContainerReplica::getSequenceId)
-              .reversed())
+              .thenComparing(ContainerReplica::hashCode))
           .collect(Collectors.toList());
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -253,7 +252,7 @@ public class TestRatisOverReplicationHandler {
         getOverReplicatedHealthResult(), 1);
     Pair<DatanodeDetails, SCMCommand<?>> commandPair
         = commands.iterator().next();
-    Assert.assertEquals(shouldDelete.getDatanodeDetails(),
+    assertEquals(shouldDelete.getDatanodeDetails(),
         commandPair.getKey());
   }
 
@@ -274,7 +273,7 @@ public class TestRatisOverReplicationHandler {
             getOverReplicatedHealthResult(), 1);
     Pair<DatanodeDetails, SCMCommand<?>> commandPair
         = commands.iterator().next();
-    Assert.assertEquals(lowestSequenceIDReplica.getDatanodeDetails(),
+    assertEquals(lowestSequenceIDReplica.getDatanodeDetails(),
         commandPair.getKey());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -238,7 +238,7 @@ public class TestRatisOverReplicationHandler {
   }
 
   @Test
-  public void testOverReplicatedAllUnhealthyPicksLowestBCSID()
+  public void testOverReplicatedAllUnhealthySameBCSID()
       throws IOException {
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         ContainerReplicaProto.State.UNHEALTHY, 0, 0, 0, 0);
@@ -257,7 +257,7 @@ public class TestRatisOverReplicationHandler {
   }
 
   @Test
-  public void testOverReplicatedAllUnhealthySameBCSID()
+  public void testOverReplicatedAllUnhealthyPicksLowestBCSID()
       throws IOException {
     final long sequenceID = 20;
     Set<ContainerReplica> replicas = new HashSet<>();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -44,6 +45,7 @@ import org.slf4j.event.Level;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -234,6 +236,46 @@ public class TestRatisOverReplicationHandler {
 
     testProcessing(replicas, Collections.emptyList(),
         getOverReplicatedHealthResult(), 0);
+  }
+
+  @Test
+  public void testOverReplicatedAllUnhealthyPicksLowestBCSID()
+      throws IOException {
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(),
+        ContainerReplicaProto.State.UNHEALTHY, 0, 0, 0, 0);
+
+    ContainerReplica shouldDelete = replicas.stream()
+        .sorted(Comparator.comparingLong(ContainerReplica::hashCode))
+        .findFirst().get();
+
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
+        testProcessing(replicas, Collections.emptyList(),
+        getOverReplicatedHealthResult(), 1);
+    Pair<DatanodeDetails, SCMCommand<?>> commandPair
+        = commands.iterator().next();
+    Assert.assertEquals(shouldDelete.getDatanodeDetails(),
+        commandPair.getKey());
+  }
+
+  @Test
+  public void testOverReplicatedAllUnhealthySameBCSID()
+      throws IOException {
+    final long sequenceID = 20;
+    Set<ContainerReplica> replicas = new HashSet<>();
+    ContainerReplica lowestSequenceIDReplica = createContainerReplica(
+        container.containerID(), 0, IN_SERVICE, State.UNHEALTHY, sequenceID);
+    replicas.add(lowestSequenceIDReplica);
+    for (int i = 1; i < 4; i++) {
+      replicas.add(createContainerReplica(container.containerID(), 0,
+          IN_SERVICE, State.UNHEALTHY, sequenceID + i));
+    }
+    Set<Pair<DatanodeDetails, SCMCommand<?>>> commands =
+        testProcessing(replicas, Collections.emptyList(),
+            getOverReplicatedHealthResult(), 1);
+    Pair<DatanodeDetails, SCMCommand<?>> commandPair
+        = commands.iterator().next();
+    Assert.assertEquals(lowestSequenceIDReplica.getDatanodeDetails(),
+        commandPair.getKey());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
    if (allUnhealthy) {
      // prefer deleting replicas with lower sequence IDs
      return replicas.stream()
          .sorted(Comparator.comparingLong(ContainerReplica::getSequenceId)
              .reversed())
          .collect(Collectors.toList());
    }
```

This should actually be the opposite, allowing lower sequence IDs to be deleted first. If all sequence IDs are the same, we should have a secondary sort based on the containerReplica hashCode, which is already used for healthy replicas.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9747

## How was this patch tested?

New unit tests added to reproduce the issue and validate the fix.