### PR TITLE
HDDS-9902. Decommission: Admin monitor should call RM.checkContainerState to check for under-replication

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -111,6 +111,7 @@ public class ContainerHealthResult {
     private boolean isMissing = false;
     private boolean hasHealthyReplicas;
     private boolean hasUnReplicatedOfflineIndexes = false;
+    private boolean offlineIndexesOkAfterPending = false;
     private int requeueCount = 0;
 
     public UnderReplicatedHealthResult(ContainerInfo containerInfo,
@@ -229,6 +230,27 @@ public class ContainerHealthResult {
      */
     public boolean hasUnreplicatedOfflineIndexes() {
       return hasUnReplicatedOfflineIndexes;
+    }
+
+    /**
+     * Pass true if a container has some indexes which are only on nodes which
+     * are DECOMMISSIONING or ENTERING_MAINTENANCE, but the container has a
+     * pending add to correct the under replication caused by decommission, but
+     * it has not completed yet.
+     * @param val Pass True if the container has a pending add to correct the
+     *            under replication caused by decommission. False otherwise.
+     */
+    public void setOfflineIndexesOkAfterPending(boolean val) {
+      offlineIndexesOkAfterPending = val;
+    }
+
+    /**
+     * Returns true if a container has under-replication caused by offline
+     * indexes, but it is corrected by a pending add.
+     * @return
+     */
+    public boolean offlineIndexesOkAfterPending() {
+      return offlineIndexesOkAfterPending;
     }
 
     public boolean hasHealthyReplicas() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/ECReplicationCheckHandler.java
@@ -74,13 +74,19 @@ public class ECReplicationCheckHandler extends AbstractCheck {
           report.incrementAndSample(
               ReplicationManagerReport.HealthState.UNHEALTHY, containerID);
         }
+        // An EC container can be both unrecoverable and have offline replicas. In this case, we need
+        // to report both states as the decommission monitor needs to wait for an extra copy to be
+        // made of the offline replica before decommission can complete.
+        if (underHealth.hasUnreplicatedOfflineIndexes()) {
+          report.incrementAndSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED, containerID);
+        }
       } else {
         report.incrementAndSample(
             ReplicationManagerReport.HealthState.UNDER_REPLICATED, containerID);
       }
       if (!underHealth.isReplicatedOkAfterPending() &&
           (!underHealth.isUnrecoverable()
-              || underHealth.hasUnreplicatedOfflineIndexes())) {
+              || (underHealth.hasUnreplicatedOfflineIndexes() && !underHealth.offlineIndexesOkAfterPending()))) {
         request.getReplicationQueue().enqueue(underHealth);
       }
       LOG.debug("Container {} is Under Replicated. isReplicatedOkAfterPending "
@@ -140,9 +146,17 @@ public class ECReplicationCheckHandler extends AbstractCheck {
               container, remainingRedundancy, dueToOutOfService,
               replicaCount.isSufficientlyReplicated(true),
               replicaCount.isUnrecoverable());
-      if (replicaCount.decommissioningOnlyIndexes(true).size() > 0
-          || replicaCount.maintenanceOnlyIndexes(true).size() > 0) {
+      // If the container has a pending add to correct the under replication caused by decommission
+      // then we need to wait for that to complete before we can say the container is replicated OK.
+      // Therefore we should set the setHasUnReplicatedOfflineIndexes based on not considering
+      // pending.
+      if (!replicaCount.decommissioningOnlyIndexes(false).isEmpty()
+          || !replicaCount.maintenanceOnlyIndexes(false).isEmpty()) {
         result.setHasUnReplicatedOfflineIndexes(true);
+        if (replicaCount.decommissioningOnlyIndexes(true).isEmpty()
+            && replicaCount.maintenanceOnlyIndexes(true).isEmpty()) {
+          result.setOfflineIndexesOkAfterPending(true);
+        }
       }
       result.setIsMissing(replicaCount.isMissing());
       return result;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionMetrics.java
@@ -55,8 +55,8 @@ public final class NodeDecommissionMetrics implements MetricsSource {
   @Metric("Number of containers under replicated in tracked nodes.")
   private MutableGaugeLong containersUnderReplicatedTotal;
 
-  @Metric("Number of containers unhealthy in tracked nodes.")
-  private MutableGaugeLong containersUnhealthyTotal;
+  @Metric("Number of containers not fully closed in tracked nodes.")
+  private MutableGaugeLong containersUnClosedTotal;
 
   @Metric("Number of containers sufficiently replicated in tracked nodes.")
   private MutableGaugeLong containersSufficientlyReplicatedTotal;
@@ -67,7 +67,7 @@ public final class NodeDecommissionMetrics implements MetricsSource {
    */
   public static final class ContainerStateInWorkflow {
     private long sufficientlyReplicated = 0;
-    private long unhealthyContainers = 0;
+    private long unclosedContainers = 0;
     private long underReplicatedContainers = 0;
     private String host = "";
     private long pipelinesWaitingToClose = 0;
@@ -91,22 +91,18 @@ public final class NodeDecommissionMetrics implements MetricsSource {
             + "for host in decommissioning and "
             + "maintenance mode");
 
-    private static final MetricsInfo HOST_UNHEALTHY_CONTAINERS = Interns.info(
-        "UnhealthyContainersDN",
-        "Number of unhealthy containers "
-            + "for host in decommissioning and "
-            + "maintenance mode");
-
+    private static final MetricsInfo HOST_UNCLOSED_CONTAINERS = Interns.info("UnclosedContainersDN",
+        "Number of containers not fully closed for host in decommissioning and maintenance mode");
 
     public ContainerStateInWorkflow(String host,
                                     long sufficiently,
                                     long under,
-                                    long unhealthy,
+                                    long unclosed,
                                     long pipelinesToClose) {
       this.host = host;
       sufficientlyReplicated = sufficiently;
       underReplicatedContainers = under;
-      unhealthyContainers = unhealthy;
+      unclosedContainers = unclosed;
       pipelinesWaitingToClose = pipelinesToClose;
     }
 
@@ -126,8 +122,8 @@ public final class NodeDecommissionMetrics implements MetricsSource {
       return underReplicatedContainers;
     }
 
-    public long getUnhealthyContainers() {
-      return unhealthyContainers;
+    public long getUnclosedContainers() {
+      return unclosedContainers;
     }
   }
 
@@ -166,7 +162,7 @@ public final class NodeDecommissionMetrics implements MetricsSource {
     recommissionNodesTotal.snapshot(builder, all);
     pipelinesWaitingToCloseTotal.snapshot(builder, all);
     containersUnderReplicatedTotal.snapshot(builder, all);
-    containersUnhealthyTotal.snapshot(builder, all);
+    containersUnClosedTotal.snapshot(builder, all);
     containersSufficientlyReplicatedTotal.snapshot(builder, all);
 
     MetricsRecordBuilder recordBuilder = builder;
@@ -182,8 +178,8 @@ public final class NodeDecommissionMetrics implements MetricsSource {
               e.getValue().getUnderReplicatedContainers())
           .addGauge(ContainerStateInWorkflow.HOST_SUFFICIENTLY_REPLICATED,
               e.getValue().getSufficientlyReplicated())
-          .addGauge(ContainerStateInWorkflow.HOST_UNHEALTHY_CONTAINERS,
-              e.getValue().getUnhealthyContainers());
+          .addGauge(ContainerStateInWorkflow.HOST_UNCLOSED_CONTAINERS,
+              e.getValue().getUnclosedContainers());
     }
     recordBuilder.endRecord();
   }
@@ -218,10 +214,9 @@ public final class NodeDecommissionMetrics implements MetricsSource {
         .set(numTrackedUnderReplicated);
   }
 
-  public synchronized void setContainersUnhealthyTotal(
-          long numTrackedUnhealthy) {
-    containersUnhealthyTotal
-        .set(numTrackedUnhealthy);
+  public synchronized void setContainersUnClosedTotal(
+          long numTrackedUnclosed) {
+    containersUnClosedTotal.set(numTrackedUnclosed);
   }
 
   public synchronized void setContainersSufficientlyReplicatedTotal(
@@ -246,8 +241,8 @@ public final class NodeDecommissionMetrics implements MetricsSource {
     return containersUnderReplicatedTotal.value();
   }
 
-  public synchronized long getContainersUnhealthyTotal() {
-    return containersUnhealthyTotal.value();
+  public synchronized long getContainersUnClosedTotal() {
+    return containersUnClosedTotal.value();
   }
 
   public synchronized long getContainersSufficientlyReplicatedTotal() {
@@ -282,9 +277,9 @@ public final class NodeDecommissionMetrics implements MetricsSource {
   }
 
   @VisibleForTesting
-  public Long getUnhealthyContainersByHost(String host) {
+  public Long getUnClosedContainersByHost(String host) {
     ContainerStateInWorkflow workflowMetrics = metricsByHost.get(host);
     return workflowMetrics == null ? null :
-        workflowMetrics.getUnhealthyContainers();
+        workflowMetrics.getUnclosedContainers();
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -179,6 +179,7 @@ public class TestDatanodeAdminMonitor {
     DatanodeAdminMonitorTestUtil
             .mockGetContainerReplicaCount(
                     repManager,
+                    true,
                     HddsProtos.LifeCycleState.CLOSED,
                     DECOMMISSIONED,
                     IN_SERVICE,
@@ -205,6 +206,7 @@ public class TestDatanodeAdminMonitor {
     DatanodeAdminMonitorTestUtil
             .mockGetContainerReplicaCount(
                     repManager,
+                    false,
                     HddsProtos.LifeCycleState.CLOSED,
                     IN_SERVICE,
                     IN_SERVICE,
@@ -376,6 +378,7 @@ public class TestDatanodeAdminMonitor {
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCount(
             repManager,
+            true,
             HddsProtos.LifeCycleState.DELETING,
             DECOMMISSIONED,
             IN_SERVICE);
@@ -404,6 +407,7 @@ public class TestDatanodeAdminMonitor {
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCountForEC(
             repManager,
+            true,
             HddsProtos.LifeCycleState.CLOSED,
             new ECReplicationConfig(3, 2),
             Triple.of(DECOMMISSIONING, dn1, 1),
@@ -432,6 +436,7 @@ public class TestDatanodeAdminMonitor {
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCountForEC(
             repManager,
+            false,
             HddsProtos.LifeCycleState.CLOSED,
             new ECReplicationConfig(3, 2),
             Triple.of(DECOMMISSIONING, dn1, 1),
@@ -459,6 +464,7 @@ public class TestDatanodeAdminMonitor {
     DatanodeAdminMonitorTestUtil
             .mockGetContainerReplicaCount(
                     repManager,
+                    true,
                     HddsProtos.LifeCycleState.CLOSED,
                     DECOMMISSIONED,
                     IN_SERVICE,
@@ -496,6 +502,7 @@ public class TestDatanodeAdminMonitor {
     DatanodeAdminMonitorTestUtil
             .mockGetContainerReplicaCount(
                     repManager,
+                    true,
                     HddsProtos.LifeCycleState.CLOSED,
                     DECOMMISSIONED,
                     IN_SERVICE,
@@ -590,12 +597,13 @@ public class TestDatanodeAdminMonitor {
     DatanodeAdminMonitorTestUtil
             .mockGetContainerReplicaCount(
                     repManager,
+                    true,
                     HddsProtos.LifeCycleState.CLOSED,
                     IN_MAINTENANCE,
                     ENTERING_MAINTENANCE,
                     IN_MAINTENANCE);
 
-    // Add the node to the monitor, it should transiting to
+    // Add the node to the monitor, it should transition to
     // REPLICATE_CONTAINERS as the containers are under-replicated for
     // maintenance.
     monitor.startMonitoring(dn1);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
@@ -175,6 +175,7 @@ public class TestNodeDecommissionMetrics {
     nodeManager.setContainers(dn1, containers);
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCount(repManager,
+            true,
             HddsProtos.LifeCycleState.CLOSED,
             DECOMMISSIONED,
             IN_SERVICE,
@@ -214,6 +215,7 @@ public class TestNodeDecommissionMetrics {
     nodeManager.setContainers(dn1, containers);
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCount(repManager,
+            false,
             HddsProtos.LifeCycleState.CLOSED,
             IN_SERVICE,
             IN_SERVICE,
@@ -253,6 +255,7 @@ public class TestNodeDecommissionMetrics {
     nodeManager.setContainers(dn1, containers);
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCount(repManager,
+            true,
             HddsProtos.LifeCycleState.OPEN,
             IN_SERVICE);
     monitor.startMonitoring(dn1);
@@ -299,6 +302,7 @@ public class TestNodeDecommissionMetrics {
     nodeManager.setContainers(dn2, containersDn2);
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCount(repManager,
+            true,
             HddsProtos.LifeCycleState.CLOSED,
             DECOMMISSIONED,
             IN_SERVICE,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
@@ -233,11 +233,11 @@ public class TestNodeDecommissionMetrics {
   }
 
   /**
-   * Test for collecting metric for unhealthy containers
+   * Test for collecting metric for unclosed containers
    * from nodes in decommissioning and maintenance workflow.
    */
   @Test
-  public void testDecommMonitorCollectUnhealthyContainers()
+  public void testDecommMonitorCollectUnclosedContainers()
       throws ContainerNotFoundException, NodeNotFoundException {
     DatanodeDetails dn1 = MockDatanodeDetails.createDatanodeDetails(
         "datanode_host1",
@@ -249,7 +249,7 @@ public class TestNodeDecommissionMetrics {
     containers.add(ContainerID.valueOf(1));
 
     // set OPEN container with 1 replica CLOSED replica state,
-    // in-service node, generates monitored  unhealthy container replica
+    // in-service node, generates monitored  unclosed container replica
     nodeManager.setContainers(dn1, containers);
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCount(repManager,
@@ -259,12 +259,12 @@ public class TestNodeDecommissionMetrics {
 
     monitor.run();
     Assertions.assertEquals(1,
-        metrics.getContainersUnhealthyTotal());
+        metrics.getContainersUnClosedTotal());
 
     // should have host specific metric collected
     // for datanode_host1
     Assertions.assertEquals(1,
-        metrics.getUnhealthyContainersByHost(
+        metrics.getUnClosedContainersByHost(
             "datanode_host1"));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The logic in ReplicationManager is increasingly complex due to various edge cases around unhealthy and quasi-closed containers, and the differences between EC and Ratis.

It therefore makes sense for DatanodeAdminMonitor to call the new API replicationManager.checkContainerState and then check the report for under-replicated, rather than using the ReplicaCount objects. This means all the logic to decide about under-replication is confined to the replication manager.

In making this change, I needed to make a change in the EC under-replication handling where the container is unhealthy / unrecoverable but also has decommissioning indexes, as it was not being reported as under-replicated previously.

I also refactored the decommission monitor slightly to remove references to containers as "unhealthy" when they are really unclosed - renaming the metrics and variables to unClosed.

There need to be additional testing of this change, perhaps via additional PRs to after this and #5746 is been committed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9902

## How was this patch tested?

Some tests modified, but mostly the tests are the same as before 