### PR TITLE
HDDS-9888. Reduce log level for "not leader" log entries

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -496,7 +496,7 @@ public class DeletedBlockLogImpl
   public void onMessage(
       DeleteBlockStatus deleteBlockStatus, EventPublisher publisher) {
     if (!scmContext.isLeader()) {
-      LOG.warn("Skip commit transactions since current SCM is not leader.");
+      LOG.info("Skip commit transactions since current SCM is not leader.");
       return;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
@@ -79,7 +79,7 @@ public class CloseContainerEventHandler implements EventHandler<ContainerID> {
   @Override
   public void onMessage(ContainerID containerID, EventPublisher publisher) {
     if (!scmContext.isLeader()) {
-      LOG.warn("Skip close container {} since current SCM is not leader.",
+      LOG.info("Skip close container {} since current SCM is not leader.",
           containerID);
       return;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -110,7 +110,7 @@ public class IncrementalContainerReportHandler extends
               replicaProto.getContainerID());
         } catch (SCMException ex) {
           if (ex.getResult() == SCMException.ResultCodes.SCM_NOT_LEADER) {
-            LOG.warn("Failed to process {} container {}: {}",
+            LOG.info("Failed to process {} container {}: {}",
                 replicaProto.getState(), id, ex.getMessage());
           } else {
             LOG.error("Exception while processing ICR for container {}",


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9888. Reduce log level for "not leader" log entries.

Reduced log level from warning to info for the messages logged on non-leader nodes to reduce the number of warning messages.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9888

## How was this patch tested?

Manually checked log files.
