### PR TITLE
HDDS-9877. ReplicationManager: Create a data driven test framework to cover similar test scenarios

### DIFF
--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -257,6 +257,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes>
+            <exclude>**/*.json</exclude>
             <exclude>**/hs_err*.log</exclude>
             <exclude>**/.attach_*</exclude>
             <exclude>**/**.rej</exclude>

--- a/hadoop-hdds/server-scm/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/server-scm/dev-support/findbugsExcludeFile.xml
@@ -51,20 +51,4 @@
     <Class name="org.apache.hadoop.hdds.scm.metadata.TestSCMTransactionInfoCodec"/>
     <Bug pattern="NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS" />
   </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.container.replication.TestReplicationManagerScenarios$ExpectedCommands"/>
-    <Bug pattern="UWF_UNWRITTEN_FIELD" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.container.replication.TestReplicationManagerScenarios$PendingReplica"/>
-    <Bug pattern="UWF_UNWRITTEN_FIELD" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.container.replication.TestReplicationManagerScenarios$Scenario"/>
-    <Bug pattern="UWF_UNWRITTEN_FIELD" />
-  </Match>
-  <Match>
-    <Class name="org.apache.hadoop.hdds.scm.container.replication.TestReplicationManagerScenarios$TestReplica"/>
-    <Bug pattern="UWF_UNWRITTEN_FIELD" />
-  </Match>
 </FindBugsFilter>

--- a/hadoop-hdds/server-scm/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/server-scm/dev-support/findbugsExcludeFile.xml
@@ -51,4 +51,20 @@
     <Class name="org.apache.hadoop.hdds.scm.metadata.TestSCMTransactionInfoCodec"/>
     <Bug pattern="NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS" />
   </Match>
+  <Match>
+    <Class name="org.apache.hadoop.hdds.scm.container.replication.TestReplicationManagerScenarios$ExpectedCommands"/>
+    <Bug pattern="UWF_UNWRITTEN_FIELD" />
+  </Match>
+  <Match>
+    <Class name="org.apache.hadoop.hdds.scm.container.replication.TestReplicationManagerScenarios$PendingReplica"/>
+    <Bug pattern="UWF_UNWRITTEN_FIELD" />
+  </Match>
+  <Match>
+    <Class name="org.apache.hadoop.hdds.scm.container.replication.TestReplicationManagerScenarios$Scenario"/>
+    <Bug pattern="UWF_UNWRITTEN_FIELD" />
+  </Match>
+  <Match>
+    <Class name="org.apache.hadoop.hdds.scm.container.replication.TestReplicationManagerScenarios$TestReplica"/>
+    <Bug pattern="UWF_UNWRITTEN_FIELD" />
+  </Match>
 </FindBugsFilter>

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -24,12 +24,14 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.TestContainerInfo;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.Node;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -275,6 +277,12 @@ public final class ReplicationTestUtil {
       protected Node getPlacementGroup(DatanodeDetails dn) {
         // Make it look like a single rack cluster
         return rackNode;
+      }
+
+      @Override
+      public ContainerPlacementStatus
+          validateContainerPlacement(List<DatanodeDetails> dns, int replicas) {
+        return new ContainerPlacementStatusDefault(2, 2, 3);
       }
     };
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -386,7 +385,6 @@ public class TestReplicationManagerScenarios {
    * This class is used to define the replicas used in the test scenarios. It is
    * created by deserializing JSON files.
    */
-  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static class TestReplica {
     private ContainerReplicaProto.State state
         = ContainerReplicaProto.State.CLOSED;
@@ -407,6 +405,10 @@ public class TestReplicationManagerScenarios {
     private String origin;
     private UUID originId;
 
+    public void setContainerId(long containerId) {
+      this.containerId = containerId;
+    }
+
     public void setDatanode(String datanode) {
       this.datanode = datanode;
     }
@@ -415,13 +417,33 @@ public class TestReplicationManagerScenarios {
       this.origin = origin;
     }
 
+    public void setIndex(int index) {
+      this.index = index;
+    }
+
+    public void setSequenceId(int sequenceId) {
+      this.sequenceId = sequenceId;
+    }
+
     public void setState(String state) {
       this.state = ContainerReplicaProto.State.valueOf(state);
+    }
+
+    public void setKeys(long keys) {
+      this.keys = keys;
+    }
+
+    public void setUsed(long used) {
+      this.used = used;
     }
 
     public void setHealthState(String healthState) {
       this.healthState = HddsProtos.NodeState.valueOf(
           healthState.toUpperCase());
+    }
+
+    public void setIsEmpty(boolean empty) {
+      isEmpty = empty;
     }
 
     public void setOperationalState(String operationalState) {
@@ -492,7 +514,6 @@ public class TestReplicationManagerScenarios {
    * This class is used to define the expected counts for each health state and
    * queues. It is created by deserializing JSON files.
    */
-  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static class Expectation {
 
     private Map<ReplicationManagerReport.HealthState, Integer> stateCounts

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -114,6 +115,11 @@ public class TestReplicationManagerScenarios {
     File[] fileList = (new File(TestReplicationManagerScenarios.class
         .getClass().getResource(TEST_RESOURCE_PATH)
         .toURI())).listFiles();
+    if (fileList == null) {
+      Assertions.fail("No test file resources found");
+      // Make findbugs happy.
+      return Collections.emptyList();
+    }
     List<URI> uris = new ArrayList<>();
     for (File file : fileList) {
       uris.add(file.toURI());
@@ -140,6 +146,14 @@ public class TestReplicationManagerScenarios {
     List<URI> testFiles = getTestFiles();
     for (URI file : testFiles) {
       Scenario[] scenarios = loadTestsInFile(file);
+      Set<String> names = new HashSet<>();
+      for (Scenario scenario : scenarios) {
+        if (!names.add(scenario.getDescription())) {
+          Assertions.fail("Duplicate test name: " + scenario.getDescription() +
+              " in file: " + file);
+        }
+        scenario.setResourceName(file.toString());
+      }
       Collections.addAll(TEST_SCENARIOS, scenarios);
     }
   }
@@ -369,6 +383,7 @@ public class TestReplicationManagerScenarios {
    * This class is used to define the replicas used in the test scenarios. It is
    * created by deserializing JSON files.
    */
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static class TestReplica {
     private ContainerReplicaProto.State state
         = ContainerReplicaProto.State.CLOSED;
@@ -389,48 +404,16 @@ public class TestReplicationManagerScenarios {
     private String origin;
     private UUID originId;
 
-    public void setState(String state) {
+    private void setState(String state) {
       this.state = ContainerReplicaProto.State.valueOf(state);
     }
 
-    public void setContainerId(long containerId) {
-      this.containerId = containerId;
-    }
-
-    public void setDatanode(String datanode) {
-      this.datanode = datanode;
-    }
-
-    public void setIndex(int index) {
-      this.index = index;
-    }
-
-    public void setSequenceId(int sequenceId) {
-      this.sequenceId = sequenceId;
-    }
-
-    public void setKeys(long keys) {
-      this.keys = keys;
-    }
-
-    public void setUsed(long used) {
-      this.used = used;
-    }
-
-    public void setIsEmpty(boolean isEmpty) {
-      this.isEmpty = isEmpty;
-    }
-
-    public void setOrigin(String origin) {
-      this.origin = origin;
-    }
-
-    public void setHealthState(String healthState) {
+    private void setHealthState(String healthState) {
       this.healthState = HddsProtos.NodeState.valueOf(
           healthState.toUpperCase());
     }
 
-    public void setOperationalState(String operationalState) {
+    private void setOperationalState(String operationalState) {
       this.operationalState = HddsProtos.NodeOperationalState.valueOf(
           operationalState.toUpperCase());
     }
@@ -498,6 +481,7 @@ public class TestReplicationManagerScenarios {
    * This class is used to define the expected counts for each health state and
    * queues. It is created by deserializing JSON files.
    */
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static class Expectation {
 
     private Map<ReplicationManagerReport.HealthState, Integer> stateCounts
@@ -505,52 +489,44 @@ public class TestReplicationManagerScenarios {
     private int underReplicatedQueue = 0;
     private int overReplicatedQueue = 0;
 
-    public void setUnderReplicated(int underReplicated) {
+    private void setUnderReplicated(int underReplicated) {
       stateCounts.put(ReplicationManagerReport.HealthState.UNDER_REPLICATED,
           underReplicated);
     }
 
-    public void setOverReplicated(int overReplicated) {
+    private void setOverReplicated(int overReplicated) {
       stateCounts.put(ReplicationManagerReport.HealthState.OVER_REPLICATED,
           overReplicated);
     }
 
-    public void setMisReplicated(int misReplicated) {
+    private void setMisReplicated(int misReplicated) {
       stateCounts.put(ReplicationManagerReport.HealthState.MIS_REPLICATED,
           misReplicated);
     }
 
-    public void setUnhealthy(int unhealthy) {
+    private void setUnhealthy(int unhealthy) {
       stateCounts.put(ReplicationManagerReport.HealthState.UNHEALTHY,
           unhealthy);
     }
 
-    public void setMissing(int missing) {
+    private void setMissing(int missing) {
       stateCounts.put(ReplicationManagerReport.HealthState.MISSING,
           missing);
     }
 
-    public void setEmpty(int empty) {
+    private void setEmpty(int empty) {
       stateCounts.put(ReplicationManagerReport.HealthState.EMPTY,
           empty);
     }
 
-    public void setQuasiClosedStuck(int quasiClosedStuck) {
+    private void setQuasiClosedStuck(int quasiClosedStuck) {
       stateCounts.put(ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK,
           quasiClosedStuck);
     }
 
-    public void setOpenUnhealthy(int openUnhealthy) {
+    private void setOpenUnhealthy(int openUnhealthy) {
       stateCounts.put(ReplicationManagerReport.HealthState.OPEN_UNHEALTHY,
           openUnhealthy);
-    }
-
-    public void setUnderReplicatedQueue(int underReplicatedQueue) {
-      this.underReplicatedQueue = underReplicatedQueue;
-    }
-
-    public void setOverReplicatedQueue(int overReplicatedQueue) {
-      this.overReplicatedQueue = overReplicatedQueue;
     }
 
     public int getExpected(ReplicationManagerReport.HealthState state) {
@@ -570,15 +546,12 @@ public class TestReplicationManagerScenarios {
    * This class is used to define the expected commands for each replica. It is
    * created by deserializing JSON files.
    */
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static class ExpectedCommands {
     private SCMCommandProto.Type type;
     private String datanode;
 
-    public void setDatanode(String datanode) {
-      this.datanode = datanode;
-    }
-
-    public void setType(String command) {
+    private void setType(String command) {
       ReplicateContainerCommand replicateContainerCommand;
       this.type = SCMCommandProto.Type.valueOf(command);
     }
@@ -604,21 +577,14 @@ public class TestReplicationManagerScenarios {
    * This class is used to define the pending replicas for the container. It is
    * created by deserializing JSON files.
    */
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static class PendingReplica {
     private ContainerReplicaOp.PendingOpType type;
     private String datanode;
     private int replicaIndex;
 
-    public void setDatanode(String dn) {
-      this.datanode = dn;
-    }
-
-    public void setType(String type) {
+    private void setType(String type) {
       this.type = ContainerReplicaOp.PendingOpType.valueOf(type);
-    }
-
-    public void setReplicaIndex(int index) {
-      this.replicaIndex = index;
     }
 
     public DatanodeDetails getDatanodeDetails() {
@@ -645,8 +611,10 @@ public class TestReplicationManagerScenarios {
    * deserializing JSON files. It defines the base container used for the test,
    * and provides getter for the replicas and expected results.
    */
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static class Scenario {
     private String description;
+    private String resourceName;
     private int ecMaintenanceRedundancy;
     private int ratisMaintenanceMinimum;
     private HddsProtos.LifeCycleState containerState =
@@ -671,16 +639,8 @@ public class TestReplicationManagerScenarios {
       ratisMaintenanceMinimum = conf.getMaintenanceReplicaMinimum();
     }
 
-    public void setDescription(String description) {
-      this.description = description;
-    }
-
-    public void setEcMaintenanceRedundancy(int val) {
-      this.ecMaintenanceRedundancy = val;
-    }
-
-    public void setRatisMaintenanceMinimum(int val) {
-      this.ratisMaintenanceMinimum = val;
+    public void setResourceName(String resourceName) {
+      this.description = resourceName;
     }
 
     public int getEcMaintenanceRedundancy() {
@@ -695,60 +655,20 @@ public class TestReplicationManagerScenarios {
       return description;
     }
 
-    public void setContainerState(String containerState) {
+    private void setContainerState(String containerState) {
       this.containerState = HddsProtos.LifeCycleState.valueOf(containerState);
     }
 
-    public void setSequenceId(int sequenceId) {
-      this.sequenceId = sequenceId;
-    }
-
-    public void setReplicas(TestReplica[] replicas) {
-      this.replicas = replicas;
-    }
-
-    public void setUsed(long used) {
-      this.used = used;
-    }
-
-    public void setOwner(String owner) {
-      this.owner = owner;
-    }
-
-    public void setKeys(long keys) {
-      this.keys = keys;
-    }
-
-    public void setId(long id) {
-      this.id = id;
-    }
-
-    public void setPendingReplicas(PendingReplica[] pending) {
-      this.pendingReplicas = pending;
-    }
-
     public PendingReplica[] getPendingReplicas() {
-      return this.pendingReplicas;
-    }
-
-    public void setExpectation(Expectation expectation) {
-      this.expectation = expectation;
-    }
-
-    public void setCommands(ExpectedCommands[] commands) {
-      this.commands = commands;
-    }
-
-    public void setCheckCommands(ExpectedCommands[] cmds) {
-      this.checkCommands = cmds;
+      return this.pendingReplicas.clone();
     }
 
     public ExpectedCommands[] getCheckCommands() {
-      return checkCommands;
+      return checkCommands.clone();
     }
 
     public TestReplica[] getReplicas() {
-      return replicas;
+      return replicas.clone();
     }
 
     public Expectation getExpectation() {
@@ -761,7 +681,7 @@ public class TestReplicationManagerScenarios {
      *    EC:rs-3-2-1024k
      * @param replicationConfig
      */
-    public void setReplicationConfig(String replicationConfig) {
+    private void setReplicationConfig(String replicationConfig) {
       String[] parts = replicationConfig.split(":");
       if (parts.length != 2) {
         throw new IllegalArgumentException(
@@ -795,12 +715,12 @@ public class TestReplicationManagerScenarios {
     }
 
     public ExpectedCommands[] getCommands() {
-      return commands;
+      return commands.clone();
     }
 
     @Override
     public String toString() {
-      return description;
+      return resourceName + ": " + description;
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -295,12 +295,10 @@ public class TestReplicationManagerScenarios {
     Expectation expectation = scenario.getExpectation();
     Assertions.assertEquals(expectation.getUnderReplicatedQueue(),
         repQueue.underReplicatedQueueSize(), "Test: "
-            + scenario.getDescription()
-            + ": Unexpected count for underReplicatedQueue");
+            + scenario + ": Unexpected count for underReplicatedQueue");
     Assertions.assertEquals(expectation.getOverReplicatedQueue(),
         repQueue.overReplicatedQueueSize(), "Test: "
-            + scenario.getDescription()
-            + ": Unexpected count for overReplicatedQueue");
+            + scenario + ": Unexpected count for overReplicatedQueue");
 
     assertExpectedCommands(scenario, scenario.getCheckCommands());
     commandsSent.clear();
@@ -329,15 +327,14 @@ public class TestReplicationManagerScenarios {
         ReplicationManagerReport.HealthState.values()) {
       Assertions.assertEquals(expectation.getExpected(state),
           report.getStat(state), "Test: "
-              + scenario.getDescription() + ": Unexpected count for " + state);
+              + scenario + ": Unexpected count for " + state);
     }
   }
 
   private void assertExpectedCommands(Scenario scenario,
       ExpectedCommands[] expectedCommands) {
     Assertions.assertEquals(expectedCommands.length, commandsSent.size(),
-        "Test: " + scenario.getDescription()
-            + ": Unexpected count for commands sent");
+        "Test: " + scenario + ": Unexpected count for commands sent");
     // Iterate the expected commands and check that they were all sent. If we
     // have a target datanode, then we need to check that the command was sent
     // to that target. The targets in the tests work off aliases for the
@@ -365,7 +362,7 @@ public class TestReplicationManagerScenarios {
           }
         }
       }
-      Assertions.assertTrue(found, "Test: " + scenario.getDescription()
+      Assertions.assertTrue(found, "Test: " + scenario
           + ": Expected command not sent: " + expectedCommand.getType());
     }
   }
@@ -640,7 +637,7 @@ public class TestReplicationManagerScenarios {
     }
 
     public void setResourceName(String resourceName) {
-      this.description = resourceName;
+      this.resourceName = resourceName;
     }
 
     public int getEcMaintenanceRedundancy() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -1,0 +1,676 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.apache.ozone.test.TestClock;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * This class tests the replication manager using a set of scenarios defined in
+ * JSON files. The scenarios define a container and a set of replicas, and the
+ * expected results from the replication manager. The scenarios are defined in
+ * JSON files in the test resources directory. The test files are loaded in
+ * {@link #init()} and the tests are run in {@link #testAllScenarios(Scenario)}.
+ *
+ * There are several inner class defined within this class, and they are used to
+ * deserialize the JSON files into Java objects. In general any field which is a
+ * setter on the inner class can be set in the JSON file.
+ *
+ */
+
+public class TestReplicationManagerScenarios {
+  private static final Map<String, UUID> ORIGINS = new HashMap<>();
+  private static final Map<String, DatanodeDetails> DATANODE_ALIASES
+      = new HashMap<>();
+  private static final Map<DatanodeDetails, NodeStatus> NODE_STATUS_MAP
+      = new HashMap<>();
+  private static final String TEST_RESOURCE_PATH = "/replicationManagerTests";
+  private static final List<Scenario> TEST_SCENARIOS = new ArrayList<>();
+
+  private Map<ContainerID, Set<ContainerReplica>> containerReplicaMap;
+  private Set<ContainerInfo> containerInfoSet;
+
+  private OzoneConfiguration configuration;
+  private ReplicationManager replicationManager;
+  private LegacyReplicationManager legacyReplicationManager;
+  private ContainerManager containerManager;
+  private PlacementPolicy ratisPlacementPolicy;
+  private PlacementPolicy ecPlacementPolicy;
+  private EventPublisher eventPublisher;
+  private SCMContext scmContext;
+  private NodeManager nodeManager;
+  private TestClock clock;
+  private ContainerReplicaPendingOps containerReplicaPendingOps;
+
+  private ReplicationManagerReport repReport;
+  private ReplicationQueue repQueue;
+  private Set<Pair<UUID, SCMCommand<?>>> commandsSent;
+
+  private static List<URI> getTestFiles() throws URISyntaxException {
+    File[] fileList = (new File(TestReplicationManagerScenarios.class
+        .getClass().getResource(TEST_RESOURCE_PATH)
+        .toURI())).listFiles();
+    List<URI> uris = new ArrayList<>();
+    for (File file : fileList) {
+      uris.add(file.toURI());
+    }
+    return uris;
+  }
+
+  private static Scenario[] loadTestsInFile(URI testFile) throws IOException {
+    try (InputStream stream = testFile.toURL().openStream()) {
+      return new ObjectMapper().readValue(stream, Scenario[].class);
+    } catch (Exception e) {
+      System.out.println("Failed to load test file: " + testFile);
+      throw e;
+    }
+  }
+
+  /**
+   * Load all the JSON files in the test resources directory and add them to the
+   * list of tests to run. If there is a parsing failure in any of the json
+   * files, the entire test will fail.
+   */
+  @BeforeAll
+  public static void init() throws IOException, URISyntaxException {
+    List<URI> testFiles = getTestFiles();
+    for (URI file : testFiles) {
+      Scenario[] scenarios = loadTestsInFile(file);
+      Collections.addAll(TEST_SCENARIOS, scenarios);
+    }
+  }
+
+  @BeforeEach
+  public void setup() throws IOException, NodeNotFoundException {
+    configuration = new OzoneConfiguration();
+    configuration.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
+    containerManager = Mockito.mock(ContainerManager.class);
+
+    scmContext = Mockito.mock(SCMContext.class);
+    nodeManager = Mockito.mock(NodeManager.class);
+
+    ratisPlacementPolicy = ReplicationTestUtil
+        .getSimpleTestPlacementPolicy(nodeManager, configuration);
+    ecPlacementPolicy = ReplicationTestUtil
+        .getSimpleTestPlacementPolicy(nodeManager, configuration);
+
+    commandsSent = new HashSet<>();
+    eventPublisher = Mockito.mock(EventPublisher.class);
+    Mockito.doAnswer(invocation -> {
+      commandsSent.add(Pair.of(invocation.getArgument(0),
+          invocation.getArgument(1)));
+      return null;
+    }).when(nodeManager).addDatanodeCommand(any(), any());
+
+    legacyReplicationManager = Mockito.mock(LegacyReplicationManager.class);
+    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    containerReplicaPendingOps =
+        new ContainerReplicaPendingOps(clock);
+
+    Mockito.when(containerManager
+        .getContainerReplicas(Mockito.any(ContainerID.class))).thenAnswer(
+            invocation -> {
+              ContainerID cid = invocation.getArgument(0);
+              return containerReplicaMap.get(cid);
+            });
+
+    Mockito.when(containerManager.getContainers()).thenAnswer(
+        invocation -> new ArrayList<>(containerInfoSet));
+
+    Mockito.when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenAnswer(invocation -> {
+          DatanodeDetails dn = invocation.getArgument(0);
+          return NODE_STATUS_MAP.getOrDefault(dn,
+              NodeStatus.inServiceHealthy());
+        });
+
+    final HashMap<SCMCommandProto.Type, Integer> countMap = new HashMap<>();
+    for (SCMCommandProto.Type type : SCMCommandProto.Type.values()) {
+      countMap.put(type, 0);
+    }
+    Mockito.when(
+        nodeManager.getTotalDatanodeCommandCounts(any(DatanodeDetails.class),
+            any(SCMCommandProto.Type.class), any(SCMCommandProto.Type.class)))
+        .thenReturn(countMap);
+
+    replicationManager = createReplicationManager();
+    containerReplicaMap = new HashMap<>();
+    containerInfoSet = new HashSet<>();
+    repReport = new ReplicationManagerReport();
+    repQueue = new ReplicationQueue();
+
+    // Ensure that RM will run when asked.
+    Mockito.when(scmContext.isLeaderReady()).thenReturn(true);
+    Mockito.when(scmContext.isInSafeMode()).thenReturn(false);
+
+    ORIGINS.clear();
+    DATANODE_ALIASES.clear();
+    NODE_STATUS_MAP.clear();
+  }
+
+  private ReplicationManager createReplicationManager() throws IOException {
+    return new ReplicationManager(
+        configuration,
+        containerManager,
+        ratisPlacementPolicy,
+        ecPlacementPolicy,
+        eventPublisher,
+        scmContext,
+        nodeManager,
+        clock,
+        legacyReplicationManager,
+        containerReplicaPendingOps) {
+      @Override
+      protected void startSubServices() {
+        // do not start any threads for processing
+      }
+    };
+  }
+
+  protected static UUID getOrCreateOrigin(String origin) {
+    return ORIGINS.computeIfAbsent(origin, (k) -> UUID.randomUUID());
+  }
+
+  private static Stream<Scenario> getTestScenarios() {
+    return TEST_SCENARIOS.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("getTestScenarios")
+  public void testAllScenarios(Scenario scenario) throws IOException {
+    ContainerInfo containerInfo = scenario.buildContainerInfo();
+
+    Set<ContainerReplica> replicas = new HashSet<>();
+    for (TestReplica replica : scenario.getReplicas()) {
+      replicas.add(replica.buildContainerReplica());
+    }
+    // Set up the maps used by the mocks passed into Replication Manager, so it
+    // can find the replicas and containers created here.
+    containerInfoSet.add(containerInfo);
+    containerReplicaMap.put(containerInfo.containerID(), replicas);
+
+    // Run the replication manager check phase.
+    replicationManager.processContainer(containerInfo, repQueue, repReport);
+
+    // Check the results in the report and queue against the expected results.
+    Expectations expectations = scenario.getExpectation();
+    for (ReplicationManagerReport.HealthState state :
+        ReplicationManagerReport.HealthState.values()) {
+      Assertions.assertEquals(expectations.getExpected(state),
+          repReport.getStat(state), "Test: "
+              + scenario.getDescription() + ": Unexpected count for " + state);
+    }
+
+    Assertions.assertEquals(expectations.getUnderReplicatedQueue(),
+        repQueue.underReplicatedQueueSize(), "Test: "
+            + scenario.getDescription()
+            + ": Unexpected count for underReplicatedQueue");
+    Assertions.assertEquals(expectations.getOverReplicatedQueue(),
+        repQueue.overReplicatedQueueSize(), "Test: "
+            + scenario.getDescription()
+            + ": Unexpected count for overReplicatedQueue");
+
+    // TODO - check command sent in check phase, eg to close containers etc.
+
+    commandsSent.clear();
+
+    // TODO - run in read only and check expectations but also no commands sent.
+
+
+    // Now run the replication manager execute phase, where we expect commands
+    // to be sent to fix the under and over replicated containers.
+    if (repQueue.underReplicatedQueueSize() > 0) {
+      replicationManager.processUnderReplicatedContainer(
+          repQueue.dequeueUnderReplicatedContainer());
+    } else if (repQueue.overReplicatedQueueSize() > 0) {
+      replicationManager.processOverReplicatedContainer(
+          repQueue.dequeueOverReplicatedContainer());
+    }
+    ExpectedCommands[] expectedCommands = scenario.getCommands();
+
+    Assertions.assertEquals(expectedCommands.length, commandsSent.size(),
+        "Test: " + scenario.getDescription()
+        + ": Unexpected count for commands sent");
+
+    // Iterate the expected commands and check that they were all sent. If we
+    // have a target datanode, then we need to check that the command was sent
+    // to that target. The targets in the tests work off aliases for the
+    // datanodes.
+    for (ExpectedCommands expectedCommand : expectedCommands) {
+      boolean found = false;
+      for (Pair<UUID, SCMCommand<?>> command : commandsSent) {
+        if (command.getRight().getType() == expectedCommand.getType()) {
+          DatanodeDetails targetDatanode = expectedCommand.getTargetDatanode();
+          if (targetDatanode != null) {
+            // We need to assert against the command the datanode is sent to
+            DatanodeDetails commandDatanode =
+                findDatanodeFromUUID(command.getKey());
+            if (commandDatanode != null && commandDatanode.equals(
+                targetDatanode)) {
+              found = true;
+              commandsSent.remove(command);
+              break;
+            }
+          } else {
+            // We don't care what datanode the command is sent to.
+            found = true;
+            commandsSent.remove(command);
+            break;
+          }
+        }
+      }
+      Assertions.assertTrue(found, "Test: " + scenario.getDescription()
+          + ": Expected command not sent: " + expectedCommand.getType());
+    }
+
+    // TODO - set maintenance allowed
+    // TODO - is there a way to handle mis-replication here?
+  }
+
+  private DatanodeDetails findDatanodeFromUUID(UUID uuid) {
+    for (DatanodeDetails dn : DATANODE_ALIASES.values()) {
+      if (dn.getUuid().equals(uuid)) {
+        return dn;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * This class is used to define the replicas used in the test scenarios. It is
+   * created by deserializing JSON files.
+   */
+  public static class TestReplica {
+    private ContainerReplicaProto.State state
+        = ContainerReplicaProto.State.CLOSED;
+    private long containerId = 1;
+    // This is a string identifier for a datanode that can be referenced in
+    // test expectations and commands. The real datanode will be generated.
+    private String datanode;
+    private DatanodeDetails datanodeDetails =
+        MockDatanodeDetails.randomDatanodeDetails();
+    private HddsProtos.NodeOperationalState operationalState
+        = HddsProtos.NodeOperationalState.IN_SERVICE;
+    private HddsProtos.NodeState healthState = HddsProtos.NodeState.HEALTHY;
+
+    private int index = 0;
+    private int sequenceId = 0;
+    private long keys = 10;
+    private long used = 10;
+    private boolean isEmpty = false;
+    private String origin;
+    private UUID originId;
+
+    public void setState(String state) {
+      this.state = ContainerReplicaProto.State.valueOf(state);
+    }
+
+    public void setContainerId(long containerId) {
+      this.containerId = containerId;
+    }
+
+    public void setDatanode(String datanode) {
+      this.datanode = datanode;
+      this.datanodeDetails = DATANODE_ALIASES.computeIfAbsent(datanode, (k) ->
+          MockDatanodeDetails.randomDatanodeDetails());
+    }
+
+    public void setIndex(int index) {
+      this.index = index;
+    }
+
+    public void setSequenceId(int sequenceId) {
+      this.sequenceId = sequenceId;
+    }
+
+    public void setKeys(long keys) {
+      this.keys = keys;
+    }
+
+    public void setUsed(long used) {
+      this.used = used;
+    }
+
+    public void setIsEmpty(boolean isEmpty) {
+      this.isEmpty = isEmpty;
+    }
+
+    public void setOrigin(String origin) {
+      this.origin = origin;
+      this.originId = getOrCreateOrigin(origin);
+    }
+
+    public void setHealthState(String healthState) {
+      this.healthState = HddsProtos.NodeState.valueOf(
+          healthState.toUpperCase());
+    }
+
+    public void setOperationalState(String operationalState) {
+      this.operationalState = HddsProtos.NodeOperationalState.valueOf(
+          operationalState.toUpperCase());
+    }
+
+    public String getOrigin() {
+      return origin;
+    }
+
+    // This returns the datanode identifier, not the real datanode.
+    public String getDatanode() {
+      return datanode;
+    }
+
+    public DatanodeDetails getDatanodeDetails() {
+      return datanodeDetails;
+    }
+
+    public ContainerReplica buildContainerReplica() {
+
+      NODE_STATUS_MAP.put(datanodeDetails,
+          new NodeStatus(operationalState, healthState));
+      datanodeDetails.setPersistedOpState(operationalState);
+
+      ContainerReplica.ContainerReplicaBuilder builder =
+          new ContainerReplica.ContainerReplicaBuilder();
+      return builder.setReplicaIndex(index)
+          .setContainerID(new ContainerID(containerId))
+          .setContainerState(state)
+          .setSequenceId(sequenceId)
+          .setDatanodeDetails(datanodeDetails)
+          .setKeyCount(keys)
+          .setBytesUsed(used)
+          .setEmpty(isEmpty)
+          .setOriginNodeId(originId).build();
+    }
+  }
+
+  /**
+   * This class is used to define the expected counts for each health state and
+   * queues. It is created by deserializing JSON files.
+   */
+  public static class Expectations {
+
+    private Map<ReplicationManagerReport.HealthState, Integer> stateCounts
+        = new HashMap<>();
+    private int underReplicatedQueue = 0;
+    private int overReplicatedQueue = 0;
+
+    public void setUnderReplicated(int underReplicated) {
+      stateCounts.put(ReplicationManagerReport.HealthState.UNDER_REPLICATED,
+          underReplicated);
+    }
+
+    public void setOverReplicated(int overReplicated) {
+      stateCounts.put(ReplicationManagerReport.HealthState.OVER_REPLICATED,
+          overReplicated);
+    }
+
+    public void setMisReplicated(int misReplicated) {
+      stateCounts.put(ReplicationManagerReport.HealthState.MIS_REPLICATED,
+          misReplicated);
+    }
+
+    public void setUnhealthy(int unhealthy) {
+      stateCounts.put(ReplicationManagerReport.HealthState.UNHEALTHY,
+          unhealthy);
+    }
+
+    public void setMissing(int missing) {
+      stateCounts.put(ReplicationManagerReport.HealthState.MISSING,
+          missing);
+    }
+
+    public void setEmpty(int empty) {
+      stateCounts.put(ReplicationManagerReport.HealthState.EMPTY,
+          empty);
+    }
+
+    public void setQuasiClosedStuck(int quasiClosedStuck) {
+      stateCounts.put(ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK,
+          quasiClosedStuck);
+    }
+
+    public void setOpenUnhealthy(int openUnhealthy) {
+      stateCounts.put(ReplicationManagerReport.HealthState.OPEN_UNHEALTHY,
+          openUnhealthy);
+    }
+
+    public void setUnderReplicatedQueue(int underReplicatedQueue) {
+      this.underReplicatedQueue = underReplicatedQueue;
+    }
+
+    public void setOverReplicatedQueue(int overReplicatedQueue) {
+      this.overReplicatedQueue = overReplicatedQueue;
+    }
+
+    public int getExpected(ReplicationManagerReport.HealthState state) {
+      return stateCounts.getOrDefault(state, 0);
+    }
+
+    public int getUnderReplicatedQueue() {
+      return underReplicatedQueue;
+    }
+
+    public int getOverReplicatedQueue() {
+      return overReplicatedQueue;
+    }
+  }
+
+  /**
+   * This class is used to define the expected commands for each replica. It is
+   * created by deserializing JSON files.
+   */
+  public static class ExpectedCommands {
+    private SCMCommandProto.Type type;
+    private String datanode;
+
+    public void setDatanode(String datanode) {
+      this.datanode = datanode;
+    }
+
+    public void setType(String command) {
+      ReplicateContainerCommand replicateContainerCommand;
+      this.type = SCMCommandProto.Type.valueOf(command);
+    }
+
+    public SCMCommandProto.Type getType () {
+      return type;
+    }
+
+    public DatanodeDetails getTargetDatanode() {
+      if (datanode == null) {
+        return null;
+      }
+      DatanodeDetails datanodeDetails = DATANODE_ALIASES.get(this.datanode);
+      if (datanodeDetails == null) {
+        Assertions.fail("Unable to find a datanode for the alias: " + datanode
+            + " in the expected commands.");
+      }
+      return datanodeDetails;
+    }
+  }
+
+  /**
+   * This class is used to define the test scenarios. It is created by
+   * deserializing JSON files. It defines the base container used for the test,
+   * and provides getter for the replicas and expected results.
+   */
+  public static class Scenario {
+    private String description;
+    private HddsProtos.LifeCycleState containerState =
+        HddsProtos.LifeCycleState.CLOSED;
+    private long used = 10;
+    private long keys = 10;
+    private long id = 1;
+    private String owner = "theowner";
+    private int sequenceId = 0;
+    private ReplicationConfig replicationConfig = RatisReplicationConfig
+        .getInstance(HddsProtos.ReplicationFactor.THREE);
+    private TestReplica[] replicas;
+    private Expectations expectation;
+    private ExpectedCommands[] commands;
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setContainerState(String containerState) {
+      this.containerState = HddsProtos.LifeCycleState.valueOf(containerState);
+    }
+
+    public void setSequenceId(int sequenceId) {
+      this.sequenceId = sequenceId;
+    }
+
+    public void setReplicas(TestReplica[] replicas) {
+      this.replicas = replicas;
+    }
+
+    public void setUsed(long used) {
+      this.used = used;
+    }
+
+    public void setOwner(String owner) {
+      this.owner = owner;
+    }
+
+    public void setKeys(long keys) {
+      this.keys = keys;
+    }
+
+    public void setId(long id) {
+      this.id = id;
+    }
+
+    public void setExpectation(Expectations expectation) {
+      this.expectation = expectation;
+    }
+
+    public void setCommands(ExpectedCommands[] commands) {
+      this.commands = commands;
+    }
+
+    public TestReplica[] getReplicas() {
+      return replicas;
+    }
+
+    public Expectations getExpectation() {
+      return expectation;
+    }
+
+    /**
+     * Should be in the format of "type:factor".
+     * Eg RATIS:THREE
+     *    EC:rs-3-2-1024k
+     * @param replicationConfig
+     */
+    public void setReplicationConfig(String replicationConfig) {
+      String[] parts = replicationConfig.split(":");
+      if (parts.length != 2) {
+        throw new IllegalArgumentException(
+            "Replication config should be in the format of \"type:factor\". " +
+            " Eg RATIS:THREE");
+      }
+      switch (parts[0].toUpperCase()) {
+      case "RATIS":
+        this.replicationConfig = RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.valueOf(parts[1]));
+        break;
+      case "EC":
+        this.replicationConfig = new ECReplicationConfig(parts[1]);
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "Unknown replication type: " + parts[0]);
+      }
+    }
+
+    public ContainerInfo buildContainerInfo() {
+      ContainerInfo.Builder builder = new ContainerInfo.Builder();
+      builder.setState(containerState)
+          .setSequenceId(sequenceId)
+          .setReplicationConfig(replicationConfig)
+          .setNumberOfKeys(keys)
+          .setOwner(owner)
+          .setContainerID(id)
+          .setUsedBytes(used);
+      return builder.build();
+    }
+
+    public ExpectedCommands[] getCommands() {
+      return commands;
+    }
+
+    @Override
+    public String toString() {
+      return description;
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -114,7 +114,7 @@ public class TestReplicationManagerScenarios {
 
   private static List<URI> getTestFiles() throws URISyntaxException {
     File[] fileList = (new File(TestReplicationManagerScenarios.class
-        .getClass().getResource(TEST_RESOURCE_PATH)
+        .getResource(TEST_RESOURCE_PATH)
         .toURI())).listFiles();
     if (fileList == null) {
       Assertions.fail("No test file resources found");
@@ -154,8 +154,7 @@ public class TestReplicationManagerScenarios {
       Set<String> names = new HashSet<>();
       for (Scenario scenario : scenarios) {
         if (!names.add(scenario.getDescription())) {
-          Assertions.fail("Duplicate test name: " + scenario.getDescription() +
-              " in file: " + file);
+          Assertions.fail("Duplicate test name: " + scenario.getDescription() + " in file: " + file);
         }
         scenario.setResourceName(file.toString());
       }
@@ -172,10 +171,8 @@ public class TestReplicationManagerScenarios {
     scmContext = Mockito.mock(SCMContext.class);
     nodeManager = Mockito.mock(NodeManager.class);
 
-    ratisPlacementPolicy = ReplicationTestUtil
-        .getSimpleTestPlacementPolicy(nodeManager, configuration);
-    ecPlacementPolicy = ReplicationTestUtil
-        .getSimpleTestPlacementPolicy(nodeManager, configuration);
+    ratisPlacementPolicy = ReplicationTestUtil.getSimpleTestPlacementPolicy(nodeManager, configuration);
+    ecPlacementPolicy = ReplicationTestUtil.getSimpleTestPlacementPolicy(nodeManager, configuration);
 
     commandsSent = new HashSet<>();
     eventPublisher = Mockito.mock(EventPublisher.class);
@@ -187,15 +184,13 @@ public class TestReplicationManagerScenarios {
 
     legacyReplicationManager = Mockito.mock(LegacyReplicationManager.class);
     clock = new TestClock(Instant.now(), ZoneId.systemDefault());
-    containerReplicaPendingOps =
-        new ContainerReplicaPendingOps(clock);
+    containerReplicaPendingOps = new ContainerReplicaPendingOps(clock);
 
-    Mockito.when(containerManager
-        .getContainerReplicas(Mockito.any(ContainerID.class))).thenAnswer(
-            invocation -> {
-              ContainerID cid = invocation.getArgument(0);
-              return containerReplicaMap.get(cid);
-            });
+    Mockito.when(containerManager.getContainerReplicas(Mockito.any(ContainerID.class))).thenAnswer(
+        invocation -> {
+          ContainerID cid = invocation.getArgument(0);
+          return containerReplicaMap.get(cid);
+        });
 
     Mockito.when(containerManager.getContainers()).thenAnswer(
         invocation -> new ArrayList<>(containerInfoSet));
@@ -203,8 +198,7 @@ public class TestReplicationManagerScenarios {
     Mockito.when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
-          return NODE_STATUS_MAP.getOrDefault(dn,
-              NodeStatus.inServiceHealthy());
+          return NODE_STATUS_MAP.getOrDefault(dn, NodeStatus.inServiceHealthy());
         });
 
     final HashMap<SCMCommandProto.Type, Integer> countMap = new HashMap<>();
@@ -258,12 +252,10 @@ public class TestReplicationManagerScenarios {
   private void loadPendingOps(ContainerInfo container, Scenario scenario) {
     for (PendingReplica r : scenario.getPendingReplicas()) {
       if (r.getType() == ContainerReplicaOp.PendingOpType.ADD) {
-        containerReplicaPendingOps.scheduleAddReplica(
-            container.containerID(), r.getDatanodeDetails(),
+        containerReplicaPendingOps.scheduleAddReplica(container.containerID(), r.getDatanodeDetails(),
             r.getReplicaIndex(), Long.MAX_VALUE);
       } else if (r.getType() == ContainerReplicaOp.PendingOpType.DELETE) {
-        containerReplicaPendingOps.scheduleDeleteReplica(
-            container.containerID(), r.getDatanodeDetails(),
+        containerReplicaPendingOps.scheduleDeleteReplica(container.containerID(), r.getDatanodeDetails(),
             r.getReplicaIndex(), Long.MAX_VALUE);
       }
     }
@@ -274,8 +266,7 @@ public class TestReplicationManagerScenarios {
   public void testAllScenarios(Scenario scenario) throws IOException {
     ReplicationManager.ReplicationManagerConfiguration conf =
         new ReplicationManager.ReplicationManagerConfiguration();
-    conf.setMaintenanceRemainingRedundancy(
-        scenario.getEcMaintenanceRedundancy());
+    conf.setMaintenanceRemainingRedundancy(scenario.getEcMaintenanceRedundancy());
     conf.setMaintenanceReplicaMinimum(scenario.getRatisMaintenanceMinimum());
     configuration.setFromObject(conf);
     replicationManager = createReplicationManager();
@@ -298,12 +289,10 @@ public class TestReplicationManagerScenarios {
     // Check the results in the report and queue against the expected results.
     assertExpectations(scenario, repReport);
     Expectation expectation = scenario.getExpectation();
-    Assertions.assertEquals(expectation.getUnderReplicatedQueue(),
-        repQueue.underReplicatedQueueSize(), "Test: "
-            + scenario + ": Unexpected count for underReplicatedQueue");
-    Assertions.assertEquals(expectation.getOverReplicatedQueue(),
-        repQueue.overReplicatedQueueSize(), "Test: "
-            + scenario + ": Unexpected count for overReplicatedQueue");
+    Assertions.assertEquals(expectation.getUnderReplicatedQueue(), repQueue.underReplicatedQueueSize(),
+        "Test: " + scenario + ": Unexpected count for underReplicatedQueue");
+    Assertions.assertEquals(expectation.getOverReplicatedQueue(), repQueue.overReplicatedQueueSize(),
+        "Test: " + scenario + ": Unexpected count for overReplicatedQueue");
 
     assertExpectedCommands(scenario, scenario.getCheckCommands());
     commandsSent.clear();
@@ -316,11 +305,9 @@ public class TestReplicationManagerScenarios {
     // Now run the replication manager execute phase, where we expect commands
     // to be sent to fix the under and over replicated containers.
     if (repQueue.underReplicatedQueueSize() > 0) {
-      replicationManager.processUnderReplicatedContainer(
-          repQueue.dequeueUnderReplicatedContainer());
+      replicationManager.processUnderReplicatedContainer(repQueue.dequeueUnderReplicatedContainer());
     } else if (repQueue.overReplicatedQueueSize() > 0) {
-      replicationManager.processOverReplicatedContainer(
-          repQueue.dequeueOverReplicatedContainer());
+      replicationManager.processOverReplicatedContainer(repQueue.dequeueOverReplicatedContainer());
     }
     assertExpectedCommands(scenario, scenario.getCommands());
   }
@@ -330,9 +317,8 @@ public class TestReplicationManagerScenarios {
     Expectation expectation = scenario.getExpectation();
     for (ReplicationManagerReport.HealthState state :
         ReplicationManagerReport.HealthState.values()) {
-      Assertions.assertEquals(expectation.getExpected(state),
-          report.getStat(state), "Test: "
-              + scenario + ": Unexpected count for " + state);
+      Assertions.assertEquals(expectation.getExpected(state), report.getStat(state),
+          "Test: " + scenario + ": Unexpected count for " + state);
     }
   }
 
@@ -351,10 +337,8 @@ public class TestReplicationManagerScenarios {
           DatanodeDetails targetDatanode = expectedCommand.getTargetDatanode();
           if (targetDatanode != null) {
             // We need to assert against the command the datanode is sent to
-            DatanodeDetails commandDatanode =
-                findDatanodeFromUUID(command.getKey());
-            if (commandDatanode != null && commandDatanode.equals(
-                targetDatanode)) {
+            DatanodeDetails commandDatanode = findDatanodeFromUUID(command.getKey());
+            if (commandDatanode != null && commandDatanode.equals(targetDatanode)) {
               found = true;
               commandsSent.remove(command);
               break;
@@ -367,8 +351,7 @@ public class TestReplicationManagerScenarios {
           }
         }
       }
-      Assertions.assertTrue(found, "Test: " + scenario
-          + ": Expected command not sent: " + expectedCommand.getType());
+      Assertions.assertTrue(found, "Test: " + scenario + ": Expected command not sent: " + expectedCommand.getType());
     }
   }
 
@@ -386,15 +369,13 @@ public class TestReplicationManagerScenarios {
    * created by deserializing JSON files.
    */
   public static class TestReplica {
-    private ContainerReplicaProto.State state
-        = ContainerReplicaProto.State.CLOSED;
+    private ContainerReplicaProto.State state = ContainerReplicaProto.State.CLOSED;
     private long containerId = 1;
     // This is a string identifier for a datanode that can be referenced in
     // test expectations and commands. The real datanode will be generated.
     private String datanode;
     private DatanodeDetails datanodeDetails;
-    private HddsProtos.NodeOperationalState operationalState
-        = HddsProtos.NodeOperationalState.IN_SERVICE;
+    private HddsProtos.NodeOperationalState operationalState = HddsProtos.NodeOperationalState.IN_SERVICE;
     private HddsProtos.NodeState healthState = HddsProtos.NodeState.HEALTHY;
 
     private int index = 0;
@@ -447,8 +428,7 @@ public class TestReplicationManagerScenarios {
     }
 
     public void setOperationalState(String operationalState) {
-      this.operationalState = HddsProtos.NodeOperationalState.valueOf(
-          operationalState.toUpperCase());
+      this.operationalState = HddsProtos.NodeOperationalState.valueOf(operationalState.toUpperCase());
     }
 
     public String getOrigin() {
@@ -469,12 +449,10 @@ public class TestReplicationManagerScenarios {
     public ContainerReplica buildContainerReplica() {
       createDatanodeDetails();
       createOrigin();
-      NODE_STATUS_MAP.put(datanodeDetails,
-          new NodeStatus(operationalState, healthState));
+      NODE_STATUS_MAP.put(datanodeDetails, new NodeStatus(operationalState, healthState));
       datanodeDetails.setPersistedOpState(operationalState);
 
-      ContainerReplica.ContainerReplicaBuilder builder =
-          new ContainerReplica.ContainerReplicaBuilder();
+      ContainerReplica.ContainerReplicaBuilder builder = new ContainerReplica.ContainerReplicaBuilder();
       return builder.setReplicaIndex(index)
           .setContainerID(new ContainerID(containerId))
           .setContainerState(state)
@@ -516,49 +494,40 @@ public class TestReplicationManagerScenarios {
    */
   public static class Expectation {
 
-    private Map<ReplicationManagerReport.HealthState, Integer> stateCounts
-        = new HashMap<>();
+    private Map<ReplicationManagerReport.HealthState, Integer> stateCounts = new HashMap<>();
     private int underReplicatedQueue = 0;
     private int overReplicatedQueue = 0;
 
     private void setUnderReplicated(int underReplicated) {
-      stateCounts.put(ReplicationManagerReport.HealthState.UNDER_REPLICATED,
-          underReplicated);
+      stateCounts.put(ReplicationManagerReport.HealthState.UNDER_REPLICATED, underReplicated);
     }
 
     private void setOverReplicated(int overReplicated) {
-      stateCounts.put(ReplicationManagerReport.HealthState.OVER_REPLICATED,
-          overReplicated);
+      stateCounts.put(ReplicationManagerReport.HealthState.OVER_REPLICATED, overReplicated);
     }
 
     private void setMisReplicated(int misReplicated) {
-      stateCounts.put(ReplicationManagerReport.HealthState.MIS_REPLICATED,
-          misReplicated);
+      stateCounts.put(ReplicationManagerReport.HealthState.MIS_REPLICATED, misReplicated);
     }
 
     private void setUnhealthy(int unhealthy) {
-      stateCounts.put(ReplicationManagerReport.HealthState.UNHEALTHY,
-          unhealthy);
+      stateCounts.put(ReplicationManagerReport.HealthState.UNHEALTHY, unhealthy);
     }
 
     private void setMissing(int missing) {
-      stateCounts.put(ReplicationManagerReport.HealthState.MISSING,
-          missing);
+      stateCounts.put(ReplicationManagerReport.HealthState.MISSING, missing);
     }
 
     private void setEmpty(int empty) {
-      stateCounts.put(ReplicationManagerReport.HealthState.EMPTY,
-          empty);
+      stateCounts.put(ReplicationManagerReport.HealthState.EMPTY,  empty);
     }
 
     private void setQuasiClosedStuck(int quasiClosedStuck) {
-      stateCounts.put(ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK,
-          quasiClosedStuck);
+      stateCounts.put(ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK, quasiClosedStuck);
     }
 
     private void setOpenUnhealthy(int openUnhealthy) {
-      stateCounts.put(ReplicationManagerReport.HealthState.OPEN_UNHEALTHY,
-          openUnhealthy);
+      stateCounts.put(ReplicationManagerReport.HealthState.OPEN_UNHEALTHY, openUnhealthy);
     }
 
     public int getExpected(ReplicationManagerReport.HealthState state) {
@@ -601,8 +570,7 @@ public class TestReplicationManagerScenarios {
       }
       DatanodeDetails datanodeDetails = DATANODE_ALIASES.get(this.datanode);
       if (datanodeDetails == null) {
-        Assertions.fail("Unable to find a datanode for the alias: " + datanode
-            + " in the expected commands.");
+        Assertions.fail("Unable to find a datanode for the alias: " + datanode + " in the expected commands.");
       }
       return datanodeDetails;
     }
@@ -658,8 +626,7 @@ public class TestReplicationManagerScenarios {
     private String resourceName;
     private int ecMaintenanceRedundancy;
     private int ratisMaintenanceMinimum;
-    private HddsProtos.LifeCycleState containerState =
-        HddsProtos.LifeCycleState.CLOSED;
+    private HddsProtos.LifeCycleState containerState = HddsProtos.LifeCycleState.CLOSED;
     private long used = 10;
     private long keys = 10;
     private long id = 1;
@@ -778,20 +745,17 @@ public class TestReplicationManagerScenarios {
       String[] parts = replicationConfig.split(":");
       if (parts.length != 2) {
         throw new IllegalArgumentException(
-            "Replication config should be in the format of \"type:factor\". " +
-            " Eg RATIS:THREE");
+            "Replication config should be in the format of \"type:factor\". Eg RATIS:THREE");
       }
       switch (parts[0].toUpperCase()) {
       case "RATIS":
-        this.replicationConfig = RatisReplicationConfig.getInstance(
-            HddsProtos.ReplicationFactor.valueOf(parts[1]));
+        this.replicationConfig = RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.valueOf(parts[1]));
         break;
       case "EC":
         this.replicationConfig = new ECReplicationConfig(parts[1]);
         break;
       default:
-        throw new IllegalArgumentException(
-            "Unknown replication type: " + parts[0]);
+        throw new IllegalArgumentException("Unknown replication type: " + parts[0]);
       }
     }
 

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/basic.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/basic.json
@@ -95,7 +95,7 @@
       { "state": "CLOSED", "index": 5, "datanode": "d6", "sequenceId": 0, "isEmpty": false, "origin": "o5"}
     ],
     "expectation": { "overReplicated": 0, "overReplicatedQueue": 0, "underReplicated": 1, "underReplicatedQueue": 1 },
-    "commands": [ { "type": "reconstructECContainersCommand"} ]
+    "commands": [ { "type": "reconstructECContainersCommand" } ]
   },
 
   { "description": "Replication Over Replicated Ratis Pending Delete", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/basic.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/basic.json
@@ -21,13 +21,22 @@
     "commands": []
   },
 
-  { "description": "Under Replication", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+  { "description": "Ratis Under Replication", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
     "replicas": [
         { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
         { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"}
     ],
     "expectation": { "underReplicated": 1, "underReplicatedQueue": 1 },
     "commands": [ { "type": "replicateContainerCommand"} ]
+  },
+
+  { "description": "Ratis Under Replication pending add", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+      { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"}
+    ],
+    "pendingReplicas": [ { "type": "ADD" } ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 0 }
   },
 
   { "description": "Under Replication EC", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
@@ -64,6 +73,19 @@
     "commands": [ { "type": "deleteContainerCommand"} ]
   },
 
+  { "description": "Over Replication EC pending delete", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
+    "replicas": [
+      { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+      { "state": "CLOSED", "index": 2, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 3, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"},
+      { "state": "CLOSED", "index": 4, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o4"},
+      { "state": "CLOSED", "index": 5, "datanode": "d5", "sequenceId": 0, "isEmpty": false, "origin": "o5"},
+      { "state": "CLOSED", "index": 5, "datanode": "d6", "sequenceId": 0, "isEmpty": false, "origin": "o5"}
+    ],
+    "pendingReplicas": [ { "type": "DELETE", "replicaIndex": 5, "datanode": "d6" } ],
+    "expectation": { "overReplicated": 1, "overReplicatedQueue": 0 }
+  },
+
   { "description": "Over and Under Replication EC", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
     "replicas": [
       { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
@@ -74,5 +96,18 @@
     ],
     "expectation": { "overReplicated": 0, "overReplicatedQueue": 0, "underReplicated": 1, "underReplicatedQueue": 1 },
     "commands": [ { "type": "reconstructECContainersCommand"} ]
+  },
+
+  { "description": "Replication Over Replicated Ratis Pending Delete", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+      { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 0, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"},
+      { "state": "CLOSED", "index": 0, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o3"}
+    ],
+    "pendingReplicas": [ { "type":  "DELETE", "datanode":  "d2" } ],
+    "expectation": { "overReplicated":  1, "overReplicatedQueue":  0},
+    "checkCommands": [],
+    "commands": []
   }
 ]

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/basic.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/basic.json
@@ -1,0 +1,78 @@
+[
+  { "description": "Perfect Replication Ratis", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+        { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+        { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+        { "state": "CLOSED", "index": 0, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": {},
+    "commands": []
+  },
+
+  { "description": "Perfect Replication EC", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
+    "replicas": [
+      { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+      { "state": "CLOSED", "index": 2, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 3, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"},
+      { "state": "CLOSED", "index": 4, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o4"},
+      { "state": "CLOSED", "index": 5, "datanode": "d5", "sequenceId": 0, "isEmpty": false, "origin": "o5"}
+    ],
+    "expectation": {},
+    "commands": []
+  },
+
+  { "description": "Under Replication", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+        { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+        { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1 },
+    "commands": [ { "type": "replicateContainerCommand"} ]
+  },
+
+  { "description": "Under Replication EC", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
+    "replicas": [
+      { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+      { "state": "CLOSED", "index": 2, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 3, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1 },
+    "commands": [ { "type": "reconstructECContainersCommand"} ]
+  },
+
+  { "description": "Over Replicated", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+        { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+        { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+        { "state": "CLOSED", "index": 0, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"},
+        { "state": "CLOSED", "index": 0, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "overReplicated": 1, "overReplicatedQueue": 1 },
+    "commands": [ { "type": "deleteContainerCommand"} ]
+  },
+
+  { "description": "Over Replication EC", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
+    "replicas": [
+      { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+      { "state": "CLOSED", "index": 2, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 3, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"},
+      { "state": "CLOSED", "index": 4, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o4"},
+      { "state": "CLOSED", "index": 5, "datanode": "d5", "sequenceId": 0, "isEmpty": false, "origin": "o5"},
+      { "state": "CLOSED", "index": 5, "datanode": "d6", "sequenceId": 0, "isEmpty": false, "origin": "o5"}
+    ],
+    "expectation": { "overReplicated": 1, "overReplicatedQueue": 1 },
+    "commands": [ { "type": "deleteContainerCommand"} ]
+  },
+
+  { "description": "Over and Under Replication EC", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
+    "replicas": [
+      { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
+      { "state": "CLOSED", "index": 2, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 4, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o4"},
+      { "state": "CLOSED", "index": 5, "datanode": "d5", "sequenceId": 0, "isEmpty": false, "origin": "o5"},
+      { "state": "CLOSED", "index": 5, "datanode": "d6", "sequenceId": 0, "isEmpty": false, "origin": "o5"}
+    ],
+    "expectation": { "overReplicated": 0, "overReplicatedQueue": 0, "underReplicated": 1, "underReplicatedQueue": 1 },
+    "commands": [ { "type": "reconstructECContainersCommand"} ]
+  }
+]

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/mismatched_replicas.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/mismatched_replicas.json
@@ -1,0 +1,15 @@
+[
+  { "description": "Mis-matched replicas", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "OPEN", "index": 0,   "datanode": "d1", "sequenceId": 12, "isEmpty": false, "origin": "o1"},
+      { "state": "OPEN", "index": 0,   "datanode": "d2", "sequenceId": 12, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 0, "datanode": "d3", "sequenceId": 12, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "overReplicated": 0, "overReplicatedQueue":  0},
+    "checkCommands": [
+      { "type":  "closeContainerCommand", "datanode": "d1"},
+      { "type":  "closeContainerCommand", "datanode": "d2"}
+    ],
+    "commands": []
+  }
+]

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/simple_decommission.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/simple_decommission.json
@@ -1,0 +1,23 @@
+[
+  { "description": "Simple Decommission Ratis", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "replicas": [
+      { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1", "operationalState": "DECOMMISSIONING"},
+      { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 0, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1 },
+    "commands": [ { "type": "replicateContainerCommand"} ]
+  },
+
+  { "description": "Simple Decommission EC", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
+    "replicas": [
+      { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1", "operationalState": "DECOMMISSIONING"},
+      { "state": "CLOSED", "index": 2, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
+      { "state": "CLOSED", "index": 3, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"},
+      { "state": "CLOSED", "index": 4, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o4"},
+      { "state": "CLOSED", "index": 5, "datanode": "d5", "sequenceId": 0, "isEmpty": false, "origin": "o5"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1 },
+    "commands": [ { "type": "replicateContainerCommand"} ]
+  }
+]

--- a/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/simple_maintenance.json
+++ b/hadoop-hdds/server-scm/src/test/resources/replicationManagerTests/simple_maintenance.json
@@ -1,0 +1,46 @@
+[
+
+  { "description": "Ratis Simple Maintenance", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "ratisMaintenanceMinimum": 1,
+    "replicas": [
+      { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1", "operationalState": "ENTERING_MAINTENANCE" },
+      { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2", "operationalState": "ENTERING_MAINTENANCE" },
+      { "state": "CLOSED", "index": 0, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"}
+    ]
+  },
+
+  { "description": "EC Simple Maintenance", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
+    "ecMaintenanceRedundancy": 0,
+    "replicas": [
+      { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1", "operationalState": "ENTERING_MAINTENANCE" },
+      { "state": "CLOSED", "index": 2, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2", "operationalState": "ENTERING_MAINTENANCE" },
+      { "state": "CLOSED", "index": 3, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"},
+      { "state": "CLOSED", "index": 4, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o4"},
+      { "state": "CLOSED", "index": 5, "datanode": "d5", "sequenceId": 0, "isEmpty": false, "origin": "o5"}
+    ]
+  },
+
+  { "description": "Ratis Simple Maintenance Requires Replication", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
+    "ratisMaintenanceMinimum": 2,
+    "replicas": [
+      { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1", "operationalState": "ENTERING_MAINTENANCE" },
+      { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2", "operationalState": "ENTERING_MAINTENANCE" },
+      { "state": "CLOSED", "index": 0, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1 },
+    "commands": [ { "type": "replicateContainerCommand"} ]
+  },
+
+  { "description": "EC Simple Maintenance requires replication", "containerState": "CLOSED", "replicationConfig": "EC:RS-3-2-1024k",
+    "ecMaintenanceRedundancy": 2,
+    "replicas": [
+      { "state": "CLOSED", "index": 1, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1", "operationalState": "ENTERING_MAINTENANCE" },
+      { "state": "CLOSED", "index": 2, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2", "operationalState": "ENTERING_MAINTENANCE" },
+      { "state": "CLOSED", "index": 3, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"},
+      { "state": "CLOSED", "index": 4, "datanode": "d4", "sequenceId": 0, "isEmpty": false, "origin": "o4"},
+      { "state": "CLOSED", "index": 5, "datanode": "d5", "sequenceId": 0, "isEmpty": false, "origin": "o5"}
+    ],
+    "expectation": { "underReplicated": 1, "underReplicatedQueue": 1 },
+    "commands": [ { "type": "replicateContainerCommand"}, { "type": "replicateContainerCommand"} ]
+  }
+]


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change added a new test class called TestReplicationManagerScenarios. It work via test definitions in JSON, such as:

```
  { "description": "Perfect Replication Ratis", "containerState": "CLOSED", "replicationConfig": "RATIS:THREE", "sequenceId": 12,
    "replicas": [
        { "state": "CLOSED", "index": 0, "datanode": "d1", "sequenceId": 0, "isEmpty": false, "origin": "o1"},
        { "state": "CLOSED", "index": 0, "datanode": "d2", "sequenceId": 0, "isEmpty": false, "origin": "o2"},
        { "state": "CLOSED", "index": 0, "datanode": "d3", "sequenceId": 0, "isEmpty": false, "origin": "o3"}
    ],
    "expectation": {},
    "commands": []
  }
```

Which defines the container state and the replica states, along with expected commands and outputs from processing the container.

For each scenario, it runs through the Replication Manager check phase, re-runs the check-phase in read only mode and also runs the processing phase, where RM will send commands to fix the problems.

There are also some tests added to prove the framework is working, but further Jira's would allow us to expand the test scenarios and remove many similar unit tests that are harder to understand.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9877

## How was this patch tested?

This change adds only tests.
