### PR TITLE
HDDS-9744. Set descriptive title for upgrade Robot tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.3.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.3.0/callback.sh
@@ -20,11 +20,11 @@ source "$TEST_DIR"/testlib.sh
 with_this_version_pre_finalized() {
   # New layout features were added in this version, so OM and SCM should be
   # pre-finalized.
-  execute_robot_test "$SCM" --include pre-finalized upgrade/check-finalization.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include pre-finalized upgrade/check-finalization.robot
   # Test that EC is disabled when pre-finalized.
-  execute_robot_test "$SCM" --include pre-finalized-ec-tests ec/upgrade-ec-check.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-ec" --include pre-finalized-ec-tests ec/upgrade-ec-check.robot
 }
 
 with_this_version_finalized() {
-  execute_robot_test "$SCM" --include post-finalized-ec-tests ec/upgrade-ec-check.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-ec" --include post-finalized-ec-tests ec/upgrade-ec-check.robot
 }

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.4.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.4.0/callback.sh
@@ -21,12 +21,12 @@ source "$TEST_DIR"/testlib.sh
 ### CALLBACKS ###
 
 with_this_version_pre_finalized() {
-  execute_robot_test "$SCM" --include pre-finalized upgrade/check-finalization.robot
-  execute_robot_test "$SCM" --include pre-finalized-snapshot-tests snapshot/upgrade-snapshot-check.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include pre-finalized upgrade/check-finalization.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-snapshot" --include pre-finalized-snapshot-tests snapshot/upgrade-snapshot-check.robot
 }
 
 with_this_version_finalized() {
-  execute_robot_test "$SCM" --include finalized upgrade/check-finalization.robot
-  execute_robot_test "$SCM" snapshot/snapshot-sh.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-snapshot" snapshot/snapshot-sh.robot
 }
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/common/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/common/callback.sh
@@ -24,7 +24,7 @@ source "$TEST_DIR"/testlib.sh
 ## @param All parameters after the first one are passed directly to the robot command,
 ##        see https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-command-line-options
 generate() {
-    execute_robot_test "$SCM" -v PREFIX:"$1" ${@:2} upgrade/generate.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-generate-${1}" -v PREFIX:"$1" ${@:2} upgrade/generate.robot
 }
 
 ## @description Validates that data exists on the cluster.
@@ -32,13 +32,13 @@ generate() {
 ## @param All parameters after the first one are passed directly to the robot command,
 ##        see https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-command-line-options
 validate() {
-    execute_robot_test "$SCM" -v PREFIX:"$1" ${@:2} upgrade/validate.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-validate-${1}" -v PREFIX:"$1" ${@:2} upgrade/validate.robot
 }
 
 ### CALLBACKS ###
 
 with_old_version() {
-  execute_robot_test "$SCM" --include finalized upgrade/check-finalization.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
   generate old1
   validate old1
 }
@@ -55,7 +55,7 @@ with_this_version_pre_finalized() {
 }
 
 with_old_version_downgraded() {
-  execute_robot_test "$SCM" --include finalized upgrade/check-finalization.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
   validate old1
   validate new1
 
@@ -68,7 +68,7 @@ with_old_version_downgraded() {
 }
 
 with_this_version_finalized() {
-  execute_robot_test "$SCM" --include finalized upgrade/check-finalization.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
   validate old1
   validate new1
   validate old2

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/driver.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/driver.sh
@@ -45,7 +45,7 @@ set_downgrade_om_args() {
 }
 
 echo "--- SETTING UP OLD VERSION $OZONE_UPGRADE_FROM ---"
-OUTPUT_NAME="$OZONE_UPGRADE_FROM"-original
+OUTPUT_NAME="${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}-1-original"
 export OM_HA_ARGS='--'
 prepare_for_image "$OZONE_UPGRADE_FROM"
 
@@ -53,34 +53,34 @@ echo "--- RUNNING WITH OLD VERSION $OZONE_UPGRADE_FROM ---"
 start_docker_env
 callback with_old_version
 
-execute_robot_test "$SCM" upgrade/prepare.robot
+execute_robot_test "$SCM" -N "${OUTPUT_NAME}-prepare" upgrade/prepare.robot
 stop_docker_env
 prepare_for_image "$OZONE_UPGRADE_TO"
 export OM_HA_ARGS='--upgrade'
 
 echo "--- RUNNING WITH NEW VERSION $OZONE_UPGRADE_TO PRE-FINALIZED ---"
-OUTPUT_NAME="$OZONE_UPGRADE_TO"-pre-finalized
+OUTPUT_NAME="${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}-2-pre-finalized"
 OZONE_KEEP_RESULTS=true start_docker_env
 callback with_this_version_pre_finalized
-execute_robot_test "$SCM" upgrade/prepare.robot
+execute_robot_test "$SCM" -N "${OUTPUT_NAME}-prepare" upgrade/prepare.robot
 stop_docker_env
 prepare_for_image "$OZONE_UPGRADE_FROM"
 set_downgrade_om_args
 
 echo "--- RUNNING WITH OLD VERSION $OZONE_UPGRADE_FROM AFTER DOWNGRADE ---"
-OUTPUT_NAME="$OZONE_UPGRADE_FROM"-downgraded
+OUTPUT_NAME="${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}-3-downgraded"
 OZONE_KEEP_RESULTS=true start_docker_env
 callback with_old_version_downgraded
 
-execute_robot_test "$SCM" upgrade/prepare.robot
+execute_robot_test "$SCM" -N "${OUTPUT_NAME}-prepare" upgrade/prepare.robot
 stop_docker_env
 prepare_for_image "$OZONE_UPGRADE_TO"
 export OM_HA_ARGS='--upgrade'
 
 echo "--- RUNNING WITH NEW VERSION $OZONE_UPGRADE_TO FINALIZED ---"
-OUTPUT_NAME="$OZONE_UPGRADE_TO"-finalized
+OUTPUT_NAME="${OZONE_UPGRADE_FROM}-${OZONE_UPGRADE_TO}-4-finalized"
 OZONE_KEEP_RESULTS=true start_docker_env
 
 # Sends commands to finalize OM and SCM.
-execute_robot_test "$SCM" upgrade/finalize.robot
+execute_robot_test "$SCM" -N "${OUTPUT_NAME}-finalize" upgrade/finalize.robot
 callback with_this_version_finalized


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade acceptance test runs the same Robot test files on different Ozone versions and in different states of the cluster. Robot test statistics (log.html) show the same suite name for each of these.

This change adds cluster state / version information to make these steps easier to understand.

https://issues.apache.org/jira/browse/HDDS-9744

## How was this patch tested?

Ran upgrade acceptance tests.  Robot test log.html attached to HDDS-9744 [before](https://issues.apache.org/jira/secure/attachment/13064868/before.html)/[after](https://issues.apache.org/jira/secure/attachment/13064867/after.html) the change.

CI:
https://github.com/adoroszlai/ozone/actions/runs/7051917960