### PR TITLE
HDDS-9950. 'ozone fs -ls' on volume shows the volume owner as the bucket owner

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1018,31 +1018,31 @@ public class TestRootedOzoneFileSystem {
    */
   @Test
   public void testListStatusWithDifferentBucketOwner() throws IOException {
-    String volumeName = getRandomNonExistVolumeName();
-    objectStore.createVolume(volumeName);
-    OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
+    String volName = getRandomNonExistVolumeName();
+    objectStore.createVolume(volName);
+    OzoneVolume ozoneVolume = objectStore.getVolume(volName);
 
-    String bucketName = "bucket-" + RandomStringUtils.randomNumeric(5);
+    String buckName = "bucket-" + RandomStringUtils.randomNumeric(5);
     UserGroupInformation currUgi = UserGroupInformation.getCurrentUser();
     String bucketOwner = currUgi.getUserName() + RandomStringUtils.randomNumeric(5);
     BucketArgs bucketArgs = BucketArgs.newBuilder()
         .setOwner(bucketOwner)
         .build();
-    ozoneVolume.createBucket(bucketName, bucketArgs);
+    ozoneVolume.createBucket(buckName, bucketArgs);
 
-    Path volumePath = new Path(OZONE_URI_DELIMITER + volumeName);
+    Path volPath = new Path(OZONE_URI_DELIMITER + volName);
 
-    OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
+    OzoneBucket ozoneBucket = ozoneVolume.getBucket(buckName);
 
-    FileStatus[] fileStatusVolume = ofs.listStatus(volumePath);
+    FileStatus[] fileStatusVolume = ofs.listStatus(volPath);
     assertEquals(1, fileStatusVolume.length);
     // FileStatus owner is different from the volume owner.
     // Owner is the same as the bucket owner returned by the ObjectStore.
     assertNotEquals(ozoneVolume.getOwner(), fileStatusVolume[0].getOwner());
     assertEquals(ozoneBucket.getOwner(), fileStatusVolume[0].getOwner());
 
-    ozoneVolume.deleteBucket(bucketName);
-    objectStore.deleteVolume(volumeName);
+    ozoneVolume.deleteBucket(buckName);
+    objectStore.deleteVolume(volName);
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -790,15 +790,14 @@ public class BasicRootedOzoneClientAdapterImpl
     OFSPath ofsStartPath = new OFSPath(startPath, config);
     // list buckets in the volume
     OzoneVolume volume = objectStore.getVolume(volumeStr);
-    UserGroupInformation ugi =
-        UserGroupInformation.createRemoteUser(volume.getOwner());
-    String owner = ugi.getShortUserName();
-    String group = getGroupName(ugi);
     Iterator<? extends OzoneBucket> iter =
         volume.listBuckets(null, ofsStartPath.getBucketName());
     List<FileStatusAdapter> res = new ArrayList<>();
     while (iter.hasNext() && res.size() < numEntries) {
       OzoneBucket bucket = iter.next();
+      UserGroupInformation ugi = UserGroupInformation.createRemoteUser(bucket.getOwner());
+      String owner = ugi.getShortUserName();
+      String group = getGroupName(ugi);
       res.add(getFileStatusAdapterForBucket(bucket, uri, owner, group));
       if (recursive) {
         String pathStrNext = volumeStr + OZONE_URI_DELIMITER + bucket.getName();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -795,10 +795,7 @@ public class BasicRootedOzoneClientAdapterImpl
     List<FileStatusAdapter> res = new ArrayList<>();
     while (iter.hasNext() && res.size() < numEntries) {
       OzoneBucket bucket = iter.next();
-      UserGroupInformation ugi = UserGroupInformation.createRemoteUser(bucket.getOwner());
-      String owner = ugi.getShortUserName();
-      String group = getGroupName(ugi);
-      res.add(getFileStatusAdapterForBucket(bucket, uri, owner, group));
+      res.add(getFileStatusAdapterForBucket(bucket, uri));
       if (recursive) {
         String pathStrNext = volumeStr + OZONE_URI_DELIMITER + bucket.getName();
         res.addAll(listStatus(pathStrNext, recursive, startPath,
@@ -1160,12 +1157,9 @@ public class BasicRootedOzoneClientAdapterImpl
    * Generate a FileStatusAdapter for a bucket.
    * @param ozoneBucket OzoneBucket object.
    * @param uri Full URI to OFS root.
-   * @param owner Owner of the parent volume of the bucket.
-   * @param group Group of the parent volume of the bucket.
    * @return FileStatusAdapter for a bucket.
    */
-  private static FileStatusAdapter getFileStatusAdapterForBucket(
-      OzoneBucket ozoneBucket, URI uri, String owner, String group) {
+  private static FileStatusAdapter getFileStatusAdapterForBucket(OzoneBucket ozoneBucket, URI uri) {
     String pathStr = uri.toString() +
         OZONE_URI_DELIMITER + ozoneBucket.getVolumeName() +
         OZONE_URI_DELIMITER + ozoneBucket.getName();
@@ -1175,6 +1169,9 @@ public class BasicRootedOzoneClientAdapterImpl
               ozoneBucket.getName(), pathStr);
     }
     Path path = new Path(pathStr);
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(ozoneBucket.getOwner());
+    String owner = ugi.getShortUserName();
+    String group = getGroupName(ugi);
     return new FileStatusAdapter(0L, 0L, path, true, (short)0, 0L,
         ozoneBucket.getCreationTime().getEpochSecond() * 1000, 0L,
         FsPermission.getDirDefault().toShort(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

When doing a `listStatus` on a volume, we are setting the volume owner as the resource owner. Therefore, `ozone fs -ls` is resulting in displaying the volume owner as the owner of every bucket. 

Check the jira description for a test-case for manually reproducing it. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9950

## How was this patch tested?

A new test was added under `TestRootedOzoneFileSystem`. The patch was also tested manually in ozone docker dev env like so
```
> pwd
/projects/ozone/hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose/ozone

  // Start docker env
> docker-compose up --scale datanode=5 -d

  // Create volume with the default user, hadoop
> docker-compose exec om ozone sh volume create /vol1

  // Create bucket and set the owner as testuser
> docker-compose exec om ozone sh bucket create /vol1/bucket1 --user testuser 

  // Create bucket and set the owner as testuser2
> docker-compose exec om ozone sh bucket create /vol1/bucket2 --user testuser2 

  // fs -ls
> docker-compose exec om ozone fs -ls /vol1                
Found 2 items
drwxrwxrwx   - testuser  testuser           0 2023-12-18 16:57 /vol1/bucket1
drwxrwxrwx   - testuser2 testuser2          0 2023-12-18 16:57 /vol1/bucket2

  // update the volume owner
> docker-compose exec om ozone sh volume update --user testuser /vol1
{
  "metadata" : { },
  "name" : "vol1",
  "admin" : "hadoop",
  "owner" : "testuser",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "usedNamespace" : 2,
  "creationTime" : "2023-12-18T16:57:07.500Z",
  "modificationTime" : "2023-12-18T16:57:40.318Z",
  "acls" : [ {
    "type" : "USER",
    "name" : "hadoop",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  }, {
    "type" : "GROUP",
    "name" : "hadoop",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  } ],
  "refCount" : 0
}

  // fs -ls
> docker-compose exec om ozone fs -ls /vol1
Found 2 items
drwxrwxrwx   - testuser  testuser           0 2023-12-18 16:57 /vol1/bucket1
drwxrwxrwx   - testuser2 testuser2          0 2023-12-18 16:57 /vol1/bucket2
```