### PR TITLE
HDDS-9784. Reduce default log.appender.wait-time.min to 0us in Datanode

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -183,13 +183,13 @@ public class TestDatanodeConfiguration {
 
     final DatanodeRatisServerConfig ratisConf = conf.getObject(
         DatanodeRatisServerConfig.class);
-    Assertions.assertEquals(1, ratisConf.getLogAppenderWaitTimeMin(),
+    Assertions.assertEquals(0, ratisConf.getLogAppenderWaitTimeMin(),
         "getLogAppenderWaitTimeMin");
 
-    assertWaitTimeMin(TimeDuration.ONE_MILLISECOND, conf);
-    ratisConf.setLogAppenderWaitTimeMin(0);
-    conf.setFromObject(ratisConf);
     assertWaitTimeMin(TimeDuration.ZERO, conf);
+    ratisConf.setLogAppenderWaitTimeMin(1);
+    conf.setFromObject(ratisConf);
+    assertWaitTimeMin(TimeDuration.ONE_MILLISECOND, conf);
   }
 
   static void assertWaitTimeMin(TimeDuration expected,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
@@ -193,7 +193,7 @@ public class DatanodeRatisServerConfig {
 
   /** @see RaftServerConfigKeys.Log.Appender#WAIT_TIME_MIN_KEY */
   @Config(key = "log.appender.wait-time.min",
-      defaultValue = "1ms",
+      defaultValue = "5us",
       type = ConfigType.TIME,
       tags = {OZONE, DATANODE, RATIS, PERFORMANCE},
       description = "Minimum wait time between two appendEntries calls."

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
@@ -193,10 +193,14 @@ public class DatanodeRatisServerConfig {
 
   /** @see RaftServerConfigKeys.Log.Appender#WAIT_TIME_MIN_KEY */
   @Config(key = "log.appender.wait-time.min",
-      defaultValue = "5us",
+      defaultValue = "0us",
       type = ConfigType.TIME,
       tags = {OZONE, DATANODE, RATIS, PERFORMANCE},
-      description = "Minimum wait time between two appendEntries calls."
+      description = "The minimum wait time between two appendEntries calls. " +
+          "In some error conditions, the leader may keep retrying " +
+          "appendEntries. If it happens, increasing this value to, say, " +
+          "5us (microseconds) can help avoid the leader being too busy " +
+          "retrying."
   )
   private long logAppenderWaitTimeMin;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix performance issues with DN
Detail:
https://issues.apache.org/jira/browse/HDDS-9784

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9784

## How was this patch tested?
existing test
