### PR TITLE
HDDS-9360. Throw an IOException if continuation token for snapshot diff is more than the total diff entries

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -110,7 +110,7 @@ public class SnapshotDiffReportOzone
             .append(token);
       }
     } else {
-      str.append("No diff or no more diff for with the request parameters.");
+      str.append("No diff or no more diff for the request parameters.");
     }
     return str.toString();
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -101,13 +101,16 @@ public class SnapshotDiffReportOzone
         .append(" and snapshot: ")
         .append(getLaterSnapshotName())
         .append(LINE_SEPARATOR);
-    for (DiffReportEntry entry : getDiffList()) {
-      str.append(entry.toString()).append(LINE_SEPARATOR);
-    }
-    if (StringUtils.isNotEmpty(token)) {
-      str.append("Next token: ")
-          .append(token)
-          .append(LINE_SEPARATOR);
+    if (!getDiffList().isEmpty()) {
+      for (DiffReportEntry entry : getDiffList()) {
+        str.append(entry.toString()).append(LINE_SEPARATOR);
+      }
+      if (StringUtils.isNotEmpty(token)) {
+        str.append("Next token: ")
+            .append(token);
+      }
+    } else {
+      str.append("No diff or no more diff for with the request parameters.");
     }
     return str.toString();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -1432,10 +1432,10 @@ public abstract class TestOmSnapshot {
 
     IOException ioException = assertThrows(IOException.class,
         () -> store.snapshotDiff(volume, bucket, snap6,
-            snap7, "2", 0, forceFullSnapshotDiff, disableNativeDiff));
-    assertThat(ioException.getMessage(), containsString("Index (given: 2) " +
+            snap7, "3", 0, forceFullSnapshotDiff, disableNativeDiff));
+    assertThat(ioException.getMessage(), containsString("Index (given: 3) " +
         "should be a number >= 0 and < totalDiffEntries: 2. Page size " +
-        "(given: 2) should be a positive number > 0."));
+        "(given: 1000) should be a positive number > 0."));
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -1430,10 +1430,6 @@ public abstract class TestOmSnapshot {
         );
     assertEquals(expectedDiffList, diff5.getDiffList());
 
-    SnapshotDiffReportOzone diff12 = store.snapshotDiff(volume, bucket, snap6,
-        snap7, null, 2, forceFullSnapshotDiff, disableNativeDiff)
-        .getSnapshotDiffReport();
-
     IOException ioException = assertThrows(IOException.class,
         () -> store.snapshotDiff(volume, bucket, snap6,
             snap7, "2", 0, forceFullSnapshotDiff, disableNativeDiff));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -1429,6 +1429,18 @@ public abstract class TestOmSnapshot {
                 SnapshotDiffReport.DiffType.MODIFY, key3)
         );
     assertEquals(expectedDiffList, diff5.getDiffList());
+
+    SnapshotDiffReportOzone diff12 = store.snapshotDiff(volume, bucket, snap6,
+        snap7, null, 2, forceFullSnapshotDiff, disableNativeDiff)
+        .getSnapshotDiffReport();
+
+    IOException ioException = assertThrows(IOException.class,
+        () -> store.snapshotDiff(volume, bucket, snap6,
+            snap7, "2", 0, forceFullSnapshotDiff, disableNativeDiff));
+    assertThat(ioException.getMessage(), containsString("Index (given: 2) " +
+        "should be a number >= 0 and < totalDiffEntries: 2. Page size " +
+        "(given: 2) should be a positive number > 0."));
+
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -569,11 +569,12 @@ public class SnapshotDiffManager implements AutoCloseable {
       final int index,
       final int pageSize
   ) throws IOException {
-    if (index < 0 || pageSize <= 0) {
-      throw new IllegalArgumentException(String.format(
-          "Index should be a number >= 0. Given index %d. Page size " +
-              "should be a positive number > 0. Given page size is %d",
-          index, pageSize));
+    if (index < 0 || index > snapDiffJob.getTotalDiffEntries()
+        || pageSize <= 0) {
+      throw new IOException(String.format(
+          "Index (given: %d) should be a number >= 0 and < totalDiffEntries: " +
+              "%d. Page size (given: %d) should be a positive number > 0.",
+          index, snapDiffJob.getTotalDiffEntries(), pageSize));
     }
 
     OFSPath path = getSnapshotRootPath(volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -893,7 +893,7 @@ public class TestSnapshotDiffManager {
    * objectId Map of diff keys to be checked with their corresponding key names.
    */
   @ParameterizedTest
-  @CsvSource({"0,10,1000", "1,10,8", "1000,1000,10", "-1,1000,10000",
+  @CsvSource({"0,10,1000", "1,10,8", "10,1000,10", "-1,1000,10000",
       "1,0,1000", "1,-1,1000"})
   public void testCreatePageResponse(int startIdx,
                                      int pageSize,
@@ -933,7 +933,7 @@ public class TestSnapshotDiffManager {
         codecRegistry.asRawData(snapshotDiffJob2));
 
     if (pageSize <= 0 || startIdx < 0) {
-      Assertions.assertThrows(IllegalArgumentException.class,
+      Assertions.assertThrows(IOException.class,
           () -> snapshotDiffManager.createPageResponse(snapshotDiffJob, "vol",
               "buck", "fs", "ts", startIdx, pageSize));
       return;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, we print empty line if snapshot diff entry list is empty because continuation token more than the total diff entries. This change is to throw an IOException if continuation token for snapshot diff is more than the total diff entries. Also updated the response printing if DiffEntryList is empty.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9360

## How was this patch tested?
Updated integ tests and also checked the response on docker.
```
sh-4.2$ ozone sh volume create vol1
sh-4.2$ ozone sh bucket create vol1/bucket1
sh-4.2$ ozone sh key put vol1/bucket1/key1 README.md
sh-4.2$ ozone sh snapshot create vol1/bucket1 snap1
sh-4.2$ ozone sh key put vol1/bucket1/key2 README.md
sh-4.2$ ozone sh key put vol1/bucket1/key3 README.md
sh-4.2$ ozone sh key put vol1/bucket1/key4 README.md
sh-4.2$ ozone sh key put vol1/bucket1/key5 README.md
sh-4.2$ ozone sh snapshot create vol1/bucket1 snap2
sh-4.2$ ozone sh snapshot snapshotDiff vol1/bucket1 snap1 snap2
Snapshot diff job is IN_PROGRESS. Please retry after 60000 ms.
sh-4.2$ ozone sh snapshot snapshotDiff vol1/bucket1 snap1 snap2
Difference between snapshot: snap1 and snapshot: snap2
+       ./key2
+       ./key3
+       ./key4
+       ./key5
sh-4.2$ ozone sh snapshot diff  -t 150 vol1/bucket1 snap1 snap2  
INTERNAL_ERROR Index (given: 150) should be a number >= 0 and < totalDiffEntries: 4. Page size (given: 1000) should be a positive number > 0.
sh-4.2$ ozone sh snapshot diff  -t 4 vol1/bucket1 snap1 snap2
Difference between snapshot: snap1 and snapshot: snap2
No diff or no more diff for with the request parameters.

sh-4.2$ ozone sh snapshot diff  -t 2 vol1/bucket1 snap1 snap2
Difference between snapshot: snap1 and snapshot: snap2
+       ./key4
+       ./key5

```
