### PR TITLE
HDDS-9762. Fix dfs s3a protocol for FSO bucket.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -1227,6 +1227,7 @@ public class OzoneBucket extends WithMetadata {
         // Consider the case, keyPrefix="test/", prevKey="" or 'test1/',
         // then 'test/' will be added to the list result.
         startKey = nextOneKeys.get(0).getName();
+        startKey = startKey == null ? "" : startKey;
         if (getKeyPrefix().endsWith(OZONE_URI_DELIMITER) &&
             startKey.equals(getKeyPrefix())) {
           resultList.add(nextOneKeys.get(0));
@@ -1462,6 +1463,7 @@ public class OzoneBucket extends WithMetadata {
         // Note that the startKey needs to be an immediate child of the
         // keyPrefix or black before calling listStatus.
         startKey = adjustStartKey(startKey);
+        startKey = startKey == null ? "" : startKey;
       }
 
       // 2. Get immediate children by listStatus method.

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -116,10 +116,10 @@ public class BucketEndpoint extends EndpointBase {
     S3GAction s3GAction = S3GAction.GET_BUCKET;
     PerformanceStringBuilder perf = new PerformanceStringBuilder();
 
-    Iterator<? extends OzoneKey> ozoneKeyIterator;
+    Iterator<? extends OzoneKey> ozoneKeyIterator = null;
     ContinueToken decodedToken =
         ContinueToken.decodeFromString(continueToken);
-    OzoneBucket bucket;
+    OzoneBucket bucket = null;
 
     try {
       if (aclMarker != null) {
@@ -164,8 +164,10 @@ public class BucketEndpoint extends EndpointBase {
       getMetrics().updateGetBucketFailureStats(startNanos);
       if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
+      } else if(ex.getResult() == ResultCodes.FILE_NOT_FOUND) {
+        // File not found, send normal response with 0 keyCount
       } else {
-        throw ex;
+          throw ex;
       }
     } catch (Exception ex) {
       getMetrics().updateGetBucketFailureStats(startNanos);
@@ -206,9 +208,9 @@ public class BucketEndpoint extends EndpointBase {
     }
     String lastKey = null;
     int count = 0;
-    while (ozoneKeyIterator.hasNext()) {
+    while (ozoneKeyIterator != null && ozoneKeyIterator.hasNext()) {
       OzoneKey next = ozoneKeyIterator.next();
-      if (bucket.getBucketLayout().isFileSystemOptimized() &&
+      if (bucket != null && bucket.getBucketLayout().isFileSystemOptimized() &&
           StringUtils.isNotEmpty(prefix) &&
           !next.getName().startsWith(prefix)) {
         // prefix has delimiter but key don't have

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -164,10 +164,11 @@ public class BucketEndpoint extends EndpointBase {
       getMetrics().updateGetBucketFailureStats(startNanos);
       if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
-      } else if(ex.getResult() == ResultCodes.FILE_NOT_FOUND) {
-        // File not found, send normal response with 0 keyCount
+      } else if (ex.getResult() == ResultCodes.FILE_NOT_FOUND) {
+        // File not found, continue and send normal response with 0 keyCount
+        LOG.debug("Key Not found prefix: {}", prefix);
       } else {
-          throw ex;
+        throw ex;
       }
     } catch (Exception ex) {
       getMetrics().updateGetBucketFailureStats(startNanos);


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are two problem which is handled in this PR
1. Handle NPE in `OzoneBucket` as `startKey` doesn't accept NULL value, which impacts LightWeight ListKeys API (Using Lightweight API introduced in [HDDS-8773](https://issues.apache.org/jira/browse/HDDS-8773)).
2. After [HDDS-8773](https://issues.apache.org/jira/browse/HDDS-8773) fix, it just query the shallow list keys, Because of this in this case if key doesn't exist KEY_NOT_FOUND exception is getting thrown in BucketEnd Point, which in turn throw exception to s3api.
But in case if key not found case also, it should return normal response with 0 keycount to s3api.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9762

## How was this patch tested?

Manually verified
