### PR TITLE
HDDS-9825. Fix ListKeys trailing slash prefix issue.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -273,6 +273,18 @@ public class TestListKeysWithFSO {
   }
 
   @Test
+  public void testListKeysWithAndWithoutTrailingSlashInPrefix()
+      throws Exception {
+    List<String> expectedKeys = new ArrayList<>();
+    expectedKeys.add("a1/b2/d2/d21.tx");
+    // With trailing slash
+    checkKeyList("a1/b2/d2/d21.tx/", "", expectedKeys, fsoOzoneBucket);
+
+    //Without trailing slash
+    checkKeyList("a1/b2/d2/d21.tx", "", expectedKeys, fsoOzoneBucket);
+  }
+
+  @Test
   public void testListKeysWithNonExistentStartKey() throws Exception {
     // case-1: StartKey LeafNode is lexographically ahead than prefixKey.
     // So, will return EmptyList

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import static org.apache.hadoop.hdds.scm.net.NetConstants.PATH_SEPARATOR_STR;
 import static org.apache.hadoop.ozone.om.OzoneManagerUtils.getBucketLayout;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
@@ -690,7 +691,10 @@ public final class OMFileRequest {
 
       if (omDirInfo != null) {
         lastKnownParentId = omDirInfo.getObjectID();
-      } else if (!elements.hasNext()) {
+      } else if (!elements.hasNext() && 
+          (!keyName.endsWith(PATH_SEPARATOR_STR))) {
+        // If the requested keyName contains "/" at the end then we need to
+        // just check the directory table.
         // reached last path component. Check file exists for the given path.
         OmKeyInfo omKeyInfo = OMFileRequest.getOmKeyInfoFromFileTable(false,
                 omMetadataMgr, dbNodeName, keyName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `prefix` is passed with trailing slash in `getOMKeyInfoIfExists` still we are querying in `fileTable` and returning back the result. Instead this `prefix` is assumed to be checked only in directory table in this case. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9825

## How was this patch tested?

New integration test added.