### PR TITLE
HDDS-9501. Migrate misc. tests in hadoop-ozone to JUnit5

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.Iterator;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -48,6 +49,11 @@ public class TestAbstractLayoutVersionManager {
   @BeforeEach
   public void setup() {
     MockitoAnnotations.initMocks(this);
+  }
+
+  @AfterEach
+  public void close() {
+    versionManager.close();
   }
 
   @Test

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -79,11 +79,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-hadoop-dependency-test</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -27,6 +27,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <description>Apache Ozone Insight Tool</description>
   <name>Apache Ozone Insight Tool</name>
   <packaging>jar</packaging>
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestBaseInsightPoint.java
+++ b/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestBaseInsightPoint.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.ozone.insight;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,14 +42,14 @@ public class TestBaseInsightPoint {
     Map<String, String> filters = new HashMap<>();
     filters.put("datanode", "123");
 
-    Assert.assertTrue(insightPoint
+    Assertions.assertTrue(insightPoint
         .filterLog(filters, "This a log specific to [datanode=123]"));
 
-    Assert.assertFalse(insightPoint
+    Assertions.assertFalse(insightPoint
         .filterLog(filters, "This a log specific to [datanode=234]"));
 
     //with empty filters
-    Assert.assertTrue(insightPoint
+    Assertions.assertTrue(insightPoint
         .filterLog(new HashMap<>(), "This a log specific to [datanode=234]"));
 
     //with multiple filters
@@ -57,14 +57,14 @@ public class TestBaseInsightPoint {
     filters.put("datanode", "123");
     filters.put("pipeline", "abcd");
 
-    Assert.assertFalse(insightPoint
+    Assertions.assertFalse(insightPoint
         .filterLog(filters, "This a log specific to [datanode=123]"));
 
-    Assert.assertTrue(insightPoint
+    Assertions.assertTrue(insightPoint
         .filterLog(filters,
             "This a log specific to [datanode=123] [pipeline=abcd]"));
 
-    Assert.assertFalse(insightPoint
+    Assertions.assertFalse(insightPoint
         .filterLog(filters,
             "This a log specific to [datanode=456] [pipeline=abcd]"));
 

--- a/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestConfigurationSubCommand.java
@@ -27,10 +27,10 @@ import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Test insight report which prints out configs.
@@ -41,12 +41,12 @@ public class TestConfigurationSubCommand {
 
   private final ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     System.setOut(new PrintStream(out, false, StandardCharsets.UTF_8.name()));
   }
 
-  @After
+  @AfterEach
   public void reset() {
     System.setOut(OLD_OUT);
   }
@@ -60,12 +60,12 @@ public class TestConfigurationSubCommand {
     subCommand.printConfig(CustomConfig.class, conf);
 
     final String output = out.toString(StandardCharsets.UTF_8.name());
-    Assert.assertTrue(output.contains(">>> ozone.scm.client.address"));
-    Assert.assertTrue(output.contains("default: localhost"));
-    Assert.assertTrue(output.contains("current: omclient"));
-    Assert.assertTrue(output.contains(">>> ozone.scm.client.secure"));
-    Assert.assertTrue(output.contains("default: true"));
-    Assert.assertTrue(output.contains("current: true"));
+    Assertions.assertTrue(output.contains(">>> ozone.scm.client.address"));
+    Assertions.assertTrue(output.contains("default: localhost"));
+    Assertions.assertTrue(output.contains("current: omclient"));
+    Assertions.assertTrue(output.contains(">>> ozone.scm.client.secure"));
+    Assertions.assertTrue(output.contains("default: true"));
+    Assertions.assertTrue(output.contains("current: true"));
   }
 
   /**

--- a/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestLogSubcommand.java
+++ b/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestLogSubcommand.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.ozone.insight;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testing utility methods of the log subcommand test.
@@ -36,6 +36,6 @@ public class TestLogSubcommand {
             + "storageLocation: \"/tmp/hadoop-neo/dfs/data\"\\n  capacity: "
             + "250438021120\\n  scmUsed: 16384\\n  remaining: 212041244672\\n  "
             + "storageType: DISK\\n  failed: false\\n}\\n</json>");
-    Assert.assertEquals(10, result.split("\n").length);
+    Assertions.assertEquals(10, result.split("\n").length);
   }
 }

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -27,6 +27,9 @@
   <description>Apache Ozone Storage Interface</description>
   <name>Apache Ozone Storage Interface</name>
   <packaging>jar</packaging>
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
   <dependencies>
 
     <dependency>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -67,12 +67,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
   <build>
     <plugins>

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
 import org.apache.hadoop.io.MD5Hash;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
@@ -36,9 +36,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 /**

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfoCodec.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -58,7 +58,7 @@ public class TestOmMultipartKeyInfoCodec
     } catch (java.io.IOException e) {
       e.printStackTrace();
     }
-    Assert.assertNotNull(data);
+    Assertions.assertNotNull(data);
 
     OmMultipartKeyInfo multipartKeyInfo = null;
     try {
@@ -66,7 +66,7 @@ public class TestOmMultipartKeyInfoCodec
     } catch (java.io.IOException e) {
       e.printStackTrace();
     }
-    Assert.assertEquals(omMultipartKeyInfo, multipartKeyInfo);
+    Assertions.assertEquals(omMultipartKeyInfo, multipartKeyInfo);
 
     // When random byte data passed returns null.
     try {

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -91,7 +91,7 @@ public class TestOmPrefixInfo {
         ACCESS);
     OmPrefixInfo clonePrefixInfo = omPrefixInfo.copyObject();
 
-    Assert.assertEquals(omPrefixInfo, clonePrefixInfo);
+    Assertions.assertEquals(omPrefixInfo, clonePrefixInfo);
 
 
     // Change acls and check.
@@ -99,7 +99,7 @@ public class TestOmPrefixInfo {
         IAccessAuthorizer.ACLIdentityType.USER, username,
         IAccessAuthorizer.ACLType.READ, ACCESS));
 
-    Assert.assertNotEquals(omPrefixInfo, clonePrefixInfo);
+    Assertions.assertNotEquals(omPrefixInfo, clonePrefixInfo);
 
   }
 
@@ -116,10 +116,10 @@ public class TestOmPrefixInfo {
 
     OmPrefixInfo ompri = OmPrefixInfo.getFromProtobuf(prefixInfo);
 
-    Assert.assertEquals(prefixInfoPath, ompri.getName());
-    Assert.assertEquals(1, ompri.getMetadata().size());
-    Assert.assertEquals(metaval, ompri.getMetadata().get(metakey));
-    Assert.assertEquals(1, ompri.getAcls().size());
+    Assertions.assertEquals(prefixInfoPath, ompri.getName());
+    Assertions.assertEquals(1, ompri.getMetadata().size());
+    Assertions.assertEquals(metaval, ompri.getMetadata().get(metakey));
+    Assertions.assertEquals(1, ompri.getAcls().size());
   }
 
   @Test
@@ -133,8 +133,8 @@ public class TestOmPrefixInfo {
     omPrefixInfo.getMetadata().put("key", "value");
     OzoneManagerStorageProtos.PersistedPrefixInfo pi =
         omPrefixInfo.getProtobuf();
-    Assert.assertEquals(testPath, pi.getName());
-    Assert.assertEquals(1, pi.getAclsCount());
-    Assert.assertEquals(1, pi.getMetadataCount());
+    Assertions.assertEquals(testPath, pi.getName());
+    Assertions.assertEquals(1, pi.getAclsCount());
+    Assertions.assertEquals(1, pi.getMetadataCount());
   }
 }

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfoCodec.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -57,6 +57,6 @@ public class TestOmPrefixInfoCodec extends Proto2CodecTestBase<OmPrefixInfo> {
     OmPrefixInfo opiLoad = codec.fromPersistedFormat(
         codec.toPersistedFormat(opiSave));
 
-    Assert.assertEquals("Loaded not equals to saved", opiSave, opiLoad);
+    Assertions.assertEquals(opiSave, opiLoad, "Loaded not equals to saved");
   }
 }

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestRepeatedOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestRepeatedOmKeyInfoCodec.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
 import org.apache.hadoop.util.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,10 +36,10 @@ import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test {@link RepeatedOmKeyInfo#getCodec(boolean)}.

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestS3SecretValueCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestS3SecretValueCodec.java
@@ -22,8 +22,8 @@ import java.util.UUID;
 
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test {@link S3SecretValue#getCodec()}.
@@ -44,10 +44,10 @@ public class TestS3SecretValueCodec
             UUID.randomUUID().toString());
 
     byte[] data = codec.toPersistedFormat(s3SecretValue);
-    Assert.assertNotNull(data);
+    Assertions.assertNotNull(data);
 
     S3SecretValue docdedS3Secret = codec.fromPersistedFormat(data);
 
-    Assert.assertEquals(s3SecretValue, docdedS3Secret);
+    Assertions.assertEquals(s3SecretValue, docdedS3Secret);
   }
 }

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestTransactionInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestTransactionInfoCodec.java
@@ -21,12 +21,12 @@ import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test {@link TransactionInfo#getCodec()}.
@@ -48,7 +48,7 @@ public class TestTransactionInfoCodec
     TransactionInfo convertedTransactionInfo =
         codec.fromPersistedFormat(codec.toPersistedFormat(transactionInfo));
 
-    Assert.assertEquals(transactionInfo, convertedTransactionInfo);
+    assertEquals(transactionInfo, convertedTransactionInfo);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate the following test classes to JUnit5. See parent task for details.

hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestBaseInsightPoint.java
hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestConfigurationSubCommand.java
hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestLogSubcommand.java
hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfoCodec.java
hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfoCodec.java
hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfoCodec.java
hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestRepeatedOmKeyInfoCodec.java
hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestS3SecretValueCodec.java
hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestTransactionInfoCodec.java


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9501

## How was this patch tested?
Manually tested the test cases. Tested it in CI build as well.
