### PR TITLE
HDDS-9947. Change log level of NotLeaderException to info

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,6 +117,9 @@ public class IncrementalContainerReportHandler extends
             LOG.error("Exception while processing ICR for container {}",
                 replicaProto.getContainerID(), ex);
           }
+        } catch (NotLeaderException ex) {
+          LOG.info("Exception while processing ICR for container {}",
+              replicaProto.getContainerID(), ex);
         } catch (IOException | InvalidStateTransitionException |
                  TimeoutException e) {
           LOG.error("Exception while processing ICR for container {}",


### PR DESCRIPTION
## What changes were proposed in this pull request?

The logs for NotLeaderException should be Informational and not error. So this has been changed in IncrementalContainerReportHandler 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9947

## How was this patch tested?

Tested manually using docker
