### PR TITLE
HDDS-9797. Pass defaultInstance instead of a class in Proto2/3Codec.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ExtendedDatanodeDetailsProto;
 import org.apache.hadoop.hdds.scm.net.NetConstants;
 import org.apache.hadoop.hdds.scm.net.NodeImpl;
 
@@ -69,7 +70,7 @@ public class DatanodeDetails extends NodeImpl implements
       LoggerFactory.getLogger(DatanodeDetails.class);
 
   private static final Codec<DatanodeDetails> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(HddsProtos.ExtendedDatanodeDetailsProto.class),
+      Proto2Codec.get(ExtendedDatanodeDetailsProto.getDefaultInstance()),
       DatanodeDetails::getFromProtoBuf,
       DatanodeDetails::getExtendedProtoBufMessage);
 
@@ -392,7 +393,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @return DatanodeDetails
    */
   public static DatanodeDetails getFromProtoBuf(
-      HddsProtos.ExtendedDatanodeDetailsProto extendedDetailsProto) {
+      ExtendedDatanodeDetailsProto extendedDetailsProto) {
     DatanodeDetails.Builder builder;
     if (extendedDetailsProto.hasDatanodeDetails()) {
       builder = newBuilder(extendedDetailsProto.getDatanodeDetails());
@@ -480,12 +481,12 @@ public class DatanodeDetails extends NodeImpl implements
 
   /**
    * Returns a ExtendedDatanodeDetails protobuf message from a datanode ID.
-   * @return HddsProtos.ExtendedDatanodeDetailsProto
+   * @return ExtendedDatanodeDetailsProto
    */
   @JsonIgnore
-  public HddsProtos.ExtendedDatanodeDetailsProto getExtendedProtoBufMessage() {
-    HddsProtos.ExtendedDatanodeDetailsProto.Builder extendedBuilder =
-        HddsProtos.ExtendedDatanodeDetailsProto.newBuilder()
+  public ExtendedDatanodeDetailsProto getExtendedProtoBufMessage() {
+    final ExtendedDatanodeDetailsProto.Builder extendedBuilder
+        = ExtendedDatanodeDetailsProto.newBuilder()
             .setDatanodeDetails(getProtoBufMessage());
 
     if (!Strings.isNullOrEmpty(getVersion())) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -44,7 +44,7 @@ public final class ContainerInfo implements Comparable<ContainerInfo> {
       = Comparator.comparingLong(info -> info.getLastUsed().toEpochMilli());
 
   private static final Codec<ContainerInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(HddsProtos.ContainerInfoProto.class),
+      Proto2Codec.get(HddsProtos.ContainerInfoProto.getDefaultInstance()),
       ContainerInfo::fromProtobuf,
       ContainerInfo::getProtobuf);
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -62,7 +62,7 @@ public final class Pipeline {
    * -- the creation time may change.
    */
   private static final Codec<Pipeline> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(HddsProtos.Pipeline.class),
+      Proto2Codec.get(HddsProtos.Pipeline.getDefaultInstance()),
       Pipeline::getFromProtobufSetCreationTimestamp,
       p -> p.getProtobufMessage(ClientVersion.CURRENT_VERSION),
       DelegatedCodec.CopyType.UNSUPPORTED);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
@@ -41,25 +41,16 @@ public final class Proto2Codec<M extends MessageLite>
   /**
    * @return the {@link Codec} for the given class.
    */
-  public static <T extends MessageLite> Codec<T> get(Class<T> clazz) {
-    final Codec<?> codec = CODECS.computeIfAbsent(clazz, Proto2Codec::new);
+  public static <T extends MessageLite> Codec<T> get(T t) {
+    final Codec<?> codec = CODECS.computeIfAbsent(t.getClass(),
+        key -> new Proto2Codec<>(t));
     return (Codec<T>) codec;
-  }
-
-  private static <T extends MessageLite> Parser<T> getParser(Class<T> clazz) {
-    final String name = "PARSER";
-    try {
-      return (Parser<T>) clazz.getField(name).get(null);
-    } catch (Exception e) {
-      throw new IllegalStateException(
-          "Failed to get " + name + " field from " + clazz, e);
-    }
   }
 
   private final Parser<M> parser;
 
-  private Proto2Codec(Class<M> clazz) {
-    this.parser = getParser(clazz);
+  private Proto2Codec(M m) {
+    this.parser = (Parser<M>) m.getParserForType();
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto3Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto3Codec.java
@@ -41,25 +41,16 @@ public final class Proto3Codec<M extends MessageLite>
   /**
    * @return the {@link Codec} for the given class.
    */
-  public static <T extends MessageLite> Codec<T> get(Class<T> clazz) {
-    final Codec<?> codec = CODECS.computeIfAbsent(clazz, Proto3Codec::new);
+  public static <T extends MessageLite> Codec<T> get(T t) {
+    final Codec<?> codec = CODECS.computeIfAbsent(t.getClass(),
+        key -> new Proto3Codec<>(t));
     return (Codec<T>) codec;
-  }
-
-  private static <T extends MessageLite> Parser<T> getParser(Class<T> clazz) {
-    final String name = "PARSER";
-    try {
-      return (Parser<T>) clazz.getField(name).get(null);
-    } catch (Exception e) {
-      throw new IllegalStateException(
-          "Failed to get " + name + " field from " + clazz, e);
-    }
   }
 
   private final Parser<M> parser;
 
-  private Proto3Codec(Class<M> clazz) {
-    this.parser = getParser(clazz);
+  private Proto3Codec(M m) {
+    this.parser = (Parser<M>) m.getParserForType();
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
  */
 public class BlockData {
   private static final Codec<BlockData> CODEC = new DelegatedCodec<>(
-      Proto3Codec.get(ContainerProtos.BlockData.class),
+      Proto3Codec.get(ContainerProtos.BlockData.getDefaultInstance()),
       BlockData::getFromProtoBuf,
       BlockData::getProtoBufMessage);
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfoList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfoList.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class ChunkInfoList {
   private static final Codec<ChunkInfoList> CODEC = new DelegatedCodec<>(
-      Proto3Codec.get(ContainerProtos.ChunkInfoList.class),
+      Proto3Codec.get(ContainerProtos.ChunkInfoList.getDefaultInstance()),
       ChunkInfoList::getFromProtoBuf,
       ChunkInfoList::getProtoBufMessage,
       DelegatedCodec.CopyType.SHALLOW);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
@@ -90,7 +90,7 @@ public class DatanodeSchemaThreeDBDefinition
           String.class,
           FixedLengthStringCodec.get(),
           DeletedBlocksTransaction.class,
-          Proto2Codec.get(DeletedBlocksTransaction.class));
+          Proto2Codec.get(DeletedBlocksTransaction.getDefaultInstance()));
 
   private static String separator = "";
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -74,7 +74,7 @@ public class DatanodeSchemaTwoDBDefinition
           Long.class,
           LongCodec.get(),
           StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction.class,
-          Proto2Codec.get(DeletedBlocksTransaction.class));
+          Proto2Codec.get(DeletedBlocksTransaction.getDefaultInstance()));
 
   public DatanodeSchemaTwoDBDefinition(String dbPath,
       ConfigurationSource config) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/MoveDataNodePair.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/MoveDataNodePair.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 public class MoveDataNodePair {
   private static final Codec<MoveDataNodePair> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(MoveDataNodePairProto.class),
+      Proto2Codec.get(MoveDataNodePairProto.getDefaultInstance()),
       MoveDataNodePair::getFromProtobuf,
       pair -> pair.getProtobufMessage(ClientVersion.CURRENT_VERSION),
       DelegatedCodec.CopyType.SHALLOW);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
@@ -37,7 +37,7 @@ import java.util.Objects;
  */
 public final class CertInfo implements Comparable<CertInfo>, Serializable {
   private static final Codec<CertInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(CertInfoProto.class),
+      Proto2Codec.get(CertInfoProto.getDefaultInstance()),
       CertInfo::fromProtobuf,
       CertInfo::getProtobuf);
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLInfo.java
@@ -41,7 +41,7 @@ public final class CRLInfo implements Comparator<CRLInfo>,
     Comparable<CRLInfo> {
 
   private static final Codec<CRLInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(CRLInfoProto.class),
+      Proto2Codec.get(CRLInfoProto.getDefaultInstance()),
       proto -> fromProtobuf(proto, CRLCodec::toIOException),
       CRLInfo::getProtobuf);
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -255,8 +255,8 @@ public final class DBStoreBuilder {
     return this;
   }
 
-  public <T extends MessageLite> DBStoreBuilder addProto2Codec(Class<T> type) {
-    return addCodec(type, Proto2Codec.get(type));
+  public <T extends MessageLite> DBStoreBuilder addProto2Codec(T type) {
+    return addCodec((Class<T>)type.getClass(), Proto2Codec.get(type));
   }
 
   public DBStoreBuilder setDBOptions(ManagedDBOptions option) {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 public final class CompactionLogEntry implements
     CopyObject<CompactionLogEntry> {
   private static final Codec<CompactionLogEntry> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(CompactionLogEntryProto.class),
+      Proto2Codec.get(CompactionLogEntryProto.getDefaultInstance()),
       CompactionLogEntry::getFromProtobuf,
       CompactionLogEntry::getProtobuf);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -58,7 +58,7 @@ public class SCMDBDefinition extends DBDefinition.WithMap {
           Long.class,
           LongCodec.get(),
           DeletedBlocksTransaction.class,
-          Proto2Codec.get(DeletedBlocksTransaction.class));
+          Proto2Codec.get(DeletedBlocksTransaction.getDefaultInstance()));
 
   public static final DBColumnFamilyDefinition<BigInteger, X509Certificate>
       VALID_CERTS =

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -45,7 +45,7 @@ import com.google.common.base.Preconditions;
  */
 public final class OmBucketInfo extends WithObjectID implements Auditable {
   private static final Codec<OmBucketInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(BucketInfo.class),
+      Proto2Codec.get(BucketInfo.getDefaultInstance()),
       OmBucketInfo::getFromProtobuf,
       OmBucketInfo::getProtobuf);
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  */
 public final class OmDBAccessIdInfo {
   private static final Codec<OmDBAccessIdInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(ExtendedUserAccessIdInfo.class),
+      Proto2Codec.get(ExtendedUserAccessIdInfo.getDefaultInstance()),
       OmDBAccessIdInfo::getFromProtobuf,
       OmDBAccessIdInfo::getProtobuf,
       DelegatedCodec.CopyType.SHALLOW);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.om.helpers;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantState;
 
 import java.util.Objects;
 
@@ -31,7 +31,7 @@ import java.util.Objects;
  */
 public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   private static final Codec<OmDBTenantState> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(OzoneManagerProtocolProtos.TenantState.class),
+      Proto2Codec.get(TenantState.getDefaultInstance()),
       OmDBTenantState::getFromProtobuf,
       OmDBTenantState::getProtobuf,
       DelegatedCodec.CopyType.SHALLOW);
@@ -112,7 +112,7 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
 
   /**
    * Returns the bucket namespace name. a.k.a. volume name.
-   *
+   * <p>
    * Note: This returns an empty string ("") if the tenant is somehow not
    * associated with a volume. Should never return null.
    */
@@ -139,8 +139,8 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   /**
    * Convert OmDBTenantState to protobuf to be persisted to DB.
    */
-  public OzoneManagerProtocolProtos.TenantState getProtobuf() {
-    return OzoneManagerProtocolProtos.TenantState.newBuilder()
+  public TenantState getProtobuf() {
+    return TenantState.newBuilder()
         .setTenantId(tenantId)
         .setBucketNamespaceName(bucketNamespaceName)
         .setUserRoleName(userRoleName)
@@ -153,8 +153,7 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   /**
    * Convert protobuf to OmDBTenantState.
    */
-  public static OmDBTenantState getFromProtobuf(
-      OzoneManagerProtocolProtos.TenantState proto) {
+  public static OmDBTenantState getFromProtobuf(TenantState proto) {
     return new Builder()
         .setTenantId(proto.getTenantId())
         .setBucketNamespaceName(proto.getBucketNamespaceName())

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
@@ -35,7 +35,7 @@ import java.util.Set;
 public final class OmDBUserPrincipalInfo {
   private static final Codec<OmDBUserPrincipalInfo> CODEC
       = new DelegatedCodec<>(
-          Proto2Codec.get(TenantUserPrincipalInfo.class),
+          Proto2Codec.get(TenantUserPrincipalInfo.getDefaultInstance()),
           OmDBUserPrincipalInfo::getFromProtobuf,
           OmDBUserPrincipalInfo::getProtobuf);
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hdds.utils.db.CopyObject;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DirectoryInfo;
 
 import java.util.BitSet;
 import java.util.HashMap;
@@ -40,7 +40,7 @@ import java.util.Objects;
 public class OmDirectoryInfo extends WithParentObjectId
     implements CopyObject<OmDirectoryInfo> {
   private static final Codec<OmDirectoryInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(OzoneManagerProtocolProtos.DirectoryInfo.class),
+      Proto2Codec.get(DirectoryInfo.getDefaultInstance()),
       OmDirectoryInfo::getFromProtobuf,
       OmDirectoryInfo::getProtobuf);
 
@@ -191,9 +191,9 @@ public class OmDirectoryInfo extends WithParentObjectId
   /**
    * Creates DirectoryInfo protobuf from OmDirectoryInfo.
    */
-  public OzoneManagerProtocolProtos.DirectoryInfo getProtobuf() {
-    OzoneManagerProtocolProtos.DirectoryInfo.Builder pib =
-            OzoneManagerProtocolProtos.DirectoryInfo.newBuilder().setName(name)
+  public DirectoryInfo getProtobuf() {
+    final DirectoryInfo.Builder pib =
+            DirectoryInfo.newBuilder().setName(name)
                     .setCreationTime(creationTime)
                     .setModificationTime(modificationTime)
                     .addAllMetadata(KeyValueUtil.toProtobuf(metadata))
@@ -211,8 +211,7 @@ public class OmDirectoryInfo extends WithParentObjectId
    * @param dirInfo
    * @return instance of OmDirectoryInfo
    */
-  public static OmDirectoryInfo getFromProtobuf(
-          OzoneManagerProtocolProtos.DirectoryInfo dirInfo) {
+  public static OmDirectoryInfo getFromProtobuf(DirectoryInfo dirInfo) {
     OmDirectoryInfo.Builder opib = OmDirectoryInfo.newBuilder()
             .setName(dirInfo.getName())
             .setCreationTime(dirInfo.getCreationTime())

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -62,7 +62,7 @@ public final class OmKeyInfo extends WithParentObjectId
 
   private static Codec<OmKeyInfo> newCodec(boolean ignorePipeline) {
     return new DelegatedCodec<>(
-        Proto2Codec.get(KeyInfo.class),
+        Proto2Codec.get(KeyInfo.getDefaultInstance()),
         OmKeyInfo::getFromProtobuf,
         k -> k.getProtobuf(ignorePipeline, ClientVersion.CURRENT_VERSION));
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
@@ -39,7 +39,7 @@ import java.util.TreeMap;
  */
 public final class OmMultipartKeyInfo extends WithObjectID {
   private static final Codec<OmMultipartKeyInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(MultipartKeyInfo.class),
+      Proto2Codec.get(MultipartKeyInfo.getDefaultInstance()),
       OmMultipartKeyInfo::getFromProto,
       OmMultipartKeyInfo::getProto);
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
@@ -44,7 +44,7 @@ import com.google.common.base.Preconditions;
 public final class OmVolumeArgs extends WithObjectID
     implements CopyObject<OmVolumeArgs>, Auditable {
   private static final Codec<OmVolumeArgs> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(VolumeInfo.class),
+      Proto2Codec.get(VolumeInfo.getDefaultInstance()),
       OmVolumeArgs::getFromProtobuf,
       OmVolumeArgs::getProtobuf);
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -45,7 +45,7 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
 
   private static Codec<RepeatedOmKeyInfo> newCodec(boolean ignorePipeline) {
     return new DelegatedCodec<>(
-        Proto2Codec.get(RepeatedKeyInfo.class),
+        Proto2Codec.get(RepeatedKeyInfo.getDefaultInstance()),
         RepeatedOmKeyInfo::getFromProto,
         k -> k.getProto(ignorePipeline, ClientVersion.CURRENT_VERSION));
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.om.helpers;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Secret;
 
 import java.util.Objects;
 
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 public class S3SecretValue {
   private static final Codec<S3SecretValue> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(OzoneManagerProtocolProtos.S3Secret.class),
+      Proto2Codec.get(S3Secret.getDefaultInstance()),
       S3SecretValue::fromProtobuf,
       S3SecretValue::getProtobuf);
 
@@ -91,13 +91,12 @@ public class S3SecretValue {
     this.transactionLogIndex = transactionLogIndex;
   }
 
-  public static S3SecretValue fromProtobuf(
-      OzoneManagerProtocolProtos.S3Secret s3Secret) {
+  public static S3SecretValue fromProtobuf(S3Secret s3Secret) {
     return new S3SecretValue(s3Secret.getKerberosID(), s3Secret.getAwsSecret());
   }
 
-  public OzoneManagerProtocolProtos.S3Secret getProtobuf() {
-    return OzoneManagerProtocolProtos.S3Secret.newBuilder()
+  public S3Secret getProtobuf() {
+    return S3Secret.newBuilder()
         .setAwsSecret(this.awsSecret)
         .setKerberosID(this.kerberosID)
         .build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -55,7 +55,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
  */
 public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
   private static final Codec<SnapshotInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(OzoneManagerProtocolProtos.SnapshotInfo.class),
+      Proto2Codec.get(
+          OzoneManagerProtocolProtos.SnapshotInfo.getDefaultInstance()),
       SnapshotInfo::getFromProtobuf,
       SnapshotInfo::getProtobuf);
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -44,7 +44,7 @@ public class SnapshotDiffReportOzone
     extends org.apache.hadoop.hdfs.protocol.SnapshotDiffReport {
 
   private static final Codec<DiffReportEntry> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(DiffReportEntryProto.class),
+      Proto2Codec.get(DiffReportEntryProto.getDefaultInstance()),
       SnapshotDiffReportOzone::fromProtobufDiffReportEntry,
       SnapshotDiffReportOzone::toProtobufDiffReportEntry,
       DelegatedCodec.CopyType.SHALLOW);

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 // TODO: support Auditable interface
 public final class OmPrefixInfo extends WithObjectID {
   private static final Codec<OmPrefixInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(PersistedPrefixInfo.class),
+      Proto2Codec.get(PersistedPrefixInfo.getDefaultInstance()),
       OmPrefixInfo::getFromProtobuf,
       OmPrefixInfo::getProtobuf);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -634,7 +634,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .addCodec(RepeatedOmKeyInfo.class, RepeatedOmKeyInfo.getCodec(true))
         .addCodec(OmBucketInfo.class, OmBucketInfo.getCodec())
         .addCodec(OmVolumeArgs.class, OmVolumeArgs.getCodec())
-        .addProto2Codec(PersistedUserVolumeInfo.class)
+        .addProto2Codec(PersistedUserVolumeInfo.getDefaultInstance())
         .addCodec(OmMultipartKeyInfo.class, OmMultipartKeyInfo.getCodec())
         .addCodec(S3SecretValue.class, S3SecretValue.getCodec())
         .addCodec(OmPrefixInfo.class, OmPrefixInfo.getCodec())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -62,13 +62,12 @@ public class OMDBDefinition extends DBDefinition.WithMap {
                     RepeatedOmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, PersistedUserVolumeInfo>
-            USER_TABLE =
-            new DBColumnFamilyDefinition<>(
-                    OmMetadataManagerImpl.USER_TABLE,
-                    String.class,
-                    StringCodec.get(),
-                    PersistedUserVolumeInfo.class,
-                    Proto2Codec.get(PersistedUserVolumeInfo.class));
+      USER_TABLE = new DBColumnFamilyDefinition<>(
+          OmMetadataManagerImpl.USER_TABLE,
+          String.class,
+          StringCodec.get(),
+          PersistedUserVolumeInfo.class,
+          Proto2Codec.get(PersistedUserVolumeInfo.getDefaultInstance()));
 
   public static final DBColumnFamilyDefinition<String, OmVolumeArgs>
             VOLUME_TABLE =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ContainerReplicaHistoryList.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ContainerReplicaHistoryList.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 public class ContainerReplicaHistoryList {
   private static final Codec<ContainerReplicaHistoryList> CODEC
       = new DelegatedCodec<>(Proto2Codec.get(
-      ContainerReplicaHistoryListProto.class),
+      ContainerReplicaHistoryListProto.getDefaultInstance()),
       ContainerReplicaHistoryList::fromProto,
       ContainerReplicaHistoryList::toProto);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, we pass a proto class and use reflection to get the parser for a proto class. The reflection can be avoided by passing a proto defaultInstance and invoking getParserForType()

## What is the link to the Apache JIRA

HDDS-9797

## How was this patch tested?

By existing unit tests.