### PR TITLE
HDDS-9917. Autolink Hadoop and Ratis issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,6 +22,11 @@ github:
     - big-data
     - s3
     - kubernetes
+  autolink_jira:
+    - HADOOP
+    - HDDS
+    - HDFS
+    - RATIS
   enabled_merge_buttons:
     squash:  true
     merge:   false


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable Github to Jira [autolink feature](https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=git+-+.asf.yaml+features#Git.asf.yamlfeatures-AutolinksforJira) for Hadoop and Ratis issues.  These projects are closely related, automatic linking makes references in PR descriptions easier.

https://issues.apache.org/jira/browse/HDDS-9917

## How was this patch tested?

Not tested, syntax taken from ASF doc and the `.asf.yaml` [file](https://github.com/apache/ozone-site/blob/177c30e0989032a6241caff2ed556c99599758f4/.asf.yaml#L24-L25) in `ozone-site` repo.