### PR TITLE
HDDS-9910. Slow ozone hdfs performance when lots of config files.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -86,12 +86,15 @@ public class TrashOzoneFileSystem extends FileSystem {
   private static final Logger LOG =
       LoggerFactory.getLogger(TrashOzoneFileSystem.class);
 
+  private final OzoneConfiguration ozoneConfiguration;
+
   public TrashOzoneFileSystem(OzoneManager ozoneManager) throws IOException {
     this.ozoneManager = ozoneManager;
     this.userName =
           UserGroupInformation.getCurrentUser().getShortUserName();
     this.runCount = new AtomicLong(0);
     setConf(ozoneManager.getConfiguration());
+    ozoneConfiguration = OzoneConfiguration.of(getConf());
   }
 
   private RaftClientRequest getRatisRequest(
@@ -156,8 +159,8 @@ public class TrashOzoneFileSystem extends FileSystem {
     ozoneManager.getMetrics().incNumTrashRenames();
     LOG.trace("Src:" + src + "Dst:" + dst);
     // check whether the src and dst belong to the same bucket & trashroot.
-    OFSPath srcPath = new OFSPath(src, OzoneConfiguration.of(getConf()));
-    OFSPath dstPath = new OFSPath(dst, OzoneConfiguration.of(getConf()));
+    OFSPath srcPath = new OFSPath(src, ozoneConfiguration);
+    OFSPath dstPath = new OFSPath(dst, ozoneConfiguration);
     OmBucketInfo bucket = ozoneManager.getBucketInfo(srcPath.getVolumeName(),
         srcPath.getBucketName());
     if (bucket.getBucketLayout().isFileSystemOptimized()) {
@@ -191,7 +194,7 @@ public class TrashOzoneFileSystem extends FileSystem {
   @Override
   public boolean delete(Path path, boolean b) throws IOException {
     ozoneManager.getMetrics().incNumTrashDeletes();
-    OFSPath srcPath = new OFSPath(path, OzoneConfiguration.of(getConf()));
+    OFSPath srcPath = new OFSPath(path, ozoneConfiguration);
     OmBucketInfo bucket = ozoneManager.getBucketInfo(srcPath.getVolumeName(),
         srcPath.getBucketName());
     if (bucket.getBucketLayout().isFileSystemOptimized()) {
@@ -283,7 +286,7 @@ public class TrashOzoneFileSystem extends FileSystem {
   }
 
   private OmKeyArgs constructOmKeyArgs(Path path) {
-    OFSPath ofsPath = new OFSPath(path, OzoneConfiguration.of(getConf()));
+    OFSPath ofsPath = new OFSPath(path, ozoneConfiguration);
     String volume = ofsPath.getVolumeName();
     String bucket = ofsPath.getBucketName();
     String key = ofsPath.getKeyName();
@@ -363,7 +366,7 @@ public class TrashOzoneFileSystem extends FileSystem {
         this.pathKey = addTrailingSlashIfNeeded(pathKey);
       }
       OFSPath fsPath = new OFSPath(pathKey,
-          OzoneConfiguration.of(getConf()));
+          ozoneConfiguration);
       keyIterator =
           getKeyIterator(fsPath.getVolumeName(), fsPath.getBucketName(),
               fsPath.getKeyName());
@@ -411,7 +414,7 @@ public class TrashOzoneFileSystem extends FileSystem {
       if (status.isDirectory()) {
         LOG.trace("Iterating directory: {}", pathKey);
         OFSPath ofsPath = new OFSPath(pathKey,
-            OzoneConfiguration.of(getConf()));
+            ozoneConfiguration);
         String ofsPathprefix =
             ofsPath.getNonKeyPathNoPrefixDelim() + OZONE_URI_DELIMITER;
         while (keyIterator.hasNext()) {
@@ -510,9 +513,9 @@ public class TrashOzoneFileSystem extends FileSystem {
       for (String keyPath : keyPathList) {
         String newPath = dstPath.concat(keyPath.substring(srcPath.length()));
         OFSPath src = new OFSPath(keyPath,
-            OzoneConfiguration.of(getConf()));
+            ozoneConfiguration);
         OFSPath dst = new OFSPath(newPath,
-            OzoneConfiguration.of(getConf()));
+            ozoneConfiguration);
 
         OzoneManagerProtocolProtos.OMRequest omRequest =
             getRenameKeyRequest(src, dst);
@@ -582,7 +585,7 @@ public class TrashOzoneFileSystem extends FileSystem {
       LOG.trace("Deleting keys: {}", keyPathList);
       for (String keyPath : keyPathList) {
         OFSPath path = new OFSPath(keyPath,
-            OzoneConfiguration.of(getConf()));
+            ozoneConfiguration);
         OzoneManagerProtocolProtos.OMRequest omRequest =
             getDeleteKeysRequest(path);
         try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -80,6 +80,8 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
 
   private OzoneManager om;
 
+  private OzoneConfiguration ozoneConfiguration;
+
   public TrashPolicyOzone() {
   }
 
@@ -110,6 +112,7 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
           + "Changing to default value 0", deletionInterval);
       this.deletionInterval = 0;
     }
+    ozoneConfiguration = OzoneConfiguration.of(this.configuration);
   }
 
   TrashPolicyOzone(FileSystem fs, Configuration conf, OzoneManager om) {
@@ -152,8 +155,7 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
       Path trashPath;
       Path baseTrashPath;
       if (fs.getUri().getScheme().equals(OzoneConsts.OZONE_OFS_URI_SCHEME)) {
-        OFSPath ofsPath = new OFSPath(path,
-            OzoneConfiguration.of(configuration));
+        OFSPath ofsPath = new OFSPath(path, ozoneConfiguration);
         // trimming volume and bucket in order to be compatible with o3fs
         // Also including volume and bucket name in the path is redundant as
         // the key is already in a particular volume and bucket.
@@ -228,8 +230,7 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
     // Check to see if bucket is path item to be deleted.
     // Cannot moveToTrash if bucket is deleted,
     // return error for this condition
-    OFSPath ofsPath = new OFSPath(key.substring(1),
-        OzoneConfiguration.of(configuration));
+    OFSPath ofsPath = new OFSPath(key.substring(1), ozoneConfiguration);
     if (path.isRoot() || ofsPath.isBucket()) {
       throw new IOException("Recursive rm of bucket "
           + path.toString() + " not permitted");

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -128,6 +128,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       "ofs://om-host.example.com:5678/path/to/key";
 
   private static final int PATH_DEPTH_TO_BUCKET = 2;
+  private OzoneConfiguration ozoneConfiguration;
+
 
   @Override
   public void initialize(URI name, Configuration conf) throws IOException {
@@ -200,6 +202,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       LOG.error(msg, ue);
       throw new IOException(msg, ue);
     }
+    ozoneConfiguration = OzoneConfiguration.of(getConfSource());
   }
 
   protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
@@ -328,7 +331,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       LOG.trace("rename from:{} to:{}", this.srcPath, this.dstPath);
       // Initialize bucket here to reduce number of RPC calls
       OFSPath ofsPath = new OFSPath(srcPath,
-          OzoneConfiguration.of(getConfSource()));
+          ozoneConfiguration);
       // TODO: Refactor later.
       adapterImpl = (BasicRootedOzoneClientAdapterImpl) adapter;
       this.bucket = adapterImpl.getBucket(ofsPath, false);
@@ -386,9 +389,9 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
     // src and dst should be in the same bucket
     OFSPath ofsSrc = new OFSPath(src,
-        OzoneConfiguration.of(getConfSource()));
+        ozoneConfiguration);
     OFSPath ofsDst = new OFSPath(dst,
-        OzoneConfiguration.of(getConfSource()));
+        ozoneConfiguration);
     if (!ofsSrc.isInSameBucketAs(ofsDst)) {
       throw new IOException("Cannot rename a key to a different bucket");
     }
@@ -551,7 +554,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       }
       // Initialize bucket here to reduce number of RPC calls
       OFSPath ofsPath = new OFSPath(f,
-          OzoneConfiguration.of(getConfSource()));
+          ozoneConfiguration);
       // TODO: Refactor later.
       adapterImpl = (BasicRootedOzoneClientAdapterImpl) adapter;
       this.bucket = adapterImpl.getBucket(ofsPath, false);
@@ -582,7 +585,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       this.recursive = recursive;
       // Initialize bucket here to reduce number of RPC calls
       OFSPath ofsPath = new OFSPath(f,
-          OzoneConfiguration.of(getConfSource()));
+          ozoneConfiguration);
       adapterImpl = (BasicRootedOzoneClientAdapterImpl) adapter;
       this.bucket = adapterImpl.getBucket(ofsPath, false);
       LOG.debug("Deleting bucket with name {} is via DeleteIteratorWithFSO.",
@@ -614,7 +617,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       this.path = f;
       this.recursive = recursive;
       this.ofsPath = new OFSPath(f,
-          OzoneConfiguration.of(getConfSource()));
+          ozoneConfiguration);
     }
 
     OzoneListingIterator getDeleteIterator()
@@ -669,7 +672,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
     String key = pathToKey(f);
     OFSPath ofsPath = new OFSPath(key,
-        OzoneConfiguration.of(getConfSource()));
+        ozoneConfiguration);
     // Handle rm root
     if (ofsPath.isRoot()) {
       // Intentionally drop support for rm root
@@ -970,7 +973,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public Path getTrashRoot(Path path) {
     OFSPath ofsPath = new OFSPath(path,
-        OzoneConfiguration.of(getConfSource()));
+        ozoneConfiguration);
     return this.makeQualified(ofsPath.getTrashRoot());
   }
 
@@ -1135,7 +1138,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   public RemoteIterator<FileStatus> listStatusIterator(Path f)
       throws IOException {
     OFSPath ofsPath = new OFSPath(f,
-        OzoneConfiguration.of(getConfSource()));
+        ozoneConfiguration);
     if (ofsPath.isRoot() || ofsPath.isVolume()) {
       LOG.warn("Recursive root/volume list using ofs is not supported");
       throw new IOException("Recursive list root/volume " +
@@ -1387,7 +1390,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       if (status.isDir()) {
         LOG.trace("Iterating directory: {}", pathKey);
         OFSPath ofsPath = new OFSPath(pathKey,
-            OzoneConfiguration.of(getConfSource()));
+            ozoneConfiguration);
         String ofsPathPrefix =
             ofsPath.getNonKeyPathNoPrefixDelim() + OZONE_URI_DELIMITER;
         if (isFSO) {
@@ -1396,7 +1399,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
           for (FileStatusAdapter fileStatus : fileStatuses) {
             String keyName =
                 new OFSPath(fileStatus.getPath().toString(),
-                    OzoneConfiguration.of(getConfSource())).getKeyName();
+                    ozoneConfiguration).getKeyName();
             keyPathList.add(ofsPathPrefix + keyName);
           }
           if (keyPathList.size() >= batchSize) {
@@ -1538,7 +1541,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public Path getLinkTarget(Path f) throws IOException {
     OFSPath ofsPath = new OFSPath(f,
-        OzoneConfiguration.of(getConfSource()));
+        ozoneConfiguration);
     if (ofsPath.isBucket()) {  // only support bucket links
       OzoneBucket bucket = adapterImpl.getBucket(ofsPath, false);
       if (bucket.isLink()) {
@@ -1554,7 +1557,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       final String fromSnapshot, final String toSnapshot)
       throws IOException, InterruptedException {
     OFSPath ofsPath =
-        new OFSPath(snapshotDir, OzoneConfiguration.of(getConf()));
+        new OFSPath(snapshotDir, ozoneConfiguration);
     Preconditions.checkArgument(ofsPath.isBucket(),
         "Unsupported : Path is not a bucket");
     // TODO:HDDS-7681 support snapdiff when toSnapshot="." referring to


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improving hdfs perf by eliminating redundant config reads, and replacing them with a single one when the fs is initialized.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9910

## How was this patch tested?

Current tests still apply.

Rename perf under spark improved by a factor of 5:
```
spark-shell --master local --conf spark.kerberos.access.hadoopFileSystems=ofs://vol1 --conf spark.ui.enabled=false --conf spark.port.maxRetries=64


// The following commands are all run from within the sparkshell

// init the fs
import org.apache.hadoop.fs.Path
val ozone_fs = org.apache.hadoop.fs.FileSystem.get(new java.net.URI("ofs://vol1/bdpe/squirrelfso"), sc.hadoopConfiguration)
ozone_fs.delete(new Path(s"ofs://vol1/bdpe/squirrelfso/file1/part10001"))
ozone_fs.copyFromLocalFile(new Path(s"/etc/hosts"), new Path(s"ofs://vol1/bdpe/squirrelfso/file1/part1"))

// run the test

spark.time(Range.inclusive(1, 10000).foreach(i => ozone_fs.rename(new Path(s"ofs://vol1/bdpe/squirrelfso/file1/part${i.toString()}"), new Path(s"ofs://vol1/bdpe/squirrelfso/file1/part${(i + 1).toString()}"))))

Time taken: 17763 ms
```
