### PR TITLE
HDDS-9936. Create a DispatcherContext for ReadChunk and GetSmallFile.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -424,9 +424,12 @@ public final class HddsUtils {
    * @param proto ContainerCommand Request proto
    * @return True if its readOnly , false otherwise.
    */
-  public static boolean isReadOnly(
-      ContainerCommandRequestProtoOrBuilder proto) {
-    switch (proto.getCmdType()) {
+  public static boolean isReadOnly(ContainerCommandRequestProtoOrBuilder proto) {
+    return isReadOnly(proto.getCmdType());
+  }
+
+  public static boolean isReadOnly(ContainerProtos.Type type) {
+    switch (type) {
     case ReadContainer:
     case ReadChunk:
     case ListBlock:

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
@@ -108,18 +108,7 @@ public class GrpcXceiverService extends
 
       @Override
       public void onNext(ContainerCommandRequestProto request) {
-        final DispatcherContext context;
-        switch (request.getCmdType()) {
-        case ReadChunk:
-          context = DispatcherContext.getHandleReadChunk();
-          break;
-        case GetSmallFile:
-          context = DispatcherContext.getHandleGetSmallFile();
-          break;
-        default:
-          context = null;
-        }
-
+        final DispatcherContext context = DispatcherContext.getDispatcherContext(request.getCmdType());
         try {
           final ContainerCommandResponseProto resp = dispatcher.dispatch(request, context);
           responseObserver.onNext(resp);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.UncheckedAutoCloseable;
@@ -26,6 +27,8 @@ import org.apache.ratis.util.UncheckedAutoCloseable;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.ReadChunk;
 
 /**
  * DispatcherContext class holds transport protocol specific context info
@@ -53,6 +56,17 @@ public final class DispatcherContext implements UncheckedAutoCloseable {
 
   public static DispatcherContext getHandlePutSmallFile() {
     return HANDLE_PUT_SMALL_FILE;
+  }
+
+  public static DispatcherContext getDispatcherContext(ContainerProtos.Type type) {
+    switch (type) {
+      case ReadChunk:
+        return DispatcherContext.getHandleReadChunk();
+      case GetSmallFile:
+        return DispatcherContext.getHandleGetSmallFile();
+      default:
+        return null;
+    }
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -187,7 +187,7 @@ public final class ChunkUtils {
     }
   }
 
-  public static ChunkBuffer readData(long len, int bufferCapacity,
+  public static ChunkBuffer readData(int len, int bufferCapacity,
       File file, long off, HddsVolume volume, int readMappedBufferThreshold)
       throws StorageContainerException {
     if (len > readMappedBufferThreshold) {
@@ -454,15 +454,15 @@ public final class ChunkUtils {
     }
   }
 
-  public static void limitReadSize(long len)
-      throws StorageContainerException {
-    if (len > OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE) {
-      String err = String.format(
-          "Oversize read. max: %d, actual: %d",
-          OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE, len);
-      LOG.error(err);
-      throw new StorageContainerException(err, UNSUPPORTED_REQUEST);
+  public static int limitReadSize(long len) throws StorageContainerException {
+    final int max = OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE;
+    if (len <= max) {
+      return Math.toIntExact(len);
     }
+
+    final String err = String.format("Oversize read. max: %d, actual: %d", max, len);
+    LOG.error(err);
+    throw new StorageContainerException(err, UNSUPPORTED_REQUEST);
   }
 
   public static StorageContainerException wrapInStorageContainerException(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
@@ -72,9 +72,8 @@ public class ChunkManagerDummyImpl implements ChunkManager {
       ChunkInfo info, DispatcherContext dispatcherContext)
       throws StorageContainerException {
 
-    limitReadSize(info.getLen());
     // stats are handled in ChunkManagerImpl
-    return ChunkBuffer.allocate(Math.toIntExact(info.getLen()));
+    return ChunkBuffer.allocate(limitReadSize(info.getLen()));
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
@@ -32,8 +32,6 @@ import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
 
-import java.nio.ByteBuffer;
-
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.limitReadSize;
 
 /**
@@ -76,7 +74,7 @@ public class ChunkManagerDummyImpl implements ChunkManager {
 
     limitReadSize(info.getLen());
     // stats are handled in ChunkManagerImpl
-    return ChunkBuffer.wrap(ByteBuffer.allocate((int) info.getLen()));
+    return ChunkBuffer.allocate(Math.toIntExact(info.getLen()));
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -181,7 +181,7 @@ public class FilePerBlockStrategy implements ChunkManager {
       return ChunkBuffer.wrap(ByteBuffer.wrap(new byte[0]));
     }
 
-    limitReadSize(info.getLen());
+    final int len = limitReadSize(info.getLen());
 
     KeyValueContainerData containerData = (KeyValueContainerData) container
         .getContainerData();
@@ -190,7 +190,6 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     File chunkFile = getChunkFile(container, blockID, info);
 
-    final long len = info.getLen();
     long offset = info.getOffset();
     int bufferCapacity =  ChunkManager.getBufferCapacityForChunkRead(info,
         defaultReadBufferCapacity);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -209,7 +209,7 @@ public class FilePerChunkStrategy implements ChunkManager {
       throws StorageContainerException {
 
     checkLayoutVersion(container);
-    limitReadSize(info.getLen());
+    final int len = limitReadSize(info.getLen());
 
     KeyValueContainer kvContainer = (KeyValueContainer) container;
     KeyValueContainerData containerData = kvContainer.getContainerData();
@@ -229,7 +229,6 @@ public class FilePerChunkStrategy implements ChunkManager {
       possibleFiles.add(finalChunkFile);
     }
 
-    final long len = info.getLen();
     int bufferCapacity = ChunkManager.getBufferCapacityForChunkRead(info,
         defaultReadBufferCapacity);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -258,8 +258,8 @@ public class TestHddsDispatcher {
       ContainerCommandRequestProto writeChunkRequest =
           getWriteChunkRequest(dd.getUuidString(), 1L, 1L);
       // send read chunk request and make sure container does not exist
-      ContainerCommandResponseProto response =
-          hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
+      ContainerCommandResponseProto response = hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest),
+          DispatcherContext.getHandleReadChunk());
       assertEquals(response.getResult(),
           ContainerProtos.Result.CONTAINER_NOT_FOUND);
       // send write chunk request without sending create container
@@ -267,8 +267,8 @@ public class TestHddsDispatcher {
       // container should be created as part of write chunk request
       assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       // send read chunk request to read the chunk written above
-      response =
-          hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
+      response = hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest),
+          DispatcherContext.getHandleReadChunk());
       assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       ByteString responseData = BufferUtils.concatByteStrings(
           response.getReadChunk().getDataBuffers().getBuffersList());
@@ -314,8 +314,8 @@ public class TestHddsDispatcher {
           getWriteChunkRequest(dd.getUuidString(), 1L, 1L);
 
       // send read chunk request and make sure container does not exist
-      ContainerCommandResponseProto response =
-          hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
+      ContainerCommandResponseProto response = hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest),
+          DispatcherContext.getHandleReadChunk());
       assertEquals(
           ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
 
@@ -394,8 +394,8 @@ public class TestHddsDispatcher {
 
       assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
       // Send Read Chunk request for written chunk.
-      response =
-          hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
+      response = hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest),
+          DispatcherContext.getHandleReadChunk());
       assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
 
       ByteString responseData = BufferUtils.concatByteStrings(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.container.common.impl.HddsDispatcher;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -244,8 +245,8 @@ public class TestKeyValueHandler {
     // Test Get Small File Request handling
     ContainerCommandRequestProto getSmallFileRequest =
         getDummyCommandRequestProto(ContainerProtos.Type.GetSmallFile);
-    KeyValueHandler
-        .dispatchRequest(handler, getSmallFileRequest, container, null);
+    KeyValueHandler.dispatchRequest(handler, getSmallFileRequest, container,
+        DispatcherContext.getHandleGetSmallFile());
     Mockito.verify(handler, times(1)).handleGetSmallFile(
         any(ContainerCommandRequestProto.class), any(), any());
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -247,7 +247,7 @@ public class TestKeyValueHandler {
     KeyValueHandler
         .dispatchRequest(handler, getSmallFileRequest, container, null);
     Mockito.verify(handler, times(1)).handleGetSmallFile(
-        any(ContainerCommandRequestProto.class), any());
+        any(ContainerCommandRequestProto.class), any(), any());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
@@ -20,26 +20,27 @@ package org.apache.hadoop.ozone.container.keyvalue;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.report.IncrementalReportSender;
-import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 
+import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_INTERNAL_ERROR;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.SUCCESS;
@@ -58,25 +59,15 @@ import static org.mockito.Mockito.when;
  * container is unhealthy.
  */
 public class TestKeyValueHandlerWithUnhealthyContainer {
-  public static final Logger LOG = LoggerFactory.getLogger(
-      TestKeyValueHandlerWithUnhealthyContainer.class);
-
-  private IncrementalReportSender<Container> mockIcrSender;
-
-  @BeforeEach
-  public void init() {
-    mockIcrSender = Mockito.mock(IncrementalReportSender.class);
-  }
+  public static final Logger LOG = LoggerFactory.getLogger(TestKeyValueHandlerWithUnhealthyContainer.class);
 
   @Test
   public void testRead() {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
-    ContainerProtos.ContainerCommandResponseProto response =
-        handler.handleReadContainer(
-            getDummyCommandRequestProto(ContainerProtos.Type.ReadContainer),
-            container);
+    final ContainerCommandRequestProto request = getDummyCommandRequestProto(Type.ReadContainer);
+    final ContainerCommandResponseProto response = handler.handleReadContainer(request, container);
     assertEquals(SUCCESS, response.getResult());
   }
 
@@ -85,10 +76,8 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
-    ContainerProtos.ContainerCommandResponseProto response =
-        handler.handleGetBlock(
-            getDummyCommandRequestProto(ContainerProtos.Type.GetBlock),
-            container);
+    final ContainerCommandRequestProto request = getDummyCommandRequestProto(Type.GetBlock);
+    final ContainerCommandResponseProto response = handler.handleGetBlock(request, container);
     assertEquals(UNKNOWN_BCSID, response.getResult());
   }
 
@@ -97,11 +86,8 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
-    ContainerProtos.ContainerCommandResponseProto response =
-        handler.handleGetCommittedBlockLength(
-            getDummyCommandRequestProto(
-                ContainerProtos.Type.GetCommittedBlockLength),
-            container);
+    final ContainerCommandRequestProto request = getDummyCommandRequestProto(Type.GetCommittedBlockLength);
+    final ContainerCommandResponseProto response = handler.handleGetCommittedBlockLength(request, container);
     assertEquals(UNKNOWN_BCSID, response.getResult());
   }
 
@@ -110,12 +96,11 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
-    ContainerProtos.ContainerCommandResponseProto response =
-        handler.handleReadChunk(
-            getDummyCommandRequestProto(
-                ContainerProtos.Type.ReadChunk),
-            container, null);
-    assertEquals(UNKNOWN_BCSID, response.getResult());
+    try (DispatcherContext ctx = DispatcherContext.getHandleReadChunk()) {
+      final ContainerCommandRequestProto request = getDummyCommandRequestProto(Type.ReadChunk);
+      final ContainerCommandResponseProto response = handler.handleReadChunk(request, container, ctx);
+      assertEquals(UNKNOWN_BCSID, response.getResult());
+    }
   }
 
   @Test
@@ -123,12 +108,11 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
     KeyValueContainer container = getMockUnhealthyContainer();
     KeyValueHandler handler = getDummyHandler();
 
-    ContainerProtos.ContainerCommandResponseProto response =
-        handler.handleGetSmallFile(
-            getDummyCommandRequestProto(
-                ContainerProtos.Type.GetSmallFile),
-            container);
-    assertEquals(UNKNOWN_BCSID, response.getResult());
+    try (DispatcherContext ctx = DispatcherContext.getHandleGetSmallFile()) {
+      final ContainerCommandRequestProto request = getDummyCommandRequestProto(Type.GetSmallFile);
+      final ContainerCommandResponseProto response = handler.handleGetSmallFile(request, container, ctx);
+      assertEquals(UNKNOWN_BCSID, response.getResult());
+    }
   }
 
   @Test
@@ -136,22 +120,20 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
     KeyValueContainer container = new KeyValueContainer(
         mock(KeyValueContainerData.class),
         new OzoneConfiguration());
-    KeyValueHandler subject = getDummyHandler();
+    final KeyValueHandler handler = getDummyHandler();
 
     BlockID blockID = getTestBlockID(1);
-    ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
-        getWriteChunkRequest(MockPipeline.createSingleNodePipeline(),
-            blockID, 123);
-    ContainerProtos.ContainerCommandResponseProto response =
-        subject.handle(
-            getPutBlockRequest(writeChunkRequest),
-            container, null);
+    final Pipeline pipeline = MockPipeline.createSingleNodePipeline();
+    final ContainerCommandRequestProto writeChunkRequest = getWriteChunkRequest(pipeline, blockID, 123);
+    final ContainerCommandRequestProto putBlockRequest = getPutBlockRequest(writeChunkRequest);
+    final ContainerCommandResponseProto response = handler.handle(putBlockRequest, container, null);
     assertEquals(CONTAINER_INTERNAL_ERROR, response.getResult());
   }
 
   @Test
   public void testMarkContainerUnhealthyInFailedVolume() throws IOException {
-    KeyValueHandler handler = getDummyHandler();
+    final IncrementalReportSender<Container> mockIcrSender = mock(IncrementalReportSender.class);
+    KeyValueHandler handler = getDummyHandler(mockIcrSender);
     KeyValueContainerData mockContainerData = mock(KeyValueContainerData.class);
     HddsVolume mockVolume = mock(HddsVolume.class);
     Mockito.when(mockContainerData.getVolume()).thenReturn(mockVolume);
@@ -175,30 +157,24 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
 
   // -- Helper methods below.
 
-  private KeyValueHandler getDummyHandler() {
-    DatanodeDetails dnDetails = DatanodeDetails.newBuilder()
-        .setUuid(UUID.fromString(DATANODE_UUID))
-        .setHostName("dummyHost")
-        .setIpAddress("1.2.3.4")
-        .build();
-    DatanodeStateMachine stateMachine = mock(DatanodeStateMachine.class);
-    when(stateMachine.getDatanodeDetails()).thenReturn(dnDetails);
-
-    return new KeyValueHandler(
-        new OzoneConfiguration(),
-        stateMachine.getDatanodeDetails().getUuidString(),
-        mock(ContainerSet.class),
-        mock(MutableVolumeSet.class),
-        mock(ContainerMetrics.class), mockIcrSender);
+  private static KeyValueHandler getDummyHandler() {
+    return getDummyHandler(mock(IncrementalReportSender.class));
   }
 
-  private KeyValueContainer getMockUnhealthyContainer() {
+  private static KeyValueHandler getDummyHandler(IncrementalReportSender<Container> sender) {
+    return new KeyValueHandler(new OzoneConfiguration(),
+        DATANODE_UUID,
+        mock(ContainerSet.class),
+        mock(MutableVolumeSet.class),
+        mock(ContainerMetrics.class), sender);
+  }
+
+  private static KeyValueContainer getMockUnhealthyContainer() {
     KeyValueContainerData containerData = mock(KeyValueContainerData.class);
-    when(containerData.getState()).thenReturn(
-        ContainerProtos.ContainerDataProto.State.UNHEALTHY);
+    when(containerData.getState()).thenReturn(ContainerDataProto.State.UNHEALTHY);
     when(containerData.getBlockCommitSequenceId()).thenReturn(100L);
-    when(containerData.getProtoBufMessage()).thenReturn(ContainerProtos
-        .ContainerDataProto.newBuilder().setContainerID(1).build());
+    final ContainerDataProto data = ContainerDataProto.newBuilder().setContainerID(1).build();
+    when(containerData.getProtoBufMessage()).thenReturn(data);
     return new KeyValueContainer(containerData, new OzoneConfiguration());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -71,7 +71,7 @@ public class TestChunkUtils {
   private static final int MAPPED_BUFFER_THRESHOLD = 32 << 10;
   private static final Random RANDOM = new Random();
 
-  static ChunkBuffer readData(File file, long off, long len)
+  static ChunkBuffer readData(File file, long off, int len)
       throws StorageContainerException {
     LOG.info("off={}, len={}", off, len);
     return ChunkUtils.readData(len, BUFFER_CAPACITY, file, off, null,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
@@ -22,6 +22,9 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -38,6 +41,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfigurati
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask;
+import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.DbVolume;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -725,12 +729,11 @@ public class TestDatanodeUpgradeToSchemaV3 {
     dispatchRequest(request, ContainerProtos.Result.SUCCESS);
   }
 
-  public void dispatchRequest(
-      ContainerProtos.ContainerCommandRequestProto request,
-      ContainerProtos.Result expectedResult) {
-    ContainerProtos.ContainerCommandResponseProto response =
-        dsm.getContainer().getDispatcher().dispatch(request, null);
+  public void dispatchRequest(ContainerCommandRequestProto request, Result expectedResult) {
+    final DispatcherContext context = DispatcherContext.getDispatcherContext(request.getCmdType());
+    ContainerCommandResponseProto response = dsm.getContainer().getDispatcher().dispatch(request, context);
     Assertions.assertEquals(expectedResult, response.getResult());
+    context.close();
   }
 
   /// VOLUME OPERATIONS ///

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.*;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
@@ -37,6 +38,7 @@ import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask;
+import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.replication.ContainerImporter;
@@ -680,12 +682,11 @@ public class TestDatanodeUpgradeToScmHA {
     dispatchRequest(request, ContainerProtos.Result.SUCCESS);
   }
 
-  public void dispatchRequest(
-      ContainerProtos.ContainerCommandRequestProto request,
-      ContainerProtos.Result expectedResult) {
-    ContainerProtos.ContainerCommandResponseProto response =
-        dsm.getContainer().getDispatcher().dispatch(request, null);
+  void dispatchRequest(ContainerCommandRequestProto request, Result expectedResult) {
+    final DispatcherContext context = DispatcherContext.getDispatcherContext(request.getCmdType());
+    final ContainerCommandResponseProto response = dsm.getContainer().getDispatcher().dispatch(request, context);
     Assertions.assertEquals(expectedResult, response.getResult());
+    context.close();
   }
 
   /// VOLUME OPERATIONS ///


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ReadChunk` and `GetSmallFile` currently do not really require a `DispatcherContext`. So [HDDS-9697](https://issues.apache.org/jira/browse/HDDS-9697) set a constant context for them.

In this pull request, we change it to creating a new `DispatcherContext` for `ReadChunk` and `GetSmallFile`. It is required by [HDDS-9536](https://issues.apache.org/jira/browse/HDDS-9536) for storing the read buffers in order to release the buffers after the operation has completed.

## What is the link to the Apache JIRA

HDDS-9936

## How was this patch tested?

Updating some tests.