### PR TITLE
HDDS-9822. Format audit log message lazily

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
@@ -29,7 +29,9 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -52,6 +54,7 @@ public class AuditLogger {
   public static final String AUDIT_LOG_DEBUG_CMD_LIST_PREFIX =
       "ozone.audit.log.debug.cmd.list.";
   private AuditLoggerType type;
+  private final Map<String, String> opNameCache = new ConcurrentHashMap<>();
 
   /**
    * Parametrized Constructor to initialize logger.
@@ -130,8 +133,11 @@ public class AuditLogger {
   }
 
   private boolean shouldLogAtDebug(AuditMessage auditMessage) {
-    return debugCmdSetRef.get()
-        .contains(auditMessage.getOp().toLowerCase(Locale.ROOT));
+    return debugCmdSetRef.get().contains(getLowerCaseOp(auditMessage.getOp()));
+  }
+
+  private String getLowerCaseOp(String op) {
+    return opNameCache.computeIfAbsent(op, k -> k.toLowerCase(Locale.ROOT));
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
  * Defines audit message structure.
  */
 public final class AuditMessage implements Message {
-  private final Supplier<String> messageSupplier;
+  private final transient Supplier<String> messageSupplier;
   private final String op;
   private final Throwable throwable;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
@@ -27,6 +27,9 @@ import java.util.function.Supplier;
  * Defines audit message structure.
  */
 public final class AuditMessage implements Message {
+
+  private static final long serialVersionUID = 1L;
+
   private final transient Supplier<String> messageSupplier;
   private final String op;
   private final Throwable throwable;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
@@ -16,38 +16,33 @@
  */
 package org.apache.hadoop.ozone.audit;
 
+import org.apache.hadoop.ozone.audit.AuditLogger.PerformanceStringBuilder;
 import org.apache.logging.log4j.message.Message;
+import org.apache.ratis.util.MemoizedSupplier;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Defines audit message structure.
  */
 public final class AuditMessage implements Message {
-
-  private final String message;
-  private final String user;
-  private final String ip;
+  private final Supplier<String> messageSupplier;
   private final String op;
-  private final Map<String, String> params;
-  private final String ret;
   private final Throwable throwable;
 
   private AuditMessage(String user, String ip, String op,
       Map<String, String> params, String ret, Throwable throwable,
-      String performance) {
-    this.user = user;
-    this.ip = ip;
+      PerformanceStringBuilder performance) {
     this.op = op;
-    this.params = params;
-    this.ret = ret;
-    this.message = formMessage(user, ip, op, params, ret, performance);
+    this.messageSupplier = MemoizedSupplier.valueOf(
+        () -> formMessage(user, ip, op, params, ret, performance));
     this.throwable = throwable;
   }
 
   @Override
   public String getFormattedMessage() {
-    return message;
+    return messageSupplier.get();
   }
 
   @Override
@@ -79,7 +74,7 @@ public final class AuditMessage implements Message {
     private String op;
     private Map<String, String> params;
     private String ret;
-    private String performance;
+    private PerformanceStringBuilder performance;
 
     public Builder setUser(String usr) {
       this.user = usr;
@@ -111,7 +106,7 @@ public final class AuditMessage implements Message {
       return this;
     }
 
-    public Builder setPerformance(String perf) {
+    public Builder setPerformance(PerformanceStringBuilder perf) {
       this.performance = perf;
       return this;
     }
@@ -124,9 +119,9 @@ public final class AuditMessage implements Message {
 
   private String formMessage(String userStr, String ipStr, String opStr,
       Map<String, String> paramsMap, String retStr,
-      String performanceMap) {
-    String perf = performanceMap != null && !performanceMap.isEmpty()
-        ? " | perf=" + performanceMap : "";
+      PerformanceStringBuilder performanceMap) {
+    String perf = performanceMap != null
+        ? " | perf=" + performanceMap.build() : "";
     return "user=" + userStr + " | ip=" + ipStr + " | " + "op=" + opStr
         + " " + paramsMap + " | ret=" + retStr + perf;
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -275,7 +275,7 @@ public class BucketEndpoint extends EndpointBase {
     perf.appendCount(keyCount);
     perf.appendOpLatencyNanos(opLatencyNs);
     AUDIT.logReadSuccess(buildAuditMessageForSuccess(s3GAction,
-        getAuditParameters(), perf.build()));
+        getAuditParameters(), perf));
     response.setKeyCount(keyCount);
     return Response.ok(response).build();
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.AuditLogger.PerformanceStringBuilder;
 import org.apache.hadoop.ozone.audit.AuditLoggerType;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.audit.Auditor;
@@ -354,7 +355,7 @@ public abstract class EndpointBase implements Auditor {
   }
 
   public AuditMessage buildAuditMessageForSuccess(AuditAction op,
-      Map<String, String> auditMap, String performance) {
+      Map<String, String> auditMap, PerformanceStringBuilder performance) {
     AuditMessage.Builder builder = auditMessageBaseBuilder(op, auditMap)
         .withResult(AuditEventStatus.SUCCESS);
     builder.setPerformance(performance);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -370,7 +370,7 @@ public class ObjectEndpoint extends EndpointBase {
         long opLatencyNs = getMetrics().updateCreateKeySuccessStats(startNanos);
         perf.appendOpLatencyNanos(opLatencyNs);
         AUDIT.logWriteSuccess(buildAuditMessageForSuccess(s3GAction,
-            getAuditParameters(), perf.build()));
+            getAuditParameters(), perf));
       }
     }
   }
@@ -405,7 +405,7 @@ public class ObjectEndpoint extends EndpointBase {
         Response response = listParts(bucketName, keyPath, uploadId,
             partMarker, maxParts, perf);
         AUDIT.logReadSuccess(buildAuditMessageForSuccess(s3GAction,
-            getAuditParameters(), perf.build()));
+            getAuditParameters(), perf));
         return response;
       }
 
@@ -444,7 +444,7 @@ public class ObjectEndpoint extends EndpointBase {
           long opLatencyNs =  getMetrics().updateGetKeySuccessStats(startNanos);
           perf.appendOpLatencyNanos(opLatencyNs);
           AUDIT.logReadSuccess(buildAuditMessageForSuccess(S3GAction.GET_KEY,
-              getAuditParameters(), perf.build()));
+              getAuditParameters(), perf));
         };
         responseBuilder = Response
             .ok(output)
@@ -468,7 +468,7 @@ public class ObjectEndpoint extends EndpointBase {
           long opLatencyNs = getMetrics().updateGetKeySuccessStats(startNanos);
           perf.appendOpLatencyNanos(opLatencyNs);
           AUDIT.logReadSuccess(buildAuditMessageForSuccess(S3GAction.GET_KEY,
-              getAuditParameters(), perf.build()));
+              getAuditParameters(), perf));
         };
         responseBuilder = Response
             .status(Status.PARTIAL_CONTENT)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implementation of lazy audit log message building by the `MessageSupplier`, which performs audit log building only when the log will be output.

```java
  public void logWriteSuccess(AuditMessage.Builder msg) {
    if (shouldLogAtDebug(msg)) {
      this.logger.logIfEnabled(
          FQCN, Level.DEBUG, WRITE_MARKER, msg::build, null);
    } else {
      this.logger.logIfEnabled(
          FQCN, Level.INFO, WRITE_MARKER, msg::build, null);
    }
  }
```
`logIfEnabled`: 
```java

public interface ExtendedLogger extends L
ogger {
//...
  /**
     * Logs a message which is only to be constructed if the specified level is active.
     *
     * @param fqcn The fully qualified class name of the logger entry point, used to determine the caller class and
     *            method when location information needs to be logged.
     * @param level The logging Level to check.
     * @param marker A Marker or null.
     * @param msgSupplier A function, which when called, produces the desired log message.
     * @param t the exception to log, including its stack trace.
     */
    void logIfEnabled(String fqcn, Level level, Marker marker, MessageSupplier msgSupplier, Throwable t);

}
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9822

## How was this patch tested?
existing test
