### PR TITLE
HDDS-9849. Improve UUID generator and get rid of java-uuid-generator dependency

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -240,10 +240,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${io.grpc.version}</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.uuid</groupId>
-      <artifactId>java-uuid-generator</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/UUIDUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/UUIDUtil.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.util;
 
 import java.security.SecureRandom;
-import java.util.UUID;
 
 /**
  * Helper methods to deal with random UUIDs.
@@ -33,23 +32,6 @@ public final class UUIDUtil {
   private static final ThreadLocal<SecureRandom> GENERATOR =
       ThreadLocal.withInitial(SecureRandom::new);
 
-  public static UUID randomUUID() {
-    long r1;
-    long r2;
-    byte[] uuidBytes = randomUUIDBytes();
-    r1 = toLong(uuidBytes, 0);
-    r2 = toLong(uuidBytes, 1);
-
-    // first, ensure type is ok
-    r1 &= ~0xF000L; // remove high nibble of 6th byte
-    r1 |= (long) (4 << 12);
-    // second, ensure variant is properly set too
-    // (8th byte; most-sig byte of second long)
-    r2 = ((r2 << 2) >>> 2); // remove 2 MSB
-    r2 |= (2L << 62); // set 2 MSB to '10'
-    return new UUID(r1, r2);
-  }
-
   public static byte[] randomUUIDBytes() {
     final byte[] bytes = new byte[16];
     GENERATOR.get().nextBytes(bytes);
@@ -59,20 +41,6 @@ public final class UUIDUtil {
     bytes[8]  &= 0x3f;
     bytes[8]  |= 0x80;
     return bytes;
-  }
-
-  private static long toLong(byte[] buffer, int offset) {
-    long l1 = toInt(buffer, offset);
-    long l2 = toInt(buffer, offset + 4);
-    long l = (l1 << 32) + ((l2 << 32) >>> 32);
-    return l;
-  }
-
-  private static long toInt(byte[] buffer, int offset) {
-    return (buffer[offset] << 24)
-        + ((buffer[++offset] & 0xFF) << 16)
-        + ((buffer[++offset] & 0xFF) << 8)
-        + (buffer[++offset] & 0xFF);
   }
 
 }

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -448,7 +448,6 @@ Apache License 2.0
    org.yaml:snakeyaml
    software.amazon.ion:ion-java
    org.awaitility:awaitility
-   com.fasterxml.uuid:java-uuid-generator
 
 MIT
 =====================

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -274,4 +274,3 @@ share/ozone/lib/woodstox-core.jar
 share/ozone/lib/zookeeper.jar
 share/ozone/lib/zookeeper-jute.jar
 share/ozone/lib/zstd-jni.jar
-share/ozone/lib/java-uuid-generator.jar

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
@@ -33,8 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -98,11 +96,7 @@ public class OzoneManagerServiceGrpc extends OzoneManagerServiceImplBase {
   }
 
   private static byte[] getClientId() {
-    UUID uuid = UUIDUtil.randomUUID();
-    ByteBuffer buf = ByteBuffer.wrap(new byte[16]);
-    buf.putLong(uuid.getMostSignificantBits());
-    buf.putLong(uuid.getLeastSignificantBits());
-    return buf.array();
+    return UUIDUtil.randomUUIDBytes();
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jgrapht.version>1.0.1</jgrapht.version>
 
     <vault.driver.version>5.1.0</vault.driver.version>
-    <java.uuid.generator.version>4.3.0</java.uuid.generator.version>
     <native.lib.tmp.dir></native.lib.tmp.dir>
   </properties>
 
@@ -1579,11 +1578,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>mockito-inline</artifactId>
         <version>${mockito2.version}</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.uuid</groupId>
-        <artifactId>java-uuid-generator</artifactId>
-        <version>${java.uuid.generator.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Provide a method to get generated UUID as a bytes array and get rid of the fasterxml:java-uuid-generator dependency

Please describe your PR in detail:
* a new method was written to provide a generate UUID as a bytes array - org.apache.hadoop.util.UUIDUtil#randomUUIDBytes
* the org.apache.hadoop.util.UUIDUtil#randomUUID method was rewritten to use the method described above and a couple of private methods to compute the most and the least significant bits

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9849

## How was this patch tested?
manually
