### PR TITLE
HDDS-9897. Option to enable Ratis in SCM.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DefaultConfigManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DefaultConfigManager.java
@@ -47,6 +47,10 @@ public final class DefaultConfigManager {
     return (T) CONFIG_DEFAULT_MAP.getOrDefault(config, defaultValue);
   }
 
+  public static <T> void forceUpdateConfigValue(String config, T value) {
+    CONFIG_DEFAULT_MAP.put(config, value);
+  }
+
   @VisibleForTesting
   public static void clearDefaultConfigs() {
     CONFIG_DEFAULT_MAP.clear();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/AbstractLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/AbstractLayoutVersionManager.java
@@ -221,6 +221,7 @@ public abstract class AbstractLayoutVersionManager<T extends LayoutFeature>
     }
   }
 
+  @Override
   public void close() {
     if (mBean != null) {
       MBeans.unregister(mBean);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/LayoutVersionManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/LayoutVersionManager.java
@@ -80,4 +80,6 @@ public interface LayoutVersionManager {
     return null;
   }
 
+  void close();
+
 }

--- a/hadoop-hdds/docs/content/feature/SCM-HA.md
+++ b/hadoop-hdds/docs/content/feature/SCM-HA.md
@@ -33,13 +33,6 @@ This document explains the HA setup of Storage Container Manager (SCM), please c
 
 ## Configuration
 
-> &#x26a0;&#xfe0f; **IMPORTANT** &#x26a0;&#xfe0f;
->
-> SCM HA is currently supported only for fresh installations.
-> SCM HA must be enabled when starting the Ozone service in the beginning.
-> Once an SCM has been started in non-HA mode,
-> changing it to HA mode is unsupported.
-
 HA mode of Storage Container Manager can be enabled with the following settings in `ozone-site.xml`:
 
 ```XML

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.DefaultConfigManager;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -169,24 +168,21 @@ public class SCMHANodeDetails {
     if (Storage.StorageState.INITIALIZED.equals(state) &&
             scmHAEnabled != scmHAEnableDefault) {
       String errorMessage = String.format("Current State of SCM: %s",
-              scmHAEnableDefault ? "Ratis SCM is enabled "
-              : "SCM is running in Non-HA without Ratis")
-              + " Ratis SCM -> Non Ratis SCM or " +
-              "Non HA SCM -> HA SCM is not supported";
-      if (StringUtils.isNotEmpty(
-          conf.get(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY))) {
+              scmHAEnableDefault ? "SCM is running with Ratis. "
+              : "SCM is running without Ratis. ")
+              + "Ratis SCM -> Non Ratis SCM is not supported.";
+      if (!scmHAEnabled) {
         throw new ConfigurationException(String.format("Invalid Config %s " +
-                "Provided ConfigValue: %s, Expected Config Value: %s. %s",
-            ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, scmHAEnabled,
-            scmHAEnableDefault, errorMessage));
+                "Provided ConfigValue: false, Expected Config Value: true. %s",
+            ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, errorMessage));
       } else {
-        LOG.warn("Invalid config {}. The config was not specified, " +
-                        "but the default value {} conflicts with " +
-                        "the expected config value {}. " +
-                        "Falling back to the expected value. {}",
-                ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY,
-                ScmConfigKeys.OZONE_SCM_HA_ENABLE_DEFAULT,
-                scmHAEnableDefault, errorMessage);
+        LOG.warn("Default/Configured value of config {} conflicts with " +
+                "the expected value. " +
+                "Default/Configured: {}. " +
+                "Expected: {}. " +
+                "Falling back to the expected value. {}",
+            ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY,
+            scmHAEnabled, scmHAEnableDefault, errorMessage);
       }
     }
     DefaultConfigManager.setConfigValue(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
@@ -154,8 +154,9 @@ public class SCMHANodeDetails {
    which defaults to
    {@link org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_DEFAULT}
    For Previously Initialized SCM the values are taken from the version file
-   Ratis SCM -> Non Ratis SCM & vice versa is not supported
-   This values is validated with the config provided.
+   <br>
+   Ratis SCM -> Non Ratis SCM is not supported.
+   This value is validated with the config provided.
   **/
   private static void validateSCMHAConfig(SCMStorageConfig scmStorageConfig,
                                           OzoneConfiguration conf) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1328,9 +1328,12 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       // should fail.
       final LayoutVersionManager layoutVersionManager =
           new HDDSLayoutVersionManager(scmStorageConfig.getLayoutVersion());
-      ScmHAUnfinalizedStateValidationAction.checkScmHA(conf, scmStorageConfig,
-          layoutVersionManager);
-      layoutVersionManager.close();
+      try {
+        ScmHAUnfinalizedStateValidationAction.checkScmHA(conf, scmStorageConfig,
+            layoutVersionManager);
+      } finally {
+        layoutVersionManager.close();
+      }
 
       clusterId = scmStorageConfig.getClusterID();
       final boolean isSCMHAEnabled = scmStorageConfig.isSCMHAEnabled();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -160,6 +160,7 @@ import org.apache.hadoop.ozone.common.Storage.StorageState;
 import org.apache.hadoop.ozone.lease.LeaseManager;
 import org.apache.hadoop.ozone.lease.LeaseManagerNotRunningException;
 import org.apache.hadoop.ozone.upgrade.DefaultUpgradeFinalizationExecutor;
+import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizationExecutor;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.SecurityUtil;
@@ -1325,8 +1326,11 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       // If SCM HA was not being used before pre-finalize, and is being used
       // when the cluster is pre-finalized for the SCM HA feature, init
       // should fail.
+      final LayoutVersionManager layoutVersionManager =
+          new HDDSLayoutVersionManager(scmStorageConfig.getLayoutVersion());
       ScmHAUnfinalizedStateValidationAction.checkScmHA(conf, scmStorageConfig,
-          new HDDSLayoutVersionManager(scmStorageConfig.getLayoutVersion()));
+          layoutVersionManager);
+      layoutVersionManager.close();
 
       clusterId = scmStorageConfig.getClusterID();
       final boolean isSCMHAEnabled = scmStorageConfig.isSCMHAEnabled();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -322,7 +322,7 @@ class TestSCMHAConfiguration {
 
   @Test
   public void testRatisEnabledDefaultConfigWithInitializedSCM()
-      throws IOException, NoSuchFieldException, IllegalAccessException {
+      throws IOException {
     SCMStorageConfig scmStorageConfig = Mockito.mock(SCMStorageConfig.class);
     Mockito.when(scmStorageConfig.getState())
         .thenReturn(Storage.StorageState.INITIALIZED);
@@ -357,11 +357,10 @@ class TestSCMHAConfiguration {
         ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, !ratisEnabled));
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void testInvalidHAConfig(boolean ratisEnabled) throws IOException {
-    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, ratisEnabled);
-    SCMStorageConfig scmStorageConfig = newStorageConfig(!ratisEnabled);
+  @Test
+  void testInvalidHAConfig() throws IOException {
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, false);
+    SCMStorageConfig scmStorageConfig = newStorageConfig(true);
     String clusterID = scmStorageConfig.getClusterID();
     assertThrows(ConfigurationException.class,
         () -> StorageContainerManager.scmInit(conf, clusterID));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -336,15 +336,13 @@ class TestSCMHAConfiguration {
     assertTrue(SCMHAUtils.isSCMHAEnabled(conf));
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testRatisEnabledDefaultConflictConfigWithInitializedSCM(
-      boolean isRatisEnabled) {
+  @Test
+  public void testRatisEnabledDefaultConflictConfigWithInitializedSCM() {
     SCMStorageConfig scmStorageConfig = Mockito.mock(SCMStorageConfig.class);
     Mockito.when(scmStorageConfig.getState())
         .thenReturn(Storage.StorageState.INITIALIZED);
-    Mockito.when(scmStorageConfig.isSCMHAEnabled()).thenReturn(isRatisEnabled);
-    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, !isRatisEnabled);
+    Mockito.when(scmStorageConfig.isSCMHAEnabled()).thenReturn(true);
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, false);
     assertThrows(ConfigurationException.class,
             () -> SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalizedStateValidationAction.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalizedStateValidationAction.java
@@ -87,8 +87,13 @@ public class TestSCMHAUnfinalizedStateValidationAction {
        Ratis SCM -> Non Ratis SCM not supported
      */
     if (haEnabledPreFinalized != haEnabledBefore) {
-      Assertions.assertThrows(ConfigurationException.class,
-              () -> StorageContainerManager.scmInit(conf, CLUSTER_ID));
+      if (haEnabledBefore) {
+        Assertions.assertThrows(ConfigurationException.class,
+            () -> StorageContainerManager.scmInit(conf, CLUSTER_ID));
+      } else {
+        Assertions.assertThrows(UpgradeException.class,
+            () -> StorageContainerManager.scmInit(conf, CLUSTER_ID));
+      }
       return;
     }
     StorageContainerManager scm = HddsTestUtils.getScm(conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -637,13 +637,14 @@ public class TestStorageContainerManager {
     MiniOzoneCluster cluster =
         MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
     cluster.waitForClusterToBeReady();
+    cluster.getStorageContainerManager().stop();
     try {
       final UUID clusterId = UUID.randomUUID();
       // This will initialize SCM
       StorageContainerManager.scmInit(conf, clusterId.toString());
       SCMStorageConfig scmStore = new SCMStorageConfig(conf);
       Assert.assertNotEquals(clusterId.toString(), scmStore.getClusterID());
-      Assert.assertFalse(scmStore.isSCMHAEnabled());
+      Assert.assertTrue(scmStore.isSCMHAEnabled());
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -1080,6 +1080,37 @@ public class TestStorageContainerManager {
     containerReportExecutors.close();
   }
 
+  @Test
+  public void testNonRatisToRatis()
+      throws IOException, AuthenticationException, InterruptedException,
+      TimeoutException {
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    final String clusterID = UUID.randomUUID().toString();
+    try (MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf)
+        .setClusterId(clusterID)
+        .setScmId(UUID.randomUUID().toString())
+        .setNumDatanodes(3)
+        .build()) {
+      final StorageContainerManager nonRatisSCM = cluster
+          .getStorageContainerManager();
+      Assert.assertNull(nonRatisSCM.getScmHAManager().getRatisServer());
+      Assert.assertFalse(nonRatisSCM.getScmStorageConfig().isSCMHAEnabled());
+      nonRatisSCM.stop();
+      nonRatisSCM.join();
+
+      DefaultConfigManager.clearDefaultConfigs();
+      conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
+      StorageContainerManager.scmInit(conf, clusterID);
+      cluster.restartStorageContainerManager(false);
+
+      final StorageContainerManager ratisSCM = cluster
+          .getStorageContainerManager();
+      Assert.assertNotNull(ratisSCM.getScmHAManager().getRatisServer());
+      Assert.assertTrue(ratisSCM.getScmStorageConfig().isSCMHAEnabled());
+
+    }
+  }
+
   private void addTransactions(StorageContainerManager scm,
       DeletedBlockLog delLog,
       Map<Long, List<Long>> containerBlocksMap)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, we don't have any steps/ways to enable SCM HA on a Non-HA setup. This is because `ozone.scm.ratis.enable` cannot be modified once the cluster is initialized ([HDDS-6695](https://issues.apache.org/jira/browse/HDDS-6695)).

We have to initialize Ratis (once the upgrade is finalized) as part of `scm --init` command to support enabling of SCM HA in a Non-HA cluster.

After this change, once the cluster is upgraded running `scm --init` will enable and initialize Ratis in a Non-HA (non Ratis) setup.

## What is the link to the Apache JIRA
[HDDS-9879
](https://issues.apache.org/jira/browse/HDDS-9897)
## How was this patch tested?
An additional unit test is added to verify the new behavior.
