### PR TITLE
HDDS-9780. Intermittent failure in testS3SecretCacheSizePostDoubleBufferFlush.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -365,7 +365,6 @@ class TestOzoneManagerDoubleBuffer {
       Assertions.assertTrue(cache.get(userPrincipalId1) == null);
     } finally {
       // cleanup metrics
-      doubleBuffer.stopDaemon();
       OzoneManagerDoubleBufferMetrics metrics =
           doubleBuffer.getOzoneManagerDoubleBufferMetrics();
       metrics.setMaxNumberOfTransactionsFlushedInOneIteration(0);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -340,6 +340,10 @@ class TestOzoneManagerDoubleBuffer {
     Assertions.assertEquals("alice", ugiAlice.getShortUserName());
     when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(true);
 
+    // Stop the double buffer thread to prevent automatic flushing every second
+    // and to enable manual flushing.
+    doubleBuffer.stopDaemon();
+
     // Create 3 secrets and store them in the cache and double buffer.
     processSuccessSecretRequest(userPrincipalId1, 1, true);
     processSuccessSecretRequest(userPrincipalId2, 2, true);
@@ -353,7 +357,7 @@ class TestOzoneManagerDoubleBuffer {
 
     // Flush the current buffer.
     doubleBuffer.flushCurrentBuffer();
-
+    cache = secretManager.cache();
     // Check if all the three secrets are cleared from the cache.
     Assertions.assertTrue(cache.get(userPrincipalId3) == null);
     Assertions.assertTrue(cache.get(userPrincipalId2) == null);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -340,39 +340,41 @@ class TestOzoneManagerDoubleBuffer {
     Assertions.assertEquals("alice", ugiAlice.getShortUserName());
     when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(true);
 
-    // Stop the double buffer thread to prevent automatic flushing every second
-    // and to enable manual flushing.
-    doubleBuffer.stopDaemon();
+    try {
+      // Stop the double buffer thread to prevent automatic flushing every
+      // second and to enable manual flushing.
+      doubleBuffer.stopDaemon();
 
-    // Create 3 secrets and store them in the cache and double buffer.
-    processSuccessSecretRequest(userPrincipalId1, 1, true);
-    processSuccessSecretRequest(userPrincipalId2, 2, true);
-    processSuccessSecretRequest(userPrincipalId3, 3, true);
+      // Create 3 secrets and store them in the cache and double buffer.
+      processSuccessSecretRequest(userPrincipalId1, 1, true);
+      processSuccessSecretRequest(userPrincipalId2, 2, true);
+      processSuccessSecretRequest(userPrincipalId3, 3, true);
 
-    S3SecretCache cache = secretManager.cache();
-    // Check if all the three secrets are cached.
-    Assertions.assertTrue(cache.get(userPrincipalId1) != null);
-    Assertions.assertTrue(cache.get(userPrincipalId2) != null);
-    Assertions.assertTrue(cache.get(userPrincipalId3) != null);
+      S3SecretCache cache = secretManager.cache();
+      // Check if all the three secrets are cached.
+      Assertions.assertTrue(cache.get(userPrincipalId1) != null);
+      Assertions.assertTrue(cache.get(userPrincipalId2) != null);
+      Assertions.assertTrue(cache.get(userPrincipalId3) != null);
 
-    // Flush the current buffer.
-    doubleBuffer.flushCurrentBuffer();
-    cache = secretManager.cache();
-    // Check if all the three secrets are cleared from the cache.
-    Assertions.assertTrue(cache.get(userPrincipalId3) == null);
-    Assertions.assertTrue(cache.get(userPrincipalId2) == null);
-    Assertions.assertTrue(cache.get(userPrincipalId1) == null);
+      // Flush the current buffer.
+      doubleBuffer.flushCurrentBuffer();
 
-    // cleanup metrics
-    doubleBuffer.stopDaemon();
-    OzoneManagerDoubleBufferMetrics metrics =
-        doubleBuffer.getOzoneManagerDoubleBufferMetrics();
-    metrics.setMaxNumberOfTransactionsFlushedInOneIteration(0);
-    metrics.setAvgFlushTransactionsInOneIteration(0);
-    metrics.incrTotalSizeOfFlushedTransactions(
-        -metrics.getTotalNumOfFlushedTransactions());
-    metrics.incrTotalNumOfFlushOperations(
-        -metrics.getTotalNumOfFlushOperations());
+      // Check if all the three secrets are cleared from the cache.
+      Assertions.assertTrue(cache.get(userPrincipalId3) == null);
+      Assertions.assertTrue(cache.get(userPrincipalId2) == null);
+      Assertions.assertTrue(cache.get(userPrincipalId1) == null);
+    } finally {
+      // cleanup metrics
+      doubleBuffer.stopDaemon();
+      OzoneManagerDoubleBufferMetrics metrics =
+          doubleBuffer.getOzoneManagerDoubleBufferMetrics();
+      metrics.setMaxNumberOfTransactionsFlushedInOneIteration(0);
+      metrics.setAvgFlushTransactionsInOneIteration(0);
+      metrics.incrTotalSizeOfFlushedTransactions(
+          -metrics.getTotalNumOfFlushedTransactions());
+      metrics.incrTotalNumOfFlushOperations(
+          -metrics.getTotalNumOfFlushOperations());
+    }
   }
 
   private void processSuccessSecretRequest(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since the background thread, `doubleBufferFlush`, flushes the double buffer every **1 second**, when we create a user, it would immediately flush the user to the double buffer, preventing us from verifying the values in the doubleBuffer and cache accurately. Therefore, we have added a trigger to stop it.

Earlier the following error was being thrown by the Test as an Intermittent failure :- 
https://github.com/adoroszlai/ozone-build-results/blob/master/2023/11/27/27054/unit/hadoop-ozone/ozone-manager/org.apache.hadoop.ozone.om.ratis.TestOzoneManagerDoubleBuffer.txt
```
Tests run: 8, Failures: 6, Errors: 0, Skipped: 0, Time elapsed: 10.18 s <<< FAILURE! -- in org.apache.hadoop.ozone.om.ratis.TestOzoneManagerDoubleBuffer
TestOzoneManagerDoubleBuffer.testS3SecretCacheSizePostDoubleBufferFlush -- Time elapsed: 2.087 s <<< FAILURE!
AssertionFailedError: expected: <true> but was: <false>
  ...
  at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:179)
  at org.apache.hadoop.ozone.om.ratis.TestOzoneManagerDoubleBuffer.testS3SecretCacheSizePostDoubleBufferFlush(TestOzoneManagerDoubleBuffer.java:360)
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9780

## How was this patch tested?

Tested it over 300 times in the following iterations on my fork :- 
Test Run 1 :- https://github.com/ArafatKhan2198/ozone/actions/runs/7028348940
Test Run 2 :- https://github.com/ArafatKhan2198/ozone/actions/runs/7028351456
Test Run 3 :- https://github.com/ArafatKhan2198/ozone/actions/runs/7028352692
