### PR TITLE
HDDS-9772. Avoid recreating typesafe config objects unnecessarily

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -162,6 +162,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     this.conf = conf;
     Objects.requireNonNull(dd, "id == null");
     datanodeDetails = dd;
+    ratisServerConfig = conf.getObject(DatanodeRatisServerConfig.class);
     assignPorts();
     this.streamEnable = conf.getBoolean(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_ENABLED,
@@ -173,7 +174,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     this.raftPeerId = RatisHelper.toRaftPeerId(dd);
     String threadNamePrefix = datanodeDetails.threadNamePrefix();
     chunkExecutors = createChunkExecutors(conf, threadNamePrefix);
-    ratisServerConfig = conf.getObject(DatanodeRatisServerConfig.class);
     nodeFailureTimeoutMs = ratisServerConfig.getFollowerSlownessTimeout();
     shouldDeleteRatisLogDirectory =
         ratisServerConfig.shouldDeleteRatisLogDirectory();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -94,7 +94,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
     this.failoverProxyProvider = proxyProvider;
     this.rpcProxy = (ScmBlockLocationProtocolPB) RetryProxy.create(
         ScmBlockLocationProtocolPB.class, failoverProxyProvider,
-        failoverProxyProvider.getSCMBlockLocationRetryPolicy(null));
+        failoverProxyProvider.getSCMBlockLocationRetryPolicy());
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -56,6 +56,7 @@ public class SCMBlockLocationFailoverProxyProvider implements
     FailoverProxyProvider<ScmBlockLocationProtocolPB>, Closeable {
   public static final Logger LOG =
       LoggerFactory.getLogger(SCMBlockLocationFailoverProxyProvider.class);
+  private final SCMClientConfig scmClientConfig;
 
   private Map<String, ProxyInfo<ScmBlockLocationProtocolPB>> scmProxies;
   private Map<String, SCMProxyInfo> scmProxyInfoMap;
@@ -107,9 +108,9 @@ public class SCMBlockLocationFailoverProxyProvider implements
     this.currentProxyIndex = 0;
     currentProxySCMNodeId = scmNodeIds.get(currentProxyIndex);
 
-    SCMClientConfig config = conf.getObject(SCMClientConfig.class);
-    this.maxRetryCount = config.getRetryCount();
-    this.retryInterval = config.getRetryInterval();
+    scmClientConfig = conf.getObject(SCMClientConfig.class);
+    this.maxRetryCount = scmClientConfig.getRetryCount();
+    this.retryInterval = scmClientConfig.getRetryInterval();
 
     LOG.info("Created block location fail-over proxy with {} nodes: {}",
         scmNodeIds.size(), scmProxyInfoMap.values());
@@ -269,7 +270,7 @@ public class SCMBlockLocationFailoverProxyProvider implements
     return RPC.getProtocolProxy(ScmBlockLocationProtocolPB.class, scmVersion,
         scmAddress, ugi, hadoopConf,
         NetUtils.getDefaultSocketFactory(hadoopConf),
-        (int)conf.getObject(SCMClientConfig.class).getRpcTimeOut(),
+        (int) scmClientConfig.getRpcTimeOut(),
         connectionRetryPolicy).getProxy();
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -58,8 +58,8 @@ public class SCMBlockLocationFailoverProxyProvider implements
       LoggerFactory.getLogger(SCMBlockLocationFailoverProxyProvider.class);
   private final SCMClientConfig scmClientConfig;
 
-  private Map<String, ProxyInfo<ScmBlockLocationProtocolPB>> scmProxies;
-  private Map<String, SCMProxyInfo> scmProxyInfoMap;
+  private final Map<String, ProxyInfo<ScmBlockLocationProtocolPB>> scmProxies;
+  private final Map<String, SCMProxyInfo> scmProxyInfoMap;
   private List<String> scmNodeIds;
 
   // As SCM Client is shared across threads, performFailOver()
@@ -147,15 +147,15 @@ public class SCMBlockLocationFailoverProxyProvider implements
     nextProxyIndex();
   }
 
-  @VisibleForTesting
-  public synchronized String getCurrentProxySCMNodeId() {
+  private synchronized String getCurrentProxySCMNodeId() {
     return currentProxySCMNodeId;
   }
 
   @Override
   public synchronized ProxyInfo<ScmBlockLocationProtocolPB> getProxy() {
     String currentProxyNodeId = getCurrentProxySCMNodeId();
-    ProxyInfo currentProxyInfo = scmProxies.get(currentProxyNodeId);
+    ProxyInfo<ScmBlockLocationProtocolPB> currentProxyInfo =
+        scmProxies.get(currentProxyNodeId);
     if (currentProxyInfo == null) {
       currentProxyInfo = createSCMProxy(currentProxyNodeId);
     }
@@ -239,8 +239,8 @@ public class SCMBlockLocationFailoverProxyProvider implements
   /**
    * Creates proxy object.
    */
-  private ProxyInfo createSCMProxy(String nodeId) {
-    ProxyInfo proxyInfo;
+  private ProxyInfo<ScmBlockLocationProtocolPB> createSCMProxy(String nodeId) {
+    ProxyInfo<ScmBlockLocationProtocolPB> proxyInfo;
     SCMProxyInfo scmProxyInfo = scmProxyInfoMap.get(nodeId);
     InetSocketAddress address = scmProxyInfo.getAddress();
     try {
@@ -274,8 +274,8 @@ public class SCMBlockLocationFailoverProxyProvider implements
         connectionRetryPolicy).getProxy();
   }
 
-  public RetryPolicy getSCMBlockLocationRetryPolicy(String newLeader) {
-    RetryPolicy retryPolicy = new RetryPolicy() {
+  public RetryPolicy getSCMBlockLocationRetryPolicy() {
+    return new RetryPolicy() {
       @Override
       public RetryAction shouldRetry(Exception e, int retry,
                                      int failover, boolean b) {
@@ -288,7 +288,6 @@ public class SCMBlockLocationFailoverProxyProvider implements
             getRetryInterval());
       }
     };
-    return retryPolicy;
   }
 
   public synchronized int getCurrentProxyIndex() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
@@ -79,7 +80,7 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
    * @throws IOException
    */
   public BlockManagerImpl(final ConfigurationSource conf,
-                          final StorageContainerManager scm)
+      ScmConfig scmConfig, final StorageContainerManager scm)
       throws IOException {
     Objects.requireNonNull(scm, "SCM cannot be null");
     this.scm = scm;
@@ -108,7 +109,7 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
     blockDeletingService =
         new SCMBlockDeletingService(deletedBlockLog,
             scm.getScmNodeManager(), scm.getEventQueue(), scm.getScmContext(),
-            scm.getSCMServiceManager(), conf,
+            scm.getSCMServiceManager(), conf, scmConfig,
             metrics, scm.getSystemClock(), scm.getReconfigurationHandler());
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -81,8 +81,7 @@ public class SCMBlockDeletingService extends BackgroundService
   private final SCMContext scmContext;
   private final ScmConfig scmConf;
 
-  private int blockDeleteLimitSize;
-  private ScmBlockDeletingServiceMetrics metrics;
+  private final ScmBlockDeletingServiceMetrics metrics;
 
   /**
    * SCMService related variables.
@@ -119,10 +118,9 @@ public class SCMBlockDeletingService extends BackgroundService
     this.scmContext = scmContext;
     this.metrics = metrics;
     scmConf = scmConfig;
-    reconfigurationHandler.register(scmConf);
-    blockDeleteLimitSize = scmConf.getBlockDeletionLimit();
-    Preconditions.checkArgument(blockDeleteLimitSize > 0,
+    Preconditions.checkArgument(scmConf.getBlockDeletionLimit() > 0,
         "Block deletion limit should be positive.");
+    reconfigurationHandler.register(scmConf);
 
     // register SCMBlockDeletingService to SCMServiceManager
     serviceManager.register(this);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -99,11 +99,10 @@ public class SCMBlockDeletingService extends BackgroundService
              NodeManager nodeManager, EventPublisher eventPublisher,
              SCMContext scmContext, SCMServiceManager serviceManager,
              ConfigurationSource conf,
-             ScmBlockDeletingServiceMetrics metrics,
+      ScmConfig scmConfig, ScmBlockDeletingServiceMetrics metrics,
              Clock clock, ReconfigurationHandler reconfigurationHandler) {
     super("SCMBlockDeletingService",
-        conf.getObject(ScmConfig.class)
-            .getBlockDeletionInterval().toMillis(),
+        scmConfig.getBlockDeletionInterval().toMillis(),
         TimeUnit.MILLISECONDS, BLOCK_DELETING_SERVICE_CORE_POOL_SIZE,
         conf.getTimeDuration(OZONE_BLOCK_DELETING_SERVICE_TIMEOUT,
             OZONE_BLOCK_DELETING_SERVICE_TIMEOUT_DEFAULT,
@@ -119,7 +118,7 @@ public class SCMBlockDeletingService extends BackgroundService
     this.eventPublisher = eventPublisher;
     this.scmContext = scmContext;
     this.metrics = metrics;
-    scmConf = conf.getObject(ScmConfig.class);
+    scmConf = scmConfig;
     reconfigurationHandler.register(scmConf);
     blockDeleteLimitSize = scmConf.getBlockDeletionLimit();
     Preconditions.checkArgument(blockDeleteLimitSize > 0,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -788,7 +788,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     if (configurator.getScmBlockManager() != null) {
       scmBlockManager = configurator.getScmBlockManager();
     } else {
-      scmBlockManager = new BlockManagerImpl(conf, this);
+      scmBlockManager = new BlockManagerImpl(conf, scmConfig, this);
     }
     if (configurator.getReplicationManager() != null) {
       replicationManager = configurator.getReplicationManager();


### PR DESCRIPTION
## What changes were proposed in this pull request?

`XceiverServerRatis` creates `DatanodeRatisServerConfig` repeatedly for accessing individual properties.  It should create it only once and reuse.

Some other similar usage patterns are also fixed.

Ideally we should strive to pass these objects from fewer places, but that change would affect many classes, and cause conflict in other tasks in-progress.  Hence this change is limited in scope.

https://issues.apache.org/jira/browse/HDDS-9772

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7019067260