### PR TITLE
HDDS-9423. Throw appropriate error messages when deleting a file in .snapshot path

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -103,6 +103,13 @@ public final class OmUtils {
   public static final int EPOCH_WHEN_RATIS_NOT_ENABLED = 1;
   public static final int EPOCH_WHEN_RATIS_ENABLED = 2;
 
+  public static final String SNAPSHOT_CREATE_KEY_EXCEPTION_MESSAGE =
+      "Cannot create key under path reserved for snapshot: " +
+          OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX;
+  public static final String SNAPSHOT_DELETE_KEY_EXCEPTION_MESSAGE =
+      "Cannot delete key under path reserved for snapshot: " +
+          OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX;
+
   private OmUtils() {
   }
 
@@ -623,24 +630,25 @@ public final class OmUtils {
    */
   public static void verifyKeyNameWithSnapshotReservedWord(String keyName)
       throws OMException {
+    if (keyNameWithSnapshotReservedWord(keyName)) {
+      throw new OMException(SNAPSHOT_CREATE_KEY_EXCEPTION_MESSAGE,
+          OMException.ResultCodes.INVALID_KEY_NAME);
+    }
+  }
+
+  public static boolean keyNameWithSnapshotReservedWord(String keyName) {
     if (keyName != null &&
         keyName.startsWith(OM_SNAPSHOT_INDICATOR)) {
       if (keyName.length() > OM_SNAPSHOT_INDICATOR.length()) {
-        if (keyName.substring(OM_SNAPSHOT_INDICATOR.length())
-            .startsWith(OM_KEY_PREFIX)) {
-          throw new OMException(
-              "Cannot create key under path reserved for "
-                  + "snapshot: " + OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX,
-              OMException.ResultCodes.INVALID_KEY_NAME);
-        }
+        return (keyName.substring(OM_SNAPSHOT_INDICATOR.length())
+            .startsWith(OM_KEY_PREFIX));
       } else {
-        // We checked for startsWith OM_SNAPSHOT_INDICATOR and the length is
+        // We checked for startsWith OM_SNAPSHOT_INDICATOR, and the length is
         // the same, so it must be equal OM_SNAPSHOT_INDICATOR.
-        throw new OMException(
-            "Cannot create key with reserved name: " + OM_SNAPSHOT_INDICATOR,
-            OMException.ResultCodes.INVALID_KEY_NAME);
+        return true;
       }
     }
+    return false;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -103,13 +103,6 @@ public final class OmUtils {
   public static final int EPOCH_WHEN_RATIS_NOT_ENABLED = 1;
   public static final int EPOCH_WHEN_RATIS_ENABLED = 2;
 
-  public static final String SNAPSHOT_CREATE_KEY_EXCEPTION_MESSAGE =
-      "Cannot create key under path reserved for snapshot: " +
-          OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX;
-  public static final String SNAPSHOT_DELETE_KEY_EXCEPTION_MESSAGE =
-      "Cannot delete key under path reserved for snapshot: " +
-          OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX;
-
   private OmUtils() {
   }
 
@@ -630,25 +623,45 @@ public final class OmUtils {
    */
   public static void verifyKeyNameWithSnapshotReservedWord(String keyName)
       throws OMException {
-    if (keyNameWithSnapshotReservedWord(keyName)) {
-      throw new OMException(SNAPSHOT_CREATE_KEY_EXCEPTION_MESSAGE,
-          OMException.ResultCodes.INVALID_KEY_NAME);
-    }
-  }
-
-  public static boolean keyNameWithSnapshotReservedWord(String keyName) {
     if (keyName != null &&
         keyName.startsWith(OM_SNAPSHOT_INDICATOR)) {
       if (keyName.length() > OM_SNAPSHOT_INDICATOR.length()) {
-        return (keyName.substring(OM_SNAPSHOT_INDICATOR.length())
-            .startsWith(OM_KEY_PREFIX));
+        if (keyName.substring(OM_SNAPSHOT_INDICATOR.length())
+            .startsWith(OM_KEY_PREFIX)) {
+          throw new OMException(
+              "Cannot create key under path reserved for snapshot: " + OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX,
+              OMException.ResultCodes.INVALID_KEY_NAME);
+        }
       } else {
         // We checked for startsWith OM_SNAPSHOT_INDICATOR, and the length is
         // the same, so it must be equal OM_SNAPSHOT_INDICATOR.
-        return true;
+        throw new OMException("Cannot create key with reserved name: " + OM_SNAPSHOT_INDICATOR,
+            OMException.ResultCodes.INVALID_KEY_NAME);
       }
     }
-    return false;
+  }
+
+  /**
+   * Verify if key name contains snapshot reserved word.
+   * This is similar to verifyKeyNameWithSnapshotReservedWord. The only difference is exception message.
+   */
+  public static void verifyKeyNameWithSnapshotReservedWordForDeletion(String keyName)  throws OMException {
+    if (keyName != null &&
+        keyName.startsWith(OM_SNAPSHOT_INDICATOR)) {
+      if (keyName.length() > OM_SNAPSHOT_INDICATOR.length()) {
+        if (keyName.substring(OM_SNAPSHOT_INDICATOR.length())
+            .startsWith(OM_KEY_PREFIX)) {
+          throw new OMException(
+              "Cannot delete key under path reserved for snapshot: " + OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX,
+              OMException.ResultCodes.INVALID_KEY_NAME);
+        }
+      } else {
+        // We checked for startsWith OM_SNAPSHOT_INDICATOR, and the length is
+        // the same, so it must be equal OM_SNAPSHOT_INDICATOR.
+        throw new OMException("Cannot delete key with reserved name: " + OM_SNAPSHOT_INDICATOR,
+            OMException.ResultCodes.INVALID_KEY_NAME);
+      }
+    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -77,10 +77,9 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     Preconditions.checkNotNull(deleteKeyRequest);
 
     OzoneManagerProtocolProtos.KeyArgs keyArgs = deleteKeyRequest.getKeyArgs();
-
-    OmUtils.verifyKeyNameWithSnapshotReservedWordForDeletion(deleteKeyRequest.getKeyArgs().getKeyName());
-
     String keyPath = keyArgs.getKeyName();
+
+    OmUtils.verifyKeyNameWithSnapshotReservedWordForDeletion(keyPath);
     keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
         keyPath, getBucketLayout());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -78,11 +78,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
     OzoneManagerProtocolProtos.KeyArgs keyArgs = deleteKeyRequest.getKeyArgs();
 
-    if (OmUtils.keyNameWithSnapshotReservedWord(
-        deleteKeyRequest.getKeyArgs().getKeyName())) {
-      throw new OMException(OmUtils.SNAPSHOT_DELETE_KEY_EXCEPTION_MESSAGE,
-          OMException.ResultCodes.INVALID_KEY_NAME);
-    }
+    OmUtils.verifyKeyNameWithSnapshotReservedWordForDeletion(deleteKeyRequest.getKeyArgs().getKeyName());
 
     String keyPath = keyArgs.getKeyName();
     keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.Map;
 
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -76,6 +77,12 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     Preconditions.checkNotNull(deleteKeyRequest);
 
     OzoneManagerProtocolProtos.KeyArgs keyArgs = deleteKeyRequest.getKeyArgs();
+
+    if (OmUtils.keyNameWithSnapshotReservedWord(
+        deleteKeyRequest.getKeyArgs().getKeyName())) {
+      throw new OMException(OmUtils.SNAPSHOT_DELETE_KEY_EXCEPTION_MESSAGE,
+          OMException.ResultCodes.INVALID_KEY_NAME);
+    }
 
     String keyPath = keyArgs.getKeyName();
     keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.Map;
-import java.util.HashMap;
 
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -41,15 +39,12 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CreateFileRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .KeyArgs;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateFileRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
-import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.FILE_ALREADY_EXISTS;
@@ -481,40 +476,25 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     }
   }
 
-  @Test
-  public void testPreExecuteWithInvalidKeyPrefix() throws Exception {
-    Map<String, String> invalidKeyScenarios = new HashMap<String, String>() {
-      {
-        put(OM_SNAPSHOT_INDICATOR + "/" + keyName,
-            "Cannot create key under path reserved for snapshot: "
-                + OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX);
-        put(OM_SNAPSHOT_INDICATOR + "/a/" + keyName,
-            "Cannot create key under path reserved for snapshot: "
-                + OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX);
-        put(OM_SNAPSHOT_INDICATOR + "/a/b" + keyName,
-            "Cannot create key under path reserved for snapshot: "
-                + OM_SNAPSHOT_INDICATOR + OM_KEY_PREFIX);
-        put(OM_SNAPSHOT_INDICATOR,
-            "Cannot create key with reserved name: " + OM_SNAPSHOT_INDICATOR);
-      }
-    };
+  @ParameterizedTest
+  @CsvSource(value = {
+      ".snapshot/keyName,Cannot create key under path reserved for snapshot: .snapshot/",
+      ".snapshot/a/keyName,Cannot create key under path reserved for snapshot: .snapshot/",
+      ".snapshot/a/b/keyName,Cannot create key under path reserved for snapshot: .snapshot/",
+      ".snapshot,Cannot create key with reserved name: .snapshot"})
+  public void testPreExecuteWithInvalidKeyPrefix(String invalidKeyName,
+                                                 String expectedErrorMessage) {
 
-    for (Map.Entry<String, String> entry : invalidKeyScenarios.entrySet()) {
-      String invalidKeyName = entry.getKey();
-      String expectedErrorMessage = entry.getValue();
+    OMRequest omRequest = createFileRequest(volumeName, bucketName,
+        invalidKeyName, HddsProtos.ReplicationFactor.ONE,
+        HddsProtos.ReplicationType.RATIS, false, false);
 
-      OMRequest omRequest = createFileRequest(volumeName, bucketName,
-          invalidKeyName, HddsProtos.ReplicationFactor.ONE,
-          HddsProtos.ReplicationType.RATIS, false, false);
+    OMFileCreateRequest omFileCreateRequest =
+        getOMFileCreateRequest(omRequest);
 
-      OMFileCreateRequest omFileCreateRequest =
-          getOMFileCreateRequest(omRequest);
-
-      OMException ex = Assertions.assertThrows(OMException.class,
-          () -> omFileCreateRequest.preExecute(ozoneManager));
-
-      Assertions.assertTrue(ex.getMessage().contains(expectedErrorMessage));
-    }
+    OMException ex = Assertions.assertThrows(OMException.class,
+        () -> omFileCreateRequest.preExecute(ozoneManager));
+    Assertions.assertTrue(ex.getMessage().contains(expectedErrorMessage));
   }
 
   protected void testNonRecursivePath(String key,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
@@ -57,7 +57,6 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
         getOmKeyDeleteRequest(createDeleteKeyRequest(testKeyName));
     OMException omException = Assertions.assertThrows(OMException.class,
         () -> deleteKeyRequest.preExecute(ozoneManager));
-    System.out.println(omException.getMessage());
     Assertions.assertEquals(expectedExceptionMessage, omException.getMessage());
     Assertions.assertEquals(OMException.ResultCodes.INVALID_KEY_NAME, omException.getResult());
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
+import org.apache.hadoop.fs.PathPermissionException;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -548,13 +549,15 @@ public class BasicRootedOzoneClientAdapterImpl
       bucket.deleteDirectory(keyName, recursive);
       return true;
     } catch (OMException ome) {
-      LOG.error("delete key failed {}", ome.getMessage());
+      LOG.error("Delete key failed. {}", ome.getMessage());
       if (OMException.ResultCodes.DIRECTORY_NOT_EMPTY == ome.getResult()) {
         throw new PathIsNotEmptyDirectoryException(ome.getMessage());
+      } else if (OMException.ResultCodes.INVALID_KEY_NAME == ome.getResult()) {
+        throw new PathPermissionException(ome.getMessage());
       }
       return false;
     } catch (IOException ioe) {
-      LOG.error("delete key failed " + ioe.getMessage());
+      LOG.error("Delete key failed. {}", ioe.getMessage());
       return false;
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -60,9 +61,10 @@ public class DeleteKeyHandler extends KeyHandler {
     OzoneBucket bucket = vol.getBucket(bucketName);
     String keyName = address.getKeyName();
 
-    if (OmUtils.keyNameWithSnapshotReservedWord(keyName)) {
-      out().printf("Operation not permitted: %s %n",
-          OmUtils.SNAPSHOT_DELETE_KEY_EXCEPTION_MESSAGE);
+    try {
+      OmUtils.verifyKeyNameWithSnapshotReservedWordForDeletion(keyName);
+    } catch (OMException omException) {
+      out().printf("Operation not permitted: %s %n", omException.getMessage());
       return;
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.shell.keys;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
@@ -58,6 +59,12 @@ public class DeleteKeyHandler extends KeyHandler {
     OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = vol.getBucket(bucketName);
     String keyName = address.getKeyName();
+
+    if (OmUtils.keyNameWithSnapshotReservedWord(keyName)) {
+      out().printf("Operation not permitted: %s %n",
+          OmUtils.SNAPSHOT_DELETE_KEY_EXCEPTION_MESSAGE);
+      return;
+    }
 
     if (bucket.getBucketLayout().isFileSystemOptimized()) {
       // Handle FSO delete key which supports trash also


### PR DESCRIPTION
## What changes were proposed in this pull request?
Snapshots are readable only and don't support deletion of key from snapshots. Currently exception is thrown but exception message is not clear. It says `Key not found .snapshot/snap1` for ozone shell and `Unable to get file status: volume: vol1 bucket: buck1 key: .snapshot/snap1` for ozone fs command.
This change is to correct exception message and properly return it to client.

## What is the link to the Apache JIRA
HDDS-9423

## How was this patch tested?
1. Added/updated unit tests.
1. Tested in docker:
```
sh-4.2$ ozone sh key delete vol1/bucket1/.snapshot/snap1
Operation not permitted Cannot delete key under path reserved for snapshot: .snapshot/ 
sh-4.2$ ozone sh key delete vol1/bucket1/.snapshot/snap1/key1
Operation not permitted Cannot delete key under path reserved for snapshot: .snapshot/ 
sh-4.2$ ozone sh key delete vol1/bucket1/.snapshot/snap1/key1
Operation not permitted Cannot delete key under path reserved for snapshot: .snapshot/ 
sh-4.2$ ozone fs -rm -r -f -skipTrash ofs://om/vol1/bucket1/.snapshot/snap1
rm: `Cannot delete key under path reserved for snapshot: .snapshot/': Operation not permitted
sh-4.2$ ozone fs -rm -r -f -skipTrash ofs://om/vol1/bucket1/.snapshot/snap1/key1
rm: `Cannot delete key under path reserved for snapshot: .snapshot/': Operation not permitted
```
