### PR TITLE
HDDS-9923. Update line length limit in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ We use GitHub pull requests for contributing changes to the repository. The main
 Basic code conventions followed by Ozone:
 
  * 2 spaces indentation
- * 80-char line length limit
+ * 120-char line length limit
  * Apache license header required in most files
  * no `@author` tags, authorship is indicated by Git history
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Line length limit was increased to 120 chars in PR #921 . So update CONTRIBUTING.md to reflect that.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9923

## How was this patch tested?
Did a change in CONTRIBUTING.md and manually verified it
