### PR TITLE
HDDS-9938. Migrate TimedOutTestsListener to JUnit5

### DIFF
--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -52,7 +52,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.reload4j</groupId>

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/TimedOutTestsListener.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/TimedOutTestsListener.java
@@ -17,8 +17,6 @@
  */
 package org.apache.ozone.test;
 
-import java.io.BufferedWriter;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.LockInfo;
@@ -31,43 +29,35 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
-import org.junit.runner.notification.Failure;
-import org.junit.runner.notification.RunListener;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import javax.annotation.Nullable;
 
 /**
- * JUnit run listener which prints full thread dump into System.err
- * in case a test is failed due to timeout.
+ * JUnit test execution listener which prints full thread dump to System.err
+ * in case a test fails due to timeout.
  */
-public class TimedOutTestsListener extends RunListener {
-
-  private static final String TEST_TIMED_OUT_PREFIX = "test timed out after";
+public class TimedOutTestsListener implements TestExecutionListener {
 
   private static final String INDENT = "    ";
 
-  private final PrintWriter output;
-  
-  public TimedOutTestsListener() {
-    this(new PrintWriter(new BufferedWriter(new OutputStreamWriter(
-        System.err, UTF_8))));
-  }
-  
-  public TimedOutTestsListener(PrintWriter output) {
-    this.output = output;
-  }
-
   @Override
-  public void testFailure(Failure failure) throws Exception {
-    if (failure != null && failure.getMessage() != null
-        && failure.getMessage().startsWith(TEST_TIMED_OUT_PREFIX)) {
-      output.println("====> TEST TIMED OUT. PRINTING THREAD DUMP. <====");
-      output.println();
-      output.print(buildThreadDiagnosticString());
+  public void executionFinished(TestIdentifier identifier, TestExecutionResult result) {
+    if (result.getStatus() == TestExecutionResult.Status.FAILED) {
+      result.getThrowable().ifPresent(t -> {
+        if (t instanceof TimeoutException) {
+          System.err.println("====> " + identifier.getDisplayName() + " TIMED OUT. PRINTING THREAD DUMP. <====");
+          System.err.println();
+          System.err.print(buildThreadDiagnosticString());
+        }
+      });
     }
   }
-  
+
   public static String buildThreadDiagnosticString() {
     StringWriter sw = new StringWriter();
     PrintWriter output = new PrintWriter(sw);
@@ -88,7 +78,7 @@ public class TimedOutTestsListener extends RunListener {
     return sw.toString();
   }
 
-  static String buildThreadDump() {
+  private static String buildThreadDump() {
     StringBuilder dump = new StringBuilder();
     Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
     for (Map.Entry<Thread, StackTraceElement[]> e : stackTraces.entrySet()) {
@@ -112,8 +102,9 @@ public class TimedOutTestsListener extends RunListener {
     }
     return dump.toString();
   }
-  
-  static String buildDeadlockInfo() {
+
+  @Nullable
+  private static String buildDeadlockInfo() {
     ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
     long[] threadIds = threadBean.findMonitorDeadlockedThreads();
     if (threadIds != null && threadIds.length > 0) {

--- a/hadoop-hdds/test-utils/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/hadoop-hdds/test-utils/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.ozone.test.TimedOutTestsListener

--- a/pom.xml
+++ b/pom.xml
@@ -1975,10 +1975,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <require.test.libhadoop>${require.test.libhadoop}</require.test.libhadoop>
           </systemPropertyVariables>
           <properties>
-            <property>
-              <name>listener</name>
-              <value>org.apache.ozone.test.TimedOutTestsListener</value>
-            </property>
+            <configurationParameters>
+              junit.platform.output.capture.stdout = true
+              junit.platform.output.capture.stderr = true
+            </configurationParameters>
           </properties>
           <includes>
             <include>**/Test*.java</include>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let `TimedOutTestsListener` implement JUnit5's `TestExecutionListener` to print thread dump in case tests time out.

https://issues.apache.org/jira/browse/HDDS-9938

## How was this patch tested?

Added a test in `hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileGenerator.java` which always times out:

```java
  @Test
  @Timeout(1)
  void timeoutTest() throws Exception {
    Thread.sleep(2000);
  }
```

ran the test:

```
mvn -am -pl :hdds-config -Dtest=TestConfigFileGenerator clean test
```

and verified the output file created for the test:

```
====> timeoutTest() TIMED OUT. PRINTING THREAD DUMP. <====

Timestamp: 2023-12-16 04:04:27,669

...

"main"  prio=5 tid=1 runnable
java.lang.Thread.State: RUNNABLE
  at java.lang.Thread.dumpThreads(Native Method)
  at java.lang.Thread.getAllStackTraces(Thread.java:1615)
  at org.apache.ozone.test.TimedOutTestsListener.buildThreadDump(TimedOutTestsListener.java:83)
  at org.apache.ozone.test.TimedOutTestsListener.buildThreadDiagnosticString(TimedOutTestsListener.java:69)
  at org.apache.ozone.test.TimedOutTestsListener.lambda$executionFinished$0(TimedOutTestsListener.java:55)
  at org.apache.ozone.test.TimedOutTestsListener$$Lambda$452/996796369.accept(Unknown Source)
  at java.util.Optional.ifPresent(Optional.java:159)
  at org.apache.ozone.test.TimedOutTestsListener.executionFinished(TimedOutTestsListener.java:51)
  ...
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7232674785