### PR TITLE
HDDS-9850. Bump okhttp to 4.12.0, okio to 3.6.0, kotlin to 1.9.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <spotbugs.version>3.1.12</spotbugs.version>
     <dnsjava.version>2.1.7</dnsjava.version>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>
-    <okhttp3.version>4.9.3</okhttp3.version>
+    <okhttp3.version>4.12.0</okhttp3.version>
     <stax2.version>4.2.1</stax2.version>
     <jakarta.inject.version>2.6.1</jakarta.inject.version>
     <jakarta.annotation.version>1.3.5</jakarta.annotation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <disruptor.version>3.4.2</disruptor.version>
     <reload4j.version>1.2.22</reload4j.version>
 
-    <kotlin.version>1.6.21</kotlin.version>
+    <kotlin.version>1.9.21</kotlin.version>
     <metainf-services.version>1.8</metainf-services.version>
     <picocli.version>4.7.5</picocli.version>
     <prometheus.version>0.7.0</prometheus.version>
@@ -217,7 +217,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <objenesis.version>1.0</objenesis.version>
     <okhttp.version>2.7.5</okhttp.version>
-    <okio.version>3.4.0</okio.version>
+    <okio.version>3.6.0</okio.version>
     <mockito1-powermock.version>1.10.19</mockito1-powermock.version>
     <mockito2.version>3.5.9</mockito2.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -1388,13 +1388,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </dependency>
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
+        <artifactId>kotlin-bom</artifactId>
         <version>${kotlin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-common</artifactId>
-        <version>${kotlin.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.opentracing</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Bump `okhttp` to 4.12.0, `okio` to 3.6.0, `kotlin` to 1.9.21
* Use `kotlin-bom` to ensure consistent versions of various `org.jetbrains.kotlin` artifacts (they are also transitive dependency of `okhttp`)

https://issues.apache.org/jira/browse/HDDS-9850

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7112934454