### PR TITLE
HDDS-9943. TokenRenewer should close OzoneClient after use

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -37,7 +36,6 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.SafeModeAction;
-import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -69,7 +67,6 @@ import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.security.token.TokenRenewer;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -468,56 +465,6 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @VisibleForTesting
   void setClock(Clock monotonicClock) {
     this.clock = monotonicClock;
-  }
-
-  /**
-   * Ozone Delegation Token Renewer.
-   */
-  @InterfaceAudience.Private
-  public static class Renewer extends TokenRenewer {
-
-    //Ensure that OzoneConfiguration files are loaded before trying to use
-    // the renewer.
-    static {
-      OzoneConfiguration.activate();
-    }
-
-    public Text getKind() {
-      return OzoneTokenIdentifier.KIND_NAME;
-    }
-
-    @Override
-    public boolean handleKind(Text kind) {
-      return getKind().equals(kind);
-    }
-
-    @Override
-    public boolean isManaged(Token<?> token) throws IOException {
-      return true;
-    }
-
-    @Override
-    public long renew(Token<?> token, Configuration conf)
-        throws IOException, InterruptedException {
-      Token<OzoneTokenIdentifier> ozoneDt =
-          (Token<OzoneTokenIdentifier>) token;
-
-      OzoneClient ozoneClient =
-          OzoneClientFactory.getOzoneClient(OzoneConfiguration.of(conf),
-              ozoneDt);
-      return ozoneClient.getObjectStore().renewDelegationToken(ozoneDt);
-    }
-
-    @Override
-    public void cancel(Token<?> token, Configuration conf)
-        throws IOException, InterruptedException {
-      Token<OzoneTokenIdentifier> ozoneDt =
-          (Token<OzoneTokenIdentifier>) token;
-      OzoneClient ozoneClient =
-          OzoneClientFactory.getOzoneClient(OzoneConfiguration.of(conf),
-              ozoneDt);
-      ozoneClient.getObjectStore().cancelDelegationToken(ozoneDt);
-    }
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -43,7 +42,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -80,7 +78,6 @@ import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.security.token.TokenRenewer;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -956,55 +953,6 @@ public class BasicRootedOzoneClientAdapterImpl
   @Override
   public String getCanonicalServiceName() {
     return objectStore.getCanonicalServiceName();
-  }
-
-  /**
-   * Ozone Delegation Token Renewer.
-   */
-  @InterfaceAudience.Private
-  public static class Renewer extends TokenRenewer {
-
-    //Ensure that OzoneConfiguration files are loaded before trying to use
-    // the renewer.
-    static {
-      OzoneConfiguration.activate();
-    }
-
-    public Text getKind() {
-      return OzoneTokenIdentifier.KIND_NAME;
-    }
-
-    @Override
-    public boolean handleKind(Text kind) {
-      return getKind().equals(kind);
-    }
-
-    @Override
-    public boolean isManaged(Token<?> token) throws IOException {
-      return true;
-    }
-
-    @Override
-    public long renew(Token<?> token, Configuration conf)
-        throws IOException, InterruptedException {
-      Token<OzoneTokenIdentifier> ozoneDt =
-          (Token<OzoneTokenIdentifier>) token;
-      OzoneClient ozoneClient =
-          OzoneClientFactory.getOzoneClient(OzoneConfiguration.of(conf),
-              ozoneDt);
-      return ozoneClient.getObjectStore().renewDelegationToken(ozoneDt);
-    }
-
-    @Override
-    public void cancel(Token<?> token, Configuration conf)
-        throws IOException, InterruptedException {
-      Token<OzoneTokenIdentifier> ozoneDt =
-          (Token<OzoneTokenIdentifier>) token;
-      OzoneClient ozoneClient =
-          OzoneClientFactory.getOzoneClient(OzoneConfiguration.of(conf),
-              ozoneDt);
-      ozoneClient.getObjectStore().cancelDelegationToken(ozoneDt);
-    }
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDelegationTokenRenewer.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDelegationTokenRenewer.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenRenewer;
+
+import java.io.IOException;
+
+/**
+ * Ozone Delegation Token Renewer.
+ */
+@InterfaceAudience.Private
+public class OzoneDelegationTokenRenewer extends TokenRenewer {
+
+  //Ensure that OzoneConfiguration files are loaded before trying to use
+  // the renewer.
+  static {
+    OzoneConfiguration.activate();
+  }
+
+  public Text getKind() {
+    return OzoneTokenIdentifier.KIND_NAME;
+  }
+
+  @Override
+  public boolean handleKind(Text kind) {
+    return getKind().equals(kind);
+  }
+
+  @Override
+  public boolean isManaged(Token<?> token) throws IOException {
+    return true;
+  }
+
+  @Override
+  public long renew(Token<?> token, Configuration conf)
+      throws IOException, InterruptedException {
+    Token<OzoneTokenIdentifier> ozoneDt =
+        (Token<OzoneTokenIdentifier>) token;
+    OzoneClient ozoneClient =
+        OzoneClientFactory.getOzoneClient(OzoneConfiguration.of(conf),
+            ozoneDt);
+    return ozoneClient.getObjectStore().renewDelegationToken(ozoneDt);
+  }
+
+  @Override
+  public void cancel(Token<?> token, Configuration conf)
+      throws IOException, InterruptedException {
+    Token<OzoneTokenIdentifier> ozoneDt =
+        (Token<OzoneTokenIdentifier>) token;
+    OzoneClient ozoneClient =
+        OzoneClientFactory.getOzoneClient(OzoneConfiguration.of(conf),
+            ozoneDt);
+    ozoneClient.getObjectStore().cancelDelegationToken(ozoneDt);
+  }
+}

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDelegationTokenRenewer.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDelegationTokenRenewer.java
@@ -51,13 +51,12 @@ public class OzoneDelegationTokenRenewer extends TokenRenewer {
   }
 
   @Override
-  public boolean isManaged(Token<?> token) throws IOException {
+  public boolean isManaged(Token<?> token) {
     return true;
   }
 
   @Override
-  public long renew(Token<?> token, Configuration conf)
-      throws IOException, InterruptedException {
+  public long renew(Token<?> token, Configuration conf) throws IOException {
     Token<OzoneTokenIdentifier> ozoneDt =
         (Token<OzoneTokenIdentifier>) token;
     OzoneClient ozoneClient =

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDelegationTokenRenewer.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneDelegationTokenRenewer.java
@@ -22,12 +22,13 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenRenewer;
 
 import java.io.IOException;
+
+import static org.apache.hadoop.ozone.client.OzoneClientFactory.getOzoneClient;
 
 /**
  * Ozone Delegation Token Renewer.
@@ -59,10 +60,10 @@ public class OzoneDelegationTokenRenewer extends TokenRenewer {
   public long renew(Token<?> token, Configuration conf) throws IOException {
     Token<OzoneTokenIdentifier> ozoneDt =
         (Token<OzoneTokenIdentifier>) token;
-    OzoneClient ozoneClient =
-        OzoneClientFactory.getOzoneClient(OzoneConfiguration.of(conf),
-            ozoneDt);
-    return ozoneClient.getObjectStore().renewDelegationToken(ozoneDt);
+    OzoneConfiguration ozoneConf = OzoneConfiguration.of(conf);
+    try (OzoneClient ozoneClient = getOzoneClient(ozoneConf, ozoneDt)) {
+      return ozoneClient.getObjectStore().renewDelegationToken(ozoneDt);
+    }
   }
 
   @Override
@@ -70,9 +71,9 @@ public class OzoneDelegationTokenRenewer extends TokenRenewer {
       throws IOException, InterruptedException {
     Token<OzoneTokenIdentifier> ozoneDt =
         (Token<OzoneTokenIdentifier>) token;
-    OzoneClient ozoneClient =
-        OzoneClientFactory.getOzoneClient(OzoneConfiguration.of(conf),
-            ozoneDt);
-    ozoneClient.getObjectStore().cancelDelegationToken(ozoneDt);
+    OzoneConfiguration ozoneConf = OzoneConfiguration.of(conf);
+    try (OzoneClient ozoneClient = getOzoneClient(ozoneConf, ozoneDt)) {
+      ozoneClient.getObjectStore().cancelDelegationToken(ozoneDt);
+    }
   }
 }

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenRenewer
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenRenewer
@@ -16,5 +16,4 @@
 # limitations under the License.
 #
 
-org.apache.hadoop.fs.ozone.BasicOzoneClientAdapterImpl$Renewer
-org.apache.hadoop.fs.ozone.BasicRootedOzoneClientAdapterImpl$Renewer
+org.apache.hadoop.fs.ozone.OzoneDelegationTokenRenewer

--- a/hadoop-ozone/ozonefs/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenRenewer
+++ b/hadoop-ozone/ozonefs/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenRenewer
@@ -16,5 +16,4 @@
 # limitations under the License.
 #
 
-org.apache.hadoop.fs.ozone.BasicOzoneClientAdapterImpl$Renewer
-org.apache.hadoop.fs.ozone.BasicRootedOzoneClientAdapterImpl$Renewer
+org.apache.hadoop.fs.ozone.OzoneDelegationTokenRenewer


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone's `TokenRenewer` implementations do not close `OzoneClient` after use.

Both O3FS and OFS define their own `TokenRenewer` implementation.

Hadoop finds implementations via `ServiceLoader`, and uses the first one that handles the kind of token being used:

https://github.com/apache/hadoop/blob/7db9895000860605a66dd6403005b0c61a6ed744/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/token/Token.java#L454-L470

The two implementations are the same (not FileSystem-specific), kind is the same for both, so we can remove the duplicate one.

https://issues.apache.org/jira/browse/HDDS-9943

## How was this patch tested?

Ran `ozonesecure-mr/test.sh`, checked OM audit log for delegation token operations:

```
...  | OMAudit | user=hadoop/rm@EXAMPLE.COM | ip=172.31.0.11 | op=GET_DELEGATION_TOKEN {kind=OzoneToken, service=172.31.0.9:9862, renewer=rm} | ret=SUCCESS |  
...  | OMAudit | user=rm/rm@EXAMPLE.COM | ip=172.31.0.11 | op=RENEW_DELEGATION_TOKEN {kind=OzoneToken, service=172.31.0.9:9862, renewer=rm} | ret=SUCCESS |  
...  | OMAudit | user=hadoop/rm@EXAMPLE.COM | ip=172.31.0.11 | op=GET_DELEGATION_TOKEN {kind=OzoneToken, service=172.31.0.9:9862, renewer=rm} | ret=SUCCESS |  
...  | OMAudit | user=rm/rm@EXAMPLE.COM | ip=172.31.0.11 | op=RENEW_DELEGATION_TOKEN {kind=OzoneToken, service=172.31.0.9:9862, renewer=rm} | ret=SUCCESS |  
...  | OMAudit | user=rm/rm@EXAMPLE.COM | ip=172.31.0.11 | op=CANCEL_DELEGATION_TOKEN {kind=OzoneToken, service=172.31.0.9:9862} | ret=SUCCESS |  
...  | OMAudit | user=rm/rm@EXAMPLE.COM | ip=172.31.0.11 | op=CANCEL_DELEGATION_TOKEN {kind=OzoneToken, service=172.31.0.9:9862} | ret=SUCCESS |  
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7237484751