### PR TITLE
HDDS-9893. Client in clientCache is not properly invalidated with security enabled

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -235,10 +235,6 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
       // create different client different pipeline node based on
       // network topology
       String key = getPipelineCacheKey(pipeline, topologyAware);
-      // Append user short name to key to prevent a different user
-      // from using same instance of xceiverClient.
-      key = isSecurityEnabled ?
-          key + UserGroupInformation.getCurrentUser().getShortUserName() : key;
       return clientCache.get(key, new Callable<XceiverClientSpi>() {
         @Override
           public XceiverClientSpi call() throws Exception {
@@ -296,6 +292,15 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
         LOG.error("Failed to get closest node to create pipeline cache key:" +
             e.getMessage());
       }
+    }
+    // Append user short name to key to prevent a different user
+    // from using same instance of xceiverClient.
+    try {
+      key = isSecurityEnabled ?
+          key + UserGroupInformation.getCurrentUser().getShortUserName() : key;
+    } catch (IOException e) {
+      LOG.error("Failed to get current user to create pipeline cache key:" +
+          e.getMessage());
     }
     return key;
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -293,14 +293,16 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
             e.getMessage());
       }
     }
-    // Append user short name to key to prevent a different user
-    // from using same instance of xceiverClient.
-    try {
-      key = isSecurityEnabled ?
-          key + UserGroupInformation.getCurrentUser().getShortUserName() : key;
-    } catch (IOException e) {
-      LOG.error("Failed to get current user to create pipeline cache key:" +
-          e.getMessage());
+
+    if (isSecurityEnabled) {
+      // Append user short name to key to prevent a different user
+      // from using same instance of xceiverClient.
+      try {
+        key += UserGroupInformation.getCurrentUser().getShortUserName();
+      } catch (IOException e) {
+        LOG.error("Failed to get current user to create pipeline cache key:" +
+            e.getMessage());
+      }
     }
     return key;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

clientCache in XceiverClientManager hold the client created in XceiverClientManager. Client in clientCache will be invalidated by two ways,
one is the explicitly call XceiverClientManager#releaseClient for this client,
another is when the client in clientCache is not accessed for a predefined period of time.

When XceiverClientManager#releaseClient is called, it will invalidate the client based on the constructed cache key, where it doesn't match the key constructed when client is put into clientCache when security is enabled.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9893

## How was this patch tested?
unit test 