### PR TITLE
HDDS-9494. Migrate parameterized tests in hdds-container-service to JUnit5

### DIFF
--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -27,7 +27,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <description>Apache Ozone Distributed Data Store Container Service</description>
   <name>Apache Ozone HDDS Container Service</name>
   <packaging>jar</packaging>
-
+  <properties>
+    <allow.junit4>false</allow.junit4>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -71,12 +71,13 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.apache.ozone.test.JUnit5AwareTimeout;
@@ -147,7 +148,7 @@ public class TestBlockDeletingService {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     CodecBuffer.enableLeakDetection();
 
@@ -165,7 +166,7 @@ public class TestBlockDeletingService {
     createDbInstancesForTestIfNeeded(volumeSet, scmId, scmId, conf);
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     BlockUtils.shutdownCache(conf);
     FileUtils.deleteDirectory(testRoot);
@@ -899,7 +900,7 @@ public class TestBlockDeletingService {
   }
 
   @Test
-  @org.junit.Ignore
+  @Disabled
   public void testContainerThrottle() throws Exception {
     // Properties :
     //  - Number of containers : 2

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -72,7 +72,7 @@ import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
@@ -460,11 +460,11 @@ public class TestBlockDeletingService {
         0, 1);
     try (DBHandle db = BlockUtils.getDB(incorrectData, conf)) {
       // Check pre-create state.
-      Assert.assertEquals(0, getUnderDeletionBlocksCount(db,
+      Assertions.assertEquals(0, getUnderDeletionBlocksCount(db,
           incorrectData));
-      Assert.assertEquals(0, db.getStore().getMetadataTable()
+      Assertions.assertEquals(0, db.getStore().getMetadataTable()
           .get(incorrectData.getPendingDeleteBlockCountKey()).longValue());
-      Assert.assertEquals(0,
+      Assertions.assertEquals(0,
           incorrectData.getNumPendingDeletionBlocks());
 
       // Alter the pending delete value in memory and the DB.
@@ -479,12 +479,12 @@ public class TestBlockDeletingService {
     KeyValueContainerData correctData = createToDeleteBlocks(containerSet,
         correctNumBlocksToDelete, 1);
     // Check its metadata was set up correctly.
-    Assert.assertEquals(correctNumBlocksToDelete,
+    Assertions.assertEquals(correctNumBlocksToDelete,
         correctData.getNumPendingDeletionBlocks());
     try (DBHandle db = BlockUtils.getDB(correctData, conf)) {
-      Assert.assertEquals(correctNumBlocksToDelete,
+      Assertions.assertEquals(correctNumBlocksToDelete,
           getUnderDeletionBlocksCount(db, correctData));
-      Assert.assertEquals(correctNumBlocksToDelete,
+      Assertions.assertEquals(correctNumBlocksToDelete,
           db.getStore().getMetadataTable()
               .get(correctData.getPendingDeleteBlockCountKey()).longValue());
     }
@@ -508,20 +508,20 @@ public class TestBlockDeletingService {
 
     // Pending delete block count in the incorrect container should be fixed
     // and reset to 0.
-    Assert.assertEquals(0, incorrectData.getNumPendingDeletionBlocks());
+    Assertions.assertEquals(0, incorrectData.getNumPendingDeletionBlocks());
     try (DBHandle db = BlockUtils.getDB(incorrectData, conf)) {
-      Assert.assertEquals(0, getUnderDeletionBlocksCount(db,
+      Assertions.assertEquals(0, getUnderDeletionBlocksCount(db,
           incorrectData));
-      Assert.assertEquals(0, db.getStore().getMetadataTable()
+      Assertions.assertEquals(0, db.getStore().getMetadataTable()
           .get(incorrectData.getPendingDeleteBlockCountKey()).longValue());
     }
     // Correct container should not have been processed.
-    Assert.assertEquals(correctNumBlocksToDelete,
+    Assertions.assertEquals(correctNumBlocksToDelete,
         correctData.getNumPendingDeletionBlocks());
     try (DBHandle db = BlockUtils.getDB(correctData, conf)) {
-      Assert.assertEquals(correctNumBlocksToDelete,
+      Assertions.assertEquals(correctNumBlocksToDelete,
           getUnderDeletionBlocksCount(db, correctData));
-      Assert.assertEquals(correctNumBlocksToDelete,
+      Assertions.assertEquals(correctNumBlocksToDelete,
           db.getStore().getMetadataTable()
               .get(correctData.getPendingDeleteBlockCountKey()).longValue());
     }
@@ -532,20 +532,20 @@ public class TestBlockDeletingService {
 
     // The incorrect container should remain in the same state after being
     // fixed.
-    Assert.assertEquals(0, incorrectData.getNumPendingDeletionBlocks());
+    Assertions.assertEquals(0, incorrectData.getNumPendingDeletionBlocks());
     try (DBHandle db = BlockUtils.getDB(incorrectData, conf)) {
-      Assert.assertEquals(0, getUnderDeletionBlocksCount(db,
+      Assertions.assertEquals(0, getUnderDeletionBlocksCount(db,
           incorrectData));
-      Assert.assertEquals(0, db.getStore().getMetadataTable()
+      Assertions.assertEquals(0, db.getStore().getMetadataTable()
           .get(incorrectData.getPendingDeleteBlockCountKey()).longValue());
     }
     // The correct container should have been processed this run and had its
     // blocks deleted.
-    Assert.assertEquals(0, correctData.getNumPendingDeletionBlocks());
+    Assertions.assertEquals(0, correctData.getNumPendingDeletionBlocks());
     try (DBHandle db = BlockUtils.getDB(correctData, conf)) {
-      Assert.assertEquals(0, getUnderDeletionBlocksCount(db,
+      Assertions.assertEquals(0, getUnderDeletionBlocksCount(db,
           correctData));
-      Assert.assertEquals(0, db.getStore().getMetadataTable()
+      Assertions.assertEquals(0, db.getStore().getMetadataTable()
           .get(correctData.getPendingDeleteBlockCountKey()).longValue());
     }
   }
@@ -573,7 +573,7 @@ public class TestBlockDeletingService {
     // Ensure 1 container was created
     List<ContainerData> containerData = Lists.newArrayList();
     containerSet.listContainer(0L, 1, containerData);
-    Assert.assertEquals(1, containerData.size());
+    Assertions.assertEquals(1, containerData.size());
     KeyValueContainerData data = (KeyValueContainerData) containerData.get(0);
     KeyPrefixFilter filter = isSameSchemaVersion(schemaVersion, SCHEMA_V1) ?
         data.getDeletingBlockKeyFilter() : data.getUnprefixedKeyFilter();
@@ -597,40 +597,40 @@ public class TestBlockDeletingService {
           deletingServiceMetrics.getTotalBlockChosenCount();
       long totalContainerChosenCount =
           deletingServiceMetrics.getTotalContainerChosenCount();
-      Assert.assertEquals(0, transactionId);
+      Assertions.assertEquals(0, transactionId);
 
       // Ensure there are 3 blocks under deletion and 0 deleted blocks
-      Assert.assertEquals(3, getUnderDeletionBlocksCount(meta, data));
-      Assert.assertEquals(3, meta.getStore().getMetadataTable()
+      Assertions.assertEquals(3, getUnderDeletionBlocksCount(meta, data));
+      Assertions.assertEquals(3, meta.getStore().getMetadataTable()
           .get(data.getPendingDeleteBlockCountKey()).longValue());
 
       // Container contains 3 blocks. So, space used by the container
       // should be greater than zero.
-      Assert.assertTrue(containerSpace > 0);
+      Assertions.assertTrue(containerSpace > 0);
 
       // An interval will delete 1 * 2 blocks
       deleteAndWait(svc, 1);
 
       GenericTestUtils.waitFor(() ->
-              containerData.get(0).getBytesUsed() == containerSpace /
-                      3, 100, 3000);
+          containerData.get(0).getBytesUsed() == containerSpace /
+              3, 100, 3000);
       // After first interval 2 blocks will be deleted. Hence, current space
       // used by the container should be less than the space used by the
       // container initially(before running deletion services).
-      Assert.assertTrue(containerData.get(0).getBytesUsed() < containerSpace);
-      Assert.assertEquals(2,
+      Assertions.assertTrue(containerData.get(0).getBytesUsed() < containerSpace);
+      Assertions.assertEquals(2,
           deletingServiceMetrics.getSuccessCount()
               - deleteSuccessCount);
-      Assert.assertEquals(2,
+      Assertions.assertEquals(2,
           deletingServiceMetrics.getTotalBlockChosenCount()
               - totalBlockChosenCount);
-      Assert.assertEquals(1,
+      Assertions.assertEquals(1,
           deletingServiceMetrics.getTotalContainerChosenCount()
               - totalContainerChosenCount);
       // The value of the getTotalPendingBlockCount Metrics is obtained
       // before the deletion is processing
       // So the Pending Block count will be 3
-      Assert.assertEquals(3,
+      Assertions.assertEquals(3,
           deletingServiceMetrics.getTotalPendingBlockCount());
 
       deleteAndWait(svc, 2);
@@ -642,18 +642,18 @@ public class TestBlockDeletingService {
 
       // Check finally DB counters.
       // Not checking bytes used, as handler is a mock call.
-      Assert.assertEquals(0, meta.getStore().getMetadataTable()
+      Assertions.assertEquals(0, meta.getStore().getMetadataTable()
           .get(data.getPendingDeleteBlockCountKey()).longValue());
-      Assert.assertEquals(0,
+      Assertions.assertEquals(0,
           meta.getStore().getMetadataTable().get(data.getBlockCountKey())
               .longValue());
-      Assert.assertEquals(3,
+      Assertions.assertEquals(3,
           deletingServiceMetrics.getSuccessCount()
               - deleteSuccessCount);
-      Assert.assertEquals(3,
+      Assertions.assertEquals(3,
           deletingServiceMetrics.getTotalBlockChosenCount()
               - totalBlockChosenCount);
-      Assert.assertEquals(2,
+      Assertions.assertEquals(2,
           deletingServiceMetrics.getTotalContainerChosenCount()
               - totalContainerChosenCount);
 
@@ -662,7 +662,7 @@ public class TestBlockDeletingService {
       // The value of the getTotalPendingBlockCount Metrics is obtained
       // before the deletion is processing
       // So the Pending Block count will be 1
-      Assert.assertEquals(1,
+      Assertions.assertEquals(1,
           deletingServiceMetrics.getTotalPendingBlockCount());
     }
     svc.shutdown();
@@ -699,7 +699,7 @@ public class TestBlockDeletingService {
     // Ensure 2 container was created
     List<ContainerData> containerData = Lists.newArrayList();
     containerSet.listContainer(0L, 2, containerData);
-    Assert.assertEquals(2, containerData.size());
+    Assertions.assertEquals(2, containerData.size());
     KeyValueContainerData ctr1 = (KeyValueContainerData) containerData.get(0);
     KeyValueContainerData ctr2 = (KeyValueContainerData) containerData.get(1);
     KeyPrefixFilter filter = isSameSchemaVersion(schemaVersion, SCHEMA_V1) ?
@@ -737,7 +737,7 @@ public class TestBlockDeletingService {
       for (int m = 0; m < numExistingOnDiskUnrecordedBlocks; m++) {
         File chunk = iter.next();
         createRandomContentFile(chunk.getName(), chunkDir, 100);
-        Assert.assertTrue(chunk.exists());
+        Assertions.assertTrue(chunk.exists());
       }
 
       createTxn(ctr1, unrecordedBlockIds, 100, ctr1.getContainerID());
@@ -746,12 +746,12 @@ public class TestBlockDeletingService {
       updateMetaData(ctr1, (KeyValueContainer) containerSet.getContainer(
           ctr1.getContainerID()), 3, 1);
       // Ensure there are 3 + 4 = 7 blocks under deletion
-      Assert.assertEquals(7, getUnderDeletionBlocksCount(meta, ctr1));
+      Assertions.assertEquals(7, getUnderDeletionBlocksCount(meta, ctr1));
     }
 
     assertBlockDataTableRecordCount(3, ctr1, filter);
     assertBlockDataTableRecordCount(3, ctr2, filter);
-    Assert.assertEquals(3, ctr2.getNumPendingDeletionBlocks());
+    Assertions.assertEquals(3, ctr2.getNumPendingDeletionBlocks());
 
     // Totally 2 container * 3 blocks + 4 unrecorded block = 10 blocks
     // So we shall experience 5 rounds to delete all blocks
@@ -765,18 +765,18 @@ public class TestBlockDeletingService {
         200, 2000);
 
     // To make sure the container stat calculation is right
-    Assert.assertEquals(0, ctr1.getBlockCount());
-    Assert.assertEquals(0, ctr1.getBytesUsed());
-    Assert.assertEquals(0, ctr2.getBlockCount());
-    Assert.assertEquals(0, ctr2.getBytesUsed());
+    Assertions.assertEquals(0, ctr1.getBlockCount());
+    Assertions.assertEquals(0, ctr1.getBytesUsed());
+    Assertions.assertEquals(0, ctr2.getBlockCount());
+    Assertions.assertEquals(0, ctr2.getBytesUsed());
 
     // check if blockData get deleted
     assertBlockDataTableRecordCount(0, ctr1, filter);
     assertBlockDataTableRecordCount(0, ctr2, filter);
 
     // check if all the unreferenced chunks get deleted
-    for (File f: unrecordedChunks) {
-      Assert.assertFalse(f.exists());
+    for (File f : unrecordedChunks) {
+      Assertions.assertFalse(f.exists());
     }
 
     svc.shutdown();
@@ -874,7 +874,7 @@ public class TestBlockDeletingService {
 
       // The block deleting successfully and shouldn't catch timed
       // out warning log.
-      Assert.assertFalse(newLog.getOutput().contains(
+      Assertions.assertFalse(newLog.getOutput().contains(
           "Background task executes timed out, retrying in next interval"));
     }
     svc.shutdown();
@@ -949,7 +949,7 @@ public class TestBlockDeletingService {
                       containerData.get(1).getBytesUsed() == 0),
               100, 3000);
 
-      Assert.assertFalse((containerData.get(0).getBytesUsed() == 0) && (
+      Assertions.assertFalse((containerData.get(0).getBytesUsed() == 0) && (
           containerData.get(1).getBytesUsed() == 0));
 
       // Deleting the second container. Hence, space used by both the
@@ -1006,7 +1006,7 @@ public class TestBlockDeletingService {
         // a timeout except the last one, where a "deletion transaction"
         // will be created for each Block, so it will start
         // blocksPerContainer - 1 timeout.
-        Assert.assertEquals(blocksPerContainer - 1,
+        Assertions.assertEquals(blocksPerContainer - 1,
             StringUtils.countMatches(log.getOutput(), "Max lock hold time"));
       }
     } finally {
@@ -1136,9 +1136,9 @@ public class TestBlockDeletingService {
         count += 1;
       }
     }
-    Assert.assertEquals("Excepted: " + expectedCount
+    Assertions.assertEquals(expectedCount, count, "Excepted: " + expectedCount
         + ", but actual: " + count + " in the blockData table of container: "
-        + containerID + ".", expectedCount, count);
+        + containerID + ".");
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
@@ -26,9 +26,8 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,29 +38,29 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * This class is used to test the KeyValueContainerData.
  */
-@RunWith(Parameterized.class)
 public class TestKeyValueContainerData {
 
   private static final long MAXSIZE = (long) StorageUnit.GB.toBytes(5);
 
-  private final ContainerLayoutVersion layout;
-  private final String schemaVersion;
-  private final OzoneConfiguration conf;
+  private ContainerLayoutVersion layout;
+  private String schemaVersion;
+  private OzoneConfiguration conf;
 
-  public TestKeyValueContainerData(ContainerTestVersionInfo versionInfo) {
+  private void initVersionInfo(ContainerTestVersionInfo versionInfo) {
     this.layout = versionInfo.getLayout();
     this.schemaVersion = versionInfo.getSchemaVersion();
     this.conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
   }
 
-  @Parameterized.Parameters
-  public static Iterable<Object[]> parameters() {
+  private static Iterable<Object[]> versionInfo() {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @Test
-  public void testKeyValueData() {
+  @ParameterizedTest
+  @MethodSource("versionInfo")
+  public void testKeyValueData(ContainerTestVersionInfo versionInfo) {
+    initVersionInfo(versionInfo);
     long containerId = 1L;
     ContainerProtos.ContainerType containerType = ContainerProtos
         .ContainerType.KeyValueContainer;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import org.apache.hadoop.ozone.container.metadata.SchemaOneDeletedBlocksTable;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -69,6 +70,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTA
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -133,6 +135,11 @@ public class TestSchemaOneBackwardsCompatibility {
         metadataDir.getAbsolutePath());
   }
 
+  @AfterEach
+  public void cleanup() {
+    BlockUtils.shutdownCache(conf);
+  }
+
   /**
    * Because all tables in schema version one map back to the default table,
    * directly iterating any of the table instances should be forbidden.
@@ -156,13 +163,7 @@ public class TestSchemaOneBackwardsCompatibility {
   }
 
   private void assertTableIteratorUnsupported(Table<?, ?> table) {
-    try {
-      table.iterator();
-      fail("Table iterator should have thrown " +
-          "UnsupportedOperationException.");
-    } catch (IOException | UnsupportedOperationException ex) {
-      // Exception thrown as expected.
-    }
+    assertThrows(UnsupportedOperationException.class, table::iterator);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import org.apache.hadoop.ozone.container.metadata.SchemaOneDeletedBlocksTable;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
@@ -68,10 +68,10 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -157,7 +157,7 @@ public class TestSchemaOneBackwardsCompatibility {
   private void assertTableIteratorUnsupported(Table<?, ?> table) {
     try {
       table.iterator();
-      Assert.fail("Table iterator should have thrown " +
+      Assertions.fail("Table iterator should have thrown " +
               "UnsupportedOperationException.");
     } catch (IOException | UnsupportedOperationException ex) {
       // Exception thrown as expected.
@@ -355,14 +355,14 @@ public class TestSchemaOneBackwardsCompatibility {
         preUpgradeBlocks.add(chunkListKV.getKey());
         try {
           chunkListKV.getValue();
-          Assert.fail("No exception thrown when trying to retrieve old " +
+          Assertions.fail("No exception thrown when trying to retrieve old " +
                   "deleted blocks values as chunk lists.");
         } catch (IOException ex) {
           // Exception thrown as expected.
         }
       }
 
-      Assert.assertEquals(TestDB.NUM_DELETED_BLOCKS, preUpgradeBlocks.size());
+      Assertions.assertEquals(TestDB.NUM_DELETED_BLOCKS, preUpgradeBlocks.size());
 
       long initialTotalSpace = newKvData().getBytesUsed();
       long blockSpace = initialTotalSpace / TestDB.KEY_COUNT;
@@ -386,7 +386,7 @@ public class TestSchemaOneBackwardsCompatibility {
 
       // The blocks that were originally marked for deletion should now be
       // deleted.
-      Assert.assertEquals(TestDB.NUM_PENDING_DELETION_BLOCKS,
+      Assertions.assertEquals(TestDB.NUM_PENDING_DELETION_BLOCKS,
               numberOfBlocksDeleted);
     }
   }
@@ -402,7 +402,7 @@ public class TestSchemaOneBackwardsCompatibility {
       for (String blockID: TestDB.BLOCK_IDS) {
         String blockKey = cData.getBlockKey(Long.parseLong(blockID));
         BlockData blockData = blockDataTable.get(blockKey);
-        Assert.assertEquals(Long.toString(blockData.getLocalID()), blockID);
+        Assertions.assertEquals(Long.toString(blockData.getLocalID()), blockID);
       }
 
       // Test decoding keys from the database.
@@ -417,7 +417,7 @@ public class TestSchemaOneBackwardsCompatibility {
         decodedKeys.add(blockDataKV.getKey());
       }
 
-      Assert.assertEquals(TestDB.BLOCK_IDS, decodedKeys);
+      Assertions.assertEquals(TestDB.BLOCK_IDS, decodedKeys);
 
       // Test reading blocks with block iterator.
       try (BlockIterator<BlockData> iter =
@@ -430,7 +430,7 @@ public class TestSchemaOneBackwardsCompatibility {
           iteratorBlockIDs.add(Long.toString(localID));
         }
 
-        Assert.assertEquals(TestDB.BLOCK_IDS, iteratorBlockIDs);
+        Assertions.assertEquals(TestDB.BLOCK_IDS, iteratorBlockIDs);
       }
     }
   }
@@ -446,7 +446,7 @@ public class TestSchemaOneBackwardsCompatibility {
         String blockKey = cData.getDeletingBlockKey(
             Long.parseLong(blockID));
         BlockData blockData = blockDataTable.get(blockKey);
-        Assert.assertEquals(Long.toString(blockData.getLocalID()), blockID);
+        Assertions.assertEquals(Long.toString(blockData.getLocalID()), blockID);
       }
 
       // Test decoding keys from the database.
@@ -467,7 +467,7 @@ public class TestSchemaOneBackwardsCompatibility {
           .map(key -> cData.getDeletingBlockKey(Long.parseLong(key)))
           .collect(Collectors.toList());
 
-      Assert.assertEquals(expectedKeys, decodedKeys);
+      Assertions.assertEquals(expectedKeys, decodedKeys);
 
       // Test reading deleting blocks with block iterator.
       KeyPrefixFilter filter = cData.getDeletingBlockKeyFilter();
@@ -483,7 +483,7 @@ public class TestSchemaOneBackwardsCompatibility {
           iteratorBlockIDs.add(Long.toString(localID));
         }
 
-        Assert.assertEquals(TestDB.DELETING_BLOCK_IDS, iteratorBlockIDs);
+        Assertions.assertEquals(TestDB.DELETING_BLOCK_IDS, iteratorBlockIDs);
       }
     }
   }
@@ -495,11 +495,11 @@ public class TestSchemaOneBackwardsCompatibility {
       Table<String, Long> metadataTable =
           refCountedDB.getStore().getMetadataTable();
 
-      Assert.assertEquals(TestDB.KEY_COUNT,
+      Assertions.assertEquals(TestDB.KEY_COUNT,
           metadataTable.get(cData.getBlockCountKey()).longValue());
-      Assert.assertEquals(TestDB.BYTES_USED,
+      Assertions.assertEquals(TestDB.BYTES_USED,
           metadataTable.get(cData.getBytesUsedKey()).longValue());
-      Assert.assertEquals(TestDB.NUM_PENDING_DELETION_BLOCKS,
+      Assertions.assertEquals(TestDB.NUM_PENDING_DELETION_BLOCKS,
           metadataTable.get(cData.getPendingDeleteBlockCountKey())
               .longValue());
     }
@@ -515,7 +515,7 @@ public class TestSchemaOneBackwardsCompatibility {
       for (String blockID: TestDB.DELETED_BLOCK_IDS) {
         // Since chunk info for deleted blocks was not stored in schema
         // version 1, there is no value to retrieve here.
-        Assert.assertTrue(deletedBlocksTable.isExist(blockID));
+        Assertions.assertTrue(deletedBlocksTable.isExist(blockID));
       }
 
       // Test decoding keys from the database.
@@ -530,7 +530,7 @@ public class TestSchemaOneBackwardsCompatibility {
         decodedKeys.add(kv.getKey());
       }
 
-      Assert.assertEquals(TestDB.DELETED_BLOCK_IDS, decodedKeys);
+      Assertions.assertEquals(TestDB.DELETED_BLOCK_IDS, decodedKeys);
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -48,9 +48,9 @@ import org.apache.hadoop.ozone.container.metadata.SchemaOneDeletedBlocksTable;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -114,7 +114,7 @@ public class TestSchemaOneBackwardsCompatibility {
     });
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     TestDB testDB = new TestDB();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.StaleRecoveringContainerScrubbingService;
 import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
@@ -169,7 +169,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //closed container should not be scrubbed
-    Assert.assertTrue(containerSet.containerCount() == 5);
+    Assertions.assertTrue(containerSet.containerCount() == 5);
 
     containerStateMap.putAll(createTestContainers(containerSet, 5,
             RECOVERING).stream()
@@ -177,9 +177,9 @@ public class TestStaleRecoveringContainerScrubbingService {
     testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //recovering container should be scrubbed since recovering timeout
-    Assert.assertEquals(10, containerSet.containerCount());
+    Assertions.assertEquals(10, containerSet.containerCount());
     for (Container<?> entry : containerSet) {
-      Assert.assertEquals(entry.getContainerState(),
+      Assertions.assertEquals(entry.getContainerState(),
               containerStateMap.get(entry.getContainerData().getContainerID()));
     }
 
@@ -191,9 +191,9 @@ public class TestStaleRecoveringContainerScrubbingService {
     testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //recovering container should not be scrubbed
-    Assert.assertEquals(15, containerSet.containerCount());
+    Assertions.assertEquals(15, containerSet.containerCount());
     for (Container<?> entry : containerSet) {
-      Assert.assertEquals(entry.getContainerState(),
+      Assertions.assertEquals(entry.getContainerState(),
               containerStateMap.get(entry.getContainerData().getContainerID()));
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -37,16 +37,15 @@ import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.StaleR
 import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
-import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -68,17 +67,16 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests to stale recovering container scrubbing service.
  */
-@RunWith(Parameterized.class)
 public class TestStaleRecoveringContainerScrubbingService {
 
-  @Rule
-  public final TemporaryFolder tempDir = new TemporaryFolder();
+  @TempDir
+  private Path tempDir;
   private String datanodeUuid;
   private OzoneConfiguration conf;
   private HddsVolume hddsVolume;
 
-  private final ContainerLayoutVersion layout;
-  private final String schemaVersion;
+  private ContainerLayoutVersion layout;
+  private String schemaVersion;
   private String clusterID;
   private int containerIdNum = 0;
   private MutableVolumeSet volumeSet;
@@ -86,22 +84,22 @@ public class TestStaleRecoveringContainerScrubbingService {
   private final TestClock testClock =
       new TestClock(Instant.now(), ZoneOffset.UTC);
 
-  public TestStaleRecoveringContainerScrubbingService(
-      ContainerTestVersionInfo versionInfo) {
+  private void initVersionInfo(ContainerTestVersionInfo versionInfo)
+      throws IOException {
     this.layout = versionInfo.getLayout();
     this.schemaVersion = versionInfo.getSchemaVersion();
     conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
+    init();
   }
 
-  @Parameterized.Parameters
-  public static Iterable<Object[]> parameters() {
+  private static Iterable<Object[]> versionInfo() {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @BeforeEach
-  public void init() throws IOException {
-    File volumeDir = tempDir.newFolder();
+  private void init() throws IOException {
+    File volumeDir =
+        Files.createDirectory(tempDir.resolve("volumeDir")).toFile();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, volumeDir.getAbsolutePath());
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, volumeDir.getAbsolutePath());
     datanodeUuid = UUID.randomUUID().toString();
@@ -150,9 +148,11 @@ public class TestStaleRecoveringContainerScrubbingService {
     return createdIds;
   }
 
-  @Test
-  public void testScrubbingStaleRecoveringContainers()
-      throws Exception {
+  @ParameterizedTest
+  @MethodSource("versionInfo")
+  public void testScrubbingStaleRecoveringContainers(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    initVersionInfo(versionInfo);
     ContainerSet containerSet = new ContainerSet(10);
     containerSet.setClock(testClock);
     StaleRecoveringContainerScrubbingService srcss =
@@ -162,7 +162,7 @@ public class TestStaleRecoveringContainerScrubbingService {
             containerSet);
     testClock.fastForward(1000L);
     Map<Long, ContainerProtos.ContainerDataProto.State> containerStateMap =
-            new HashMap<>();
+        new HashMap<>();
     containerStateMap.putAll(createTestContainers(containerSet, 5, CLOSED)
             .stream().collect(Collectors.toMap(i -> i, i -> CLOSED)));
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -35,11 +35,11 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.StaleRecoveringContainerScrubbingService;
 import org.apache.ozone.test.TestClock;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -99,7 +99,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     File volumeDir = tempDir.newFolder();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, volumeDir.getAbsolutePath());
@@ -117,7 +117,7 @@ public class TestStaleRecoveringContainerScrubbingService {
         .thenReturn(hddsVolume);
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     BlockUtils.shutdownCache(conf);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.junit.Assert;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -32,9 +32,8 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +50,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * This class tests create/read .container files.
  */
-@RunWith(Parameterized.class)
 public class TestContainerDataYaml {
 
   private long testContainerID = 1234;
@@ -64,15 +62,14 @@ public class TestContainerDataYaml {
   private static final String VOLUME_OWNER = "hdfs";
   private static final String CONTAINER_DB_TYPE = "RocksDB";
 
-  private final ContainerLayoutVersion layout;
+  private ContainerLayoutVersion layoutVersion;
   private OzoneConfiguration conf = new OzoneConfiguration();
-    
-  public TestContainerDataYaml(ContainerLayoutVersion layout) {
-    this.layout = layout;
+
+  private void setLayoutVersion(ContainerLayoutVersion layoutVersion) {
+    this.layoutVersion = layoutVersion;
   }
 
-  @Parameterized.Parameters
-  public static Iterable<Object[]> parameters() {
+  private static Iterable<Object[]> layoutVersion() {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
@@ -87,7 +84,7 @@ public class TestContainerDataYaml {
     String containerPath = containerID + ".container";
 
     KeyValueContainerData keyValueContainerData = new KeyValueContainerData(
-        containerID, layout, MAXSIZE,
+        containerID, layoutVersion, MAXSIZE,
         UUID.randomUUID().toString(),
         UUID.randomUUID().toString());
     keyValueContainerData.setContainerDBType(CONTAINER_DB_TYPE);
@@ -114,8 +111,11 @@ public class TestContainerDataYaml {
     FileUtil.fullyDelete(new File(testRoot));
   }
 
-  @Test
-  public void testCreateContainerFile() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testCreateContainerFile(ContainerLayoutVersion layout)
+      throws IOException {
+    setLayoutVersion(layout);
     long containerID = testContainerID++;
 
     File containerFile = createContainerFile(containerID, 7);
@@ -174,13 +174,16 @@ public class TestContainerDataYaml {
     assertEquals(MAXSIZE, kvData.getMaxSize());
     assertTrue(kvData.lastDataScanTime().isPresent());
     assertEquals(SCAN_TIME.toEpochMilli(),
-                 kvData.lastDataScanTime().get().toEpochMilli());
+        kvData.lastDataScanTime().get().toEpochMilli());
     assertEquals(SCAN_TIME.toEpochMilli(),
-                 kvData.getDataScanTimestamp().longValue());
+        kvData.getDataScanTimestamp().longValue());
   }
 
-  @Test
-  public void testCreateContainerFileWithoutReplicaIndex() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testCreateContainerFileWithoutReplicaIndex(
+      ContainerLayoutVersion layout) throws IOException {
+    setLayoutVersion(layout);
     long containerID = testContainerID++;
 
     File containerFile = createContainerFile(containerID, 0);
@@ -194,8 +197,11 @@ public class TestContainerDataYaml {
   }
 
 
-  @Test
-  public void testIncorrectContainerFile() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testIncorrectContainerFile(ContainerLayoutVersion layout)
+      throws IOException {
+    setLayoutVersion(layout);
     try {
       String containerFile = "incorrect.container";
       //Get file from resources folder
@@ -210,9 +216,11 @@ public class TestContainerDataYaml {
   }
 
 
-  @Test
-  public void testCheckBackWardCompatibilityOfContainerFile() throws
-      IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testCheckBackWardCompatibilityOfContainerFile(
+      ContainerLayoutVersion layout) {
+    setLayoutVersion(layout);
     // This test is for if we upgrade, and then .container files added by new
     // server will have new fields added to .container file, after a while we
     // decided to rollback. Then older ozone can read .container files
@@ -250,8 +258,11 @@ public class TestContainerDataYaml {
   /**
    * Test to verify {@link ContainerUtils#verifyChecksum(ContainerData)}.
    */
-  @Test
-  public void testChecksumInContainerFile() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testChecksumInContainerFile(ContainerLayoutVersion layout)
+      throws IOException {
+    setLayoutVersion(layout);
     long containerID = testContainerID++;
 
     File containerFile = createContainerFile(containerID, 0);
@@ -267,8 +278,11 @@ public class TestContainerDataYaml {
   /**
    * Test to verify {@link ContainerUtils#verifyChecksum(ContainerData)}.
    */
-  @Test
-  public void testChecksumInContainerFileWithReplicaIndex() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testChecksumInContainerFileWithReplicaIndex(
+      ContainerLayoutVersion layout) throws IOException {
+    setLayoutVersion(layout);
     long containerID = testContainerID++;
 
     File containerFile = createContainerFile(containerID, 10);
@@ -292,8 +306,10 @@ public class TestContainerDataYaml {
   /**
    * Test to verify incorrect checksum is detected.
    */
-  @Test
-  public void testIncorrectChecksum() {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testIncorrectChecksum(ContainerLayoutVersion layout) {
+    setLayoutVersion(layout);
     try {
       KeyValueContainerData kvData = getKeyValueContainerData();
       ContainerUtils.verifyChecksum(kvData, conf);
@@ -307,11 +323,14 @@ public class TestContainerDataYaml {
   /**
    * Test to verify disabled checksum with incorrect checksum.
    */
-  @Test
-  public void testDisabledChecksum() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testDisabledChecksum(ContainerLayoutVersion layout)
+      throws IOException {
+    setLayoutVersion(layout);
     KeyValueContainerData kvData = getKeyValueContainerData();
     conf.setBoolean(HddsConfigKeys.
-                    HDDS_CONTAINER_CHECKSUM_VERIFICATION_ENABLED, false);
+        HDDS_CONTAINER_CHECKSUM_VERIFICATION_ENABLED, false);
     ContainerUtils.verifyChecksum(kvData, conf);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
@@ -43,9 +43,9 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_CHUNK;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 /**
@@ -188,7 +188,7 @@ public class TestContainerDataYaml {
     final String content =
         FileUtils.readFileToString(containerFile, Charset.defaultCharset());
 
-    Assert.assertFalse("ReplicaIndex shouldn't be persisted if zero",
+    Assertions.assertFalse("ReplicaIndex shouldn't be persisted if zero",
         content.contains("replicaIndex"));
     cleanup();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -188,8 +188,8 @@ public class TestContainerDataYaml {
     final String content =
         FileUtils.readFileToString(containerFile, Charset.defaultCharset());
 
-    Assertions.assertFalse("ReplicaIndex shouldn't be persisted if zero",
-        content.contains("replicaIndex"));
+    Assertions.assertFalse(content.contains("replicaIndex"),
+        "ReplicaIndex shouldn't be persisted if zero");
     cleanup();
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.common.impl.BlockDeletingService.ContainerBlockInfo;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -86,7 +86,7 @@ public class TestContainerDeletionChoosingPolicy {
     if (containerDir.exists()) {
       FileUtils.deleteDirectory(new File(path));
     }
-    Assert.assertTrue(containerDir.mkdirs());
+    Assertions.assertTrue(containerDir.mkdirs());
 
     conf.set(
         ScmConfigKeys.OZONE_SCM_KEY_VALUE_CONTAINER_DELETION_CHOOSING_POLICY,
@@ -105,7 +105,7 @@ public class TestContainerDeletionChoosingPolicy {
       data.closeContainer();
       KeyValueContainer container = new KeyValueContainer(data, conf);
       containerSet.addContainer(container);
-      Assert.assertTrue(
+      Assertions.assertTrue(
           containerSet.getContainerMapCopy()
               .containsKey(data.getContainerID()));
     }
@@ -121,7 +121,7 @@ public class TestContainerDeletionChoosingPolicy {
     for (ContainerBlockInfo pr : result0) {
       totPendingBlocks += pr.getNumBlocksToDelete();
     }
-    Assert.assertTrue(totPendingBlocks >= blockLimitPerInterval);
+    Assertions.assertTrue(totPendingBlocks >= blockLimitPerInterval);
 
     // test random choosing. We choose 100 times the 3 datanodes twice.
     //We expect different order at least once.
@@ -138,7 +138,7 @@ public class TestContainerDeletionChoosingPolicy {
         }
       }
     }
-    Assert.fail("Chosen container results were same 100 times");
+    Assertions.fail("Chosen container results were same 100 times");
 
   }
 
@@ -148,7 +148,7 @@ public class TestContainerDeletionChoosingPolicy {
     if (containerDir.exists()) {
       FileUtils.deleteDirectory(new File(path));
     }
-    Assert.assertTrue(containerDir.mkdirs());
+    Assertions.assertTrue(containerDir.mkdirs());
 
     conf.set(
         ScmConfigKeys.OZONE_SCM_KEY_VALUE_CONTAINER_DELETION_CHOOSING_POLICY,
@@ -179,7 +179,7 @@ public class TestContainerDeletionChoosingPolicy {
       KeyValueContainer container = new KeyValueContainer(data, conf);
       data.closeContainer();
       containerSet.addContainer(container);
-      Assert.assertTrue(
+      Assertions.assertTrue(
           containerSet.getContainerMapCopy().containsKey(containerId));
     }
     numberOfBlocks.sort(Collections.reverseOrder());
@@ -193,7 +193,7 @@ public class TestContainerDeletionChoosingPolicy {
     for (ContainerBlockInfo pr : result0) {
       totPendingBlocks += pr.getNumBlocksToDelete();
     }
-    Assert.assertTrue(totPendingBlocks >= blockLimitPerInterval);
+    Assertions.assertTrue(totPendingBlocks >= blockLimitPerInterval);
 
 
     List<ContainerBlockInfo> result1 = blockDeletingService
@@ -208,7 +208,7 @@ public class TestContainerDeletionChoosingPolicy {
         break;
       }
     }
-    Assert.assertEquals(containerCount, result1.size());
+    Assertions.assertEquals(containerCount, result1.size());
 
     // verify the order of return list
     int initialName2CountSize = name2Count.size();
@@ -217,11 +217,11 @@ public class TestContainerDeletionChoosingPolicy {
       int currentCount =
           name2Count.remove(data.getContainerData().getContainerID());
       // previous count should not smaller than next one
-      Assert.assertTrue(currentCount > 0 && currentCount <= lastCount);
+      Assertions.assertTrue(currentCount > 0 && currentCount <= lastCount);
       lastCount = currentCount;
     }
     // ensure all the container data are compared
-    Assert.assertEquals(result1.size(),
+    Assertions.assertEquals(result1.size(),
         initialName2CountSize - name2Count.size());
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -42,8 +42,8 @@ import org.apache.hadoop.ozone.container.common.impl.BlockDeletingService.Contai
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
@@ -73,7 +73,7 @@ public class TestContainerDeletionChoosingPolicy {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
-  @Before
+  @BeforeEach
   public void init() throws Throwable {
     conf = new OzoneConfiguration();
     path = GenericTestUtils

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -43,15 +43,13 @@ import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 /**
  * The class for testing container deletion choosing policy.
  */
-@RunWith(Parameterized.class)
 public class TestContainerDeletionChoosingPolicy {
   private String path;
   private OzoneContainer ozoneContainer;
@@ -62,14 +60,13 @@ public class TestContainerDeletionChoosingPolicy {
   private static final int SERVICE_TIMEOUT_IN_MILLISECONDS = 0;
   private static final int SERVICE_INTERVAL_IN_MILLISECONDS = 1000;
 
-  private final ContainerLayoutVersion layout;
+  private ContainerLayoutVersion layoutVersion;
 
-  public TestContainerDeletionChoosingPolicy(ContainerLayoutVersion layout) {
-    this.layout = layout;
+  public void setLayoutVersion(ContainerLayoutVersion layout) {
+    this.layoutVersion = layout;
   }
 
-  @Parameterized.Parameters
-  public static Iterable<Object[]> parameters() {
+  private static Iterable<Object[]> layoutVersion() {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
@@ -80,8 +77,11 @@ public class TestContainerDeletionChoosingPolicy {
         .getTempPath(TestContainerDeletionChoosingPolicy.class.getSimpleName());
   }
 
-  @Test
-  public void testRandomChoosingPolicy() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testRandomChoosingPolicy(ContainerLayoutVersion layout)
+      throws IOException {
+    setLayoutVersion(layout);
     File containerDir = new File(path);
     if (containerDir.exists()) {
       FileUtils.deleteDirectory(new File(path));
@@ -133,7 +133,7 @@ public class TestContainerDeletionChoosingPolicy {
       boolean hasShuffled = false;
       for (int i = 0; i < result1.size(); i++) {
         if (result1.get(i).getContainerData().getContainerID() != result2.get(i)
-                .getContainerData().getContainerID()) {
+            .getContainerData().getContainerID()) {
           return;
         }
       }
@@ -142,8 +142,11 @@ public class TestContainerDeletionChoosingPolicy {
 
   }
 
-  @Test
-  public void testTopNOrderedChoosingPolicy() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testTopNOrderedChoosingPolicy(ContainerLayoutVersion layout)
+      throws IOException {
+    setLayoutVersion(layout);
     File containerDir = new File(path);
     if (containerDir.exists()) {
       FileUtils.deleteDirectory(new File(path));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -457,11 +457,12 @@ public class TestContainerPersistence {
     // Volume setup should have created the tmp directory for container
     // deletion.
     File volumeTmpDir = hddsVolume.getTmpDir();
-    Assertions.assertTrue(String.format("Volume level tmp dir %s not created.",
-            volumeTmpDir), volumeTmpDir.exists());
+    Assertions.assertTrue(volumeTmpDir.exists(), String.format("Volume level " +
+        "tmp dir %s not created.", volumeTmpDir));
     File deletedContainerDir = hddsVolume.getDeletedContainerDir();
-    Assertions.assertTrue(String.format("Volume level container deleted directory" +
-        " %s not created.", deletedContainerDir), deletedContainerDir.exists());
+    Assertions.assertTrue(deletedContainerDir.exists(),
+        String.format("Volume level container deleted directory" +
+            " %s not created.", deletedContainerDir));
 
     // Move containers to delete directory. RocksDB should not yet be updated.
     KeyValueContainerUtil.moveToDeletedContainerDir(container1Data, hddsVolume);
@@ -912,8 +913,8 @@ public class TestContainerPersistence {
     File containerBaseDir = new File(actualNewData.getMetadataPath())
         .getParentFile();
     File newContainerFile = ContainerUtils.getContainerFile(containerBaseDir);
-    Assertions.assertTrue("Container file should exist.",
-        newContainerFile.exists());
+    Assertions.assertTrue(newContainerFile.exists(),
+        "Container file should exist.");
     Assertions.assertEquals("Container file should be in same location.",
         orgContainerFile.getAbsolutePath(),
         newContainerFile.getAbsolutePath());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -84,10 +84,10 @@ import static org.apache.hadoop.ozone.container.ContainerTestHelper.getData;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.setDataChecksum;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
@@ -171,7 +171,7 @@ public class TestContainerPersistence {
         volumeSet.getVolumesList())) {
       boolean success = StorageVolumeUtil.checkVolume(volume, SCM_ID, SCM_ID,
           conf, null, null);
-      Assert.assertTrue(success);
+      Assertions.assertTrue(success);
     }
     blockManager = new BlockManagerImpl(conf);
     chunkManager = ChunkManagerFactory.createChunkManager(conf, blockManager,
@@ -223,7 +223,7 @@ public class TestContainerPersistence {
         .getVolume().getCommittedBytes();
     commitIncrement = commitBytesAfter - commitBytesBefore;
     // did we commit space for the new container?
-    Assert.assertTrue(commitIncrement ==
+    Assertions.assertTrue(commitIncrement ==
         ContainerTestHelper.CONTAINER_MAX_SIZE);
     return container;
   }
@@ -232,24 +232,24 @@ public class TestContainerPersistence {
   public void testCreateContainer() throws Exception {
     long testContainerID = getTestContainerID();
     addContainer(containerSet, testContainerID);
-    Assert.assertTrue(containerSet.getContainerMapCopy()
+    Assertions.assertTrue(containerSet.getContainerMapCopy()
         .containsKey(testContainerID));
     KeyValueContainerData kvData =
         (KeyValueContainerData) containerSet.getContainer(testContainerID)
             .getContainerData();
 
-    Assert.assertNotNull(kvData);
-    Assert.assertTrue(new File(kvData.getMetadataPath()).exists());
-    Assert.assertTrue(new File(kvData.getChunksPath()).exists());
-    Assert.assertTrue(kvData.getDbFile().exists());
+    Assertions.assertNotNull(kvData);
+    Assertions.assertTrue(new File(kvData.getMetadataPath()).exists());
+    Assertions.assertTrue(new File(kvData.getChunksPath()).exists());
+    Assertions.assertTrue(kvData.getDbFile().exists());
 
     Path meta = kvData.getDbFile().toPath().getParent();
-    Assert.assertTrue(meta != null && Files.exists(meta));
+    Assertions.assertTrue(meta != null && Files.exists(meta));
 
     DBHandle store = null;
     try {
       store = BlockUtils.getDB(kvData, conf);
-      Assert.assertNotNull(store);
+      Assertions.assertNotNull(store);
     } finally {
       if (store != null) {
         store.close();
@@ -266,7 +266,7 @@ public class TestContainerPersistence {
       containerSet.addContainer(container);
       fail("Expected Exception not thrown.");
     } catch (IOException ex) {
-      Assert.assertNotNull(ex);
+      Assertions.assertNotNull(ex);
     }
   }
 
@@ -283,13 +283,13 @@ public class TestContainerPersistence {
         addContainer(containerSet, testContainerID);
     container.close();
 
-    Assert.assertTrue(containerSet.getContainerMapCopy()
+    Assertions.assertTrue(containerSet.getContainerMapCopy()
         .containsKey(testContainerID));
 
     KeyValueContainerUtil.removeContainer(container.getContainerData(), conf);
     container.delete();
     containerSet.removeContainer(testContainerID);
-    Assert.assertFalse(containerSet.getContainerMapCopy()
+    Assertions.assertFalse(containerSet.getContainerMapCopy()
         .containsKey(testContainerID));
 
     // Adding block to a deleted container should fail.
@@ -308,7 +308,7 @@ public class TestContainerPersistence {
         addContainer(containerSet, testContainerID);
     container.close();
 
-    Assert.assertTrue(containerSet.getContainerMapCopy()
+    Assertions.assertTrue(containerSet.getContainerMapCopy()
         .containsKey(testContainerID));
 
     // Deleting a non-empty container should fail.
@@ -331,7 +331,7 @@ public class TestContainerPersistence {
     exception.expectMessage(
         "Non-force deletion of non-empty container is not allowed.");
     kvHandler.deleteContainer(container, false);
-    Assert.assertTrue(containerSet.getContainerMapCopy()
+    Assertions.assertTrue(containerSet.getContainerMapCopy()
         .containsKey(testContainerID));
   }
 
@@ -343,7 +343,7 @@ public class TestContainerPersistence {
         testContainerID);
     BlockID blockID = addBlockToContainer(container);
     container.close();
-    Assert.assertTrue(containerSet.getContainerMapCopy()
+    Assertions.assertTrue(containerSet.getContainerMapCopy()
         .containsKey(testContainerID));
     KeyValueContainerData containerData = container.getContainerData();
 
@@ -355,7 +355,7 @@ public class TestContainerPersistence {
         container.getContainerData().getVolume().getConf());
     container.delete();
     containerSet.removeContainer(testContainerID);
-    Assert.assertFalse(containerSet.getContainerMapCopy()
+    Assertions.assertFalse(containerSet.getContainerMapCopy()
         .containsKey(testContainerID));
 
     // Block data and metadata tables should be cleared.
@@ -376,9 +376,9 @@ public class TestContainerPersistence {
       Table<String, Long> metadataTable = store.getMetadataTable();
 
       // Block data and metadata tables should have data.
-      Assert.assertNotNull(blockTable
+      Assertions.assertNotNull(blockTable
           .getIfExist(containerData.getBlockKey(testBlock.getLocalID())));
-      Assert.assertNotNull(metadataTable
+      Assertions.assertNotNull(metadataTable
           .getIfExist(containerData.getBlockCountKey()));
     }
   }
@@ -398,9 +398,9 @@ public class TestContainerPersistence {
       Table<String, Long> metadataTable = store.getMetadataTable();
 
       // Block data and metadata tables should have data.
-      Assert.assertNull(blockTable
+      Assertions.assertNull(blockTable
           .getIfExist(containerData.getBlockKey(testBlock.getLocalID())));
-      Assert.assertNull(metadataTable
+      Assertions.assertNull(metadataTable
           .getIfExist(containerData.getBlockCountKey()));
     }
   }
@@ -446,9 +446,9 @@ public class TestContainerPersistence {
     KeyValueContainerData container2Data = container2.getContainerData();
     assertContainerInSchema3DB(container2Data, container2Block);
 
-    Assert.assertTrue(containerSet.getContainerMapCopy()
+    Assertions.assertTrue(containerSet.getContainerMapCopy()
         .containsKey(testContainerID1));
-    Assert.assertTrue(containerSet.getContainerMapCopy()
+    Assertions.assertTrue(containerSet.getContainerMapCopy()
         .containsKey(testContainerID2));
 
     // Since this test only uses one volume, both containers will reside in
@@ -457,10 +457,10 @@ public class TestContainerPersistence {
     // Volume setup should have created the tmp directory for container
     // deletion.
     File volumeTmpDir = hddsVolume.getTmpDir();
-    Assert.assertTrue(String.format("Volume level tmp dir %s not created.",
+    Assertions.assertTrue(String.format("Volume level tmp dir %s not created.",
             volumeTmpDir), volumeTmpDir.exists());
     File deletedContainerDir = hddsVolume.getDeletedContainerDir();
-    Assert.assertTrue(String.format("Volume level container deleted directory" +
+    Assertions.assertTrue(String.format("Volume level container deleted directory" +
         " %s not created.", deletedContainerDir), deletedContainerDir.exists());
 
     // Move containers to delete directory. RocksDB should not yet be updated.
@@ -471,17 +471,17 @@ public class TestContainerPersistence {
 
     // Both containers should be present in the deleted directory.
     File[] deleteDirFilesArray = deletedContainerDir.listFiles();
-    Assert.assertNotNull(deleteDirFilesArray);
+    Assertions.assertNotNull(deleteDirFilesArray);
     Set<File> deleteDirFiles = Arrays.stream(deleteDirFilesArray)
         .collect(Collectors.toSet());
-    Assert.assertEquals(2, deleteDirFiles.size());
+    Assertions.assertEquals(2, deleteDirFiles.size());
 
     File container1Dir = KeyValueContainerUtil.getTmpDirectoryPath(
         container1Data, hddsVolume).toFile();
-    Assert.assertTrue(deleteDirFiles.contains(container1Dir));
+    Assertions.assertTrue(deleteDirFiles.contains(container1Dir));
     File container2Dir = KeyValueContainerUtil.getTmpDirectoryPath(
         container2Data, hddsVolume).toFile();
-    Assert.assertTrue(deleteDirFiles.contains(container2Dir));
+    Assertions.assertTrue(deleteDirFiles.contains(container2Dir));
 
     // Delete container1 from the disk. Container2 should remain in the
     // deleted containers directory.
@@ -494,9 +494,9 @@ public class TestContainerPersistence {
 
     // Check the delete directory again. Only container 2 should remain.
     deleteDirFilesArray = deletedContainerDir.listFiles();
-    Assert.assertNotNull(deleteDirFilesArray);
-    Assert.assertEquals(1, deleteDirFilesArray.length);
-    Assert.assertEquals(deleteDirFilesArray[0], container2Dir);
+    Assertions.assertNotNull(deleteDirFilesArray);
+    Assertions.assertEquals(1, deleteDirFilesArray.length);
+    Assertions.assertEquals(deleteDirFilesArray[0], container2Dir);
 
     // Delete container2 from the disk.
     KeyValueContainerUtil.removeContainerDB(
@@ -509,15 +509,15 @@ public class TestContainerPersistence {
     // Remove containers from containerSet
     containerSet.removeContainer(testContainerID1);
     containerSet.removeContainer(testContainerID2);
-    Assert.assertFalse(containerSet.getContainerMapCopy()
+    Assertions.assertFalse(containerSet.getContainerMapCopy()
         .containsKey(testContainerID1));
-    Assert.assertFalse(containerSet.getContainerMapCopy()
+    Assertions.assertFalse(containerSet.getContainerMapCopy()
         .containsKey(testContainerID2));
 
     // Deleted containers directory should now be empty.
     deleteDirFilesArray = deletedContainerDir.listFiles();
-    Assert.assertNotNull(deleteDirFilesArray);
-    Assert.assertEquals(0, deleteDirFilesArray.length);
+    Assertions.assertNotNull(deleteDirFilesArray);
+    Assertions.assertEquals(0, deleteDirFilesArray.length);
   }
 
   @Test
@@ -540,13 +540,13 @@ public class TestContainerPersistence {
     // and closed) reports.
     List<StorageContainerDatanodeProtocolProtos.ContainerReplicaProto> reports =
         containerSet.getContainerReport().getReportsList();
-    Assert.assertEquals(10, reports.size());
+    Assertions.assertEquals(10, reports.size());
     for (StorageContainerDatanodeProtocolProtos.ContainerReplicaProto report :
         reports) {
       long actualContainerID = report.getContainerID();
-      Assert.assertTrue(containerIDs.remove(actualContainerID));
+      Assertions.assertTrue(containerIDs.remove(actualContainerID));
     }
-    Assert.assertTrue(containerIDs.isEmpty());
+    Assertions.assertTrue(containerIDs.isEmpty());
   }
 
   /**
@@ -579,13 +579,13 @@ public class TestContainerPersistence {
       long nextKey = results.get(results.size() - 1).getContainerID();
 
       //Assert that container is returning results in a sorted fashion.
-      Assert.assertTrue(prevKey < nextKey);
+      Assertions.assertTrue(prevKey < nextKey);
       prevKey = nextKey + 1;
       results.clear();
     }
     // Assert that we listed all the keys that we had put into
     // container.
-    Assert.assertTrue(testMap.isEmpty());
+    Assertions.assertTrue(testMap.isEmpty());
   }
 
   private ChunkInfo writeChunkHelper(BlockID blockID) throws IOException {
@@ -610,7 +610,7 @@ public class TestContainerPersistence {
         .getVolume().getCommittedBytes();
     commitDecrement = commitBytesBefore - commitBytesAfter;
     // did we decrement commit bytes by the amount of data we wrote?
-    Assert.assertTrue(commitDecrement == info.getLen());
+    Assertions.assertTrue(commitDecrement == info.getLen());
     return info;
 
   }
@@ -660,7 +660,7 @@ public class TestContainerPersistence {
 
     KeyValueContainerData cNewData =
         (KeyValueContainerData) container.getContainerData();
-    Assert.assertNotNull(cNewData);
+    Assertions.assertNotNull(cNewData);
     Path dataDir = Paths.get(cNewData.getChunksPath());
 
     // Read chunk via file system and verify.
@@ -672,7 +672,7 @@ public class TestContainerPersistence {
       final ChunkBuffer data = chunkManager.readChunk(container, blockID, info,
           DispatcherContext.getHandleReadChunk());
       ChecksumData checksumData = checksum.computeChecksum(data);
-      Assert.assertEquals(info.getChecksumData(), checksumData);
+      Assertions.assertEquals(info.getChecksumData(), checksumData);
     }
   }
 
@@ -707,10 +707,10 @@ public class TestContainerPersistence {
     chunkManager.writeChunk(container, blockID, info, data,
         DispatcherContext.getHandleWriteChunk());
     long bytesUsed = container.getContainerData().getBytesUsed();
-    Assert.assertEquals(datalen, bytesUsed);
+    Assertions.assertEquals(datalen, bytesUsed);
 
     long bytesWrite = container.getContainerData().getWriteBytes();
-    Assert.assertEquals(datalen * 3, bytesWrite);
+    Assertions.assertEquals(datalen * 3, bytesWrite);
   }
 
   /**
@@ -761,7 +761,7 @@ public class TestContainerPersistence {
         getBlock(container, blockData.getBlockID());
     ChunkInfo readChunk =
         ChunkInfo.getFromProtoBuf(readBlockData.getChunks().get(0));
-    Assert.assertEquals(info.getChecksumData(), readChunk.getChecksumData());
+    Assertions.assertEquals(info.getChecksumData(), readChunk.getChecksumData());
   }
 
   /**
@@ -800,9 +800,9 @@ public class TestContainerPersistence {
       // read with bcsId higher than container bcsId
       blockManager.
           getBlock(container, blockID1);
-      Assert.fail("Expected exception not thrown");
+      Assertions.fail("Expected exception not thrown");
     } catch (StorageContainerException sce) {
-      Assert.assertTrue(sce.getResult() == UNKNOWN_BCSID);
+      Assertions.assertTrue(sce.getResult() == UNKNOWN_BCSID);
     }
 
     try {
@@ -811,15 +811,15 @@ public class TestContainerPersistence {
       // bcsId.
       blockManager.
           getBlock(container, blockID1);
-      Assert.fail("Expected exception not thrown");
+      Assertions.fail("Expected exception not thrown");
     } catch (StorageContainerException sce) {
-      Assert.assertTrue(sce.getResult() == BCSID_MISMATCH);
+      Assertions.assertTrue(sce.getResult() == BCSID_MISMATCH);
     }
     readBlockData = blockManager.
         getBlock(container, blockData.getBlockID());
     ChunkInfo readChunk =
         ChunkInfo.getFromProtoBuf(readBlockData.getChunks().get(0));
-    Assert.assertEquals(info.getChecksumData(), readChunk.getChecksumData());
+    Assertions.assertEquals(info.getChecksumData(), readChunk.getChecksumData());
   }
 
   /**
@@ -850,13 +850,13 @@ public class TestContainerPersistence {
     }
 
     long bytesUsed = container.getContainerData().getBytesUsed();
-    Assert.assertEquals(totalSize, bytesUsed);
+    Assertions.assertEquals(totalSize, bytesUsed);
     long writeBytes = container.getContainerData().getWriteBytes();
-    Assert.assertEquals(chunkCount * datalen, writeBytes);
+    Assertions.assertEquals(chunkCount * datalen, writeBytes);
     long readCount = container.getContainerData().getReadCount();
-    Assert.assertEquals(0, readCount);
+    Assertions.assertEquals(0, readCount);
     long writeCount = container.getContainerData().getWriteCount();
-    Assert.assertEquals(chunkCount, writeCount);
+    Assertions.assertEquals(chunkCount, writeCount);
 
     BlockData blockData = new BlockData(blockID);
     List<ContainerProtos.ChunkInfo> chunkProtoList = new LinkedList<>();
@@ -871,7 +871,7 @@ public class TestContainerPersistence {
     ChunkInfo readChunk =
         ChunkInfo.getFromProtoBuf(readBlockData.getChunks().get(readBlockData
             .getChunks().size() - 1));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         lastChunk.getChecksumData(), readChunk.getChecksumData());
   }
 
@@ -888,7 +888,7 @@ public class TestContainerPersistence {
         (KeyValueContainer) addContainer(containerSet, testContainerID);
 
     File orgContainerFile = container.getContainerFile();
-    Assert.assertTrue(orgContainerFile.exists());
+    Assertions.assertTrue(orgContainerFile.exists());
 
     Map<String, String> newMetadata = Maps.newHashMap();
     newMetadata.put("VOLUME", "shire_new");
@@ -896,33 +896,33 @@ public class TestContainerPersistence {
 
     container.update(newMetadata, false);
 
-    Assert.assertEquals(1, containerSet.getContainerMapCopy().size());
-    Assert.assertTrue(containerSet.getContainerMapCopy()
+    Assertions.assertEquals(1, containerSet.getContainerMapCopy().size());
+    Assertions.assertTrue(containerSet.getContainerMapCopy()
         .containsKey(testContainerID));
 
     // Verify in-memory map
     KeyValueContainerData actualNewData = (KeyValueContainerData)
         containerSet.getContainer(testContainerID).getContainerData();
-    Assert.assertEquals("shire_new",
+    Assertions.assertEquals("shire_new",
         actualNewData.getMetadata().get("VOLUME"));
-    Assert.assertEquals("bilbo_new",
+    Assertions.assertEquals("bilbo_new",
         actualNewData.getMetadata().get("owner"));
 
     // Verify container data on disk
     File containerBaseDir = new File(actualNewData.getMetadataPath())
         .getParentFile();
     File newContainerFile = ContainerUtils.getContainerFile(containerBaseDir);
-    Assert.assertTrue("Container file should exist.",
+    Assertions.assertTrue("Container file should exist.",
         newContainerFile.exists());
-    Assert.assertEquals("Container file should be in same location.",
+    Assertions.assertEquals("Container file should be in same location.",
         orgContainerFile.getAbsolutePath(),
         newContainerFile.getAbsolutePath());
 
     ContainerData actualContainerData = ContainerDataYaml.readContainerFile(
         newContainerFile);
-    Assert.assertEquals("shire_new",
+    Assertions.assertEquals("shire_new",
         actualContainerData.getMetadata().get("VOLUME"));
-    Assert.assertEquals("bilbo_new",
+    Assertions.assertEquals("bilbo_new",
         actualContainerData.getMetadata().get("owner"));
 
 
@@ -932,7 +932,7 @@ public class TestContainerPersistence {
     try {
       container.update(newMetadata, false);
     } catch (StorageContainerException ex) {
-      Assert.assertEquals("Updating a closed container without " +
+      Assertions.assertEquals("Updating a closed container without " +
           "force option is not allowed. ContainerID: " +
           testContainerID, ex.getMessage());
     }
@@ -945,9 +945,9 @@ public class TestContainerPersistence {
     // Verify in-memory map
     actualNewData = (KeyValueContainerData)
         containerSet.getContainer(testContainerID).getContainerData();
-    Assert.assertEquals("shire_new_1",
+    Assertions.assertEquals("shire_new_1",
         actualNewData.getMetadata().get("VOLUME"));
-    Assert.assertEquals("bilbo_new_1",
+    Assertions.assertEquals("bilbo_new_1",
         actualNewData.getMetadata().get("owner"));
 
   }
@@ -978,13 +978,13 @@ public class TestContainerPersistence {
     // List all blocks
     List<BlockData> result = blockManager.listBlock(
         container, 0, 100);
-    Assert.assertEquals(10, result.size());
+    Assertions.assertEquals(10, result.size());
 
     int index = 0;
     for (int i = index; i < result.size(); i++) {
       BlockData data = result.get(i);
-      Assert.assertEquals(testContainerID, data.getContainerID());
-      Assert.assertEquals(expectedBlocks.get(i).getLocalID(),
+      Assertions.assertEquals(testContainerID, data.getContainerID());
+      Assertions.assertEquals(expectedBlocks.get(i).getLocalID(),
           data.getLocalID());
       index++;
     }
@@ -993,9 +993,9 @@ public class TestContainerPersistence {
     long k6 = expectedBlocks.get(6).getLocalID();
     result = blockManager.listBlock(container, k6, 100);
 
-    Assert.assertEquals(4, result.size());
+    Assertions.assertEquals(4, result.size());
     for (int i = 6; i < 10; i++) {
-      Assert.assertEquals(expectedBlocks.get(i).getLocalID(),
+      Assertions.assertEquals(expectedBlocks.get(i).getLocalID(),
           result.get(i - 6).getLocalID());
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -82,8 +82,8 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getChunk;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getData;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.setDataChecksum;
-import org.junit.After;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.Assert;
 
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
@@ -91,10 +91,10 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
@@ -146,7 +146,7 @@ public class TestContainerPersistence {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     conf = new OzoneConfiguration();
     hddsPath = GenericTestUtils
@@ -156,12 +156,12 @@ public class TestContainerPersistence {
     volumeChoosingPolicy = new RoundRobinVolumeChoosingPolicy();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws IOException {
     FileUtils.deleteDirectory(new File(hddsPath));
   }
 
-  @Before
+  @BeforeEach
   public void setupPaths() throws IOException {
     containerSet = new ContainerSet(1000);
     volumeSet = new MutableVolumeSet(DATANODE_UUID, conf, null,
@@ -183,7 +183,7 @@ public class TestContainerPersistence {
     }
   }
 
-  @After
+  @AfterEach
   public void cleanupDir() throws IOException {
     // Cleanup cache
     BlockUtils.shutdownCache(conf);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -30,9 +30,8 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -56,24 +55,25 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Class used to test ContainerSet operations.
  */
-@RunWith(Parameterized.class)
 public class TestContainerSet {
 
   private static final int FIRST_ID = 2;
 
-  private final ContainerLayoutVersion layout;
+  private ContainerLayoutVersion layoutVersion;
 
-  public TestContainerSet(ContainerLayoutVersion layout) {
-    this.layout = layout;
+  private void setLayoutVersion(ContainerLayoutVersion layoutVersion) {
+    this.layoutVersion = layoutVersion;
   }
 
-  @Parameterized.Parameters
-  public static Iterable<Object[]> parameters() {
+  private static Iterable<Object[]> layoutVersion() {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
-  @Test
-  public void testAddGetRemoveContainer() throws StorageContainerException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testAddGetRemoveContainer(ContainerLayoutVersion layout)
+      throws StorageContainerException {
+    setLayoutVersion(layout);
     ContainerSet containerSet = new ContainerSet(1000);
     long containerId = 100L;
     ContainerProtos.ContainerDataProto.State state = ContainerProtos
@@ -112,8 +112,11 @@ public class TestContainerSet {
     assertFalse(containerSet.removeContainer(1000L));
   }
 
-  @Test
-  public void testIteratorsAndCount() throws StorageContainerException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testIteratorsAndCount(ContainerLayoutVersion layout)
+      throws StorageContainerException {
+    setLayoutVersion(layout);
 
     ContainerSet containerSet = createContainerSet();
 
@@ -156,8 +159,11 @@ public class TestContainerSet {
 
   }
 
-  @Test
-  public void testIteratorPerVolume() throws StorageContainerException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testIteratorPerVolume(ContainerLayoutVersion layout)
+      throws StorageContainerException {
+    setLayoutVersion(layout);
     HddsVolume vol1 = Mockito.mock(HddsVolume.class);
     Mockito.when(vol1.getStorageID()).thenReturn("uuid-1");
     HddsVolume vol2 = Mockito.mock(HddsVolume.class);
@@ -199,8 +205,11 @@ public class TestContainerSet {
     assertEquals(5, count2);
   }
 
-  @Test
-  public void iteratorIsOrderedByScanTime() throws StorageContainerException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void iteratorIsOrderedByScanTime(ContainerLayoutVersion layout)
+      throws StorageContainerException {
+    setLayoutVersion(layout);
     HddsVolume vol = Mockito.mock(HddsVolume.class);
     Mockito.when(vol.getStorageID()).thenReturn("uuid-1");
     Random random = new Random();
@@ -250,8 +259,11 @@ public class TestContainerSet {
     assertEquals(containerCount, containersToBeScanned);
   }
 
-  @Test
-  public void testGetContainerReport() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testGetContainerReport(ContainerLayoutVersion layout)
+      throws IOException {
+    setLayoutVersion(layout);
 
     ContainerSet containerSet = createContainerSet();
 
@@ -262,9 +274,11 @@ public class TestContainerSet {
   }
 
 
-
-  @Test
-  public void testListContainer() throws StorageContainerException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testListContainer(ContainerLayoutVersion layout)
+      throws StorageContainerException {
+    setLayoutVersion(layout);
     ContainerSet containerSet = createContainerSet();
     int count = 5;
     int startId = FIRST_ID + 3;
@@ -275,8 +289,11 @@ public class TestContainerSet {
     assertContainerIds(startId, count, result);
   }
 
-  @Test
-  public void testListContainerFromFirstKey() throws StorageContainerException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testListContainerFromFirstKey(ContainerLayoutVersion layout)
+      throws StorageContainerException {
+    setLayoutVersion(layout);
     ContainerSet containerSet = createContainerSet();
     int count = 6;
     List<ContainerData> result = new ArrayList<>(count);
@@ -301,7 +318,7 @@ public class TestContainerSet {
     ContainerSet containerSet = new ContainerSet(1000);
     for (int i = FIRST_ID; i < FIRST_ID + 10; i++) {
       KeyValueContainerData kvData = new KeyValueContainerData(i,
-          layout,
+          layoutVersion,
           (long) StorageUnit.GB.toBytes(5), UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
       if (i % 2 == 0) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -46,12 +46,12 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.stream.LongStream;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Class used to test ContainerSet operations.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -62,7 +62,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -86,9 +86,9 @@ import static org.apache.hadoop.hdds.fs.MockSpaceUsageSource.fixed;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getContainerCommandResponse;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.COMMIT_STAGE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -150,7 +150,7 @@ public class TestHddsDispatcher {
       hddsDispatcher.setClusterId(scmId.toString());
       ContainerCommandResponseProto responseOne = hddsDispatcher
           .dispatch(getWriteChunkRequest(dd.getUuidString(), 1L, 1L), null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS,
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
           responseOne.getResult());
       verify(context, times(0))
           .addContainerActionIfAbsent(Mockito.any(ContainerAction.class));
@@ -158,7 +158,7 @@ public class TestHddsDispatcher {
           StorageUnit.MB.toBytes(950)).longValue());
       ContainerCommandResponseProto responseTwo = hddsDispatcher
           .dispatch(getWriteChunkRequest(dd.getUuidString(), 1L, 2L), null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS,
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
           responseTwo.getResult());
       verify(context, times(1))
           .addContainerActionIfAbsent(Mockito.any(ContainerAction.class));
@@ -220,7 +220,7 @@ public class TestHddsDispatcher {
           .ifPresent(volumeInfo -> volumeInfo.incrementUsedSpace(50));
       ContainerCommandResponseProto response = hddsDispatcher
           .dispatch(getWriteChunkRequest(dd.getUuidString(), 1L, 1L), null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS,
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
           response.getResult());
       verify(context, times(1))
           .addContainerActionIfAbsent(Mockito.any(ContainerAction.class));
@@ -262,38 +262,38 @@ public class TestHddsDispatcher {
       // send read chunk request and make sure container does not exist
       ContainerCommandResponseProto response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
-      Assert.assertEquals(response.getResult(),
+      Assertions.assertEquals(response.getResult(),
           ContainerProtos.Result.CONTAINER_NOT_FOUND);
       // send write chunk request without sending create container
       response = hddsDispatcher.dispatch(writeChunkRequest, null);
       // container should be created as part of write chunk request
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       // send read chunk request to read the chunk written above
       response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       ByteString responseData = BufferUtils.concatByteStrings(
           response.getReadChunk().getDataBuffers().getBuffersList());
-      Assert.assertEquals(writeChunkRequest.getWriteChunk().getData(),
+      Assertions.assertEquals(writeChunkRequest.getWriteChunk().getData(),
           responseData);
       // put block
       ContainerCommandRequestProto putBlockRequest =
           ContainerTestHelper.getPutBlockRequest(writeChunkRequest);
       response =  hddsDispatcher.dispatch(putBlockRequest, null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       // send list block request
       ContainerCommandRequestProto listBlockRequest =
           ContainerTestHelper.getListBlockRequest(writeChunkRequest);
       response =  hddsDispatcher.dispatch(listBlockRequest, null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-      Assert.assertEquals(1, response.getListBlock().getBlockDataList().size());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(1, response.getListBlock().getBlockDataList().size());
       for (ContainerProtos.BlockData blockData :
           response.getListBlock().getBlockDataList()) {
-        Assert.assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
+        Assertions.assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
             blockData.getBlockID());
-        Assert.assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
+        Assertions.assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
             .getLen(), blockData.getSize());
-        Assert.assertEquals(1, blockData.getChunksCount());
+        Assertions.assertEquals(1, blockData.getChunksCount());
       }
     } finally {
       ContainerMetrics.remove();
@@ -318,7 +318,7 @@ public class TestHddsDispatcher {
       // send read chunk request and make sure container does not exist
       ContainerCommandResponseProto response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
 
       GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
@@ -326,7 +326,7 @@ public class TestHddsDispatcher {
       // send write chunk request without sending create container
       response = hddsDispatcher.dispatch(writeChunkRequest, COMMIT_STAGE);
       // container should not be found
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
 
       assertTrue(logCapturer.getOutput().contains(
@@ -394,15 +394,15 @@ public class TestHddsDispatcher {
       hddsDispatcher.dispatch(writeChunkRequest, null);
       response = hddsDispatcher.dispatch(writeChunkRequest, null);
 
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       // Send Read Chunk request for written chunk.
       response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
 
       ByteString responseData = BufferUtils.concatByteStrings(
           response.getReadChunk().getDataBuffers().getBuffersList());
-      Assert.assertEquals(writeChunkRequest.getWriteChunk().getData(),
+      Assertions.assertEquals(writeChunkRequest.getWriteChunk().getData(),
           responseData);
 
       // Put Block
@@ -413,21 +413,21 @@ public class TestHddsDispatcher {
       hddsDispatcher.dispatch(putBlockRequest, null);
       hddsDispatcher.dispatch(putBlockRequest, null);
       response =  hddsDispatcher.dispatch(putBlockRequest, null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
 
       // Check PutBlock Data
       ContainerCommandRequestProto listBlockRequest =
           ContainerTestHelper.getListBlockRequest(writeChunkRequest);
       response =  hddsDispatcher.dispatch(listBlockRequest, null);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-      Assert.assertEquals(1, response.getListBlock().getBlockDataList().size());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(1, response.getListBlock().getBlockDataList().size());
       for (ContainerProtos.BlockData blockData :
           response.getListBlock().getBlockDataList()) {
-        Assert.assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
+        Assertions.assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
             blockData.getBlockID());
-        Assert.assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
+        Assertions.assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
             .getLen(), blockData.getSize());
-        Assert.assertEquals(1, blockData.getChunksCount());
+        Assertions.assertEquals(1, blockData.getChunksCount());
       }
     } finally {
       ContainerMetrics.remove();
@@ -565,7 +565,7 @@ public class TestHddsDispatcher {
       final TokenVerifier tokenVerifier = new TokenVerifier() {
         private void verify() {
           final boolean previous = verified.getAndSet(true);
-          Assert.assertFalse(previous);
+          Assertions.assertFalse(previous);
         }
 
         @Override
@@ -594,9 +594,9 @@ public class TestHddsDispatcher {
       };
       for (DispatcherContext context : notVerify) {
         LOG.info("notVerify {}", context);
-        Assert.assertFalse(verified.get());
+        Assertions.assertFalse(verified.get());
         dispatcher.dispatch(request, context);
-        Assert.assertFalse(verified.get());
+        Assertions.assertFalse(verified.get());
       }
 
       final Op[] verify = {
@@ -610,9 +610,9 @@ public class TestHddsDispatcher {
 
       for (Op op : verify) {
         final DispatcherContext context = newContext(op);
-        Assert.assertFalse(verified.get());
+        Assertions.assertFalse(verified.get());
         dispatcher.dispatch(request, context);
-        Assert.assertTrue(verified.getAndSet(false));
+        Assertions.assertTrue(verified.getAndSet(false));
       }
     } finally {
       ContainerMetrics.remove();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -63,7 +63,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -62,10 +62,9 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,6 +86,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getContainerCommandResponse;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.COMMIT_STAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
@@ -95,27 +95,23 @@ import static org.mockito.Mockito.verify;
 /**
  * Test-cases to verify the functionality of HddsDispatcher.
  */
-@RunWith(Parameterized.class)
 public class TestHddsDispatcher {
   private static final Logger LOG = LoggerFactory.getLogger(
       TestHddsDispatcher.class);
 
-  public static final IncrementalReportSender<Container>
-      NO_OP_ICR_SENDER = c -> { };
+  public static final IncrementalReportSender<Container> NO_OP_ICR_SENDER =
+      c -> {
+      };
 
-  private final ContainerLayoutVersion layout;
-
-  public TestHddsDispatcher(ContainerLayoutVersion layout) {
-    this.layout = layout;
-  }
-
-  @Parameterized.Parameters
-  public static Iterable<Object[]> parameters() {
+  private static Iterable<Object[]> layoutVersion() {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
-  @Test
-  public void testContainerCloseActionWhenFull() throws IOException {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testContainerCloseActionWhenFull(
+      ContainerLayoutVersion layout) throws IOException {
+
     String testDir = GenericTestUtils.getTempPath(
         TestHddsDispatcher.class.getSimpleName());
     OzoneConfiguration conf = new OzoneConfiguration();
@@ -150,7 +146,7 @@ public class TestHddsDispatcher {
       hddsDispatcher.setClusterId(scmId.toString());
       ContainerCommandResponseProto responseOne = hddsDispatcher
           .dispatch(getWriteChunkRequest(dd.getUuidString(), 1L, 1L), null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
+      assertEquals(ContainerProtos.Result.SUCCESS,
           responseOne.getResult());
       verify(context, times(0))
           .addContainerActionIfAbsent(Mockito.any(ContainerAction.class));
@@ -158,7 +154,7 @@ public class TestHddsDispatcher {
           StorageUnit.MB.toBytes(950)).longValue());
       ContainerCommandResponseProto responseTwo = hddsDispatcher
           .dispatch(getWriteChunkRequest(dd.getUuidString(), 1L, 2L), null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
+      assertEquals(ContainerProtos.Result.SUCCESS,
           responseTwo.getResult());
       verify(context, times(1))
           .addContainerActionIfAbsent(Mockito.any(ContainerAction.class));
@@ -170,8 +166,10 @@ public class TestHddsDispatcher {
     }
   }
 
-  @Test
-  public void testContainerCloseActionWhenVolumeFull() throws Exception {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void testContainerCloseActionWhenVolumeFull(
+      ContainerLayoutVersion layoutVersion) throws Exception {
     String testDir = GenericTestUtils.getTempPath(
         TestHddsDispatcher.class.getSimpleName());
     OzoneConfiguration conf = new OzoneConfiguration();
@@ -198,8 +196,8 @@ public class TestHddsDispatcher {
       StateContext context = ContainerTestUtils.getMockContext(dd, conf);
       // create a 50 byte container
       KeyValueContainerData containerData = new KeyValueContainerData(1L,
-          layout,
-           50, UUID.randomUUID().toString(),
+          layoutVersion,
+          50, UUID.randomUUID().toString(),
           dd.getUuidString());
       Container container = new KeyValueContainer(containerData, conf);
       container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
@@ -220,7 +218,7 @@ public class TestHddsDispatcher {
           .ifPresent(volumeInfo -> volumeInfo.incrementUsedSpace(50));
       ContainerCommandResponseProto response = hddsDispatcher
           .dispatch(getWriteChunkRequest(dd.getUuidString(), 1L, 1L), null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
+      assertEquals(ContainerProtos.Result.SUCCESS,
           response.getResult());
       verify(context, times(1))
           .addContainerActionIfAbsent(Mockito.any(ContainerAction.class));
@@ -229,7 +227,7 @@ public class TestHddsDispatcher {
       // threshold
 
       KeyValueContainerData containerData2 = new KeyValueContainerData(1L,
-          layout,
+          layoutVersion,
           50, UUID.randomUUID().toString(),
           dd.getUuidString());
       Container container2 = new KeyValueContainer(containerData2, conf);
@@ -262,38 +260,38 @@ public class TestHddsDispatcher {
       // send read chunk request and make sure container does not exist
       ContainerCommandResponseProto response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
-      Assertions.assertEquals(response.getResult(),
+      assertEquals(response.getResult(),
           ContainerProtos.Result.CONTAINER_NOT_FOUND);
       // send write chunk request without sending create container
       response = hddsDispatcher.dispatch(writeChunkRequest, null);
       // container should be created as part of write chunk request
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       // send read chunk request to read the chunk written above
       response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       ByteString responseData = BufferUtils.concatByteStrings(
           response.getReadChunk().getDataBuffers().getBuffersList());
-      Assertions.assertEquals(writeChunkRequest.getWriteChunk().getData(),
+      assertEquals(writeChunkRequest.getWriteChunk().getData(),
           responseData);
       // put block
       ContainerCommandRequestProto putBlockRequest =
           ContainerTestHelper.getPutBlockRequest(writeChunkRequest);
-      response =  hddsDispatcher.dispatch(putBlockRequest, null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      response = hddsDispatcher.dispatch(putBlockRequest, null);
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       // send list block request
       ContainerCommandRequestProto listBlockRequest =
           ContainerTestHelper.getListBlockRequest(writeChunkRequest);
-      response =  hddsDispatcher.dispatch(listBlockRequest, null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-      Assertions.assertEquals(1, response.getListBlock().getBlockDataList().size());
+      response = hddsDispatcher.dispatch(listBlockRequest, null);
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      assertEquals(1, response.getListBlock().getBlockDataList().size());
       for (ContainerProtos.BlockData blockData :
           response.getListBlock().getBlockDataList()) {
-        Assertions.assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
+        assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
             blockData.getBlockID());
-        Assertions.assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
+        assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
             .getLen(), blockData.getSize());
-        Assertions.assertEquals(1, blockData.getChunksCount());
+        assertEquals(1, blockData.getChunksCount());
       }
     } finally {
       ContainerMetrics.remove();
@@ -318,7 +316,7 @@ public class TestHddsDispatcher {
       // send read chunk request and make sure container does not exist
       ContainerCommandResponseProto response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
-      Assertions.assertEquals(
+      assertEquals(
           ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
 
       GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
@@ -326,7 +324,7 @@ public class TestHddsDispatcher {
       // send write chunk request without sending create container
       response = hddsDispatcher.dispatch(writeChunkRequest, COMMIT_STAGE);
       // container should not be found
-      Assertions.assertEquals(
+      assertEquals(
           ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
 
       assertTrue(logCapturer.getOutput().contains(
@@ -394,15 +392,15 @@ public class TestHddsDispatcher {
       hddsDispatcher.dispatch(writeChunkRequest, null);
       response = hddsDispatcher.dispatch(writeChunkRequest, null);
 
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       // Send Read Chunk request for written chunk.
       response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
 
       ByteString responseData = BufferUtils.concatByteStrings(
           response.getReadChunk().getDataBuffers().getBuffersList());
-      Assertions.assertEquals(writeChunkRequest.getWriteChunk().getData(),
+      assertEquals(writeChunkRequest.getWriteChunk().getData(),
           responseData);
 
       // Put Block
@@ -412,22 +410,22 @@ public class TestHddsDispatcher {
       //Send same PutBlockRequest
       hddsDispatcher.dispatch(putBlockRequest, null);
       hddsDispatcher.dispatch(putBlockRequest, null);
-      response =  hddsDispatcher.dispatch(putBlockRequest, null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      response = hddsDispatcher.dispatch(putBlockRequest, null);
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
 
       // Check PutBlock Data
       ContainerCommandRequestProto listBlockRequest =
           ContainerTestHelper.getListBlockRequest(writeChunkRequest);
-      response =  hddsDispatcher.dispatch(listBlockRequest, null);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-      Assertions.assertEquals(1, response.getListBlock().getBlockDataList().size());
+      response = hddsDispatcher.dispatch(listBlockRequest, null);
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      assertEquals(1, response.getListBlock().getBlockDataList().size());
       for (ContainerProtos.BlockData blockData :
           response.getListBlock().getBlockDataList()) {
-        Assertions.assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
+        assertEquals(writeChunkRequest.getWriteChunk().getBlockID(),
             blockData.getBlockID());
-        Assertions.assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
+        assertEquals(writeChunkRequest.getWriteChunk().getChunkData()
             .getLen(), blockData.getSize());
-        Assertions.assertEquals(1, blockData.getChunksCount());
+        assertEquals(1, blockData.getChunksCount());
       }
     } finally {
       ContainerMetrics.remove();
@@ -565,7 +563,7 @@ public class TestHddsDispatcher {
       final TokenVerifier tokenVerifier = new TokenVerifier() {
         private void verify() {
           final boolean previous = verified.getAndSet(true);
-          Assertions.assertFalse(previous);
+          assertFalse(previous);
         }
 
         @Override
@@ -594,9 +592,9 @@ public class TestHddsDispatcher {
       };
       for (DispatcherContext context : notVerify) {
         LOG.info("notVerify {}", context);
-        Assertions.assertFalse(verified.get());
+        assertFalse(verified.get());
         dispatcher.dispatch(request, context);
-        Assertions.assertFalse(verified.get());
+        assertFalse(verified.get());
       }
 
       final Op[] verify = {
@@ -610,9 +608,9 @@ public class TestHddsDispatcher {
 
       for (Op op : verify) {
         final DispatcherContext context = newContext(op);
-        Assertions.assertFalse(verified.get());
+        assertFalse(verified.get());
         dispatcher.dispatch(request, context);
-        Assertions.assertTrue(verified.getAndSet(false));
+        assertTrue(verified.getAndSet(false));
       }
     } finally {
       ContainerMetrics.remove();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
@@ -35,10 +35,8 @@ import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -55,7 +53,6 @@ import static org.mockito.Mockito.when;
 /**
  * Test cases to verify CloseContainerCommandHandler in datanode.
  */
-@RunWith(Parameterized.class)
 public class TestCloseContainerCommandHandler {
 
   private static final long CONTAINER_ID = 123L;
@@ -72,25 +69,25 @@ public class TestCloseContainerCommandHandler {
   private CloseContainerCommandHandler subject =
       new CloseContainerCommandHandler(1, 1000, "");
 
-  private final ContainerLayoutVersion layout;
+  private ContainerLayoutVersion layoutVersion;
 
-  public TestCloseContainerCommandHandler(ContainerLayoutVersion layout) {
-    this.layout = layout;
+  public void initLayoutVerison(ContainerLayoutVersion layout)
+      throws Exception {
+    this.layoutVersion = layout;
+    init();
   }
 
-  @Parameterized.Parameters
-  public static Iterable<Object[]> parameters() {
+  private static Iterable<Object[]> layoutVersion() {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
-  @BeforeEach
-  public void before() throws Exception {
+  private void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     context = ContainerTestUtils.getMockContext(randomDatanodeDetails(), conf);
     pipelineID = PipelineID.randomId();
 
     KeyValueContainerData data = new KeyValueContainerData(CONTAINER_ID,
-        layout, GB,
+        layoutVersion, GB,
         pipelineID.getId().toString(), null);
 
     container = new KeyValueContainer(data, conf);
@@ -112,8 +109,11 @@ public class TestCloseContainerCommandHandler {
         .thenReturn(false);
   }
 
-  @Test
-  public void closeContainerWithPipeline() throws Exception {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void closeContainerWithPipeline(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     // close a container that's associated with an existing pipeline
     subject.handle(closeWithKnownPipeline(), ozoneContainer, context, null);
     waitTillFinishExecution(subject);
@@ -125,8 +125,11 @@ public class TestCloseContainerCommandHandler {
         .quasiCloseContainer(eq(container), any());
   }
 
-  @Test
-  public void closeContainerWithoutPipeline() throws Exception {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void closeContainerWithoutPipeline(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     // close a container that's NOT associated with an open pipeline
     subject.handle(closeWithUnknownPipeline(), ozoneContainer, context, null);
     waitTillFinishExecution(subject);
@@ -141,8 +144,11 @@ public class TestCloseContainerCommandHandler {
         .quasiCloseContainer(eq(container), any());
   }
 
-  @Test
-  public void closeContainerWithForceFlagSet() throws Exception {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void closeContainerWithForceFlagSet(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     // close a container that's associated with an existing pipeline
     subject.handle(forceCloseWithoutPipeline(), ozoneContainer, context, null);
     waitTillFinishExecution(subject);
@@ -153,8 +159,11 @@ public class TestCloseContainerCommandHandler {
     verify(containerHandler).closeContainer(container);
   }
 
-  @Test
-  public void forceCloseQuasiClosedContainer() throws Exception {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void forceCloseQuasiClosedContainer(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     // force-close a container that's already quasi closed
     container.getContainerData()
         .setState(ContainerProtos.ContainerDataProto.State.QUASI_CLOSED);
@@ -168,8 +177,11 @@ public class TestCloseContainerCommandHandler {
         .closeContainer(container);
   }
 
-  @Test
-  public void forceCloseOpenContainer() throws Exception {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void forceCloseOpenContainer(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     // force-close a container that's NOT associated with an open pipeline
     subject.handle(forceCloseWithoutPipeline(), ozoneContainer, context, null);
     waitTillFinishExecution(subject);
@@ -182,8 +194,11 @@ public class TestCloseContainerCommandHandler {
         .closeContainer(container);
   }
 
-  @Test
-  public void forceCloseOpenContainerWithPipeline() throws Exception {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void forceCloseOpenContainerWithPipeline(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     // force-close a container that's associated with an existing pipeline
     subject.handle(forceCloseWithPipeline(), ozoneContainer, context, null);
     waitTillFinishExecution(subject);
@@ -198,8 +213,11 @@ public class TestCloseContainerCommandHandler {
         .closeContainer(container);
   }
 
-  @Test
-  public void closeAlreadyClosedContainer() throws Exception {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void closeAlreadyClosedContainer(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     container.getContainerData()
         .setState(ContainerProtos.ContainerDataProto.State.CLOSED);
 
@@ -220,28 +238,34 @@ public class TestCloseContainerCommandHandler {
         .submitRequest(any(), any());
   }
 
-  @Test
-  public void closeNonExistenceContainer() {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void closeNonExistenceContainer(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     long containerID = 1L;
     try {
       controller.markContainerForClose(containerID);
     } catch (IOException e) {
 
       GenericTestUtils.assertExceptionContains("The Container " +
-                      "is not found. ContainerID: " + containerID, e);
+          "is not found. ContainerID: " + containerID, e);
     }
   }
 
-  @Test
-  public void closeMissingContainer() {
+  @ParameterizedTest
+  @MethodSource("layoutVersion")
+  public void closeMissingContainer(ContainerLayoutVersion layout)
+      throws Exception {
+    initLayoutVerison(layout);
     long containerID = 2L;
     containerSet.getMissingContainerSet().add(containerID);
     try {
       controller.markContainerForClose(containerID);
     } catch (IOException e) {
       GenericTestUtils.assertExceptionContains("The Container is in " +
-              "the MissingContainerSet hence we can't close it. " +
-              "ContainerID: " + containerID, e);
+          "the MissingContainerSet hence we can't close it. " +
+          "ContainerID: " + containerID, e);
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -83,7 +83,7 @@ public class TestCloseContainerCommandHandler {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     context = ContainerTestUtils.getMockContext(randomDatanodeDetails(), conf);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -30,11 +30,11 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler.SchemaHandler;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.apache.ozone.test.JUnit5AwareTimeout;
@@ -101,7 +101,7 @@ public class TestDeleteBlocksCommandHandler {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
     layout = ContainerLayoutVersion.FILE_PER_BLOCK;
@@ -138,7 +138,7 @@ public class TestDeleteBlocksCommandHandler {
     handler.getSchemaHandlers().put(SCHEMA_V3, testSchemaHandler3);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     handler.stop();
     BlockDeletingServiceMetrics.unRegister();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler.SchemaHandler;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
@@ -147,7 +147,7 @@ public class TestDeleteBlocksCommandHandler {
   @Test
   public void testDeleteBlocksCommandHandler()
       throws IOException {
-    Assert.assertTrue(containerSet.containerCount() > 0);
+    Assertions.assertTrue(containerSet.containerCount() > 0);
     Container<?> container = containerSet.getContainerIterator(volume1).next();
     DeletedBlocksTransaction transaction = createDeletedBlocksTransaction(1,
         container.getContainerData().getContainerID());
@@ -163,16 +163,16 @@ public class TestDeleteBlocksCommandHandler {
     Mockito.verify(handler,
         times(1)).submitTasks(any());
 
-    Assert.assertEquals(1, results.size());
-    Assert.assertTrue(results.get(0).getSuccess());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertTrue(results.get(0).getSuccess());
+    Assertions.assertEquals(0,
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
   }
 
   @Test
   public void testDeleteBlocksCommandHandlerWithTimeoutFailed()
       throws IOException {
-    Assert.assertTrue(containerSet.containerCount() >= 2);
+    Assertions.assertTrue(containerSet.containerCount() >= 2);
     Iterator<Container<?>> iterator =
         containerSet.getContainerIterator(volume1);
     Container<?> lockedContainer = iterator.next();
@@ -204,22 +204,22 @@ public class TestDeleteBlocksCommandHandler {
         times(1)).submitTasks(eq(transactions));
     Mockito.verify(handler,
         times(1)).submitTasks(eq(Arrays.asList(transaction1)));
-    Assert.assertEquals(2, results.size());
+    Assertions.assertEquals(2, results.size());
 
     // Only one transaction will succeed
     Map<Long, DeleteBlockTransactionResult> resultsMap = new HashMap<>();
     results.forEach(result -> resultsMap.put(result.getTxID(), result));
-    Assert.assertFalse(resultsMap.get(transaction1.getTxID()).getSuccess());
-    Assert.assertTrue(resultsMap.get(transaction2.getTxID()).getSuccess());
+    Assertions.assertFalse(resultsMap.get(transaction1.getTxID()).getSuccess());
+    Assertions.assertTrue(resultsMap.get(transaction2.getTxID()).getSuccess());
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
   }
 
   @Test
   public void testDeleteBlocksCommandHandlerSuccessfulAfterFirstTimeout()
       throws IOException {
-    Assert.assertTrue(containerSet.containerCount() > 0);
+    Assertions.assertTrue(containerSet.containerCount() > 0);
     Container<?> lockedContainer =
         containerSet.getContainerIterator(volume1).next();
     DeletedBlocksTransaction transaction = createDeletedBlocksTransaction(1,
@@ -258,10 +258,10 @@ public class TestDeleteBlocksCommandHandler {
         times(2)).submitTasks(any());
     Mockito.verify(handler.getSchemaHandlers().get(schemaVersionOrDefault),
         times(1)).handle(any(), any());
-    Assert.assertEquals(1, results.size());
-    Assert.assertTrue(results.get(0).getSuccess());
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertTrue(results.get(0).getSuccess());
 
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
   }
 
@@ -277,13 +277,13 @@ public class TestDeleteBlocksCommandHandler {
         spy(new DeleteBlocksCommandHandler(
         container, tmpConf, dnConf, "test"));
 
-    Assert.assertEquals(tmpConf.getTimeDuration(
+    Assertions.assertEquals(tmpConf.getTimeDuration(
         BLOCK_DELETE_COMMAND_WORKER_INTERVAL,
         BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT.getSeconds(),
         TimeUnit.SECONDS), 3);
     DeleteBlocksCommandHandler.DeleteCmdWorker deleteCmdWorker =
         commandHandler.new DeleteCmdWorker(4000);
-    Assert.assertEquals(deleteCmdWorker.getInterval(), 4000);
+    Assertions.assertEquals(deleteCmdWorker.getInterval(), 4000);
   }
 
   private DeletedBlocksTransaction createDeletedBlocksTransaction(long txID,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -69,7 +69,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult.FAILED;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.any;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.util.DiskChecker.DiskErrorException;
 import org.apache.hadoop.util.FakeTimer;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.rules.TemporaryFolder;
 import org.junit.jupiter.api.Test;
@@ -69,8 +69,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult.FAILED;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.isNull;
@@ -269,14 +269,14 @@ public class TestStorageVolumeChecker {
     // delete the volume directory
     FileUtils.deleteDirectory(volParentDir);
 
-    Assert.assertEquals(2, volumeSet.getVolumesList().size());
+    Assertions.assertEquals(2, volumeSet.getVolumesList().size());
     volumeSet.checkAllVolumes();
     // failed volume should be removed from volumeSet volume list
-    Assert.assertEquals(1, volumeSet.getVolumesList().size());
-    Assert.assertEquals(1, volumeSet.getFailedVolumesList().size());
+    Assertions.assertEquals(1, volumeSet.getVolumesList().size());
+    Assertions.assertEquals(1, volumeSet.getFailedVolumesList().size());
 
     // All containers should be removed from containerSet
-    Assert.assertEquals(0, containerSet.getContainerMap().size());
+    Assertions.assertEquals(0, containerSet.getContainerMap().size());
 
     ozoneContainer.stop();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -40,11 +40,11 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker.DiskErrorException;
 import org.apache.hadoop.util.FakeTimer;
 import org.junit.Rule;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.rules.TemporaryFolder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
@@ -114,7 +114,7 @@ public class TestStorageVolumeChecker {
     this.layout = layout;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, folder.getRoot()
@@ -123,7 +123,7 @@ public class TestStorageVolumeChecker {
         folder.newFolder().getAbsolutePath());
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     FileUtils.deleteDirectory(folder.getRoot());
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -54,9 +54,9 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import org.junit.jupiter.api.AfterEach;
 
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -57,15 +57,14 @@ import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.create
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * This class is used to test KeyValue container block iterator.
  */
-@RunWith(Parameterized.class)
 public class TestKeyValueBlockIterator {
 
   private static final long CONTAINER_ID = 105L;
@@ -76,13 +75,13 @@ public class TestKeyValueBlockIterator {
   private OzoneConfiguration conf;
   private File testRoot;
   private DBHandle db;
-  private final ContainerLayoutVersion layout;
+  private ContainerLayoutVersion layout;
   private String schemaVersion;
   private String datanodeID = UUID.randomUUID().toString();
   private String clusterID = UUID.randomUUID().toString();
 
-  public TestKeyValueBlockIterator(ContainerTestVersionInfo versionInfo,
-      String keySeparator) {
+  private void initTest(ContainerTestVersionInfo versionInfo,
+      String keySeparator) throws Exception {
     this.layout = versionInfo.getLayout();
     this.schemaVersion = versionInfo.getSchemaVersion();
     this.conf = new OzoneConfiguration();
@@ -90,26 +89,25 @@ public class TestKeyValueBlockIterator {
     DatanodeConfiguration dc = conf.getObject(DatanodeConfiguration.class);
     dc.setContainerSchemaV3KeySeparator(keySeparator);
     conf.setFromObject(dc);
+    setup();
   }
 
-  @Parameterized.Parameters
-  public static Iterable<Object[]> data() {
-    List listA =
+  private static List<Arguments> provideTestData() {
+    List<Arguments> listA =
         ContainerTestVersionInfo.getLayoutList().stream().map(
-            each -> new Object[] {each, ""})
+                each -> Arguments.of(each, ""))
             .collect(toList());
-    List listB =
+    List<Arguments> listB =
         ContainerTestVersionInfo.getLayoutList().stream().map(
-            each -> new Object[] {each,
-                new DatanodeConfiguration().getContainerSchemaV3KeySeparator()})
+                each -> Arguments.of(each, new DatanodeConfiguration()
+                    .getContainerSchemaV3KeySeparator()))
             .collect(toList());
 
     listB.addAll(listA);
     return listB;
   }
 
-  @BeforeEach
-  public void setUp() throws Exception {
+  public void setup() throws Exception {
     testRoot = GenericTestUtils.getRandomizedTestDir();
     conf.set(HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());
     conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testRoot.getAbsolutePath());
@@ -118,9 +116,9 @@ public class TestKeyValueBlockIterator {
     createDbInstancesForTestIfNeeded(volumeSet, clusterID, clusterID, conf);
 
     containerData = new KeyValueContainerData(105L,
-            layout,
-            (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
-            UUID.randomUUID().toString());
+        layout,
+        (long) StorageUnit.GB.toBytes(1), UUID.randomUUID().toString(),
+        UUID.randomUUID().toString());
     // Init the container.
     container = new KeyValueContainer(containerData, conf);
     container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
@@ -138,22 +136,26 @@ public class TestKeyValueBlockIterator {
     FileUtil.fullyDelete(testRoot);
   }
 
-  @Test
-  public void testKeyValueBlockIteratorWithMixedBlocks() throws Exception {
+  @ParameterizedTest
+  @MethodSource("provideTestData")
+  public void testKeyValueBlockIteratorWithMixedBlocks(
+      ContainerTestVersionInfo versionInfo, String keySeparator)
+      throws Exception {
+    initTest(versionInfo, keySeparator);
     int deletingBlocks = 5;
     int normalBlocks = 5;
     Map<String, List<Long>> blockIDs = createContainerWithBlocks(CONTAINER_ID,
-            normalBlocks, deletingBlocks);
+        normalBlocks, deletingBlocks);
 
     // Default filter used is all unprefixed blocks.
     List<Long> unprefixedBlockIDs = blockIDs.get("");
     try (BlockIterator<BlockData> keyValueBlockIterator =
-                db.getStore().getBlockIterator(CONTAINER_ID)) {
+             db.getStore().getBlockIterator(CONTAINER_ID)) {
 
       Iterator<Long> blockIDIter = unprefixedBlockIDs.iterator();
       while (keyValueBlockIterator.hasNext()) {
         BlockData blockData = keyValueBlockIterator.nextBlock();
-        assertEquals(blockData.getLocalID(), (long)blockIDIter.next());
+        assertEquals(blockData.getLocalID(), (long) blockIDIter.next());
       }
       assertFalse(keyValueBlockIterator.hasNext());
       assertFalse(blockIDIter.hasNext());
@@ -176,15 +178,19 @@ public class TestKeyValueBlockIterator {
     }
   }
 
-  @Test
-  public void testKeyValueBlockIteratorWithNextBlock() throws Exception {
+  @ParameterizedTest
+  @MethodSource("provideTestData")
+  public void testKeyValueBlockIteratorWithNextBlock(
+      ContainerTestVersionInfo versionInfo, String keySeparator)
+      throws Exception {
+    initTest(versionInfo, keySeparator);
     List<Long> blockIDs = createContainerWithBlocks(CONTAINER_ID, 2);
     try (BlockIterator<BlockData> keyValueBlockIterator =
-                db.getStore().getBlockIterator(CONTAINER_ID)) {
-      assertEquals((long)blockIDs.get(0),
-              keyValueBlockIterator.nextBlock().getLocalID());
-      assertEquals((long)blockIDs.get(1),
-              keyValueBlockIterator.nextBlock().getLocalID());
+             db.getStore().getBlockIterator(CONTAINER_ID)) {
+      assertEquals((long) blockIDs.get(0),
+          keyValueBlockIterator.nextBlock().getLocalID());
+      assertEquals((long) blockIDs.get(1),
+          keyValueBlockIterator.nextBlock().getLocalID());
 
       try {
         keyValueBlockIterator.nextBlock();
@@ -195,11 +201,15 @@ public class TestKeyValueBlockIterator {
     }
   }
 
-  @Test
-  public void testKeyValueBlockIteratorWithHasNext() throws Exception {
+  @ParameterizedTest
+  @MethodSource("provideTestData")
+  public void testKeyValueBlockIteratorWithHasNext(
+      ContainerTestVersionInfo versionInfo, String keySeparator)
+      throws Exception {
+    initTest(versionInfo, keySeparator);
     List<Long> blockIDs = createContainerWithBlocks(CONTAINER_ID, 2);
     try (BlockIterator<BlockData> blockIter =
-                db.getStore().getBlockIterator(CONTAINER_ID)) {
+             db.getStore().getBlockIterator(CONTAINER_ID)) {
 
       // Even calling multiple times hasNext() should not move entry forward.
       assertTrue(blockIter.hasNext());
@@ -207,18 +217,18 @@ public class TestKeyValueBlockIterator {
       assertTrue(blockIter.hasNext());
       assertTrue(blockIter.hasNext());
       assertTrue(blockIter.hasNext());
-      assertEquals((long)blockIDs.get(0),
-              blockIter.nextBlock().getLocalID());
+      assertEquals((long) blockIDs.get(0),
+          blockIter.nextBlock().getLocalID());
 
       assertTrue(blockIter.hasNext());
       assertTrue(blockIter.hasNext());
       assertTrue(blockIter.hasNext());
       assertTrue(blockIter.hasNext());
       assertTrue(blockIter.hasNext());
-      assertEquals((long)blockIDs.get(1), blockIter.nextBlock().getLocalID());
+      assertEquals((long) blockIDs.get(1), blockIter.nextBlock().getLocalID());
 
       blockIter.seekToFirst();
-      assertEquals((long)blockIDs.get(0), blockIter.nextBlock().getLocalID());
+      assertEquals((long) blockIDs.get(0), blockIter.nextBlock().getLocalID());
       assertEquals((long)blockIDs.get(1), blockIter.nextBlock().getLocalID());
 
       try {
@@ -230,22 +240,26 @@ public class TestKeyValueBlockIterator {
     }
   }
 
-  @Test
-  public void testKeyValueBlockIteratorWithFilter() throws Exception {
+  @ParameterizedTest
+  @MethodSource("provideTestData")
+  public void testKeyValueBlockIteratorWithFilter(
+      ContainerTestVersionInfo versionInfo, String keySeparator)
+      throws Exception {
+    initTest(versionInfo, keySeparator);
     int normalBlocks = 5;
     int deletingBlocks = 5;
     Map<String, List<Long>> blockIDs = createContainerWithBlocks(CONTAINER_ID,
-            normalBlocks, deletingBlocks);
+        normalBlocks, deletingBlocks);
     try (BlockIterator<BlockData> keyValueBlockIterator =
-                db.getStore().getBlockIterator(CONTAINER_ID,
-                        containerData.getDeletingBlockKeyFilter())) {
+             db.getStore().getBlockIterator(CONTAINER_ID,
+                 containerData.getDeletingBlockKeyFilter())) {
       List<Long> deletingBlockIDs =
-              blockIDs.get(OzoneConsts.DELETING_KEY_PREFIX);
+          blockIDs.get(OzoneConsts.DELETING_KEY_PREFIX);
       int counter = 0;
       while (keyValueBlockIterator.hasNext()) {
         BlockData blockData = keyValueBlockIterator.nextBlock();
-        assertEquals((long)deletingBlockIDs.get(counter),
-                blockData.getLocalID());
+        assertEquals((long) deletingBlockIDs.get(counter),
+            blockData.getLocalID());
         counter++;
       }
 
@@ -253,12 +267,15 @@ public class TestKeyValueBlockIterator {
     }
   }
 
-  @Test
-  public void testKeyValueBlockIteratorWithOnlyDeletedBlocks() throws
-      Exception {
+  @ParameterizedTest
+  @MethodSource("provideTestData")
+  public void testKeyValueBlockIteratorWithOnlyDeletedBlocks(
+      ContainerTestVersionInfo versionInfo, String keySeparator)
+      throws Exception {
+    initTest(versionInfo, keySeparator);
     createContainerWithBlocks(CONTAINER_ID, 0, 5);
     try (BlockIterator<BlockData> keyValueBlockIterator =
-                db.getStore().getBlockIterator(CONTAINER_ID)) {
+             db.getStore().getBlockIterator(CONTAINER_ID)) {
       //As all blocks are deleted blocks, blocks does not match with normal key
       // filter.
       assertFalse(keyValueBlockIterator.hasNext());
@@ -285,9 +302,12 @@ public class TestKeyValueBlockIterator {
    *
    * @throws Exception
    */
-  @Test
-  public void testKeyValueBlockIteratorWithAdvancedFilter() throws
-          Exception {
+  @ParameterizedTest
+  @MethodSource("provideTestData")
+  public void testKeyValueBlockIteratorWithAdvancedFilter(
+      ContainerTestVersionInfo versionInfo, String keySeparator)
+      throws Exception {
+    initTest(versionInfo, keySeparator);
     // Block data table currently only uses one prefix type.
     // Introduce a second prefix type to make sure the iterator functions
     // correctly if more prefixes were to be added in the future.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -51,14 +51,14 @@ import org.apache.ozone.test.GenericTestUtils;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -108,7 +108,7 @@ public class TestKeyValueBlockIterator {
     return listB;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     testRoot = GenericTestUtils.getRandomizedTestDir();
     conf.set(HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());
@@ -129,7 +129,7 @@ public class TestKeyValueBlockIterator {
   }
 
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     db.close();
     db.cleanup();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -573,17 +573,17 @@ public class TestKeyValueContainer {
         .getMetadataPath();
     File containerMetaDataLoc = new File(containerMetaDataPath);
 
-    assertFalse("Container directory still exists", containerMetaDataLoc
-        .getParentFile().exists());
+    assertFalse(containerMetaDataLoc
+        .getParentFile().exists(), "Container directory still exists");
 
-    assertFalse("Container File still exists",
-        keyValueContainer.getContainerFile().exists());
+    assertFalse(keyValueContainer.getContainerFile().exists(),
+        "Container File still exists");
 
     if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
       assertTrue(keyValueContainer.getContainerDBFile().exists());
     } else {
-      assertFalse("Container DB file still exists",
-          keyValueContainer.getContainerDBFile().exists());
+      assertFalse(keyValueContainer.getContainerDBFile().exists(),
+          "Container DB file still exists");
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.util.DiskChecker;
 
 import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
@@ -99,10 +99,10 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 import static org.apache.ratis.util.Preconditions.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -217,12 +217,12 @@ public class TestKeyValueContainer {
     populate(0);
     KeyValueContainerData data = keyValueContainer.getContainerData();
     File chunksDir = new File(data.getChunksPath());
-    Assert.assertTrue(chunksDir.delete());
+    Assertions.assertTrue(chunksDir.delete());
 
     // When the container is loaded, the missing chunks directory should
     // be created.
     KeyValueContainerUtil.parseKVContainerData(data, CONF);
-    Assert.assertTrue(chunksDir.exists());
+    Assertions.assertTrue(chunksDir.exists());
   }
 
   @Test
@@ -423,12 +423,12 @@ public class TestKeyValueContainer {
   private void checkContainerFilesPresent(KeyValueContainerData data,
       long expectedNumFilesInChunksDir) throws IOException {
     File chunksDir = new File(data.getChunksPath());
-    Assert.assertTrue(Files.isDirectory(chunksDir.toPath()));
+    Assertions.assertTrue(Files.isDirectory(chunksDir.toPath()));
     try (Stream<Path> stream = Files.list(chunksDir.toPath())) {
-      Assert.assertEquals(expectedNumFilesInChunksDir, stream.count());
+      Assertions.assertEquals(expectedNumFilesInChunksDir, stream.count());
     }
-    Assert.assertTrue(data.getDbFile().exists());
-    Assert.assertTrue(KeyValueContainer.getContainerFile(data.getMetadataPath(),
+    Assertions.assertTrue(data.getDbFile().exists());
+    Assertions.assertTrue(KeyValueContainer.getContainerFile(data.getMetadataPath(),
         data.getContainerID()).exists());
   }
 
@@ -610,14 +610,14 @@ public class TestKeyValueContainer {
   @Test
   public void testReportOfUnhealthyContainer() throws Exception {
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
-    Assert.assertNotNull(keyValueContainer.getContainerReport());
+    Assertions.assertNotNull(keyValueContainer.getContainerReport());
     keyValueContainer.markContainerUnhealthy();
     File containerFile = keyValueContainer.getContainerFile();
     keyValueContainerData = (KeyValueContainerData) ContainerDataYaml
         .readContainerFile(containerFile);
     assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY,
         keyValueContainerData.getState());
-    Assert.assertNotNull(keyValueContainer.getContainerReport());
+    Assertions.assertNotNull(keyValueContainer.getContainerReport());
   }
 
   @Test
@@ -672,11 +672,11 @@ public class TestKeyValueContainer {
       long defaultCacheSize = 64 * OzoneConsts.MB;
       long cacheSize = Long.parseLong(store
           .getProperty("rocksdb.block-cache-capacity"));
-      Assert.assertEquals(defaultCacheSize, cacheSize);
+      Assertions.assertEquals(defaultCacheSize, cacheSize);
       for (ColumnFamily handle : store.getColumnFamilies()) {
         cacheSize = Long.parseLong(
             store.getProperty(handle, "rocksdb.block-cache-capacity"));
-        Assert.assertEquals(defaultCacheSize, cacheSize);
+        Assertions.assertEquals(defaultCacheSize, cacheSize);
       }
     }
   }
@@ -693,7 +693,7 @@ public class TestKeyValueContainer {
           .getColumnFamilyOptions(new OzoneConfiguration());
       ColumnFamilyOptions columnFamilyOptions2 = dbProfileSupplier.get()
           .getColumnFamilyOptions(new OzoneConfiguration());
-      Assert.assertEquals(columnFamilyOptions1, columnFamilyOptions2);
+      Assertions.assertEquals(columnFamilyOptions1, columnFamilyOptions2);
 
       // ColumnFamilyOptions should be same when queried multiple times
       // for a particulat configuration
@@ -701,16 +701,16 @@ public class TestKeyValueContainer {
           .getColumnFamilyOptions(conf);
       columnFamilyOptions2 = dbProfileSupplier.get()
           .getColumnFamilyOptions(conf);
-      Assert.assertEquals(columnFamilyOptions1, columnFamilyOptions2);
+      Assertions.assertEquals(columnFamilyOptions1, columnFamilyOptions2);
     }
 
     // Make sure ColumnFamilyOptions are different for different db profile
     DatanodeDBProfile diskProfile = new DatanodeDBProfile.Disk();
     DatanodeDBProfile ssdProfile = new DatanodeDBProfile.SSD();
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         diskProfile.getColumnFamilyOptions(new OzoneConfiguration()),
         ssdProfile.getColumnFamilyOptions(new OzoneConfiguration()));
-    Assert.assertNotEquals(diskProfile.getColumnFamilyOptions(conf),
+    Assertions.assertNotEquals(diskProfile.getColumnFamilyOptions(conf),
         ssdProfile.getColumnFamilyOptions(conf));
   }
 
@@ -724,7 +724,7 @@ public class TestKeyValueContainer {
     try (DBHandle db1 =
         BlockUtils.getDB(keyValueContainer.getContainerData(), CONF)) {
       DatanodeStore store1 = db1.getStore();
-      Assert.assertTrue(store1 instanceof AbstractDatanodeStore);
+      Assertions.assertTrue(store1 instanceof AbstractDatanodeStore);
       outProfile1 = ((AbstractDatanodeStore) store1).getDbProfile();
     }
 
@@ -745,17 +745,17 @@ public class TestKeyValueContainer {
     try (DBHandle db2 =
         BlockUtils.getDB(keyValueContainer.getContainerData(), otherConf)) {
       DatanodeStore store2 = db2.getStore();
-      Assert.assertTrue(store2 instanceof AbstractDatanodeStore);
+      Assertions.assertTrue(store2 instanceof AbstractDatanodeStore);
       outProfile2 = ((AbstractDatanodeStore) store2).getDbProfile();
     }
 
     // DBOtions should be different, except SCHEMA-V3
     if (isSameSchemaVersion(schemaVersion, OzoneConsts.SCHEMA_V3)) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           outProfile1.getDBOptions().compactionReadaheadSize(),
           outProfile2.getDBOptions().compactionReadaheadSize());
     } else {
-      Assert.assertNotEquals(
+      Assertions.assertNotEquals(
           outProfile1.getDBOptions().compactionReadaheadSize(),
           outProfile2.getDBOptions().compactionReadaheadSize());
     }
@@ -875,7 +875,7 @@ public class TestKeyValueContainer {
       Thread.sleep(7000);
       List<LiveFileMetaData> fileMetaDataList2 =
           ((RDBStore)(dnStore.getStore())).getDb().getLiveFilesMetaData();
-      Assert.assertTrue(fileMetaDataList2.size() < fileMetaDataList1.size());
+      Assertions.assertTrue(fileMetaDataList2.size() < fileMetaDataList1.size());
     } catch (Exception e) {
       Fail.fail("TestAutoCompactionSmallSstFile failed");
     } finally {
@@ -930,7 +930,7 @@ public class TestKeyValueContainer {
       }
 
       // After import check whether isEmpty flag is false
-      Assert.assertFalse(container.getContainerData().isEmpty());
+      Assertions.assertFalse(container.getContainerData().isEmpty());
     }
   }
 
@@ -977,7 +977,7 @@ public class TestKeyValueContainer {
 
       // After import check whether isEmpty flag is true
       // since there are no blocks in rocksdb
-      Assert.assertTrue(container.getContainerData().isEmpty());
+      Assertions.assertTrue(container.getContainerData().isEmpty());
     }
   }
 
@@ -1042,10 +1042,10 @@ public class TestKeyValueContainer {
 
     // verify container schema
     if (schemaV3Enabled) {
-      Assert.assertEquals(SCHEMA_V3,
+      Assertions.assertEquals(SCHEMA_V3,
           container.getContainerData().getSchemaVersion());
     } else {
-      Assert.assertEquals(SCHEMA_V2,
+      Assertions.assertEquals(SCHEMA_V2,
           container.getContainerData().getSchemaVersion());
     }
 
@@ -1075,9 +1075,9 @@ public class TestKeyValueContainer {
       importedContainer.importContainerData(fio, packer);
     }
 
-    Assert.assertEquals(schemaV3Enabled ? SCHEMA_V3 : SCHEMA_V2,
+    Assertions.assertEquals(schemaV3Enabled ? SCHEMA_V3 : SCHEMA_V2,
         importedContainer.getContainerData().getSchemaVersion());
-    Assert.assertEquals(pendingDeleteBlockCount,
+    Assertions.assertEquals(pendingDeleteBlockCount,
         importedContainer.getContainerData().getNumPendingDeletionBlocks());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -57,12 +57,12 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker;
 
 import org.assertj.core.api.Fail;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.rules.TemporaryFolder;
 
@@ -143,7 +143,7 @@ public class TestKeyValueContainer {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     CodecBuffer.enableLeakDetection();
 
@@ -183,7 +183,7 @@ public class TestKeyValueContainer {
     keyValueContainer = new KeyValueContainer(keyValueContainerData, CONF);
   }
 
-  @After
+  @AfterEach
   public void after() {
     CodecBuffer.assertNoLeaks();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -50,10 +50,10 @@ public class TestKeyValueContainerCheck
    * Sanity test, when there are no corruptions induced.
    */
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testKeyValueContainerCheckNoCorruption(
       ContainerTestVersionInfo versionInfo) throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     long containerID = 101;
     int deletedBlocks = 1;
     int normalBlocks = 3;
@@ -86,10 +86,10 @@ public class TestKeyValueContainerCheck
    * Sanity test, when there are corruptions induced.
    */
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testKeyValueContainerCheckCorruption(
       ContainerTestVersionInfo versionInfo) throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     long containerID = 102;
     int deletedBlocks = 1;
     int normalBlocks = 3;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -72,9 +72,9 @@ public class TestKeyValueContainerIntegrityChecks {
   protected static final int CHUNK_LEN = 3 * UNIT_LEN;
   protected static final int CHUNKS_PER_BLOCK = 4;
 
-  private void initialize(ContainerTestVersionInfo versionInfo) {
-    LOG.info("new TestKeyValueContainerIntegrityChecks for {}", versionInfo);
-    conf = new OzoneConfiguration();
+  void initTestData(ContainerTestVersionInfo versionInfo) throws Exception {
+    LOG.info("new {} for {}", getClass().getSimpleName(), versionInfo);
+    this.conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(
         versionInfo.getSchemaVersion(), conf);
     if (versionInfo.getLayout()
@@ -83,14 +83,14 @@ public class TestKeyValueContainerIntegrityChecks {
     } else {
       containerLayoutTestInfo = ContainerLayoutTestInfo.FILE_PER_CHUNK;
     }
+    setup();
   }
 
-  private static Stream<Object> data() {
-    return ContainerTestVersionInfo.versionParametersStream();
+  static Iterable<Object[]> versionInfo() {
+    return ContainerTestVersionInfo.versionParameters();
   }
 
-  public void setUp(ContainerTestVersionInfo versionInfo) throws Exception {
-    initialize(versionInfo);
+  private void setup() throws Exception {
     LOG.info("Testing  layout:{}", containerLayoutTestInfo.getLayout());
     this.testRoot = GenericTestUtils.getRandomizedTestDir();
     conf.set(HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
@@ -27,10 +27,10 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
@@ -91,7 +91,7 @@ public class TestKeyValueContainerMarkUnhealthy {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new OzoneConfiguration();
     datanodeId = UUID.randomUUID();
@@ -120,7 +120,7 @@ public class TestKeyValueContainerMarkUnhealthy {
         keyValueContainerData, conf);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     volumeSet = null;
     keyValueContainer = null;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
@@ -48,8 +48,8 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.OPEN;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
@@ -49,7 +49,7 @@ import java.util.UUID;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.OPEN;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -59,10 +59,10 @@ public class TestKeyValueContainerMetadataInspector
   private static final long CONTAINER_ID = 102;
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testRunDisabled(ContainerTestVersionInfo versionInfo)
       throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     // Create incorrect container.
     KeyValueContainer container = createClosedContainer(3);
     KeyValueContainerData containerData = container.getContainerData();
@@ -85,10 +85,10 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testSystemPropertyAndReadOnly(
       ContainerTestVersionInfo versionInfo) throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     System.clearProperty(KeyValueContainerMetadataInspector.SYSTEM_PROPERTY);
     ContainerInspector inspector = new KeyValueContainerMetadataInspector();
     assertFalse(inspector.load());
@@ -120,10 +120,10 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testIncorrectTotalsNoData(ContainerTestVersionInfo versionInfo)
       throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     int createBlocks = 0;
     int setBlocks = -3;
     int setBytes = -2;
@@ -135,10 +135,10 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testIncorrectTotalsWithData(ContainerTestVersionInfo versionInfo)
       throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     int createBlocks = 3;
     int setBlocks = 4;
     int setBytes = -2;
@@ -151,11 +151,10 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testCorrectTotalsNoData(ContainerTestVersionInfo versionInfo)
       throws Exception {
-    setUp(versionInfo);
-
+    initTestData(versionInfo);
     int createBlocks = 0;
     int setBytes = 0;
 
@@ -166,10 +165,10 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testCorrectTotalsWithData(ContainerTestVersionInfo versionInfo)
       throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     int createBlocks = 3;
     int setBytes = CHUNK_LEN * CHUNKS_PER_BLOCK * createBlocks;
 
@@ -209,10 +208,10 @@ public class TestKeyValueContainerMetadataInspector
       = new DeletedBlocksTransactionGeneratorForTesting();
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testCorrectDeleteWithTransaction(
       ContainerTestVersionInfo versionInfo) throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     final int createBlocks = 4;
     final int setBytes = CHUNK_LEN * CHUNKS_PER_BLOCK * createBlocks;
     final int deleteCount = 10;
@@ -233,10 +232,10 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testIncorrectDeleteWithTransaction(
       ContainerTestVersionInfo versionInfo) throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     final int createBlocks = 4;
     final int setBytes = CHUNK_LEN * CHUNKS_PER_BLOCK * createBlocks;
     final int deleteCount = 10;
@@ -258,10 +257,10 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   @ParameterizedTest
-  @MethodSource("data")
+  @MethodSource("versionInfo")
   public void testIncorrectDeleteWithoutTransaction(
       ContainerTestVersionInfo versionInfo) throws Exception {
-    setUp(versionInfo);
+    initTestData(versionInfo);
     final int createBlocks = 4;
     final int setBytes = CHUNK_LEN * CHUNKS_PER_BLOCK * createBlocks;
     final int deleteCount = 10;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -59,9 +59,9 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.ozone.test.JUnit5AwareTimeout;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
@@ -107,7 +107,7 @@ public class TestKeyValueHandler {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws StorageContainerException {
     // Create mock HddsDispatcher and KeyValueHandler.
     handler = Mockito.mock(KeyValueHandler.class);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -344,8 +344,9 @@ public class TestKeyValueHandler {
     ContainerProtos.ContainerCommandResponseProto response =
         handler.handleCloseContainer(closeContainerRequest, container);
 
-    assertEquals("Close container should return Invalid container error",
-        ContainerProtos.Result.INVALID_CONTAINER_STATE, response.getResult());
+    assertEquals(ContainerProtos.Result.INVALID_CONTAINER_STATE,
+        response.getResult(),
+        "Close container should return Invalid container error");
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -55,10 +55,10 @@ import org.apache.ozone.test.GenericTestUtils;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
@@ -389,12 +389,12 @@ public class TestKeyValueHandler {
           createContainerRequest(datanodeId, containerID);
 
       kvHandler.handleCreateContainer(createContainer, null);
-      Assert.assertEquals(1, icrReceived.get());
-      Assert.assertNotNull(containerSet.getContainer(containerID));
+      Assertions.assertEquals(1, icrReceived.get());
+      Assertions.assertNotNull(containerSet.getContainer(containerID));
 
       kvHandler.deleteContainer(containerSet.getContainer(containerID), true);
-      Assert.assertEquals(2, icrReceived.get());
-      Assert.assertNull(containerSet.getContainer(containerID));
+      Assertions.assertEquals(2, icrReceived.get());
+      Assertions.assertNull(containerSet.getContainer(containerID));
 
       File[] deletedContainers =
           hddsVolume.getDeletedContainerDir().listFiles();
@@ -411,9 +411,9 @@ public class TestKeyValueHandler {
 
       kvHandler.handleCreateContainer(createContainer2, null);
 
-      Assert.assertEquals(3, icrReceived.get());
+      Assertions.assertEquals(3, icrReceived.get());
       Container<?> container = containerSet.getContainer(container2ID);
-      Assert.assertNotNull(container);
+      Assertions.assertNotNull(container);
       File deletedContainerDir = hddsVolume.getDeletedContainerDir();
       // to simulate failed move
       File dummyDir = new File(DUMMY_PATH);
@@ -421,7 +421,7 @@ public class TestKeyValueHandler {
       try {
         kvHandler.deleteContainer(container, true);
       } catch (StorageContainerException sce) {
-        Assert.assertTrue(
+        Assertions.assertTrue(
             sce.getMessage().contains("Failed to move container"));
       }
       Mockito.verify(volumeSet).checkVolumeAsync(hddsVolume);
@@ -438,7 +438,7 @@ public class TestKeyValueHandler {
       String expectedLog =
           "Delete container issued on containerID 2 which is " +
               "in a failed volume";
-      Assert.assertTrue(kvHandlerLogs.getOutput().contains(expectedLog));
+      Assertions.assertTrue(kvHandlerLogs.getOutput().contains(expectedLog));
     } finally {
       FileUtils.deleteDirectory(new File(testDir));
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -245,10 +245,9 @@ public class TestTarContainerPacker {
     assertExampleChunkFileIsGood(
         Paths.get(destinationContainerData.getChunksPath()),
         TEST_CHUNK_FILE_NAME);
-    Assertions.assertFalse(
+    Assertions.assertFalse(destinationContainer.getContainerFile().exists(),
         "Descriptor file should not have been extracted by the "
-            + "unpackContainerData Call",
-        destinationContainer.getContainerFile().exists());
+            + "unpackContainerData Call");
     Assertions.assertEquals(TEST_DESCRIPTOR_FILE_CONTENT, descriptor);
     inputForUnpackData.assertClosedExactlyOnce();
   }
@@ -403,10 +402,9 @@ public class TestTarContainerPacker {
 
     Path exampleFile = parentPath.resolve(filename);
 
-    Assertions.assertTrue(
-        "example file is missing after pack/unpackContainerData: "
-            + exampleFile,
-        Files.exists(exampleFile));
+    Assertions.assertTrue(Files.exists(exampleFile),
+        "example file is missing after pack/unpackContainerData: " +
+            exampleFile);
 
     try (FileInputStream testFile =
              new FileInputStream(exampleFile.toFile())) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -46,10 +46,10 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.ozone.container.replication.CopyContainerCompression;
 import org.apache.ozone.test.SpyInputStream;
 import org.apache.ozone.test.SpyOutputStream;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -115,14 +115,14 @@ public class TestTarContainerPacker {
     return parameterList;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws IOException {
     initDir(SOURCE_CONTAINER_ROOT);
     initDir(DEST_CONTAINER_ROOT);
     initDir(TEMP_DIR);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     FileUtils.deleteDirectory(SOURCE_CONTAINER_ROOT.toFile());
     FileUtils.deleteDirectory(DEST_CONTAINER_ROOT.toFile());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.ozone.container.replication.CopyContainerCompression;
 import org.apache.ozone.test.SpyInputStream;
 import org.apache.ozone.test.SpyOutputStream;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -57,7 +57,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newInputStream;
 import static java.nio.file.Files.newOutputStream;
 import static org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker.CONTAINER_FILE_NAME;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test the tar/untar for a given container.
@@ -201,13 +201,13 @@ public class TestTarContainerPacker {
       Map<String, TarArchiveEntry> entries = new HashMap<>();
       while ((entry = tarStream.getNextTarEntry()) != null) {
         if (first) {
-          Assert.assertEquals(CONTAINER_FILE_NAME, entry.getName());
+          Assertions.assertEquals(CONTAINER_FILE_NAME, entry.getName());
           first = false;
         }
         entries.put(entry.getName(), entry);
       }
 
-      Assert.assertTrue(entries.containsKey(CONTAINER_FILE_NAME));
+      Assertions.assertTrue(entries.containsKey(CONTAINER_FILE_NAME));
     } finally {
       if (tarStream != null) {
         tarStream.close();
@@ -221,7 +221,7 @@ public class TestTarContainerPacker {
     String containerYaml = new String(
         packer.unpackContainerDescriptor(inputForUnpackDescriptor),
         UTF_8);
-    Assert.assertEquals(TEST_DESCRIPTOR_FILE_CONTENT, containerYaml);
+    Assertions.assertEquals(TEST_DESCRIPTOR_FILE_CONTENT, containerYaml);
     inputForUnpackDescriptor.assertClosedExactlyOnce();
 
     KeyValueContainerData destinationContainerData =
@@ -245,11 +245,11 @@ public class TestTarContainerPacker {
     assertExampleChunkFileIsGood(
         Paths.get(destinationContainerData.getChunksPath()),
         TEST_CHUNK_FILE_NAME);
-    Assert.assertFalse(
+    Assertions.assertFalse(
         "Descriptor file should not have been extracted by the "
             + "unpackContainerData Call",
         destinationContainer.getContainerFile().exists());
-    Assert.assertEquals(TEST_DESCRIPTOR_FILE_CONTENT, descriptor);
+    Assertions.assertEquals(TEST_DESCRIPTOR_FILE_CONTENT, descriptor);
     inputForUnpackData.assertClosedExactlyOnce();
   }
 
@@ -403,7 +403,7 @@ public class TestTarContainerPacker {
 
     Path exampleFile = parentPath.resolve(filename);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         "example file is missing after pack/unpackContainerData: "
             + exampleFile,
         Files.exists(exampleFile));
@@ -411,8 +411,8 @@ public class TestTarContainerPacker {
     try (FileInputStream testFile =
              new FileInputStream(exampleFile.toFile())) {
       List<String> strings = IOUtils.readLines(testFile, UTF_8);
-      Assert.assertEquals(1, strings.size());
-      Assert.assertEquals(content, strings.get(0));
+      Assertions.assertEquals(1, strings.size());
+      Assertions.assertEquals(content, strings.get(0));
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -49,9 +49,9 @@ import org.apache.ozone.test.SpyOutputStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newInputStream;
@@ -62,7 +62,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Test the tar/untar for a given container.
  */
-@RunWith(Parameterized.class)
 public class TestTarContainerPacker {
 
   private static final String TEST_DB_FILE_NAME = "test1";
@@ -88,28 +87,26 @@ public class TestTarContainerPacker {
 
   private static final AtomicInteger CONTAINER_ID = new AtomicInteger(1);
 
-  private final ContainerLayoutVersion layout;
-  private final String schemaVersion;
+  private ContainerLayoutVersion layout;
+  private String schemaVersion;
   private OzoneConfiguration conf;
 
-  public TestTarContainerPacker(ContainerTestVersionInfo versionInfo,
+  private void initTests(ContainerTestVersionInfo versionInfo,
       CopyContainerCompression compression) {
     this.layout = versionInfo.getLayout();
     this.schemaVersion = versionInfo.getSchemaVersion();
     this.conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
     packer = new TarContainerPacker(compression);
-
   }
 
-  @Parameterized.Parameters
-  public static Iterable<Object[]> parameters() {
+  public static List<Arguments> getLayoutAndCompression() {
     List<ContainerTestVersionInfo> layoutList =
         ContainerTestVersionInfo.getLayoutList();
-    List<Object[]> parameterList = new ArrayList<>();
+    List<Arguments> parameterList = new ArrayList<>();
     for (ContainerTestVersionInfo containerTestVersionInfo : layoutList) {
       for (CopyContainerCompression compr : CopyContainerCompression.values()) {
-        parameterList.add(new Object[]{containerTestVersionInfo, compr});
+        parameterList.add(Arguments.of(containerTestVersionInfo, compr));
       }
     }
     return parameterList;
@@ -165,8 +162,11 @@ public class TestTarContainerPacker {
     return containerData;
   }
 
-  @Test
-  public void pack() throws IOException {
+  @ParameterizedTest
+  @MethodSource("getLayoutAndCompression")
+  public void pack(ContainerTestVersionInfo versionInfo,
+      CopyContainerCompression compression) throws IOException {
+    initTests(versionInfo, compression);
     //GIVEN
     KeyValueContainerData sourceContainerData =
         createContainer(SOURCE_CONTAINER_ROOT);
@@ -252,9 +252,13 @@ public class TestTarContainerPacker {
     inputForUnpackData.assertClosedExactlyOnce();
   }
 
-  @Test
-  public void unpackContainerDataWithValidRelativeDbFilePath()
+  @ParameterizedTest
+  @MethodSource("getLayoutAndCompression")
+  public void unpackContainerDataWithValidRelativeDbFilePath(
+      ContainerTestVersionInfo versionInfo,
+      CopyContainerCompression compression)
       throws Exception {
+    initTests(versionInfo, compression);
     //GIVEN
     KeyValueContainerData sourceContainerData =
         createContainer(SOURCE_CONTAINER_ROOT);
@@ -273,9 +277,13 @@ public class TestTarContainerPacker {
         TarContainerPacker.getDbPath(dest), fileName);
   }
 
-  @Test
-  public void unpackContainerDataWithValidRelativeChunkFilePath()
+  @ParameterizedTest
+  @MethodSource("getLayoutAndCompression")
+  public void unpackContainerDataWithValidRelativeChunkFilePath(
+      ContainerTestVersionInfo versionInfo,
+      CopyContainerCompression compression)
       throws Exception {
+    initTests(versionInfo, compression);
     //GIVEN
     KeyValueContainerData sourceContainerData =
         createContainer(SOURCE_CONTAINER_ROOT);
@@ -293,9 +301,13 @@ public class TestTarContainerPacker {
     assertExampleChunkFileIsGood(Paths.get(dest.getChunksPath()), fileName);
   }
 
-  @Test
-  public void unpackContainerDataWithInvalidRelativeDbFilePath()
+  @ParameterizedTest
+  @MethodSource("getLayoutAndCompression")
+  public void unpackContainerDataWithInvalidRelativeDbFilePath(
+      ContainerTestVersionInfo versionInfo,
+      CopyContainerCompression compression)
       throws Exception {
+    initTests(versionInfo, compression);
     //GIVEN
     KeyValueContainerData sourceContainerData =
         createContainer(SOURCE_CONTAINER_ROOT);
@@ -310,9 +322,13 @@ public class TestTarContainerPacker {
         () -> unpackContainerData(containerFile));
   }
 
-  @Test
-  public void unpackContainerDataWithInvalidRelativeChunkFilePath()
+  @ParameterizedTest
+  @MethodSource("getLayoutAndCompression")
+  public void unpackContainerDataWithInvalidRelativeChunkFilePath(
+      ContainerTestVersionInfo versionInfo,
+      CopyContainerCompression compression)
       throws Exception {
+    initTests(versionInfo, compression);
     //GIVEN
     KeyValueContainerData sourceContainerData =
         createContainer(SOURCE_CONTAINER_ROOT);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -35,10 +35,10 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -90,7 +90,7 @@ public class TestBlockManagerImpl {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     UUID datanodeId = UUID.randomUUID();
     HddsVolume hddsVolume = new HddsVolume.Builder(folder.getRoot()
@@ -145,7 +145,7 @@ public class TestBlockManagerImpl {
 
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     BlockUtils.shutdownCache(config);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -48,9 +48,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -43,12 +43,12 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -104,7 +104,7 @@ public class TestContainerReader {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
 
     File volumeDir = tempDir.newFolder();
@@ -150,7 +150,7 @@ public class TestContainerReader {
     ContainerCache.getInstance(conf).shutdownCache();
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     BlockUtils.shutdownCache(conf);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.jupiter.api.Assertions;
@@ -242,9 +242,9 @@ public class TestContainerReader {
     thread.join();
 
     //recovering container should be marked unhealthy, so the count should be 3
-    Assert.assertEquals(UNHEALTHY, containerSet.getContainer(
+    Assertions.assertEquals(UNHEALTHY, containerSet.getContainer(
         recoveringContainerData.getContainerID()).getContainerState());
-    Assert.assertEquals(3, containerSet.containerCount());
+    Assertions.assertEquals(3, containerSet.containerCount());
 
     for (int i = 0; i < 2; i++) {
       Container keyValueContainer = containerSet.getContainer(i);
@@ -253,13 +253,13 @@ public class TestContainerReader {
           keyValueContainer.getContainerData();
 
       // Verify block related metadata.
-      Assert.assertEquals(blockCount,
+      Assertions.assertEquals(blockCount,
           keyValueContainerData.getBlockCount());
 
-      Assert.assertEquals(blockCount * blockLen,
+      Assertions.assertEquals(blockCount * blockLen,
           keyValueContainerData.getBytesUsed());
 
-      Assert.assertEquals(i,
+      Assertions.assertEquals(i,
           keyValueContainerData.getNumPendingDeletionBlocks());
     }
   }
@@ -299,7 +299,7 @@ public class TestContainerReader {
             keyValueContainer.getContainerData().getContainerPath();
         File containerPath = new File(containerPathStr);
         String renamePath = containerPathStr + "-aa";
-        Assert.assertTrue(containerPath.renameTo(new File(renamePath)));
+        Assertions.assertTrue(containerPath.renameTo(new File(renamePath)));
       }
     }
     ContainerCache.getInstance(conf).shutdownCache();
@@ -307,7 +307,7 @@ public class TestContainerReader {
     ContainerReader containerReader = new ContainerReader(volumeSet1,
         hddsVolume1, containerSet1, conf, true);
     containerReader.readVolume(hddsVolume1.getHddsRootDir());
-    Assert.assertEquals(containerCount - 1, containerSet1.containerCount());
+    Assertions.assertEquals(containerCount - 1, containerSet1.containerCount());
   }
 
   @Test
@@ -379,11 +379,11 @@ public class TestContainerReader {
     }
     System.out.println("Open " + volumeNum + " Volume with " + containerCount +
         " costs " + (System.currentTimeMillis() - startTime) / 1000 + "s");
-    Assert.assertEquals(containerCount,
+    Assertions.assertEquals(containerCount,
         containerSet.getContainerMap().entrySet().size());
     // There should be no open containers cached by the ContainerReader as it
     // opens and closed them avoiding the cache.
-    Assert.assertEquals(0, cache.size());
+    Assertions.assertEquals(0, cache.size());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -250,8 +250,8 @@ public class TestOzoneContainer {
       String key = getVolumeKey(dnVol);
       long expectedCommit = commitSpaceMap.get(key).longValue();
       long volumeCommitted = dnVol.getCommittedBytes();
-      assertEquals("Volume committed space not initialized correctly",
-          expectedCommit, volumeCommitted);
+      assertEquals(expectedCommit, volumeCommitted,
+          "Volume committed space not initialized correctly");
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -81,7 +81,6 @@ public class TestOzoneContainer {
   private KeyValueContainer keyValueContainer;
   private final DatanodeDetails datanodeDetails = createDatanodeDetails();
   private HashMap<String, Long> commitSpaceMap; //RootDir -> committed space
-  private final int numTestContainers = 10;
 
   private ContainerLayoutVersion layout;
   private String schemaVersion;
@@ -133,6 +132,7 @@ public class TestOzoneContainer {
     }
 
     // Add containers to disk
+    int numTestContainers = 10;
     for (int i = 0; i < numTestContainers; i++) {
       long freeBytes = 0;
       long volCommitBytes;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -45,11 +45,11 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -105,7 +105,7 @@ public class TestOzoneContainer {
     return ContainerTestVersionInfo.versionParameters();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, folder.getRoot()
         .getAbsolutePath());
@@ -118,7 +118,7 @@ public class TestOzoneContainer {
     volumeChoosingPolicy = new RoundRobinVolumeChoosingPolicy();
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     BlockUtils.shutdownCache(conf);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -46,7 +46,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
@@ -65,8 +65,8 @@ import java.util.ArrayList;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.DISK_OUT_OF_SPACE;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createDbInstancesForTestIfNeeded;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This class is used to test OzoneContainer.
@@ -193,12 +193,12 @@ public class TestOzoneContainer {
     ContainerTestUtils.enableSchemaV3(conf);
     OzoneContainer ozoneContainer = ContainerTestUtils
         .getOzoneContainer(datanodeDetails, conf);
-    Assert.assertEquals(volumeSet.getVolumesList().size(),
+    Assertions.assertEquals(volumeSet.getVolumesList().size(),
             ozoneContainer.getNodeReport().getStorageReportList().size());
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
             ozoneContainer.getNodeReport().getMetadataStorageReportList()
                     .size());
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
             ozoneContainer.getNodeReport().getDbStorageReportList().size());
   }
 
@@ -206,9 +206,9 @@ public class TestOzoneContainer {
   public void testBuildNodeReportWithDefaultRatisLogDir() throws Exception {
     OzoneContainer ozoneContainer = ContainerTestUtils
         .getOzoneContainer(datanodeDetails, conf);
-    Assert.assertEquals(volumeSet.getVolumesList().size(),
+    Assertions.assertEquals(volumeSet.getVolumesList().size(),
             ozoneContainer.getNodeReport().getStorageReportList().size());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
             ozoneContainer.getNodeReport().getMetadataStorageReportList()
                     .size());
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -63,10 +63,10 @@ import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
@@ -123,7 +123,7 @@ public class TestReplicationSupervisor {
     return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     clock = new TestClock(Instant.now(), ZoneId.systemDefault());
     set = new ContainerSet(1000);
@@ -138,7 +138,7 @@ public class TestReplicationSupervisor {
     Mockito.when(stateMachine.getDatanodeDetails()).thenReturn(datanode);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     replicatorRef.set(null);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -64,7 +64,7 @@ import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -157,16 +157,16 @@ public class TestReplicationSupervisor {
       supervisor.addTask(createTask(2L));
       supervisor.addTask(createTask(5L));
 
-      Assert.assertEquals(3, supervisor.getReplicationRequestCount());
-      Assert.assertEquals(3, supervisor.getReplicationSuccessCount());
-      Assert.assertEquals(0, supervisor.getReplicationFailureCount());
-      Assert.assertEquals(0, supervisor.getTotalInFlightReplications());
-      Assert.assertEquals(0, supervisor.getQueueSize());
-      Assert.assertEquals(3, set.containerCount());
+      Assertions.assertEquals(3, supervisor.getReplicationRequestCount());
+      Assertions.assertEquals(3, supervisor.getReplicationSuccessCount());
+      Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
+      Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
+      Assertions.assertEquals(0, supervisor.getQueueSize());
+      Assertions.assertEquals(3, set.containerCount());
 
       MetricsCollectorImpl metricsCollector = new MetricsCollectorImpl();
       metrics.getMetrics(metricsCollector, true);
-      Assert.assertEquals(1, metricsCollector.getRecords().size());
+      Assertions.assertEquals(1, metricsCollector.getRecords().size());
     } finally {
       metrics.unRegister();
       supervisor.stop();
@@ -187,13 +187,13 @@ public class TestReplicationSupervisor {
       supervisor.addTask(createTask(6L));
 
       //THEN
-      Assert.assertEquals(4, supervisor.getReplicationRequestCount());
-      Assert.assertEquals(1, supervisor.getReplicationSuccessCount());
-      Assert.assertEquals(0, supervisor.getReplicationFailureCount());
-      Assert.assertEquals(3, supervisor.getReplicationSkippedCount());
-      Assert.assertEquals(0, supervisor.getTotalInFlightReplications());
-      Assert.assertEquals(0, supervisor.getQueueSize());
-      Assert.assertEquals(1, set.containerCount());
+      Assertions.assertEquals(4, supervisor.getReplicationRequestCount());
+      Assertions.assertEquals(1, supervisor.getReplicationSuccessCount());
+      Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
+      Assertions.assertEquals(3, supervisor.getReplicationSkippedCount());
+      Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
+      Assertions.assertEquals(0, supervisor.getQueueSize());
+      Assertions.assertEquals(1, set.containerCount());
     } finally {
       supervisor.stop();
     }
@@ -211,13 +211,13 @@ public class TestReplicationSupervisor {
       supervisor.addTask(task);
 
       //THEN
-      Assert.assertEquals(1, supervisor.getReplicationRequestCount());
-      Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
-      Assert.assertEquals(1, supervisor.getReplicationFailureCount());
-      Assert.assertEquals(0, supervisor.getTotalInFlightReplications());
-      Assert.assertEquals(0, supervisor.getQueueSize());
-      Assert.assertEquals(0, set.containerCount());
-      Assert.assertEquals(ReplicationTask.Status.FAILED, task.getStatus());
+      Assertions.assertEquals(1, supervisor.getReplicationRequestCount());
+      Assertions.assertEquals(0, supervisor.getReplicationSuccessCount());
+      Assertions.assertEquals(1, supervisor.getReplicationFailureCount());
+      Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
+      Assertions.assertEquals(0, supervisor.getQueueSize());
+      Assertions.assertEquals(0, set.containerCount());
+      Assertions.assertEquals(ReplicationTask.Status.FAILED, task.getStatus());
     } finally {
       supervisor.stop();
     }
@@ -238,16 +238,16 @@ public class TestReplicationSupervisor {
       supervisor.addTask(createECTask(5L));
 
       //THEN
-      Assert.assertEquals(0, supervisor.getReplicationRequestCount());
-      Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
-      Assert.assertEquals(0, supervisor.getReplicationFailureCount());
-      Assert.assertEquals(5, supervisor.getTotalInFlightReplications());
-      Assert.assertEquals(3, supervisor.getInFlightReplications(
+      Assertions.assertEquals(0, supervisor.getReplicationRequestCount());
+      Assertions.assertEquals(0, supervisor.getReplicationSuccessCount());
+      Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
+      Assertions.assertEquals(5, supervisor.getTotalInFlightReplications());
+      Assertions.assertEquals(3, supervisor.getInFlightReplications(
           ReplicationTask.class));
-      Assert.assertEquals(2, supervisor.getInFlightReplications(
+      Assertions.assertEquals(2, supervisor.getInFlightReplications(
           ECReconstructionCoordinatorTask.class));
-      Assert.assertEquals(0, supervisor.getQueueSize());
-      Assert.assertEquals(0, set.containerCount());
+      Assertions.assertEquals(0, supervisor.getQueueSize());
+      Assertions.assertEquals(0, set.containerCount());
     } finally {
       supervisor.stop();
     }
@@ -267,15 +267,15 @@ public class TestReplicationSupervisor {
       supervisor.addTask(createTask(3L));
 
       //THEN
-      Assert.assertEquals(3, supervisor.getTotalInFlightReplications());
-      Assert.assertEquals(2, supervisor.getQueueSize());
+      Assertions.assertEquals(3, supervisor.getTotalInFlightReplications());
+      Assertions.assertEquals(2, supervisor.getQueueSize());
       // Sleep 4s, wait all tasks processed
       try {
         Thread.sleep(4000);
       } catch (InterruptedException e) {
       }
-      Assert.assertEquals(0, supervisor.getTotalInFlightReplications());
-      Assert.assertEquals(0, supervisor.getQueueSize());
+      Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
+      Assertions.assertEquals(0, supervisor.getQueueSize());
     } finally {
       supervisor.stop();
     }
@@ -320,9 +320,9 @@ public class TestReplicationSupervisor {
         .captureLogs(DownloadAndImportReplicator.LOG);
 
     supervisor.addTask(createTask(1L));
-    Assert.assertEquals(1, supervisor.getReplicationFailureCount());
-    Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
-    Assert.assertTrue(logCapturer.getOutput()
+    Assertions.assertEquals(1, supervisor.getReplicationFailureCount());
+    Assertions.assertEquals(0, supervisor.getReplicationSuccessCount());
+    Assertions.assertTrue(logCapturer.getOutput()
         .contains("Container 1 replication was unsuccessful."));
   }
 
@@ -348,13 +348,13 @@ public class TestReplicationSupervisor {
     supervisor.addTask(task2);
     supervisor.addTask(task3);
 
-    Assert.assertEquals(3, supervisor.getReplicationRequestCount());
-    Assert.assertEquals(2, supervisor.getReplicationSuccessCount());
-    Assert.assertEquals(0, supervisor.getReplicationFailureCount());
-    Assert.assertEquals(0, supervisor.getTotalInFlightReplications());
-    Assert.assertEquals(0, supervisor.getQueueSize());
-    Assert.assertEquals(1, supervisor.getReplicationTimeoutCount());
-    Assert.assertEquals(2, set.containerCount());
+    Assertions.assertEquals(3, supervisor.getReplicationRequestCount());
+    Assertions.assertEquals(2, supervisor.getReplicationSuccessCount());
+    Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
+    Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
+    Assertions.assertEquals(0, supervisor.getQueueSize());
+    Assertions.assertEquals(1, supervisor.getReplicationTimeoutCount());
+    Assertions.assertEquals(2, set.containerCount());
 
   }
 
@@ -373,13 +373,13 @@ public class TestReplicationSupervisor {
     supervisor.addTask(new ReplicationTask(pushCmd, replicatorRef.get()));
     supervisor.addTask(new ReplicationTask(pullCmd, replicatorRef.get()));
 
-    Assert.assertEquals(2, supervisor.getReplicationRequestCount());
-    Assert.assertEquals(1, supervisor.getReplicationSuccessCount());
-    Assert.assertEquals(0, supervisor.getReplicationFailureCount());
-    Assert.assertEquals(0, supervisor.getTotalInFlightReplications());
-    Assert.assertEquals(0, supervisor.getQueueSize());
-    Assert.assertEquals(0, supervisor.getReplicationTimeoutCount());
-    Assert.assertEquals(1, set.containerCount());
+    Assertions.assertEquals(2, supervisor.getReplicationRequestCount());
+    Assertions.assertEquals(1, supervisor.getReplicationSuccessCount());
+    Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
+    Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
+    Assertions.assertEquals(0, supervisor.getQueueSize());
+    Assertions.assertEquals(0, supervisor.getReplicationTimeoutCount());
+    Assertions.assertEquals(1, set.containerCount());
   }
 
   @Test
@@ -391,8 +391,8 @@ public class TestReplicationSupervisor {
     context.setTermOfLeaderSCM(newTerm);
     supervisor.addTask(createTask(1L));
 
-    Assert.assertEquals(1, supervisor.getReplicationRequestCount());
-    Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
+    Assertions.assertEquals(1, supervisor.getReplicationRequestCount());
+    Assertions.assertEquals(0, supervisor.getReplicationSuccessCount());
   }
 
   @Test
@@ -447,19 +447,19 @@ public class TestReplicationSupervisor {
     // Before unblocking the queue, check the queue count for the OrderedTask.
     // We loaded 3 High / normal priority and 2 low. The counter should not
     // include the low counts.
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
         supervisor.getInFlightReplications(OrderedTask.class));
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         supervisor.getInFlightReplications(BlockingTask.class));
 
     // Unblock the queue
     completeRunning.countDown();
     // Wait for all tasks to complete
     tasksCompleteLatch.await();
-    Assert.assertEquals(expectedOrder, completionOrder);
-    Assert.assertEquals(0,
+    Assertions.assertEquals(expectedOrder, completionOrder);
+    Assertions.assertEquals(0,
         supervisor.getInFlightReplications(OrderedTask.class));
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         supervisor.getInFlightReplications(BlockingTask.class));
   }
 
@@ -599,7 +599,7 @@ public class TestReplicationSupervisor {
       }
 
       // assumes same-thread execution
-      Assert.assertEquals(1, supervisor.getTotalInFlightReplications());
+      Assertions.assertEquals(1, supervisor.getTotalInFlightReplications());
 
       KeyValueContainerData kvcd =
           new KeyValueContainerData(task.getContainerId(),
@@ -612,7 +612,7 @@ public class TestReplicationSupervisor {
         set.addContainer(kvc);
         task.setStatus(DONE);
       } catch (Exception e) {
-        Assert.fail("Unexpected error: " + e.getMessage());
+        Assertions.fail("Unexpected error: " + e.getMessage());
       }
     }
   }
@@ -710,21 +710,21 @@ public class TestReplicationSupervisor {
 
     // in progress task will be limited by max. queue size,
     // since all tasks are discarded by the executor, none of them complete
-    Assert.assertEquals(maxQueueSize, rs.getTotalInFlightReplications());
+    Assertions.assertEquals(maxQueueSize, rs.getTotalInFlightReplications());
 
     // queue size is doubled
     rs.nodeStateUpdated(HddsProtos.NodeOperationalState.DECOMMISSIONING);
-    Assert.assertEquals(2 * maxQueueSize, rs.getMaxQueueSize());
-    Assert.assertEquals(2 * replicationMaxStreams, threadPoolSize.get());
+    Assertions.assertEquals(2 * maxQueueSize, rs.getMaxQueueSize());
+    Assertions.assertEquals(2 * replicationMaxStreams, threadPoolSize.get());
 
     // can schedule more tasks
     scheduleTasks(datanodes, rs);
-    Assert.assertEquals(2 * maxQueueSize, rs.getTotalInFlightReplications());
+    Assertions.assertEquals(2 * maxQueueSize, rs.getTotalInFlightReplications());
 
     // queue size is restored
     rs.nodeStateUpdated(IN_SERVICE);
-    Assert.assertEquals(maxQueueSize, rs.getMaxQueueSize());
-    Assert.assertEquals(replicationMaxStreams, threadPoolSize.get());
+    Assertions.assertEquals(maxQueueSize, rs.getMaxQueueSize());
+    Assertions.assertEquals(replicationMaxStreams, threadPoolSize.get());
   }
 
   //schedule 10 container replication

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
@@ -617,8 +617,9 @@ public class TestDatanodeUpgradeToSchemaV3 {
     if (exactMatch) {
       Assertions.assertEquals(expectedMlv, mlv);
     } else {
-      Assertions.assertTrue("Expected minimum mlv(" + expectedMlv
-          + ") is smaller than mlv(" + mlv + ").", expectedMlv <= mlv);
+      Assertions.assertTrue(expectedMlv <= mlv,
+          "Expected minimum mlv(" + expectedMlv
+              + ") is smaller than mlv(" + mlv + ").");
     }
 
     callVersionEndpointTask();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
@@ -44,11 +44,11 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -111,7 +111,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
         OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_RANDOM_PORT, true);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     tempFolder = new TemporaryFolder();
     tempFolder.create();
@@ -123,7 +123,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
         tempFolder.getRoot().getAbsolutePath());
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (scmRpcServer != null) {
       scmRpcServer.stop();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
@@ -148,22 +148,22 @@ public class TestDatanodeUpgradeToSchemaV3 {
     startPreFinalizedDatanode();
     HddsVolume dataVolume = (HddsVolume) dsm.getContainer().getVolumeSet()
         .getVolumesList().get(0);
-    Assert.assertNull(dataVolume.getDbVolume());
-    Assert.assertFalse(dataVolume.isDbLoaded());
+    Assertions.assertNull(dataVolume.getDbVolume());
+    Assertions.assertFalse(dataVolume.isDbLoaded());
 
     dsm.finalizeUpgrade();
     // RocksDB is created during upgrade
     File dbFile = new File(dataVolume.getStorageDir().getAbsolutePath() + "/" +
         dataVolume.getClusterID() + "/" + dataVolume.getStorageID());
-    Assert.assertTrue(dbFile.exists());
+    Assertions.assertTrue(dbFile.exists());
 
     // RocksDB loaded when SchemaV3 is enabled
     if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
-      Assert.assertTrue(dataVolume.getDbParentDir().getAbsolutePath()
+      Assertions.assertTrue(dataVolume.getDbParentDir().getAbsolutePath()
           .startsWith(dataVolume.getStorageDir().toString()));
     } else {
       // RocksDB is not loaded when SchemaV3 is disabled.
-      Assert.assertFalse(dataVolume.isDbLoaded());
+      Assertions.assertFalse(dataVolume.isDbLoaded());
     }
   }
 
@@ -182,26 +182,26 @@ public class TestDatanodeUpgradeToSchemaV3 {
     startPreFinalizedDatanode();
     HddsVolume dataVolume = (HddsVolume) dsm.getContainer().getVolumeSet()
         .getVolumesList().get(0);
-    Assert.assertNull(dataVolume.getDbParentDir());
+    Assertions.assertNull(dataVolume.getDbParentDir());
 
     dsm.finalizeUpgrade();
     // RocksDB is created during upgrade
     DbVolume dbVolume = (DbVolume) dsm.getContainer().getDbVolumeSet()
         .getVolumesList().get(0);
-    Assert.assertEquals(dbVolume, dataVolume.getDbVolume());
-    Assert.assertTrue(
+    Assertions.assertEquals(dbVolume, dataVolume.getDbVolume());
+    Assertions.assertTrue(
         dbVolume.getHddsVolumeIDs().contains(dataVolume.getStorageID()));
     File dbFile = new File(dbVolume.getStorageDir().getAbsolutePath() + "/" +
         dbVolume.getClusterID() + "/" + dataVolume.getStorageID());
-    Assert.assertTrue(dbFile.exists());
+    Assertions.assertTrue(dbFile.exists());
 
     // RocksDB loaded when SchemaV3 is enabled
     if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
-      Assert.assertTrue(dataVolume.getDbParentDir().getAbsolutePath()
+      Assertions.assertTrue(dataVolume.getDbParentDir().getAbsolutePath()
           .startsWith(dbVolume.getStorageDir().toString()));
     } else {
       // RocksDB is not loaded when SchemaV3 is disabled.
-      Assert.assertFalse(dataVolume.isDbLoaded());
+      Assertions.assertFalse(dataVolume.isDbLoaded());
     }
   }
 
@@ -229,10 +229,10 @@ public class TestDatanodeUpgradeToSchemaV3 {
     dataVolume.format(CLUSTER_ID);
     File idDir = new File(dataVolume.getStorageDir(), CLUSTER_ID);
     if (!idDir.mkdir()) {
-      Assert.fail("Failed to create id directory");
+      Assertions.fail("Failed to create id directory");
     }
 
-    Assert.assertNull(dataVolume.getDbParentDir());
+    Assertions.assertNull(dataVolume.getDbParentDir());
 
     // Restart DN and finalize upgrade
     restartDatanode(
@@ -242,11 +242,11 @@ public class TestDatanodeUpgradeToSchemaV3 {
     // RocksDB is created by upgrade action
     dataVolume = ((HddsVolume) dsm.getContainer().getVolumeSet()
         .getVolumesList().get(0));
-    Assert.assertNotNull(dataVolume.getDbParentDir());
+    Assertions.assertNotNull(dataVolume.getDbParentDir());
     if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
-      Assert.assertTrue(dataVolume.isDbLoaded());
+      Assertions.assertTrue(dataVolume.isDbLoaded());
     } else {
-      Assert.assertFalse(dataVolume.isDbLoaded());
+      Assertions.assertFalse(dataVolume.isDbLoaded());
     }
   }
 
@@ -267,11 +267,11 @@ public class TestDatanodeUpgradeToSchemaV3 {
 
     DbVolume dbVolume = ((HddsVolume) dsm.getContainer().getVolumeSet()
         .getVolumesList().get(0)).getDbVolume();
-    Assert.assertNotNull(dbVolume);
+    Assertions.assertNotNull(dbVolume);
 
     dsm.finalizeUpgrade();
     // DB Dir should be the same.
-    Assert.assertEquals(dbVolume, ((HddsVolume) dsm.getContainer()
+    Assertions.assertEquals(dbVolume, ((HddsVolume) dsm.getContainer()
         .getVolumeSet().getVolumesList().get(0)).getDbVolume());
   }
 
@@ -295,11 +295,11 @@ public class TestDatanodeUpgradeToSchemaV3 {
         dsm.getContainer().getVolumeSet().getVolumesList()) {
       HddsVolume hddsVolume = (HddsVolume) vol;
       if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
-        Assert.assertTrue(hddsVolume.isDbLoaded());
-        Assert.assertTrue(hddsVolume.getDbParentDir().getAbsolutePath()
+        Assertions.assertTrue(hddsVolume.isDbLoaded());
+        Assertions.assertTrue(hddsVolume.getDbParentDir().getAbsolutePath()
             .startsWith(hddsVolume.getStorageDir().getAbsolutePath()));
       } else {
-        Assert.assertFalse(hddsVolume.isDbLoaded());
+        Assertions.assertFalse(hddsVolume.isDbLoaded());
       }
     }
   }
@@ -315,11 +315,11 @@ public class TestDatanodeUpgradeToSchemaV3 {
     startPreFinalizedDatanode();
     HddsVolume hddsVolume = (HddsVolume) dsm.getContainer().getVolumeSet()
         .getVolumesList().get(0);
-    Assert.assertNull(hddsVolume.getDbParentDir());
+    Assertions.assertNull(hddsVolume.getDbParentDir());
     dsm.finalizeUpgrade();
     // DB is created during upgrade
     File dbDir = hddsVolume.getDbParentDir();
-    Assert.assertTrue(dbDir.getAbsolutePath().startsWith(
+    Assertions.assertTrue(dbDir.getAbsolutePath().startsWith(
         hddsVolume.getStorageDir().getAbsolutePath()));
 
     // Add a new DbVolume
@@ -330,13 +330,13 @@ public class TestDatanodeUpgradeToSchemaV3 {
     // HddsVolume should still use the rocksDB under it's volume
     DbVolume dbVolume = (DbVolume) dsm.getContainer().getDbVolumeSet()
         .getVolumesList().get(0);
-    Assert.assertEquals(0, dbVolume.getHddsVolumeIDs().size());
+    Assertions.assertEquals(0, dbVolume.getHddsVolumeIDs().size());
 
     if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
       hddsVolume = (HddsVolume) dsm.getContainer().getVolumeSet()
           .getVolumesList().get(0);
-      Assert.assertEquals(dbDir, hddsVolume.getDbParentDir());
-      Assert.assertTrue(hddsVolume.isDbLoaded());
+      Assertions.assertEquals(dbDir, hddsVolume.getDbParentDir());
+      Assertions.assertTrue(hddsVolume.isDbLoaded());
     }
   }
 
@@ -367,22 +367,22 @@ public class TestDatanodeUpgradeToSchemaV3 {
       if (hddsVolume.getStorageDir().getAbsolutePath().startsWith(
           newDataVolume.getAbsolutePath())) {
         if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
-          Assert.assertEquals(dbVolume, hddsVolume.getDbVolume());
+          Assertions.assertEquals(dbVolume, hddsVolume.getDbVolume());
         }
         // RocksDB of newly added HddsVolume is created on the newly added
         // DbVolume
         dbFile = new File(dbVolume.getStorageDir() + "/" +
             hddsVolume.getClusterID() + "/" + hddsVolume.getStorageID());
       } else {
-        Assert.assertNull(hddsVolume.getDbVolume());
+        Assertions.assertNull(hddsVolume.getDbVolume());
         dbFile = new File(hddsVolume.getStorageDir() + "/" +
             hddsVolume.getClusterID() + "/" + hddsVolume.getStorageID());
       }
       if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
-        Assert.assertTrue(hddsVolume.isDbLoaded());
-        Assert.assertTrue(hddsVolume.getDbParentDir().exists());
-        Assert.assertTrue(dbFile.exists());
-        Assert.assertEquals(dbFile, hddsVolume.getDbParentDir());
+        Assertions.assertTrue(hddsVolume.isDbLoaded());
+        Assertions.assertTrue(hddsVolume.getDbParentDir().exists());
+        Assertions.assertTrue(dbFile.exists());
+        Assertions.assertEquals(dbFile, hddsVolume.getDbParentDir());
       }
     }
   }
@@ -421,7 +421,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
     KeyValueContainer container = (KeyValueContainer)
         dsm.getContainer().getContainerSet().getContainer(containerID1);
     // When SchemaV3 is disabled, new data should be saved as SchemaV2.
-    Assert.assertEquals(OzoneConsts.SCHEMA_V2,
+    Assertions.assertEquals(OzoneConsts.SCHEMA_V2,
         container.getContainerData().getSchemaVersion());
 
     // Set SchemaV3 enable status
@@ -438,7 +438,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
         dsm.getContainer().getContainerSet().getContainer(containerID2);
     // If SchemaV3 is enabled, new data should be saved as SchemaV3
     // If SchemaV3 is still disabled, new data should still be saved as SchemaV2
-    Assert.assertEquals(expectedVersion,
+    Assertions.assertEquals(expectedVersion,
         container.getContainerData().getSchemaVersion());
   }
 
@@ -500,9 +500,9 @@ public class TestDatanodeUpgradeToSchemaV3 {
     dataVolume.format(CLUSTER_ID);
     File idDir = new File(dataVolume.getStorageDir(), CLUSTER_ID);
     if (!idDir.mkdir()) {
-      Assert.fail("Failed to create id directory");
+      Assertions.fail("Failed to create id directory");
     }
-    Assert.assertNull(dataVolume.getDbParentDir());
+    Assertions.assertNull(dataVolume.getDbParentDir());
 
     // Restart DN
     restartDatanode(
@@ -516,7 +516,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
     closeContainer(containerID, pipeline);
     KeyValueContainer container = (KeyValueContainer)
         dsm.getContainer().getContainerSet().getContainer(containerID);
-    Assert.assertEquals(OzoneConsts.SCHEMA_V2,
+    Assertions.assertEquals(OzoneConsts.SCHEMA_V2,
         container.getContainerData().getSchemaVersion());
 
 
@@ -538,7 +538,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
     // Check that old data is readable
     container = (KeyValueContainer)
         dsm.getContainer().getContainerSet().getContainer(containerID);
-    Assert.assertEquals(OzoneConsts.SCHEMA_V2,
+    Assertions.assertEquals(OzoneConsts.SCHEMA_V2,
         container.getContainerData().getSchemaVersion());
     readChunk(writeChunk, pipeline);
 
@@ -549,7 +549,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
     // Old data is readable after DN restart
     container = (KeyValueContainer)
         dsm.getContainer().getContainerSet().getContainer(containerID);
-    Assert.assertEquals(OzoneConsts.SCHEMA_V2,
+    Assertions.assertEquals(OzoneConsts.SCHEMA_V2,
         container.getContainerData().getSchemaVersion());
     readChunk(writeChunk, pipeline);
   }
@@ -558,13 +558,13 @@ public class TestDatanodeUpgradeToSchemaV3 {
     KeyValueContainerData data =
         (KeyValueContainerData) dsm.getContainer().getContainerSet()
             .getContainer(containerID).getContainerData();
-    Assert.assertTrue(data.getChunksPath().contains(expectedID));
-    Assert.assertTrue(data.getMetadataPath().contains(expectedID));
+    Assertions.assertTrue(data.getChunksPath().contains(expectedID));
+    Assertions.assertTrue(data.getMetadataPath().contains(expectedID));
   }
 
   public List<File> getHddsSubdirs(File volume) {
     File[] subdirsArray = getHddsRoot(volume).listFiles(File::isDirectory);
-    Assert.assertNotNull(subdirsArray);
+    Assertions.assertNotNull(subdirsArray);
     return Arrays.asList(subdirsArray);
   }
 
@@ -594,7 +594,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
     DatanodeDetails dd = ContainerTestUtils.createDatanodeDetails();
     DatanodeStateMachine newDsm = new DatanodeStateMachine(dd, conf);
     int actualMlv = newDsm.getLayoutVersionManager().getMetadataLayoutVersion();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         HDDSLayoutFeature.ERASURE_CODED_STORAGE_SUPPORT.layoutVersion(),
         actualMlv);
     if (dsm != null) {
@@ -615,9 +615,9 @@ public class TestDatanodeUpgradeToSchemaV3 {
     dsm = new DatanodeStateMachine(dd, conf);
     int mlv = dsm.getLayoutVersionManager().getMetadataLayoutVersion();
     if (exactMatch) {
-      Assert.assertEquals(expectedMlv, mlv);
+      Assertions.assertEquals(expectedMlv, mlv);
     } else {
-      Assert.assertTrue("Expected minimum mlv(" + expectedMlv
+      Assertions.assertTrue("Expected minimum mlv(" + expectedMlv
           + ") is smaller than mlv(" + mlv + ").", expectedMlv <= mlv);
     }
 
@@ -718,7 +718,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
       ContainerProtos.Result expectedResult) {
     ContainerProtos.ContainerCommandResponseProto response =
         dsm.getContainer().getDispatcher().dispatch(request, null);
-    Assert.assertEquals(expectedResult, response.getResult());
+    Assertions.assertEquals(expectedResult, response.getResult());
   }
 
   /// VOLUME OPERATIONS ///

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -45,12 +45,9 @@ import org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicatio
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
-import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -60,7 +57,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -76,15 +72,14 @@ import static org.apache.hadoop.ozone.container.replication.CopyContainerCompres
  * SCM ID to the post-SCM HA volume format using cluster ID. If SCM HA was
  * already being used before the upgrade, there should be no changes.
  */
-@RunWith(Parameterized.class)
 public class TestDatanodeUpgradeToScmHA {
-  @Rule
-  public TemporaryFolder tempFolder;
+  @TempDir
+  private Path tempFolder;
 
   private DatanodeStateMachine dsm;
-  private final OzoneConfiguration conf;
+  private OzoneConfiguration conf;
   private static final String CLUSTER_ID = "clusterID";
-  private final boolean scmHAAlreadyEnabled;
+  private boolean scmHAAlreadyEnabled;
 
   private RPC.Server scmRpcServer;
   private InetSocketAddress address;
@@ -92,24 +87,15 @@ public class TestDatanodeUpgradeToScmHA {
 
   private Random random;
 
-  @Parameterized.Parameters(name = "{index}: scmHAAlreadyEnabled={0}")
-  public static Collection<Object[]> getSchemaFiles() {
-    Collection<Object[]> parameters = new ArrayList<>();
-    parameters.add(new Boolean[]{false});
-    parameters.add(new Boolean[]{true});
-    return parameters;
-  }
-
-  public TestDatanodeUpgradeToScmHA(boolean scmHAAlreadyEnabled) {
-    this.scmHAAlreadyEnabled = scmHAAlreadyEnabled;
+  private void setScmHAEnabled(boolean enableSCMHA)
+      throws Exception {
+    this.scmHAAlreadyEnabled = enableSCMHA;
     conf = new OzoneConfiguration();
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, scmHAAlreadyEnabled);
+    setup();
   }
 
-  @BeforeEach
-  public void setup() throws Exception {
-    tempFolder = new TemporaryFolder();
-    tempFolder.create();
+  private void setup() throws Exception {
     random = new Random();
 
     address = SCMTestUtils.getReuseableAddress();
@@ -127,8 +113,11 @@ public class TestDatanodeUpgradeToScmHA {
     }
   }
 
-  @Test
-  public void testReadsDuringFinalization() throws Exception {
+  @ParameterizedTest(name = "{index}: scmHAAlreadyEnabled={0}")
+  @ValueSource(booleans = {true, false})
+  public void testReadsDuringFinalization(boolean enableSCMHA)
+      throws Exception {
+    setScmHAEnabled(enableSCMHA);
     // start DN and SCM
     startScmServer();
     addVolume();
@@ -160,8 +149,10 @@ public class TestDatanodeUpgradeToScmHA {
     readFuture.get();
   }
 
-  @Test
-  public void testImportContainer() throws Exception {
+  @ParameterizedTest(name = "{index}: scmHAAlreadyEnabled={0}")
+  @ValueSource(booleans = {true, false})
+  public void testImportContainer(boolean enableSCMHA) throws Exception {
+    setScmHAEnabled(enableSCMHA);
     // start DN and SCM
     startScmServer();
     addVolume();
@@ -228,8 +219,11 @@ public class TestDatanodeUpgradeToScmHA {
     readChunk(exportWriteChunk2, pipeline);
   }
 
-  @Test
-  public void testFailedVolumeDuringFinalization() throws Exception {
+  @ParameterizedTest(name = "{index}: scmHAAlreadyEnabled={0}")
+  @ValueSource(booleans = {true, false})
+  public void testFailedVolumeDuringFinalization(boolean enableSCMHA)
+      throws Exception {
+    setScmHAEnabled(enableSCMHA);
     /// SETUP ///
 
     String originalScmID = startScmServer();
@@ -314,8 +308,10 @@ public class TestDatanodeUpgradeToScmHA {
     checkContainerPathID(newContainerID, CLUSTER_ID);
   }
 
-  @Test
-  public void testFormattingNewVolumes() throws Exception {
+  @ParameterizedTest(name = "{index}: scmHAAlreadyEnabled={0}")
+  @ValueSource(booleans = {true, false})
+  public void testFormattingNewVolumes(boolean enableSCMHA) throws Exception {
+    setScmHAEnabled(enableSCMHA);
     /// SETUP ///
 
     String originalScmID = startScmServer();
@@ -508,7 +504,7 @@ public class TestDatanodeUpgradeToScmHA {
   public void startPreFinalizedDatanode() throws Exception {
     // Set layout version.
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
-        tempFolder.getRoot().getAbsolutePath());
+        tempFolder.toString());
     DatanodeLayoutStorage layoutStorage = new DatanodeLayoutStorage(conf,
         UUID.randomUUID().toString(),
         HDDSLayoutFeature.INITIAL_VERSION.layoutVersion());
@@ -651,7 +647,8 @@ public class TestDatanodeUpgradeToScmHA {
 
     replicationSource.prepare(containerId);
 
-    File destination = tempFolder.newFile();
+    File destination =
+        Files.createFile(tempFolder.resolve("destFile" + containerId)).toFile();
     try (FileOutputStream fos = new FileOutputStream(destination)) {
       replicationSource.copyData(containerId, fos, NO_COMPRESSION);
     }
@@ -669,8 +666,9 @@ public class TestDatanodeUpgradeToScmHA {
             dsm.getContainer().getController(),
             dsm.getContainer().getVolumeSet());
 
-    File tempFile = tempFolder.newFile(
-        ContainerUtils.getContainerTarName(containerID));
+    File tempFile = Files.createFile(
+            tempFolder.resolve(ContainerUtils.getContainerTarName(containerID)))
+        .toFile();
     Files.copy(source.toPath(), tempFile.toPath(),
         StandardCopyOption.REPLACE_EXISTING);
     replicator.importContainer(containerID, tempFile.toPath(), null,
@@ -697,7 +695,9 @@ public class TestDatanodeUpgradeToScmHA {
    * @return The root directory for the new volume.
    */
   public File addVolume() throws Exception {
-    File vol = tempFolder.newFolder(UUID.randomUUID().toString());
+
+    File vol = Files.createDirectory(
+        tempFolder.resolve(UUID.randomUUID().toString())).toFile();
     String[] existingVolumes =
         conf.getStrings(ScmConfigKeys.HDDS_DATANODE_DIR_KEY);
     List<String> allVolumes = new ArrayList<>();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.ozone.container.replication.ContainerReplicationSource;
 import org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
@@ -239,9 +239,9 @@ public class TestDatanodeUpgradeToScmHA {
 
     /// PRE-FINALIZED: Write and Read from formatted volume ///
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         dsm.getContainer().getVolumeSet().getVolumesList().size());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         dsm.getContainer().getVolumeSet().getFailedVolumesList().size());
 
     // Add container with data, make sure it can be read and written.
@@ -262,7 +262,7 @@ public class TestDatanodeUpgradeToScmHA {
         ContainerProtos.Result.CONTAINER_FILES_CREATE_ERROR);
     State containerState = dsm.getContainer().getContainerSet()
         .getContainer(containerID).getContainerState();
-    Assert.assertEquals(State.UNHEALTHY, containerState);
+    Assertions.assertEquals(State.UNHEALTHY, containerState);
     dsm.finalizeUpgrade();
     LambdaTestUtils.await(2000, 500,
         () -> dsm.getLayoutVersionManager()
@@ -271,9 +271,9 @@ public class TestDatanodeUpgradeToScmHA {
     /// FINALIZED: Volume marked failed but gets restored on disk ///
 
     // Check that volume is marked failed during finalization.
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         dsm.getContainer().getVolumeSet().getVolumesList().size());
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         dsm.getContainer().getVolumeSet().getFailedVolumesList().size());
 
     // Since the volume was out during the upgrade, it should maintain its
@@ -294,9 +294,9 @@ public class TestDatanodeUpgradeToScmHA {
 
     restartDatanode(HDDSLayoutFeature.SCM_HA.layoutVersion(), false);
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         dsm.getContainer().getVolumeSet().getVolumesList().size());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         dsm.getContainer().getVolumeSet().getFailedVolumesList().size());
 
     checkFinalizedVolumePathID(volume, originalScmID, CLUSTER_ID);
@@ -325,9 +325,9 @@ public class TestDatanodeUpgradeToScmHA {
 
     /// PRE-FINALIZED: Write and Read from formatted volume ///
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         dsm.getContainer().getVolumeSet().getVolumesList().size());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         dsm.getContainer().getVolumeSet().getFailedVolumesList().size());
 
     // Add container with data, make sure it can be read and written.
@@ -350,9 +350,9 @@ public class TestDatanodeUpgradeToScmHA {
 
     restartDatanode(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion(), true);
 
-    Assert.assertEquals(2,
+    Assertions.assertEquals(2,
         dsm.getContainer().getVolumeSet().getVolumesList().size());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         dsm.getContainer().getVolumeSet().getFailedVolumesList().size());
 
     // Because DN mlv would be behind SCM mlv, only reads are allowed.
@@ -385,9 +385,9 @@ public class TestDatanodeUpgradeToScmHA {
 
     restartDatanode(HDDSLayoutFeature.SCM_HA.layoutVersion(), false);
 
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
         dsm.getContainer().getVolumeSet().getVolumesList().size());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         dsm.getContainer().getVolumeSet().getFailedVolumesList().size());
 
     checkFinalizedVolumePathID(preFinVolume1, originalScmID, CLUSTER_ID);
@@ -426,8 +426,8 @@ public class TestDatanodeUpgradeToScmHA {
     KeyValueContainerData data =
         (KeyValueContainerData) dsm.getContainer().getContainerSet()
             .getContainer(containerID).getContainerData();
-    Assert.assertTrue(data.getChunksPath().contains(expectedID));
-    Assert.assertTrue(data.getMetadataPath().contains(expectedID));
+    Assertions.assertTrue(data.getChunksPath().contains(expectedID));
+    Assertions.assertTrue(data.getMetadataPath().contains(expectedID));
   }
 
   public void checkFinalizedVolumePathID(File volume, String scmID,
@@ -441,16 +441,16 @@ public class TestDatanodeUpgradeToScmHA {
 
       // Volume should have SCM ID and cluster ID directory, where cluster ID
       // is a symlink to SCM ID.
-      Assert.assertEquals(2, subdirs.size());
+      Assertions.assertEquals(2, subdirs.size());
 
       File scmIDDir = new File(hddsRoot, scmID);
-      Assert.assertTrue(subdirs.contains(scmIDDir));
+      Assertions.assertTrue(subdirs.contains(scmIDDir));
 
       File clusterIDDir = new File(hddsRoot, CLUSTER_ID);
-      Assert.assertTrue(subdirs.contains(clusterIDDir));
-      Assert.assertTrue(Files.isSymbolicLink(clusterIDDir.toPath()));
+      Assertions.assertTrue(subdirs.contains(clusterIDDir));
+      Assertions.assertTrue(Files.isSymbolicLink(clusterIDDir.toPath()));
       Path symlinkTarget = Files.readSymbolicLink(clusterIDDir.toPath());
-      Assert.assertEquals(scmID, symlinkTarget.toString());
+      Assertions.assertEquals(scmID, symlinkTarget.toString());
     }
   }
 
@@ -479,14 +479,14 @@ public class TestDatanodeUpgradeToScmHA {
     }
 
     // Volume should only have the specified ID directory.
-    Assert.assertEquals(1, subdirs.size());
+    Assertions.assertEquals(1, subdirs.size());
     File idDir = new File(hddsRoot, expectedID);
-    Assert.assertTrue(subdirs.contains(idDir));
+    Assertions.assertTrue(subdirs.contains(idDir));
   }
 
   public List<File> getHddsSubdirs(File volume) {
     File[] subdirsArray = getHddsRoot(volume).listFiles(File::isDirectory);
-    Assert.assertNotNull(subdirsArray);
+    Assertions.assertNotNull(subdirsArray);
     return Arrays.asList(subdirsArray);
   }
 
@@ -518,7 +518,7 @@ public class TestDatanodeUpgradeToScmHA {
     DatanodeDetails dd = ContainerTestUtils.createDatanodeDetails();
     DatanodeStateMachine newDsm = new DatanodeStateMachine(dd, conf);
     int actualMlv = newDsm.getLayoutVersionManager().getMetadataLayoutVersion();
-    Assert.assertEquals(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion(),
+    Assertions.assertEquals(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion(),
         actualMlv);
     dsm = newDsm;
 
@@ -535,9 +535,9 @@ public class TestDatanodeUpgradeToScmHA {
     dsm = new DatanodeStateMachine(dd, conf);
     int mlv = dsm.getLayoutVersionManager().getMetadataLayoutVersion();
     if (exactMatch) {
-      Assert.assertEquals(expectedMlv, mlv);
+      Assertions.assertEquals(expectedMlv, mlv);
     } else {
-      Assert.assertTrue("Expected minimum mlv(" + expectedMlv
+      Assertions.assertTrue("Expected minimum mlv(" + expectedMlv
           + ") is smaller than mlv(" + mlv + ").", expectedMlv <= mlv);
     }
 
@@ -686,7 +686,7 @@ public class TestDatanodeUpgradeToScmHA {
       ContainerProtos.Result expectedResult) {
     ContainerProtos.ContainerCommandResponseProto response =
         dsm.getContainer().getDispatcher().dispatch(request, null);
-    Assert.assertEquals(expectedResult, response.getResult());
+    Assertions.assertEquals(expectedResult, response.getResult());
   }
 
   /// VOLUME OPERATIONS ///
@@ -717,7 +717,7 @@ public class TestDatanodeUpgradeToScmHA {
    */
   public void failVolume(File volume) {
     File failedVolume = getFailedVolume(volume);
-    Assert.assertTrue(volume.renameTo(failedVolume));
+    Assertions.assertTrue(volume.renameTo(failedVolume));
   }
 
   /**
@@ -727,7 +727,7 @@ public class TestDatanodeUpgradeToScmHA {
    */
   public void restoreVolume(File volume) {
     File failedVolume = getFailedVolume(volume);
-    Assert.assertTrue(failedVolume.renameTo(volume));
+    Assertions.assertTrue(failedVolume.renameTo(volume));
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -43,11 +43,11 @@ import org.apache.hadoop.ozone.container.replication.ContainerImporter;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicationSource;
 import org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -106,7 +106,7 @@ public class TestDatanodeUpgradeToScmHA {
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, scmHAAlreadyEnabled);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     tempFolder = new TemporaryFolder();
     tempFolder.create();
@@ -116,7 +116,7 @@ public class TestDatanodeUpgradeToScmHA {
     conf.setSocketAddr(ScmConfigKeys.OZONE_SCM_NAMES, address);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (scmRpcServer != null) {
       scmRpcServer.stop();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -537,8 +537,9 @@ public class TestDatanodeUpgradeToScmHA {
     if (exactMatch) {
       Assertions.assertEquals(expectedMlv, mlv);
     } else {
-      Assertions.assertTrue("Expected minimum mlv(" + expectedMlv
-          + ") is smaller than mlv(" + mlv + ").", expectedMlv <= mlv);
+      Assertions.assertTrue(expectedMlv <= mlv,
+          "Expected minimum mlv(" + expectedMlv
+          + ") is smaller than mlv(" + mlv + ").");
     }
 
     callVersionEndpointTask();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrate parameterized tests in hdds-container-service to JUnit5. With this all container-service tests have been migrated to Junit5.

There is an ongoing effort to migrate all tests to JUnit5 in this ticket I'm migrating the parameterized tests in container-service. After this there shouldn't be any more JUnit4 tests remaining in the module.

[HDDS-9494](https://issues.apache.org/jira/browse/HDDS-9494)

## How was this patch tested?

Run each test locally after the fix was finished as well as getting a green CI run here:
https://github.com/Galsza/ozone/actions/runs/7214752431