### PR TITLE
HDDS-9675. Eliminate unnecessary stream in SCMBlockProtocolServer#sortDatanodes

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopology.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopology.java
@@ -244,6 +244,6 @@ public interface NetworkTopology {
    * or shuffled input nodes otherwise. The size of returned list is limited
    * by activeLen parameter.
    */
-  List<? extends Node> sortByDistanceCost(Node reader,
-      List<? extends Node> nodes, int activeLen);
+  <N extends Node> List<N> sortByDistanceCost(Node reader,
+      List<N> nodes, int activeLen);
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -790,12 +790,8 @@ public class NetworkTopologyImpl implements NetworkTopology {
     for (int i = 0; i < activeLen; i++) {
       int cost = costs[i];
       N node = nodes.get(i);
-      List<N> list = tree.get(cost);
-      if (list == null) {
-        list = Lists.newArrayListWithExpectedSize(1);
-        tree.put(cost, list);
-      }
-      list.add(node);
+      tree.computeIfAbsent(cost, k -> Lists.newArrayListWithExpectedSize(1))
+          .add(node);
     }
 
     List<N> ret = new ArrayList<>();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -62,7 +62,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
   /** The algorithm to randomize nodes with equal distances. */
   private final Consumer<List<? extends Node>> shuffleOperation;
   /** Lock to coordinate cluster tree access. */
-  private ReadWriteLock netlock = new ReentrantReadWriteLock(true);
+  private final ReadWriteLock netlock = new ReentrantReadWriteLock(true);
 
   public NetworkTopologyImpl(ConfigurationSource conf) {
     schemaManager = NodeSchemaManager.getInstance();
@@ -137,7 +137,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
   @Override
   public void update(Node oldNode, Node newNode) {
     Preconditions.checkArgument(newNode != null, "newNode cannot be null");
-    if (oldNode != null && oldNode instanceof InnerNode) {
+    if (oldNode instanceof InnerNode) {
       throw new IllegalArgumentException(
               "Not allowed to update an inner node: "
                       + oldNode.getNetworkFullPath());
@@ -226,10 +226,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
     while (parent != null && parent != clusterTree) {
       parent = parent.getParent();
     }
-    if (parent == clusterTree) {
-      return true;
-    }
-    return false;
+    return parent == clusterTree;
   }
 
   /**
@@ -385,7 +382,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
       scope = ROOT;
     }
     if (scope.startsWith(SCOPE_REVERSE_STR)) {
-      ArrayList<String> excludedScopes = new ArrayList();
+      ArrayList<String> excludedScopes = new ArrayList<>();
       excludedScopes.add(scope.substring(1));
       return chooseRandom(ROOT, excludedScopes, null, null,
           ANCESTOR_GENERATION_DEFAULT);
@@ -426,7 +423,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
       scope = ROOT;
     }
     if (scope.startsWith(SCOPE_REVERSE_STR)) {
-      ArrayList<String> excludedScopes = new ArrayList();
+      ArrayList<String> excludedScopes = new ArrayList<>();
       excludedScopes.add(scope.substring(1));
       return chooseRandom(ROOT, excludedScopes, excludedNodes, null,
           ANCESTOR_GENERATION_DEFAULT);
@@ -461,7 +458,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
       scope = ROOT;
     }
     if (scope.startsWith(SCOPE_REVERSE_STR)) {
-      ArrayList<String> excludedScopes = new ArrayList();
+      ArrayList<String> excludedScopes = new ArrayList<>();
       excludedScopes.add(scope.substring(1));
       return chooseRandom(ROOT, excludedScopes, excludedNodes, null,
           ancestorGen);
@@ -799,9 +796,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
     for (List<N> list : tree.values()) {
       if (list != null) {
         shuffleOperation.accept(list);
-        for (N n : list) {
-          ret.add(n);
-        }
+        ret.addAll(list);
       }
     }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -786,7 +787,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
       costs[i] = getDistanceCost(reader, nodes.get(i));
     }
     // Add cost/node pairs to a TreeMap to sort
-    TreeMap<Integer, List<N>> tree = new TreeMap<>();
+    NavigableMap<Integer, List<N>> tree = new TreeMap<>();
     for (int i = 0; i < activeLen; i++) {
       int cost = costs[i];
       N node = nodes.get(i);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -771,11 +771,11 @@ public class NetworkTopologyImpl implements NetworkTopology {
    * by activeLen parameter.
    */
   @Override
-  public List<? extends Node> sortByDistanceCost(Node reader,
-      List<? extends Node> nodes, int activeLen) {
+  public <N extends Node> List<N> sortByDistanceCost(Node reader,
+      List<N> nodes, int activeLen) {
     // shuffle input list of nodes if reader is not defined
     if (reader == null) {
-      List<? extends Node> shuffledNodes =
+      List<N> shuffledNodes =
           new ArrayList<>(nodes.subList(0, activeLen));
       shuffleOperation.accept(shuffledNodes);
       return shuffledNodes;
@@ -786,11 +786,11 @@ public class NetworkTopologyImpl implements NetworkTopology {
       costs[i] = getDistanceCost(reader, nodes.get(i));
     }
     // Add cost/node pairs to a TreeMap to sort
-    TreeMap<Integer, List<Node>> tree = new TreeMap<Integer, List<Node>>();
+    TreeMap<Integer, List<N>> tree = new TreeMap<>();
     for (int i = 0; i < activeLen; i++) {
       int cost = costs[i];
-      Node node = nodes.get(i);
-      List<Node> list = tree.get(cost);
+      N node = nodes.get(i);
+      List<N> list = tree.get(cost);
       if (list == null) {
         list = Lists.newArrayListWithExpectedSize(1);
         tree.put(cost, list);
@@ -798,11 +798,11 @@ public class NetworkTopologyImpl implements NetworkTopology {
       list.add(node);
     }
 
-    List<Node> ret = new ArrayList<>();
-    for (List<Node> list: tree.values()) {
+    List<N> ret = new ArrayList<>();
+    for (List<N> list : tree.values()) {
       if (list != null) {
         shuffleOperation.accept(list);
-        for (Node n: list) {
+        for (N n : list) {
           ret.add(n);
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -28,7 +28,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -353,17 +352,15 @@ public class SCMBlockProtocolServer implements
       if (client == null) {
         client = getOtherNode(clientMachine);
       }
-      List<Node> nodeList = new ArrayList<>();
+      List<DatanodeDetails> nodeList = new ArrayList<>();
       nodes.forEach(uuid -> {
         DatanodeDetails node = nodeManager.getNodeByUuid(uuid);
         if (node != null) {
           nodeList.add(node);
         }
       });
-      List<? extends Node> sortedNodeList = scm.getClusterMap()
+      return scm.getClusterMap()
           .sortByDistanceCost(client, nodeList, nodeList.size());
-      return sortedNodeList.stream().map(r -> (DatanodeDetails) r).collect(
-          Collectors.toList());
     } catch (Exception ex) {
       auditSuccess = false;
       AUDIT.logReadFailure(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently `SCMBlockProtocolServer#sortDatanodes` has to create a new list just to cast all items (defined as `Node`) to `DatanodeDetails` (which implements `Node`).  This is necessary because `NetworkTopology` defines its return type too loosely.  We can fix that by using method-local type definition.

https://issues.apache.org/jira/browse/HDDS-9675

## How was this patch tested?

Refactoring, covered by existing build/test.

https://github.com/adoroszlai/ozone/actions/runs/7020414682