### PR TITLE
HDDS-9873. Intermittent failure at hadoop-maven-plugins in compile check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,12 @@ jobs:
       - name: Untar sources
         run: |
           tar --strip-components 1 -xzvf ozone*-src.tar.gz
+      - name: Workaround for HADOOP-19011
+        run: |
+          git init
+          git config user.name 'Github Actions'
+          git config user.email 'noreply@github.com'
+          git commit --allow-empty -a -m 'workaround for HADOOP-19011'
       - name: Cache for maven dependencies
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

`hadoop-maven-plugins` has a [bug](https://issues.apache.org/jira/browse/HADOOP-19011) that causes intermittent `ConcurrentModificationException` in the `version-info` goal:

```
[INFO] --- hadoop-maven-plugins:3.3.6:version-info (version-info) @ hdds-common ---
[WARNING] [git, branch] failed with error code 128
[INFO] SCM: NONE
[INFO] Computed MD5: f7acef9f5512e5cf4e753b29d1490
...
[INFO] --- hadoop-maven-plugins:3.3.6:version-info (version-info) @ ozone-common ---
[WARNING] [git, branch] failed with error code 128
...
[INFO] BUILD FAILURE
...
[ERROR] Failed to execute goal org.apache.hadoop:hadoop-maven-plugins:3.3.6:version-info (version-info) on project ozone-common: java.util.ConcurrentModificationException
```

The problem can happen if the command returns with error.  In our case `git branch` fails because the `compile` check builds Ozone from the source tarball, not from git checkout.  This is a valid use-case, the error itself is not fatal, but the intermittent `ConcurrentModificationException` fails the build.

The `git branch` error can be reproduced:

```
$ curl -LOSs https://dlcdn.apache.org/ozone/1.3.0/ozone-1.3.0-src.tar.gz
$ tar -xzf ozone-1.3.0-src.tar.gz
$ cd ozone-1.3.0-src
$ git branch
fatal: not a git repository (or any of the parent directories): .git
$ echo $?
128
```

Until HADOOP-19011 is fixed (and released, which may be far away), this PR proposes to work around it by initializing a temporary git repo for the `compile` check.

https://issues.apache.org/jira/browse/HDDS-9873

## How was this patch tested?

```
[INFO] --- hadoop-maven-plugins:3.3.6:version-info (version-info) @ ozone-common ---
[INFO] SCM: GIT
[INFO] Computed MD5: f54e59c621eb6c94a5a05f5c5abda8
```

https://github.com/adoroszlai/ozone/actions/runs/7196940600/job/19603852775#step:7:1679