### PR TITLE
HDDS-6152. Migrate TestOzoneFileSystem to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
@@ -126,10 +126,6 @@
     <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
   </Match>
   <Match>
-    <Class name="org.apache.hadoop.fs.ozone.TestOzoneFileSystem"/>
-    <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
-  </Match>
-  <Match>
     <Class name="org.apache.hadoop.fs.ozone.TestOzoneFileSystemMissingParent"/>
     <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
   </Match>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -64,15 +64,11 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -106,20 +102,20 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZ
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.helpers.BucketLayout.FILE_SYSTEM_OPTIMIZED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Ozone file system tests that are not covered by contract tests.
  */
-@RunWith(Parameterized.class)
-public class TestOzoneFileSystem {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractOzoneFileSystemTest {
 
   private static final float TRASH_INTERVAL = 0.05f; // 3 seconds
 
@@ -132,58 +128,31 @@ public class TestOzoneFileSystem {
   private static final PathFilter EXCLUDE_TRASH =
       p -> !p.toUri().getPath().startsWith(TRASH_ROOT.toString());
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[]{true, true},
-        new Object[]{true, false},
-        new Object[]{false, true},
-        new Object[]{false, false});
+  AbstractOzoneFileSystemTest(boolean setDefaultFs, boolean enableOMRatis, BucketLayout layout) {
+    enabledFileSystemPaths = setDefaultFs;
+    omRatisEnabled = enableOMRatis;
+    bucketLayout = layout;
   }
-
-  public TestOzoneFileSystem(boolean setDefaultFs, boolean enableOMRatis) {
-    // Checking whether 'defaultFS' and 'omRatis' flags represents next
-    // parameter index values. This is to ensure that initialize
-    // TestOzoneFileSystem#init() function will be invoked only at the
-    // beginning of every new set of Parameterized.Parameters.
-    if (enabledFileSystemPaths != setDefaultFs ||
-            omRatisEnabled != enableOMRatis || cluster == null) {
-      enabledFileSystemPaths = setDefaultFs;
-      omRatisEnabled = enableOMRatis;
-      try {
-        teardown();
-        init();
-      } catch (Exception e) {
-        LOG.info("Unexpected exception", e);
-        fail("Unexpected exception:" + e.getMessage());
-      }
-    }
-  }
-
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(600));
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(TestOzoneFileSystem.class);
+      LoggerFactory.getLogger(AbstractOzoneFileSystemTest.class);
 
-  private static BucketLayout bucketLayout = BucketLayout.LEGACY;
-  private static boolean enabledFileSystemPaths;
-  private static boolean omRatisEnabled;
+  private final BucketLayout bucketLayout;
+  private final boolean enabledFileSystemPaths;
+  private final boolean omRatisEnabled;
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneClient client;
-  private static OzoneManagerProtocol writeClient;
-  private static FileSystem fs;
-  private static OzoneFileSystem o3fs;
-  private static OzoneBucket ozoneBucket;
-  private static String volumeName;
-  private static String bucketName;
-  private static Trash trash;
+  private MiniOzoneCluster cluster;
+  private OzoneClient client;
+  private OzoneManagerProtocol writeClient;
+  private FileSystem fs;
+  private OzoneFileSystem o3fs;
+  private OzoneBucket ozoneBucket;
+  private String volumeName;
+  private String bucketName;
+  private Trash trash;
 
-  private void init() throws Exception {
+  @BeforeAll
+  void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setFloat(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
     conf.setFloat(FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
@@ -224,8 +193,8 @@ public class TestOzoneFileSystem {
     o3fs = (OzoneFileSystem) fs;
   }
 
-  @AfterClass
-  public static void teardown() {
+  @AfterAll
+  void teardown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
@@ -233,7 +202,7 @@ public class TestOzoneFileSystem {
     IOUtils.closeQuietly(fs);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     try {
       deleteRootDir();
@@ -243,28 +212,24 @@ public class TestOzoneFileSystem {
     }
   }
 
-  public static MiniOzoneCluster getCluster() {
+  public MiniOzoneCluster getCluster() {
     return cluster;
   }
 
-  public static FileSystem getFs() {
+  public FileSystem getFs() {
     return fs;
   }
 
-  public static void setBucketLayout(BucketLayout bLayout) {
-    bucketLayout = bLayout;
-  }
-
-  public static String getBucketName() {
+  public String getBucketName() {
     return bucketName;
   }
 
-  public static String getVolumeName() {
+  public String getVolumeName() {
     return volumeName;
   }
 
   public BucketLayout getBucketLayout() {
-    return BucketLayout.DEFAULT;
+    return bucketLayout;
   }
 
   @Test
@@ -284,7 +249,7 @@ public class TestOzoneFileSystem {
     Path parent = new Path("/d1/d2/d3/d4/");
     Path file1 = new Path(parent, "key1");
     try (FSDataOutputStream outputStream = fs.create(file1, false)) {
-      assertNotNull("Should be able to create file", outputStream);
+      assertNotNull(outputStream, "Should be able to create file");
     }
 
     Path dir1 = new Path("/d1/d2/d3/d4/key2");
@@ -297,7 +262,7 @@ public class TestOzoneFileSystem {
 
     Path file2 = new Path("/d1/d2/d3/d4/key3");
     try (FSDataOutputStream outputStream2 = fs.create(file2, false)) {
-      assertNotNull("Should be able to create file", outputStream2);
+      assertNotNull(outputStream2, "Should be able to create file");
     }
     try {
       fs.mkdirs(file2);
@@ -316,10 +281,8 @@ public class TestOzoneFileSystem {
 
     // Directory
     FileStatus fileStatus = fs.getFileStatus(parent);
-    assertEquals("FileStatus did not return the directory",
-            "/d1/d2/d3/d4", fileStatus.getPath().toUri().getPath());
-    assertTrue("FileStatus did not return the directory",
-            fileStatus.isDirectory());
+    assertEquals("/d1/d2/d3/d4", fileStatus.getPath().toUri().getPath());
+    assertTrue(fileStatus.isDirectory());
 
     // invalid sub directory
     try {
@@ -351,12 +314,12 @@ public class TestOzoneFileSystem {
     Path parent = new Path("/d1/d2/d3/d4/");
     Path file1 = new Path(parent, "key1");
     try (FSDataOutputStream outputStream = fs.create(file1, false)) {
-      assertNotNull("Should be able to create file", outputStream);
+      assertNotNull(outputStream, "Should be able to create file");
     }
 
     Path subdir = new Path("/d1/d2/");
     boolean status = fs.mkdirs(subdir);
-    assertTrue("Shouldn't send error if dir exists", status);
+    assertTrue(status, "Shouldn't send error if dir exists");
   }
 
   @Test
@@ -412,9 +375,8 @@ public class TestOzoneFileSystem {
   public void testOzoneFsServiceLoader() throws IOException {
     assumeFalse(FILE_SYSTEM_OPTIMIZED.equals(getBucketLayout()));
 
-    assertEquals(
-        FileSystem.getFileSystemClass(OzoneConsts.OZONE_URI_SCHEME, null),
-        OzoneFileSystem.class);
+    assertEquals(OzoneFileSystem.class,
+        FileSystem.getFileSystemClass(OzoneConsts.OZONE_URI_SCHEME, null));
   }
 
   @Test
@@ -435,10 +397,8 @@ public class TestOzoneFileSystem {
     }
 
     // List status on the parent should show the child file
-    assertEquals("List status of parent should include the 1 child file", 1L,
-        fs.listStatus(parent).length);
-    assertTrue("Parent directory does not appear to be a directory",
-        fs.getFileStatus(parent).isDirectory());
+    assertEquals(1L, fs.listStatus(parent).length, "List status of parent should include the 1 child file");
+    assertTrue(fs.getFileStatus(parent).isDirectory(), "Parent directory does not appear to be a directory");
   }
 
   @Test
@@ -601,22 +561,19 @@ public class TestOzoneFileSystem {
     Path file2 = new Path(parent, "key2");
 
     FileStatus[] fileStatuses = o3fs.listStatus(ROOT, EXCLUDE_TRASH);
-    assertEquals("Should be empty", 0, fileStatuses.length);
+    assertEquals(0, fileStatuses.length, "Should be empty");
 
     ContractTestUtils.touch(fs, file1);
     ContractTestUtils.touch(fs, file2);
 
     fileStatuses = o3fs.listStatus(ROOT, EXCLUDE_TRASH);
-    assertEquals("Should have created parent",
-            1, fileStatuses.length);
-    assertEquals("Parent path doesn't match",
-            fileStatuses[0].getPath().toUri().getPath(), parent.toString());
+    assertEquals(1, fileStatuses.length, "Should have created parent");
+    assertEquals(fileStatuses[0].getPath().toUri().getPath(), parent.toString(), "Parent path doesn't match");
 
     // ListStatus on a directory should return all subdirs along with
     // files, even if there exists a file and sub-dir with the same name.
     fileStatuses = o3fs.listStatus(parent);
-    assertEquals("FileStatus did not return all children of the directory",
-        2, fileStatuses.length);
+    assertEquals(2, fileStatuses.length, "FileStatus did not return all children of the directory");
 
     // ListStatus should return only the immediate children of a directory.
     Path file3 = new Path(parent, "dir1/key3");
@@ -624,8 +581,7 @@ public class TestOzoneFileSystem {
     ContractTestUtils.touch(fs, file3);
     ContractTestUtils.touch(fs, file4);
     fileStatuses = o3fs.listStatus(parent);
-    assertEquals("FileStatus did not return all children of the directory",
-        3, fileStatuses.length);
+    assertEquals(3, fileStatuses.length, "FileStatus did not return all children of the directory");
   }
 
   @Test
@@ -661,7 +617,7 @@ public class TestOzoneFileSystem {
     FileStatus[] fileStatuses = fs.listStatus(ROOT, EXCLUDE_TRASH);
 
     // the number of immediate children of root is 1
-    assertEquals(Arrays.toString(fileStatuses), 1, fileStatuses.length);
+    assertEquals(1, fileStatuses.length, Arrays.toString(fileStatuses));
     writeClient.deleteKey(keyArgs);
   }
 
@@ -694,8 +650,7 @@ public class TestOzoneFileSystem {
     FileStatus[] fileStatuses = fs.listStatus(ROOT, EXCLUDE_TRASH);
     // the number of immediate children of root is 1
     assertEquals(1, fileStatuses.length);
-    assertEquals(fileStatuses[0].isErasureCoded(),
-            !bucketLayout.isFileSystemOptimized());
+    assertEquals(fileStatuses[0].isErasureCoded(), !bucketLayout.isFileSystemOptimized());
     fileStatuses = fs.listStatus(new Path(
             fileStatuses[0].getPath().toString() + "/object-name1"));
     assertEquals(1, fileStatuses.length);
@@ -718,8 +673,7 @@ public class TestOzoneFileSystem {
     // exist) and dir2 only. dir12 is not an immediate child of root and
     // hence should not be listed.
     FileStatus[] fileStatuses = o3fs.listStatus(ROOT, EXCLUDE_TRASH);
-    assertEquals("FileStatus should return only the immediate children",
-        2, fileStatuses.length);
+    assertEquals(2, fileStatuses.length, "FileStatus should return only the immediate children");
 
     // Verify that dir12 is not included in the result of the listStatus on root
     String fileStatus1 = fileStatuses[0].getPath().toUri().getPath();
@@ -767,9 +721,7 @@ public class TestOzoneFileSystem {
         LOG.info("actualPathList: {}", actualPathList);
       }
     }
-    assertEquals(
-        "Total directories listed do not match the existing directories",
-        numDirs, fileStatuses.length);
+    assertEquals(numDirs, fileStatuses.length, "Total directories listed do not match the existing directories");
 
     for (int i = 0; i < numDirs; i++) {
       assertTrue(paths.contains(fileStatuses[i].getPath().getName()));
@@ -802,8 +754,7 @@ public class TestOzoneFileSystem {
 
     fileStatuses = fs.listStatus(new Path("/dir1/dir2"));
     assertEquals(1, fileStatuses.length);
-    assertEquals("/dir1/dir2/key1",
-        fileStatuses[0].getPath().toUri().getPath());
+    assertEquals("/dir1/dir2/key1", fileStatuses[0].getPath().toUri().getPath());
     assertTrue(fileStatuses[0].isFile());
   }
 
@@ -824,11 +775,11 @@ public class TestOzoneFileSystem {
       for (FileStatus fileStatus : fileStatuses) {
         LOG.error("Unexpected file, should have been deleted: {}", fileStatus);
       }
-      assertEquals("Delete root failed!", 0, fileStatuses.length);
+      assertEquals(0, fileStatuses.length, "Delete root failed!");
     }
   }
 
-  private static void deleteRootRecursively(FileStatus[] fileStatuses)
+  private void deleteRootRecursively(FileStatus[] fileStatuses)
       throws IOException {
     for (FileStatus fStatus : fileStatuses) {
       fs.delete(fStatus.getPath(), true);
@@ -861,8 +812,7 @@ public class TestOzoneFileSystem {
     fs.mkdirs(dir2);
 
     FileStatus[] fileStatuses = o3fs.listStatus(dir1);
-    assertEquals("FileStatus should return only the immediate children", 2,
-        fileStatuses.length);
+    assertEquals(2, fileStatuses.length, "FileStatus should return only the immediate children");
 
     // Verify that the two children of /dir1 returned by listStatus operation
     // are /dir1/dir11 and /dir1/dir12.
@@ -894,8 +844,7 @@ public class TestOzoneFileSystem {
       while (it.hasNext()) {
         FileStatus fileStatus = it.next();
         assertNotNull(fileStatus);
-        assertEquals("Parent path doesn't match",
-            fileStatus.getPath().toUri().getPath(), parent.toString());
+        assertEquals(fileStatus.getPath().toUri().getPath(), parent.toString(), "Parent path doesn't match");
       }
       // Iterator on a directory should return all subdirs along with
       // files, even if there exists a file and sub-dir with the same name.
@@ -906,9 +855,7 @@ public class TestOzoneFileSystem {
         FileStatus fileStatus = it.next();
         assertNotNull(fileStatus);
       }
-      assertEquals(
-          "Iterator did not return all the file status",
-          2, iCount);
+      assertEquals(2, iCount, "Iterator did not return all the file status");
       // Iterator should return file status for only the
       // immediate children of a directory.
       Path file3 = new Path(parent, "dir1/key3");
@@ -923,8 +870,8 @@ public class TestOzoneFileSystem {
         FileStatus fileStatus = it.next();
         assertNotNull(fileStatus);
       }
-      assertEquals("Iterator did not return file status " +
-          "of all the children of the directory", 3, iCount);
+      assertEquals(3, iCount, "Iterator did not return file status " +
+          "of all the children of the directory");
 
     } finally {
       // Cleanup
@@ -955,11 +902,9 @@ public class TestOzoneFileSystem {
         assertNotNull(fileStatus);
         // Verify that dir12 is not included in the result
         // of the listStatusIterator on root.
-        assertNotEquals(fileStatus.getPath().toUri().getPath(),
-            dir12.toString());
+        assertNotEquals(fileStatus.getPath().toUri().getPath(), dir12.toString());
       }
-      assertEquals("FileStatus should return only the immediate children",
-          2, iCount);
+      assertEquals(2, iCount, "FileStatus should return only the immediate children");
     } finally {
       // Cleanup
       fs.delete(dir2, true);
@@ -1010,8 +955,7 @@ public class TestOzoneFileSystem {
             equals(dir11.toString()) || fileStatus.getPath().toUri().getPath()
             .equals(dir12.toString()));
       }
-      assertEquals("FileStatus should return only the immediate children", 2,
-          iCount);
+      assertEquals(2, iCount, "FileStatus should return only the immediate children");
     } finally {
       // Cleanup
       fs.delete(dir2, true);
@@ -1035,8 +979,7 @@ public class TestOzoneFileSystem {
       fs.open(fileNotExists);
       fail("Should throw FileNotFoundException as file doesn't exist!");
     } catch (FileNotFoundException fnfe) {
-      assertTrue("Expected KEY_NOT_FOUND error",
-              fnfe.getMessage().contains("KEY_NOT_FOUND"));
+      assertTrue(fnfe.getMessage().contains("KEY_NOT_FOUND"), "Expected KEY_NOT_FOUND error");
     }
   }
 
@@ -1059,14 +1002,12 @@ public class TestOzoneFileSystem {
       FileStatus fileStatus = fs.getFileStatus(file);
       long blkSize = fileStatus.getBlockSize();
       long fileLength = fileStatus.getLen();
-      assertTrue("Block allocation should happen",
-              fileLength > blkSize);
+      assertTrue(fileLength > blkSize, "Block allocation should happen");
 
       long newNumBlockAllocations =
               cluster.getOzoneManager().getMetrics().getNumBlockAllocates();
 
-      assertTrue("Block allocation should happen",
-              (newNumBlockAllocations > numBlockAllocationsOrg));
+      assertTrue((newNumBlockAllocations > numBlockAllocationsOrg), "Block allocation should happen");
 
       stream.seek(fileLength);
       assertEquals(-1, stream.read());
@@ -1097,11 +1038,10 @@ public class TestOzoneFileSystem {
     // after rename listStatus for interimPath should succeed and
     // interimPath should have no children
     FileStatus[] statuses = fs.listStatus(interimPath);
-    assertNotNull("liststatus returns a null array", statuses);
-    assertEquals("Statuses array is not empty", 0, statuses.length);
+    assertNotNull(statuses, "liststatus returns a null array");
+    assertEquals(0, statuses.length, "Statuses array is not empty");
     FileStatus fileStatus = fs.getFileStatus(interimPath);
-    assertEquals("FileStatus does not point to interimPath",
-        interimPath.getName(), fileStatus.getPath().getName());
+    assertEquals(interimPath.getName(), fileStatus.getPath().getName(), "FileStatus does not point to interimPath");
   }
 
   /**
@@ -1120,8 +1060,7 @@ public class TestOzoneFileSystem {
     LOG.info("Created destin dir: {}", destin);
 
     LOG.info("Rename op-> source:{} to destin:{}}", source, destin);
-    assertFalse("Expected to fail rename as src doesn't exist",
-            fs.rename(source, destin));
+    assertFalse(fs.rename(source, destin), "Expected to fail rename as src doesn't exist");
   }
 
   /**
@@ -1188,12 +1127,12 @@ public class TestOzoneFileSystem {
     fs.mkdirs(acPath);
 
     // Rename from /a to /b.
-    assertTrue("Rename failed", fs.rename(aSourcePath, bDestinPath));
+    assertTrue(fs.rename(aSourcePath, bDestinPath), "Rename failed");
 
     final Path baPath = new Path(fs.getUri().toString() + "/b/a");
     final Path bacPath = new Path(fs.getUri().toString() + "/b/a/c");
-    assertTrue("Rename failed", fs.exists(baPath));
-    assertTrue("Rename failed", fs.exists(bacPath));
+    assertTrue(fs.exists(baPath), "Rename failed");
+    assertTrue(fs.exists(bacPath), "Rename failed");
   }
 
   /**
@@ -1219,8 +1158,7 @@ public class TestOzoneFileSystem {
     final Path baPath = new Path(fs.getUri().toString() + "/b/a/c");
     fs.mkdirs(baPath);
 
-    assertFalse("New destin sub-path /b/a already exists",
-            fs.rename(aSourcePath, bDestinPath));
+    assertFalse(fs.rename(aSourcePath, bDestinPath), "New destin sub-path /b/a already exists");
 
     // Case-5.b) Rename file from /a/b/c/file1 to /a.
     // Should be failed since /a/file1 exists.
@@ -1234,8 +1172,7 @@ public class TestOzoneFileSystem {
 
     final Path aDestinPath = new Path(fs.getUri().toString() + "/a");
 
-    assertFalse("New destin sub-path /b/a already exists",
-            fs.rename(abcFile1, aDestinPath));
+    assertFalse(fs.rename(abcFile1, aDestinPath), "New destin sub-path /b/a already exists");
   }
 
   /**
@@ -1251,8 +1188,7 @@ public class TestOzoneFileSystem {
     ContractTestUtils.touch(fs, file1Destin);
     Path abcRootPath = new Path(fs.getUri().toString() + "/a/b/c");
     fs.mkdirs(abcRootPath);
-    assertFalse("key already exists /root_dir/file1",
-            fs.rename(abcRootPath, file1Destin));
+    assertFalse(fs.rename(abcRootPath, file1Destin), "key already exists /root_dir/file1");
   }
 
   /**
@@ -1268,8 +1204,8 @@ public class TestOzoneFileSystem {
             + "/file1_Copy");
     ContractTestUtils.touch(fs, file1Source);
     Path file1Destin = new Path(fs.getUri().toString() + root + "/file1");
-    assertTrue("Renamed failed", fs.rename(file1Source, file1Destin));
-    assertTrue("Renamed failed: /root/file1", fs.exists(file1Destin));
+    assertTrue(fs.rename(file1Source, file1Destin), "Renamed failed");
+    assertTrue(fs.exists(file1Destin), "Renamed failed: /root/file1");
 
     /**
      * Reading several times, this is to verify that OmKeyInfo#keyName cached
@@ -1278,8 +1214,8 @@ public class TestOzoneFileSystem {
      */
     for (int i = 0; i < 10; i++) {
       FileStatus[] fStatus = fs.listStatus(rootPath);
-      assertEquals("Renamed failed", 1, fStatus.length);
-      assertEquals("Wrong path name!", file1Destin, fStatus[0].getPath());
+      assertEquals(1, fStatus.length, "Renamed failed");
+      assertEquals(file1Destin, fStatus[0].getPath(), "Wrong path name!");
     }
   }
 
@@ -1296,9 +1232,9 @@ public class TestOzoneFileSystem {
     ContractTestUtils.touch(fs, file1Destin);
     Path abcRootPath = new Path(fs.getUri().toString() + "/a/b/c");
     fs.mkdirs(abcRootPath);
-    assertTrue("Renamed failed", fs.rename(file1Destin, abcRootPath));
-    assertTrue("Renamed filed: /a/b/c/file1", fs.exists(new Path(abcRootPath,
-            "file1")));
+    assertTrue(fs.rename(file1Destin, abcRootPath), "Renamed failed");
+    assertTrue(fs.exists(new Path(abcRootPath,
+            "file1")), "Renamed filed: /a/b/c/file1");
   }
 
   @Test
@@ -1374,18 +1310,16 @@ public class TestOzoneFileSystem {
     ContractTestUtils.touch(fs, file1Source);
 
     // rename source directory to its parent directory(destination).
-    assertTrue("Rename failed", fs.rename(dir2SourcePath, destRootPath));
+    assertTrue(fs.rename(dir2SourcePath, destRootPath), "Rename failed");
     final Path expectedPathAfterRename =
             new Path(fs.getUri().toString() + root + "/dir2");
-    assertTrue("Rename failed",
-            fs.exists(expectedPathAfterRename));
+    assertTrue(fs.exists(expectedPathAfterRename), "Rename failed");
 
     // rename source file to its parent directory(destination).
-    assertTrue("Rename failed", fs.rename(file1Source, destRootPath));
+    assertTrue(fs.rename(file1Source, destRootPath), "Rename failed");
     final Path expectedFilePathAfterRename =
             new Path(fs.getUri().toString() + root + "/file2");
-    assertTrue("Rename failed",
-            fs.exists(expectedFilePathAfterRename));
+    assertTrue(fs.exists(expectedFilePathAfterRename), "Rename failed");
   }
 
   @Test
@@ -1399,11 +1333,10 @@ public class TestOzoneFileSystem {
     LOG.info("Created dir {}", subdir);
     LOG.info("Will move {} to {}", source, dest);
     fs.rename(source, dest);
-    assertTrue("Directory rename failed", fs.exists(dest));
+    assertTrue(fs.exists(dest), "Directory rename failed");
     // Verify that the subdir is also renamed i.e. keys corresponding to the
     // sub-directories of the renamed directory have also been renamed.
-    assertTrue("Keys under the renamed directory not renamed",
-        fs.exists(new Path(dest, "sub_dir1")));
+    assertTrue(fs.exists(new Path(dest, "sub_dir1")), "Keys under the renamed directory not renamed");
 
     // Test if one path belongs to other FileSystem.
     IllegalArgumentException exception = assertThrows(
@@ -1440,8 +1373,7 @@ public class TestOzoneFileSystem {
     FileStatus[] fileStatuses = o3fs.listStatus(mdir11);
     // Above listStatus result should only have one entry: mdir111
     assertEquals(1, fileStatuses.length);
-    assertEquals(mdir111.toString(),
-        fileStatuses[0].getPath().toUri().getPath());
+    assertEquals(mdir111.toString(), fileStatuses[0].getPath().toUri().getPath());
     assertTrue(fileStatuses[0].isDirectory());
     // The dir key is actually created on server,
     // so modification time should always be the same value.
@@ -1457,8 +1389,7 @@ public class TestOzoneFileSystem {
     fileStatuses = o3fs.listStatus(mdir1);
     // Above listStatus result should only have one entry: mdir11
     assertEquals(1, fileStatuses.length);
-    assertEquals(mdir11.toString(),
-        fileStatuses[0].getPath().toUri().getPath());
+    assertEquals(mdir11.toString(), fileStatuses[0].getPath().toUri().getPath());
     assertTrue(fileStatuses[0].isDirectory());
     // Since the dir key doesn't exist on server, the modification time is
     // set to current time upon every listStatus request.
@@ -1538,9 +1469,8 @@ public class TestOzoneFileSystem {
       OzoneFileSystem o3FS, Path keyPath, ReplicationType expectedType)
       throws IOException {
     o3FS.createFile(keyPath).build().close();
-    assertEquals(expectedType.name(),
-        bucket.getKey(o3FS.pathToKey(keyPath)).getReplicationConfig()
-            .getReplicationType().name());
+    assertEquals(expectedType.name(), bucket.getKey(o3FS.pathToKey(keyPath)).getReplicationConfig()
+        .getReplicationType().name());
   }
 
   @Test
@@ -1554,8 +1484,7 @@ public class TestOzoneFileSystem {
     fs.mkdirs(userTrash);
     res = o3fs.getTrashRoots(false);
     assertEquals(1, res.size());
-    res.forEach(e -> assertEquals(
-        userTrash.toString(), e.getPath().toUri().getPath()));
+    res.forEach(e -> assertEquals(userTrash.toString(), e.getPath().toUri().getPath()));
     // Only have one user trash for now
     res = o3fs.getTrashRoots(true);
     assertEquals(1, res.size());
@@ -1572,8 +1501,7 @@ public class TestOzoneFileSystem {
     // allUsers = false should still return current user trash
     res = o3fs.getTrashRoots(false);
     assertEquals(1, res.size());
-    res.forEach(e -> assertEquals(
-        userTrash.toString(), e.getPath().toUri().getPath()));
+    res.forEach(e -> assertEquals(userTrash.toString(), e.getPath().toUri().getPath()));
     // allUsers = true should return all user trash
     res = o3fs.getTrashRoots(true);
     assertEquals(6, res.size());
@@ -1663,8 +1591,7 @@ public class TestOzoneFileSystem {
           cluster.getOzoneManager().getKeyManager());
       fail("Non-existent key name!");
     } catch (OMException ome) {
-      assertEquals(OMException.ResultCodes.KEY_NOT_FOUND,
-          ome.getResult());
+      assertEquals(OMException.ResultCodes.KEY_NOT_FOUND, ome.getResult());
     }
 
     OzonePrefixPathImpl ozonePrefixPath =
@@ -1678,7 +1605,7 @@ public class TestOzoneFileSystem {
 
     Iterator<? extends OzoneFileStatus> pathItr =
         ozonePrefixPath.getChildren(keyName);
-    assertTrue("Failed to list keyPath:" + keyName, pathItr.hasNext());
+    assertTrue(pathItr.hasNext(), "Failed to list keyPath:" + keyName);
 
     Set<String> actualPaths = new TreeSet<>();
     while (pathItr.hasNext()) {
@@ -1689,17 +1616,15 @@ public class TestOzoneFileSystem {
       Iterator<? extends OzoneFileStatus> subPathItr =
           ozonePrefixPath.getChildren(pathname);
       assertNotNull(subPathItr);
-      assertFalse("Failed to list keyPath: " + pathname,
-          subPathItr.hasNext());
+      assertFalse(subPathItr.hasNext(), "Failed to list keyPath: " + pathname);
     }
 
-    assertEquals("ListStatus failed", paths.size(),
-        actualPaths.size());
+    assertEquals(paths.size(), actualPaths.size(), "ListStatus failed");
 
     for (String pathname : actualPaths) {
       paths.remove(pathname);
     }
-    assertTrue("ListStatus failed:" + paths, paths.isEmpty());
+    assertTrue(paths.isEmpty(), "ListStatus failed:" + paths);
   }
 
   @Test
@@ -1760,8 +1685,7 @@ public class TestOzoneFileSystem {
       fail("Should throw Exception due to loop in Link Buckets");
     } catch (OMException oe) {
       // Expected exception
-      assertEquals(OMException.ResultCodes.DETECTED_LOOP_IN_BUCKET_LINKS,
-          oe.getResult());
+      assertEquals(OMException.ResultCodes.DETECTED_LOOP_IN_BUCKET_LINKS, oe.getResult());
     } finally {
       volume.deleteBucket(linkBucket1Name);
       volume.deleteBucket(linkBucket2Name);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTestWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTestWithFSO.java
@@ -33,60 +33,40 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Ozone file system tests that are not covered by contract tests,
  * - prefix layout.
  *
  */
-@RunWith(Parameterized.class)
-public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-            new Object[]{true, true},
-            new Object[]{true, false});
-  }
-
-  @BeforeClass
-  public static void init() {
-    setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED);
-  }
-
-  public TestOzoneFileSystemWithFSO(boolean setDefaultFs,
-      boolean enableOMRatis) {
-    super(setDefaultFs, enableOMRatis);
-  }
-
-  @After
-  @Override
-  public void cleanup() {
-    super.cleanup();
-  }
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+abstract class AbstractOzoneFileSystemTestWithFSO extends AbstractOzoneFileSystemTest {
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(TestOzoneFileSystemWithFSO.class);
+      LoggerFactory.getLogger(AbstractOzoneFileSystemTestWithFSO.class);
+
+  AbstractOzoneFileSystemTestWithFSO(boolean enableOMRatis) {
+    super(true, enableOMRatis, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+  }
 
   @Test
   public void testListStatusWithoutRecursiveSearch() throws Exception {
@@ -102,32 +82,27 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
     Path key1 = new Path("/key1");
     try (FSDataOutputStream outputStream = getFs().create(key1,
             false)) {
-      assertNotNull("Should be able to create file: key1",
-              outputStream);
+      assertNotNull(outputStream, "Should be able to create file: key1");
     }
     Path d1 = new Path("/d1");
     Path dir1Key1 = new Path(d1, "key1");
     try (FSDataOutputStream outputStream = getFs().create(dir1Key1, false)) {
-      assertNotNull("Should be able to create file: " + dir1Key1,
-              outputStream);
+      assertNotNull(outputStream, "Should be able to create file: " + dir1Key1);
     }
     Path d2 = new Path("/d2");
     Path dir2Key1 = new Path(d2, "key1");
     try (FSDataOutputStream outputStream = getFs().create(dir2Key1, false)) {
-      assertNotNull("Should be able to create file: " + dir2Key1,
-              outputStream);
+      assertNotNull(outputStream, "Should be able to create file: " + dir2Key1);
     }
     Path dir1Dir2 = new Path("/d1/d2/");
     Path dir1Dir2Key1 = new Path(dir1Dir2, "key1");
     try (FSDataOutputStream outputStream = getFs().create(dir1Dir2Key1,
             false)) {
-      assertNotNull("Should be able to create file: " + dir1Dir2Key1,
-              outputStream);
+      assertNotNull(outputStream, "Should be able to create file: " + dir1Dir2Key1);
     }
     Path d1Key2 = new Path(d1, "key2");
     try (FSDataOutputStream outputStream = getFs().create(d1Key2, false)) {
-      assertNotNull("Should be able to create file: " + d1Key2,
-              outputStream);
+      assertNotNull(outputStream, "Should be able to create file: " + d1Key2);
     }
 
     Path dir1Dir3 = new Path("/d1/d3/");
@@ -141,8 +116,7 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
 
     // Root Directory
     FileStatus[] fileStatusList = getFs().listStatus(new Path("/"));
-    assertEquals("FileStatus should return files and directories",
-            3, fileStatusList.length);
+    assertEquals(3, fileStatusList.length, "FileStatus should return files and directories");
     ArrayList<String> expectedPaths = new ArrayList<>();
     expectedPaths.add("o3fs://" + bucketName + "." + volumeName + "/d1");
     expectedPaths.add("o3fs://" + bucketName + "." + volumeName + "/d2");
@@ -150,13 +124,11 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
     for (FileStatus fileStatus : fileStatusList) {
       expectedPaths.remove(fileStatus.getPath().toString());
     }
-    assertEquals("Failed to return the filestatus[]" + expectedPaths,
-            0, expectedPaths.size());
+    assertEquals(0, expectedPaths.size(), "Failed to return the filestatus[]" + expectedPaths);
 
     // level-1 sub-dirs
     fileStatusList = getFs().listStatus(new Path("/d1"));
-    assertEquals("FileStatus should return files and directories",
-            5, fileStatusList.length);
+    assertEquals(5, fileStatusList.length, "FileStatus should return files and directories");
     expectedPaths = new ArrayList<>();
     expectedPaths.add("o3fs://" + bucketName + "." + volumeName + "/d1/d2");
     expectedPaths.add("o3fs://" + bucketName + "." + volumeName + "/d1/d3");
@@ -166,34 +138,29 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
     for (FileStatus fileStatus : fileStatusList) {
       expectedPaths.remove(fileStatus.getPath().toString());
     }
-    assertEquals("Failed to return the filestatus[]" + expectedPaths,
-            0, expectedPaths.size());
+    assertEquals(0, expectedPaths.size(), "Failed to return the filestatus[]" + expectedPaths);
 
     // level-2 sub-dirs
     fileStatusList = getFs().listStatus(new Path("/d1/d2"));
-    assertEquals("FileStatus should return files and directories",
-            1, fileStatusList.length);
+    assertEquals(1, fileStatusList.length, "FileStatus should return files and directories");
     expectedPaths = new ArrayList<>();
     expectedPaths.add("o3fs://" + bucketName + "." + volumeName + "/d1/d2/" +
             "key1");
     for (FileStatus fileStatus : fileStatusList) {
       expectedPaths.remove(fileStatus.getPath().toString());
     }
-    assertEquals("Failed to return the filestatus[]" + expectedPaths,
-            0, expectedPaths.size());
+    assertEquals(0, expectedPaths.size(), "Failed to return the filestatus[]" + expectedPaths);
 
     // level-2 key2
     fileStatusList = getFs().listStatus(new Path("/d1/d2/key1"));
-    assertEquals("FileStatus should return files and directories",
-            1, fileStatusList.length);
+    assertEquals(1, fileStatusList.length, "FileStatus should return files and directories");
     expectedPaths = new ArrayList<>();
     expectedPaths.add("o3fs://" + bucketName + "." + volumeName + "/d1/d2/" +
             "key1");
     for (FileStatus fileStatus : fileStatusList) {
       expectedPaths.remove(fileStatus.getPath().toString());
     }
-    assertEquals("Failed to return the filestatus[]" + expectedPaths,
-            0, expectedPaths.size());
+    assertEquals(0, expectedPaths.size(), "Failed to return the filestatus[]" + expectedPaths);
 
     // invalid root key
     try {
@@ -222,24 +189,21 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
     Path dir1Dir1Dir2Key1 = new Path("/d1/d1/d2/key1");
     try (FSDataOutputStream outputStream = getFs().create(dir1Dir1Dir2Key1,
             false)) {
-      assertNotNull("Should be able to create file: " + dir1Dir1Dir2Key1,
-              outputStream);
+      assertNotNull(outputStream, "Should be able to create file: " + dir1Dir1Dir2Key1);
     }
     Path key1 = new Path("/key1");
     try (FSDataOutputStream outputStream = getFs().create(key1, false)) {
-      assertNotNull("Should be able to create file: " + key1,
-              outputStream);
+      assertNotNull(outputStream, "Should be able to create file: " + key1);
     }
     Path key2 = new Path("/key2");
     try (FSDataOutputStream outputStream = getFs().create(key2, false)) {
-      assertNotNull("Should be able to create file: key2",
-              outputStream);
+      assertNotNull(outputStream, "Should be able to create file: key2");
     }
     Path dir1Dir2Dir1Dir2Key1 = new Path("/d1/d2/d1/d2/key1");
     try (FSDataOutputStream outputStream = getFs().create(dir1Dir2Dir1Dir2Key1,
             false)) {
-      assertNotNull("Should be able to create file: "
-              + dir1Dir2Dir1Dir2Key1, outputStream);
+      assertNotNull(outputStream, "Should be able to create file: "
+              + dir1Dir2Dir1Dir2Key1);
     }
     RemoteIterator<LocatedFileStatus> fileStatusItr = getFs().listFiles(
             new Path("/"), true);
@@ -256,10 +220,8 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
       expectedPaths.remove(status.getPath().toString());
       actualCount++;
     }
-    assertEquals("Failed to get all the files: " + expectedPaths,
-            expectedFilesCount, actualCount);
-    assertEquals("Failed to get all the files: " + expectedPaths, 0,
-            expectedPaths.size());
+    assertEquals(expectedFilesCount, actualCount, "Failed to get all the files: " + expectedPaths);
+    assertEquals(0, expectedPaths.size(), "Failed to get all the files: " + expectedPaths);
 
     // Recursive=false
     fileStatusItr = getFs().listFiles(new Path("/"), false);
@@ -273,10 +235,8 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
       expectedPaths.remove(status.getPath().toString());
       actualCount++;
     }
-    assertEquals("Failed to get all the files: " + expectedPaths, 0,
-            expectedPaths.size());
-    assertEquals("Failed to get all the files: " + expectedPaths,
-            expectedFilesCount, actualCount);
+    assertEquals(0, expectedPaths.size(), "Failed to get all the files: " + expectedPaths);
+    assertEquals(expectedFilesCount, actualCount, "Failed to get all the files: " + expectedPaths);
   }
 
   /**
@@ -431,8 +391,7 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
     // reset metrics
     long numKeys = getCluster().getOzoneManager().getMetrics().getNumKeys();
     getCluster().getOzoneManager().getMetrics().decNumKeys(numKeys);
-    assertEquals(0,
-        getCluster().getOzoneManager().getMetrics().getNumKeys());
+    assertEquals(0, getCluster().getOzoneManager().getMetrics().getNumKeys());
 
     // Op 1. create dir -> /d1/d2/d3/d4/
     // Op 2. create dir -> /d1/d2/d3/d4/d5
@@ -444,7 +403,7 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
         getCluster().getOzoneManager().getMetadataManager();
     OmBucketInfo omBucketInfo = omMgr.getBucketTable()
         .get(omMgr.getBucketKey(getVolumeName(), getBucketName()));
-    assertNotNull("Failed to find bucketInfo", omBucketInfo);
+    assertNotNull(omBucketInfo, "Failed to find bucketInfo");
 
     final long volumeId = omMgr.getVolumeId(getVolumeName());
     final long bucketId = omMgr.getBucketId(getVolumeName(), getBucketName());
@@ -462,8 +421,7 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
         verifyDirKey(volumeId, bucketId, d3ObjectID,
                 "d4", "/d1/d2/d3/d4", dirKeys, omMgr);
 
-    assertEquals("Wrong OM numKeys metrics", 4,
-        getCluster().getOzoneManager().getMetrics().getNumKeys());
+    assertEquals(4, getCluster().getOzoneManager().getMetrics().getNumKeys(), "Wrong OM numKeys metrics");
 
     // create sub-dirs under same parent
     Path subDir5 = new Path("/d1/d2/d3/d4/d5");
@@ -476,15 +434,14 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
     long d6ObjectID =
         verifyDirKey(volumeId, bucketId, d4ObjectID,
                 "d6", "/d1/d2/d3/d4/d6", dirKeys, omMgr);
-    assertTrue(
-        "Wrong objectIds for sub-dirs[" + d5ObjectID + "/d5, " + d6ObjectID
-            + "/d6] of same parent!", d5ObjectID != d6ObjectID);
+    assertTrue(d5ObjectID != d6ObjectID, "Wrong objectIds for sub-dirs[" + d5ObjectID + "/d5, " + d6ObjectID
+        + "/d6] of same parent!");
 
-    assertEquals("Wrong OM numKeys metrics", 6,
-        getCluster().getOzoneManager().getMetrics().getNumKeys());
+    assertEquals(6, getCluster().getOzoneManager().getMetrics().getNumKeys(), "Wrong OM numKeys metrics");
   }
 
   @Test
+  @Order(1)
   public void testCreateFile() throws Exception {
     // Op 1. create dir -> /d1/d2/d3/d4/
     Path parent = new Path("/d1/d2/");
@@ -496,7 +453,7 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
         getCluster().getOzoneManager().getMetadataManager();
     OmBucketInfo omBucketInfo = omMgr.getBucketTable()
         .get(omMgr.getBucketKey(getVolumeName(), getBucketName()));
-    assertNotNull("Failed to find bucketInfo", omBucketInfo);
+    assertNotNull(omBucketInfo, "Failed to find bucketInfo");
 
     ArrayList<String> dirKeys = new ArrayList<>();
 
@@ -516,7 +473,7 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
     outputStream.close();
 
     OmKeyInfo omKeyInfo = omMgr.getKeyTable(getBucketLayout()).get(openFileKey);
-    assertNotNull("Invalid Key!", omKeyInfo);
+    assertNotNull(omKeyInfo, "Invalid Key!");
     verifyOMFileInfoFormat(omKeyInfo, file.getName(), d2ObjectID);
 
     // wait for DB updates
@@ -571,11 +528,10 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
 
   private void verifyOMFileInfoFormat(OmKeyInfo omKeyInfo, String fileName,
       long parentID) {
-    assertEquals("Wrong keyName", fileName, omKeyInfo.getKeyName());
-    assertEquals("Wrong parentID", parentID,
-        omKeyInfo.getParentObjectID());
+    assertEquals(fileName, omKeyInfo.getKeyName(), "Wrong keyName");
+    assertEquals(parentID, omKeyInfo.getParentObjectID(), "Wrong parentID");
     String dbKey = parentID + OzoneConsts.OM_KEY_PREFIX + fileName;
-    assertEquals("Wrong path format", dbKey, omKeyInfo.getPath());
+    assertEquals(dbKey, omKeyInfo.getPath(), "Wrong path format");
   }
 
   long verifyDirKey(long volumeId, long bucketId, long parentId,
@@ -586,21 +542,13 @@ public class TestOzoneFileSystemWithFSO extends TestOzoneFileSystem {
             parentId + "/" + dirKey;
     dirKeys.add(dbKey);
     OmDirectoryInfo dirInfo = omMgr.getDirectoryTable().get(dbKey);
-    assertNotNull("Failed to find " + absolutePath +
-        " using dbKey: " + dbKey, dirInfo);
-    assertEquals("Parent Id mismatches", parentId,
-        dirInfo.getParentObjectID());
-    assertEquals("Mismatches directory name", dirKey,
-        dirInfo.getName());
-    assertTrue("Mismatches directory creation time param",
-        dirInfo.getCreationTime() > 0);
-    assertEquals("Mismatches directory modification time param",
-        dirInfo.getCreationTime(), dirInfo.getModificationTime());
+    assertNotNull(dirInfo, "Failed to find " + absolutePath +
+        " using dbKey: " + dbKey);
+    assertEquals(parentId, dirInfo.getParentObjectID(), "Parent Id mismatches");
+    assertEquals(dirKey, dirInfo.getName(), "Mismatches directory name");
+    assertTrue(dirInfo.getCreationTime() > 0, "Mismatches directory creation time param");
+    assertEquals(dirInfo.getCreationTime(), dirInfo.getModificationTime());
     return dirInfo.getObjectID();
   }
 
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FS.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestO3FS extends AbstractOzoneFileSystemTest {
+  TestO3FS() {
+    super(false, false, BucketLayout.LEGACY);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithFSO.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestO3FSWithFSO extends AbstractOzoneFileSystemTestWithFSO {
+  TestO3FSWithFSO() {
+    super(false);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithFSOAndOMRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithFSOAndOMRatis.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestO3FSWithFSOAndOMRatis extends AbstractOzoneFileSystemTestWithFSO {
+  TestO3FSWithFSOAndOMRatis() {
+    super(true);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithFSPaths.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithFSPaths.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestO3FSWithFSPaths extends AbstractOzoneFileSystemTest {
+  TestO3FSWithFSPaths() {
+    super(true, false, BucketLayout.LEGACY);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithFSPathsAndOMRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithFSPathsAndOMRatis.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestO3FSWithFSPathsAndOMRatis extends AbstractOzoneFileSystemTest {
+  TestO3FSWithFSPathsAndOMRatis() {
+    super(true, true, BucketLayout.LEGACY);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithOMRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestO3FSWithOMRatis.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestO3FSWithOMRatis extends AbstractOzoneFileSystemTest {
+  TestO3FSWithOMRatis() {
+    super(false, true, BucketLayout.LEGACY);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate `TestOzoneFileSystem` and its subclass `TestOzoneFileSystemWithFSO` to JUnit5.

https://issues.apache.org/jira/browse/HDDS-6152

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7213522269/job/19654186050