### PR TITLE
HDDS-9934. Display 'Last Heartbeat' in SCM UI in the Node Status section

### DIFF
--- a/hadoop-hdds/framework/src/main/resources/webapps/static/ozone.css
+++ b/hadoop-hdds/framework/src/main/resources/webapps/static/ozone.css
@@ -80,7 +80,7 @@ body {
      display: block;
      font-family: 'Glyphicons Halflings';
  }
-.nodeStausInfo {
+.nodeStatusInfo {
     position: relative;
  }
 .wrap-table{

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -46,12 +46,14 @@
 <table class="table table-bordered table-striped col-md-6">
     <thead>
         <tr>
-            <th ng-click = "columnSort('hostname')" class="nodeStausInfo"><span ng-class = "{'sorting' : (columnName != 'hostname'), 'sortasc' : (columnName == 'hostname' && !reverse),
+            <th ng-click = "columnSort('hostname')" class="nodeStatusInfo"><span ng-class = "{'sorting' : (columnName != 'hostname'), 'sortasc' : (columnName == 'hostname' && !reverse),
                                         'sortdesc':(columnName == 'hostname' && !reverse)}">HostName</span></th>
-            <th ng-click = "columnSort('opstate')" class="nodeStausInfo" ><span ng-class="{'sorting' : (columnName != 'opstate'), 'sortasc' : (columnName == 'opstate' && !reverse),
+            <th ng-click = "columnSort('opstate')" class="nodeStatusInfo" ><span ng-class="{'sorting' : (columnName != 'opstate'), 'sortasc' : (columnName == 'opstate' && !reverse),
                                         'sortdesc':(columnName == 'opstate' && !reverse)}">Operational State</span></th>
-            <th ng-click = "columnSort('comstate')" class="nodeStausInfo">  <span ng-class="{'sorting' : (columnName != 'comstate'), 'sortasc' : (columnName == 'comstate' && !reverse),
+            <th ng-click = "columnSort('comstate')" class="nodeStatusInfo">  <span ng-class="{'sorting' : (columnName != 'comstate'), 'sortasc' : (columnName == 'comstate' && !reverse),
                                         'sortdesc':(columnName == 'comstate' && !reverse)}">Commisioned State</span> </th>
+            <th ng-click = "columnSort('lastheartbeat')" class="nodeStatusInfo">  <span ng-class="{'sorting' : (columnName != 'lastheartbeat'), 'sortasc' : (columnName == 'heartbeat' && !reverse),
+                                        'sortdesc':(columnName == 'lastheartbeat' && !reverse)}">Last Heartbeat</span> </th>
         </tr>
     </thead>
     <tbody>
@@ -66,6 +68,7 @@
             </td>
             <td>{{typestat.opstate}}</td>
             <td>{{typestat.comstate}}</td>
+            <td>{{typestat.lastheartbeat}}</td>
        </tr>
     </tbody>
 </table>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -69,6 +69,7 @@
                                     hostname: key,
                                     opstate: value && value.find((element) => element.key === "OPSTATE").value,
                                     comstate: value && value.find((element) => element.key === "COMSTATE").value,
+                                    lastheartbeat: value && value.find((element) => element.key === "LASTHEARTBEAT").value,
                                     port: portSpec.port,
                                     protocol: portSpec.proto
                                 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -77,6 +77,7 @@ import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.ozone.protocol.commands.SetNodeOperationalStateCommand;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -235,6 +236,38 @@ public class TestSCMNodeManager {
       Thread.sleep(4 * 1000);
       assertEquals(nodeManager.getAllNodes().size(), registeredNodes,
           "Heartbeat thread should have picked up the scheduled heartbeats.");
+    }
+  }
+
+  @Test
+  public void testGetLastHeartbeatTimeDiff() throws Exception {
+    try (SCMNodeManager nodeManager = createNodeManager(getConf())) {
+      String timeNow = nodeManager.getLastHeartbeatTimeDiff(Time.monotonicNow());
+      assertEquals("Just now", timeNow);
+
+      String time1s = nodeManager.getLastHeartbeatTimeDiff(Time.monotonicNow() - 10000);
+      assertEquals("10s ago", time1s);
+
+      String time1m = nodeManager.getLastHeartbeatTimeDiff(Time.monotonicNow() - 60000);
+      assertEquals("1m ago", time1m);
+
+      String time1m10s = nodeManager.getLastHeartbeatTimeDiff(Time.monotonicNow() - 70000);
+      assertEquals("1m 10s ago", time1m10s);
+
+      // 1h 1m 10s
+      // 10000ms = 10s
+      // 60000ms = 1m
+      // 60000ms * 60 = 3600000ms = 1h
+      String time1h1m10s = nodeManager.getLastHeartbeatTimeDiff(Time.monotonicNow() - 3670000);
+      assertEquals("1h 1m 10s ago", time1h1m10s);
+
+      // 1d 1h 1m 10s
+      // 10000ms = 10s
+      // 60000ms = 1m
+      // 60000ms * 60 = 3600000ms = 1h
+      // 3600000ms * 24 = 86400000ms = 1d
+      String time1d1h1m10s = nodeManager.getLastHeartbeatTimeDiff(Time.monotonicNow() - 90070000);
+      assertEquals("1d 1h 1m 10s ago", time1d1h1m10s);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

It's useful for the cluster admin to have a datanodes 'Last Heartbeat' available in the SCM UI. This patch is adding that change. The time is presented in a relative value e.g. `2s ago`, `3m 1s ago` etc.

The method for making the calculations, could be in a Util class and not in `SCMNodeManager`. Feel free to provide any feedback on that.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9934

## How was this patch tested?

A new unit test was added for this patch. It was also tested manually. Check the attached screenshots from SCM UI.

<img width="1998" alt="scm-ui-1" src="https://github.com/apache/ozone/assets/74301312/56c482a8-9fef-49ba-92c3-d6e094f9e8d6">

<img width="1975" alt="scm-ui-2" src="https://github.com/apache/ozone/assets/74301312/c129e703-22ef-4458-b22d-84ae313c1845">

