### PR TITLE
HDDS-9830. Propagate DBUpdateSuccess flag from OM response to client

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -446,6 +446,10 @@ public class RDBStore implements DBStore {
             dbUpdatesWrapper.getCurrentSequenceNumber() - sequenceNumber);
       }
     }
+    if (!dbUpdatesWrapper.isDBUpdateSuccess()) {
+      LOG.warn("Returned DBUpdates isDBUpdateSuccess: {}",
+          dbUpdatesWrapper.isDBUpdateSuccess());
+    }
     return dbUpdatesWrapper;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -474,4 +474,8 @@ public class RDBStore implements DBStore {
   public RDBMetrics getMetrics() {
     return rdbMetrics;
   }
+
+  public static Logger getLogger() {
+    return LOG;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2176,6 +2176,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         dbUpdatesResponse.getSequenceNumber());
     dbUpdatesWrapper.setLatestSequenceNumber(
         dbUpdatesResponse.getLatestSequenceNumber());
+    dbUpdatesWrapper.setDBUpdateSuccess(dbUpdatesResponse.getDbUpdateSuccess());
     return dbUpdatesWrapper;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -28,6 +28,8 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LOOP_LIMIT;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmDeltaRequest;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmSnapshotRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -63,36 +65,26 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test Ozone Recon.
  */
+@Timeout(300)
 public class TestReconWithOzoneManager {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
   private static MiniOzoneCluster cluster = null;
   private static OzoneConfiguration conf;
   private static OMMetadataManager metadataManager;
   private static CloseableHttpClient httpClient;
-  private static String containerKeyServiceURL;
   private static String taskStatusURL;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     int socketTimeout = (int) conf.getTimeDuration(
@@ -135,8 +127,6 @@ public class TestReconWithOzoneManager {
     InetSocketAddress address =
         cluster.getReconServer().getHttpServer().getHttpAddress();
     String reconHTTPAddress = address.getHostName() + ":" + address.getPort();
-    containerKeyServiceURL = "http://" + reconHTTPAddress +
-        "/api/v1/containers";
     taskStatusURL = "http://" + reconHTTPAddress + "/api/v1/task/status";
 
     // initialize HTTPClient
@@ -146,7 +136,7 @@ public class TestReconWithOzoneManager {
         .build();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -192,8 +182,8 @@ public class TestReconWithOzoneManager {
         metadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
 
     // verify if OM has /vol0/bucket0/key0
-    Assert.assertEquals("vol0", keyInfo1.getVolumeName());
-    Assert.assertEquals("bucket0", keyInfo1.getBucketName());
+    assertEquals("vol0", keyInfo1.getVolumeName());
+    assertEquals("bucket0", keyInfo1.getBucketName());
 
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
         cluster.getReconServer().getOzoneManagerServiceProvider();
@@ -211,8 +201,8 @@ public class TestReconWithOzoneManager {
         "lastUpdatedSeqNumber");
 
     // verify sequence number after full snapshot
-    Assert.assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
-    Assert.assertEquals(0, metrics.getSequenceNumberLag().value());
+    assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+    assertEquals(0, metrics.getSequenceNumberLag().value());
 
     //add 4 keys to check for delta updates
     addKeys(1, 5);
@@ -229,8 +219,8 @@ public class TestReconWithOzoneManager {
         taskStatusResponse, OmDeltaRequest.name(), "lastUpdatedSeqNumber");
 
     //verify sequence number after Delta Updates
-    Assert.assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
-    Assert.assertEquals(0, metrics.getSequenceNumberLag().value());
+    assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+    assertEquals(0, metrics.getSequenceNumberLag().value());
 
     long beforeRestartSnapShotTimeStamp = getReconTaskAttributeFromJson(
         taskStatusResponse,
@@ -265,12 +255,115 @@ public class TestReconWithOzoneManager {
             "lastUpdatedTimestamp");
 
     // verify only Delta updates were added to recon after restart.
-    Assert.assertEquals(beforeRestartSnapShotTimeStamp,
+    assertEquals(beforeRestartSnapShotTimeStamp,
         afterRestartSnapShotTimeStamp);
 
     //verify sequence number after Delta Updates
-    Assert.assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
-    Assert.assertEquals(0, metrics.getSequenceNumberLag().value());
+    assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+    assertEquals(0, metrics.getSequenceNumberLag().value());
+  }
+
+  // This test simulates the mis-match in sequence number between Recon OM
+  // snapshot DB and OzoneManager OM active DB. Recon sync with OM DB every
+  // 5-10 mins based on configured interval and if Recon OM snapshot DB
+  // has higher sequence number than OM active DB last sequence number,
+  // then OM DB updates call since last sequence number will fail as OM DB
+  // will not know about that sequence number which is not yet written to
+  // OM Rocks DB. In such case OM sets the 'isDBUpdateSuccess' flag as false.
+  // And Recon should fall back on full snapshot and recover itself.
+  @Test
+  public void testOmDBSyncWithSeqNumberMismatch() throws Exception {
+    // add a vol, bucket and key
+    addKeys(10, 15);
+
+    // check if OM metadata has vol10/bucket10/key10 info
+    String ozoneKey = metadataManager.getOzoneKey(
+        "vol10", "bucket10", "key10");
+    OmKeyInfo keyInfo1 =
+        metadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+
+    // verify if OM has /vol10/bucket10/key10
+    assertEquals("vol10", keyInfo1.getVolumeName());
+    assertEquals("bucket10", keyInfo1.getBucketName());
+
+    OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
+        cluster.getReconServer().getOzoneManagerServiceProvider();
+    impl.syncDataFromOM();
+    OzoneManagerSyncMetrics metrics = impl.getMetrics();
+
+    // HTTP call to /api/task/status
+    long omLatestSeqNumber = ((RDBStore) metadataManager.getStore())
+        .getDb().getLatestSequenceNumber();
+
+    String taskStatusResponse = makeHttpCall(taskStatusURL);
+    long reconLatestSeqNumber = getReconTaskAttributeFromJson(
+        taskStatusResponse,
+        OmDeltaRequest.name(),
+        "lastUpdatedSeqNumber");
+
+    // verify sequence number after full snapshot
+    assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+    assertEquals(0, metrics.getSequenceNumberLag().value());
+
+    OMMetadataManager reconMetadataManagerInstance =
+        cluster.getReconServer().getOzoneManagerServiceProvider()
+            .getOMMetadataManagerInstance();
+
+    String volume = "vol15";
+    String bucket = "bucket15";
+    String key = "key15";
+    String omKey = reconMetadataManagerInstance.getOzoneKey(volume,
+        bucket, key);
+
+    // Write additional key in new volume and new bucket in Recon OM snapshot
+    // DB to increase the last sequence number by 1 in comparison to OM
+    // active DB, this simulates the mis-match between 2 DBs before triggering
+    // syncDataFromOM call.
+    reconMetadataManagerInstance.getKeyTable(getBucketLayout()).put(omKey,
+        new OmKeyInfo.Builder()
+            .setBucketName(bucket)
+            .setVolumeName(volume)
+            .setKeyName(key)
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
+                HddsProtos.ReplicationFactor.ONE))
+            .setOmKeyLocationInfos(
+                Collections.singletonList(getOmKeyLocationInfoGroup()))
+            .build());
+
+    reconLatestSeqNumber =
+        ((RDBStore) reconMetadataManagerInstance.getStore()).getDb()
+            .getLatestSequenceNumber();
+    assertEquals(omLatestSeqNumber + 1, reconLatestSeqNumber);
+
+    // This OM DB sync call will eventually fail and throw exception at OM
+    // cluster's getDBUpdates(since lastSequenceNumber) API as expected and
+    // will return 'isDBUpdateSuccess' flag as false which will force Recon
+    // to fallback on full snapshot. Full snapshot sync should normalize the
+    // OM active DB lastSequence number and Recon's OM snapshot DB lastSequence
+    // number.
+    impl.syncDataFromOM();
+    reconLatestSeqNumber =
+        ((RDBStore) reconMetadataManagerInstance.getStore()).getDb()
+            .getLatestSequenceNumber();
+    assertEquals(0, metrics.getSequenceNumberLag().value());
+    assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+    reconLatestSeqNumber = getReconTaskAttributeFromJson(
+        taskStatusResponse,
+        OmDeltaRequest.name(),
+        "lastUpdatedSeqNumber");
+    assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+  }
+
+  private static OmKeyLocationInfoGroup getOmKeyLocationInfoGroup() {
+    Pipeline pipeline = HddsTestUtils.getRandomPipeline();
+    List<OmKeyLocationInfo> omKeyLocationInfoList = new ArrayList<>();
+    BlockID blockID = new BlockID(15, 1);
+    OmKeyLocationInfo omKeyLocationInfo1 = getOmKeyLocationInfo(blockID,
+        pipeline);
+    omKeyLocationInfoList.add(omKeyLocationInfo1);
+    OmKeyLocationInfoGroup omKeyLocationInfoGroup = new
+        OmKeyLocationInfoGroup(0, omKeyLocationInfoList);
+    return omKeyLocationInfoGroup;
   }
 
   private long getReconTaskAttributeFromJson(String taskStatusResponse,
@@ -282,7 +375,7 @@ public class TestReconWithOzoneManager {
             .stream()
             .filter(task -> task.get("taskName").equals(taskName))
             .findFirst();
-    Assert.assertTrue(taskEntity.isPresent());
+    assertTrue(taskEntity.isPresent());
     return (long)(double) taskEntity.get().get(entityAttribute);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -278,6 +278,13 @@ public class TestReconWithOzoneManager {
     GenericTestUtils.LogCapturer
         logs = GenericTestUtils.LogCapturer.captureLogs(RDBStore.getLogger());
     GenericTestUtils.setLogLevel(RDBStore.getLogger(), INFO);
+
+    GenericTestUtils.LogCapturer
+        omServiceProviderImplLogs = GenericTestUtils.LogCapturer.captureLogs(
+        OzoneManagerServiceProviderImpl.getLogger());
+    GenericTestUtils.setLogLevel(OzoneManagerServiceProviderImpl.getLogger(),
+        INFO);
+
     // add a vol, bucket and key
     addKeys(10, 15);
 
@@ -349,6 +356,8 @@ public class TestReconWithOzoneManager {
     impl.syncDataFromOM();
     assertTrue(logs.getOutput()
         .contains("Requested sequence not yet written in the db"));
+    assertTrue(logs.getOutput()
+        .contains("Returned DBUpdates isDBUpdateSuccess: false"));
     reconLatestSeqNumber =
         ((RDBStore) reconMetadataManagerInstance.getStore()).getDb()
             .getLatestSequenceNumber();
@@ -361,6 +370,9 @@ public class TestReconWithOzoneManager {
     assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
     assertEquals(17, omLatestSeqNumber);
     assertEquals(17, reconLatestSeqNumber);
+    impl.syncDataFromOM();
+    assertTrue(omServiceProviderImplLogs.getOutput()
+        .contains("isDBUpdateSuccess: true"));
   }
 
   private static OmKeyLocationInfoGroup getOmKeyLocationInfoGroup() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -485,7 +485,8 @@ public class OzoneManagerServiceProviderImpl
     LOG.info("Number of updates received from OM : {}, " +
             "SequenceNumber diff: {}, SequenceNumber Lag from OM {}, " +
             "isDBUpdateSuccess: {}", numUpdates, getCurrentOMDBSequenceNumber()
-        - fromSequenceNumber, lag, dbUpdates.isDBUpdateSuccess());
+            - fromSequenceNumber, lag,
+        null != dbUpdates && dbUpdates.isDBUpdateSuccess());
     return null != dbUpdates && dbUpdates.isDBUpdateSuccess();
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -578,5 +578,9 @@ public class OzoneManagerServiceProviderImpl
   public OzoneManagerSyncMetrics getMetrics() {
     return metrics;
   }
+
+  public static Logger getLogger() {
+    return LOG;
+  }
 }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -483,8 +483,9 @@ public class OzoneManagerServiceProviderImpl
         latestSequenceNumberOfOM - getCurrentOMDBSequenceNumber();
     metrics.setSequenceNumberLag(lag);
     LOG.info("Number of updates received from OM : {}, " +
-            "SequenceNumber diff: {}, SequenceNumber Lag from OM {}.",
-        numUpdates, getCurrentOMDBSequenceNumber() - fromSequenceNumber, lag);
+            "SequenceNumber diff: {}, SequenceNumber Lag from OM {}, " +
+            "isDBUpdateSuccess: {}", numUpdates, getCurrentOMDBSequenceNumber()
+        - fromSequenceNumber, lag, dbUpdates.isDBUpdateSuccess());
     return null != dbUpdates && dbUpdates.isDBUpdateSuccess();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes the `isDBUpdateSuccess` flag being set at OzoneManger's `org.apache.hadoop.ozone.om.OzoneManager#getDBUpdates` API. This flag was being set at server side, but was not set at client layer in `org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB#getDBUpdates`. Because of this, Recon didn't knkow about any DB updates failure at OM side and Recon was not able to recover by falling back on full snapshot OM DB update. 
One of the prominent use case found for OM DB update failure is the mis-match in sequence number between Recon OM
snapshot DB and OzoneManager OM active DB.
Since Recon sync with OM DB every 5-10 mins based on configured interval and if Recon OM snapshot DB  has higher sequence number than OM active DB last sequence number, then OM DB updates call since last sequence number will fail as OM DB will not know about that sequence number which is not yet written to OM Rocks DB. In such case OM sets the 'isDBUpdateSuccess' flag as false, but because the client layer at OM side was not setting this flag, Recon never gets the correct status of getDBUpdates API call. Once `isDBUpdateSuccess` flag received as false by Recon, Recon should fall back on full snapshot and recover itself.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9830

## How was this patch tested?
This patch is tested by writing an integration test where the test has increased the lastSequenceNumber intentionally for OM DB snapshot DB at Recon and making syncOMDB call to simulate the mis-match in sequence number between Recon OM
snapshot DB and OzoneManager OM active DB.
