### PR TITLE
HDDS-8982. Infinite loop in WritableRatisContainerProvider if pipeline's nodes are not found

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -614,6 +614,11 @@ public final class ScmConfigKeys {
       "ozone.scm.ha.dbtransactionbuffer.flush.interval";
   public static final long
       OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL_DEFAULT = 600 * 1000L;
+
+  public static final String OZONE_SCM_GET_CONTAINER_MAX_RETRY =
+      "ozone.scm.get.container.max.retry";
+  public static final int OZONE_SCM_GET_CONTAINER_MAX_RETRY_DEFAULT = 4096;
+
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -615,10 +615,6 @@ public final class ScmConfigKeys {
   public static final long
       OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL_DEFAULT = 600 * 1000L;
 
-  public static final String OZONE_SCM_GET_CONTAINER_MAX_RETRY =
-      "ozone.scm.get.container.max.retry";
-  public static final int OZONE_SCM_GET_CONTAINER_MAX_RETRY_DEFAULT = 4096;
-
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -818,6 +818,14 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.get.container.max.retry</name>
+    <value>4096</value>
+    <tag>OZONE, SCM</tag>
+    <description>
+      This property determines how many times SCM is going to retry getContainer operation for Ratis type container.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.chunk.size</name>
     <value>4MB</value>
     <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -818,14 +818,6 @@
     </description>
   </property>
   <property>
-    <name>ozone.scm.get.container.max.retry</name>
-    <value>4096</value>
-    <tag>OZONE, SCM</tag>
-    <description>
-      This property determines how many times SCM is going to retry getContainer operation for Ratis type container.
-    </description>
-  </property>
-  <property>
     <name>ozone.scm.chunk.size</name>
     <value>4MB</value>
     <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -340,7 +340,10 @@ public class ContainerManagerImpl implements ContainerManager {
       }
     } catch (Exception e) {
       LOG.warn("Container allocation failed on pipeline={}", pipeline, e);
-      return null;
+      return new ContainerInfo.Builder()
+          .setContainerID(-1)
+          .setPipelineID(pipeline.getId())
+          .build();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -341,7 +341,7 @@ public class ContainerManagerImpl implements ContainerManager {
     } catch (Exception e) {
       LOG.warn("Container allocation failed on pipeline={}", pipeline, e);
       return new ContainerInfo.Builder()
-          .setContainerID(-1)
+          .setContainerID(0)
           .setPipelineID(pipeline.getId())
           .build();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -207,6 +207,9 @@ public class WritableECContainerProvider
         excludedNodes, Collections.emptyList());
     ContainerInfo container =
         containerManager.getMatchingContainer(size, owner, newPipeline);
+    if (container != null && container.getContainerID() == -1) {
+      container = null;
+    }
     pipelineManager.openPipeline(newPipeline.getId());
     LOG.info("Created and opened new pipeline {}", newPipeline);
     return container;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
@@ -49,7 +49,8 @@ public class WritableRatisContainerProvider
   private final PipelineManager pipelineManager;
   private final PipelineChoosePolicy pipelineChoosePolicy;
   private final ContainerManager containerManager;
-  private static final int MAX_RETRY_GET_CONTAINER = 4096;
+  // added in HDDS-8982, it shouldn't be exposed to users to configure
+  private static int MAX_RETRY_GET_CONTAINER = 4096;
 
 
   public WritableRatisContainerProvider(ConfigurationSource conf,
@@ -88,7 +89,7 @@ public class WritableRatisContainerProvider
     //in downstream managers.
 
     int currentCount = 0;
-    while (currentCount < MAX_RETRY_GET_CONTAINER) {
+    while (currentCount < getMaxRetryGetContainer()) {
       List<Pipeline> availablePipelines;
       Pipeline pipeline;
       // Acquire pipeline manager lock, to avoid any updates to pipeline
@@ -105,8 +106,8 @@ public class WritableRatisContainerProvider
               excludeList);
         }
         if (containerInfo != null) {
-          // if containerID == -1, means Container allocation
-          // failed on selected pipeline
+          // selectContainer returns containerID with 0 whenever
+          // container allocation failed on selected pipeline
           if (containerInfo.getContainerID() != 0) {
             return containerInfo;
           } else {
@@ -227,6 +228,10 @@ public class WritableRatisContainerProvider
 
     return containerInfo;
 
+  }
+
+  public int getMaxRetryGetContainer() {
+    return MAX_RETRY_GET_CONTAINER;
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
@@ -50,7 +50,7 @@ public class WritableRatisContainerProvider
   private final PipelineChoosePolicy pipelineChoosePolicy;
   private final ContainerManager containerManager;
   // added in HDDS-8982, it shouldn't be exposed to users to configure
-  private static int MAX_RETRY_GET_CONTAINER = 4096;
+  private static int maxRetryGetContainer = 4096;
 
 
   public WritableRatisContainerProvider(ConfigurationSource conf,
@@ -231,7 +231,7 @@ public class WritableRatisContainerProvider
   }
 
   public int getMaxRetryGetContainer() {
-    return MAX_RETRY_GET_CONTAINER;
+    return maxRetryGetContainer;
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
@@ -98,6 +98,8 @@ public class TestWritableRatisContainerProvider {
     containerManager = mock(ContainerManager.class);
     provider = spy(new WritableRatisContainerProvider(conf,
         pipelineManager, containerManager, policy));
+    when(provider.getMaxRetryGetContainer())
+        .thenReturn(testSCMGetContainerMaxRetry);
   }
 
   @ParameterizedTest

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
+import org.apache.hadoop.hdds.scm.PipelineRequestInformation;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
+import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy;
+import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_GET_CONTAINER_MAX_RETRY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Tests to validate the WritableRatisContainerProvider works correctly.
+ */
+public class TestWritableRatisContainerProvider {
+
+  private static final String OWNER = "SCM";
+  private PipelineManager pipelineManager;
+  private ContainerManager containerManager;
+  private OzoneConfiguration conf;
+  private WritableRatisContainerProvider provider;
+  private ReplicationConfig repConfig;
+
+  private int testSCMGetContainerMaxRetry;
+
+  @Parameterized.Parameters
+  public static Collection<PipelineChoosePolicy> policies() {
+    Collection<PipelineChoosePolicy> policies = new ArrayList<>();
+
+    Pipeline pipeline = mock(Pipeline.class);
+    RandomPipelineChoosePolicy randomPipelineChoosePolicy =
+        mock(RandomPipelineChoosePolicy.class);
+    when(randomPipelineChoosePolicy.choosePipeline(anyList(),
+        any(PipelineRequestInformation.class))).thenReturn(pipeline);
+
+    HealthyPipelineChoosePolicy healthyPipelineChoosePolicy =
+        mock(HealthyPipelineChoosePolicy.class);
+    when(healthyPipelineChoosePolicy.choosePipeline(anyList(),
+        any(PipelineRequestInformation.class))).thenReturn(pipeline);
+
+    policies.add(randomPipelineChoosePolicy);
+    policies.add(healthyPipelineChoosePolicy);
+
+    return policies;
+  }
+
+  void setup(PipelineChoosePolicy policy) {
+    conf = new OzoneConfiguration();
+    testSCMGetContainerMaxRetry = 3;
+    conf.setInt(OZONE_SCM_GET_CONTAINER_MAX_RETRY,
+        testSCMGetContainerMaxRetry);
+
+    repConfig = mock(ReplicationConfig.class);
+    pipelineManager = mock(PipelineManager.class);
+    containerManager = mock(ContainerManager.class);
+    provider = spy(new WritableRatisContainerProvider(conf,
+        pipelineManager, containerManager, policy));
+  }
+
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testSelectContainerShouldNoMoreThanMaxRetry(
+      PipelineChoosePolicy policy) {
+    setup(policy);
+    List<Pipeline> pipelines = mock(ArrayList.class);
+    when(pipelines.size()).thenReturn(3);
+    when(pipelineManager.getPipelines(any(ReplicationConfig.class),
+        any(Pipeline.PipelineState.class), anyCollection(),
+        anyCollection())).thenReturn(pipelines);
+    ContainerInfo containerInfo = mock(ContainerInfo.class);
+    when(containerInfo.getContainerID()).thenReturn(-1L);
+    when(containerManager.getMatchingContainer(anyLong(), anyString(),
+        any(Pipeline.class), anySet())).thenReturn(containerInfo);
+
+    ExcludeList exclude = mock(ExcludeList.class);
+
+    try {
+      provider.getContainer(
+          1, repConfig, OWNER, exclude);
+      fail("expected IOException");
+    } catch (IOException e) {
+      assertTrue(e.getMessage()
+          .contains("Unable to allocate a container to the block"));
+    }
+
+    verify(provider, times(testSCMGetContainerMaxRetry))
+        .selectContainer(anyList(), anyLong(),
+            anyString(), any(ExcludeList.class));
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("policies")
+  public void testSelectContainerShouldNoMoreThanMaxRetryAfterCreateNewPipeline(
+      PipelineChoosePolicy policy) throws IOException {
+    setup(policy);
+    List<Pipeline> emptyPipelines = new ArrayList<>();
+    List<Pipeline> pipelines = mock(ArrayList.class);
+    when(pipelines.size()).thenReturn(3);
+    when(pipelineManager.getPipelines(any(ReplicationConfig.class),
+        any(Pipeline.PipelineState.class), anyCollection(), anyCollection()))
+        .thenReturn(emptyPipelines, pipelines);
+
+    Pipeline pipeline1 = mock(Pipeline.class);
+    when(pipeline1.getId()).thenReturn(mock(PipelineID.class));
+    when(pipelineManager.createPipeline(any(ReplicationConfig.class)))
+        .thenReturn(pipeline1);
+
+    ContainerInfo containerInfo = mock(ContainerInfo.class);
+    when(containerInfo.getContainerID()).thenReturn(-1L);
+
+    PipelineID pipelineID2 = PipelineID.valueOf(UUID.randomUUID());
+
+    when(containerInfo.getPipelineID()).thenReturn(pipelineID2);
+    when(containerManager.getMatchingContainer(anyLong(), anyString(), any(
+        Pipeline.class), anySet())).thenReturn(containerInfo);
+
+    ExcludeList exclude = new ExcludeList();
+
+    try {
+      provider.getContainer(
+          1, repConfig, OWNER, exclude);
+      fail("expected IOException");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().
+          contains("Unable to allocate a container to the block"));
+    }
+
+    assertEquals(exclude.getPipelineIds(),
+        new HashSet<>(Arrays.asList(pipelineID2)));
+    verify(provider, times(testSCMGetContainerMaxRetry))
+        .selectContainer(anyList(), anyLong(), anyString(),
+            any(ExcludeList.class));
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_GET_CONTAINER_MAX_RETRY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -93,8 +92,6 @@ public class TestWritableRatisContainerProvider {
   void setup(PipelineChoosePolicy policy) {
     conf = new OzoneConfiguration();
     testSCMGetContainerMaxRetry = 3;
-    conf.setInt(OZONE_SCM_GET_CONTAINER_MAX_RETRY,
-        testSCMGetContainerMaxRetry);
 
     repConfig = mock(ReplicationConfig.class);
     pipelineManager = mock(PipelineManager.class);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
@@ -111,7 +111,7 @@ public class TestWritableRatisContainerProvider {
         any(Pipeline.PipelineState.class), anyCollection(),
         anyCollection())).thenReturn(pipelines);
     ContainerInfo containerInfo = mock(ContainerInfo.class);
-    when(containerInfo.getContainerID()).thenReturn(-1L);
+    when(containerInfo.getContainerID()).thenReturn(0L);
     when(containerManager.getMatchingContainer(anyLong(), anyString(),
         any(Pipeline.class), anySet())).thenReturn(containerInfo);
 
@@ -150,7 +150,7 @@ public class TestWritableRatisContainerProvider {
         .thenReturn(pipeline1);
 
     ContainerInfo containerInfo = mock(ContainerInfo.class);
-    when(containerInfo.getContainerID()).thenReturn(-1L);
+    when(containerInfo.getContainerID()).thenReturn(0L);
 
     PipelineID pipelineID2 = PipelineID.valueOf(UUID.randomUUID());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-8982. Prevent infinite loop in getContainer which causes log flooded by WritableRatisContainerProvider if pipeline's nodes are not found

Please describe your PR in detail:
- add the failed pipeline in exclude list on WritableRatisContainerProvider side
- add maxRetry in configuration to make sure the while loop only executes no more than maxRetry of times.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8982

## How was this patch tested?
unit test
