### PR TITLE
HDDS-9801. Increase the timeout in TestPipelineClose#testPipelineCloseWithPipelineAction.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -199,7 +199,7 @@ public class TestPipelineClose {
         }
       }
       return true;
-    }, 500, 5000);
+    }, 500, 10000);
 
     assertThrows(PipelineNotFoundException.class, () ->
             pipelineManager.getPipeline(pipelineID),


### PR DESCRIPTION
## What changes were proposed in this pull request?
The`TestPipelineClose#testPipelineCloseWithPipelineAction` only waits for 5 seconds before it timeout and fails. 
The `ozone.scm.pipeline.destroy.timeout` is set to 5 seconds in the test. So, SCM will send close pipeline command to Datanode only after 5 seconds and the datanode is not getting enough time to remove the pipeline.

It's good to increase the max wait time in test to at least 10 seconds.

## What is the link to the Apache JIRA
HDDS-9801

## How was this patch tested?
Executed the test multiple times in local to make sure that the test consistently passes.
