### PR TITLE
HDDS-9483. ozone freon --server is broken by HDDS-6176.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -39,6 +39,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -49,6 +51,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.ConfServlet;
 import org.apache.hadoop.conf.Configuration.IntegerRanges;
@@ -64,6 +67,8 @@ import org.apache.hadoop.http.FilterInitializer;
 import org.apache.hadoop.http.lib.StaticUserWebFilter;
 import org.apache.hadoop.jmx.JMXJsonServlet;
 import org.apache.hadoop.log.LogLevel;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.util.ShutdownHookManager;
 import org.apache.hadoop.security.AuthenticationFilterInitializer;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -1757,5 +1762,33 @@ public final class HttpServer2 implements FilterContainer {
   @VisibleForTesting
   protected List<ServerConnector> getListeners() {
     return listeners;
+  }
+
+  /**
+   * Utility method to initialize config key ozone.http.basedir and create a
+   * temporary directory under the current working directory if not set.
+   *
+   * @param ozoneConfiguration current configuration.
+   * @throws IOException if unable to create a temp directory.
+   */
+  public static void setHttpBaseDir(OzoneConfiguration ozoneConfiguration)
+          throws IOException {
+    if (org.apache.commons.lang3.StringUtils.isEmpty(ozoneConfiguration.get(
+            OzoneConfigKeys.OZONE_HTTP_BASEDIR))) {
+      // Setting ozone.http.basedir to cwd if not set so that server setup
+      // doesn't fail.
+      File tmpMetaDir = Files.createTempDirectory(Paths.get(""),
+              "ozone_http_tmp_base_dir").toFile();
+      ShutdownHookManager.get().addShutdownHook(() -> {
+        try {
+          FileUtils.deleteDirectory(tmpMetaDir);
+        } catch (IOException e) {
+          LOG.error("Failed to cleanup temporary metadata directory {}",
+                  tmpMetaDir.getAbsolutePath(), e);
+        }
+      }, 0);
+      ozoneConfiguration.set(OzoneConfigKeys.OZONE_HTTP_BASEDIR,
+              tmpMetaDir.getAbsolutePath());
+    }
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -17,19 +17,13 @@
  */
 package org.apache.hadoop.ozone.s3;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
@@ -46,6 +40,7 @@ import picocli.CommandLine.Command;
 
 import static org.apache.hadoop.hdds.StringUtils.startupShutdownMessage;
 import static org.apache.hadoop.hdds.ratis.RatisHelper.newJvmPauseMonitor;
+import static org.apache.hadoop.hdds.server.http.HttpServer2.setHttpBaseDir;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_KERBEROS_PRINCIPAL_KEY;
@@ -73,26 +68,7 @@ public class Gateway extends GenericCli {
     new Gateway().run(args);
   }
 
-  private void setHttpBaseDir()
-      throws IOException {
-    if (StringUtils.isEmpty(ozoneConfiguration.get(
-        OzoneConfigKeys.OZONE_HTTP_BASEDIR))) {
-      //Setting ozone.http.basedir to cwd if not set so that server setup
-      // doesn't fail.
-      File tmpMetaDir = Files.createTempDirectory(Paths.get(""),
-          "ozone_s3g_tmp_base_dir").toFile();
-      ShutdownHookManager.get().addShutdownHook(() -> {
-        try {
-          FileUtils.deleteDirectory(tmpMetaDir);
-        } catch (IOException e) {
-          LOG.error("Failed to cleanup temporary S3 Gateway Metadir {}",
-              tmpMetaDir.getAbsolutePath(), e);
-        }
-      }, 0);
-      ozoneConfiguration.set(OzoneConfigKeys.OZONE_HTTP_BASEDIR,
-          tmpMetaDir.getAbsolutePath());
-    }
-  }
+
 
   @Override
   public Void call() throws Exception {
@@ -101,7 +77,7 @@ public class Gateway extends GenericCli {
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     UserGroupInformation.setConfiguration(ozoneConfiguration);
     loginS3GUser(ozoneConfiguration);
-    setHttpBaseDir();
+    setHttpBaseDir(ozoneConfiguration);
     httpServer = new S3GatewayHttpServer(ozoneConfiguration, "s3gateway");
     metrics = S3GatewayMetrics.create();
     start();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -16,28 +16,23 @@
  */
 package org.apache.hadoop.ozone.freon;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.freon.containergenerator.GeneratorDatanode;
 import org.apache.hadoop.ozone.freon.containergenerator.GeneratorOm;
 import org.apache.hadoop.ozone.freon.containergenerator.GeneratorScm;
-import org.apache.hadoop.ozone.util.ShutdownHookManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+
+import static org.apache.hadoop.hdds.server.http.HttpServer2.setHttpBaseDir;
 
 /**
  * Ozone data generator and performance test tool.
@@ -118,31 +113,10 @@ public class Freon extends GenericCli {
     }
   }
 
-  private void setHttpBaseDir()
-      throws IOException {
-    if (StringUtils.isEmpty(conf.get(
-        OzoneConfigKeys.OZONE_HTTP_BASEDIR))) {
-      //Setting ozone.http.basedir to cwd if not set so that server setup
-      // doesn't fail.
-      File tmpMetaDir = Files.createTempDirectory(Paths.get(""),
-          "ozone_freon_tmp_base_dir").toFile();
-      ShutdownHookManager.get().addShutdownHook(() -> {
-        try {
-          FileUtils.deleteDirectory(tmpMetaDir);
-        } catch (IOException e) {
-          LOG.error("Failed to cleanup temporary Freon Metadir {}",
-              tmpMetaDir.getAbsolutePath(), e);
-        }
-      }, 0);
-      conf.set(OzoneConfigKeys.OZONE_HTTP_BASEDIR,
-          tmpMetaDir.getAbsolutePath());
-    }
-  }
-
   public void startHttpServer() {
     if (httpServer) {
       try {
-        setHttpBaseDir();
+        setHttpBaseDir(conf);
         freonHttpServer = new FreonHttpServer(conf);
         freonHttpServer.start();
       } catch (IOException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Specify a default temporary directory for HttpServer2 for 'ozone freon --server' command.

Please describe your PR in detail:
Essentially copy-pasted from HDDS-8253

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9483

## How was this patch tested?

Manually tested on a cluster.