### PR TITLE
HDDS-9594. Make the number of containers logged configurable in DatanodeAdminMonitorImpl

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -483,6 +483,10 @@ public final class ScmConfigKeys {
       "ozone.scm.datanode.admin.monitor.interval";
   public static final String OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL_DEFAULT =
       "30s";
+  public static final String OZONE_SCM_DATANODE_ADMIN_MONITOR_LOGGING_LIMIT =
+      "ozone.scm.datanode.admin.monitor.logging.limit";
+  public static final int
+      OZONE_SCM_DATANODE_ADMIN_MONITOR_LOGGING_LIMIT_DEFAULT = 1000;
 
   public static final String OZONE_SCM_INFO_WAIT_DURATION =
       "ozone.scm.info.wait.duration";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3219,6 +3219,17 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.datanode.admin.monitor.logging.limit</name>
+    <value>1000</value>
+    <tag>SCM</tag>
+    <description>
+      When a node is checked for decommission or maintenance, this setting
+      controls how many degraded containers are logged on each pass. The limit
+      is applied separately for each type of container, ie under-replicated and
+      unhealthy will each have their own limit.
+    </description>
+  </property>
+  <property>
     <name>ozone.client.list.trash.keys.max</name>
     <value>1000</value>
     <tag>OZONE, CLIENT</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
@@ -92,7 +93,7 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
       LoggerFactory.getLogger(DatanodeAdminMonitorImpl.class);
   // The number of containers for each of under replicated and unhealthy
   // that will be logged in detail each time a node is checked.
-  private static final int CONTAINER_DETAILS_LOGGING_LIMIT = 5;
+  private final int containerDetailsLoggingLimit;
 
   public DatanodeAdminMonitorImpl(
       OzoneConfiguration conf,
@@ -103,7 +104,9 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
     this.eventQueue = eventQueue;
     this.nodeManager = nodeManager;
     this.replicationManager = replicationManager;
-
+    containerDetailsLoggingLimit = conf.getInt(
+        ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_LOGGING_LIMIT,
+        ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_LOGGING_LIMIT_DEFAULT);
     containerStateByHost = new HashMap<>();
   }
 
@@ -364,7 +367,7 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
           if (LOG.isDebugEnabled()) {
             underReplicatedIDs.add(cid);
           }
-          if (underReplicated < CONTAINER_DETAILS_LOGGING_LIMIT
+          if (underReplicated < containerDetailsLoggingLimit
               || LOG.isDebugEnabled()) {
             LOG.info("Under Replicated Container {} {}; {}",
                 cid, replicaSet, replicaDetails(replicaSet.getReplicas()));
@@ -389,7 +392,7 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
           if (LOG.isDebugEnabled()) {
             unhealthyIDs.add(cid);
           }
-          if (unhealthy < CONTAINER_DETAILS_LOGGING_LIMIT
+          if (unhealthy < containerDetailsLoggingLimit
               || LOG.isDebugEnabled()) {
             LOG.info("Unhealthy Container {} {}; {}",
                 cid, replicaSet, replicaDetails(replicaSet.getReplicas()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently only 5 under-replicated containers are logged on each pass of the DatanodeAdminMonitor. This impacts debugging, as multiple debugging iterations are needed to resolve all the problems.

This PR changes the default log limit to 1000, and also makes it configurable so it can be turned up or down as needed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9594

## How was this patch tested?

Manually inspected in a docker cluster.
