### PR TITLE
HDDS-9901. Selective checks: skip tests for IntelliJ config change

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -394,6 +394,18 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=false
 }
 
+@test "IntelliJ config" {
+  run dev-support/ci/selective_ci_checks.sh 92bf0913b6
+
+  assert_output -p 'basic-checks=["rat"]'
+  assert_output -p needs-build=false
+  assert_output -p needs-compile=false
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-dependency-check=false
+  assert_output -p needs-integration-tests=false
+  assert_output -p needs-kubernetes-tests=false
+}
+
 @test "dependency helper" {
   run dev-support/ci/selective_ci_checks.sh 47a5671cc5
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -487,6 +487,7 @@ function get_count_misc_files() {
         "^.github"
         "^hadoop-hdds/dev-support/checkstyle"
         "^hadoop-ozone/dev-support/checks"
+        "^hadoop-ozone/dev-support/intellij"
         "^hadoop-ozone/dist/src/main/license"
         "\.bats$"
         "\.txt$"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tests can be skipped for changes in IntelliJ configuration (e.g. HDDS-9899), since these are not covered by any tests.

https://issues.apache.org/jira/browse/HDDS-9901

## How was this patch tested?

Added bats test case.

CI:
https://github.com/adoroszlai/ozone/actions/runs/7171239020