### PR TITLE
HDDS-9809. Migrate assertions in integration tests to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -68,7 +68,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -84,7 +83,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -187,8 +187,7 @@ public class TestHSync {
           RepeatedOmKeyInfo val = kv.getValue();
           LOG.error("Unexpected deletedTable entry: key = {}, val = {}",
               key, val);
-          Assertions.fail("deletedTable should not have such entry. key = " +
-              key);
+          fail("deletedTable should not have such entry. key = " + key);
         }
       }
     }
@@ -332,7 +331,7 @@ public class TestHSync {
     int offset = 0;
     try (FSDataInputStream in = fs.open(file)) {
       final long skipped = in.skip(length);
-      Assertions.assertEquals(length, skipped);
+      assertEquals(length, skipped);
 
       for (; ;) {
         final int n = in.read(buffer, 0, buffer.length);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
@@ -20,12 +20,13 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for StorageContainerDatanodeProtocolProtos.
@@ -44,9 +45,9 @@ public class TestSCMDatanodeProtocolServer {
     StorageContainerDatanodeProtocolProtos.SCMCommandProto proto =
         SCMDatanodeProtocolServer.getCommandResponse(command, scm);
 
-    Assert.assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
+    assertEquals(StorageContainerDatanodeProtocolProtos.SCMCommandProto
         .Type.replicateContainerCommand, proto.getCommandType());
-    Assert.assertEquals(5L, proto.getTerm());
-    Assert.assertEquals(1234L, proto.getDeadlineMsSinceEpoch());
+    assertEquals(5L, proto.getTerm());
+    assertEquals(1234L, proto.getDeadlineMsSinceEpoch());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ozone.test.tag.Flaky;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,6 +51,11 @@ import java.util.Map;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Class to test install snapshot feature for SCM HA.
@@ -115,9 +119,9 @@ public class TestSCMInstallSnapshot {
     String snapshotDir =
         conf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_SNAPSHOT_DIR);
     final File[] files = FileUtil.listFiles(provider.getScmSnapshotDir());
-    Assert.assertTrue(files[0].getName().startsWith(
+    assertTrue(files[0].getName().startsWith(
         OzoneConsts.SCM_DB_NAME + "-" + scmNodeDetails.getNodeId()));
-    Assert.assertTrue(files[0].getAbsolutePath().startsWith(snapshotDir));
+    assertTrue(files[0].getAbsolutePath().startsWith(snapshotDir));
     return checkpoint;
   }
 
@@ -133,7 +137,7 @@ public class TestSCMInstallSnapshot {
     // Hack the transaction index in the checkpoint so as to ensure the
     // checkpointed transaction index is higher than when it was downloaded
     // from.
-    Assert.assertNotNull(db);
+    assertNotNull(db);
     HAUtils.getTransactionInfoTable(db, new SCMDBDefinition())
         .put(OzoneConsts.TRANSACTION_INFO_KEY, TransactionInfo.builder()
             .setCurrentTerm(10).setTransactionIndex(100).build());
@@ -144,9 +148,9 @@ public class TestSCMInstallSnapshot {
         scm.getPipelineManager().getPipelines().get(0).getId();
     scm.getScmMetadataStore().getPipelineTable().delete(pipelineID);
     scm.getContainerManager().deleteContainer(cid);
-    Assert.assertNull(
+    assertNull(
         scm.getScmMetadataStore().getPipelineTable().get(pipelineID));
-    Assert.assertFalse(scm.getContainerManager().containerExist(cid));
+    assertFalse(scm.getContainerManager().containerExist(cid));
 
     SCMStateMachine sm =
         scm.getScmHAManager().getRatisServer().getSCMStateMachine();
@@ -154,16 +158,14 @@ public class TestSCMInstallSnapshot {
     sm.setInstallingSnapshotData(checkpoint, null);
     sm.reinitialize();
 
-    Assert.assertNotNull(
-        scm.getScmMetadataStore().getPipelineTable().get(pipelineID));
-    Assert.assertNotNull(
-        scm.getScmMetadataStore().getContainerTable().get(cid));
-    Assert.assertTrue(scm.getPipelineManager().containsPipeline(pipelineID));
-    Assert.assertTrue(scm.getContainerManager().containerExist(cid));
-    Assert.assertEquals(100, scm.getScmMetadataStore().
+    assertNotNull(scm.getScmMetadataStore().getPipelineTable().get(pipelineID));
+    assertNotNull(scm.getScmMetadataStore().getContainerTable().get(cid));
+    assertTrue(scm.getPipelineManager().containsPipeline(pipelineID));
+    assertTrue(scm.getContainerManager().containerExist(cid));
+    assertEquals(100, scm.getScmMetadataStore().
         getTransactionInfoTable().get(OzoneConsts.TRANSACTION_INFO_KEY)
         .getTransactionIndex());
-    Assert.assertEquals(100,
+    assertEquals(100,
         scm.getScmHAManager().asSCMHADBTransactionBuffer().getLatestTrxInfo()
             .getTermIndex().getIndex());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionExcepti
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.Test;
@@ -51,6 +50,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for ContainerStateManager.
@@ -100,21 +105,21 @@ public class TestContainerStateManagerIntegration {
     ContainerInfo info = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
             container1.getPipeline());
-    Assert.assertNotEquals(container1.getContainerInfo().getContainerID(),
+    assertNotEquals(container1.getContainerInfo().getContainerID(),
         info.getContainerID());
-    Assert.assertEquals(OzoneConsts.OZONE, info.getOwner());
-    Assert.assertEquals(SCMTestUtils.getReplicationType(conf),
+    assertEquals(OzoneConsts.OZONE, info.getOwner());
+    assertEquals(SCMTestUtils.getReplicationType(conf),
         info.getReplicationType());
-    Assert.assertEquals(SCMTestUtils.getReplicationFactor(conf),
+    assertEquals(SCMTestUtils.getReplicationFactor(conf),
         ReplicationConfig.getLegacyFactor(info.getReplicationConfig()));
-    Assert.assertEquals(HddsProtos.LifeCycleState.OPEN, info.getState());
+    assertEquals(HddsProtos.LifeCycleState.OPEN, info.getState());
 
     // Check there are two containers in ALLOCATED state after allocation
     ContainerWithPipeline container2 = scm.getClientProtocolServer()
         .allocateContainer(
             SCMTestUtils.getReplicationType(conf),
             SCMTestUtils.getReplicationFactor(conf), OzoneConsts.OZONE);
-    Assert.assertNotEquals(container1.getContainerInfo().getContainerID(),
+    assertNotEquals(container1.getContainerInfo().getContainerID(),
         container2.getContainerInfo().getContainerID());
   }
 
@@ -128,7 +133,7 @@ public class TestContainerStateManagerIntegration {
     ContainerInfo info = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
             container1.getPipeline());
-    Assert.assertNotNull(info);
+    assertNotNull(info);
 
     String newContainerOwner = "OZONE_NEW";
     ContainerWithPipeline container2 = scm.getClientProtocolServer()
@@ -137,9 +142,9 @@ public class TestContainerStateManagerIntegration {
     ContainerInfo info2 = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, newContainerOwner,
             container1.getPipeline());
-    Assert.assertNotNull(info2);
+    assertNotNull(info2);
 
-    Assert.assertNotEquals(info.containerID(), info2.containerID());
+    assertNotEquals(info.containerID(), info2.containerID());
   }
 
   @Test
@@ -179,7 +184,7 @@ public class TestContainerStateManagerIntegration {
         .filter(info ->
             info.getState() == HddsProtos.LifeCycleState.OPEN)
         .count();
-    Assert.assertEquals(5, matchCount);
+    assertEquals(5, matchCount);
     matchCount = result.stream()
         .filter(info ->
             info.getOwner().equals(OzoneConsts.OZONE))
@@ -191,7 +196,7 @@ public class TestContainerStateManagerIntegration {
         .filter(info ->
             info.getState() == HddsProtos.LifeCycleState.CLOSING)
         .count();
-    Assert.assertEquals(5, matchCount);
+    assertEquals(5, matchCount);
   }
 
   @Test
@@ -209,7 +214,7 @@ public class TestContainerStateManagerIntegration {
       ContainerInfo info = containerManager
           .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
               container1.getPipeline());
-      Assert.assertTrue(info.getContainerID() > cid);
+      assertTrue(info.getContainerID() > cid);
       cid = info.getContainerID();
     }
 
@@ -218,7 +223,7 @@ public class TestContainerStateManagerIntegration {
     ContainerInfo info = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
             container1.getPipeline());
-    Assert.assertEquals(container1.getContainerInfo().getContainerID(),
+    assertEquals(container1.getContainerInfo().getContainerID(),
         info.getContainerID());
   }
 
@@ -248,7 +253,7 @@ public class TestContainerStateManagerIntegration {
 
     // make sure pipeline has has numContainerPerOwnerInPipeline number of
     // containers.
-    Assert.assertEquals(scm.getPipelineManager()
+    assertEquals(scm.getPipelineManager()
             .getNumberOfContainers(container1.getPipeline().getId()),
         numContainerPerOwnerInPipeline);
     Thread.sleep(5000);
@@ -259,7 +264,7 @@ public class TestContainerStateManagerIntegration {
       // TODO: #CLUTIL Look at the division of block allocations in different
       // containers.
       LOG.error("Total allocated block = " + matchedCount);
-      Assert.assertTrue(matchedCount <=
+      assertTrue(matchedCount <=
           numBlockAllocates / container2MatchedCount.size() + threshold
           && matchedCount >=
           numBlockAllocates / container2MatchedCount.size() - threshold);
@@ -272,7 +277,7 @@ public class TestContainerStateManagerIntegration {
     Set<ContainerID> containerList = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.OPEN);
     int containers = containerList == null ? 0 : containerList.size();
-    Assert.assertEquals(0, containers);
+    assertEquals(0, containers);
 
     // Allocate container1 and update its state from
     // OPEN -> CLOSING -> CLOSED -> DELETING -> DELETED
@@ -282,35 +287,35 @@ public class TestContainerStateManagerIntegration {
             SCMTestUtils.getReplicationFactor(conf), OzoneConsts.OZONE);
     containerList = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.OPEN);
-    Assert.assertEquals(1, containerList.size());
+    assertEquals(1, containerList.size());
 
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.FINALIZE);
     containerList = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.CLOSING);
-    Assert.assertEquals(1, containerList.size());
+    assertEquals(1, containerList.size());
 
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLOSE);
     containerList = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.CLOSED);
-    Assert.assertEquals(1, containerList.size());
+    assertEquals(1, containerList.size());
 
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.DELETE);
     containerList = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETING);
-    Assert.assertEquals(1, containerList.size());
+    assertEquals(1, containerList.size());
 
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLEANUP);
     containerList = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.DELETED);
-    Assert.assertEquals(1, containerList.size());
+    assertEquals(1, containerList.size());
 
     // Allocate container1 and update its state from
     // OPEN -> CLOSING -> CLOSED
@@ -329,7 +334,7 @@ public class TestContainerStateManagerIntegration {
             HddsProtos.LifeCycleEvent.CLOSE);
     containerList = containerStateManager
         .getContainerIDs(HddsProtos.LifeCycleState.CLOSED);
-    Assert.assertEquals(1, containerList.size());
+    assertEquals(1, containerList.size());
   }
 
 
@@ -346,7 +351,7 @@ public class TestContainerStateManagerIntegration {
     ContainerID containerID = ContainerID.valueOf(RandomUtils.nextLong());
     Set<ContainerReplica> replicaSet =
         containerStateManager.getContainerReplicas(containerID);
-    Assert.assertNull(replicaSet);
+    assertNull(replicaSet);
 
     ContainerWithPipeline container = scm.getClientProtocolServer()
         .allocateContainer(
@@ -369,44 +374,44 @@ public class TestContainerStateManagerIntegration {
     containerStateManager.updateContainerReplica(id, replicaOne);
     containerStateManager.updateContainerReplica(id, replicaTwo);
     replicaSet = containerStateManager.getContainerReplicas(id);
-    Assert.assertEquals(2, replicaSet.size());
-    Assert.assertTrue(replicaSet.contains(replicaOne));
-    Assert.assertTrue(replicaSet.contains(replicaTwo));
+    assertEquals(2, replicaSet.size());
+    assertTrue(replicaSet.contains(replicaOne));
+    assertTrue(replicaSet.contains(replicaTwo));
 
     // Test 3: Remove one replica node and then test
     containerStateManager.removeContainerReplica(id, replicaOne);
     replicaSet = containerStateManager.getContainerReplicas(id);
-    Assert.assertEquals(1, replicaSet.size());
-    Assert.assertFalse(replicaSet.contains(replicaOne));
-    Assert.assertTrue(replicaSet.contains(replicaTwo));
+    assertEquals(1, replicaSet.size());
+    assertFalse(replicaSet.contains(replicaOne));
+    assertTrue(replicaSet.contains(replicaTwo));
 
     // Test 3: Remove second replica node and then test
     containerStateManager.removeContainerReplica(id, replicaTwo);
     replicaSet = containerStateManager.getContainerReplicas(id);
-    Assert.assertEquals(0, replicaSet.size());
-    Assert.assertFalse(replicaSet.contains(replicaOne));
-    Assert.assertFalse(replicaSet.contains(replicaTwo));
+    assertEquals(0, replicaSet.size());
+    assertFalse(replicaSet.contains(replicaOne));
+    assertFalse(replicaSet.contains(replicaTwo));
 
     // Test 4: Re-insert dn1
     containerStateManager.updateContainerReplica(id, replicaOne);
     replicaSet = containerStateManager.getContainerReplicas(id);
-    Assert.assertEquals(1, replicaSet.size());
-    Assert.assertTrue(replicaSet.contains(replicaOne));
-    Assert.assertFalse(replicaSet.contains(replicaTwo));
+    assertEquals(1, replicaSet.size());
+    assertTrue(replicaSet.contains(replicaOne));
+    assertFalse(replicaSet.contains(replicaTwo));
 
     // Re-insert dn2
     containerStateManager.updateContainerReplica(id, replicaTwo);
     replicaSet = containerStateManager.getContainerReplicas(id);
-    Assert.assertEquals(2, replicaSet.size());
-    Assert.assertTrue(replicaSet.contains(replicaOne));
-    Assert.assertTrue(replicaSet.contains(replicaTwo));
+    assertEquals(2, replicaSet.size());
+    assertTrue(replicaSet.contains(replicaOne));
+    assertTrue(replicaSet.contains(replicaTwo));
 
     // Re-insert dn1
     containerStateManager.updateContainerReplica(id, replicaOne);
     replicaSet = containerStateManager.getContainerReplicas(id);
-    Assert.assertEquals(2, replicaSet.size());
-    Assert.assertTrue(replicaSet.contains(replicaOne));
-    Assert.assertTrue(replicaSet.contains(replicaTwo));
+    assertEquals(2, replicaSet.size());
+    assertTrue(replicaSet.contains(replicaOne));
+    assertTrue(replicaSet.contains(replicaTwo));
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Unhealthy;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -41,6 +40,8 @@ import java.util.UUID;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_LEADER_CHOOSING_POLICY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for LeaderChoosePolicy.
@@ -93,9 +94,9 @@ public class TestLeaderChoosePolicy {
       leaderCount.put(leader, leaderCount.get(leader) + 1);
     }
 
-    Assert.assertTrue(leaderCount.size() == dnNum);
+    assertTrue(leaderCount.size() == dnNum);
     for (Map.Entry<UUID, Integer> entry: leaderCount.entrySet()) {
-      Assert.assertTrue(leaderCount.get(entry.getKey()) == leaderNumOfEachDn);
+      assertTrue(leaderCount.get(entry.getKey()) == leaderNumOfEachDn);
     }
   }
 
@@ -114,7 +115,7 @@ public class TestLeaderChoosePolicy {
     // make sure two pipelines are created
     waitForPipelines(pipelineNum);
     // No Factor ONE pipeline is auto created.
-    Assert.assertEquals(0,
+    assertEquals(0,
         pipelineManager.getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
@@ -132,7 +133,7 @@ public class TestLeaderChoosePolicy {
         cluster.getStorageContainerManager().getPipelineManager()
             .getPipelines();
 
-    Assert.assertEquals(
+    assertEquals(
         pipelinesBeforeRestart.size(), pipelinesAfterRestart.size());
 
     for (Pipeline p : pipelinesBeforeRestart) {
@@ -144,7 +145,7 @@ public class TestLeaderChoosePolicy {
         }
       }
 
-      Assert.assertTrue(equal);
+      assertTrue(equal);
     }
   }
 
@@ -163,7 +164,7 @@ public class TestLeaderChoosePolicy {
     // make sure pipelines are created
     waitForPipelines(pipelineNum);
     // No Factor ONE pipeline is auto created.
-    Assert.assertEquals(0, pipelineManager.getPipelines(
+    assertEquals(0, pipelineManager.getPipelines(
         RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.Test;
@@ -62,6 +61,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for Pipeline Closing.
@@ -126,8 +128,8 @@ public class TestPipelineClose {
         .getContainersInPipeline(ratisContainer.getPipeline().getId());
 
     ContainerID cId = ratisContainer.getContainerInfo().containerID();
-    Assert.assertEquals(1, set.size());
-    set.forEach(containerID -> Assert.assertEquals(containerID, cId));
+    assertEquals(1, set.size());
+    set.forEach(containerID -> assertEquals(containerID, cId));
 
     // Now close the container and it should not show up while fetching
     // containers by pipeline
@@ -138,13 +140,13 @@ public class TestPipelineClose {
 
     Set<ContainerID> setClosed = pipelineManager
         .getContainersInPipeline(ratisContainer.getPipeline().getId());
-    Assert.assertEquals(0, setClosed.size());
+    assertEquals(0, setClosed.size());
 
     pipelineManager.closePipeline(ratisContainer.getPipeline().getId());
     pipelineManager.deletePipeline(ratisContainer.getPipeline().getId());
     for (DatanodeDetails dn : ratisContainer.getPipeline().getNodes()) {
       // Assert that the pipeline has been removed from Node2PipelineMap as well
-      Assert.assertFalse(scm.getScmNodeManager().getPipelines(dn)
+      assertFalse(scm.getScmNodeManager().getPipelines(dn)
           .contains(ratisContainer.getPipeline().getId()));
     }
   }
@@ -154,7 +156,7 @@ public class TestPipelineClose {
       throws IOException, TimeoutException, InterruptedException {
     Set<ContainerID> setOpen = pipelineManager.getContainersInPipeline(
         ratisContainer.getPipeline().getId());
-    Assert.assertEquals(1, setOpen.size());
+    assertEquals(1, setOpen.size());
 
     pipelineManager
         .closePipeline(ratisContainer.getPipeline(), false);
@@ -230,7 +232,7 @@ public class TestPipelineClose {
     try {
       pipelineManager.getPipeline(openPipeline.getId());
     } catch (PipelineNotFoundException e) {
-      Assert.assertTrue("pipeline should exist", false);
+      assertTrue(false, "pipeline should exist");
     }
 
     DatanodeDetails datanodeDetails = openPipeline.getNodes().get(0);
@@ -277,8 +279,7 @@ public class TestPipelineClose {
       }
     }
 
-    Assert.assertTrue("SCM did not receive a Close action for the Pipeline",
-        found);
+    assertTrue(found, "SCM did not receive a Close action for the Pipeline");
     return found;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
@@ -30,11 +30,10 @@ import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -81,7 +80,7 @@ public class TestRatisPipelineCreateAndDestroy {
     init(numOfDatanodes);
     // make sure two pipelines are created
     waitForPipelines(2);
-    Assert.assertEquals(numOfDatanodes, pipelineManager.getPipelines(
+    Assertions.assertEquals(numOfDatanodes, pipelineManager.getPipelines(
         RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
@@ -103,7 +102,7 @@ public class TestRatisPipelineCreateAndDestroy {
     // make sure two pipelines are created
     waitForPipelines(2);
     // No Factor ONE pipeline is auto created.
-    Assert.assertEquals(0, pipelineManager.getPipelines(
+    Assertions.assertEquals(0, pipelineManager.getPipelines(
         RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
@@ -140,17 +139,12 @@ public class TestRatisPipelineCreateAndDestroy {
                     100, 10 * 1000);
 
     // try creating another pipeline now
-    try {
-      pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
-          ReplicationFactor.THREE));
-      Assert.fail("pipeline creation should fail after shutting down pipeline");
-    } catch (IOException ioe) {
-      // As now all datanodes are shutdown, they move to stale state, there
-      // will be no sufficient datanodes to create the pipeline.
-      Assert.assertTrue(ioe instanceof SCMException);
-      Assert.assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES,
-          ((SCMException) ioe).getResult());
-    }
+    SCMException ioe = Assertions.assertThrows(SCMException.class, () ->
+        pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
+            ReplicationFactor.THREE)),
+        "pipeline creation should fail after shutting down pipeline");
+    Assertions.assertEquals(
+        SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES, ioe.getResult());
 
     // make sure pipelines is destroyed
     waitForPipelines(0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -77,10 +77,8 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,6 +112,10 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.READ;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.WRITE;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.newWriteChunkRequestBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class tests container commands on EC containers.
@@ -382,8 +384,8 @@ public class TestContainerCommandsEC {
           .filter(bd -> bd.getBlockID().getLocalID() == localID)
           .count();
 
-      Assert.assertEquals(0L, count);
-      Assert.assertEquals(0, response.getBlockDataList().size());
+      assertEquals(0L, count);
+      assertEquals(0, response.getBlockDataList().size());
     }
   }
 
@@ -410,25 +412,24 @@ public class TestContainerCommandsEC {
               .map(expectedChunksFunc::apply).sum();
       if (minNumExpectedBlocks == 0) {
         final int j = i;
-        Throwable t = Assertions.assertThrows(StorageContainerException.class,
+        Throwable t = assertThrows(StorageContainerException.class,
             () -> ContainerProtocolCalls
                 .listBlock(clients.get(j), containerID, null,
                     minNumExpectedBlocks + 1, containerToken));
-        Assertions
-            .assertEquals("ContainerID " + containerID + " does not exist",
+        assertEquals("ContainerID " + containerID + " does not exist",
                 t.getMessage());
         continue;
       }
       ListBlockResponseProto response = ContainerProtocolCalls
           .listBlock(clients.get(i), containerID, null, Integer.MAX_VALUE,
               containerToken);
-      Assertions.assertTrue(
+      assertTrue(
           minNumExpectedBlocks <= response.getBlockDataList().stream().filter(
               k -> k.getChunksCount() > 0 && k.getChunks(0).getLen() > 0)
               .collect(Collectors.toList()).size(),
           "blocks count should be same or more than min expected" +
               " blocks count on DN " + i);
-      Assertions.assertTrue(
+      assertTrue(
           minNumExpectedChunks <= response.getBlockDataList().stream()
               .mapToInt(BlockData::getChunksCount).sum(),
           "chunks count should be same or more than min expected" +
@@ -492,10 +493,10 @@ public class TestContainerCommandsEC {
         ContainerProtos.ReadContainerResponseProto readContainerResponseProto =
             ContainerProtocolCalls.readContainer(dnClient,
                 container.containerID().getProtobuf().getId(), encodedToken);
-        Assert.assertEquals(ContainerProtos.ContainerDataProto.State.RECOVERING,
+        assertEquals(ContainerProtos.ContainerDataProto.State.RECOVERING,
             readContainerResponseProto.getContainerData().getState());
         // Container at SCM should be still in closed state.
-        Assert.assertEquals(HddsProtos.LifeCycleState.CLOSED,
+        assertEquals(HddsProtos.LifeCycleState.CLOSED,
             scm.getContainerManager().getContainerStateManager()
                 .getContainer(container.containerID()).getState());
         // close container call
@@ -505,7 +506,7 @@ public class TestContainerCommandsEC {
         readContainerResponseProto = ContainerProtocolCalls
             .readContainer(dnClient,
                 container.containerID().getProtobuf().getId(), encodedToken);
-        Assert.assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
+        assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
             readContainerResponseProto.getContainerData().getState());
         ContainerProtos.ReadChunkResponseProto readChunkResponseProto =
             ContainerProtocolCalls.readChunk(dnClient,
@@ -514,10 +515,10 @@ public class TestContainerCommandsEC {
         ByteBuffer[] readOnlyByteBuffersArray = BufferUtils
             .getReadOnlyByteBuffersArray(
                 readChunkResponseProto.getDataBuffers().getBuffersList());
-        Assert.assertEquals(readOnlyByteBuffersArray[0].limit(), data.length);
+        assertEquals(readOnlyByteBuffersArray[0].limit(), data.length);
         byte[] readBuff = new byte[readOnlyByteBuffersArray[0].limit()];
         readOnlyByteBuffersArray[0].get(readBuff, 0, readBuff.length);
-        Assert.assertArrayEquals(data, readBuff);
+        assertArrayEquals(data, readBuff);
       } finally {
         xceiverClientManager.releaseClient(dnClient, false);
       }
@@ -563,7 +564,7 @@ public class TestContainerCommandsEC {
         cluster.restartHddsDatanode(targetDN, true);
 
         // Recovering container state after DN restart should be UNHEALTHY.
-        Assert.assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY,
+        assertEquals(ContainerProtos.ContainerDataProto.State.UNHEALTHY,
             cluster.getHddsDatanode(targetDN)
                 .getDatanodeStateMachine()
                 .getContainer()
@@ -590,7 +591,7 @@ public class TestContainerCommandsEC {
         try {
           dnClient.sendCommand(writeChunkRequest);
         } catch (StorageContainerException e) {
-          Assert.assertEquals(CONTAINER_UNHEALTHY, e.getResult());
+          assertEquals(CONTAINER_UNHEALTHY, e.getResult());
         }
 
       } finally {
@@ -635,7 +636,7 @@ public class TestContainerCommandsEC {
   @Test
   public void testECReconstructionCoordinatorWithMissingIndexes135() {
     InsufficientLocationsException exception =
-        Assert.assertThrows(InsufficientLocationsException.class, () -> {
+        assertThrows(InsufficientLocationsException.class, () -> {
           testECReconstructionCoordinator(ImmutableList.of(1, 3, 5), 3);
         });
 
@@ -643,7 +644,7 @@ public class TestContainerCommandsEC {
         "There are insufficient datanodes to read the EC block";
     String actualMessage = exception.getMessage();
 
-    Assert.assertEquals(expectedMessage, actualMessage);
+    assertEquals(expectedMessage, actualMessage);
   }
 
   private void testECReconstructionCoordinator(List<Integer> missingIndexes,
@@ -707,7 +708,7 @@ public class TestContainerCommandsEC {
         }
       }
 
-      Assert.assertEquals(missingIndexes.size(), targetNodes.size());
+      assertEquals(missingIndexes.size(), targetNodes.size());
 
       List<org.apache.hadoop.ozone.container.common.helpers.BlockData[]>
           blockDataArrList = new ArrayList<>();
@@ -766,7 +767,7 @@ public class TestContainerCommandsEC {
                   .listBlock(conID, newTargetPipeline.getFirstNode(),
                       (ECReplicationConfig) newTargetPipeline
                           .getReplicationConfig(), cToken);
-          Assert.assertEquals(blockDataArrList.get(i).length,
+          assertEquals(blockDataArrList.get(i).length,
               reconstructedBlockData.length);
           checkBlockData(blockDataArrList.get(i), reconstructedBlockData);
           XceiverClientSpi client = xceiverClientManager.acquireClient(
@@ -776,14 +777,14 @@ public class TestContainerCommandsEC {
                 ContainerProtocolCalls.readContainer(
                     client, conID,
                     cToken.encodeToUrlString());
-            Assert.assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
+            assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED,
                 readContainerResponse.getContainerData().getState());
           } finally {
             xceiverClientManager.releaseClient(client, false);
           }
           i++;
         }
-        Assertions.assertEquals(metrics.getReconstructionTotal(), 1L);
+        assertEquals(1L, metrics.getReconstructionTotal());
       }
     }
   }
@@ -796,7 +797,7 @@ public class TestContainerCommandsEC {
     try (OzoneOutputStream out = bucket.createKey(keyString, 4096,
         new ECReplicationConfig(3, 2, EcCodec.RS, EC_CHUNK_SIZE),
         new HashMap<>())) {
-      Assert.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
+      assertTrue(out.getOutputStream() instanceof KeyOutputStream);
       for (int i = 0; i < numChunks; i++) {
         out.write(inputChunks[i]);
       }
@@ -856,7 +857,7 @@ public class TestContainerCommandsEC {
         MockDatanodeDetails.randomDatanodeDetails();
     targetNodeMap.put(3, invalidTargetNode);
 
-    Assert.assertThrows(IOException.class, () -> {
+    assertThrows(IOException.class, () -> {
       try (ECReconstructionCoordinator coordinator =
                new ECReconstructionCoordinator(config, certClient,
                    secretKeyClient,
@@ -868,14 +869,14 @@ public class TestContainerCommandsEC {
     });
     final DatanodeDetails targetDNToCheckContainerCLeaned = goodTargetNode;
     StorageContainerException ex =
-        Assert.assertThrows(StorageContainerException.class, () -> {
+        assertThrows(StorageContainerException.class, () -> {
           try (ECContainerOperationClient client =
               new ECContainerOperationClient(config, certClient)) {
             client.listBlock(conID, targetDNToCheckContainerCLeaned,
                 new ECReplicationConfig(3, 2), cToken);
           }
         });
-    Assert.assertEquals("ContainerID 1 does not exist", ex.getMessage());
+    assertEquals("ContainerID 1 does not exist", ex.getMessage());
   }
 
   private void closeContainer(long conID)
@@ -905,7 +906,7 @@ public class TestContainerCommandsEC {
           // let's ignore the empty chunks
           continue;
         }
-        Assert.assertEquals(chunkInfo, newBlockDataChunks.get(j));
+        assertEquals(chunkInfo, newBlockDataChunks.get(j));
       }
     }
   }
@@ -963,10 +964,10 @@ public class TestContainerCommandsEC {
                     .stream()
                     .map(ContainerInfo::containerID)
                     .collect(Collectors.toList());
-    Assertions.assertEquals(1, containerIDs.size());
+    assertEquals(1, containerIDs.size());
     containerID = containerIDs.get(0).getId();
     List<Pipeline> pipelines = scm.getPipelineManager().getPipelines(repConfig);
-    Assertions.assertEquals(1, pipelines.size());
+    assertEquals(1, pipelines.size());
     pipeline = pipelines.get(0);
     datanodeDetails = pipeline.getNodes();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -34,6 +34,10 @@ import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.ALREADY_FI
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_DONE;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_REQUIRED;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.STARTING_FINALIZATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -82,7 +86,6 @@ import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.apache.ozone.test.tag.Slow;
@@ -229,12 +232,12 @@ public class TestHDDSUpgrade {
       throws IOException, TimeoutException {
     Pipeline ratisPipeline1 = scmPipelineManager.createPipeline(RATIS_THREE);
     scmPipelineManager.openPipeline(ratisPipeline1.getId());
-    Assert.assertEquals(0,
+    assertEquals(0,
         scmPipelineManager.getNumberOfContainers(ratisPipeline1.getId()));
     PipelineID pid = scmContainerManager.allocateContainer(RATIS_THREE,
         "Owner1").getPipelineID();
-    Assert.assertEquals(1, scmPipelineManager.getNumberOfContainers(pid));
-    Assert.assertEquals(pid, ratisPipeline1.getId());
+    assertEquals(1, scmPipelineManager.getNumberOfContainers(pid));
+    assertEquals(pid, ratisPipeline1.getId());
   }
 
   /*
@@ -290,7 +293,7 @@ public class TestHDDSUpgrade {
     // Trigger Finalization on the SCM
     StatusAndMessages status = scm.getFinalizationManager().finalizeUpgrade(
         "xyz");
-    Assert.assertEquals(STARTING_FINALIZATION, status.status());
+    assertEquals(STARTING_FINALIZATION, status.status());
 
     // Wait for the Finalization to complete on the SCM.
     TestHddsUpgradeUtils.waitForFinalizationFromClient(
@@ -308,7 +311,7 @@ public class TestHDDSUpgrade {
         .stream()
         .filter(postUpgradeOpenPipelines::contains)
         .count();
-    Assert.assertEquals(0, numPreUpgradeOpenPipelines);
+    assertEquals(0, numPreUpgradeOpenPipelines);
 
     // Verify Post-Upgrade conditions on the SCM.
     TestHddsUpgradeUtils.testPostUpgradeConditionsSCM(
@@ -447,7 +450,7 @@ public class TestHDDSUpgrade {
       });
     } catch (Exception e) {
       LOG.info("DataNode Restart Failed!");
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
     return t;
   }
@@ -515,7 +518,7 @@ public class TestHDDSUpgrade {
         BEFORE_PRE_FINALIZE_UPGRADE,
         this::injectSCMFailureDuringSCMUpgrade);
     testFinalizationWithFailureInjectionHelper(null);
-    Assert.assertTrue(testPassed.get());
+    assertTrue(testPassed.get());
   }
 
   /*
@@ -534,7 +537,7 @@ public class TestHDDSUpgrade {
         AFTER_PRE_FINALIZE_UPGRADE,
         this::injectSCMFailureDuringSCMUpgrade);
     testFinalizationWithFailureInjectionHelper(null);
-    Assert.assertTrue(testPassed.get());
+    assertTrue(testPassed.get());
   }
 
   /*
@@ -553,7 +556,7 @@ public class TestHDDSUpgrade {
         AFTER_COMPLETE_FINALIZATION,
         () -> this.injectSCMFailureDuringSCMUpgrade());
     testFinalizationWithFailureInjectionHelper(null);
-    Assert.assertTrue(testPassed.get());
+    assertTrue(testPassed.get());
   }
 
   /*
@@ -572,7 +575,7 @@ public class TestHDDSUpgrade {
         AFTER_POST_FINALIZE_UPGRADE,
         () -> this.injectSCMFailureDuringSCMUpgrade());
     testFinalizationWithFailureInjectionHelper(null);
-    Assert.assertTrue(testPassed.get());
+    assertTrue(testPassed.get());
   }
 
   /*
@@ -591,7 +594,7 @@ public class TestHDDSUpgrade {
         BEFORE_PRE_FINALIZE_UPGRADE,
         this::injectDataNodeFailureDuringSCMUpgrade);
     testFinalizationWithFailureInjectionHelper(null);
-    Assert.assertTrue(testPassed.get());
+    assertTrue(testPassed.get());
   }
 
   /*
@@ -610,7 +613,7 @@ public class TestHDDSUpgrade {
         AFTER_PRE_FINALIZE_UPGRADE,
         this::injectDataNodeFailureDuringSCMUpgrade);
     testFinalizationWithFailureInjectionHelper(null);
-    Assert.assertTrue(testPassed.get());
+    assertTrue(testPassed.get());
   }
 
   /*
@@ -629,7 +632,7 @@ public class TestHDDSUpgrade {
         AFTER_COMPLETE_FINALIZATION,
         this::injectDataNodeFailureDuringSCMUpgrade);
     testFinalizationWithFailureInjectionHelper(null);
-    Assert.assertTrue(testPassed.get());
+    assertTrue(testPassed.get());
   }
 
   /*
@@ -648,7 +651,7 @@ public class TestHDDSUpgrade {
         AFTER_POST_FINALIZE_UPGRADE,
         this::injectDataNodeFailureDuringSCMUpgrade);
     testFinalizationWithFailureInjectionHelper(null);
-    Assert.assertTrue(testPassed.get());
+    assertTrue(testPassed.get());
   }
 
   /*
@@ -683,7 +686,7 @@ public class TestHDDSUpgrade {
           .getUpgradeFinalizer())
           .setFinalizationExecutor(dataNodeFinalizationExecutor);
       testFinalizationWithFailureInjectionHelper(failureInjectionThread);
-      Assert.assertTrue(testPassed.get());
+      assertTrue(testPassed.get());
       synchronized (cluster) {
         shutdown();
         init();
@@ -736,7 +739,7 @@ public class TestHDDSUpgrade {
             .setFinalizationExecutor(dataNodeFinalizationExecutor);
         testFinalizationWithFailureInjectionHelper(
             dataNodefailureInjectionThread);
-        Assert.assertTrue(testPassed.get());
+        assertTrue(testPassed.get());
         synchronized (cluster) {
           shutdown();
           init();
@@ -777,7 +780,7 @@ public class TestHDDSUpgrade {
       scm.getFinalizationManager().getUpgradeFinalizer()
           .setFinalizationExecutor(finalizationExecutor);
       testFinalizationWithFailureInjectionHelper(helpingFailureInjectionThread);
-      Assert.assertTrue(testPassed.get());
+      assertTrue(testPassed.get());
       synchronized (cluster) {
         shutdown();
         init();
@@ -817,7 +820,7 @@ public class TestHDDSUpgrade {
           .getUpgradeFinalizer())
           .setFinalizationExecutor(dataNodeFinalizationExecutor);
       testFinalizationWithFailureInjectionHelper(helpingFailureInjectionThread);
-      Assert.assertTrue(testPassed.get());
+      assertTrue(testPassed.get());
       synchronized (cluster) {
         shutdown();
         init();
@@ -843,7 +846,7 @@ public class TestHDDSUpgrade {
     // Trigger Finalization on the SCM
     StatusAndMessages status =
         scm.getFinalizationManager().finalizeUpgrade("xyz");
-    Assert.assertEquals(STARTING_FINALIZATION, status.status());
+    assertEquals(STARTING_FINALIZATION, status.status());
 
     // Make sure that any outstanding thread created by failure injection
     // has completed its job.
@@ -907,7 +910,7 @@ public class TestHDDSUpgrade {
         DatanodeStateMachine dsm = dataNode.getDatanodeStateMachine();
         Set<PipelineID> pipelines =
             scm.getScmNodeManager().getPipelines(dsm.getDatanodeDetails());
-        Assert.assertTrue(pipelines != null);
+        assertNotNull(pipelines);
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachin
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +49,10 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.OPEN;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.ALREADY_FINALIZED;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_DONE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Helper methods for testing HDDS upgrade finalization in integration tests.
@@ -73,7 +76,7 @@ public final class TestHddsUpgradeUtils {
           .queryUpgradeFinalizationProgress(clientID, true, true)
           .status();
       LOG.info("Waiting for upgrade finalization to complete from client." +
-              " Current status is {}.", status);
+          " Current status is {}.", status);
       return status == FINALIZATION_DONE || status == ALREADY_FINALIZED;
     });
   }
@@ -84,11 +87,11 @@ public final class TestHddsUpgradeUtils {
   public static void testPreUpgradeConditionsSCM(
       List<StorageContainerManager> scms) {
     for (StorageContainerManager scm : scms) {
-      Assert.assertEquals(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion(),
+      assertEquals(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion(),
           scm.getLayoutVersionManager().getMetadataLayoutVersion());
       for (ContainerInfo ci : scm.getContainerManager()
           .getContainers()) {
-        Assert.assertEquals(HddsProtos.LifeCycleState.OPEN, ci.getState());
+        assertEquals(HddsProtos.LifeCycleState.OPEN, ci.getState());
       }
     }
   }
@@ -106,15 +109,15 @@ public final class TestHddsUpgradeUtils {
   }
 
   public static void testPostUpgradeConditionsSCM(StorageContainerManager scm,
-      int numContainers, int numDatanodes) {
+                                                  int numContainers, int numDatanodes) {
 
-    Assert.assertTrue(scm.getScmContext().getFinalizationCheckpoint()
+    assertTrue(scm.getScmContext().getFinalizationCheckpoint()
         .hasCrossed(FinalizationCheckpoint.FINALIZATION_COMPLETE));
 
     HDDSLayoutVersionManager scmVersionManager = scm.getLayoutVersionManager();
-    Assert.assertEquals(scmVersionManager.getSoftwareLayoutVersion(),
+    assertEquals(scmVersionManager.getSoftwareLayoutVersion(),
         scmVersionManager.getMetadataLayoutVersion());
-    Assert.assertTrue(scmVersionManager.getMetadataLayoutVersion() >= 1);
+    assertTrue(scmVersionManager.getMetadataLayoutVersion() >= 1);
 
     // SCM should not return from finalization until there is at least one
     // pipeline to use.
@@ -124,7 +127,7 @@ public final class TestHddsUpgradeUtils {
           () -> scmPipelineManager.getPipelines(RATIS_THREE, OPEN).size() >= 1,
           500, 60000);
     } catch (TimeoutException | InterruptedException e) {
-      Assert.fail("Timeout waiting for Upgrade to complete on SCM.");
+      fail("Timeout waiting for Upgrade to complete on SCM.");
     }
 
     // SCM will not return from finalization until there is at least one
@@ -137,26 +140,26 @@ public final class TestHddsUpgradeUtils {
       HddsProtos.LifeCycleState ciState = ci.getState();
       LOG.info("testPostUpgradeConditionsSCM: container state is {}",
           ciState.name());
-      Assert.assertTrue((ciState == HddsProtos.LifeCycleState.CLOSED) ||
+      assertTrue((ciState == HddsProtos.LifeCycleState.CLOSED) ||
           (ciState == HddsProtos.LifeCycleState.CLOSING) ||
           (ciState == HddsProtos.LifeCycleState.DELETING) ||
           (ciState == HddsProtos.LifeCycleState.DELETED) ||
           (ciState == HddsProtos.LifeCycleState.QUASI_CLOSED));
       countContainers++;
     }
-    Assert.assertTrue(countContainers >= numContainers);
+    assertTrue(countContainers >= numContainers);
   }
 
   /*
    * Helper function to test Pre-Upgrade conditions on all the DataNodes.
    */
   public static void testPreUpgradeConditionsDataNodes(
-        List<HddsDatanodeService> datanodes) {
+      List<HddsDatanodeService> datanodes) {
     for (HddsDatanodeService dataNode : datanodes) {
       DatanodeStateMachine dsm = dataNode.getDatanodeStateMachine();
       HDDSLayoutVersionManager dnVersionManager =
           dsm.getLayoutVersionManager();
-      Assert.assertEquals(0, dnVersionManager.getMetadataLayoutVersion());
+      assertEquals(0, dnVersionManager.getMetadataLayoutVersion());
     }
 
     int countContainers = 0;
@@ -165,12 +168,12 @@ public final class TestHddsUpgradeUtils {
       // Also verify that all the existing containers are open.
       for (Container<?> container :
           dsm.getContainer().getController().getContainers()) {
-        Assert.assertSame(container.getContainerState(),
+        assertSame(container.getContainerState(),
             ContainerProtos.ContainerDataProto.State.OPEN);
         countContainers++;
       }
     }
-    Assert.assertTrue(countContainers >= 1);
+    assertTrue(countContainers >= 1);
   }
 
   /*
@@ -204,7 +207,7 @@ public final class TestHddsUpgradeUtils {
         return true;
       }, 500, 60000);
     } catch (TimeoutException | InterruptedException e) {
-      Assert.fail("Timeout waiting for Upgrade to complete on Data Nodes.");
+      fail("Timeout waiting for Upgrade to complete on Data Nodes.");
     }
 
     int countContainers = 0;
@@ -212,21 +215,20 @@ public final class TestHddsUpgradeUtils {
       DatanodeStateMachine dsm = dataNode.getDatanodeStateMachine();
       HDDSLayoutVersionManager dnVersionManager =
           dsm.getLayoutVersionManager();
-      Assert.assertEquals(dnVersionManager.getSoftwareLayoutVersion(),
+      assertEquals(dnVersionManager.getSoftwareLayoutVersion(),
           dnVersionManager.getMetadataLayoutVersion());
-      Assert.assertTrue(dnVersionManager.getMetadataLayoutVersion() >= 1);
+      assertTrue(dnVersionManager.getMetadataLayoutVersion() >= 1);
 
       // Also verify that all the existing containers are closed.
       for (Container<?> container :
-           dsm.getContainer().getController().getContainers()) {
-        Assert.assertTrue("Container had unexpected state " +
-                container.getContainerState(),
-            closeStates.stream().anyMatch(
-                state -> container.getContainerState().equals(state)));
+          dsm.getContainer().getController().getContainers()) {
+        assertTrue(closeStates.stream().anyMatch(
+                state -> container.getContainerState().equals(state)),
+            "Container had unexpected state " + container.getContainerState());
         countContainers++;
       }
     }
-    Assert.assertTrue(countContainers >= numContainers);
+    assertTrue(countContainers >= numContainers);
   }
 
   public static void testDataNodesStateOnSCM(List<StorageContainerManager> scms,
@@ -251,14 +253,14 @@ public final class TestHddsUpgradeUtils {
       try {
         HddsProtos.NodeState dnState =
             scm.getScmNodeManager().getNodeStatus(dn).getHealth();
-        Assert.assertTrue((dnState == state) ||
+        assertTrue((dnState == state) ||
             (alternateState != null && dnState == alternateState));
       } catch (NodeNotFoundException e) {
         e.printStackTrace();
-        Assert.fail("Node not found");
+        fail("Node not found");
       }
       ++countNodes;
     }
-    Assert.assertEquals(expectedDatanodeCount, countNodes);
+    assertEquals(expectedDatanodeCount, countNodes);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -34,9 +34,9 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils.VoidCallable;
-
 import org.apache.ratis.util.function.CheckedConsumer;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+
 
 /**
  * Helper class for Tests.
@@ -92,7 +92,7 @@ public final class OzoneTestUtils {
             .updateContainerState(ContainerID.valueOf(blockID.getContainerID()),
                 HddsProtos.LifeCycleEvent.CLOSE);
       }
-      Assert.assertFalse(scm.getContainerManager()
+      Assertions.assertFalse(scm.getContainerManager()
           .getContainer(ContainerID.valueOf(blockID.getContainerID()))
           .isOpen());
     }, omKeyLocationInfoGroups);
@@ -144,9 +144,9 @@ public final class OzoneTestUtils {
       throws Exception {
     try {
       eval.call();
-      Assert.fail("OMException is expected");
+      Assertions.fail("OMException is expected");
     } catch (OMException ex) {
-      Assert.assertEquals(code, ex.getResult());
+      Assertions.assertEquals(code, ex.getResult());
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
@@ -56,9 +56,10 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-
+import org.apache.ratis.util.ExitUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.scm.ScmConfig.ConfigStrings.HDDS_SCM_KERBEROS_KEYTAB_FILE_KEY;
@@ -85,13 +86,13 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.slf4j.event.Level.INFO;
 
-import org.apache.ratis.util.ExitUtils;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,7 +102,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.slf4j.event.Level.INFO;
 
 /**
  * Test class to for security enabled Ozone cluster.
@@ -362,10 +362,9 @@ public final class TestDelegationToken {
           "Auth successful for " + username + " (auth:TOKEN)"));
       OzoneTestUtils.expectOmException(VOLUME_NOT_FOUND,
           () -> omClient.deleteVolume("vol1"));
-      assertTrue(
-          "Log file doesn't contain successful auth for user " + username,
-          logs.getOutput().contains("Auth successful for "
-              + username + " (auth:TOKEN)"));
+      assertTrue(logs.getOutput().contains("Auth successful for "
+              + username + " (auth:TOKEN)"),
+          "Log file doesn't contain successful auth for user " + username);
 
       // Case 4: Test failure of token renewal.
       // Call to renewDelegationToken will fail but it will confirm that

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -86,18 +86,22 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVA
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.QUASI_CLOSED;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.storage.FileInfo;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
-import static org.hamcrest.core.Is.is;
 
 import org.apache.ratis.statemachine.impl.StatemachineImplTestUtil;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.Assert;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -212,7 +216,7 @@ public class TestContainerStateMachineFailures {
         getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
@@ -268,7 +272,7 @@ public class TestContainerStateMachineFailures {
             (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
             groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
             cluster);
@@ -287,7 +291,7 @@ public class TestContainerStateMachineFailures {
     long containerID = omKeyLocationInfo.getContainerID();
 
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(
+    assertTrue(
             dn.getDatanodeStateMachine()
                     .getContainer().getContainerSet()
                     .getContainer(containerID)
@@ -305,7 +309,7 @@ public class TestContainerStateMachineFailures {
     cluster.restartHddsDatanode(dn.getDatanodeDetails(), false);
     ozoneContainer = cluster.getHddsDatanodes().get(index)
             .getDatanodeStateMachine().getContainer();
-    Assert.assertNull(ozoneContainer.getContainerSet().
+    assertNull(ozoneContainer.getContainerSet().
                     getContainer(containerID));
   }
 
@@ -323,7 +327,7 @@ public class TestContainerStateMachineFailures {
             .getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
             groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
             cluster);
@@ -332,7 +336,7 @@ public class TestContainerStateMachineFailures {
                     .getContainer().getContainerSet()
                     .getContainer(omKeyLocationInfo.getContainerID())
                     .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+    assertTrue(containerData instanceof KeyValueContainerData);
     KeyValueContainerData keyValueContainerData =
             (KeyValueContainerData) containerData;
     // delete the container db file
@@ -348,7 +352,7 @@ public class TestContainerStateMachineFailures {
     long containerID = omKeyLocationInfo.getContainerID();
 
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(
+    assertTrue(
             dn.getDatanodeStateMachine()
                     .getContainer().getContainerSet().getContainer(containerID)
                     .getContainerState()
@@ -388,7 +392,7 @@ public class TestContainerStateMachineFailures {
     request.setCloseContainer(
             ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
     request.setDatanodeUuid(dnService.getDatanodeDetails().getUuidString());
-    Assert.assertEquals(ContainerProtos.Result.CONTAINER_UNHEALTHY,
+    assertEquals(ContainerProtos.Result.CONTAINER_UNHEALTHY,
             dispatcher.dispatch(request.build(), null)
                     .getResult());
   }
@@ -408,7 +412,7 @@ public class TestContainerStateMachineFailures {
             getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
             groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
             cluster);
@@ -417,7 +421,7 @@ public class TestContainerStateMachineFailures {
                     .getContainer().getContainerSet()
                     .getContainer(omKeyLocationInfo.getContainerID())
                     .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+    assertTrue(containerData instanceof KeyValueContainerData);
     KeyValueContainerData keyValueContainerData =
             (KeyValueContainerData) containerData;
     key.close();
@@ -431,8 +435,8 @@ public class TestContainerStateMachineFailures {
     final Path parentPath = snapshot.getPath();
     // Since the snapshot threshold is set to 1, since there are
     // applyTransactions, we should see snapshots
-    Assert.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
-    Assert.assertNotNull(snapshot);
+    assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
+    assertNotNull(snapshot);
     long containerID = omKeyLocationInfo.getContainerID();
     // delete the container db file
     FileUtil.fullyDelete(new File(keyValueContainerData.getContainerPath()));
@@ -452,14 +456,14 @@ public class TestContainerStateMachineFailures {
 
     try {
       xceiverClient.sendCommand(request.build());
-      Assert.fail("Expected exception not thrown");
+      fail("Expected exception not thrown");
     } catch (IOException e) {
       // Exception should be thrown
     } finally {
       xceiverClientManager.releaseClient(xceiverClient, false);
     }
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(dn.getDatanodeStateMachine()
+    assertTrue(dn.getDatanodeStateMachine()
                     .getContainer().getContainerSet().getContainer(containerID)
                     .getContainerState()
                     == ContainerProtos.ContainerDataProto.State.UNHEALTHY);
@@ -467,16 +471,16 @@ public class TestContainerStateMachineFailures {
       // try to take a new snapshot, ideally it should just fail
       stateMachine.takeSnapshot();
     } catch (IOException ioe) {
-      Assert.assertTrue(ioe instanceof StateMachineException);
+      assertTrue(ioe instanceof StateMachineException);
     }
 
     if (snapshot.getPath().toFile().exists()) {
       // Make sure the latest snapshot is same as the previous one
       try {
         final FileInfo latestSnapshot = getSnapshotFileInfo(storage);
-        Assert.assertTrue(snapshot.getPath().equals(latestSnapshot.getPath()));
+        assertTrue(snapshot.getPath().equals(latestSnapshot.getPath()));
       } catch (Throwable e) {
-        Assert.assertFalse(snapshot.getPath().toFile().exists());
+        assertFalse(snapshot.getPath().toFile().exists());
       }
     }
     
@@ -500,7 +504,7 @@ public class TestContainerStateMachineFailures {
     KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
             groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
             cluster);
@@ -508,7 +512,7 @@ public class TestContainerStateMachineFailures {
                     .getContainer().getContainerSet()
                     .getContainer(omKeyLocationInfo.getContainerID())
                     .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+    assertTrue(containerData instanceof KeyValueContainerData);
     key.close();
     ContainerStateMachine stateMachine =
             (ContainerStateMachine) TestHelper.getStateMachine(dn,
@@ -518,8 +522,8 @@ public class TestContainerStateMachineFailures {
     final FileInfo snapshot = getSnapshotFileInfo(storage);
     final Path parentPath = snapshot.getPath();
     stateMachine.takeSnapshot();
-    Assert.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
-    Assert.assertNotNull(snapshot);
+    assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
+    assertNotNull(snapshot);
     long markIndex1 = StatemachineImplTestUtil.findLatestSnapshot(storage)
         .getIndex();
     long containerID = omKeyLocationInfo.getContainerID();
@@ -537,19 +541,19 @@ public class TestContainerStateMachineFailures {
     try {
       xceiverClient.sendCommand(request.build());
     } catch (IOException e) {
-      Assert.fail("Exception should not be thrown");
+      fail("Exception should not be thrown");
     }
-    Assert.assertTrue(
+    assertTrue(
             TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
                     .getDatanodeStateMachine()
                     .getContainer().getContainerSet().getContainer(containerID)
                     .getContainerState()
                     == ContainerProtos.ContainerDataProto.State.CLOSED);
-    Assert.assertTrue(stateMachine.isStateMachineHealthy());
+    assertTrue(stateMachine.isStateMachineHealthy());
     try {
       stateMachine.takeSnapshot();
     } catch (IOException ioe) {
-      Assert.fail("Exception should not be thrown");
+      fail("Exception should not be thrown");
     } finally {
       xceiverClientManager.releaseClient(xceiverClient, false);
     }
@@ -566,7 +570,7 @@ public class TestContainerStateMachineFailures {
       }
     }), 1000, 30000);
     final FileInfo latestSnapshot = getSnapshotFileInfo(storage);
-    Assert.assertFalse(snapshot.getPath().equals(latestSnapshot.getPath()));
+    assertFalse(snapshot.getPath().equals(latestSnapshot.getPath()));
   }
 
   // The test injects multiple write chunk requests along with closed container
@@ -590,7 +594,7 @@ public class TestContainerStateMachineFailures {
             .getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
             groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
             cluster);
@@ -599,7 +603,7 @@ public class TestContainerStateMachineFailures {
                     .getContainer().getContainerSet()
                     .getContainer(omKeyLocationInfo.getContainerID())
                     .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+    assertTrue(containerData instanceof KeyValueContainerData);
     key.close();
     ContainerStateMachine stateMachine =
             (ContainerStateMachine) TestHelper.getStateMachine(dn,
@@ -611,8 +615,8 @@ public class TestContainerStateMachineFailures {
     stateMachine.takeSnapshot();
     // Since the snapshot threshold is set to 1, since there are
     // applyTransactions, we should see snapshots
-    Assert.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
-    Assert.assertNotNull(snapshot);
+    assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
+    assertNotNull(snapshot);
     long containerID = omKeyLocationInfo.getContainerID();
     Pipeline pipeline = cluster.getStorageContainerLocationClient()
             .getContainerWithPipeline(containerID).getPipeline();
@@ -653,10 +657,9 @@ public class TestContainerStateMachineFailures {
           failCount.incrementAndGet();
         }
         String message = e.getMessage();
-        Assert.assertFalse(message,
-            message.contains("hello"));
-        Assert.assertTrue(message,
-            message.contains(HddsUtils.REDACTED.toStringUtf8()));
+        assertFalse(message.contains("hello"), message);
+        assertTrue(message.contains(HddsUtils.REDACTED.toStringUtf8()),
+            message);
       }
     };
 
@@ -681,21 +684,21 @@ public class TestContainerStateMachineFailures {
       if (failCount.get() > 0) {
         fail("testWriteStateMachineDataIdempotencyWithClosedContainer failed");
       }
-      Assert.assertTrue(
+      assertTrue(
           TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
               .getDatanodeStateMachine()
               .getContainer().getContainerSet().getContainer(containerID)
               .getContainerState()
               == ContainerProtos.ContainerDataProto.State.CLOSED);
-      Assert.assertTrue(stateMachine.isStateMachineHealthy());
+      assertTrue(stateMachine.isStateMachineHealthy());
       try {
         stateMachine.takeSnapshot();
       } catch (IOException ioe) {
-        Assert.fail("Exception should not be thrown");
+        fail("Exception should not be thrown");
       }
 
       final FileInfo latestSnapshot = getSnapshotFileInfo(storage);
-      Assert.assertFalse(snapshot.getPath().equals(latestSnapshot.getPath()));
+      assertFalse(snapshot.getPath().equals(latestSnapshot.getPath()));
 
       r2.run();
     } finally {
@@ -720,7 +723,7 @@ public class TestContainerStateMachineFailures {
         getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
@@ -733,7 +736,7 @@ public class TestContainerStateMachineFailures {
       key.close();
     } catch (Exception ioe) {
       // Should not fail..
-      Assert.fail("Exception " + ioe.getMessage());
+      fail("Exception " + ioe.getMessage());
     }
     validateData("ratis1", 2, "ratisratisratisratis");
   }
@@ -755,7 +758,7 @@ public class TestContainerStateMachineFailures {
         getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    assertEquals(1, locationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
@@ -768,7 +771,7 @@ public class TestContainerStateMachineFailures {
       key.close();
     } catch (Exception ioe) {
       // Should not fail..
-      Assert.fail("Exception " + ioe.getMessage());
+      fail("Exception " + ioe.getMessage());
     }
     validateData("ratis1", 2, "ratisratisratisratis");
   }
@@ -794,7 +797,7 @@ public class TestContainerStateMachineFailures {
           ContainerData containerData =
               container
                   .getContainerData();
-          Assert.assertTrue(containerData instanceof KeyValueContainerData);
+          assertTrue(containerData instanceof KeyValueContainerData);
           KeyValueContainerData keyValueContainerData =
               (KeyValueContainerData) containerData;
           FileUtil.fullyDelete(new File(keyValueContainerData.getChunksPath()));
@@ -817,7 +820,7 @@ public class TestContainerStateMachineFailures {
     try {
       keyInfo = cluster.getOzoneManager().lookupKey(omKeyArgs);
 
-      Assert.assertEquals(locationCount,
+      assertEquals(locationCount,
           keyInfo.getLatestVersionLocations().getLocationListCount());
       byte[] buffer = new byte[1024];
       try (OzoneInputStream o = objectStore.getVolume(volumeName)
@@ -828,9 +831,9 @@ public class TestContainerStateMachineFailures {
       String response = new String(buffer, 0,
           end,
           StandardCharsets.UTF_8);
-      Assert.assertEquals(payload, response);
+      assertEquals(payload, response);
     } catch (IOException e) {
-      Assert.fail("Exception not expected " + e.getMessage());
+      fail("Exception not expected " + e.getMessage());
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.client.rpc;
 
 import java.io.IOException;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -63,11 +62,14 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -173,16 +175,16 @@ public class TestFailureHandlingByClient {
     key.write(data);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     // assert that the exclude list's expire time equals to
     // default value 600000 ms in OzoneClientConfig.java
-    Assert.assertEquals(((KeyOutputStream) key.getOutputStream())
+    assertEquals(((KeyOutputStream) key.getOutputStream())
         .getExcludeList().getExpiryTime(), 600000);
     KeyOutputStream groupOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertTrue(locationInfoList.size() == 1);
+    assertEquals(1, locationInfoList.size());
     long containerId = locationInfoList.get(0).getContainerID();
     ContainerInfo container = cluster.getStorageContainerManager()
         .getContainerManager()
@@ -204,7 +206,7 @@ public class TestFailureHandlingByClient {
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
-    Assert.assertEquals(data.length, keyInfo.getDataSize());
+    assertEquals(data.length, keyInfo.getDataSize());
     validateData(keyName, data);
 
     // Verify that the block information is updated correctly in the DB on
@@ -277,12 +279,11 @@ public class TestFailureHandlingByClient {
               .getLocalID()));
       // The first Block could have 1 or 2 chunkSize of data
       int block1NumChunks = blockData1.getChunks().size();
-      Assert.assertTrue(block1NumChunks >= 1);
+      assertTrue(block1NumChunks >= 1);
 
-      Assert.assertEquals(chunkSize * block1NumChunks, blockData1.getSize());
-      Assert.assertEquals(1, containerData1.getBlockCount());
-      Assert.assertEquals(chunkSize * block1NumChunks,
-          containerData1.getBytesUsed());
+      assertEquals(chunkSize * block1NumChunks, blockData1.getSize());
+      assertEquals(1, containerData1.getBlockCount());
+      assertEquals(chunkSize * block1NumChunks, containerData1.getBytesUsed());
     }
 
     // Verify that the second block has the remaining 0.5*chunkSize of data
@@ -295,17 +296,17 @@ public class TestFailureHandlingByClient {
           containerData2.getBlockKey(locationList.get(1).getBlockID()
               .getLocalID()));
       // The second Block should have 0.5 chunkSize of data
-      Assert.assertEquals(block2ExpectedChunkCount,
+      assertEquals(block2ExpectedChunkCount,
           blockData2.getChunks().size());
-      Assert.assertEquals(1, containerData2.getBlockCount());
+      assertEquals(1, containerData2.getBlockCount());
       int expectedBlockSize;
       if (block2ExpectedChunkCount == 1) {
         expectedBlockSize = chunkSize / 2;
       } else {
         expectedBlockSize = chunkSize + chunkSize / 2;
       }
-      Assert.assertEquals(expectedBlockSize, blockData2.getSize());
-      Assert.assertEquals(expectedBlockSize, containerData2.getBytesUsed());
+      assertEquals(expectedBlockSize, blockData2.getSize());
+      assertEquals(expectedBlockSize, containerData2.getBytesUsed());
     }
   }
 
@@ -319,7 +320,7 @@ public class TestFailureHandlingByClient {
         .getFixedLengthString(keyString,  chunkSize / 2);
     key.write(data.getBytes(UTF_8));
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
@@ -347,11 +348,10 @@ public class TestFailureHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(data.getBytes(UTF_8).length,
-        keyInfo.getDataSize());
+    assertEquals(data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName, data.getBytes(UTF_8));
   }
 
@@ -367,14 +367,14 @@ public class TestFailureHandlingByClient {
         .getFixedLengthString(keyString,  chunkSize);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<BlockOutputStreamEntry> streamEntryList =
         keyOutputStream.getStreamEntries();
 
     // Assert that 1 block will be preallocated
-    Assert.assertEquals(1, streamEntryList.size());
+    assertEquals(1, streamEntryList.size());
     key.write(data.getBytes(UTF_8));
     key.flush();
     long containerId = streamEntryList.get(0).getBlockID().getContainerID();
@@ -391,12 +391,10 @@ public class TestFailureHandlingByClient {
     key.write(data.getBytes(UTF_8));
     key.flush();
 
-    Assert.assertTrue(keyOutputStream.getExcludeList().getContainerIds()
+    assertTrue(keyOutputStream.getExcludeList().getContainerIds()
         .contains(ContainerID.valueOf(containerId)));
-    Assert.assertTrue(
-        keyOutputStream.getExcludeList().getDatanodes().isEmpty());
-    Assert.assertTrue(
-        keyOutputStream.getExcludeList().getPipelineIds().isEmpty());
+    assertTrue(keyOutputStream.getExcludeList().getDatanodes().isEmpty());
+    assertTrue(keyOutputStream.getExcludeList().getPipelineIds().isEmpty());
 
     // The close will just write to the buffer
     key.close();
@@ -408,11 +406,10 @@ public class TestFailureHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(2 * data.getBytes(UTF_8).length,
-        keyInfo.getDataSize());
+    assertEquals(2 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName, data.concat(data).getBytes(UTF_8));
   }
 
@@ -426,14 +423,14 @@ public class TestFailureHandlingByClient {
         .getFixedLengthString(keyString,  chunkSize);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<BlockOutputStreamEntry> streamEntryList =
         keyOutputStream.getStreamEntries();
 
     // Assert that 1 block will be preallocated
-    Assert.assertEquals(1, streamEntryList.size());
+    assertEquals(1, streamEntryList.size());
     key.write(data.getBytes(UTF_8));
     key.flush();
     long containerId = streamEntryList.get(0).getBlockID().getContainerID();
@@ -454,12 +451,10 @@ public class TestFailureHandlingByClient {
     key.write(data.getBytes(UTF_8));
     key.flush();
 
-    Assert.assertTrue(keyOutputStream.getExcludeList().getDatanodes()
+    assertTrue(keyOutputStream.getExcludeList().getDatanodes()
         .contains(datanodes.get(0)));
-    Assert.assertTrue(
-        keyOutputStream.getExcludeList().getContainerIds().isEmpty());
-    Assert.assertTrue(
-        keyOutputStream.getExcludeList().getPipelineIds().isEmpty());
+    assertTrue(keyOutputStream.getExcludeList().getContainerIds().isEmpty());
+    assertTrue(keyOutputStream.getExcludeList().getPipelineIds().isEmpty());
     // The close will just write to the buffer
     key.close();
 
@@ -471,10 +466,10 @@ public class TestFailureHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
+    assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName, data.concat(data).concat(data).getBytes(UTF_8));
   }
 
@@ -489,14 +484,14 @@ public class TestFailureHandlingByClient {
         .getFixedLengthString(keyString,  chunkSize);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<BlockOutputStreamEntry> streamEntryList =
         keyOutputStream.getStreamEntries();
 
     // Assert that 1 block will be preallocated
-    Assert.assertEquals(1, streamEntryList.size());
+    assertEquals(1, streamEntryList.size());
     key.write(data.getBytes(UTF_8));
     key.flush();
     long containerId = streamEntryList.get(0).getBlockID().getContainerID();
@@ -517,12 +512,10 @@ public class TestFailureHandlingByClient {
     key.write(data.getBytes(UTF_8));
     key.write(data.getBytes(UTF_8));
     key.flush();
-    Assert.assertTrue(keyOutputStream.getExcludeList().getPipelineIds()
+    assertTrue(keyOutputStream.getExcludeList().getPipelineIds()
         .contains(pipeline.getId()));
-    Assert.assertTrue(
-        keyOutputStream.getExcludeList().getContainerIds().isEmpty());
-    Assert.assertTrue(
-        keyOutputStream.getExcludeList().getDatanodes().isEmpty());
+    assertTrue(keyOutputStream.getExcludeList().getContainerIds().isEmpty());
+    assertTrue(keyOutputStream.getExcludeList().getDatanodes().isEmpty());
     // The close will just write to the buffer
     key.close();
 
@@ -534,10 +527,10 @@ public class TestFailureHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
+    assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName, data.concat(data).concat(data).getBytes(UTF_8));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -52,15 +52,16 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.THREE;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class is to test all the public facing APIs of Ozone Client with an
@@ -132,7 +133,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] b = new byte[value.getBytes(UTF_8).length];
       is.read(b);
-      Assert.assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
+      assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
     } catch (OzoneChecksumException e) {
       fail("Read key should succeed");
     }
@@ -141,7 +142,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] b = new byte[value.getBytes(UTF_8).length];
       is.read(b);
-      Assert.assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
+      assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
     } catch (OzoneChecksumException e) {
       fail("Read file should succeed");
     }
@@ -156,7 +157,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
       try (OzoneInputStream is = newBucket.readKey(keyName)) {
         byte[] b = new byte[value.getBytes(UTF_8).length];
         is.read(b);
-        Assert.assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
+        assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
       } catch (OzoneChecksumException e) {
         fail("Read key should succeed");
       }
@@ -165,7 +166,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
       try (OzoneInputStream is = newBucket.readFile(keyName)) {
         byte[] b = new byte[value.getBytes(UTF_8).length];
         is.read(b);
-        Assert.assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
+        assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
       } catch (OzoneChecksumException e) {
         fail("Read file should succeed");
       }
@@ -197,9 +198,9 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
 
     assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    assertEquals(volumeName, multipartInfo.getVolumeName());
+    assertEquals(bucketName, multipartInfo.getBucketName());
+    assertEquals(keyName, multipartInfo.getKeyName());
     assertNotNull(multipartInfo.getUploadID());
 
     OzoneDataStreamOutput ozoneStreamOutput = bucket.createMultipartStreamKey(
@@ -211,11 +212,11 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     OzoneMultipartUploadPartListParts parts =
         bucket.listParts(keyName, uploadID, 0, 1);
 
-    Assert.assertEquals(parts.getPartInfoList().size(), 1);
+    assertEquals(parts.getPartInfoList().size(), 1);
 
     OzoneMultipartUploadPartListParts.PartInfo partInfo =
         parts.getPartInfoList().get(0);
-    Assert.assertEquals(valueLength, partInfo.getSize());
+    assertEquals(valueLength, partInfo.getSize());
 
   }
 
@@ -269,8 +270,8 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
 
     // verify the key details
     final OzoneKeyDetails keyDetails = bucket.getKey(keyName);
-    Assertions.assertEquals(keyName, keyDetails.getName());
-    Assertions.assertEquals(data.length, keyDetails.getDataSize());
+    assertEquals(keyName, keyDetails.getName());
+    assertEquals(data.length, keyDetails.getDataSize());
 
     // verify the key content
     final byte[] buffer = new byte[data.length];
@@ -283,6 +284,6 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
         off += n;
       }
     }
-    Assertions.assertArrayEquals(data, buffer);
+    assertArrayEquals(data, buffer);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -65,8 +65,12 @@ import org.apache.ozone.test.tag.Flaky;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.apache.ratis.protocol.exceptions.GroupMismatchException;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -183,43 +187,42 @@ public class TestWatchForCommit {
         ContainerTestHelper.getFixedLengthString(keyString, dataLength)
             .getBytes(UTF_8);
     key.write(data1);
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream = (KeyOutputStream)key.getOutputStream();
 
     OutputStream stream = keyOutputStream.getStreamEntries().get(0)
         .getOutputStream();
-    Assert.assertTrue(stream instanceof BlockOutputStream);
+    assertTrue(stream instanceof BlockOutputStream);
     RatisBlockOutputStream blockOutputStream = (RatisBlockOutputStream) stream;
     // we have just written data more than flush Size(2 chunks), at this time
     // buffer pool will have 3 buffers allocated worth of chunk size
-    Assert.assertEquals(4, blockOutputStream.getBufferPool().getSize());
+    assertEquals(4, blockOutputStream.getBufferPool().getSize());
     // writtenDataLength as well flushedDataLength will be updated here
-    Assert.assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
-    Assert.assertEquals(maxFlushSize,
+    assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
+    assertEquals(maxFlushSize,
         blockOutputStream.getTotalDataFlushedLength());
     // since data equals to maxBufferSize is written, this will be a blocking
     // call and hence will wait for atleast flushSize worth of data to get
     // acked by all servers right here
-    Assert.assertTrue(blockOutputStream.getTotalAckDataLength() >= flushSize);
+    assertTrue(blockOutputStream.getTotalAckDataLength() >= flushSize);
     // watchForCommit will clean up atleast one entry from the map where each
     // entry corresponds to flushSize worth of data
-    Assert.assertTrue(
+    assertTrue(
         blockOutputStream.getCommitIndex2flushedDataMap().size() <= 1);
     // Now do a flush. This will flush the data and update the flush length and
     // the map.
     key.flush();
     // Since the data in the buffer is already flushed, flush here will have
     // no impact on the counters and data structures
-    Assert.assertEquals(4, blockOutputStream.getBufferPool().getSize());
-    Assert.assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
-    Assert.assertEquals(dataLength,
-        blockOutputStream.getTotalDataFlushedLength());
+    assertEquals(4, blockOutputStream.getBufferPool().getSize());
+    assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
+    assertEquals(dataLength, blockOutputStream.getTotalDataFlushedLength());
     // flush will make sure one more entry gets updated in the map
-    Assert.assertTrue(
+    assertTrue(
         blockOutputStream.getCommitIndex2flushedDataMap().size() <= 2);
     XceiverClientRatis raftClient =
         (XceiverClientRatis) blockOutputStream.getXceiverClient();
-    Assert.assertEquals(3, raftClient.getCommitInfoMap().size());
+    assertEquals(3, raftClient.getCommitInfoMap().size());
     Pipeline pipeline = raftClient.getPipeline();
     cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
     cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
@@ -234,16 +237,13 @@ public class TestWatchForCommit {
     // and one flush for partial chunk
     key.flush();
     // Make sure the retryCount is reset after the exception is handled
-    Assert.assertTrue(keyOutputStream.getRetryCount() == 0);
+    assertEquals(0, keyOutputStream.getRetryCount());
     // now close the stream, It will update the ack length after watchForCommit
     key.close();
-    Assert
-        .assertEquals(dataLength, blockOutputStream.getTotalAckDataLength());
+    assertEquals(dataLength, blockOutputStream.getTotalAckDataLength());
     // make sure the bufferPool is empty
-    Assert
-        .assertEquals(0, blockOutputStream.getBufferPool().computeBufferData());
-    Assert.assertTrue(
-        blockOutputStream.getCommitIndex2flushedDataMap().isEmpty());
+    assertEquals(0, blockOutputStream.getBufferPool().computeBufferData());
+    assertTrue(blockOutputStream.getCommitIndex2flushedDataMap().isEmpty());
     validateData(keyName, data1);
   }
 
@@ -257,9 +257,8 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      Assert.assertEquals(1, xceiverClient.getRefcount());
-      Assert.assertEquals(container1.getPipeline(),
-          xceiverClient.getPipeline());
+      assertEquals(1, xceiverClient.getRefcount());
+      assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
       Pipeline pipeline = xceiverClient.getPipeline();
       TestHelper.createPipelineOnDatanode(pipeline, cluster);
       XceiverClientReply reply = xceiverClient.sendCommandAsync(
@@ -280,19 +279,18 @@ public class TestWatchForCommit {
         // The basic idea here is just to test if its throws an exception.
         xceiverClient
             .watchForCommit(index + new Random().nextInt(100) + 10);
-        Assert.fail("expected exception not thrown");
+        fail("expected exception not thrown");
       } catch (Exception e) {
-        Assert.assertTrue(e instanceof ExecutionException);
+        assertTrue(e instanceof ExecutionException);
         // since the timeout value is quite long, the watch request will either
         // fail with NotReplicated exceptio, RetryFailureException or
         // RuntimeException
-        Assert.assertFalse(HddsClientUtils
+        assertFalse(HddsClientUtils
             .checkForException(e) instanceof TimeoutException);
         // client should not attempt to watch with
         // MAJORITY_COMMITTED replication level, except the grpc IO issue
         if (!logCapturer.getOutput().contains("Connection refused")) {
-          Assert.assertFalse(
-              e.getMessage().contains("Watch-MAJORITY_COMMITTED"));
+          assertFalse(e.getMessage().contains("Watch-MAJORITY_COMMITTED"));
         }
       }
       clientManager.releaseClient(xceiverClient, false);
@@ -310,9 +308,8 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      Assert.assertEquals(1, xceiverClient.getRefcount());
-      Assert.assertEquals(container1.getPipeline(),
-          xceiverClient.getPipeline());
+      assertEquals(1, xceiverClient.getRefcount());
+      assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
       Pipeline pipeline = xceiverClient.getPipeline();
       TestHelper.createPipelineOnDatanode(pipeline, cluster);
       XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
@@ -321,7 +318,7 @@ public class TestWatchForCommit {
               container1.getContainerInfo().getContainerID(),
               xceiverClient.getPipeline()));
       reply.getResponse().get();
-      Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
+      assertEquals(3, ratisClient.getCommitInfoMap().size());
       List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();
       for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
         // shutdown the ratis follower
@@ -338,12 +335,12 @@ public class TestWatchForCommit {
       xceiverClient.watchForCommit(reply.getLogIndex());
 
       // commitInfo Map will be reduced to 2 here
-      Assert.assertEquals(2, ratisClient.getCommitInfoMap().size());
+      assertEquals(2, ratisClient.getCommitInfoMap().size());
       clientManager.releaseClient(xceiverClient, false);
       String output = logCapturer.getOutput();
-      Assert.assertTrue(output.contains("3 way commit failed"));
-      Assert.assertTrue(output.contains("TimeoutException"));
-      Assert.assertTrue(output.contains("Committed by majority"));
+      assertTrue(output.contains("3 way commit failed"));
+      assertTrue(output.contains("TimeoutException"));
+      assertTrue(output.contains("Committed by majority"));
     }
     logCapturer.stopCapturing();
   }
@@ -356,9 +353,8 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      Assert.assertEquals(1, xceiverClient.getRefcount());
-      Assert.assertEquals(container1.getPipeline(),
-          xceiverClient.getPipeline());
+      assertEquals(1, xceiverClient.getRefcount());
+      assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
       Pipeline pipeline = xceiverClient.getPipeline();
       XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
       long containerId = container1.getContainerInfo().getContainerID();
@@ -366,7 +362,7 @@ public class TestWatchForCommit {
           ContainerTestHelper.getCreateContainerRequest(containerId,
               xceiverClient.getPipeline()));
       reply.getResponse().get();
-      Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
+      assertEquals(3, ratisClient.getCommitInfoMap().size());
       List<Pipeline> pipelineList = new ArrayList<>();
       pipelineList.add(pipeline);
       TestHelper.waitForPipelineClose(pipelineList, cluster);
@@ -377,9 +373,9 @@ public class TestWatchForCommit {
         xceiverClient
             .watchForCommit(reply.getLogIndex() +
                 new Random().nextInt(100) + 10);
-        Assert.fail("Expected exception not thrown");
+        fail("Expected exception not thrown");
       } catch (Exception e) {
-        Assert.assertTrue(HddsClientUtils
+        assertTrue(HddsClientUtils
             .checkForException(e) instanceof GroupMismatchException);
       }
       clientManager.releaseClient(xceiverClient, false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -62,11 +62,13 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.statemachine.StateMachine;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Helpers for container tests.
@@ -186,7 +188,7 @@ public final class TestHelper {
       sha1.update(data);
       MessageDigest sha2 = MessageDigest.getInstance(OzoneConsts.FILE_HASH);
       sha2.update(readData);
-      Assert.assertTrue(Arrays.equals(sha1.digest(), sha2.digest()));
+      assertTrue(Arrays.equals(sha1.digest(), sha2.digest()));
     }
   }
 
@@ -203,7 +205,7 @@ public final class TestHelper {
         containerIdList.add(id);
       }
     }
-    Assert.assertTrue(!containerIdList.isEmpty());
+    assertTrue(!containerIdList.isEmpty());
     waitForContainerClose(cluster, containerIdList.toArray(new Long[0]));
   }
 
@@ -221,7 +223,7 @@ public final class TestHelper {
         containerIdList.add(id);
       }
     }
-    Assert.assertTrue(!containerIdList.isEmpty());
+    assertTrue(!containerIdList.isEmpty());
     waitForContainerClose(cluster, containerIdList.toArray(new Long[0]));
   }
 
@@ -239,7 +241,7 @@ public final class TestHelper {
         containerIdList.add(id);
       }
     }
-    Assert.assertTrue(!containerIdList.isEmpty());
+    assertFalse(containerIdList.isEmpty());
     waitForPipelineClose(cluster, waitForContainerCreation,
         containerIdList.toArray(new Long[0]));
   }
@@ -268,10 +270,10 @@ public final class TestHelper {
           GenericTestUtils
               .waitFor(() -> isContainerPresent(cluster, containerID, details),
                   500, 100 * 1000);
-          Assert.assertTrue(isContainerPresent(cluster, containerID, details));
+          assertTrue(isContainerPresent(cluster, containerID, details));
 
           // make sure the container gets created first
-          Assert.assertFalse(isContainerClosed(cluster, containerID, details));
+          assertFalse(isContainerClosed(cluster, containerID, details));
         }
       }
     }
@@ -294,7 +296,7 @@ public final class TestHelper {
         XceiverServerSpi server =
             cluster.getHddsDatanodes().get(cluster.getHddsDatanodeIndex(dn))
                 .getDatanodeStateMachine().getContainer().getWriteChannel();
-        Assert.assertTrue(server instanceof XceiverServerRatis);
+        assertTrue(server instanceof XceiverServerRatis);
         GenericTestUtils.waitFor(() -> !server.isExist(pipelineId),
             100, 30_000);
       }
@@ -311,7 +313,7 @@ public final class TestHelper {
               cluster.getHddsDatanodes().get(cluster.getHddsDatanodeIndex(dn))
                       .getDatanodeStateMachine().getContainer()
                       .getWriteChannel();
-      Assert.assertTrue(server instanceof XceiverServerRatis);
+      assertTrue(server instanceof XceiverServerRatis);
       try {
         server.addGroup(pipeline.getId().getProtobuf(), Collections.
                 unmodifiableList(pipeline.getNodes()));
@@ -343,10 +345,10 @@ public final class TestHelper {
         GenericTestUtils
             .waitFor(() -> isContainerPresent(cluster, containerID, details),
                 500, 100 * 1000);
-        Assert.assertTrue(isContainerPresent(cluster, containerID, details));
+        assertTrue(isContainerPresent(cluster, containerID, details));
 
         // make sure the container gets created first
-        Assert.assertFalse(isContainerClosed(cluster, containerID, details));
+        assertFalse(isContainerClosed(cluster, containerID, details));
         // send the order to close the container
         cluster.getStorageContainerManager().getEventQueue()
             .fireEvent(SCMEvents.CLOSE_CONTAINER,
@@ -366,7 +368,7 @@ public final class TestHelper {
             15 * 1000);
         //double check if it's really closed
         // (waitFor also throws an exception)
-        Assert.assertTrue(
+        assertTrue(
             isContainerClosed(cluster, containerID, datanodeDetails));
       }
       index++;
@@ -410,7 +412,7 @@ public final class TestHelper {
         services.add(service);
       }
     }
-    Assert.assertEquals(pipelineNodes.size(), services.size());
+    assertEquals(pipelineNodes.size(), services.size());
     return services;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -70,7 +70,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -631,7 +630,7 @@ public class TestBlockDeletion {
         = scm.getContainerManager().getContainerReplicas(containerId);
 
     // Ensure for all replica isEmpty are false in SCM
-    Assert.assertTrue(scm.getContainerManager().getContainerReplicas(
+    Assertions.assertTrue(scm.getContainerManager().getContainerReplicas(
             containerId).stream().
         allMatch(replica -> !replica.isEmpty()));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +58,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test container closing.
@@ -131,12 +133,11 @@ public class TestCloseContainerByPipeline {
     Pipeline pipeline = cluster.getStorageContainerManager()
         .getPipelineManager().getPipeline(container.getPipelineID());
     List<DatanodeDetails> datanodes = pipeline.getNodes();
-    Assert.assertEquals(datanodes.size(), 1);
+    assertEquals(1, datanodes.size());
 
     DatanodeDetails datanodeDetails = datanodes.get(0);
     HddsDatanodeService datanodeService = null;
-    Assert
-        .assertFalse(isContainerClosed(cluster, containerID, datanodeDetails));
+    assertFalse(isContainerClosed(cluster, containerID, datanodeDetails));
     for (HddsDatanodeService datanodeServiceItr : cluster.getHddsDatanodes()) {
       if (datanodeDetails.equals(datanodeServiceItr.getDatanodeDetails())) {
         datanodeService = datanodeServiceItr;
@@ -158,7 +159,7 @@ public class TestCloseContainerByPipeline {
         .waitFor(() -> isContainerClosed(cluster, containerID, datanodeDetails),
             500, 5 * 1000);
     // Make sure the closeContainerCommandHandler is Invoked
-    Assert.assertTrue(
+    assertTrue(
         closeContainerHandler.getInvocationCount() > lastInvocationCount);
   }
 
@@ -190,11 +191,10 @@ public class TestCloseContainerByPipeline {
     Pipeline pipeline = cluster.getStorageContainerManager()
         .getPipelineManager().getPipeline(container.getPipelineID());
     List<DatanodeDetails> datanodes = pipeline.getNodes();
-    Assert.assertEquals(datanodes.size(), 1);
+    assertEquals(1, datanodes.size());
 
     DatanodeDetails datanodeDetails = datanodes.get(0);
-    Assert
-        .assertFalse(isContainerClosed(cluster, containerID, datanodeDetails));
+    assertFalse(isContainerClosed(cluster, containerID, datanodeDetails));
 
     // Send the order to close the container, give random pipeline id so that
     // the container will not be closed via RATIS
@@ -211,13 +211,13 @@ public class TestCloseContainerByPipeline {
     GenericTestUtils
         .waitFor(() -> isContainerClosed(cluster, containerID, datanodeDetails),
             500, 5 * 1000);
-    Assert.assertTrue(isContainerClosed(cluster, containerID, datanodeDetails));
+    assertTrue(isContainerClosed(cluster, containerID, datanodeDetails));
 
     cluster.getStorageContainerManager().getPipelineManager()
         .closePipeline(pipeline, false);
     Thread.sleep(5000);
     // Pipeline close should not affect a container in CLOSED state
-    Assert.assertTrue(isContainerClosed(cluster, containerID, datanodeDetails));
+    assertTrue(isContainerClosed(cluster, containerID, datanodeDetails));
   }
 
   @Test
@@ -247,11 +247,11 @@ public class TestCloseContainerByPipeline {
     Pipeline pipeline = cluster.getStorageContainerManager()
         .getPipelineManager().getPipeline(container.getPipelineID());
     List<DatanodeDetails> datanodes = pipeline.getNodes();
-    Assert.assertEquals(3, datanodes.size());
+    assertEquals(3, datanodes.size());
 
     List<DBHandle> metadataStores = new ArrayList<>(datanodes.size());
     for (DatanodeDetails details : datanodes) {
-      Assert.assertFalse(isContainerClosed(cluster, containerID, details));
+      assertFalse(isContainerClosed(cluster, containerID, details));
       //send the order to close the container
       SCMCommand<?> command = new CloseContainerCommand(
           containerID, pipeline.getId());
@@ -270,8 +270,7 @@ public class TestCloseContainerByPipeline {
     }
 
     // There should be as many rocks db as the number of datanodes in pipeline.
-    Assert.assertEquals(datanodes.size(),
-        metadataStores.stream().distinct().count());
+    assertEquals(datanodes.size(), metadataStores.stream().distinct().count());
 
     // Make sure that it is CLOSED
     for (DatanodeDetails datanodeDetails : datanodes) {
@@ -279,8 +278,7 @@ public class TestCloseContainerByPipeline {
           () -> isContainerClosed(cluster, containerID, datanodeDetails), 500,
           15 * 1000);
       //double check if it's really closed (waitFor also throws an exception)
-      Assert.assertTrue(isContainerClosed(cluster,
-          containerID, datanodeDetails));
+      assertTrue(isContainerClosed(cluster, containerID, datanodeDetails));
     }
   }
 
@@ -313,11 +311,10 @@ public class TestCloseContainerByPipeline {
     Pipeline pipeline = cluster.getStorageContainerManager()
         .getPipelineManager().getPipeline(container.getPipelineID());
     List<DatanodeDetails> datanodes = pipeline.getNodes();
-    Assert.assertEquals(datanodes.size(), 1);
+    assertEquals(1, datanodes.size());
 
     DatanodeDetails datanodeDetails = datanodes.get(0);
-    Assert
-        .assertFalse(isContainerClosed(cluster, containerID, datanodeDetails));
+    assertFalse(isContainerClosed(cluster, containerID, datanodeDetails));
 
     // close the pipeline
     cluster.getStorageContainerManager()
@@ -328,7 +325,7 @@ public class TestCloseContainerByPipeline {
     GenericTestUtils.waitFor(
         () -> isContainerQuasiClosed(cluster, containerID, datanodeDetails),
         500, 5 * 1000);
-    Assert.assertTrue(
+    assertTrue(
         isContainerQuasiClosed(cluster, containerID, datanodeDetails));
 
     // Send close container command from SCM to datanode with forced flag as
@@ -342,8 +339,7 @@ public class TestCloseContainerByPipeline {
     GenericTestUtils
         .waitFor(() -> isContainerClosed(
             cluster, containerID, datanodeDetails), 500, 5 * 1000);
-    Assert.assertTrue(
-        isContainerClosed(cluster, containerID, datanodeDetails));
+    assertTrue(isContainerClosed(cluster, containerID, datanodeDetails));
   }
 
   private Boolean isContainerClosed(MiniOzoneCluster ozoneCluster,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
@@ -62,23 +62,19 @@ import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.ozone.test.GenericTestUtils;
-
 import com.google.common.collect.Maps;
-
-import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
-import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
-
 import org.apache.ratis.rpc.RpcType;
-
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
-import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
 import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.apache.ratis.util.function.CheckedBiFunction;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
+import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
 
 /**
  * Test Containers.
@@ -174,7 +170,7 @@ public class TestContainerServer {
           ContainerTestHelper
               .getCreateContainerRequest(
                   ContainerTestHelper.getTestContainerID(), pipeline);
-      Assert.assertNotNull(request.getTraceID());
+      Assertions.assertNotNull(request.getTraceID());
 
       client.sendCommand(request);
     } finally {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -96,9 +95,9 @@ public class TestRandomKeyGenerator {
         "--num-of-buckets", "5",
         "--num-of-keys", "10");
 
-    Assert.assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
     randomKeyGenerator.printStats(System.out);
   }
 
@@ -114,9 +113,9 @@ public class TestRandomKeyGenerator {
         "--type", "EC"
     );
 
-    Assert.assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
   }
 
   @Test
@@ -133,9 +132,9 @@ public class TestRandomKeyGenerator {
         "--type", "RATIS"
     );
 
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(10, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
   }
 
   @Test
@@ -152,9 +151,9 @@ public class TestRandomKeyGenerator {
         "--type", "RATIS"
     );
 
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(10, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
   }
 
   @Test
@@ -172,10 +171,10 @@ public class TestRandomKeyGenerator {
         "--validate-writes"
     );
 
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
-    Assert.assertEquals(1, randomKeyGenerator.getSuccessfulValidationCount());
+    assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(1, randomKeyGenerator.getSuccessfulValidationCount());
   }
 
   @Test
@@ -193,10 +192,10 @@ public class TestRandomKeyGenerator {
         "--validate-writes"
     );
 
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
-    Assert.assertEquals(1, randomKeyGenerator.getSuccessfulValidationCount());
+    assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(1, randomKeyGenerator.getSuccessfulValidationCount());
   }
 
   @Test
@@ -212,8 +211,8 @@ public class TestRandomKeyGenerator {
         "--type", "RATIS"
     );
 
-    Assert.assertEquals(10, randomKeyGenerator.getThreadPoolSize());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(10, randomKeyGenerator.getThreadPoolSize());
+    assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
   }
 
   @Test
@@ -230,10 +229,10 @@ public class TestRandomKeyGenerator {
         "--clean-objects"
     );
 
-    Assert.assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
-    Assert.assertEquals(2, randomKeyGenerator.getNumberOfVolumesCleaned());
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCleaned());
+    assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(2, randomKeyGenerator.getNumberOfVolumesCleaned());
+    assertEquals(10, randomKeyGenerator.getNumberOfBucketsCleaned());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -49,7 +49,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.grpc.server.GrpcLogAppender;
 import org.apache.ratis.server.leader.FollowerInfo;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -58,6 +57,11 @@ import org.slf4j.event.Level;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_DUMMY_SERVICE_ID;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.TestOzoneManagerHA.createKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for OM bootstrap process.
@@ -123,14 +127,14 @@ public class TestAddRemoveOzoneManager {
     // Check that new peer exists in all OMs peers list and also in their Ratis
     // server's peer list
     for (OzoneManager om : cluster.getOzoneManagersList()) {
-      Assert.assertTrue("New OM node " + nodeId + " not present in Peer list " +
-          "of OM " + om.getOMNodeId(), om.doesPeerExist(nodeId));
-      Assert.assertTrue("New OM node " + nodeId + " not present in Peer list " +
-              "of OM " + om.getOMNodeId() + " RatisServer",
-          om.getOmRatisServer().doesPeerExist(nodeId));
-      Assert.assertTrue("New OM node " + nodeId + " not present in " +
-              "OM " + om.getOMNodeId() + "RatisServer's RaftConf",
-          om.getOmRatisServer().getCurrentPeersFromRaftConf().contains(nodeId));
+      assertTrue(om.doesPeerExist(nodeId), "New OM node " + nodeId
+          + " not present in Peer list of OM " + om.getOMNodeId());
+      assertTrue(om.getOmRatisServer().doesPeerExist(nodeId), "New OM node " + nodeId
+          + " not present in Peer list of OM " + om.getOMNodeId() + " RatisServer");
+      assertTrue(
+          om.getOmRatisServer().getCurrentPeersFromRaftConf().contains(nodeId),
+          "New OM node " + nodeId + " not present in " + "OM "
+              + om.getOMNodeId() + "RatisServer's RaftConf");
     }
 
     OzoneManager newOM = cluster.getOzoneManager(nodeId);
@@ -140,8 +144,7 @@ public class TestAddRemoveOzoneManager {
 
     // Check Ratis Dir for log files
     File[] logFiles = getRatisLogFiles(newOM);
-    Assert.assertTrue("There are no ratis logs in new OM ",
-        logFiles.length > 0);
+    assertTrue(logFiles.length > 0, "There are no ratis logs in new OM ");
   }
 
   private File[] getRatisLogFiles(OzoneManager om) {
@@ -194,8 +197,9 @@ public class TestAddRemoveOzoneManager {
     GenericTestUtils.waitFor(() -> cluster.getOMLeader() != null, 500, 30000);
     OzoneManager omLeader = cluster.getOMLeader();
 
-    Assert.assertTrue("New Bootstrapped OM not elected Leader even though " +
-        "other OMs are down", newOMNodeIds.contains(omLeader.getOMNodeId()));
+    assertTrue(newOMNodeIds.contains(omLeader.getOMNodeId()),
+        "New Bootstrapped OM not elected Leader even though" +
+            " other OMs are down");
 
     // Perform some read and write operations with new OM leader
     IOUtils.closeQuietly(client);
@@ -206,7 +210,7 @@ public class TestAddRemoveOzoneManager {
     OzoneBucket bucket = volume.getBucket(BUCKET_NAME);
     String key = createKey(bucket);
 
-    Assert.assertNotNull(bucket.getKey(key));
+    assertNotNull(bucket.getKey(key));
   }
 
   /**
@@ -236,16 +240,16 @@ public class TestAddRemoveOzoneManager {
     String newNodeId = "omNode-bootstrap-1";
     try {
       cluster.bootstrapOzoneManager(newNodeId, false, false);
-      Assert.fail("Bootstrap should have failed as configs are not updated on" +
+      fail("Bootstrap should have failed as configs are not updated on" +
           " all OMs.");
     } catch (Exception e) {
-      Assert.assertEquals(OmUtils.getOMAddressListPrintString(
+      assertEquals(OmUtils.getOMAddressListPrintString(
           Lists.newArrayList(existingOM.getNodeDetails())) + " do not have or" +
           " have incorrect information of the bootstrapping OM. Update their " +
           "ozone-site.xml before proceeding.", e.getMessage());
-      Assert.assertTrue(omLog.getOutput().contains("Remote OM config check " +
+      assertTrue(omLog.getOutput().contains("Remote OM config check " +
           "failed on OM " + existingOMNodeId));
-      Assert.assertTrue(miniOzoneClusterLog.getOutput().contains(newNodeId +
+      assertTrue(miniOzoneClusterLog.getOutput().contains(newNodeId +
           " - System Exit"));
     }
 
@@ -264,14 +268,14 @@ public class TestAddRemoveOzoneManager {
     try {
       cluster.bootstrapOzoneManager(newNodeId, false, true);
     } catch (IOException e) {
-      Assert.assertTrue(omLog.getOutput().contains("Couldn't add OM " +
+      assertTrue(omLog.getOutput().contains("Couldn't add OM " +
           newNodeId + " to peer list."));
-      Assert.assertTrue(miniOzoneClusterLog.getOutput().contains(
+      assertTrue(miniOzoneClusterLog.getOutput().contains(
           existingOMNodeId + " - System Exit: There is no OM configuration " +
               "for node ID " + newNodeId + " in ozone-site.xml."));
 
       // Verify that the existing OM has stopped.
-      Assert.assertFalse(cluster.getOzoneManager(existingOMNodeId).isRunning());
+      assertFalse(cluster.getOzoneManager(existingOMNodeId).isRunning());
     }
   }
 
@@ -310,18 +314,18 @@ public class TestAddRemoveOzoneManager {
     String newNodeId = "omNode-bootstrap-1";
     try {
       cluster.bootstrapOzoneManager(newNodeId, true, false);
-      Assert.fail("Bootstrap should have failed as configs are not updated on" +
+      fail("Bootstrap should have failed as configs are not updated on" +
           " all OMs.");
     } catch (IOException e) {
-      Assert.assertEquals(OmUtils.getOMAddressListPrintString(
+      assertEquals(OmUtils.getOMAddressListPrintString(
           Lists.newArrayList(downOM.getNodeDetails())) + " do not have or " +
           "have incorrect information of the bootstrapping OM. Update their " +
           "ozone-site.xml before proceeding.", e.getMessage());
-      Assert.assertTrue(omLog.getOutput().contains("Remote OM " + downOMNodeId +
+      assertTrue(omLog.getOutput().contains("Remote OM " + downOMNodeId +
           " configuration returned null"));
-      Assert.assertTrue(omLog.getOutput().contains("Remote OM config check " +
+      assertTrue(omLog.getOutput().contains("Remote OM config check " +
           "failed on OM " + downOMNodeId));
-      Assert.assertTrue(miniOzoneClusterLog.getOutput().contains(newNodeId +
+      assertTrue(miniOzoneClusterLog.getOutput().contains(newNodeId +
           " - System Exit"));
     }
 
@@ -338,7 +342,7 @@ public class TestAddRemoveOzoneManager {
     OzoneManager newOM = cluster.getOzoneManager(newNodeId);
 
     // Verify that the newly bootstrapped OM is running
-    Assert.assertTrue(newOM.isRunning());
+    assertTrue(newOM.isRunning());
   }
 
   /**
@@ -375,7 +379,7 @@ public class TestAddRemoveOzoneManager {
     OzoneBucket bucket = volume.getBucket(BUCKET_NAME);
     String key = createKey(bucket);
 
-    Assert.assertNotNull(bucket.getKey(key));
+    assertNotNull(bucket.getKey(key));
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -87,7 +87,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 
 import org.apache.ozone.test.GenericTestUtils;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -931,7 +930,7 @@ public class TestOMDbCheckpointServlet {
       ExecutorService executorService) {
     Future<Boolean> test = checkLock(handler, executorService);
     // Handler should fail to take the lock because the servlet has taken it.
-    Assert.assertThrows(TimeoutException.class,
+    Assertions.assertThrows(TimeoutException.class,
          () -> test.get(500, TimeUnit.MILLISECONDS));
   }
 
@@ -943,7 +942,7 @@ public class TestOMDbCheckpointServlet {
         handler.getBootstrapStateLock().lock()) {
       Future<Boolean> test = checkLock(servlet, executorService);
       // Servlet should fail to lock when other handler has taken it.
-      Assert.assertThrows(TimeoutException.class,
+      Assertions.assertThrows(TimeoutException.class,
           () -> test.get(500, TimeUnit.MILLISECONDS));
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.ReconNamespaceSummaryManagerImpl;
 import org.apache.ozone.test.GenericTestUtils;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
@@ -60,12 +59,9 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
-
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_PATH_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
-
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -136,7 +132,7 @@ public class TestReconInsightsForDeletedDirectories {
         fs.delete(fileStatus.getPath(), true);
       }
     } catch (IOException ex) {
-      fail("Failed to cleanup files.");
+      Assertions.fail("Failed to cleanup files.");
     }
   }
 
@@ -205,7 +201,7 @@ public class TestReconInsightsForDeletedDirectories {
     }
 
     if (directoryObjectId == null) {
-      fail("directoryObjectId is null. Test case cannot proceed.");
+      Assertions.fail("directoryObjectId is null. Test case cannot proceed.");
     }
 
     // Retrieve Namespace Summary for dir1 from Recon.
@@ -215,8 +211,8 @@ public class TestReconInsightsForDeletedDirectories {
     NSSummary summary =
         namespaceSummaryManager.getNSSummary(directoryObjectId);
     // Assert that the directory dir1 has 10 sub-files and size of 1000 bytes.
-    Assert.assertEquals(10, summary.getNumOfFiles());
-    Assert.assertEquals(10, summary.getSizeOfFiles());
+    Assertions.assertEquals(10, summary.getNumOfFiles());
+    Assertions.assertEquals(10, summary.getSizeOfFiles());
 
     // Delete the entire directory dir1.
     fs.delete(dir1, true);
@@ -242,7 +238,7 @@ public class TestReconInsightsForDeletedDirectories {
     KeyInsightInfoResponse entity =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
     // Assert the size of deleted directory is 10.
-    Assert.assertEquals(10, entity.getUnreplicatedDataSize());
+    Assertions.assertEquals(10, entity.getUnreplicatedDataSize());
 
     // Cleanup the tables.
     cleanupTables();
@@ -331,7 +327,7 @@ public class TestReconInsightsForDeletedDirectories {
     KeyInsightInfoResponse entity =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
     // Assert the size of deleted directory is 3.
-    Assert.assertEquals(3, entity.getUnreplicatedDataSize());
+    Assertions.assertEquals(3, entity.getUnreplicatedDataSize());
 
     // Cleanup the tables.
     cleanupTables();
@@ -393,7 +389,7 @@ public class TestReconInsightsForDeletedDirectories {
     KeyInsightInfoResponse entity =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
     // Assert the size of deleted directory is 100.
-    Assert.assertEquals(100, entity.getUnreplicatedDataSize());
+    Assertions.assertEquals(100, entity.getUnreplicatedDataSize());
 
     // Cleanup the tables.
     cleanupTables();
@@ -475,7 +471,7 @@ public class TestReconInsightsForDeletedDirectories {
       LOG.info("{} actual row count={}, expectedCount={}", table.getName(),
           count, expectedCount);
     } catch (IOException ex) {
-      fail("Test failed with: " + ex);
+      Assertions.fail("Test failed with: " + ex);
     }
     return count == expectedCount;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
@@ -202,17 +202,17 @@ public class TestReconInsightsForDeletedDirectories {
 
     if (directoryObjectId == null) {
       Assertions.fail("directoryObjectId is null. Test case cannot proceed.");
+    } else {
+      // Retrieve Namespace Summary for dir1 from Recon.
+      ReconNamespaceSummaryManagerImpl namespaceSummaryManager =
+          (ReconNamespaceSummaryManagerImpl) cluster.getReconServer()
+              .getReconNamespaceSummaryManager();
+      NSSummary summary =
+          namespaceSummaryManager.getNSSummary(directoryObjectId);
+      // Assert that the directory dir1 has 10 sub-files and size of 1000 bytes.
+      Assertions.assertEquals(10, summary.getNumOfFiles());
+      Assertions.assertEquals(10, summary.getSizeOfFiles());
     }
-
-    // Retrieve Namespace Summary for dir1 from Recon.
-    ReconNamespaceSummaryManagerImpl namespaceSummaryManager =
-        (ReconNamespaceSummaryManagerImpl) cluster.getReconServer()
-            .getReconNamespaceSummaryManager();
-    NSSummary summary =
-        namespaceSummaryManager.getNSSummary(directoryObjectId);
-    // Assert that the directory dir1 has 10 sub-files and size of 1000 bytes.
-    Assertions.assertEquals(10, summary.getNumOfFiles());
-    Assertions.assertEquals(10, summary.getSizeOfFiles());
 
     // Delete the entire directory dir1.
     fs.delete(dir1, true);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
@@ -42,8 +42,6 @@ import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +55,10 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerBalancerConfigurationProto;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getContainer;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests failover with SCM HA setup.
@@ -113,10 +115,10 @@ public class TestFailoverWithSCMHA {
     scmClientConfig.setRetryCount(1);
     scmClientConfig.setRetryInterval(100);
     scmClientConfig.setMaxRetryTimeout(1500);
-    Assert.assertEquals(scmClientConfig.getRetryCount(), 15);
+    assertEquals(scmClientConfig.getRetryCount(), 15);
     conf.setFromObject(scmClientConfig);
     StorageContainerManager scm = getLeader(cluster);
-    Assert.assertNotNull(scm);
+    assertNotNull(scm);
     SCMBlockLocationFailoverProxyProvider failoverProxyProvider =
         new SCMBlockLocationFailoverProxyProvider(conf);
     failoverProxyProvider.changeCurrentProxy(scm.getSCMNodeId());
@@ -131,7 +133,7 @@ public class TestFailoverWithSCMHA {
         .createProxy(scmBlockLocationClient, ScmBlockLocationProtocol.class,
             conf);
     scmBlockLocationProtocol.getScmInfo();
-    Assert.assertTrue(logCapture.getOutput()
+    assertTrue(logCapture.getOutput()
         .contains("Performing failover to suggested leader"));
     scm = getLeader(cluster);
     SCMContainerLocationFailoverProxyProvider proxyProvider =
@@ -148,7 +150,7 @@ public class TestFailoverWithSCMHA {
 
     scmContainerClient.allocateContainer(HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.ONE, "ozone");
-    Assert.assertTrue(logCapture.getOutput()
+    assertTrue(logCapture.getOutput()
         .contains("Performing failover to suggested leader"));
   }
 
@@ -159,10 +161,10 @@ public class TestFailoverWithSCMHA {
     scmClientConfig.setRetryCount(1);
     scmClientConfig.setRetryInterval(100);
     scmClientConfig.setMaxRetryTimeout(1500);
-    Assert.assertEquals(scmClientConfig.getRetryCount(), 15);
+    assertEquals(scmClientConfig.getRetryCount(), 15);
     conf.setFromObject(scmClientConfig);
     StorageContainerManager scm = getLeader(cluster);
-    Assert.assertNotNull(scm);
+    assertNotNull(scm);
 
     final ContainerID id =
         getContainer(HddsProtos.LifeCycleState.CLOSED).containerID();
@@ -190,19 +192,19 @@ public class TestFailoverWithSCMHA {
         .createProxy(scmBlockLocationClient, ScmBlockLocationProtocol.class,
             conf);
     scmBlockLocationProtocol.getScmInfo();
-    Assert.assertTrue(logCapture.getOutput()
+    assertTrue(logCapture.getOutput()
         .contains("Performing failover to suggested leader"));
     scm = getLeader(cluster);
-    Assert.assertNotNull(scm);
+    assertNotNull(scm);
 
     //switch to the new leader successfully, new leader should
     //get the same inflightMove
     Map<ContainerID, MoveDataNodePair> inflightMove =
         scm.getReplicationManager().getMoveScheduler().getInflightMove();
-    Assert.assertTrue(inflightMove.containsKey(id));
+    assertTrue(inflightMove.containsKey(id));
     MoveDataNodePair mp = inflightMove.get(id);
-    Assert.assertTrue(dn2.equals(mp.getTgt()));
-    Assert.assertTrue(dn1.equals(mp.getSrc()));
+    assertTrue(dn2.equals(mp.getTgt()));
+    assertTrue(dn1.equals(mp.getSrc()));
 
     //complete move in the new leader
     scm.getReplicationManager().getMoveScheduler()
@@ -223,17 +225,17 @@ public class TestFailoverWithSCMHA {
 
     scmContainerClient.allocateContainer(HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.ONE, "ozone");
-    Assert.assertTrue(logCapture.getOutput()
+    assertTrue(logCapture.getOutput()
         .contains("Performing failover to suggested leader"));
 
     //switch to the new leader successfully, new leader should
     //get the same inflightMove , which should not contains
     //that container.
     scm = getLeader(cluster);
-    Assert.assertNotNull(scm);
+    assertNotNull(scm);
     inflightMove = scm.getReplicationManager()
         .getMoveScheduler().getInflightMove();
-    Assert.assertFalse(inflightMove.containsKey(id));
+    assertFalse(inflightMove.containsKey(id));
   }
 
   /**
@@ -257,14 +259,14 @@ public class TestFailoverWithSCMHA {
         conf.getObject(SCMClientConfig.class);
     scmClientConfig.setRetryInterval(100);
     scmClientConfig.setMaxRetryTimeout(1500);
-    Assertions.assertEquals(15, scmClientConfig.getRetryCount());
+    assertEquals(15, scmClientConfig.getRetryCount());
     conf.setFromObject(scmClientConfig);
     StorageContainerManager leader = getLeader(cluster);
-    Assertions.assertNotNull(leader);
+    assertNotNull(leader);
 
     ScmClient scmClient = new ContainerOperationClient(conf);
     // assert that container balancer is not running right now
-    Assertions.assertFalse(scmClient.getContainerBalancerStatus());
+    assertFalse(scmClient.getContainerBalancerStatus());
     ContainerBalancerConfiguration balancerConf =
         conf.getObject(ContainerBalancerConfiguration.class);
     ContainerBalancer containerBalancer = leader.getContainerBalancer();
@@ -278,7 +280,7 @@ public class TestFailoverWithSCMHA {
     // assert that balancer has stopped since the cluster is already balanced
     GenericTestUtils.waitFor(() -> !containerBalancer.isBalancerRunning(),
         10, 500);
-    Assertions.assertFalse(containerBalancer.isBalancerRunning());
+    assertFalse(containerBalancer.isBalancerRunning());
 
     ByteString byteString =
         leader.getScmMetadataStore().getStatefulServiceConfigTable().get(
@@ -315,7 +317,7 @@ public class TestFailoverWithSCMHA {
               containerBalancer.getServiceName());
       ContainerBalancerConfigurationProto protobuf =
           ContainerBalancerConfigurationProto.parseFrom(byteString);
-      Assertions.assertFalse(protobuf.getShouldRun());
+      assertFalse(protobuf.getShouldRun());
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -63,6 +62,7 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic
 import static org.apache.hadoop.hdds.client.ReplicationFactor.THREE;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test cases to verify the metrics exposed by SCMPipelineManager.
@@ -151,10 +151,10 @@ public class TestSCMContainerPlacementPolicyMetrics {
         getLongCounter("DatanodeChooseFallbackCount", metrics);
 
     // Seems no under-replicated closed containers get replicated
-    Assert.assertTrue(totalRequest == 0);
-    Assert.assertTrue(tryCount == 0);
-    Assert.assertTrue(sucessCount == 0);
-    Assert.assertTrue(compromiseCount == 0);
+    assertEquals(0, totalRequest);
+    assertEquals(0, tryCount);
+    assertEquals(0, sucessCount);
+    assertEquals(0, compromiseCount);
   }
 
   @AfterEach

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -48,11 +48,13 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.server.protocol.TermIndex;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.ratis.util.LifeCycle;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -123,7 +125,7 @@ public class TestSCMInstallSnapshotWithHA {
   public void testInstallSnapshot() throws Exception {
     // Get the leader SCM
     StorageContainerManager leaderSCM = getLeader(cluster);
-    Assert.assertNotNull(leaderSCM);
+    assertNotNull(leaderSCM);
     // Find the inactive SCM
     String followerId = getInactiveSCM(cluster).getSCMNodeId();
 
@@ -155,7 +157,7 @@ public class TestSCMInstallSnapshotWithHA {
     // made while it was inactive.
     SCMMetadataStore followerMetaStore = followerSCM.getScmMetadataStore();
     for (ContainerInfo containerInfo : containers) {
-      Assert.assertNotNull(followerMetaStore.getContainerTable()
+      assertNotNull(followerMetaStore.getContainerTable()
           .get(containerInfo.containerID()));
     }
   }
@@ -206,12 +208,12 @@ public class TestSCMInstallSnapshotWithHA {
     }
 
     String errorMsg = "Reloading old state of SCM";
-    Assert.assertTrue(logCapture.getOutput().contains(errorMsg));
-    Assert.assertNull(" installed checkpoint even though checkpoint " +
-        "logIndex is less than it's lastAppliedIndex", newTermIndex);
-    Assert.assertEquals(followerTermIndex,
+    assertTrue(logCapture.getOutput().contains(errorMsg));
+    assertNull(newTermIndex, " installed checkpoint even though checkpoint " +
+        "logIndex is less than it's lastAppliedIndex");
+    assertEquals(followerTermIndex,
         followerSM.getLastAppliedTermIndex());
-    Assert.assertFalse(followerSM.getLifeCycleState().isPausingOrPaused());
+    assertFalse(followerSM.getLifeCycleState().isPausingOrPaused());
   }
 
   @Test
@@ -235,7 +237,7 @@ public class TestSCMInstallSnapshotWithHA {
         .getTrxnInfoFromCheckpoint(conf, leaderCheckpointLocation,
             new SCMDBDefinition());
 
-    Assert.assertNotNull(leaderCheckpointLocation);
+    assertNotNull(leaderCheckpointLocation);
     // Take a backup of the current DB
     String dbBackupName =
         "SCM_CHECKPOINT_BACKUP" + termIndex.getIndex() + "_" + System
@@ -272,17 +274,17 @@ public class TestSCMInstallSnapshotWithHA {
     scmhaManager.installCheckpoint(leaderCheckpointLocation,
         leaderCheckpointTrxnInfo);
 
-    Assert.assertTrue(logCapture.getOutput()
+    assertTrue(logCapture.getOutput()
         .contains("Failed to reload SCM state and instantiate services."));
     final LifeCycle.State s = followerSM.getLifeCycleState();
-    Assert.assertTrue("Unexpected lifeCycle state: " + s,
-        s == LifeCycle.State.NEW || s.isPausingOrPaused());
+    assertTrue(s == LifeCycle.State.NEW || s.isPausingOrPaused(),
+        "Unexpected lifeCycle state: " + s);
 
     // Verify correct reloading
     followerSM.setInstallingSnapshotData(
         new RocksDBCheckpoint(checkpointBackup.toPath()), null);
     followerSM.reinitialize();
-    Assert.assertEquals(followerSM.getLastAppliedTermIndex(),
+    assertEquals(followerSM.getLastAppliedTermIndex(),
         leaderCheckpointTrxnInfo.getTermIndex());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -211,8 +211,7 @@ public class TestSCMInstallSnapshotWithHA {
     assertTrue(logCapture.getOutput().contains(errorMsg));
     assertNull(newTermIndex, " installed checkpoint even though checkpoint " +
         "logIndex is less than it's lastAppliedIndex");
-    assertEquals(followerTermIndex,
-        followerSM.getLastAppliedTermIndex());
+    assertEquals(followerTermIndex, followerSM.getLastAppliedTermIndex());
     assertFalse(followerSM.getLifeCycleState().isPausingOrPaused());
   }
 
@@ -277,8 +276,7 @@ public class TestSCMInstallSnapshotWithHA {
     assertTrue(logCapture.getOutput()
         .contains("Failed to reload SCM state and instantiate services."));
     final LifeCycle.State s = followerSM.getLifeCycleState();
-    assertTrue(s == LifeCycle.State.NEW || s.isPausingOrPaused(),
-        "Unexpected lifeCycle state: " + s);
+    assertTrue(s == LifeCycle.State.NEW || s.isPausingOrPaused(), "Unexpected lifeCycle state: " + s);
 
     // Verify correct reloading
     followerSM.setInstallingSnapshotData(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -85,7 +85,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -1879,7 +1878,7 @@ public class TestOzoneShellHA {
     final ArrayList<LinkedTreeMap<String, String>> bucketListOut =
         parseOutputIntoArrayList();
 
-    Assert.assertTrue(bucketListOut.size() == 1);
+    assertEquals(1, bucketListOut.size());
     boolean link =
         String.valueOf(bucketListOut.get(0).get("link")).equals("false");
     assertTrue(link);
@@ -1898,7 +1897,7 @@ public class TestOzoneShellHA {
     final ArrayList<LinkedTreeMap<String, String>> bucketListLinked =
         parseOutputIntoArrayList();
 
-    Assert.assertTrue(bucketListLinked.size() == 2);
+    assertEquals(2, bucketListLinked.size());
     link = String.valueOf(bucketListLinked.get(1).get("link")).equals("true");
     assertTrue(link);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrate assertions in the following test classes to JUnit5:
```
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/sim/pipeline/TestLeaderChoosePolicy.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHddsUpgradeUtils.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/roc/TestContainerStateMachineFailures.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestRandomKeyGenerator.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OMUpgradeTestUtils.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeys.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java

```
Skipped one file which didn't need any change: 
```
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9809

## How was this patch tested?
Tested the suspected test cases manually and all the tested all the tests in CI-CD pipeline.
