### PR TITLE
HDDS-9900. TypedTable#iterator throws NPE on any error if prefix is null

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -418,7 +418,9 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       try {
         return newCodecBufferTableIterator(rawTable.iterator(prefixBuffer));
       } catch (Throwable t) {
-        prefixBuffer.release();
+        if (prefixBuffer != null) {
+          prefixBuffer.release();
+        }
         throw t;
       }
     } else {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
@@ -240,6 +241,17 @@ public class TestTypedRDBTableStore {
         Assertions.assertEquals(iterCount, count);
 
       }
+    }
+  }
+
+  @Test
+  public void testIteratorOnException() throws Exception {
+    RDBTable rdbTable = Mockito.mock(RDBTable.class);
+    Mockito.when(rdbTable.iterator((CodecBuffer) null))
+        .thenThrow(new IOException());
+    try (Table<String, String> testTable = new TypedTable<>(rdbTable,
+        codecRegistry, String.class, String.class)) {
+      Assertions.assertThrows(IOException.class, testTable::iterator);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
`TypedTable#iterator` will throw `NullPointerException` in any error scenario, which will hide the actual exception and make it hard to debug.

This PR changes the behavior of `TypedTable#iterator` to throw the real exception.

## What is the link to the Apache JIRA
HDDS-9900

## How was this patch tested?
An additional unit test is added to cover the new behavior.