### PR TITLE
HDDS-9885. Checkstyle check passing despite config error

### DIFF
--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -30,12 +30,13 @@ declare -i rc
 mvn ${MAVEN_OPTIONS} checkstyle:check > "${REPORT_DIR}/output.log"
 rc=$?
 if [[ ${rc} -ne 0 ]]; then
-  mvn ${MAVEN_OPTIONS} clean test-compile checkstyle:check
+  mvn ${MAVEN_OPTIONS} clean test-compile checkstyle:check > output.log
   rc=$?
   mkdir -p "$REPORT_DIR" # removed by mvn clean
-else
-  cat "${REPORT_DIR}/output.log"
+  mv output.log "${REPORT_DIR}"/
 fi
+
+cat "${REPORT_DIR}/output.log"
 
 #Print out the exact violations with parsing XML results with sed
 find "." -name checkstyle-errors.xml -print0 \
@@ -51,6 +52,11 @@ find "." -name checkstyle-errors.xml -print0 \
       -e "s/&lt;/</g" \
       -e "s/&gt;/>/g" \
   | tee "$REPORT_FILE"
+
+# check if Maven failed due to some error other than checkstyle violation
+if [[ ${rc} -ne 0 ]] && [[ ! -s "${REPORT_FILE}" ]]; then
+  grep -m1 -F '[ERROR]' "${REPORT_DIR}/output.log" > "${REPORT_FILE}"
+fi
 
 ## generate counter
 grep -c ':' "$REPORT_FILE" > "$REPORT_DIR/failures"


### PR DESCRIPTION
## What changes were proposed in this pull request?

_basic (checkstyle)_ is shown as passing if it fails with config error, not a checkstyle violation.

https://issues.apache.org/jira/browse/HDDS-9885

## How was this patch tested?

Verified that the check fails with https://github.com/apache/ozone/pull/921/commits/9b16de3fc1524cc263c5a14576559bec2722e7dd checked out (which had the config error):

```
$ hadoop-ozone/dev-support/checks/checkstyle.sh > /dev/null

$ hadoop-ozone/dev-support/checks/_summary.sh target/checkstyle/summary.txt
13:58:11,624 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2:check (default-cli) on project ozone-main: Failed during checkstyle configuration: cannot initialize module TreeWalker - TreeWalker is not allowed as a parent of LineLength Please review 'Parent Module' section for this Check in web documentation if Check is standard. -> [Help 1]

$ echo $?
1
```

Verified the check still fails if there is checkstyle violation:

```
$ hadoop-ozone/dev-support/checks/checkstyle.sh > /dev/null

$ hadoop-ozone/dev-support/checks/_summary.sh target/checkstyle/summary.txt
hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
 91: Line is longer than 80 characters (found 82).
 92: Line is longer than 80 characters (found 81).

$ echo $?
1
```

Verified the check still passes with code conforming to checkstyle rules:

```
$ hadoop-ozone/dev-support/checks/checkstyle.sh > /dev/null

$ hadoop-ozone/dev-support/checks/_summary.sh target/checkstyle/summary.txt

$ echo $?
0
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7158011023/job/19489560474