### PR TITLE
HDDS-9832. Updated ListSnapshotHandler to pass snapshot prefix and continuation token

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/ListSnapshotHandler.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.shell.snapshot;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneSnapshot;
 import org.apache.hadoop.ozone.shell.Handler;
+import org.apache.hadoop.ozone.shell.ListOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.bucket.BucketUri;
 import picocli.CommandLine;
@@ -39,6 +40,9 @@ public class ListSnapshotHandler extends Handler {
   @CommandLine.Mixin
   private BucketUri snapshotPath;
 
+  @CommandLine.Mixin
+  private ListOptions listOptions;
+
   @Override
   protected OzoneAddress getAddress() {
     return snapshotPath.getValue();
@@ -51,8 +55,9 @@ public class ListSnapshotHandler extends Handler {
     String bucketName = snapshotPath.getValue().getBucketName();
 
     Iterator<? extends OzoneSnapshot> snapshotInfos = client.getObjectStore()
-        .listSnapshot(volumeName, bucketName, null, null);
-    int counter = printAsJsonArray(snapshotInfos, Integer.MAX_VALUE);
+        .listSnapshot(volumeName, bucketName, listOptions.getPrefix(),
+            listOptions.getStartItem());
+    int counter = printAsJsonArray(snapshotInfos, listOptions.getLimit());
     if (isVerbose()) {
       err().printf("Found : %d snapshots for o3://%s/%s %n", counter,
           volumeName, bucketName);


### PR DESCRIPTION
# What changes were proposed in this pull request?
List snapshot was implemented in HDDS-7507 but ListSnapshotHandler was not passing snapshot prefix and continuation token. Which was making list snapshot ozone shell to be non-paginated.
This change is to add `ListOptions` to `ListSnapshotHandler` and pass snapshot prefix and continuation token properly.

## What is the link to the Apache JIRA
HDDS-9832

## How was this patch tested?
Tested it in docker.

After the change:
```
sh-4.2$ ozone sh snapshot ls --help
Usage: ozone sh snapshot list [-hV] [-p=<prefix>] [-s=<startItem>]
                              [[-l=<limit>] | [-a]] <value>
List snapshots for the buckets.
      <value>               URI of the volume/bucket.
                            Ozone URI could either be a full URI or short URI.
                            Full URI should start with o3://, in case of non-HA
                            clusters it should be followed by the host name and
                            optionally the port number. In case of HA clusters
                            the service id should be used. Service id provides a
                            logical name for multiple hosts and it is defined
                            in the property ozone.om.service.ids.
                            Example of a full URI with host name and port number
                            for a key:
                            o3://omhostname:9862/vol1/bucket1/key1
                            With a service id for a volume:
                            o3://omserviceid/vol1/
                            Short URI should start from the volume.
                            Example of a short URI for a bucket:
                            vol1/bucket1
                            Any unspecified information will be identified from
                            the config files.

  -a, --all                 List all results
  -h, --help                Show this help message and exit.
  -l, --length=<limit>      Maximum number of items to list
                              Default: 100
  -p, --prefix=<prefix>     Prefix to filter the items
  -s, --start=<startItem>   The item to start the listing from.
                            This will be excluded from the result.
  -V, --version             Print version information and exit.
sh-4.2$ ozone sh snapshot ls vol1/bucket1 -s snap2 -l 2 -p snap
[ {
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "snap3",
  "creationTime" : 1702381079248,
  "snapshotStatus" : "SNAPSHOT_ACTIVE",
  "snapshotId" : "b593cb89-0eb6-4ff0-8502-432beba9549c",
  "snapshotPath" : "vol1/bucket1",
  "checkpointDir" : "-b593cb89-0eb6-4ff0-8502-432beba9549c",
  "referencedSize" : 6780,
  "referencedReplicatedSize" : 20340,
  "exclusiveSize" : 0,
  "exclusiveReplicatedSize" : 0
}, {
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "snap4",
  "creationTime" : 1702381082032,
  "snapshotStatus" : "SNAPSHOT_ACTIVE",
  "snapshotId" : "c014141a-0eb9-4285-a329-d1bf1befcc69",
  "snapshotPath" : "vol1/bucket1",
  "checkpointDir" : "-c014141a-0eb9-4285-a329-d1bf1befcc69",
  "referencedSize" : 6780,
  "referencedReplicatedSize" : 20340,
  "exclusiveSize" : 0,
  "exclusiveReplicatedSize" : 0
} ]
sh-4.2$ 
```