### PR TITLE
HDDS-9896. Fix for NullPointerException when replicating closed container using freon

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerImporter.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.ozone.container.common.volume.VolumeChoosingPolicyFacto
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,9 +64,10 @@ public class ContainerImporter {
   private final Set<Long> importContainerProgress
       = Collections.synchronizedSet(new HashSet<>());
 
-  public ContainerImporter(ConfigurationSource conf, ContainerSet containerSet,
-      ContainerController controller,
-      MutableVolumeSet volumeSet) {
+  public ContainerImporter(@NotNull ConfigurationSource conf,
+                           @NotNull ContainerSet containerSet,
+                           @NotNull ContainerController controller,
+                           @NotNull MutableVolumeSet volumeSet) {
     this.containerSet = containerSet;
     this.controller = controller;
     this.volumeSet = volumeSet;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
@@ -306,8 +307,10 @@ public class TestReplicationSupervisor {
     Mockito.when(volumeSet.getVolumesList())
         .thenReturn(singletonList(
             new HddsVolume.Builder(testDir).conf(conf).build()));
+    ContainerController mockedCC =
+        Mockito.mock(ContainerController.class);
     ContainerImporter importer =
-        new ContainerImporter(conf, set, null, volumeSet);
+        new ContainerImporter(conf, set, mockedCC, volumeSet);
     ContainerReplicator replicator =
         new DownloadAndImportReplicator(conf, set, importer, moc);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -202,7 +202,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
         new ContainerController(containerSet, handlers);
 
     ContainerImporter importer = new ContainerImporter(conf, containerSet,
-        controller, null);
+        controller, volumeSet);
     replicator = new DownloadAndImportReplicator(conf, containerSet, importer,
         new SimpleContainerDownloader(conf, null));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
We are seeing NPE when replicating closed container using freon 
```
java.lang.NullPointerException
 at org.apache.hadoop.ozone.container.replication.ContainerImporter.chooseNextVolume(ContainerImporter.java:146)
 at org.apache.hadoop.ozone.container.replication.DownloadAndImportReplicator.replicate(DownloadAndImportReplicator.java:77)
 at org.apache.hadoop.ozone.container.replication.ReplicationTask.runTask(ReplicationTask.java:122)
 at org.apache.hadoop.ozone.container.replication.ReplicationSupervisor$TaskRunner.run(ReplicationSupervisor.java:359)
 at org.apache.hadoop.ozone.freon.ClosedContainerReplicator.lambda$replicateContainer$1(ClosedContainerReplicator.java:224)
 at com.codahale.metrics.Timer.time(Timer.java:101)
 at org.apache.hadoop.ozone.freon.ClosedContainerReplicator.replicateContainer(ClosedContainerReplicator.java:221)
 at org.apache.hadoop.ozone.freon.BaseFreonGenerator.tryNextTask(BaseFreonGenerator.java:220)
 at org.apache.hadoop.ozone.freon.BaseFreonGenerator.taskLoop(BaseFreonGenerator.java:200)
 at org.apache.hadoop.ozone.freon.BaseFreonGenerator.lambda$startTaskRunners$0(BaseFreonGenerator.java:174)
 at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
 at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
 at java.base/java.lang.Thread.run(Thread.java:834)
```

This change is to fix NPE and pass non-null `volumeSet` when creating `ContainerImporter` object to replicate closed container using freon. Also added @NotNull annotation on ContainerImporter's constructor for developers.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9896

## How was this patch tested?
Existing unit and integ tests for now.