### PR TITLE
HDDS-9875. Create stack dump if cannot remove docker network

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -348,6 +348,9 @@ stop_docker_env(){
       if docker-compose --ansi never down; then
         return
       fi
+      if [[ ${i} -eq 1 ]]; then
+        create_stack_dumps
+      fi
       sleep 5
     done
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sometimes acceptance tests fail due to docker not being able to remove the network during teardown.  HDDS-7531 added retry, but it looks like it may fail on repeated attempts, too.

To find out why some container cannot be stopped, let's create stack dump of such containers if `docker-compose down` fails.

```
Removing network xcompat_default
error while removing network: network xcompat_default id 81e9a46c74c2487fbfe428b07f25da18f053e8410562334d2dc7a013e254cd33 has active endpoints
...
Failed to remove all docker containers in 3 attempts.
ERROR: Test execution of xcompat/test.sh is FAILED!!!!
```

https://issues.apache.org/jira/browse/HDDS-9875

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/7129082081

Tried to reproduce the original problem in 10 runs, but it did not happen:
https://github.com/adoroszlai/ozone/actions/runs/7129891739

Hopefully we get more information on next failure if this is merged.