### PR TITLE
HDDS-9933. Recon datanode 'Last Heartbeat' should print relative values

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -42,7 +42,7 @@ interface IDatanodeResponse {
   hostname: string;
   state: DatanodeState;
   opState: DatanodeOpState;
-  lastHeartbeat: number;
+  lastHeartbeat: string;
   storageReport: IStorageReport;
   pipelines: IPipeline[];
   containers: number;
@@ -182,7 +182,7 @@ const COLUMNS = [
     isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.lastHeartbeat - b.lastHeartbeat,
     render: (heartbeat: number) => {
-      return heartbeat > 0 ? moment(heartbeat).format('ll LTS') : 'NA';
+      return heartbeat > 0 ? getTimeDiffFromTimestamp(heartbeat) : 'NA';
     }
   },
   {
@@ -302,6 +302,39 @@ const defaultColumns: IOption[] = COLUMNS.map(column => ({
   label: column.key,
   value: column.key
 }));
+
+const getTimeDiffFromTimestamp = (timestamp: number): string => {
+  const timestampDate = new Date(timestamp);
+  const currentDate = new Date();
+
+  const totalSecondsDiff = Math.floor((currentDate.getTime() - timestampDate.getTime()) / 1000);
+
+  const years = Math.floor(totalSecondsDiff / (3600 * 24 * 365));
+  const days = Math.floor((totalSecondsDiff % (3600 * 24 * 365)) / (3600 * 24));
+  const hours = Math.floor((totalSecondsDiff % (3600 * 24)) / 3600);
+  const minutes = Math.floor((totalSecondsDiff % 3600) / 60);
+  const seconds = totalSecondsDiff % 60;
+
+  let timeStr = "";
+
+  if (years > 0) {
+    timeStr += years + "y ";
+  }
+  if (days > 0 || years > 0) {
+    timeStr += days + "d ";
+  }
+  if (hours > 0 || days > 0 || years > 0) {
+    timeStr += hours + "h ";
+  }
+  if (minutes > 0 || hours > 0 || days > 0 || years > 0) {
+    timeStr += minutes + "m ";
+  }
+  if (seconds > 0 || minutes > 0 || hours > 0 || days > 0 || years > 0) {
+    timeStr += seconds + "s ";
+  }
+
+  return timeStr.trim().length === 0 ? "Just now" : timeStr.trim() + " ago";
+}
 
 let cancelSignal: AbortController;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recon's frontend receives a timestamp number from the backend and then formats the number as a date. It's more useful to the system administrator and practical, to view the `Last Heartbeat` as a relative value than an entire date. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9933

## How was this patch tested?

The patch was tested manually, see the attached screenshot.

<img width="1538" alt="recon-last-heartbeat-relative-value" src="https://github.com/apache/ozone/assets/74301312/50b876d1-2769-414b-881b-ac59eb97ea6d">

Also,  because there are no unit tests for Recon's frontend, the method was tested externally. Here are some sample values
```
[LOG]: "31s ago" 
[LOG]: "50s ago" 
[LOG]: "1m 0s ago" 
[LOG]: "1m 2s ago" 
[LOG]: "1m 15s ago" 
[LOG]: "1m 16s ago" 
[LOG]: "1m 33s ago" 
[LOG]: "2m 54s ago"
[LOG]: "7m 17s ago" 
```

BTW, this what 'Last Heartbeat' looks like in master

<img width="1553" alt="recon-last-heartbeat-date" src="https://github.com/apache/ozone/assets/74301312/98eff8e6-f9c0-4e4c-82d3-30b3516827c9">

