### PR TITLE
HDDS-9592. Replication Manager: Save UNHEALTHY replicas with highest BCSID for a QUASI_CLOSED container

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -113,6 +113,7 @@ public class ContainerHealthResult {
     private boolean hasUnReplicatedOfflineIndexes = false;
     private boolean offlineIndexesOkAfterPending = false;
     private int requeueCount = 0;
+    private boolean hasVulnerableUnhealthy = false;
 
     public UnderReplicatedHealthResult(ContainerInfo containerInfo,
         int remainingRedundancy, boolean dueToOutOfService,
@@ -267,6 +268,14 @@ public class ContainerHealthResult {
 
     public boolean isMissing() {
       return isMissing;
+    }
+
+    public void setHasVulnerableUnhealthy(boolean hasVulnerableUnhealthy) {
+      this.hasVulnerableUnhealthy = hasVulnerableUnhealthy;
+    }
+
+    public boolean hasVulnerableUnhealthy() {
+      return hasVulnerableUnhealthy;
     }
 
     @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -128,7 +128,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         container.containerID(), replicas);
 
     ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =
-        ReplicationManagerUtil.getExcludedAndUsedNodes(
+        ReplicationManagerUtil.getExcludedAndUsedNodes(container,
             new ArrayList<>(replicas), Collections.emptySet(), pendingOps,
             replicationManager);
     List<DatanodeDetails> excludedNodes

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyRatisContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyRatisContainerReplicaCount.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 
 import java.util.List;
 import java.util.Set;
@@ -130,6 +131,12 @@ public class LegacyRatisContainerReplicaCount extends
   public boolean isSufficientlyReplicatedForOffline(DatanodeDetails datanode,
       NodeManager nodeManager) {
     return super.isSufficientlyReplicated() &&
-        super.getVulnerableUnhealthyReplicas(nodeManager).isEmpty();
+        super.getVulnerableUnhealthyReplicas(dn -> {
+          try {
+            return nodeManager.getNodeStatus(dn);
+          } catch (NodeNotFoundException e) {
+            return null;
+          }
+        }).isEmpty();
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -558,7 +558,15 @@ public class LegacyReplicationManager {
          * match the container's Sequence ID.
          */
         List<ContainerReplica> vulnerableUnhealthy =
-            replicaSet.getVulnerableUnhealthyReplicas(nodeManager);
+            replicaSet.getVulnerableUnhealthyReplicas(dn -> {
+              try {
+                return nodeManager.getNodeStatus(dn);
+              } catch (NodeNotFoundException e) {
+                LOG.warn("Exception for datanode {} while getting vulnerable replicas for container {}, with all " +
+                    "replicas {}.", dn, container, replicas, e);
+                return null;
+              }
+            });
         if (!vulnerableUnhealthy.isEmpty()) {
           report.incrementAndSample(HealthState.UNDER_REPLICATED,
               container.containerID());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MisReplicationHandler.java
@@ -148,7 +148,7 @@ public abstract class MisReplicationHandler implements
             .collect(Collectors.toMap(Function.identity(), sources::contains)));
 
     ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes
-        = ReplicationManagerUtil.getExcludedAndUsedNodes(
+        = ReplicationManagerUtil.getExcludedAndUsedNodes(container,
             new ArrayList(replicas), replicasToBeReplicated,
             Collections.emptyList(), replicationManager);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -99,7 +99,7 @@ public class RatisUnderReplicationHandler
         new RatisContainerReplicaCount(containerInfo, replicas, pendingOps,
             minHealthyForMaintenance, false);
 
-    if (result.getHealthState() == ContainerHealthResult.HealthState.UNDER_REPLICATED) {
+    if (result instanceof ContainerHealthResult.UnderReplicatedHealthResult) {
       ContainerHealthResult.UnderReplicatedHealthResult
           underReplicatedResult = (ContainerHealthResult.UnderReplicatedHealthResult) result;
       if (underReplicatedResult.hasVulnerableUnhealthy()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -195,7 +195,7 @@ public class RatisUnderReplicationHandler
 
     /*
     Since we're replicating UNHEALTHY replicas, it's possible that replication keeps on failing. Shuffling gives
-    other replicas a chance to be replicated since there's a limit on inflight adds.
+    other replicas a chance to be replicated since there's a limit on in-flight adds.
     */
     Collections.shuffle(vulnerableUnhealthy);
     return replicateEachSource(replicaCount, vulnerableUnhealthy, pendingOps);
@@ -238,8 +238,7 @@ public class RatisUnderReplicationHandler
       try {
         count = sendReplicationCommands(container, ImmutableList.of(replica.getDatanodeDetails()), target);
       } catch (CommandTargetOverloadedException e) {
-        LOG.info("Exception while replicating replica {} to target {} for container {}.", replica, target, container,
-            e);
+        LOG.info("Exception while replicating {} to target {} for container {}.", replica, target, container, e);
         if (firstException == null) {
           firstException = e;
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -99,10 +99,12 @@ public class RatisUnderReplicationHandler
         new RatisContainerReplicaCount(containerInfo, replicas, pendingOps,
             minHealthyForMaintenance, false);
 
-    ContainerHealthResult.UnderReplicatedHealthResult underReplicatedResult =
-        (ContainerHealthResult.UnderReplicatedHealthResult) result;
-    if (underReplicatedResult.hasVulnerableUnhealthy()) {
-      return handleVulnerableUnhealthyReplicas(withUnhealthy, pendingOps);
+    if (result.getHealthState() == ContainerHealthResult.HealthState.UNDER_REPLICATED) {
+      ContainerHealthResult.UnderReplicatedHealthResult
+          underReplicatedResult = (ContainerHealthResult.UnderReplicatedHealthResult) result;
+      if (underReplicatedResult.hasVulnerableUnhealthy()) {
+        return handleVulnerableUnhealthyReplicas(withUnhealthy, pendingOps);
+      }
     }
 
     // verify that this container is still under replicated and we don't have

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisUnderReplicationHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -98,6 +99,12 @@ public class RatisUnderReplicationHandler
         new RatisContainerReplicaCount(containerInfo, replicas, pendingOps,
             minHealthyForMaintenance, false);
 
+    ContainerHealthResult.UnderReplicatedHealthResult underReplicatedResult =
+        (ContainerHealthResult.UnderReplicatedHealthResult) result;
+    if (underReplicatedResult.hasVulnerableUnhealthy()) {
+      return handleVulnerableUnhealthyReplicas(withUnhealthy, pendingOps);
+    }
+
     // verify that this container is still under replicated and we don't have
     // sufficient replication after considering pending adds
     RatisContainerReplicaCount replicaCount =
@@ -149,6 +156,105 @@ public class RatisUnderReplicationHandler
           replicaCount.additionalReplicaNeeded(), targetDatanodes.size());
     }
     return commandsSent;
+  }
+
+  /**
+   * Sends a replicate command for each replica specified in
+   * vulnerableUnhealthy.
+   * @param replicaCount RatisContainerReplicaCount for this container
+   * @param pendingOps List of pending ops
+   * @return number of replicate commands sent
+   */
+  private int handleVulnerableUnhealthyReplicas(RatisContainerReplicaCount replicaCount,
+      List<ContainerReplicaOp> pendingOps) throws NotLeaderException, CommandTargetOverloadedException, SCMException {
+    ContainerInfo container = replicaCount.getContainer();
+    List<ContainerReplica> vulnerableUnhealthy = replicaCount.getVulnerableUnhealthyReplicas(dn -> {
+      try {
+        return replicationManager.getNodeStatus(dn);
+      } catch (NodeNotFoundException e) {
+        LOG.warn("Exception for datanode {} while handling vulnerable replicas for container {}, with all replicas" +
+            " {}.", dn, container, replicaCount.getReplicas(), e);
+        return null;
+      }
+    });
+    LOG.info("Handling vulnerable UNHEALTHY replicas {} for container {}.", vulnerableUnhealthy, container);
+
+    int pendingAdds = 0;
+    for (ContainerReplicaOp op : pendingOps) {
+      if (op.getOpType() == ContainerReplicaOp.PendingOpType.ADD) {
+        pendingAdds++;
+      }
+    }
+    if (pendingAdds >= vulnerableUnhealthy.size()) {
+      LOG.debug("There are {} pending adds for container {}, while the number of UNHEALTHY replicas is {}.",
+          pendingAdds, container.containerID(), vulnerableUnhealthy.size());
+      return 0;
+    }
+
+    /*
+    Since we're replicating UNHEALTHY replicas, it's possible that replication keeps on failing. Shuffling gives
+    other replicas a chance to be replicated since there's a limit on inflight adds.
+    */
+    Collections.shuffle(vulnerableUnhealthy);
+    return replicateEachSource(replicaCount, vulnerableUnhealthy, pendingOps);
+  }
+
+  /**
+   * Replicates each of the ContainerReplica specified in sources to new
+   * Datanodes. Will not consider Datanodes hosting existing replicas and
+   * Datanodes pending adds as targets. Note that this method simply skips
+   * a replica if its datanode is overloaded with commands, throwing an
+   * exception once all sources have been looked at.
+   * @param replicaCount RatisContainerReplicaCount for this container
+   * @param sources List containing replicas, each will be replicated
+   */
+  private int replicateEachSource(RatisContainerReplicaCount replicaCount, List<ContainerReplica> sources,
+      List<ContainerReplicaOp> pendingOps) throws NotLeaderException, SCMException, CommandTargetOverloadedException {
+    List<ContainerReplica> allReplicas = replicaCount.getReplicas();
+    ContainerInfo container = replicaCount.getContainer();
+
+    /*
+    We use the placement policy to get a target Datanode to which a vulnerable replica will be replicated. In
+    placement policy terms, a 'used node' is a Datanode which has a legit replica of this container. An 'excluded
+    node' is a Datanode that should not be considered to host a replica of this container, but other Datanodes in this
+    Datanode's rack are available. So, Datanodes of any vulnerable replicas should be excluded nodes while Datanodes
+    of other replicas, including UNHEALTHY replicas that are not pending delete (because they have unique origin),
+    should be used nodes.
+    */
+    ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =
+        ReplicationManagerUtil.getExcludedAndUsedNodes(container, allReplicas, Collections.emptySet(), pendingOps,
+            replicationManager);
+
+    CommandTargetOverloadedException firstException = null;
+    int numCommandsSent = 0;
+    for (ContainerReplica replica : sources) {
+      // find a target for each source and send replicate command
+      final List<DatanodeDetails> target =
+          ReplicationManagerUtil.getTargetDatanodes(placementPolicy, 1, excludedAndUsedNodes.getUsedNodes(),
+              excludedAndUsedNodes.getExcludedNodes(), currentContainerSize, container);
+      int count = 0;
+      try {
+        count = sendReplicationCommands(container, ImmutableList.of(replica.getDatanodeDetails()), target);
+      } catch (CommandTargetOverloadedException e) {
+        LOG.info("Exception while replicating replica {} to target {} for container {}.", replica, target, container,
+            e);
+        if (firstException == null) {
+          firstException = e;
+        }
+      }
+
+      if (count == 1) {
+        // a command was sent to target, so it needs to be in the used nodes list because it's pending an add
+        excludedAndUsedNodes.getUsedNodes().add(target.get(0));
+      }
+      numCommandsSent += count;
+    }
+
+    if (firstException != null) {
+      throw firstException;
+    }
+
+    return numCommandsSent;
   }
 
   private void removeUnhealthyReplicaIfPossible(ContainerInfo containerInfo,
@@ -337,7 +443,7 @@ public class RatisUnderReplicationHandler
         replicaCount.getContainer().containerID(), replicaCount.getReplicas());
 
     ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =
-        ReplicationManagerUtil.getExcludedAndUsedNodes(
+        ReplicationManagerUtil.getExcludedAndUsedNodes(replicaCount.getContainer(),
             replicaCount.getReplicas(), Collections.emptySet(), pendingOps,
             replicationManager);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hdds.scm.container.replication.health.OpenContainerHand
 import org.apache.hadoop.hdds.scm.container.replication.health.QuasiClosedContainerHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.RatisReplicationCheckHandler;
 import org.apache.hadoop.hdds.scm.container.replication.health.RatisUnhealthyReplicationCheckHandler;
+import org.apache.hadoop.hdds.scm.container.replication.health.VulnerableUnhealthyReplicasHandler;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMService;
@@ -279,7 +280,8 @@ public class ReplicationManager implements SCMService {
         .addNext(ratisReplicationCheckHandler)
         .addNext(new ClosedWithUnhealthyReplicasHandler(this))
         .addNext(ecMisReplicationCheckHandler)
-        .addNext(new RatisUnhealthyReplicationCheckHandler());
+        .addNext(new RatisUnhealthyReplicationCheckHandler())
+        .addNext(new VulnerableUnhealthyReplicasHandler(this));
     start();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/VulnerableUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/VulnerableUnhealthyReplicasHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult;
+import org.apache.hadoop.hdds.scm.container.replication.RatisContainerReplicaCount;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+
+/**
+ * A QUASI_CLOSED container may have some UNHEALTHY replicas with the
+ * same Sequence ID as the container. RM should try to maintain one
+ * copy of such replicas when there are no healthy replicas that
+ * match the container's Sequence ID.
+ */
+public class VulnerableUnhealthyReplicasHandler extends AbstractCheck {
+  public static final Logger LOG = LoggerFactory.getLogger(VulnerableUnhealthyReplicasHandler.class);
+  private final ReplicationManager replicationManager;
+
+  public VulnerableUnhealthyReplicasHandler(ReplicationManager replicationManager) {
+    this.replicationManager = replicationManager;
+  }
+
+  /**
+   * Checks if the container is QUASI_CLOSED has some vulnerable UNHEALTHY replicas that need to replicated to
+   * other Datanodes. These replicas have the same sequence ID as the container while other healthy replicas don't.
+   * If the node hosting such a replica is being taken offline, then the replica may have to be replicated to another
+   * node.
+   * @param request ContainerCheckRequest object representing the container
+   * @return true if some vulnerable UNHEALTHY replicas were found, else false
+   */
+  @Override
+  public boolean handle(ContainerCheckRequest request) {
+    ContainerInfo container = request.getContainerInfo();
+    if (container.getReplicationType() != RATIS) {
+      // This handler is only for Ratis containers.
+      return false;
+    }
+    if (container.getState() != HddsProtos.LifeCycleState.QUASI_CLOSED) {
+      return false;
+    }
+    Set<ContainerReplica> replicas = request.getContainerReplicas();
+    LOG.debug("Checking whether container {} with replicas {} has vulnerable UNHEALTHY replicas.", container, replicas);
+    RatisContainerReplicaCount replicaCount =
+        new RatisContainerReplicaCount(container, replicas, request.getPendingOps(), request.getMaintenanceRedundancy(),
+            true);
+
+    List<ContainerReplica> vulnerableUnhealthy = replicaCount.getVulnerableUnhealthyReplicas(dn -> {
+      try {
+        return replicationManager.getNodeStatus(dn);
+      } catch (NodeNotFoundException e) {
+        LOG.warn("Exception for datanode {} while handling vulnerable replicas for container {}, with all replicas" +
+            " {}.", dn, container, replicaCount.getReplicas(), e);
+        return null;
+      }
+    });
+
+    if (!vulnerableUnhealthy.isEmpty()) {
+      LOG.info("Found vulnerable UNHEALTHY replicas {} for container {}.", vulnerableUnhealthy, container);
+      ReplicationManagerReport report = request.getReport();
+      report.incrementAndSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED, container.containerID());
+      if (!request.isReadOnly()) {
+        ContainerHealthResult.UnderReplicatedHealthResult underRepResult =
+            replicaCount.toUnderHealthResult();
+        underRepResult.setHasVulnerableUnhealthy(true);
+        request.getReplicationQueue().enqueue(underRepResult);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -362,19 +362,7 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
           continue;
         }
 
-        boolean isHealthy;
-        /*
-        If LegacyReplicationManager is enabled, then use the
-        isHealthyEnoughForOffline API. ReplicationManager doesn't support this
-        API yet.
-         */
-        boolean legacyEnabled = conf.getBoolean("hdds.scm.replication.enable" +
-            ".legacy", false);
-        if (legacyEnabled) {
-          isHealthy = replicaSet.isHealthyEnoughForOffline();
-        } else {
-          isHealthy = replicaSet.isHealthy();
-        }
+        boolean isHealthy = replicaSet.isHealthyEnoughForOffline();
         if (!isHealthy) {
           if (LOG.isDebugEnabled()) {
             unClosedIDs.add(cid);
@@ -391,6 +379,8 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
         // state, except for any which are unhealthy. As the container is closed, we can check
         // if it is sufficiently replicated using replicationManager, but this only works if the
         // legacy RM is not enabled.
+        boolean legacyEnabled = conf.getBoolean("hdds.scm.replication.enable" +
+            ".legacy", false);
         boolean replicatedOK;
         if (legacyEnabled) {
           replicatedOK = replicaSet.isSufficientlyReplicatedForOffline(dn, nodeManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -90,6 +91,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 
 /**
@@ -441,6 +443,63 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
     assertEquals(0, repQueue.underReplicatedQueueSize());
     assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testQuasiClosedContainerWithVulnerableUnhealthyReplica()
+      throws IOException, NodeNotFoundException {
+    RatisReplicationConfig ratisRepConfig =
+        RatisReplicationConfig.getInstance(THREE);
+    long sequenceID = 10;
+    ContainerInfo container = createContainerInfo(ratisRepConfig, 1,
+        HddsProtos.LifeCycleState.QUASI_CLOSED, sequenceID);
+
+    // this method creates replicas with same origin id and zero sequence id
+    Set<ContainerReplica> replicas =
+        createReplicasWithSameOrigin(container.containerID(),
+            ContainerReplicaProto.State.QUASI_CLOSED, 0, 0, 0);
+    replicas.add(createContainerReplica(container.containerID(), 0,
+        IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY, sequenceID));
+    ContainerReplica decommissioning =
+        createContainerReplica(container.containerID(), 0, DECOMMISSIONING,
+            ContainerReplicaProto.State.UNHEALTHY, sequenceID);
+    replicas.add(decommissioning);
+    storeContainerAndReplicas(container, replicas);
+    Mockito.when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+        .thenAnswer(invocation -> {
+          DatanodeDetails dn = invocation.getArgument(0);
+          if (dn.equals(decommissioning.getDatanodeDetails())) {
+            return new NodeStatus(DECOMMISSIONING, HddsProtos.NodeState.HEALTHY);
+          }
+
+          return NodeStatus.inServiceHealthy();
+        });
+
+    replicationManager.processContainer(container, repQueue, repReport);
+    assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    assertEquals(0, repReport.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+
+    Mockito.when(ratisPlacementPolicy.chooseDatanodes(anyList(), anyList(), eq(null), eq(1), anyLong(),
+        anyLong())).thenAnswer(invocation -> ImmutableList.of(MockDatanodeDetails.randomDatanodeDetails()));
+    Mockito.when(nodeManager.getTotalDatanodeCommandCounts(any(DatanodeDetails.class), any(), any()))
+        .thenAnswer(invocation -> {
+          Map<SCMCommandProto.Type, Integer> map = new HashMap<>();
+          map.put(SCMCommandProto.Type.replicateContainerCommand, 0);
+          map.put(SCMCommandProto.Type.reconstructECContainersCommand, 0);
+          return map;
+        });
+    RatisUnderReplicationHandler handler =
+        new RatisUnderReplicationHandler(ratisPlacementPolicy, configuration, replicationManager);
+
+    handler.processAndSendCommands(replicas, Collections.emptyList(), repQueue.dequeueUnderReplicatedContainer(), 2);
+    assertEquals(1, commandsSent.size());
+    Pair<UUID, SCMCommand<?>> command = commandsSent.iterator().next();
+    assertEquals(SCMCommandProto.Type.replicateContainerCommand, command.getValue().getType());
+    assertEquals(decommissioning.getDatanodeDetails().getUuid(), command.getKey());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -17,11 +17,13 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -37,6 +39,7 @@ import java.util.Set;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainer;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,7 +58,9 @@ public class TestReplicationManagerUtil {
 
   @Test
   public void testGetExcludedAndUsedNodes() throws NodeNotFoundException {
-    ContainerID cid = ContainerID.valueOf(1L);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+    ContainerID cid = container.containerID();
     Set<ContainerReplica> replicas = new HashSet<>();
     ContainerReplica good = createContainerReplica(cid, 0,
         IN_SERVICE, ContainerReplicaProto.State.CLOSED, 1);
@@ -108,7 +113,7 @@ public class TestReplicationManagerUtil {
         });
 
     ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =
-        ReplicationManagerUtil.getExcludedAndUsedNodes(
+        ReplicationManagerUtil.getExcludedAndUsedNodes(container,
             new ArrayList<>(replicas), toBeRemoved, pending,
             replicationManager);
 
@@ -123,6 +128,91 @@ public class TestReplicationManagerUtil {
     assertEquals(4, excludedAndUsedNodes.getExcludedNodes().size());
     assertTrue(excludedAndUsedNodes.getExcludedNodes()
         .contains(unhealthy.getDatanodeDetails()));
+    assertTrue(excludedAndUsedNodes.getExcludedNodes()
+        .contains(decommissioning.getDatanodeDetails()));
+    assertTrue(excludedAndUsedNodes.getExcludedNodes()
+        .contains(remove.getDatanodeDetails()));
+    assertTrue(excludedAndUsedNodes.getExcludedNodes()
+        .contains(pendingDelete));
+  }
+
+  @Test
+  public void testGetUsedAndExcludedNodesForQuasiClosedContainer() throws NodeNotFoundException {
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.QUASI_CLOSED,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+    ContainerID cid = container.containerID();
+    Set<ContainerReplica> replicas = new HashSet<>();
+    ContainerReplica good = createContainerReplica(cid, 0, IN_SERVICE,
+        ContainerReplicaProto.State.QUASI_CLOSED, 1);
+    replicas.add(good);
+
+    ContainerReplica remove = createContainerReplica(cid, 0,
+        IN_SERVICE, ContainerReplicaProto.State.QUASI_CLOSED, 1);
+    replicas.add(remove);
+    Set<ContainerReplica> toBeRemoved = new HashSet<>();
+    toBeRemoved.add(remove);
+
+    // this replica should be on the used nodes list
+    ContainerReplica unhealthyWithUniqueOrigin = createContainerReplica(
+        cid, 0, IN_SERVICE, ContainerReplicaProto.State.UNHEALTHY, 1);
+    replicas.add(unhealthyWithUniqueOrigin);
+
+    // this one should be on the excluded nodes list
+    ContainerReplica unhealthyWithNonUniqueOrigin = createContainerReplica(cid, 0, IN_SERVICE,
+        ContainerReplicaProto.State.UNHEALTHY, container.getNumberOfKeys(), container.getUsedBytes(),
+        MockDatanodeDetails.randomDatanodeDetails(), good.getOriginDatanodeId());
+    replicas.add(unhealthyWithNonUniqueOrigin);
+
+    ContainerReplica decommissioning =
+        createContainerReplica(cid, 0,
+            DECOMMISSIONING, ContainerReplicaProto.State.QUASI_CLOSED, 1);
+    replicas.add(decommissioning);
+
+    ContainerReplica maintenance =
+        createContainerReplica(cid, 0,
+            IN_MAINTENANCE, ContainerReplicaProto.State.QUASI_CLOSED, 1);
+    replicas.add(maintenance);
+
+    // Finally, add a pending add and delete. The add should go onto the used
+    // list and the delete added to the excluded nodes.
+    DatanodeDetails pendingAdd = MockDatanodeDetails.randomDatanodeDetails();
+    DatanodeDetails pendingDelete = MockDatanodeDetails.randomDatanodeDetails();
+    List<ContainerReplicaOp> pending = new ArrayList<>();
+    pending.add(ContainerReplicaOp.create(
+        ContainerReplicaOp.PendingOpType.ADD, pendingAdd, 0));
+    pending.add(ContainerReplicaOp.create(
+        ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0));
+
+    Mockito.when(replicationManager.getNodeStatus(Mockito.any())).thenAnswer(
+        invocation -> {
+          final DatanodeDetails dn = invocation.getArgument(0);
+          for (ContainerReplica r : replicas) {
+            if (r.getDatanodeDetails().equals(dn)) {
+              return new NodeStatus(
+                  r.getDatanodeDetails().getPersistedOpState(),
+                  HddsProtos.NodeState.HEALTHY);
+            }
+          }
+          throw new NodeNotFoundException(dn.getUuidString());
+        });
+
+    ReplicationManagerUtil.ExcludedAndUsedNodes excludedAndUsedNodes =
+        ReplicationManagerUtil.getExcludedAndUsedNodes(container,
+            new ArrayList<>(replicas), toBeRemoved, pending,
+            replicationManager);
+
+    assertEquals(4, excludedAndUsedNodes.getUsedNodes().size());
+    assertTrue(excludedAndUsedNodes.getUsedNodes()
+        .contains(good.getDatanodeDetails()));
+    assertTrue(excludedAndUsedNodes.getUsedNodes()
+        .contains(maintenance.getDatanodeDetails()));
+    assertTrue(excludedAndUsedNodes.getUsedNodes()
+        .contains(pendingAdd));
+    assertTrue(excludedAndUsedNodes.getUsedNodes().contains(unhealthyWithUniqueOrigin.getDatanodeDetails()));
+
+    assertEquals(4, excludedAndUsedNodes.getExcludedNodes().size());
+    assertTrue(excludedAndUsedNodes.getExcludedNodes()
+        .contains(unhealthyWithNonUniqueOrigin.getDatanodeDetails()));
     assertTrue(excludedAndUsedNodes.getExcludedNodes()
         .contains(decommissioning.getDatanodeDetails()));
     assertTrue(excludedAndUsedNodes.getExcludedNodes()

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestVulnerableUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestVulnerableUnhealthyReplicasHandler.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.replication.health;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link VulnerableUnhealthyReplicasHandler}.
+ */
+public class TestVulnerableUnhealthyReplicasHandler {
+  private ReplicationManager replicationManager;
+  private ReplicationConfig repConfig;
+  private ReplicationQueue repQueue;
+  private ContainerCheckRequest.Builder requestBuilder;
+  private ReplicationManagerReport report;
+  private VulnerableUnhealthyReplicasHandler handler;
+
+  @BeforeEach
+  public void setup() throws NodeNotFoundException {
+    replicationManager = Mockito.mock(ReplicationManager.class);
+    handler = new VulnerableUnhealthyReplicasHandler(replicationManager);
+    repConfig = RatisReplicationConfig.getInstance(THREE);
+    repQueue = new ReplicationQueue();
+    report = new ReplicationManagerReport();
+    requestBuilder = new ContainerCheckRequest.Builder()
+        .setReplicationQueue(repQueue)
+        .setMaintenanceRedundancy(2)
+        .setPendingOps(Collections.emptyList())
+        .setReport(report);
+
+    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+        .thenReturn(NodeStatus.inServiceHealthy());
+  }
+
+  @Test
+  public void testReturnsFalseForECContainer() {
+    ContainerInfo container = createContainerInfo(new ECReplicationConfig(3, 2));
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(), 1, 2, 3, 4);
+    requestBuilder.setContainerReplicas(replicas).setContainerInfo(container);
+
+    assertFalse(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testReturnsFalseForClosedContainer() {
+    ContainerInfo container = createContainerInfo(repConfig, 1, LifeCycleState.CLOSED);
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(), 0, 0, 0);
+    requestBuilder.setContainerReplicas(replicas).setContainerInfo(container);
+
+    assertFalse(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testReturnsFalseForQuasiClosedContainerWithNoUnhealthyReplicas() {
+    ContainerInfo container = createContainerInfo(repConfig, 1, LifeCycleState.QUASI_CLOSED);
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(), State.QUASI_CLOSED, 0, 0, 0);
+    requestBuilder.setContainerReplicas(replicas).setContainerInfo(container);
+
+    assertFalse(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testReturnsFalseForQuasiClosedContainerWithNoVulnerableReplicas() {
+    ContainerInfo container = createContainerInfo(repConfig, 1, LifeCycleState.QUASI_CLOSED);
+    Set<ContainerReplica> replicas = createReplicas(container.containerID(), 0, 0, 0);
+    // create UNHEALTHY replica with unique origin id on an IN_SERVICE node
+    replicas.add(createContainerReplica(container.containerID(), 0, IN_SERVICE, State.UNHEALTHY));
+    requestBuilder.setContainerReplicas(replicas).setContainerInfo(container);
+
+    assertFalse(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testReturnsTrueForQuasiClosedContainerWithVulnerableReplica() throws NodeNotFoundException {
+    long sequenceId = 10;
+    ContainerInfo container = createContainerInfo(repConfig, 1, LifeCycleState.QUASI_CLOSED, sequenceId);
+    Set<ContainerReplica> replicas = new HashSet<>(4);
+    for (int i = 0; i < 3; i++) {
+      replicas.add(createContainerReplica(container.containerID(), 0, IN_SERVICE, State.QUASI_CLOSED,
+          container.getSequenceId() - 1));
+    }
+    // create UNHEALTHY replica with unique origin id on a DECOMMISSIONING node
+    ContainerReplica unhealthy =
+        createContainerReplica(container.containerID(), 0, DECOMMISSIONING, State.UNHEALTHY, sequenceId);
+    replicas.add(unhealthy);
+    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+        .thenAnswer(invocation -> {
+          DatanodeDetails dn = invocation.getArgument(0);
+          if (dn.equals(unhealthy.getDatanodeDetails())) {
+            return new NodeStatus(DECOMMISSIONING, HEALTHY);
+          }
+          return NodeStatus.inServiceHealthy();
+        });
+    requestBuilder.setContainerReplicas(replicas).setContainerInfo(container);
+
+    assertTrue(handler.handle(requestBuilder.build()));
+    assertEquals(1, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testReturnsFalseForVulnerableReplicaWithAnotherCopy() throws NodeNotFoundException {
+    long sequenceId = 10;
+    ContainerInfo container = createContainerInfo(repConfig, 1, LifeCycleState.QUASI_CLOSED, sequenceId);
+    Set<ContainerReplica> replicas = new HashSet<>(4);
+    for (int i = 0; i < 3; i++) {
+      replicas.add(createContainerReplica(container.containerID(), 0, IN_SERVICE, State.QUASI_CLOSED,
+          container.getSequenceId() - 1));
+    }
+    // create UNHEALTHY replica with a non-unique origin id on a DECOMMISSIONING node
+    ContainerReplica unhealthy =
+        createContainerReplica(container.containerID(), 0, DECOMMISSIONING, State.UNHEALTHY, sequenceId);
+    replicas.add(unhealthy);
+    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+        .thenAnswer(invocation -> {
+          DatanodeDetails dn = invocation.getArgument(0);
+          if (dn.equals(unhealthy.getDatanodeDetails())) {
+            return new NodeStatus(DECOMMISSIONING, HEALTHY);
+          }
+          return NodeStatus.inServiceHealthy();
+        });
+    replicas.add(createContainerReplica(container.containerID(), 0, IN_SERVICE, State.UNHEALTHY,
+        container.getNumberOfKeys(), container.getUsedBytes(), MockDatanodeDetails.randomDatanodeDetails(),
+        unhealthy.getOriginDatanodeId(), container.getSequenceId()));
+    requestBuilder.setContainerReplicas(replicas).setContainerInfo(container);
+
+    assertFalse(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+
+  @Test
+  public void testDoesNotEnqueueForReadOnlyRequest() throws NodeNotFoundException {
+    long sequenceId = 10;
+    ContainerInfo container = createContainerInfo(repConfig, 1, LifeCycleState.QUASI_CLOSED, sequenceId);
+    Set<ContainerReplica> replicas = new HashSet<>(4);
+    for (int i = 0; i < 3; i++) {
+      replicas.add(createContainerReplica(container.containerID(), 0, IN_SERVICE, State.QUASI_CLOSED,
+          container.getSequenceId() - 1));
+    }
+    // create UNHEALTHY replica with unique origin id on a DECOMMISSIONING node
+    ContainerReplica unhealthy =
+        createContainerReplica(container.containerID(), 0, DECOMMISSIONING, State.UNHEALTHY, sequenceId);
+    replicas.add(unhealthy);
+    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+        .thenAnswer(invocation -> {
+          DatanodeDetails dn = invocation.getArgument(0);
+          if (dn.equals(unhealthy.getDatanodeDetails())) {
+            return new NodeStatus(DECOMMISSIONING, HEALTHY);
+          }
+          return NodeStatus.inServiceHealthy();
+        });
+    requestBuilder.setContainerReplicas(replicas)
+        .setContainerInfo(container)
+        .setReadOnly(true);
+
+    assertTrue(handler.handle(requestBuilder.build()));
+    assertEquals(0, repQueue.underReplicatedQueueSize());
+    assertEquals(0, repQueue.overReplicatedQueueSize());
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
@@ -193,7 +193,7 @@ public final class DatanodeAdminMonitorTestUtil {
     mockCheckContainerState(repManager, underReplicated);
   }
 
-  private static void mockCheckContainerState(ReplicationManager repManager, boolean underReplicated)
+  static void mockCheckContainerState(ReplicationManager repManager, boolean underReplicated)
       throws ContainerNotFoundException {
     Mockito.when(repManager.checkContainerStatus(Mockito.any(ContainerInfo.class),
             Mockito.any(ReplicationManagerReport.class)))


### PR DESCRIPTION
## What changes were proposed in this pull request?
A `QUASI_CLOSED` container may have some `UNHEALTHY` replicas with the same sequence id as the container, while there are no healthy replicas with the correct sequence id. Such `UNHEALTHY` replicas cannot be deleted and must be kept around.

If the DN hosting such an `UNHEALTHY` replica is put in decommission, then decommission will stay blocked because the `UNHEALTHY` cannot be lost, but at the same time RM currently does nothing about it. We try to do something about these vulnerable `UNHEALTHY` replicas in this PR so that decommission can be successful.

Changes introduced:
1. A new handler, `VulnerableUnhealthyReplicasHandler`, leverages the existing `replicaCount.getVulnerableUnhealthyReplicas` API to find such `UNHEALTHY` replicas. If found, the container is marked as under replicated and added to the under replication queue.
2. The under replicated container is then handled in `RatisUnderReplicationHandler`. It tries to find a new target DN for each `UNHEALTHY` replica and sends replicate commands. The logic is similar to what we have already done for legacy RM. Some additional changes were required to correctly find out the used and excluded nodes to pass into the placement policy API for finding target DNs.
3. Changes to the decommission monitor so that both RMs use the `replicaSet.isHealthyEnoughForOffline` API. 

The third point above basically solves [ReplicationManager: Unhealthy replicas of a sufficiently replicated container can block decommissioning](https://issues.apache.org/jira/browse/HDDS-9383). If required, this can be split off into its own PR since this one is quite large.

~~Need to add some more tests to `TestRatisUnderReplicationHandler`.~~

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9592

## How was this patch tested?

New tests.
