### PR TITLE
HDDS-9932. Compose annotation for tests parameterized with ContainerTestVersionInfo

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -76,8 +76,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -131,10 +129,6 @@ public class TestBlockDeletingService {
   private String schemaVersion;
   private int blockLimitPerInterval;
   private MutableVolumeSet volumeSet;
-
-  private static Iterable<Object[]> versionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
-  }
 
   @BeforeEach
   public void init() throws IOException {
@@ -426,8 +420,7 @@ public class TestBlockDeletingService {
    * there are no delete transactions in the DB, this metadata counter should
    * be reset to zero.
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testPendingDeleteBlockReset(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
@@ -541,9 +534,7 @@ public class TestBlockDeletingService {
     }
   }
 
-
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testBlockDeletion(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
@@ -662,8 +653,7 @@ public class TestBlockDeletingService {
     svc.shutdown();
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testWithUnrecordedBlocks(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
@@ -779,8 +769,7 @@ public class TestBlockDeletingService {
     svc.shutdown();
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testShutdownService(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
@@ -811,8 +800,7 @@ public class TestBlockDeletingService {
     GenericTestUtils.waitFor(() -> service.getThreadCount() == 0, 100, 1000);
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testBlockDeletionTimeout(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
@@ -901,9 +889,8 @@ public class TestBlockDeletingService {
     return ozoneContainer;
   }
 
-  @ParameterizedTest
   @Unhealthy
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testContainerThrottle(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
@@ -970,8 +957,7 @@ public class TestBlockDeletingService {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testContainerMaxLockHoldingTime(
       ContainerTestVersionInfo versionInfo) throws Exception {
     setLayoutAndSchemaForTest(versionInfo);
@@ -1031,8 +1017,7 @@ public class TestBlockDeletingService {
     return totalSpaceUsed;
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testBlockThrottle(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaForTest(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
@@ -26,8 +26,6 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,12 +51,7 @@ public class TestKeyValueContainerData {
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
   }
 
-  private static Iterable<Object[]> versionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
-  }
-
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testKeyValueData(ContainerTestVersionInfo versionInfo) {
     initVersionInfo(versionInfo);
     long containerId = 1L;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -38,8 +38,6 @@ import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -93,10 +91,6 @@ public class TestStaleRecoveringContainerScrubbingService {
     init();
   }
 
-  private static Iterable<Object[]> versionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
-  }
-
   private void init() throws IOException {
     File volumeDir =
         Files.createDirectory(tempDir.resolve("volumeDir")).toFile();
@@ -148,8 +142,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     return createdIds;
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testScrubbingStaleRecoveringContainers(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initVersionInfo(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -100,8 +100,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,10 +134,6 @@ public class TestContainerPersistence {
     this.layout = versionInfo.getLayout();
     this.schemaVersion = versionInfo.getSchemaVersion();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
-  }
-
-  private static Iterable<Object[]> versionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
   }
 
   @BeforeAll
@@ -224,8 +218,7 @@ public class TestContainerPersistence {
     return container;
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testCreateContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initSchemaAndVersionInfo(versionInfo);
@@ -250,8 +243,7 @@ public class TestContainerPersistence {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testCreateDuplicateContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initSchemaAndVersionInfo(versionInfo);
@@ -266,8 +258,7 @@ public class TestContainerPersistence {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testAddingBlockToDeletedContainer(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initSchemaAndVersionInfo(versionInfo);
@@ -301,8 +292,7 @@ public class TestContainerPersistence {
         Matchers.containsString("Error opening DB."));
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteNonEmptyContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initSchemaAndVersionInfo(versionInfo);
@@ -340,8 +330,7 @@ public class TestContainerPersistence {
             "Non-force deletion of non-empty container is not allowed."));
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteContainer(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -434,8 +423,7 @@ public class TestContainerPersistence {
    *
    * @throws Exception
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteContainerWithRenaming(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initSchemaAndVersionInfo(versionInfo);
@@ -532,8 +520,7 @@ public class TestContainerPersistence {
     assertEquals(0, deleteDirFilesArray.length);
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testGetContainerReports(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initSchemaAndVersionInfo(versionInfo);
@@ -570,8 +557,7 @@ public class TestContainerPersistence {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testListContainer(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -639,8 +625,7 @@ public class TestContainerPersistence {
    * @throws IOException
    * @throws NoSuchAlgorithmException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testWriteChunk(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -656,8 +641,7 @@ public class TestContainerPersistence {
    * @throws IOException
    * @throws NoSuchAlgorithmException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testWritReadManyChunks(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -705,8 +689,7 @@ public class TestContainerPersistence {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testOverWrite(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -742,8 +725,7 @@ public class TestContainerPersistence {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteChunk(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -769,8 +751,7 @@ public class TestContainerPersistence {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testPutBlock(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -796,8 +777,7 @@ public class TestContainerPersistence {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testPutBlockWithInvalidBCSId(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -855,8 +835,7 @@ public class TestContainerPersistence {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testPutBlockWithLotsOfChunks(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -910,8 +889,7 @@ public class TestContainerPersistence {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testUpdateContainer(ContainerTestVersionInfo versionInfo)
       throws IOException {
     initSchemaAndVersionInfo(versionInfo);
@@ -995,8 +973,7 @@ public class TestContainerPersistence {
     return blockData;
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testListBlock(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initSchemaAndVersionInfo(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -33,8 +33,6 @@ import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -90,10 +88,6 @@ public class TestDeleteBlocksCommandHandler {
     setup();
   }
 
-  private static Iterable<Object[]> versionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
-  }
-
   private void setup() throws Exception {
     conf = new OzoneConfiguration();
     layout = ContainerLayoutVersion.FILE_PER_BLOCK;
@@ -136,8 +130,7 @@ public class TestDeleteBlocksCommandHandler {
     BlockDeletingServiceMetrics.unRegister();
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteBlocksCommandHandler(
       ContainerTestVersionInfo versionInfo) throws Exception {
     prepareTest(versionInfo);
@@ -163,8 +156,7 @@ public class TestDeleteBlocksCommandHandler {
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteBlocksCommandHandlerWithTimeoutFailed(
       ContainerTestVersionInfo versionInfo) throws Exception {
     prepareTest(versionInfo);
@@ -212,8 +204,7 @@ public class TestDeleteBlocksCommandHandler {
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteBlocksCommandHandlerSuccessfulAfterFirstTimeout(
       ContainerTestVersionInfo versionInfo) throws Exception {
     prepareTest(versionInfo);
@@ -263,8 +254,7 @@ public class TestDeleteBlocksCommandHandler {
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteCmdWorkerInterval(
       ContainerTestVersionInfo versionInfo) throws Exception {
     prepareTest(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerTestVersionInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerTestVersionInfo.java
@@ -21,12 +21,16 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 
 /**
@@ -35,6 +39,18 @@ import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContain
  * - ChunkLayOutVersion: data layout version
  */
 public class ContainerTestVersionInfo {
+
+  /**
+   * Composite annotation for tests parameterized with {@link ContainerTestVersionInfo}.
+   */
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @ParameterizedTest
+  @MethodSource("org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo#getLayoutList")
+  public @interface ContainerTest {
+    // composite annotation
+  }
+
   private static final String[] SCHEMA_VERSIONS = new String[] {
       null,
       OzoneConsts.SCHEMA_V1,
@@ -66,20 +82,6 @@ public class ContainerTestVersionInfo {
 
   public ContainerLayoutVersion getLayout() {
     return this.layout;
-  }
-
-  public static Iterable<Object[]> versionParameters() {
-    return layoutList.stream().map(each -> new Object[] {each})
-        .collect(toList());
-  }
-
-  /**
-   * This method is created to support the parameterized data during
-   * migration to Junit5.
-   * @return Stream of ContainerTestVersionInfo objects.
-   */
-  public static Stream<Object> versionParametersStream() {
-    return layoutList.stream().map(each -> new Object[] {each});
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -62,8 +62,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.LiveFileMetaData;
@@ -133,10 +131,6 @@ public class TestKeyValueContainer {
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, CONF);
   }
 
-  private static Iterable<Object[]> versionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
-  }
-
   private void init(ContainerTestVersionInfo versionInfo) throws Exception {
     setVersionInfo(versionInfo);
     CodecBuffer.enableLeakDetection();
@@ -182,8 +176,7 @@ public class TestKeyValueContainer {
     CodecBuffer.assertNoLeaks();
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testCreateContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -209,8 +202,7 @@ public class TestKeyValueContainer {
   /**
    * Tests repair of containers affected by the bug reported in HDDS-6235.
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testMissingChunksDirCreated(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -229,8 +221,7 @@ public class TestKeyValueContainer {
     Assertions.assertTrue(chunksDir.exists());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testNextVolumeTriedOnWriteFailure(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -268,8 +259,7 @@ public class TestKeyValueContainer {
     assertEquals(2, callCount.get());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testEmptyContainerImportExport(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -303,8 +293,7 @@ public class TestKeyValueContainer {
     checkContainerFilesPresent(data, 0);
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testUnhealthyContainerImportExport(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -343,8 +332,7 @@ public class TestKeyValueContainer {
     assertEquals(numberOfKeysToWrite, keyValueContainerData.getBlockCount());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testContainerImportExport(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -518,8 +506,7 @@ public class TestKeyValueContainer {
         ContainerProtos.ContainerDataProto.State.CLOSED);
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void concurrentExport(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -552,8 +539,7 @@ public class TestKeyValueContainer {
     assertNull(failed.get());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDuplicateContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -570,8 +556,7 @@ public class TestKeyValueContainer {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDiskFullExceptionCreateContainer(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -588,8 +573,7 @@ public class TestKeyValueContainer {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDeleteContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -619,8 +603,7 @@ public class TestKeyValueContainer {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testCloseContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -642,8 +625,7 @@ public class TestKeyValueContainer {
         keyValueContainerData.getState());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testReportOfUnhealthyContainer(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -659,8 +641,7 @@ public class TestKeyValueContainer {
   }
 
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testUpdateContainer(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -684,8 +665,7 @@ public class TestKeyValueContainer {
 
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testUpdateContainerUnsupportedRequest(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -706,8 +686,7 @@ public class TestKeyValueContainer {
   }
 
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testContainerRocksDB(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -763,8 +742,7 @@ public class TestKeyValueContainer {
         ssdProfile.getColumnFamilyOptions(conf));
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testDBProfileAffectsDBOptions(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -812,8 +790,7 @@ public class TestKeyValueContainer {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testKeyValueDataProtoBufMsg(ContainerTestVersionInfo versionInfo)
       throws Exception {
     init(versionInfo);
@@ -842,8 +819,7 @@ public class TestKeyValueContainer {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testAutoCompactionSmallSstFile(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -948,8 +924,7 @@ public class TestKeyValueContainer {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testIsEmptyContainerStateWhileImport(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -998,8 +973,7 @@ public class TestKeyValueContainer {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testIsEmptyContainerStateWhileImportWithoutBlock(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -1051,8 +1025,7 @@ public class TestKeyValueContainer {
   /**
    * Test import schema V2 replica to V3 enabled HddsVolume.
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testImportV2ReplicaToV3HddsVolume(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);
@@ -1069,8 +1042,7 @@ public class TestKeyValueContainer {
   /**
    * Test import schema V3 replica to V3 disabled HddsVolume.
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testImportV3ReplicaToV2HddsVolume(
       ContainerTestVersionInfo versionInfo) throws Exception {
     init(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -29,8 +29,6 @@ import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.RandomAccessFile;
@@ -49,8 +47,7 @@ public class TestKeyValueContainerCheck
   /**
    * Sanity test, when there are no corruptions induced.
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testKeyValueContainerCheckNoCorruption(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initTestData(versionInfo);
@@ -85,8 +82,7 @@ public class TestKeyValueContainerCheck
   /**
    * Sanity test, when there are corruptions induced.
    */
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testKeyValueContainerCheckCorruption(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initTestData(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerIntegrityChecks.java
@@ -85,10 +85,6 @@ public class TestKeyValueContainerIntegrityChecks {
     setup();
   }
 
-  static Iterable<Object[]> versionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
-  }
-
   private void setup() throws Exception {
     LOG.info("Testing  layout:{}", containerLayoutTestInfo.getLayout());
     this.testRoot = GenericTestUtils.getRandomizedTestDir();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -36,8 +36,6 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
 import org.apache.log4j.PatternLayout;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,8 +56,7 @@ public class TestKeyValueContainerMetadataInspector
     extends TestKeyValueContainerIntegrityChecks {
   private static final long CONTAINER_ID = 102;
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testRunDisabled(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTestData(versionInfo);
@@ -84,8 +81,7 @@ public class TestKeyValueContainerMetadataInspector
     assertNull(runInspectorAndGetReport(containerData));
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testSystemPropertyAndReadOnly(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initTestData(versionInfo);
@@ -119,8 +115,7 @@ public class TestKeyValueContainerMetadataInspector
     System.clearProperty(KeyValueContainerMetadataInspector.SYSTEM_PROPERTY);
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testIncorrectTotalsNoData(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTestData(versionInfo);
@@ -134,8 +129,7 @@ public class TestKeyValueContainerMetadataInspector
         createBlocks, setBlocks, setBytes, 0, 0);
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testIncorrectTotalsWithData(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTestData(versionInfo);
@@ -150,8 +144,7 @@ public class TestKeyValueContainerMetadataInspector
         createBlocks, setBlocks, setBytes, 0, 0);
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testCorrectTotalsNoData(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTestData(versionInfo);
@@ -164,8 +157,7 @@ public class TestKeyValueContainerMetadataInspector
     inspectThenRepairOnCorrectContainer(container.getContainerData());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testCorrectTotalsWithData(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTestData(versionInfo);
@@ -207,8 +199,7 @@ public class TestKeyValueContainerMetadataInspector
   static final DeletedBlocksTransactionGeneratorForTesting GENERATOR
       = new DeletedBlocksTransactionGeneratorForTesting();
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testCorrectDeleteWithTransaction(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initTestData(versionInfo);
@@ -231,8 +222,7 @@ public class TestKeyValueContainerMetadataInspector
     inspectThenRepairOnCorrectContainer(container.getContainerData());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testIncorrectDeleteWithTransaction(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initTestData(versionInfo);
@@ -256,8 +246,7 @@ public class TestKeyValueContainerMetadataInspector
         deleteCount, numDeletedLocalIds);
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testIncorrectDeleteWithoutTransaction(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initTestData(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -37,8 +37,6 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.nio.file.Path;
@@ -82,10 +80,6 @@ public class TestBlockManagerImpl {
     this.config = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, config);
     initilaze();
-  }
-
-  private static Iterable<Object[]> getVersionParameters() {
-    return ContainerTestVersionInfo.versionParameters();
   }
 
   private void initilaze() throws Exception {
@@ -148,8 +142,7 @@ public class TestBlockManagerImpl {
     BlockUtils.shutdownCache(config);
   }
 
-  @ParameterizedTest
-  @MethodSource("getVersionParameters")
+  @ContainerTestVersionInfo.ContainerTest
   public void testPutBlock(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTest(versionInfo);
@@ -179,8 +172,7 @@ public class TestBlockManagerImpl {
 
   }
 
-  @ParameterizedTest
-  @MethodSource("getVersionParameters")
+  @ContainerTestVersionInfo.ContainerTest
   public void testPutAndGetBlock(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTest(versionInfo);
@@ -202,8 +194,7 @@ public class TestBlockManagerImpl {
 
   }
 
-  @ParameterizedTest
-  @MethodSource("getVersionParameters")
+  @ContainerTestVersionInfo.ContainerTest
   public void testListBlock(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTest(versionInfo);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -46,8 +46,6 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -204,8 +202,7 @@ public class TestContainerReader {
     return blkNames;
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testContainerReader(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaVersion(versionInfo);
@@ -252,8 +249,7 @@ public class TestContainerReader {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testContainerReaderWithLoadException(
       ContainerTestVersionInfo versionInfo) throws Exception {
     setLayoutAndSchemaVersion(versionInfo);
@@ -303,8 +299,7 @@ public class TestContainerReader {
     Assertions.assertEquals(containerCount - 1, containerSet1.containerCount());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testMultipleContainerReader(ContainerTestVersionInfo versionInfo)
       throws Exception {
     setLayoutAndSchemaVersion(versionInfo);
@@ -384,8 +379,7 @@ public class TestContainerReader {
     Assertions.assertEquals(0, cache.size());
   }
 
-  @ParameterizedTest
-  @MethodSource("versionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testMarkedDeletedContainerCleared(
       ContainerTestVersionInfo versionInfo) throws Exception {
     setLayoutAndSchemaVersion(versionInfo);
@@ -454,9 +448,5 @@ public class TestContainerReader {
     schemaVersion = versionInfo.getSchemaVersion();
     conf = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, conf);
-  }
-
-  private static Iterable<Object[]> versionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -48,8 +48,6 @@ import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -93,10 +91,6 @@ public class TestOzoneContainer {
     setup();
   }
 
-  private static Iterable<Object[]> getVersionInfo() {
-    return ContainerTestVersionInfo.versionParameters();
-  }
-
   private void setup() throws Exception {
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, folder.toString());
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
@@ -118,8 +112,7 @@ public class TestOzoneContainer {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("getVersionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testBuildContainerMap(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTest(versionInfo);
@@ -167,8 +160,7 @@ public class TestOzoneContainer {
     verifyCommittedSpace(ozoneContainer);
   }
 
-  @ParameterizedTest
-  @MethodSource("getVersionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testBuildNodeReport(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTest(versionInfo);
@@ -198,8 +190,7 @@ public class TestOzoneContainer {
         ozoneContainer.getNodeReport().getDbStorageReportList().size());
   }
 
-  @ParameterizedTest
-  @MethodSource("getVersionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testBuildNodeReportWithDefaultRatisLogDir(
       ContainerTestVersionInfo versionInfo) throws Exception {
     initTest(versionInfo);
@@ -212,9 +203,7 @@ public class TestOzoneContainer {
             .size());
   }
 
-
-  @ParameterizedTest
-  @MethodSource("getVersionInfo")
+  @ContainerTestVersionInfo.ContainerTest
   public void testContainerCreateDiskFull(ContainerTestVersionInfo versionInfo)
       throws Exception {
     initTest(versionInfo);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ContainerTestVersionInfo` is used in several classes to parameterize test methods.  The goal of this change is to reduce code duplication by defining a [composite annotation](https://junit.org/junit5/docs/current/user-guide/#writing-tests-meta-annotation).

(Will create follow-up tasks for other similar common parameter types.)

https://issues.apache.org/jira/browse/HDDS-9932

## How was this patch tested?

Tests changed by this PR were executed normally (no change in test count, etc.).

Before:

```
Tests run: 136, Failures: 0, Errors: 0, Skipped: 8, Time elapsed: 13.51 s -- in org.apache.hadoop.ozone.container.common.impl.TestContainerPersistence
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.915 s -- in org.apache.hadoop.ozone.container.common.statemachine.commandhandler.TestDeleteBlocksCommandHandler
Tests run: 56, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 20.63 s -- in org.apache.hadoop.ozone.container.common.TestBlockDeletingService
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.429 s -- in org.apache.hadoop.ozone.container.common.TestKeyValueContainerData
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.279 s -- in org.apache.hadoop.ozone.container.common.TestStaleRecoveringContainerScrubbingService
Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.321 s -- in org.apache.hadoop.ozone.container.keyvalue.impl.TestBlockManagerImpl
Tests run: 177, Failures: 0, Errors: 0, Skipped: 6, Time elapsed: 46.47 s -- in org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainer
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.134 s -- in org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainerCheck
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.250 s -- in org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainerMarkUnhealthy
Tests run: 72, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.854 s -- in org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainerMetadataInspector
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.85 s -- in org.apache.hadoop.ozone.container.ozoneimpl.TestContainerReader
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.389 s -- in org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer
```

After:

```
Tests run: 136, Failures: 0, Errors: 0, Skipped: 8, Time elapsed: 14.63 s -- in org.apache.hadoop.ozone.container.common.impl.TestContainerPersistence
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.825 s -- in org.apache.hadoop.ozone.container.common.statemachine.commandhandler.TestDeleteBlocksCommandHandler
Tests run: 56, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 21.34 s -- in org.apache.hadoop.ozone.container.common.TestBlockDeletingService
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.335 s -- in org.apache.hadoop.ozone.container.common.TestKeyValueContainerData
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.658 s -- in org.apache.hadoop.ozone.container.common.TestStaleRecoveringContainerScrubbingService
Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.310 s -- in org.apache.hadoop.ozone.container.keyvalue.impl.TestBlockManagerImpl
Tests run: 177, Failures: 0, Errors: 0, Skipped: 6, Time elapsed: 48.81 s -- in org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainer
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.884 s -- in org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainerCheck
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.064 s -- in org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainerMarkUnhealthy
Tests run: 72, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.305 s -- in org.apache.hadoop.ozone.container.keyvalue.TestKeyValueContainerMetadataInspector
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.66 s -- in org.apache.hadoop.ozone.container.ozoneimpl.TestContainerReader
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.223 s -- in org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7223199990