### PR TITLE
HDDS-9130. [hsync] Combine WriteData and PutBlock requests into one

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -222,6 +222,14 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private String fsDefaultBucketLayout = "FILE_SYSTEM_OPTIMIZED";
 
+  @Config(key = "stream.putblock.piggybacking",
+          defaultValue = "true",
+          type = ConfigType.BOOLEAN,
+          description = "Allow PutBlock to be piggybacked in WriteChunk " +
+                  "requests if the chunk is small.",
+          tags = ConfigTag.CLIENT)
+  private boolean enablePutblockPiggybacking = false;
+
   @PostConstruct
   private void validate() {
     Preconditions.checkState(streamBufferSize > 0);
@@ -390,6 +398,10 @@ public class OzoneClientConfig {
 
   public String getFsDefaultBucketLayout() {
     return fsDefaultBucketLayout;
+  }
+
+  public boolean getEnablePutblockPiggybacking() {
+    return enablePutblockPiggybacking;
   }
 
   public boolean isDatastreamPipelineMode() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -52,6 +52,8 @@ import org.apache.hadoop.security.token.TokenIdentifier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+
+import static org.apache.hadoop.hdds.DatanodeVersion.COMBINED_PUTBLOCK_WRITECHUNK_RPC;
 import static org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls.putBlockAsync;
 import static org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls.writeChunkAsync;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -125,6 +127,7 @@ public class BlockOutputStream extends OutputStream {
   private int replicationIndex;
   private Pipeline pipeline;
   private final ContainerClientMetrics clientMetrics;
+  private boolean allowPutBlockPiggybacking;
 
   /**
    * Creates a new BlockOutputStream.
@@ -185,6 +188,20 @@ public class BlockOutputStream extends OutputStream {
         config.getBytesPerChecksum());
     this.clientMetrics = clientMetrics;
     this.pipeline = pipeline;
+    allowPutBlockPiggybacking = config.getEnablePutblockPiggybacking() &&
+            allDataNodesSupportPiggybacking();
+  }
+
+  boolean allDataNodesSupportPiggybacking() {
+    // return true only if all DataNodes in the pipeline are on a version
+    // that supports PutBlock piggybacking.
+    for (DatanodeDetails dn : pipeline.getNodes()) {
+      if (dn.getCurrentVersion() <
+              COMBINED_PUTBLOCK_WRITECHUNK_RPC.toProtoValue()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   void refreshCurrentBuffer() {
@@ -525,7 +542,7 @@ public class BlockOutputStream extends OutputStream {
     }
   }
 
-  private void writeChunk(ChunkBuffer buffer)
+  private void writeChunkCommon(ChunkBuffer buffer)
       throws IOException {
     // This data in the buffer will be pushed to datanode and a reference will
     // be added to the bufferList. Once putBlock gets executed, this list will
@@ -536,7 +553,18 @@ public class BlockOutputStream extends OutputStream {
       bufferList = new ArrayList<>();
     }
     bufferList.add(buffer);
-    writeChunkToContainer(buffer.duplicate(0, buffer.position()));
+  }
+
+  private void writeChunk(ChunkBuffer buffer)
+      throws IOException {
+    writeChunkCommon(buffer);
+    writeChunkToContainer(buffer.duplicate(0, buffer.position()), false);
+  }
+
+  private void writeSmallChunk(ChunkBuffer buffer)
+      throws IOException {
+    writeChunkCommon(buffer);
+    writeChunkToContainer(buffer.duplicate(0, buffer.position()), true);
   }
 
   /**
@@ -568,14 +596,24 @@ public class BlockOutputStream extends OutputStream {
     if (totalDataFlushedLength < writtenDataLength) {
       refreshCurrentBuffer();
       Preconditions.checkArgument(currentBuffer.position() > 0);
-      if (currentBuffer.hasRemaining()) {
-        writeChunk(currentBuffer);
-      }
+
       // This can be a partially filled chunk. Since we are flushing the buffer
       // here, we just limit this buffer to the current position. So that next
       // write will happen in new buffer
-      updateFlushLength();
-      executePutBlock(close, false);
+      if (currentBuffer.hasRemaining()) {
+        if (writtenDataLength - totalDataFlushedLength < 100 * 1024 &&
+            allowPutBlockPiggybacking) {
+          updateFlushLength();
+          writeSmallChunk(currentBuffer);
+        } else {
+          writeChunk(currentBuffer);
+          updateFlushLength();
+          executePutBlock(close, false);
+        }
+      } else {
+        updateFlushLength();
+        executePutBlock(close, false);
+      }
     } else if (close) {
       // forcing an "empty" putBlock if stream is being closed without new
       // data since latest flush - we need to send the "EOF" flag
@@ -688,7 +726,7 @@ public class BlockOutputStream extends OutputStream {
    * @return
    */
   CompletableFuture<ContainerCommandResponseProto> writeChunkToContainer(
-      ChunkBuffer chunk) throws IOException {
+      ChunkBuffer chunk, boolean smallChunk) throws IOException {
     int effectiveChunkSize = chunk.remaining();
     final long offset = chunkOffset.getAndAdd(effectiveChunkSize);
     final ByteString data = chunk.toByteString(
@@ -700,6 +738,8 @@ public class BlockOutputStream extends OutputStream {
         .setLen(effectiveChunkSize)
         .setChecksumData(checksumData.getProtoBufMessage())
         .build();
+
+    long flushPos = totalDataFlushedLength;
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("Writing chunk {} length {} at offset {}",
@@ -718,37 +758,73 @@ public class BlockOutputStream extends OutputStream {
           + ", previous = " + previous);
     }
 
+    final List<ChunkBuffer> byteBufferList;
+    CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
+        validateFuture = null;
     try {
+      BlockData blockData = null;
+      containerBlockData.addChunks(chunkInfo);
+      if (smallChunk) {
+        Preconditions.checkNotNull(bufferList);
+        byteBufferList = bufferList;
+        bufferList = null;
+        Preconditions.checkNotNull(byteBufferList);
+
+        blockData = containerBlockData.build();
+      } else {
+        byteBufferList = null;
+      }
       XceiverClientReply asyncReply = writeChunkAsync(xceiverClient, chunkInfo,
-          blockID.get(), data, token, replicationIndex);
+          blockID.get(), data, token, replicationIndex, blockData);
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
           respFuture = asyncReply.getResponse();
-      CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
-          validateFuture = respFuture.thenApplyAsync(e -> {
-            try {
-              validateResponse(e);
-            } catch (IOException sce) {
-              respFuture.completeExceptionally(sce);
-            }
-            return e;
-          }, responseExecutor).exceptionally(e -> {
-            String msg = "Failed to write chunk " + chunkInfo.getChunkName() +
-                " into block " + blockID;
-            LOG.debug("{}, exception: {}", msg, e.getLocalizedMessage());
-            CompletionException ce = new CompletionException(msg, e);
-            setIoException(ce);
-            throw ce;
-          });
-      containerBlockData.addChunks(chunkInfo);
+      validateFuture = respFuture.thenApplyAsync(e -> {
+        try {
+          validateResponse(e);
+        } catch (IOException sce) {
+          respFuture.completeExceptionally(sce);
+        }
+        // if the ioException is not set, putBlock is successful
+        if (getIoException() == null && smallChunk) {
+          BlockID responseBlockID = BlockID.getFromProtobuf(
+              e.getWriteChunk().getCommittedBlockLength().getBlockID());
+          Preconditions.checkState(blockID.get().getContainerBlockID()
+              .equals(responseBlockID.getContainerBlockID()));
+          // updates the bcsId of the block
+          blockID.set(responseBlockID);
+          if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                "Adding index " + asyncReply.getLogIndex() + " flushLength "
+                    + flushPos + " numBuffers " + byteBufferList.size()
+                    + " blockID " + blockID + " bufferPool size" + bufferPool
+                    .getSize() + " currentBufferIndex " + bufferPool
+                    .getCurrentBufferIndex());
+          }
+          // for standalone protocol, logIndex will always be 0.
+          updateCommitInfo(asyncReply, byteBufferList);
+        }
+        return e;
+      }, responseExecutor).exceptionally(e -> {
+        String msg = "Failed to write chunk " + chunkInfo.getChunkName() +
+            " into block " + blockID;
+        LOG.debug("{}, exception: {}", msg, e.getLocalizedMessage());
+        CompletionException ce = new CompletionException(msg, e);
+        setIoException(ce);
+        throw ce;
+      });
+      //containerBlockData.addChunks(chunkInfo);
       clientMetrics.recordWriteChunk(pipeline, chunkInfo.getLen());
-      return validateFuture;
+
     } catch (IOException | ExecutionException e) {
       throw new IOException(EXCEPTION_MSG + e.toString(), e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       handleInterruptedException(ex, false);
     }
-    return null;
+    if (smallChunk) {
+      putFlushFuture(flushPos, validateFuture);
+    }
+    return validateFuture;
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -84,13 +84,14 @@ public class ECBlockOutputStream extends BlockOutputStream {
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
     this.currentChunkRspFuture =
-        writeChunkToContainer(ChunkBuffer.wrap(ByteBuffer.wrap(b, off, len)));
+        writeChunkToContainer(
+            ChunkBuffer.wrap(ByteBuffer.wrap(b, off, len)), false);
     updateWrittenDataLength(len);
   }
 
   public CompletableFuture<ContainerProtos.ContainerCommandResponseProto> write(
       ByteBuffer buff) throws IOException {
-    return writeChunkToContainer(ChunkBuffer.wrap(buff));
+    return writeChunkToContainer(ChunkBuffer.wrap(buff), false);
   }
 
   public CompletableFuture<ContainerProtos.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
@@ -31,6 +31,8 @@ public enum DatanodeVersion implements ComponentVersion {
   DEFAULT_VERSION(0, "Initial version"),
 
   SEPARATE_RATIS_PORTS_AVAILABLE(1, "Version with separated Ratis port."),
+  COMBINED_PUTBLOCK_WRITECHUNK_RPC(2, "WriteChunk can optionally support " +
+          "a PutBlock request"),
 
   FUTURE_VERSION(-1, "Used internally in the client when the server side is "
       + " newer and an unknown server version has arrived to the client.");

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -392,4 +392,6 @@ public final class HddsConfigKeys {
 
   public static final String OZONE_AUDIT_LOG_DEBUG_CMD_LIST_DNAUDIT =
       "ozone.audit.log.debug.cmd.list.dnaudit";
+
+  public static final String HDDS_DATANODE_VERSION = "hdds.datanode.version";
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ContainerCommandResponseBuilders.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ContainerCommandResponseBuilders.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutSmallFi
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadChunkResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadContainerResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ListBlockResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunkResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
@@ -218,6 +219,28 @@ public final class ContainerCommandResponseBuilders {
     return getSuccessResponseBuilder(msg)
         .setCmdType(Type.PutSmallFile)
         .setPutSmallFile(putSmallFile)
+        .build();
+  }
+
+  /**
+   * Gets a response for the putSmallFile RPC.
+   * @param msg - ContainerCommandRequestProto
+   * @return - ContainerCommandResponseProto
+   */
+  public static ContainerCommandResponseProto getWriteChunkResponseSuccess(
+      ContainerCommandRequestProto msg, BlockData blockData) {
+
+    WriteChunkResponseProto.Builder writeChunk =
+        WriteChunkResponseProto.newBuilder();
+    if (blockData != null) {
+      writeChunk.setCommittedBlockLength(
+          getCommittedBlockLengthResponseBuilder(
+              blockData.getSize(), blockData.getBlockID()));
+
+    }
+    return getSuccessResponseBuilder(msg)
+        .setCmdType(Type.WriteChunk)
+        .setWriteChunk(writeChunk)
         .build();
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -393,9 +393,10 @@ public final class ContainerProtocolCalls  {
   public static XceiverClientReply writeChunkAsync(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
       ByteString data, Token<? extends TokenIdentifier> token,
-      int replicationIndex
+      int replicationIndex, BlockData blockData
   )
       throws IOException, ExecutionException, InterruptedException {
+
     WriteChunkRequestProto.Builder writeChunkRequest =
         WriteChunkRequestProto.newBuilder()
             .setBlockID(DatanodeBlockID.newBuilder()
@@ -406,6 +407,12 @@ public final class ContainerProtocolCalls  {
                 .build())
             .setChunkData(chunk)
             .setData(data);
+    if (blockData != null) {
+      PutBlockRequestProto.Builder createBlockRequest =
+          PutBlockRequestProto.newBuilder()
+              .setBlockData(blockData);
+      writeChunkRequest.setBlock(createBlockRequest);
+    }
     String id = xceiverClient.getPipeline().getFirstNode().getUuidString();
     ContainerCommandRequestProto.Builder builder =
         ContainerCommandRequestProto.newBuilder()

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3316,6 +3316,15 @@
     </description>
   </property>
   <property>
+    <name>hdds.datanode.version</name>
+    <tag>OZONE, DATANODE</tag>
+    <value></value>
+    <description>
+      DataNode version exposed to SCM and clients. Default version is defined
+      by DatanodeVersion.CURRENT_VERSION.
+    </description>
+  </property>
+  <property>
     <name>ozone.om.keyname.character.check.enabled</name>
     <tag>OZONE, OM</tag>
     <value>false</value>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.util.Time;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VERSION;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.HTTP;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.HTTPS;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getRemoteUser;
@@ -230,7 +231,9 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       datanodeDetails.setRevision(
           HddsVersionInfo.HDDS_VERSION_INFO.getRevision());
       datanodeDetails.setBuildDate(HddsVersionInfo.HDDS_VERSION_INFO.getDate());
-      datanodeDetails.setCurrentVersion(DatanodeVersion.CURRENT_VERSION);
+      //datanodeDetails.setCurrentVersion(DatanodeVersion.CURRENT_VERSION);
+      datanodeDetails.setCurrentVersion(
+          conf.getInt(HDDS_DATANODE_VERSION, DatanodeVersion.CURRENT_VERSION));
       TracingUtil.initTracing(
           "HddsDatanodeService." + datanodeDetails.getUuidString()
               .substring(0, 8), conf);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -373,11 +373,10 @@ public class ContainerStateMachine extends BaseStateMachine {
       final WriteChunkRequestProto write = proto.getWriteChunk();
       // create the log entry proto
       final WriteChunkRequestProto commitWriteChunkProto =
-          WriteChunkRequestProto.newBuilder()
-              .setBlockID(write.getBlockID())
-              .setChunkData(write.getChunkData())
+          WriteChunkRequestProto.newBuilder(write)
               // skipping the data field as it is
               // already set in statemachine data proto
+              .clearData()
               .build();
       ContainerCommandRequestProto commitContainerCommandProto =
           ContainerCommandRequestProto
@@ -648,6 +647,7 @@ public class ContainerStateMachine extends BaseStateMachine {
       ContainerCommandRequestProto requestProto =
           getContainerCommandRequestProto(gid,
               entry.getStateMachineLogEntry().getLogData());
+
       WriteChunkRequestProto writeChunk =
           WriteChunkRequestProto.newBuilder(requestProto.getWriteChunk())
               .setData(getStateMachineData(entry.getStateMachineLogEntry()))

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -406,9 +406,11 @@ message  WriteChunkRequestProto  {
   required DatanodeBlockID blockID = 1;
   optional ChunkInfo chunkData = 2;
   optional bytes data = 3;
+  optional PutBlockRequestProto block = 4;
 }
 
 message  WriteChunkResponseProto {
+  optional GetCommittedBlockLengthResponseProto committedBlockLength = 1;
 }
 
 enum ReadChunkVersion {

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
@@ -135,21 +135,26 @@ public class MockXceiverClientSpi extends XceiverClientSpi {
   }
 
   private PutBlockResponseProto putBlock(PutBlockRequestProto putBlock) {
+    return PutBlockResponseProto.newBuilder()
+        .setCommittedBlockLength(
+            doPutBlock(putBlock.getBlockData()))
+        .build();
+  }
+
+  private GetCommittedBlockLengthResponseProto doPutBlock(
+      ContainerProtos.BlockData blockData) {
     long length = 0;
-    for (ChunkInfo chunk : putBlock.getBlockData().getChunksList()) {
+    for (ChunkInfo chunk : blockData.getChunksList()) {
       length += chunk.getLen();
     }
 
-    datanodeStorage.putBlock(putBlock.getBlockData().getBlockID(),
-        putBlock.getBlockData());
+    datanodeStorage.putBlock(blockData.getBlockID(),
+        blockData);
 
-    return PutBlockResponseProto.newBuilder()
-        .setCommittedBlockLength(
-            GetCommittedBlockLengthResponseProto.newBuilder()
-                .setBlockID(putBlock.getBlockData().getBlockID())
+    return GetCommittedBlockLengthResponseProto.newBuilder()
+                .setBlockID(blockData.getBlockID())
                 .setBlockLength(length)
-                .build())
-        .build();
+                .build();
   }
 
   private XceiverClientReply result(
@@ -172,8 +177,15 @@ public class MockXceiverClientSpi extends XceiverClientSpi {
     datanodeStorage
         .writeChunk(writeChunk.getBlockID(), writeChunk.getChunkData(),
             writeChunk.getData());
-    return WriteChunkResponseProto.newBuilder()
-        .build();
+
+    WriteChunkResponseProto.Builder builder =
+        WriteChunkResponseProto.newBuilder();
+    if (writeChunk.hasBlock()) {
+      ContainerProtos.BlockData
+          blockData = writeChunk.getBlock().getBlockData();
+      builder.setCommittedBlockLength(doPutBlock(blockData));
+    }
+    return builder.build();
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.hdds.DatanodeVersion;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.CipherSuite;
@@ -77,6 +78,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VERSION;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -116,6 +118,8 @@ public class TestHSync {
     CONF.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
     CONF.set(OZONE_DEFAULT_BUCKET_LAYOUT, layout.name());
     CONF.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
+    CONF.setInt(HDDS_DATANODE_VERSION, DatanodeVersion.CURRENT_VERSION - 1);
+    CONF.setBoolean("ozone.client.stream.putblock.piggybacking", true);
     cluster = MiniOzoneCluster.newBuilder(CONF)
         .setNumDatanodes(5)
         .setTotalPipelineNumLimit(10)
@@ -340,7 +344,8 @@ public class TestHSync {
           break;
         }
         for (int i = 0; i < n; i++) {
-          assertEquals(data[offset + i], buffer[i]);
+          assertEquals(data[offset + i], buffer[i],
+              "expected at offset " + offset + " i=" + i);
         }
         offset += n;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -215,9 +215,9 @@ public class TestBlockOutputStream {
         .getPendingContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
     Assert.assertEquals(writeChunkCount + 1,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
-    Assert.assertEquals(putBlockCount + 2,
+    Assert.assertEquals(putBlockCount + 1,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
-    Assert.assertEquals(totalOpCount + 3,
+    Assert.assertEquals(totalOpCount + 2,
         metrics.getTotalOpCount());
 
     // make sure the bufferPool is empty
@@ -382,7 +382,7 @@ public class TestBlockOutputStream {
     key.flush();
     Assert.assertEquals(writeChunkCount + 2,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
-    Assert.assertEquals(putBlockCount + 1,
+    Assert.assertEquals(putBlockCount + 0,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
     Assert.assertEquals(pendingWriteChunkCount, metrics
         .getPendingContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
@@ -415,9 +415,9 @@ public class TestBlockOutputStream {
         .getPendingContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
     Assert.assertEquals(writeChunkCount + 2,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
-    Assert.assertEquals(putBlockCount + 2,
+    Assert.assertEquals(putBlockCount + 1,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
-    Assert.assertEquals(totalOpCount + 4,
+    Assert.assertEquals(totalOpCount + 3,
         metrics.getTotalOpCount());
     Assert.assertEquals(0, keyOutputStream.getStreamEntries().size());
     validateData(keyName, data1);
@@ -486,9 +486,9 @@ public class TestBlockOutputStream {
         .getPendingContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
     Assert.assertEquals(writeChunkCount + 3,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
-    Assert.assertEquals(putBlockCount + 2,
+    Assert.assertEquals(putBlockCount + 1,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
-    Assert.assertEquals(totalOpCount + 5,
+    Assert.assertEquals(totalOpCount + 4,
         metrics.getTotalOpCount());
     Assert.assertEquals(dataLength, blockOutputStream.getTotalAckDataLength());
     // make sure the bufferPool is empty
@@ -697,9 +697,9 @@ public class TestBlockOutputStream {
         .getPendingContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
     Assert.assertEquals(writeChunkCount + 5,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
-    Assert.assertEquals(putBlockCount + 4,
+    Assert.assertEquals(putBlockCount + 3,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
-    Assert.assertEquals(totalOpCount + 9,
+    Assert.assertEquals(totalOpCount + 8,
         metrics.getTotalOpCount());
     Assert.assertEquals(dataLength, blockOutputStream.getTotalAckDataLength());
     Assert.assertTrue(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamFlushDelay.java
@@ -380,7 +380,7 @@ public class TestBlockOutputStreamFlushDelay {
     key.flush();
     Assert.assertEquals(writeChunkCount + 2,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
-    Assert.assertEquals(putBlockCount + 1,
+    Assert.assertEquals(putBlockCount + 0,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
     Assert.assertEquals(pendingWriteChunkCount, metrics
         .getPendingContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
@@ -413,9 +413,9 @@ public class TestBlockOutputStreamFlushDelay {
         .getPendingContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
     Assert.assertEquals(writeChunkCount + 2,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
-    Assert.assertEquals(putBlockCount + 2,
+    Assert.assertEquals(putBlockCount + 1,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
-    Assert.assertEquals(totalOpCount + 4,
+    Assert.assertEquals(totalOpCount + 3,
         metrics.getTotalOpCount());
     Assert.assertEquals(0, keyOutputStream.getStreamEntries().size());
     validateData(keyName, data1);
@@ -484,9 +484,9 @@ public class TestBlockOutputStreamFlushDelay {
         .getPendingContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
     Assert.assertEquals(writeChunkCount + 3,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
-    Assert.assertEquals(putBlockCount + 2,
+    Assert.assertEquals(putBlockCount + 1,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
-    Assert.assertEquals(totalOpCount + 5,
+    Assert.assertEquals(totalOpCount + 4,
         metrics.getTotalOpCount());
     Assert.assertEquals(dataLength, blockOutputStream.getTotalAckDataLength());
     // make sure the bufferPool is empty
@@ -695,9 +695,9 @@ public class TestBlockOutputStreamFlushDelay {
     Assert.assertEquals(writeChunkCount + 5,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
     // The previous flush did not trigger any action.
-    Assert.assertEquals(putBlockCount + 3,
+    Assert.assertEquals(putBlockCount + 2,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock));
-    Assert.assertEquals(totalOpCount + 8,
+    Assert.assertEquals(totalOpCount + 7,
         metrics.getTotalOpCount());
     Assert.assertEquals(dataLength, blockOutputStream.getTotalAckDataLength());
     Assert.assertTrue(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Allow WriteChunk request to optionally piggyback PutBlock request if the chunk to be sent is below a threshold.

Please describe your PR in detail:
* Hsync performance is largely determined by Ratis transaction round-trip latency. For HBase WAL use case, since each chunk to be flushed out is tiny, it makes no sense to send WriteChunk and PutBlock separately. Combining the two requests together greatly reduces latency and improves hsync throughput.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9130

## How was this patch tested?

Unit test and real cluster deployement to verify the concept does help with hsync latency and throughput.