### PR TITLE
HDDS-9542. Ozone debug chunkinfo command shows incorrect number of entries

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -292,25 +292,28 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         Thread.currentThread().interrupt();
       }
     }
-    try {
-      for (Map.Entry<DatanodeDetails,
-              CompletableFuture<ContainerCommandResponseProto> >
-              entry : futureHashMap.entrySet()) {
+    for (Map.Entry<DatanodeDetails,
+        CompletableFuture<ContainerCommandResponseProto> >
+        entry : futureHashMap.entrySet()) {
+      try {
         responseProtoHashMap.put(entry.getKey(), entry.getValue().get());
-      }
-    } catch (InterruptedException e) {
-      LOG.error("Command execution was interrupted.");
-      // Re-interrupt the thread while catching InterruptedException
-      Thread.currentThread().interrupt();
-    } catch (ExecutionException e) {
-      String message = "Failed to execute command {}.";
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(message, processForDebug(request), e);
-      } else {
-        LOG.error(message + " Exception Class: {}, Exception Message: {}",
-                request.getCmdType(), e.getClass().getName(), e.getMessage());
+      } catch (InterruptedException e) {
+        LOG.error("Command execution was interrupted.");
+        // Re-interrupt the thread while catching InterruptedException
+        Thread.currentThread().interrupt();
+      } catch (ExecutionException e) {
+        String message =
+            "Failed to execute command {} on datanode " + entry.getKey()
+                .getHostName();
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(message, processForDebug(request), e);
+        } else {
+          LOG.error(message + " Exception Class: {}, Exception Message: {}",
+              request.getCmdType(), e.getClass().getName(), e.getMessage());
+        }
       }
     }
+
     return responseProtoHashMap;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we stop one or more replica datanodes of a key and then run the "ozone debug chunkinfo" command for that key then we get an Execution exception,
`23/10/26 03:30:35 ERROR scm.XceiverClientGrpc: Failed to execute command GetBlock. Exception Class: java.util.concurrent.ExecutionException, Exception Message:`
because we don't get any container response as we have shut down the datanode and so the pipeline is closed. The exception goes away when the dead node interval is met, i.e. after the datanode is marked closed a new pipeline is created. With this PR, we would not be getting the Execution exception.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9542

## How was this patch tested?

Tested on a cluster.
