### PR TITLE
HDDS-9916. Useless execution of version-info in rocksdb-checkpoint-differ

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -99,45 +99,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>${basedir}/src/main/resources</directory>
-        <excludes>
-          <exclude>ozone-version-info.properties</exclude>
-        </excludes>
-        <filtering>false</filtering>
-      </resource>
-      <resource>
-        <directory>${basedir}/src/main/resources</directory>
-        <includes>
-          <include>ozone-version-info.properties</include>
-        </includes>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-maven-plugins</artifactId>
-        <executions>
-          <execution>
-            <id>version-info</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>version-info</goal>
-            </goals>
-            <configuration>
-              <source>
-                <directory>${basedir}/../</directory>
-                <includes>
-                  <include>*/src/main/java/**/*.java</include>
-                  <include>*/src/main/proto/*.proto</include>
-                </includes>
-              </source>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`version-info` is executed in `hdds-common` and `ozone-common` to get some values substituted into `hdds-version-info.properties` and `ozone-version-info.properties`, respectively.

`hadoop-hdds/rocksdb-checkpoint-differ` also runs `version-info`, but it's useless, the properties are not used anywhere.

https://issues.apache.org/jira/browse/HDDS-9916

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7195602829