### PR TITLE
HDDS-9899. Update RIGHT_MARGIN to 120 for IntelliJ

### DIFF
--- a/hadoop-ozone/dev-support/intellij/ozone-style.xml
+++ b/hadoop-ozone/dev-support/intellij/ozone-style.xml
@@ -18,7 +18,7 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="80" />
+    <option name="RIGHT_MARGIN" value="120" />
     <option name="INDENT_CASE_FROM_SWITCH" value="false" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="1" />


### PR DESCRIPTION
## What changes were proposed in this pull request?

As the [HDDS-3583](https://issues.apache.org/jira/browse/HDDS-3583) resolved, we should update the RIGHT_MARGIN to 120 for intellij meanwhile.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9899

## How was this patch tested?

Intellij import this config file and open an editor to verify the right margin.