### PR TITLE
HDDS-9953. Simplify assertions in hadoop-hdds

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderExceptionMessageParsing.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderExceptionMessageParsing.java
@@ -56,8 +56,7 @@ class TestServerNotLeaderExceptionMessageParsing {
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
     snle = new ServerNotLeaderException(message);
-    Assertions.assertEquals(null,
-        snle.getSuggestedLeader());
+    Assertions.assertNull(snle.getSuggestedLeader());
 
     message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
         "leader.Suggested leader is Server:localhost:98634:8988 \n" +
@@ -72,8 +71,7 @@ class TestServerNotLeaderExceptionMessageParsing {
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java)";
     snle = new ServerNotLeaderException(message);
-    Assertions.assertEquals(null,
-        snle.getSuggestedLeader());
+    Assertions.assertNull(snle.getSuggestedLeader());
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/common/helpers/TestExcludeList.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/common/helpers/TestExcludeList.java
@@ -39,9 +39,9 @@ public class TestExcludeList {
         .setIpAddress("127.0.0.1").setHostName("localhost").addPort(
             DatanodeDetails.newPort(DatanodeDetails.Port.Name.STANDALONE, 2001))
         .build());
-    Assertions.assertTrue(list.getDatanodes().size() == 1);
+    Assertions.assertEquals(1, list.getDatanodes().size());
     clock.fastForward(11);
-    Assertions.assertTrue(list.getDatanodes().size() == 0);
+    Assertions.assertEquals(0, list.getDatanodes().size());
     list.addDatanode(DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
         .setIpAddress("127.0.0.2").setHostName("localhost").addPort(
             DatanodeDetails.newPort(DatanodeDetails.Port.Name.STANDALONE, 2001))
@@ -50,7 +50,7 @@ public class TestExcludeList {
         .setIpAddress("127.0.0.3").setHostName("localhost").addPort(
             DatanodeDetails.newPort(DatanodeDetails.Port.Name.STANDALONE, 2001))
         .build());
-    Assertions.assertTrue(list.getDatanodes().size() == 2);
+    Assertions.assertEquals(2, list.getDatanodes().size());
   }
 
   @Test
@@ -60,8 +60,8 @@ public class TestExcludeList {
         .setIpAddress("127.0.0.1").setHostName("localhost").addPort(
             DatanodeDetails.newPort(DatanodeDetails.Port.Name.STANDALONE, 2001))
         .build());
-    Assertions.assertTrue(list.getDatanodes().size() == 1);
+    Assertions.assertEquals(1, list.getDatanodes().size());
     clock.fastForward(1);
-    Assertions.assertTrue(list.getDatanodes().size() == 1);
+    Assertions.assertEquals(1, list.getDatanodes().size());
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceCache.java
@@ -49,7 +49,7 @@ public class TestResourceCache {
     // put to cache with removing old element "6" as eviction FIFO
     resourceCache.put(1, "a");
     Assertions.assertNull(resourceCache.get(6));
-    Assertions.assertTrue(count.get() == 1);
+    Assertions.assertEquals(1, count.get());
 
     // add 5 should be success with no removal
     resourceCache.put(5, "a");
@@ -58,7 +58,7 @@ public class TestResourceCache {
     // remove and check queue
     resourceCache.remove(4);
     Assertions.assertNull(resourceCache.get(4));
-    Assertions.assertTrue(count.get() == 1);
+    Assertions.assertEquals(1, count.get());
   }
 
   @Test

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumImplsComputeSameValues.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumImplsComputeSameValues.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.CRC32;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests to verify that different checksum implementations compute the same
@@ -52,7 +52,7 @@ public class TestChecksumImplsComputeSameValues {
       if (NativeCRC32Wrapper.isAvailable()) {
         impls.add(new ChecksumByteBufferImpl(new NativeCheckSumCRC32(1, bpc)));
       }
-      assertEquals(true, validateImpls(data, impls, bpc));
+      assertTrue(validateImpls(data, impls, bpc));
     }
   }
 
@@ -74,7 +74,7 @@ public class TestChecksumImplsComputeSameValues {
       if (NativeCRC32Wrapper.isAvailable()) {
         impls.add(new ChecksumByteBufferImpl(new NativeCheckSumCRC32(2, bpc)));
       }
-      assertEquals(true, validateImpls(data, impls, bpc));
+      assertTrue(validateImpls(data, impls, bpc));
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -53,6 +53,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_CHECK_
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -342,8 +343,7 @@ public class TestHddsSecureDatanodeInit {
     when(scmClient.getAllRootCaCertificates()).thenReturn(rootCaList);
     // check that new cert ID should not equal to current cert ID
     String certId = newCertHolder.getSerialNumber().toString();
-    Assertions.assertFalse(certId.equals(
-        client.getCertificate().getSerialNumber().toString()));
+    assertNotEquals(certId, client.getCertificate().getSerialNumber().toString());
 
     // start monitor task to renew key and cert
     client.startCertificateRenewerService();
@@ -382,12 +382,10 @@ public class TestHddsSecureDatanodeInit {
       String newCertId = client.getCertificate().getSerialNumber().toString();
       return newCertId.equals(certId2);
     }, 1000, CERT_LIFETIME * 1000);
-    Assertions.assertFalse(client.getPrivateKey().equals(privateKey1));
-    Assertions.assertFalse(client.getPublicKey().equals(publicKey1));
-    Assertions.assertFalse(client.getCACertificate().getSerialNumber()
-        .toString().equals(caCertId1));
-    Assertions.assertFalse(client.getRootCACertificate().getSerialNumber()
-        .toString().equals(rootCaCertId1));
+    assertNotEquals(privateKey1, client.getPrivateKey());
+    assertNotEquals(publicKey1, client.getPublicKey());
+    assertNotEquals(caCertId1, client.getCACertificate().getSerialNumber().toString());
+    assertNotEquals(rootCaCertId1, client.getRootCACertificate().getSerialNumber().toString());
   }
 
   /**
@@ -417,16 +415,14 @@ public class TestHddsSecureDatanodeInit {
 
     // check that new cert ID should not equal to current cert ID
     String certId = newCertHolder.getSerialNumber().toString();
-    Assertions.assertFalse(certId.equals(
-        client.getCertificate().getSerialNumber().toString()));
+    assertNotEquals(certId, client.getCertificate().getSerialNumber().toString());
 
     // start monitor task to renew key and cert
     client.startCertificateRenewerService();
 
     // certificate failed to renew, client still hold the old expired cert.
     Thread.sleep(CERT_LIFETIME * 1000);
-    Assertions.assertFalse(certId.equals(
-        client.getCertificate().getSerialNumber().toString()));
+    assertNotEquals(certId, client.getCertificate().getSerialNumber().toString());
     try {
       client.getCertificate().checkValidity();
     } catch (Exception e) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStoreCache.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStoreCache.java
@@ -61,7 +61,7 @@ public class TestDatanodeStoreCache {
     Assertions.assertEquals(2, cache.size());
 
     // test get, test reference the same object using ==
-    Assertions.assertTrue(store1 == cache.getDB(dbPath1, conf).getStore());
+    Assertions.assertSame(store1, cache.getDB(dbPath1, conf).getStore());
 
     // test remove
     cache.removeDB(dbPath1);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestStaleRecoveringContainerScrubbingService.java
@@ -162,7 +162,7 @@ public class TestStaleRecoveringContainerScrubbingService {
     testClock.fastForward(1000L);
     srcss.runPeriodicalTaskNow();
     //closed container should not be scrubbed
-    Assertions.assertTrue(containerSet.containerCount() == 5);
+    Assertions.assertEquals(5, containerSet.containerCount());
 
     containerStateMap.putAll(createTestContainers(containerSet, 5,
             RECOVERING).stream()

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -92,6 +92,7 @@ import org.junit.jupiter.api.Assertions;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -614,7 +615,7 @@ public class TestContainerPersistence {
         .getVolume().getCommittedBytes();
     commitDecrement = commitBytesBefore - commitBytesAfter;
     // did we decrement commit bytes by the amount of data we wrote?
-    Assertions.assertTrue(commitDecrement == info.getLen());
+    assertEquals(commitDecrement, info.getLen());
     return info;
 
   }
@@ -810,7 +811,7 @@ public class TestContainerPersistence {
           getBlock(container, blockID1);
       Assertions.fail("Expected exception not thrown");
     } catch (StorageContainerException sce) {
-      Assertions.assertTrue(sce.getResult() == UNKNOWN_BCSID);
+      assertSame(UNKNOWN_BCSID, sce.getResult());
     }
 
     try {
@@ -821,7 +822,7 @@ public class TestContainerPersistence {
           getBlock(container, blockID1);
       Assertions.fail("Expected exception not thrown");
     } catch (StorageContainerException sce) {
-      Assertions.assertTrue(sce.getResult() == BCSID_MISMATCH);
+      assertSame(BCSID_MISMATCH, sce.getResult());
     }
     readBlockData = blockManager.
         getBlock(container, blockData.getBlockID());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -134,7 +134,7 @@ public class TestHeartbeatEndpointTask {
     Assertions.assertTrue(heartbeat.hasDatanodeDetails());
     Assertions.assertFalse(heartbeat.hasNodeReport());
     Assertions.assertFalse(heartbeat.hasContainerReport());
-    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
+    Assertions.assertEquals(0, heartbeat.getCommandStatusReportsCount());
     Assertions.assertFalse(heartbeat.hasContainerActions());
     OptionalLong termInDatanode = context.getTermOfLeaderSCM();
     Assertions.assertTrue(termInDatanode.isPresent());
@@ -169,7 +169,7 @@ public class TestHeartbeatEndpointTask {
     Assertions.assertTrue(heartbeat.hasDatanodeDetails());
     Assertions.assertTrue(heartbeat.hasNodeReport());
     Assertions.assertFalse(heartbeat.hasContainerReport());
-    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
+    Assertions.assertEquals(0, heartbeat.getCommandStatusReportsCount());
     Assertions.assertFalse(heartbeat.hasContainerActions());
   }
 
@@ -201,7 +201,7 @@ public class TestHeartbeatEndpointTask {
     Assertions.assertTrue(heartbeat.hasDatanodeDetails());
     Assertions.assertFalse(heartbeat.hasNodeReport());
     Assertions.assertTrue(heartbeat.hasContainerReport());
-    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
+    Assertions.assertEquals(0, heartbeat.getCommandStatusReportsCount());
     Assertions.assertFalse(heartbeat.hasContainerActions());
   }
 
@@ -266,7 +266,7 @@ public class TestHeartbeatEndpointTask {
     Assertions.assertTrue(heartbeat.hasDatanodeDetails());
     Assertions.assertFalse(heartbeat.hasNodeReport());
     Assertions.assertFalse(heartbeat.hasContainerReport());
-    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() == 0);
+    Assertions.assertEquals(0, heartbeat.getCommandStatusReportsCount());
     Assertions.assertTrue(heartbeat.hasContainerActions());
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -46,7 +46,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -202,7 +201,7 @@ public class TestBlockManagerImpl {
     List<BlockData> listBlockData = blockManager.listBlock(
         keyValueContainer, 1, 10);
     assertNotNull(listBlockData);
-    assertTrue(listBlockData.size() == 1);
+    assertEquals(1, listBlockData.size());
 
     for (long i = 2; i <= 10; i++) {
       blockID = new BlockID(1L, i);
@@ -221,6 +220,6 @@ public class TestBlockManagerImpl {
     listBlockData = blockManager.listBlock(
         keyValueContainer, 1, 10);
     assertNotNull(listBlockData);
-    assertTrue(listBlockData.size() == 10);
+    assertEquals(10, listBlockData.size());
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -562,8 +562,7 @@ public class TestRDBTableStore {
         int keyCount = 0;
         while (iter.hasNext()) {
           // iterator should only meet keys with samplePrefix
-          assertArrayEquals(
-              Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH), samplePrefix);
+          assertArrayEquals(samplePrefix, Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH));
           keyCount++;
         }
 
@@ -573,8 +572,7 @@ public class TestRDBTableStore {
         // iterator should be able to seekToFirst
         iter.seekToFirst();
         assertTrue(iter.hasNext());
-        assertArrayEquals(Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH),
-            samplePrefix);
+        assertArrayEquals(samplePrefix, Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH));
       }
     }
   }
@@ -708,9 +706,7 @@ public class TestRDBTableStore {
         int keyCount = 0;
         while (iter.hasNext()) {
           // check prefix
-          assertTrue(Arrays.equals(
-              Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH),
-              samplePrefix));
+          assertArrayEquals(Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH), samplePrefix);
           keyCount++;
         }
 
@@ -751,9 +747,7 @@ public class TestRDBTableStore {
         int keyCount = 0;
         while (iter.hasNext()) {
           // check prefix
-          assertTrue(Arrays.equals(
-              Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH),
-              samplePrefix));
+          assertArrayEquals(Arrays.copyOf(iter.next().getKey(), PREFIX_LENGTH), samplePrefix);
           keyCount++;
         }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -45,6 +45,7 @@ import org.slf4j.event.Level;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_NODE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -127,31 +128,26 @@ public class TestContainerBalancer {
     startBalancer(balancerConfiguration);
     try {
       containerBalancer.startBalancer(balancerConfiguration);
-      Assertions.assertTrue(false,
-          "Exception should be thrown when startBalancer again");
+      Assertions.fail("Exception should be thrown when startBalancer again");
     } catch (IllegalContainerBalancerStateException e) {
       // start failed again, valid case
     }
 
     try {
       containerBalancer.start();
-      Assertions.assertTrue(false,
-          "Exception should be thrown when start again");
+      Assertions.fail("Exception should be thrown when start again");
     } catch (IllegalContainerBalancerStateException e) {
       // start failed again, valid case
     }
 
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.RUNNING);
+    assertSame(ContainerBalancerTask.Status.RUNNING, containerBalancer.getBalancerStatus());
 
     stopBalancer();
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.STOPPED);
+    assertSame(ContainerBalancerTask.Status.STOPPED, containerBalancer.getBalancerStatus());
 
     try {
       containerBalancer.stopBalancer();
-      Assertions.assertTrue(false,
-          "Exception should be thrown when stop again");
+      Assertions.fail("Exception should be thrown when stop again");
     } catch (Exception e) {
       // stop failed as already stopped, valid case
     }
@@ -161,23 +157,19 @@ public class TestContainerBalancer {
   public void testStartStopSCMCalls() throws Exception {
     containerBalancer.saveConfiguration(balancerConfiguration, true, 0);
     containerBalancer.start();
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.RUNNING);
+    assertSame(ContainerBalancerTask.Status.RUNNING, containerBalancer.getBalancerStatus());
     containerBalancer.notifyStatusChanged();
     try {
       containerBalancer.start();
-      Assertions.assertTrue(false,
-          "Exception should be thrown when start again");
+      Assertions.fail("Exception should be thrown when start again");
     } catch (IllegalContainerBalancerStateException e) {
       // start failed when triggered again, valid case
     }
 
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.RUNNING);
+    assertSame(ContainerBalancerTask.Status.RUNNING, containerBalancer.getBalancerStatus());
 
     containerBalancer.stop();
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.STOPPED);
+    assertSame(ContainerBalancerTask.Status.STOPPED, containerBalancer.getBalancerStatus());
     containerBalancer.saveConfiguration(balancerConfiguration, false, 0);
   }
 
@@ -186,20 +178,16 @@ public class TestContainerBalancer {
     containerBalancer.startBalancer(balancerConfiguration);
 
     scm.getScmContext().updateLeaderAndTerm(false, 1);
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.RUNNING);
+    assertSame(ContainerBalancerTask.Status.RUNNING, containerBalancer.getBalancerStatus());
     containerBalancer.notifyStatusChanged();
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.STOPPED);
+    assertSame(ContainerBalancerTask.Status.STOPPED, containerBalancer.getBalancerStatus());
     scm.getScmContext().updateLeaderAndTerm(true, 2);
     scm.getScmContext().setLeaderReady();
     containerBalancer.notifyStatusChanged();
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.RUNNING);
+    assertSame(ContainerBalancerTask.Status.RUNNING, containerBalancer.getBalancerStatus());
 
     containerBalancer.stop();
-    Assertions.assertTrue(containerBalancer.getBalancerStatus()
-        == ContainerBalancerTask.Status.STOPPED);
+    assertSame(ContainerBalancerTask.Status.STOPPED, containerBalancer.getBalancerStatus());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -423,7 +423,7 @@ public class TestSCMContainerPlacementRackAware {
       policy.chooseDatanodes(null, null, nodeNum, STORAGE_CAPACITY + 0, 15);
       fail("Storage requested exceeds capacity, this call should fail");
     } catch (Exception e) {
-      assertTrue(e.getClass().getSimpleName().equals("SCMException"));
+      assertEquals("SCMException", e.getClass().getSimpleName());
     }
 
     // get metrics
@@ -833,8 +833,7 @@ public class TestSCMContainerPlacementRackAware {
 
     // Favoured node should be returned,
     // as favoured node is in the different rack as used nodes.
-    Assertions.assertTrue(favouredNodes.get(0).getUuid() ==
-        datanodeDetails.get(0).getUuid());
+    Assertions.assertSame(favouredNodes.get(0).getUuid(), datanodeDetails.get(0).getUuid());
 
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -84,6 +84,7 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicasWithSameOrigin;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.getNoNodesTestPlacementPolicy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -518,7 +519,7 @@ public class TestReplicationManager {
 
     boolean result = replicationManager.checkContainerStatus(
         container, repReport);
-    assertEquals(false, result);
+    assertFalse(result);
   }
 
   @Test
@@ -546,7 +547,7 @@ public class TestReplicationManager {
         container, repReport);
     assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    assertEquals(true, result);
+    assertTrue(result);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
@@ -96,9 +96,9 @@ public class TestNodeReportHandler implements EventPublisher {
         Arrays.asList(metaStorageOne)).getReport(), null);
     nodeMetric = nodeManager.getNodeStat(dn);
 
-    Assertions.assertTrue(nodeMetric.get().getCapacity().get() == 100);
-    Assertions.assertTrue(nodeMetric.get().getRemaining().get() == 90);
-    Assertions.assertTrue(nodeMetric.get().getScmUsed().get() == 10);
+    Assertions.assertEquals(100, (long) nodeMetric.get().getCapacity().get());
+    Assertions.assertEquals(90, (long) nodeMetric.get().getRemaining().get());
+    Assertions.assertEquals(10, (long) nodeMetric.get().getScmUsed().get());
 
     StorageReportProto storageTwo = HddsTestUtils
         .createStorageReport(dn.getUuid(), storagePath, 100, 10, 90, null);
@@ -107,9 +107,9 @@ public class TestNodeReportHandler implements EventPublisher {
             Arrays.asList(metaStorageOne)), this);
     nodeMetric = nodeManager.getNodeStat(dn);
 
-    Assertions.assertTrue(nodeMetric.get().getCapacity().get() == 200);
-    Assertions.assertTrue(nodeMetric.get().getRemaining().get() == 180);
-    Assertions.assertTrue(nodeMetric.get().getScmUsed().get() == 20);
+    Assertions.assertEquals(200, (long) nodeMetric.get().getCapacity().get());
+    Assertions.assertEquals(180, (long) nodeMetric.get().getRemaining().get());
+    Assertions.assertEquals(20, (long) nodeMetric.get().getScmUsed().get());
 
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -930,8 +930,7 @@ public class TestPipelineManagerImpl {
     
     ContainerInfo c = provider.getContainer(1, repConfig,
         owner, new ExcludeList());
-    Assertions.assertTrue(c.equals(container),
-        "Expected container was returned");
+    Assertions.assertEquals(c, container, "Expected container was returned");
 
     // Confirm that waitOnePipelineReady was called on allocated pipelines
     ArgumentCaptor<Collection<PipelineID>> captor =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -250,7 +250,7 @@ public class TestSCMBlockProtocolServer {
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assertions.assertTrue(datanodeDetails.size() == NODE_COUNT);
+    Assertions.assertEquals(NODE_COUNT, datanodeDetails.size());
 
     // illegal client 1
     client += "X";
@@ -258,14 +258,14 @@ public class TestSCMBlockProtocolServer {
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assertions.assertTrue(datanodeDetails.size() == NODE_COUNT);
+    Assertions.assertEquals(NODE_COUNT, datanodeDetails.size());
     // illegal client 2
     client = "/default-rack";
     datanodeDetails = server.sortDatanodes(nodes, client);
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assertions.assertTrue(datanodeDetails.size() == NODE_COUNT);
+    Assertions.assertEquals(NODE_COUNT, datanodeDetails.size());
 
     // unknown node to sort
     nodes.add(UUID.randomUUID().toString());
@@ -278,7 +278,7 @@ public class TestSCMBlockProtocolServer {
             .build();
     ScmBlockLocationProtocolProtos.SortDatanodesResponseProto resp =
         service.sortDatanodes(request, ClientVersion.CURRENT_VERSION);
-    Assertions.assertTrue(resp.getNodeList().size() == NODE_COUNT);
+    Assertions.assertEquals(NODE_COUNT, resp.getNodeList().size());
     System.out.println("client = " + client);
     resp.getNodeList().stream().forEach(
         node -> System.out.println(node.getNetworkName()));
@@ -295,7 +295,7 @@ public class TestSCMBlockProtocolServer {
         .build();
     resp = service.sortDatanodes(request, ClientVersion.CURRENT_VERSION);
     System.out.println("client = " + client);
-    Assertions.assertTrue(resp.getNodeList().size() == 0);
+    Assertions.assertEquals(0, resp.getNodeList().size());
     resp.getNodeList().stream().forEach(
         node -> System.out.println(node.getNetworkName()));
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Assertions in the form:

```
assertTrue(<x> == <y>)
assertEquals(null, <x>) or assertTrue(<x> == null)
assertTrue(<x> != null)
assertEquals(<boolean>, <x>)
```

can be simplified to:

```
assertEquals(<x>, <y>)
assertNull(<x>)
assertNotNull(<x>)
assertTrue/assertFalse(<x>)
```

Not only are these simpler, some of them also provide more information in case of failure.

This PR updates such assertions in `hadoop-hdds`.

https://issues.apache.org/jira/browse/HDDS-9953

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7250200952