### PR TITLE
HDDS-9881. Intermittent address already in use in TestSecureContainerServer.

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/MockDatanodeDetails.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/MockDatanodeDetails.java
@@ -18,15 +18,10 @@
 package org.apache.hadoop.hdds.protocol;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.net.ServerSocket;
+import org.apache.ozone.test.GenericTestUtils;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORTS;
 
@@ -34,13 +29,6 @@ import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORT
  * Provides {@link DatanodeDetails} factory methods for testing.
  */
 public final class MockDatanodeDetails {
-  private static final int MIN_PORT = 15000;
-  private static final int MAX_PORT = 32000;
-  private static final AtomicInteger NEXT_PORT = new AtomicInteger(MIN_PORT);
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(DatanodeDetails.class);
-
 
   /**
    * Creates DatanodeDetails with random UUID and random IP address.
@@ -122,27 +110,14 @@ public final class MockDatanodeDetails {
    *
    * @return DatanodeDetails
    */
-  public static DatanodeDetails randomLocalDatanodeDetails()
-      throws IOException {
-    try (ServerSocket socket = new ServerSocket(0)) {
-      return createDatanodeDetails(UUID.randomUUID().toString(),
-          socket.getInetAddress().getHostName(),
-          socket.getInetAddress().getHostAddress(), null,
-          getFreePort());
-    }
+  public static DatanodeDetails randomLocalDatanodeDetails() {
+    return createDatanodeDetails(UUID.randomUUID().toString(),
+        GenericTestUtils.PortAllocator.HOSTNAME,
+        GenericTestUtils.PortAllocator.HOST_ADDRESS, null,
+        GenericTestUtils.PortAllocator.getFreePort());
   }
 
   private MockDatanodeDetails() {
     throw new UnsupportedOperationException("no instances");
-  }
-
-  static synchronized int getFreePort() {
-    LOG.info("### Getting free port ###");
-    int port = NEXT_PORT.getAndIncrement();
-    if (port > MAX_PORT) {
-      NEXT_PORT.set(MIN_PORT);
-      port = NEXT_PORT.getAndIncrement();
-    }
-    return port;
   }
 }

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -464,7 +464,7 @@ public abstract class GenericTestUtils {
   }
 
   /**
-   * Nested class for port allocation.
+   * Helper class to get free port avoiding randomness.
    */
   public static class PortAllocator {
 

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
@@ -53,6 +54,9 @@ import static org.apache.logging.log4j.util.StackLocatorUtil.getCallerClass;
  */
 public abstract class GenericTestUtils {
 
+  private static final int MIN_PORT = 15000;
+  private static final int MAX_PORT = 32000;
+  private static final AtomicInteger NEXT_PORT = new AtomicInteger(MIN_PORT);
   public static final String SYSPROP_TEST_DATA_DIR = "test.build.data";
   public static final String DEFAULT_TEST_DATA_DIR;
   public static final String DEFAULT_TEST_DATA_PATH = "target/test/data/";
@@ -460,6 +464,39 @@ public abstract class GenericTestUtils {
     public void write(byte[] buf, int off, int len) {
       super.write(buf, off, len);
       other.write(buf, off, len);
+    }
+  }
+
+  /**
+   * Nested class for port allocation.
+   */
+  public static class PortAllocator {
+
+    public static final String HOSTNAME = "localhost";
+    public static final String HOST_ADDRESS = "127.0.0.1";
+    public static final int MIN_PORT = 15000;
+    public static final int MAX_PORT = 32000;
+    public static final AtomicInteger NEXT_PORT = new AtomicInteger(MIN_PORT);
+
+    public PortAllocator() {
+      // no instances
+    }
+
+    public static synchronized int getFreePort() {
+      int port = NEXT_PORT.getAndIncrement();
+      if (port > MAX_PORT) {
+        NEXT_PORT.set(MIN_PORT);
+        port = NEXT_PORT.getAndIncrement();
+      }
+      return port;
+    }
+
+    public static String localhostWithFreePort() {
+      return HOST_ADDRESS + getFreePort();
+    }
+
+    public static String anyHostWithFreePort() {
+      return "0.0.0.0:" + getFreePort();
     }
   }
 

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -53,10 +53,6 @@ import static org.apache.logging.log4j.util.StackLocatorUtil.getCallerClass;
  * Provides some very generic helpers which might be used across the tests.
  */
 public abstract class GenericTestUtils {
-
-  private static final int MIN_PORT = 15000;
-  private static final int MAX_PORT = 32000;
-  private static final AtomicInteger NEXT_PORT = new AtomicInteger(MIN_PORT);
   public static final String SYSPROP_TEST_DATA_DIR = "test.build.data";
   public static final String DEFAULT_TEST_DATA_DIR;
   public static final String DEFAULT_TEST_DATA_PATH = "target/test/data/";

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -488,7 +488,7 @@ public abstract class GenericTestUtils {
     }
 
     public static String localhostWithFreePort() {
-      return HOST_ADDRESS + getFreePort();
+      return HOST_ADDRESS + ":" + getFreePort();
     }
 
     public static String anyHostWithFreePort() {

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -466,7 +466,7 @@ public abstract class GenericTestUtils {
   /**
    * Helper class to get free port avoiding randomness.
    */
-  public static class PortAllocator {
+  public static final class PortAllocator {
 
     public static final String HOSTNAME = "localhost";
     public static final String HOST_ADDRESS = "127.0.0.1";
@@ -474,7 +474,7 @@ public abstract class GenericTestUtils {
     public static final int MAX_PORT = 32000;
     public static final AtomicInteger NEXT_PORT = new AtomicInteger(MIN_PORT);
 
-    public PortAllocator() {
+    private PortAllocator() {
       // no instances
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -657,36 +656,5 @@ public interface MiniOzoneCluster extends AutoCloseable {
      * @throws IOException
      */
     public abstract MiniOzoneCluster build() throws IOException;
-  }
-
-  /**
-   * Helper class to get free port avoiding randomness.
-   */
-  class PortAllocator {
-
-    private static final int MIN_PORT = 15000;
-    private static final int MAX_PORT = 32000;
-    private static final AtomicInteger NEXT_PORT = new AtomicInteger(MIN_PORT);
-
-    private PortAllocator() {
-      // no instances
-    }
-
-    static synchronized int getFreePort() {
-      int port = NEXT_PORT.getAndIncrement();
-      if (port > MAX_PORT) {
-        NEXT_PORT.set(MIN_PORT);
-        port = NEXT_PORT.getAndIncrement();
-      }
-      return port;
-    }
-
-    static String localhostWithFreePort() {
-      return "127.0.0.1:" + getFreePort();
-    }
-
-    static String anyHostWithFreePort() {
-      return "0.0.0.0:" + getFreePort();
-    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -82,6 +82,9 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.recon.ConfigurationProvider;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.anyHostWithFreePort;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.apache.commons.io.FileUtils;
@@ -900,13 +903,13 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
     protected void configureSCM() {
       conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY,
-          GenericTestUtils.PortAllocator.localhostWithFreePort());
+          localhostWithFreePort());
       conf.set(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
-          GenericTestUtils.PortAllocator.localhostWithFreePort());
+          localhostWithFreePort());
       conf.set(ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY,
-          GenericTestUtils.PortAllocator.localhostWithFreePort());
+          localhostWithFreePort());
       conf.set(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY,
-          GenericTestUtils.PortAllocator.localhostWithFreePort());
+          localhostWithFreePort());
       conf.setInt(ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY, numOfScmHandlers);
       conf.set(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
           "3s");
@@ -937,10 +940,11 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     }
 
     private void configureOM() {
-      conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY, GenericTestUtils.PortAllocator.localhostWithFreePort());
-      conf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, GenericTestUtils.PortAllocator.localhostWithFreePort());
-      conf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, GenericTestUtils.PortAllocator.localhostWithFreePort());
-      conf.setInt(OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, GenericTestUtils.PortAllocator.getFreePort());
+      conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY, localhostWithFreePort());
+      conf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, localhostWithFreePort());
+      conf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY,
+          localhostWithFreePort());
+      conf.setInt(OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, getFreePort());
       conf.setInt(OMConfigKeys.OZONE_OM_HANDLER_COUNT_KEY, numOfOmHandlers);
     }
 
@@ -951,17 +955,17 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
     protected void configureDatanodePorts(ConfigurationTarget conf) {
       conf.set(ScmConfigKeys.HDDS_REST_HTTP_ADDRESS_KEY,
-          GenericTestUtils.PortAllocator.anyHostWithFreePort());
+          anyHostWithFreePort());
       conf.set(HddsConfigKeys.HDDS_DATANODE_HTTP_ADDRESS_KEY,
-          GenericTestUtils.PortAllocator.anyHostWithFreePort());
+          anyHostWithFreePort());
       conf.set(HddsConfigKeys.HDDS_DATANODE_CLIENT_ADDRESS_KEY,
-          GenericTestUtils.PortAllocator.anyHostWithFreePort());
-      conf.setInt(DFS_CONTAINER_IPC_PORT, GenericTestUtils.PortAllocator.getFreePort());
-      conf.setInt(DFS_CONTAINER_RATIS_IPC_PORT, GenericTestUtils.PortAllocator.getFreePort());
-      conf.setInt(DFS_CONTAINER_RATIS_ADMIN_PORT, GenericTestUtils.PortAllocator.getFreePort());
-      conf.setInt(DFS_CONTAINER_RATIS_SERVER_PORT, GenericTestUtils.PortAllocator.getFreePort());
-      conf.setInt(DFS_CONTAINER_RATIS_DATASTREAM_PORT, GenericTestUtils.PortAllocator.getFreePort());
-      conf.setFromObject(new ReplicationConfig().setPort(GenericTestUtils.PortAllocator.getFreePort()));
+          anyHostWithFreePort());
+      conf.setInt(DFS_CONTAINER_IPC_PORT, getFreePort());
+      conf.setInt(DFS_CONTAINER_RATIS_IPC_PORT, getFreePort());
+      conf.setInt(DFS_CONTAINER_RATIS_ADMIN_PORT, getFreePort());
+      conf.setInt(DFS_CONTAINER_RATIS_SERVER_PORT, getFreePort());
+      conf.setInt(DFS_CONTAINER_RATIS_DATASTREAM_PORT, getFreePort());
+      conf.setFromObject(new ReplicationConfig().setPort(getFreePort()));
     }
 
     private void configureTrace() {
@@ -991,8 +995,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
           + "/ozone_recon_derby.db");
       conf.setFromObject(dbConfig);
 
-      conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, GenericTestUtils.PortAllocator.anyHostWithFreePort());
-      conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, GenericTestUtils.PortAllocator.anyHostWithFreePort());
+      conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, anyHostWithFreePort());
+      conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, anyHostWithFreePort());
       conf.set(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "10s");
 
       ConfigurationProvider.setConfiguration(conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -82,9 +82,6 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.recon.ConfigurationProvider;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.anyHostWithFreePort;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.apache.commons.io.FileUtils;
@@ -104,6 +101,10 @@ import static org.apache.hadoop.ozone.om.OmUpgradeConfig.ConfigStrings.OZONE_OM_
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.anyHostWithFreePort;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
+
 import org.hadoop.ozone.recon.codegen.ReconSqlDbConfig;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -92,9 +92,6 @@ import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD;
 import static org.apache.hadoop.hdds.scm.ScmConfig.ConfigStrings.HDDS_SCM_INIT_DEFAULT_LAYOUT_VERSION;
-import static org.apache.hadoop.ozone.MiniOzoneCluster.PortAllocator.anyHostWithFreePort;
-import static org.apache.hadoop.ozone.MiniOzoneCluster.PortAllocator.getFreePort;
-import static org.apache.hadoop.ozone.MiniOzoneCluster.PortAllocator.localhostWithFreePort;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_IPC_PORT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ADMIN_PORT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_PORT;
@@ -903,13 +900,13 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
     protected void configureSCM() {
       conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY,
-          localhostWithFreePort());
+          GenericTestUtils.PortAllocator.localhostWithFreePort());
       conf.set(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
-          localhostWithFreePort());
+          GenericTestUtils.PortAllocator.localhostWithFreePort());
       conf.set(ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY,
-          localhostWithFreePort());
+          GenericTestUtils.PortAllocator.localhostWithFreePort());
       conf.set(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY,
-          localhostWithFreePort());
+          GenericTestUtils.PortAllocator.localhostWithFreePort());
       conf.setInt(ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY, numOfScmHandlers);
       conf.set(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
           "3s");
@@ -940,11 +937,10 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     }
 
     private void configureOM() {
-      conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY, localhostWithFreePort());
-      conf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, localhostWithFreePort());
-      conf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY,
-          localhostWithFreePort());
-      conf.setInt(OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, getFreePort());
+      conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY, GenericTestUtils.PortAllocator.localhostWithFreePort());
+      conf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, GenericTestUtils.PortAllocator.localhostWithFreePort());
+      conf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, GenericTestUtils.PortAllocator.localhostWithFreePort());
+      conf.setInt(OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, GenericTestUtils.PortAllocator.getFreePort());
       conf.setInt(OMConfigKeys.OZONE_OM_HANDLER_COUNT_KEY, numOfOmHandlers);
     }
 
@@ -955,17 +951,17 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
     protected void configureDatanodePorts(ConfigurationTarget conf) {
       conf.set(ScmConfigKeys.HDDS_REST_HTTP_ADDRESS_KEY,
-          anyHostWithFreePort());
+          GenericTestUtils.PortAllocator.anyHostWithFreePort());
       conf.set(HddsConfigKeys.HDDS_DATANODE_HTTP_ADDRESS_KEY,
-          anyHostWithFreePort());
+          GenericTestUtils.PortAllocator.anyHostWithFreePort());
       conf.set(HddsConfigKeys.HDDS_DATANODE_CLIENT_ADDRESS_KEY,
-          anyHostWithFreePort());
-      conf.setInt(DFS_CONTAINER_IPC_PORT, getFreePort());
-      conf.setInt(DFS_CONTAINER_RATIS_IPC_PORT, getFreePort());
-      conf.setInt(DFS_CONTAINER_RATIS_ADMIN_PORT, getFreePort());
-      conf.setInt(DFS_CONTAINER_RATIS_SERVER_PORT, getFreePort());
-      conf.setInt(DFS_CONTAINER_RATIS_DATASTREAM_PORT, getFreePort());
-      conf.setFromObject(new ReplicationConfig().setPort(getFreePort()));
+          GenericTestUtils.PortAllocator.anyHostWithFreePort());
+      conf.setInt(DFS_CONTAINER_IPC_PORT, GenericTestUtils.PortAllocator.getFreePort());
+      conf.setInt(DFS_CONTAINER_RATIS_IPC_PORT, GenericTestUtils.PortAllocator.getFreePort());
+      conf.setInt(DFS_CONTAINER_RATIS_ADMIN_PORT, GenericTestUtils.PortAllocator.getFreePort());
+      conf.setInt(DFS_CONTAINER_RATIS_SERVER_PORT, GenericTestUtils.PortAllocator.getFreePort());
+      conf.setInt(DFS_CONTAINER_RATIS_DATASTREAM_PORT, GenericTestUtils.PortAllocator.getFreePort());
+      conf.setFromObject(new ReplicationConfig().setPort(GenericTestUtils.PortAllocator.getFreePort()));
     }
 
     private void configureTrace() {
@@ -995,8 +991,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
           + "/ozone_recon_derby.db");
       conf.setFromObject(dbConfig);
 
-      conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, anyHostWithFreePort());
-      conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, anyHostWithFreePort());
+      conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, GenericTestUtils.PortAllocator.anyHostWithFreePort());
+      conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, GenericTestUtils.PortAllocator.anyHostWithFreePort());
       conf.set(OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD, "10s");
 
       ConfigurationProvider.setConfiguration(conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -40,8 +40,6 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
-import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
 import org.apache.ratis.util.function.CheckedConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +58,8 @@ import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.scm.ScmConfig.ConfigStrings.HDDS_SCM_INIT_DEFAULT_LAYOUT_VERSION;
 import static org.apache.hadoop.ozone.om.OmUpgradeConfig.ConfigStrings.OZONE_OM_INIT_DEFAULT_LAYOUT_VERSION;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
 
 /**
  * MiniOzoneHAClusterImpl creates a complete in-process Ozone cluster

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -57,8 +57,6 @@ import java.util.function.Function;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.scm.ScmConfig.ConfigStrings.HDDS_SCM_INIT_DEFAULT_LAYOUT_VERSION;
-import static org.apache.hadoop.ozone.MiniOzoneCluster.PortAllocator.getFreePort;
-import static org.apache.hadoop.ozone.MiniOzoneCluster.PortAllocator.localhostWithFreePort;
 import static org.apache.hadoop.ozone.om.OmUpgradeConfig.ConfigStrings.OZONE_OM_INIT_DEFAULT_LAYOUT_VERSION;
 
 /**
@@ -343,10 +341,10 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     String omRatisPortKey = ConfUtils.addKeySuffixes(
         OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, omServiceId, omNodeId);
 
-    conf.set(omAddrKey, localhostWithFreePort());
-    conf.set(omHttpAddrKey, localhostWithFreePort());
-    conf.set(omHttpsAddrKey, localhostWithFreePort());
-    conf.setInt(omRatisPortKey, getFreePort());
+    conf.set(omAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
+    conf.set(omHttpAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
+    conf.set(omHttpsAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
+    conf.setInt(omRatisPortKey, GenericTestUtils.PortAllocator.getFreePort());
   }
 
   /**
@@ -650,23 +648,23 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
             scmNodeId);
 
         conf.set(scmAddrKey, "127.0.0.1");
-        conf.set(scmHttpAddrKey, localhostWithFreePort());
-        conf.set(scmHttpsAddrKey, localhostWithFreePort());
-        conf.set(scmSecurityAddrKey, localhostWithFreePort());
+        conf.set(scmHttpAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
+        conf.set(scmHttpsAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
+        conf.set(scmSecurityAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
         conf.set("ozone.scm.update.service.port", "0");
 
-        int ratisPort = getFreePort();
+        int ratisPort = GenericTestUtils.PortAllocator.getFreePort();
         conf.setInt(scmRatisPortKey, ratisPort);
         //conf.setInt("ozone.scm.ha.ratis.bind.port", ratisPort);
 
-        int dnPort = getFreePort();
+        int dnPort = GenericTestUtils.PortAllocator.getFreePort();
         conf.set(dnPortKey, "127.0.0.1:" + dnPort);
         scmNames.append(",localhost:").append(dnPort);
 
-        conf.set(ssClientKey, localhostWithFreePort());
-        conf.setInt(scmGrpcPortKey, getFreePort());
+        conf.set(ssClientKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
+        conf.setInt(scmGrpcPortKey, GenericTestUtils.PortAllocator.getFreePort());
 
-        String blockAddress = localhostWithFreePort();
+        String blockAddress = GenericTestUtils.PortAllocator.localhostWithFreePort();
         conf.set(blockClientKey, blockAddress);
         conf.set(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
             blockAddress);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -40,6 +40,8 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
 import org.apache.ratis.util.function.CheckedConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -341,10 +343,10 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     String omRatisPortKey = ConfUtils.addKeySuffixes(
         OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, omServiceId, omNodeId);
 
-    conf.set(omAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
-    conf.set(omHttpAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
-    conf.set(omHttpsAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
-    conf.setInt(omRatisPortKey, GenericTestUtils.PortAllocator.getFreePort());
+    conf.set(omAddrKey, localhostWithFreePort());
+    conf.set(omHttpAddrKey, localhostWithFreePort());
+    conf.set(omHttpsAddrKey, localhostWithFreePort());
+    conf.setInt(omRatisPortKey, getFreePort());
   }
 
   /**
@@ -648,23 +650,23 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
             scmNodeId);
 
         conf.set(scmAddrKey, "127.0.0.1");
-        conf.set(scmHttpAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
-        conf.set(scmHttpsAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
-        conf.set(scmSecurityAddrKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
+        conf.set(scmHttpAddrKey, localhostWithFreePort());
+        conf.set(scmHttpsAddrKey, localhostWithFreePort());
+        conf.set(scmSecurityAddrKey, localhostWithFreePort());
         conf.set("ozone.scm.update.service.port", "0");
 
-        int ratisPort = GenericTestUtils.PortAllocator.getFreePort();
+        int ratisPort = getFreePort();
         conf.setInt(scmRatisPortKey, ratisPort);
         //conf.setInt("ozone.scm.ha.ratis.bind.port", ratisPort);
 
-        int dnPort = GenericTestUtils.PortAllocator.getFreePort();
+        int dnPort = getFreePort();
         conf.set(dnPortKey, "127.0.0.1:" + dnPort);
         scmNames.append(",localhost:").append(dnPort);
 
-        conf.set(ssClientKey, GenericTestUtils.PortAllocator.localhostWithFreePort());
-        conf.setInt(scmGrpcPortKey, GenericTestUtils.PortAllocator.getFreePort());
+        conf.set(ssClientKey, localhostWithFreePort());
+        conf.setInt(scmGrpcPortKey, getFreePort());
 
-        String blockAddress = GenericTestUtils.PortAllocator.localhostWithFreePort();
+        String blockAddress = localhostWithFreePort();
         conf.set(blockClientKey, blockAddress);
         conf.set(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
             blockAddress);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -112,16 +112,11 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test Container servers when security is enabled.
  */
 public class TestSecureContainerServer {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestSecureContainerServer.class);
   private static final String TEST_DIR
       = GenericTestUtils.getTestDir("dfs").getAbsolutePath() + File.separator;
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
@@ -252,8 +247,7 @@ public class TestSecureContainerServer {
     for (DatanodeDetails dn : pipeline.getNodes()) {
       final XceiverServerSpi s = createServer.apply(dn, CONF);
       servers.add(s);
-      startServerWithRetry(s, 5,
-          1000); // maxRetries = 5, retryDelayMillis = 1000 ms
+      s.start();
       initServer.accept(dn, pipeline);
     }
 
@@ -346,38 +340,4 @@ public class TestSecureContainerServer {
         containerTokenSecretManager.createIdentifier(username, containerID)
     ).encodeToUrlString();
   }
-
-  private static void startServerWithRetry(XceiverServerSpi server,
-                                           int maxRetries,
-                                           long retryDelayMillis)
-      throws IOException {
-    boolean serverStarted = false;
-    for (int retry = 0; retry < maxRetries && !serverStarted; retry++) {
-      try {
-        // start the server
-        server.start();
-        serverStarted = true;
-      } catch (IOException e) {
-        if (e.getMessage().contains("Failed to bind")) {
-          LOG.warn("Failed to start server on attempt " + (retry + 1) +
-              ", retrying after delay", e);
-          try {
-            Thread.sleep(retryDelayMillis);
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            throw new IOException(
-                "Interrupted while waiting to retry server start", ie);
-          }
-        } else {
-          throw e;
-        }
-      }
-    }
-
-    if (!serverStarted) {
-      throw new IOException(
-          "Failed to start server after " + maxRetries + " attempts");
-    }
-  }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`TestSecureContainerServer` uses random ports and intermittently runs into the following binding error.
The initial thought of why we might be getting the binding error is because of the datanodes of a pipeline might be having similar port numbers due to which it is failing. To fix this we will use the `PortAllocator` method present in `MiniOzoneCluster` that replaces random ports with a simple incremental allocation starting at 15000. It applies to all MiniOzoneCluster-based tests. 
We have also shifted this `PortAllocator` to the `GenericUtils` class so as to be used by all the tests.
```
org.apache.ratis.util.ExitUtils$ExitException: Failed to start Grpc server
	at org.apache.ratis.util.ExitUtils.terminate(ExitUtils.java:141)
	at org.apache.ratis.util.ExitUtils.terminate(ExitUtils.java:151)
	at org.apache.ratis.grpc.server.GrpcService.startImpl(GrpcService.java:300)
	at org.apache.ratis.util.LifeCycle.startAndTransition(LifeCycle.java:270)
	at org.apache.ratis.server.RaftServerRpcWithProxy.start(RaftServerRpcWithProxy.java:72)
	at org.apache.ratis.server.impl.RaftServerProxy.startImpl(RaftServerProxy.java:407)
	at org.apache.ratis.util.LifeCycle.startAndTransition(LifeCycle.java:270)
	at org.apache.ratis.server.impl.RaftServerProxy.start(RaftServerProxy.java:400)
	at org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis.start(XceiverServerRatis.java:552)
	at org.apache.hadoop.ozone.container.server.TestSecureContainerServer.runTestClientServer(TestSecureContainerServer.java:250)
	at org.apache.hadoop.ozone.container.server.TestSecureContainerServer.runTestClientServerRatis(TestSecureContainerServer.java:223)
	at org.apache.hadoop.ozone.container.server.TestSecureContainerServer.testClientServerRatisGrpc(TestSecureContainerServer.java:201)
...
Caused by: java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0: 37397
	at org.apache.ratis.thirdparty.io.grpc.netty.NettyServer.start(NettyServer.java:326)
	at org.apache.ratis.thirdparty.io.grpc.internal.ServerImpl.start(ServerImpl.java:185)
	at org.apache.ratis.thirdparty.io.grpc.internal.ServerImpl.start(ServerImpl.java:94)
	at org.apache.ratis.grpc.server.GrpcService.startImpl(GrpcService.java:298)
	... 53 more
Caused by: org.apache.ratis.thirdparty.io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9881
## How was this patch tested?

Ran the fix a total of 1000 times and all passed.
### Repeated Fork Runs ➖
Test Run 1 :- https://github.com/ArafatKhan2198/ozone/actions/runs/7213894539
Test Run 2 :- https://github.com/ArafatKhan2198/ozone/actions/runs/7213892016
