### PR TITLE
HDDS-9422. Return error response when trying to create a directory under .snapshot path

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -31,6 +31,7 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -116,6 +117,9 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     CreateDirectoryRequest createDirectoryRequest =
         getOmRequest().getCreateDirectoryRequest();
     Preconditions.checkNotNull(createDirectoryRequest);
+
+    OmUtils.verifyKeyNameWithSnapshotReservedWord(
+        createDirectoryRequest.getKeyArgs().getKeyName());
 
     KeyArgs.Builder newKeyArgs = createDirectoryRequest.getKeyArgs()
         .toBuilder().setModificationTime(Time.now());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
@@ -42,6 +43,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -55,12 +58,9 @@ import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CreateDirectoryRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .KeyArgs;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateDirectoryRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.mockito.ArgumentMatchers.any;
@@ -78,12 +78,9 @@ public class TestOMDirectoryCreateRequest {
   private OzoneManager ozoneManager;
   private OMMetrics omMetrics;
   private OMMetadataManager omMetadataManager;
-  private AuditLogger auditLogger;
   // Just setting ozoneManagerDoubleBuffer which does nothing.
-  private OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper =
-      ((response, transactionIndex) -> {
-        return null;
-      });
+  private final OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper =
+      ((response, transactionIndex) -> null);
 
   @BeforeEach
   public void setup() throws Exception {
@@ -96,7 +93,7 @@ public class TestOMDirectoryCreateRequest {
         ozoneManager);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
-    auditLogger = Mockito.mock(AuditLogger.class);
+    AuditLogger auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
     when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
@@ -112,12 +109,11 @@ public class TestOMDirectoryCreateRequest {
     Mockito.framework().clearInlineMocks();
   }
 
-  @Test
-  public void testPreExecute() throws Exception {
-
+  @ParameterizedTest
+  @ValueSource(strings = {"a/b/c", "a/.snapshot/c", "a.snapshot/b/c"})
+  public void testPreExecute(String keyName) throws Exception {
     String volumeName = "vol1";
     String bucketName = "bucket1";
-    String keyName = "a/b/c";
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
@@ -130,11 +126,31 @@ public class TestOMDirectoryCreateRequest {
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
 
-    // As in preExecute, we modify original request.
+    // As in preExecute, we modify the original request.
     Assertions.assertNotEquals(omRequest, modifiedOmRequest);
-
   }
 
+  // Test verifies that .snapshot is not allowed as root dir name.
+  @Test
+  public void testPreExecuteFailure() throws Exception {
+    String volumeName = "vol1";
+    String bucketName = "bucket1";
+    String keyName = ".snapshot/a/b/c";
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+
+    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+        keyName);
+    OMDirectoryCreateRequest omDirectoryCreateRequest =
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
+
+    OMException omException = Assertions.assertThrows(OMException.class,
+        () -> omDirectoryCreateRequest.preExecute(ozoneManager));
+    Assertions.assertEquals(
+        "Cannot create key under path reserved for snapshot: .snapshot/",
+        omException.getMessage());
+  }
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently `ozone fs -mkdir` command doesn't throw an error message is key path starts with `.snapshot` and create `.snapshot` dir. `.snapshot` dir under bucket is reserved for snapshot and should not be allowed to be created using `ozone fs -mkdir` and `ozone sh`.
`ozone sh` throws an exception is key starts with `.snapshot` dir but `ozone fs` doesn't because it doesn't share the same code path to create key and file and dir can be create independently.
This change is to check dir name similar to key and file creation.

## What is the link to the Apache JIRA
HDDS-9422

## How was this patch tested?
1. Added unit test.
2. Tested it on docker E2E.
```
sh-4.2$ ozone fs -mkdir -p ofs://om/vol1/bucket1/.snapshot/key1
mkdir: Cannot create key under path reserved for snapshot: .snapshot/
sh-4.2$
```
