### PR TITLE
HDDS-9478. Add more details to Safemode verbose output.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -55,7 +55,6 @@ public class ContainerSafeModeRule extends
 
   private AtomicLong containerWithMinReplicas = new AtomicLong(0);
   private final ContainerManager containerManager;
-  private static final int SAMPLE_CONTAINER_DISPLAY_LIMIT = 5;
 
   public ContainerSafeModeRule(String ruleName, EventQueue eventQueue,
              ConfigurationSource conf,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.hdds.scm.safemode;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -141,16 +141,10 @@ public class ContainerSafeModeRule extends
 
   @Override
   public String getStatusText() {
-    List<Long> sampleContainers = new ArrayList<>();
-    if (!containerMap.isEmpty()) {
-      int count = 0;
-      for (long cId : containerMap.keySet()) {
-        if (count < SAMPLE_CONTAINER_DISPLAY_LIMIT) {
-          sampleContainers.add(cId);
-          count++;
-        }
-      }
-    }
+    List<Long> sampleContainers = containerMap.keySet()
+        .stream()
+        .limit(SAMPLE_CONTAINER_DISPLAY_LIMIT)
+        .collect(Collectors.toList());
 
     String status = String.format("%% of containers with at least one reported"
             + " replica (=%1.2f) >= safeModeCutoff (=%1.2f)",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -206,16 +206,20 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
         "healthy Ratis/THREE pipelines (=%d) >= healthyPipelineThresholdCount" +
             " (=%d)", getCurrentHealthyPipelineCount(),
         getHealthyPipelineThresholdCount());
-    synchronized (unProcessedPipelineSet) {
-      Set<PipelineID> samplePipelines =
-          unProcessedPipelineSet.stream().limit(SAMPLE_PIPELINE_DISPLAY_LIMIT)
-              .collect(Collectors.toSet());
+    status = updateStatusTextWithSamplePipelines(status);
+    return status;
+  }
 
-      if (!samplePipelines.isEmpty()) {
-        String samplePipelineText =
-            "Sample pipelines not satisfying the criteria : " + samplePipelines;
-        status = status.concat("\n").concat(samplePipelineText);
-      }
+  private synchronized String updateStatusTextWithSamplePipelines(
+      String status) {
+    Set<PipelineID> samplePipelines =
+        unProcessedPipelineSet.stream().limit(SAMPLE_PIPELINE_DISPLAY_LIMIT)
+            .collect(Collectors.toSet());
+
+    if (!samplePipelines.isEmpty()) {
+      String samplePipelineText =
+          "Sample pipelines not satisfying the criteria : " + samplePipelines;
+      status = status.concat("\n").concat(samplePipelineText);
     }
     return status;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -58,7 +58,6 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   private final int minHealthyPipelines;
   private final SCMContext scmContext;
   private final Set<PipelineID> unProcessedPipelineSet = new HashSet<>();
-  private static final int SAMPLE_PIPELINE_DISPLAY_LIMIT = 5;
 
   HealthyPipelineSafeModeRule(String ruleName, EventQueue eventQueue,
       PipelineManager pipelineManager, SCMSafeModeManager manager,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -147,15 +147,19 @@ public class OneReplicaPipelineSafeModeRule extends
         "reported Ratis/THREE pipelines with at least one datanode (=%d) "
             + ">= threshold (=%d)", getCurrentReportedPipelineCount(),
         getThresholdCount());
-    synchronized (reportedPipelineIDSet) {
-      Set<PipelineID> samplePipelines = oldPipelineIDSet.stream()
-          .filter(element -> !reportedPipelineIDSet.contains(element))
-          .limit(SAMPLE_PIPELINE_DISPLAY_LIMIT).collect(Collectors.toSet());
-      if (!samplePipelines.isEmpty()) {
-        String samplePipelineText =
-            "Sample pipelines not satisfying the criteria : " + samplePipelines;
-        status = status.concat("\n").concat(samplePipelineText);
-      }
+    status = updateStatusTextWithSamplePipelines(status);
+    return status;
+  }
+
+  private synchronized String updateStatusTextWithSamplePipelines(
+      String status) {
+    Set<PipelineID> samplePipelines = oldPipelineIDSet.stream()
+        .filter(element -> !reportedPipelineIDSet.contains(element))
+        .limit(SAMPLE_PIPELINE_DISPLAY_LIMIT).collect(Collectors.toSet());
+    if (!samplePipelines.isEmpty()) {
+      String samplePipelineText =
+          "Sample pipelines not satisfying the criteria : " + samplePipelines;
+      status = status.concat("\n").concat(samplePipelineText);
     }
     return status;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -57,6 +57,7 @@ public class OneReplicaPipelineSafeModeRule extends
   private int currentReportedPipelineCount = 0;
   private PipelineManager pipelineManager;
   private final double pipelinePercent;
+  private static final int SAMPLE_PIPELINE_DISPLAY_LIMIT = 5;
 
 
   public OneReplicaPipelineSafeModeRule(String ruleName, EventQueue eventQueue,
@@ -142,12 +143,20 @@ public class OneReplicaPipelineSafeModeRule extends
 
   @Override
   public String getStatusText() {
-    return String
-        .format(
-            "reported Ratis/THREE pipelines with at least one datanode (=%d) "
-                + ">= threshold (=%d)",
-            getCurrentReportedPipelineCount(),
-            getThresholdCount());
+    String status = String.format(
+        "reported Ratis/THREE pipelines with at least one datanode (=%d) "
+            + ">= threshold (=%d)", getCurrentReportedPipelineCount(),
+        getThresholdCount());
+    Set<PipelineID> samplePipelines = oldPipelineIDSet.stream()
+        .filter(element -> !reportedPipelineIDSet.contains(element))
+        .limit(SAMPLE_PIPELINE_DISPLAY_LIMIT)
+        .collect(Collectors.toSet());
+    if (!samplePipelines.isEmpty()) {
+      String samplePipelineText =
+          "Sample pipelines not satisfying the criteria : " + samplePipelines;
+      status = status.concat("/n").concat(samplePipelineText);
+    }
+    return status;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -57,7 +57,6 @@ public class OneReplicaPipelineSafeModeRule extends
   private int currentReportedPipelineCount = 0;
   private PipelineManager pipelineManager;
   private final double pipelinePercent;
-  private static final int SAMPLE_PIPELINE_DISPLAY_LIMIT = 5;
 
 
   public OneReplicaPipelineSafeModeRule(String ruleName, EventQueue eventQueue,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
@@ -38,6 +38,8 @@ public abstract class SafeModeExitRule<T> implements EventHandler<T> {
 
   private final SCMSafeModeManager safeModeManager;
   private final String ruleName;
+  protected static final int SAMPLE_CONTAINER_DISPLAY_LIMIT = 5;
+  protected static final int SAMPLE_PIPELINE_DISPLAY_LIMIT = 5;
 
   public SafeModeExitRule(SCMSafeModeManager safeModeManager,
       String ruleName, EventQueue eventQueue) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add details of sample containers/pipelines that do not satisfy safemode criteria in order to continue further debugging/investigation

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9478

## How was this patch tested?
Manually

Tried bringing down a DN that hosts a container with RF=1, hence pipelineSafemode will not be satisfied i.e atleast one replica of the pipeline is not reported
```bash
bash-4.2$ ozone admin safemode status --verbose
SCM is in safe mode.
validated:true, DataNodeSafeModeRule, registered datanodes (=1) >= required datanodes (=1)
validated:false, HealthyPipelineSafeModeRule, healthy Ratis/THREE pipelines (=0) >= healthyPipelineThresholdCount (=1)
Sample pipelines not satisfying the criteria : [PipelineID=a96f5a77-8d04-41b5-8532-18d0043ffbf3]
validated:true, ContainerSafeModeRule, % of containers with at least one reported replica (=1.00) >= safeModeCutoff (=0.99)
validated:true, AtleastOneDatanodeReportedRule, reported Ratis/THREE pipelines with at least one datanode (=1) >= threshold (=1)/nSample pipelines not satisfying the criteria : [PipelineID=a96f5a77-8d04-41b5-8532-18d0043ffbf3]
bash-4.2$
```