### PR TITLE
HDDS-9883. Recon - Improve the performance of processing IncrementalContainerReport from DN

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -82,16 +82,4 @@ public final class ReconConfigKeys {
 
   public static final String OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD
       = "ozone.recon.task.safemode.wait.threshold";
-
-  public static final String OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_KEY =
-      "ozone.recon.scmclient.rpc.timeout";
-
-  public static final long OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_DEFAULT =
-      1 * 60 * 1000L;
-
-  public static final String OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_KEY =
-      "ozone.recon.scmclient.failover.max.retry";
-
-  public static final int
-      OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_DEFAULT = 3;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -82,4 +82,16 @@ public final class ReconConfigKeys {
 
   public static final String OZONE_RECON_TASK_SAFEMODE_WAIT_THRESHOLD
       = "ozone.recon.task.safemode.wait.threshold";
+
+  public static final String OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_KEY =
+      "ozone.recon.scmclient.rpc.timeout";
+
+  public static final long OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_DEFAULT =
+      1 * 60 * 1000L;
+
+  public static final String OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_KEY =
+      "ozone.recon.scmclient.failover.max.retry";
+
+  public static final int
+      OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_DEFAULT = 3;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -668,6 +668,14 @@ public final class OzoneConfigKeys {
   public static final String OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION =
       "ozone.scm.close.container.wait.duration";
 
+  public static final String HDDS_SCM_CLIENT_RPC_TIME_OUT =
+      "hdds.scmclient.rpc.timeout";
+  public static final String HDDS_SCM_CLIENT_MAX_RETRY_TIMEOUT =
+      "hdds.scmclient.max.retry.timeout";
+  public static final String HDDS_SCM_CLIENT_FAILOVER_MAX_RETRY =
+      "hdds.scmclient.failover.max.retry";
+
+
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3119,6 +3119,32 @@
     </description>
   </property>
   <property>
+    <name>ozone.recon.scmclient.rpc.timeout</name>
+    <value>1m</value>
+    <tag>OZONE, RECON, SCM</tag>
+    <description>
+      RpcClient timeout on waiting for the response from SCM when Recon connects to SCM.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.scmclient.max.retry.timeout</name>
+    <value>6s</value>
+    <tag>OZONE, RECON, SCM</tag>
+    <description>
+      Max retry timeout for SCM Client when Recon connects to SCM. This config is used to
+      dynamically compute the max retry count for SCM Client when failover happens. Check the
+      SCMClientConfig class getRetryCount method.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.scmclient.failover.max.retry</name>
+    <value>3</value>
+    <tag>OZONE, RECON, SCM</tag>
+    <description>
+      Max retry count for SCM Client when failover happens.
+    </description>
+  </property>
+  <property>
     <name>ozone.recon.om.socket.timeout</name>
     <value>5s</value>
     <tag>OZONE, RECON, OM</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/ContainerReportQueue.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/ContainerReportQueue.java
@@ -112,6 +112,9 @@ public class ContainerReportQueue
 
       // 2. Add ICR report or merge to previous ICR
       List<ContainerReport> dataList = dataMap.get(uuidString);
+      if (mergeIcr(val, dataList)) {
+        return true;
+      }
       dataList.add(val);
       ++capacity;
       orderingQueue.add(uuidString);
@@ -374,5 +377,10 @@ public class ContainerReportQueue
       return droppedCount.getAndSet(0);
     }
     return 0;
+  }
+
+  protected boolean mergeIcr(ContainerReport val,
+                             List<ContainerReport> dataList) {
+    return false;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -279,6 +279,7 @@ public final class SCMDatanodeHeartbeatDispatcher {
   public interface ContainerReport {
     DatanodeDetails getDatanodeDetails();
     ContainerReportType getType();
+    void mergeReport(ContainerReport val);
   }
 
   /**
@@ -334,6 +335,9 @@ public final class SCMDatanodeHeartbeatDispatcher {
       return getDatanodeDetails().toString() + ", {type: " + getType()
           + ", size: " + getReport().getReportsList().size() + "}";
     }
+
+    @Override
+    public void mergeReport(ContainerReport nextReport) { }
   }
 
   /**
@@ -373,6 +377,15 @@ public final class SCMDatanodeHeartbeatDispatcher {
     public String getEventId() {
       return getDatanodeDetails().toString() + ", {type: " + getType()
           + ", size: " + getReport().getReportList().size() + "}";
+    }
+
+    @Override
+    public void mergeReport(ContainerReport nextReport) {
+      if (nextReport.getType() == ContainerReportType.ICR) {
+        getReport().getReportList().addAll(
+            ((ReportFromDatanode<IncrementalContainerReportProto>) nextReport)
+                .getReport().getReportList());
+      }
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -141,7 +141,10 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY,
         ScmConfigKeys.OZONE_SCM_HA_PREFIX,
         S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED,
-        HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT
+        HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT,
+        OzoneConfigKeys.HDDS_SCM_CLIENT_RPC_TIME_OUT,
+        OzoneConfigKeys.HDDS_SCM_CLIENT_MAX_RETRY_TIMEOUT,
+        OzoneConfigKeys.HDDS_SCM_CLIENT_FAILOVER_MAX_RETRY
     ));
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -168,6 +168,23 @@ public final class  ReconServerConfigKeys {
 
   public static final String
       OZONE_RECON_SCM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT = "1m";
+
+  public static final String OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_KEY =
+      "ozone.recon.scmclient.rpc.timeout";
+
+  public static final String OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_DEFAULT = "1m";
+
+  public static final String OZONE_RECON_SCM_CLIENT_MAX_RETRY_TIMEOUT_KEY =
+      "ozone.recon.scmclient.max.retry.timeout";
+
+  public static final String OZONE_RECON_SCM_CLIENT_MAX_RETRY_TIMEOUT_DEFAULT =
+      "6s";
+
+  public static final String OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_KEY =
+      "ozone.recon.scmclient.failover.max.retry";
+
+  public static final int
+      OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_DEFAULT = 3;
   /**
    * Private constructor for utility class.
    */

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -456,4 +456,8 @@ public class ReconContainerManager extends ContainerManagerImpl {
     return pipelineToOpenContainer;
   }
 
+  @VisibleForTesting
+  public StorageContainerServiceProvider getScmClient() {
+    return scmClient;
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportQueue.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportQueue.java
@@ -24,8 +24,7 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.Containe
 import java.util.List;
 
 /**
- * Customized queue to handle FCR and ICR from datanode optimally,
- * avoiding duplicate FCR reports.
+ * Customized queue to handle multiple ICR report together.
  */
 public class ReconContainerReportQueue extends ContainerReportQueue {
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportQueue.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportQueue.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.recon.scm;
+
+import org.apache.hadoop.hdds.scm.server.ContainerReportQueue;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReport;
+
+import java.util.List;
+
+/**
+ * Customized queue to handle FCR and ICR from datanode optimally,
+ * avoiding duplicate FCR reports.
+ */
+public class ReconContainerReportQueue extends ContainerReportQueue {
+
+  public ReconContainerReportQueue(int queueSize) {
+    super(queueSize);
+  }
+
+  @Override
+  protected boolean mergeIcr(ContainerReport val,
+                             List<ContainerReport> dataList) {
+    if (!dataList.isEmpty()) {
+      if (SCMDatanodeHeartbeatDispatcher.ContainerReportType.ICR
+          == dataList.get(dataList.size() - 1).getType()) {
+        dataList.get(dataList.size() - 1).mergeReport(val);
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -76,7 +76,6 @@ import org.apache.hadoop.hdds.scm.node.StaleNodeHandler;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineActionHandler;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
-import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.server.events.EventQueue;
@@ -105,6 +104,9 @@ import static org.apache.hadoop.hdds.recon.ReconConfigKeys.RECON_SCM_CONFIG_PREF
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_EXEC_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_QUEUE_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.buildRpcServerStartMessage;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_SCM_CLIENT_FAILOVER_MAX_RETRY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_SCM_CLIENT_MAX_RETRY_TIMEOUT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_SCM_CLIENT_RPC_TIME_OUT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_KEY;
@@ -190,21 +192,23 @@ public class ReconStorageContainerManagerFacade
         .setSCM(this)
         .build();
     this.ozoneConfiguration = getReconScmConfiguration(conf);
-    long scmClientRPCTimeOut = ozoneConfiguration.getTimeDuration(
+    long scmClientRPCTimeOut = conf.getTimeDuration(
         OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_KEY,
         OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_DEFAULT,
         TimeUnit.MILLISECONDS);
-    long scmClientMaxRetryTimeOut = ozoneConfiguration.getTimeDuration(
+    long scmClientMaxRetryTimeOut = conf.getTimeDuration(
         OZONE_RECON_SCM_CLIENT_MAX_RETRY_TIMEOUT_KEY,
         OZONE_RECON_SCM_CLIENT_MAX_RETRY_TIMEOUT_DEFAULT,
         TimeUnit.MILLISECONDS);
-    int scmClientFailOverMaxRetryCount = ozoneConfiguration.getInt(
+    int scmClientFailOverMaxRetryCount = conf.getInt(
         OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_KEY,
         OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_DEFAULT);
-    SCMClientConfig scmClientConfig = conf.getObject(SCMClientConfig.class);
-    scmClientConfig.setRpcTimeOut(scmClientRPCTimeOut);
-    scmClientConfig.setRetryCount(scmClientFailOverMaxRetryCount);
-    scmClientConfig.setMaxRetryTimeout(scmClientMaxRetryTimeOut);
+
+    conf.setLong(HDDS_SCM_CLIENT_RPC_TIME_OUT, scmClientRPCTimeOut);
+    conf.setLong(HDDS_SCM_CLIENT_MAX_RETRY_TIMEOUT, scmClientMaxRetryTimeOut);
+    conf.setLong(HDDS_SCM_CLIENT_FAILOVER_MAX_RETRY,
+        scmClientFailOverMaxRetryCount);
+
     this.scmStorageConfig = new ReconStorageConfig(conf, reconUtils);
     this.clusterMap = new NetworkTopologyImpl(conf);
     this.dbStore = DBStoreBuilder

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -101,15 +101,17 @@ import org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskConfig;
 import com.google.inject.Inject;
 
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_DEFAULT;
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_KEY;
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_DEFAULT;
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_KEY;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.RECON_SCM_CONFIG_PREFIX;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_EXEC_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_EVENT_REPORT_QUEUE_WAIT_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.buildRpcServerStartMessage;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CLIENT_MAX_RETRY_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CLIENT_MAX_RETRY_TIMEOUT_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_KEY;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_TASK_INITIAL_DELAY;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_TASK_INTERVAL_DEFAULT;
@@ -188,15 +190,21 @@ public class ReconStorageContainerManagerFacade
         .setSCM(this)
         .build();
     this.ozoneConfiguration = getReconScmConfiguration(conf);
-    long scmClientRPCTimeOut = ozoneConfiguration.getLong(
+    long scmClientRPCTimeOut = ozoneConfiguration.getTimeDuration(
         OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_KEY,
-        OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_DEFAULT);
+        OZONE_RECON_SCM_CLIENT_RPC_TIME_OUT_DEFAULT,
+        TimeUnit.MILLISECONDS);
+    long scmClientMaxRetryTimeOut = ozoneConfiguration.getTimeDuration(
+        OZONE_RECON_SCM_CLIENT_MAX_RETRY_TIMEOUT_KEY,
+        OZONE_RECON_SCM_CLIENT_MAX_RETRY_TIMEOUT_DEFAULT,
+        TimeUnit.MILLISECONDS);
     int scmClientFailOverMaxRetryCount = ozoneConfiguration.getInt(
         OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_KEY,
         OZONE_RECON_SCM_CLIENT_FAILOVER_MAX_RETRY_DEFAULT);
     SCMClientConfig scmClientConfig = conf.getObject(SCMClientConfig.class);
     scmClientConfig.setRpcTimeOut(scmClientRPCTimeOut);
     scmClientConfig.setRetryCount(scmClientFailOverMaxRetryCount);
+    scmClientConfig.setMaxRetryTimeout(scmClientMaxRetryTimeOut);
     this.scmStorageConfig = new ReconStorageConfig(conf, reconUtils);
     this.clusterMap = new NetworkTopologyImpl(conf);
     this.dbStore = DBStoreBuilder

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -30,7 +30,9 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
@@ -66,18 +68,28 @@ public class TestReconIncrementalContainerReportHandler
   private HDDSLayoutVersionManager versionManager;
 
   @Test
-  public void testProcessICR() throws IOException, NodeNotFoundException {
+  public void testProcessICR()
+      throws IOException, NodeNotFoundException, TimeoutException {
 
     ContainerID containerID = ContainerID.valueOf(100L);
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
     IncrementalContainerReportFromDatanode reportMock =
         mock(IncrementalContainerReportFromDatanode.class);
     when(reportMock.getDatanodeDetails()).thenReturn(datanodeDetails);
+
+    ContainerWithPipeline containerWithPipeline = getTestContainer(
+        containerID.getId(), OPEN);
+    List<ContainerWithPipeline> containerWithPipelineList = new ArrayList<>();
+    containerWithPipelineList.add(containerWithPipeline);
+    ReconContainerManager containerManager = getContainerManager();
     IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(containerID,
             State.OPEN,
             datanodeDetails.getUuidString());
     when(reportMock.getReport()).thenReturn(containerReport);
+    when(getContainerManager().getScmClient()
+        .getExistContainerWithPipelinesInBatch(any(
+            ArrayList.class))).thenReturn(containerWithPipelineList);
 
     final String path =
         GenericTestUtils.getTempPath(UUID.randomUUID().toString());
@@ -99,7 +111,6 @@ public class TestReconIncrementalContainerReportHandler
 
     nodeManager.register(datanodeDetails, null, null);
 
-    ReconContainerManager containerManager = getContainerManager();
     ReconIncrementalContainerReportHandler reconIcr =
         new ReconIncrementalContainerReportHandler(nodeManager,
             containerManager, SCMContext.emptyContext());


### PR DESCRIPTION
## What changes were proposed in this pull request?
There is a difference between SCM's  IncrementalContainerReportHandler and Recon's IncrementalContainerReportHandler , Recon always connects to SCM and verify each container before adding new container to its own containerStateManager cache. This could be a bottle neck if SCM may respond slow and frequent ICR requests may pile up in queue. So as of now, this PR will improve below multiple things:

-     Recon to verify containers in batches from SCM on receive of ICR request from DNs.
-     Reduce the scmClient configs for Recon before connecting to SCM:
         - `hdds.scmclient.rpc.timeout` - 1 min (Default value is 15 mins)
         - `hdds.scmclient.failover.max.retry` - 3 (Default value is dynamic and computed, but based on default values, computed value is 15)
          Above 2 SCM client configs will be updated to respective new values as mentioned for recon to connect to SCM. These 2 SCM client configs will be exposed and mapped with new recon configs to be able to adjust independently in recon.

        **New configs in Recon:**
             -  `ozone.recon.scmclient.rpc.timeout`
             -  `ozone.recon.scmclient.failover.max.retry`

- Merge the Incremental container report (ICR) to existing list of ICR reports.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9883

## How was this patch tested?

Tested using existing Junit tests after updating existing test - `TestReconIncrementalContainerReportHandler`
