### PR TITLE
HDDS-9876. OM state machine should add response for every write request to the double-buffer

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -175,7 +175,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public abstract class TestOzoneRpcClientAbstract {
 
   private static MiniOzoneCluster cluster = null;
-  private static OzoneClient ozClient = null;
+  protected static OzoneClient ozClient = null;
   private static ObjectStore store = null;
   private static OzoneManager ozoneManager;
   private static StorageContainerLocationProtocolClientSideTranslatorPB

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -175,7 +175,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public abstract class TestOzoneRpcClientAbstract {
 
   private static MiniOzoneCluster cluster = null;
-  protected static OzoneClient ozClient = null;
+  private static OzoneClient ozClient = null;
   private static ObjectStore store = null;
   private static OzoneManager ozoneManager;
   private static StorageContainerLocationProtocolClientSideTranslatorPB
@@ -268,6 +268,13 @@ public abstract class TestOzoneRpcClientAbstract {
     TestOzoneRpcClientAbstract.clusterId = clusterId;
   }
 
+  public static OzoneClient getClient() {
+    return TestOzoneRpcClientAbstract.ozClient;
+  }
+
+  public static MiniOzoneCluster getCluster() {
+    return TestOzoneRpcClientAbstract.cluster;
+  }
   /**
    * Test OM Proxy Provider.
    */

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -55,7 +55,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine;
 import org.apache.hadoop.ozone.om.ratis.metrics.OzoneManagerStateMachineMetrics;
 import org.apache.ozone.test.GenericTestUtils;
-import org.assertj.core.api.Fail;
+import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,8 +67,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -394,7 +392,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
         ready.await();
       } catch (InterruptedException e) {
         e.printStackTrace();
-        assertTrue(Fail.fail("resume interrupted"));
+        assertTrue(fail("resume interrupted"));
       }
       wait.countDown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -357,11 +357,10 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
           ReplicationType.RATIS, ONE, new HashMap<>());
     }
 
-    shutdownCluster();
     Assert.assertTrue(
         omSMLog.getOutput().contains("Failed to write, Exception occurred"));
-    Assert.assertTrue(
-        omSMLog.getOutput().contains("applyTransactionMap size 0"));
+    GenericTestUtils.waitFor(() -> metrics.getApplyTransactionMapSize() == 0,
+        100, 5000);
   }
 
   private static class OMRequestHandlerPauseInjector extends FaultInjector {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerStateMachineMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerStateMachineMetrics.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.ratis.metrics;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+
+/**
+ * Class which maintains metrics related to OzoneManager state machine.
+ */
+public class OzoneManagerStateMachineMetrics {
+
+  private static OzoneManagerStateMachineMetrics instance;
+
+  private static final String SOURCE_NAME =
+      OzoneManagerStateMachineMetrics.class.getSimpleName();
+
+  @Metric(about = "Number of apply transactions in applyTransactionMap.")
+  private MutableCounterLong applyTransactionMapSize;
+
+  @Metric(about = "Number of ratis transactions in ratisTransactionMap.")
+  private MutableCounterLong ratisTransactionMapSize;
+
+  public static synchronized OzoneManagerStateMachineMetrics create() {
+    if (instance != null) {
+      return instance;
+    } else {
+      MetricsSystem ms = DefaultMetricsSystem.instance();
+      OzoneManagerStateMachineMetrics omStateMachineMetrics =
+          ms.register(SOURCE_NAME,
+              "OzoneManagerStateMachine Metrics",
+              new OzoneManagerStateMachineMetrics());
+      instance = omStateMachineMetrics;
+      return omStateMachineMetrics;
+    }
+  }
+
+  public void incrApplyTransactionMapSize() {
+    this.applyTransactionMapSize.incr();
+  }
+
+  public void decrApplyTransactionMapSize() {
+    this.applyTransactionMapSize.incr(-1);
+  }
+
+  @VisibleForTesting
+  public long getApplyTransactionMapSize() {
+    return this.applyTransactionMapSize.value();
+  }
+
+  public void incrRatisTransactionMapSize() {
+    this.ratisTransactionMapSize.incr();
+  }
+
+  public void decrRatisTransactionMapSize() {
+    this.ratisTransactionMapSize.incr(-1);
+  }
+
+  @VisibleForTesting
+  public long getRatisTransactionMapSize() {
+    return this.ratisTransactionMapSize.value();
+  }
+
+  public void unRegister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(SOURCE_NAME);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerStateMachineMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerStateMachineMetrics.java
@@ -19,20 +19,27 @@
 package org.apache.hadoop.ozone.om.ratis.metrics;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Class which maintains metrics related to OzoneManager state machine.
  */
-public class OzoneManagerStateMachineMetrics {
-
-  private static OzoneManagerStateMachineMetrics instance;
+@Metrics(about = "OzoneManagerStateMachine Metrics", context = OzoneConsts.OZONE)
+public final class OzoneManagerStateMachineMetrics implements MetricsSource {
 
   private static final String SOURCE_NAME =
       OzoneManagerStateMachineMetrics.class.getSimpleName();
+  private MetricsRegistry registry;
+  private static OzoneManagerStateMachineMetrics instance;
 
   @Metric(about = "Number of apply transactions in applyTransactionMap.")
   private MutableCounterLong applyTransactionMapSize;
@@ -40,48 +47,52 @@ public class OzoneManagerStateMachineMetrics {
   @Metric(about = "Number of ratis transactions in ratisTransactionMap.")
   private MutableCounterLong ratisTransactionMapSize;
 
+  private OzoneManagerStateMachineMetrics() {
+    registry = new MetricsRegistry(SOURCE_NAME);
+  }
+
   public static synchronized OzoneManagerStateMachineMetrics create() {
     if (instance != null) {
       return instance;
     } else {
       MetricsSystem ms = DefaultMetricsSystem.instance();
-      OzoneManagerStateMachineMetrics omStateMachineMetrics =
-          ms.register(SOURCE_NAME,
-              "OzoneManagerStateMachine Metrics",
-              new OzoneManagerStateMachineMetrics());
-      instance = omStateMachineMetrics;
-      return omStateMachineMetrics;
+      OzoneManagerStateMachineMetrics metrics = new OzoneManagerStateMachineMetrics();
+      instance = ms.register(SOURCE_NAME, "OzoneManager StateMachine Metrics",
+          metrics);
+      return instance;
     }
-  }
-
-  public void incrApplyTransactionMapSize() {
-    this.applyTransactionMapSize.incr();
-  }
-
-  public void decrApplyTransactionMapSize() {
-    this.applyTransactionMapSize.incr(-1);
   }
 
   @VisibleForTesting
   public long getApplyTransactionMapSize() {
-    return this.applyTransactionMapSize.value();
-  }
-
-  public void incrRatisTransactionMapSize() {
-    this.ratisTransactionMapSize.incr();
-  }
-
-  public void decrRatisTransactionMapSize() {
-    this.ratisTransactionMapSize.incr(-1);
+    return applyTransactionMapSize.value();
   }
 
   @VisibleForTesting
   public long getRatisTransactionMapSize() {
-    return this.ratisTransactionMapSize.value();
+    return ratisTransactionMapSize.value();
+  }
+
+  public void updateApplyTransactionMapSize(long size) {
+    this.applyTransactionMapSize.incr(
+        Math.negateExact(applyTransactionMapSize.value()) + size);
+  }
+
+  public void updateRatisTransactionMapSize(long size) {
+    this.ratisTransactionMapSize.incr(
+        Math.negateExact(ratisTransactionMapSize.value()) + size);
   }
 
   public void unRegister() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.unregisterSource(SOURCE_NAME);
+  }
+
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder rb = collector.addRecord(SOURCE_NAME);
+
+    applyTransactionMapSize.snapshot(rb, all);
+    ratisTransactionMapSize.snapshot(rb, all);
+    rb.endRecord();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/DummyOMClientResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/DummyOMClientResponse.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.response;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
 import javax.annotation.Nonnull;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/DummyOMClientResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/DummyOMClientResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response;
+
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * A dummy OMClientResponse implementation.
+ */
+@CleanupTableInfo
+public class DummyOMClientResponse extends OMClientResponse {
+
+  public DummyOMClientResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+  }
+
+  @Override
+  public void addToDBBatch(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+    // do nothing
+  }
+}
+

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ServiceException;
 import org.apache.commons.lang3.StringUtils;
@@ -386,9 +387,22 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     return responseBuilder.build();
   }
 
+  @VisibleForTesting
+  public static int handle_write_sleep = 0;
+
   @Override
   public OMClientResponse handleWriteRequest(OMRequest omRequest,
       long transactionLogIndex) throws IOException {
+    
+    if (handle_write_sleep > 0) {
+      // Only for test purpose
+      try {
+        Thread.sleep(handle_write_sleep);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
     OMClientRequest omClientRequest =
         OzoneManagerRatisUtils.createClientRequest(omRequest, impl);
     return captureLatencyNs(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -148,6 +148,7 @@ public class TestCleanupTableInfo {
     subTypes.remove(OmKeyResponse.class);
     // OMEchoRPCWriteResponse does not need CleanupTable.
     subTypes.remove(OMEchoRPCWriteResponse.class);
+    subTypes.remove(DummyOMClientResponse.class);
     subTypes.forEach(aClass -> {
       Assertions.assertTrue(aClass.isAnnotationPresent(CleanupTableInfo.class),
           aClass + " does not have annotation of" +


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the current OM statemachine implementation, if the write request fails before request's validateAndUpdateCache call, this request will have no OMClientResponse in the doublebuffer, which leads to this request cannot be confirmed as completed(even with failure), so this request txIndex will be left in OM statemachine applyTransactionMap forever.  It will cause a lot of consequences, refer to HDDS-9342 for detail issues observed. 

To solve this problem, a DummyOMClientResponse is introduced for all these failed requests, to go through the doubleBuffer flush cycle, so that they will be treated as completed and their txIndex will be removed from applyTransactionMap. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9876

## How was this patch tested?

Test with newly added unit test. 
