### PR TITLE
HDDS-9776. Migrate simple client integration tests to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClientFactory.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClientFactory.java
@@ -20,8 +20,8 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
@@ -59,14 +59,14 @@ public class TestOzoneClientFactory {
         public Void run() throws IOException {
           conf.set("ozone.security.enabled", "true");
           try (OzoneClient ozoneClient =
-              OzoneClientFactory.getRpcClient("localhost",
-                  Integer.parseInt(omPort), conf)) {
+                   OzoneClientFactory.getRpcClient("localhost",
+                       Integer.parseInt(omPort), conf)) {
             ozoneClient.getObjectStore().listVolumes("/");
           }
           return null;
         }
       });
-      Assert.fail("Should throw exception here");
+      Assertions.fail("Should throw exception here");
     } catch (IOException | InterruptedException e) {
       assert e instanceof AccessControlException;
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/AbstractTestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/AbstractTestECKeyOutputStream.java
@@ -47,10 +47,10 @@ import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -132,7 +132,7 @@ abstract class AbstractTestECKeyOutputStream {
     initInputChunks();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     init(false);
   }
@@ -140,7 +140,7 @@ abstract class AbstractTestECKeyOutputStream {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -152,9 +152,9 @@ abstract class AbstractTestECKeyOutputStream {
   public void testCreateKeyWithECReplicationConfig() throws Exception {
     try (OzoneOutputStream key = TestHelper
         .createKey(keyString, new ECReplicationConfig(3, 2,
-              ECReplicationConfig.EcCodec.RS, chunkSize), inputSize,
+                ECReplicationConfig.EcCodec.RS, chunkSize), inputSize,
             objectStore, volumeName, bucketName)) {
-      Assert.assertTrue(key.getOutputStream() instanceof ECKeyOutputStream);
+      Assertions.assertTrue(key.getOutputStream() instanceof ECKeyOutputStream);
     }
   }
 
@@ -163,9 +163,9 @@ abstract class AbstractTestECKeyOutputStream {
     OzoneVolume volume = objectStore.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     try (OzoneOutputStream out = bucket.createKey("myKey", inputSize)) {
-      Assert.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
-      for (int i = 0; i < inputChunks.length; i++) {
-        out.write(inputChunks[i]);
+      Assertions.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
+      for (byte[] inputChunk : inputChunks) {
+        out.write(inputChunk);
       }
     }
   }
@@ -184,17 +184,17 @@ abstract class AbstractTestECKeyOutputStream {
     OzoneBucket bucket = volume.getBucket(myBucket);
 
     try (OzoneOutputStream out = bucket.createKey(keyString, inputSize)) {
-      Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
-      for (int i = 0; i < inputChunks.length; i++) {
-        out.write(inputChunks[i]);
+      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      for (byte[] inputChunk : inputChunks) {
+        out.write(inputChunk);
       }
     }
     byte[] buf = new byte[chunkSize];
     try (OzoneInputStream in = bucket.readKey(keyString)) {
-      for (int i = 0; i < inputChunks.length; i++) {
+      for (byte[] inputChunk : inputChunks) {
         int read = in.read(buf, 0, chunkSize);
-        Assert.assertEquals(chunkSize, read);
-        Assert.assertTrue(Arrays.equals(buf, inputChunks[i]));
+        Assertions.assertEquals(chunkSize, read);
+        Assertions.assertArrayEquals(buf, inputChunk);
       }
     }
   }
@@ -236,16 +236,16 @@ abstract class AbstractTestECKeyOutputStream {
   }
 
   private void createKeyAndCheckReplicationConfig(String keyName,
-      OzoneBucket bucket, ReplicationConfig replicationConfig)
+                                                  OzoneBucket bucket, ReplicationConfig replicationConfig)
       throws IOException {
     try (OzoneOutputStream out = bucket
         .createKey(keyName, inputSize, replicationConfig, new HashMap<>())) {
-      for (int i = 0; i < inputChunks.length; i++) {
-        out.write(inputChunks[i]);
+      for (byte[] inputChunk : inputChunks) {
+        out.write(inputChunk);
       }
     }
     OzoneKeyDetails key = bucket.getKey(keyName);
-    Assert.assertEquals(replicationConfig, key.getReplicationConfig());
+    Assertions.assertEquals(replicationConfig, key.getReplicationConfig());
   }
 
   @Test
@@ -255,9 +255,9 @@ abstract class AbstractTestECKeyOutputStream {
         "testCreateRatisKeyAndWithECBucketDefaults", 2000,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE),
         new HashMap<>())) {
-      Assert.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
-      for (int i = 0; i < inputChunks.length; i++) {
-        out.write(inputChunks[i]);
+      Assertions.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
+      for (byte[] inputChunk : inputChunks) {
+        out.write(inputChunk);
       }
     }
   }
@@ -288,14 +288,14 @@ abstract class AbstractTestECKeyOutputStream {
   }
 
   private void testMultipleChunksInSingleWriteOp(int offset,
-                                                int bufferChunks, int numChunks)
-          throws IOException {
+                                                 int bufferChunks, int numChunks)
+      throws IOException {
     byte[] inputData = getInputBytes(offset, bufferChunks, numChunks);
     final OzoneBucket bucket = getOzoneBucket();
     String keyName =
-            String.format("testMultipleChunksInSingleWriteOpOffset" +
-                    "%dBufferChunks%dNumChunks", offset, bufferChunks,
-                    numChunks);
+        String.format("testMultipleChunksInSingleWriteOpOffset" +
+                "%dBufferChunks%dNumChunks", offset, bufferChunks,
+            numChunks);
     try (OzoneOutputStream out = bucket.createKey(keyName, 4096,
         new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
             chunkSize), new HashMap<>())) {
@@ -303,7 +303,7 @@ abstract class AbstractTestECKeyOutputStream {
     }
 
     validateContent(offset, numChunks * chunkSize, inputData, bucket,
-            bucket.getKey(keyName));
+        bucket.getKey(keyName));
   }
 
   private void testMultipleChunksInSingleWriteOp(int numChunks)
@@ -344,7 +344,7 @@ abstract class AbstractTestECKeyOutputStream {
             .getNumberOfKeys() == 1) && (containerOperationClient
             .getContainerReplicas(currentKeyContainerID).size() == 5);
       } catch (IOException exception) {
-        Assert.fail("Unexpected exception " + exception);
+        Assertions.fail("Unexpected exception " + exception);
         return false;
       }
     }, 100, 10000);
@@ -358,12 +358,12 @@ abstract class AbstractTestECKeyOutputStream {
 
   private void validateContent(int offset, int length, byte[] inputData,
                                OzoneBucket bucket,
-      OzoneKey key) throws IOException {
+                               OzoneKey key) throws IOException {
     try (OzoneInputStream is = bucket.readKey(key.getName())) {
       byte[] fileContent = new byte[length];
-      Assert.assertEquals(length, is.read(fileContent));
-      Assert.assertEquals(new String(Arrays.copyOfRange(inputData, offset,
-                      offset + length), UTF_8),
+      Assertions.assertEquals(length, is.read(fileContent));
+      Assertions.assertEquals(new String(Arrays.copyOfRange(inputData, offset,
+              offset + length), UTF_8),
           new String(fileContent, UTF_8));
     }
   }
@@ -423,7 +423,7 @@ abstract class AbstractTestECKeyOutputStream {
 
         // Check the second blockGroup pipeline to make sure that the failed
         // node is not selected.
-        Assert.assertFalse(ecOut.getStreamEntries()
+        Assertions.assertFalse(ecOut.getStreamEntries()
             .get(1).getPipeline().getNodes().contains(nodeToKill));
       }
 
@@ -432,8 +432,8 @@ abstract class AbstractTestECKeyOutputStream {
         // data comes back.
         for (int i = 0; i < 2; i++) {
           byte[] fileContent = new byte[inputData.length];
-          Assert.assertEquals(inputData.length, is.read(fileContent));
-          Assert.assertEquals(new String(inputData, UTF_8),
+          Assertions.assertEquals(inputData.length, is.read(fileContent));
+          Assertions.assertEquals(new String(inputData, UTF_8),
               new String(fileContent, UTF_8));
         }
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientReply;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.
-        StorageContainerLocationProtocolClientSideTranslatorPB;
+    StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -41,31 +41,22 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.
-        OZONE_SCM_STALENODE_INTERVAL;
+    OZONE_SCM_STALENODE_INTERVAL;
 
 /**
  * This class tests the 2 way commit in Ratis.
  */
+@Timeout(300)
 public class Test2WayCommitInRatis {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
   private MiniOzoneCluster cluster;
   private OzoneClient client;
   private ObjectStore objectStore;
@@ -93,9 +84,9 @@ public class Test2WayCommitInRatis {
 
     // Make sure the pipeline does not get destroyed quickly
     conf.setTimeDuration(HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL,
-            60, TimeUnit.SECONDS);
+        60, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 60000,
-            TimeUnit.SECONDS);
+        TimeUnit.SECONDS);
     DatanodeRatisServerConfig ratisServerConfig =
         conf.getObject(DatanodeRatisServerConfig.class);
     ratisServerConfig.setRequestTimeOut(Duration.ofSeconds(3));
@@ -154,8 +145,8 @@ public class Test2WayCommitInRatis {
             HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
-    Assert.assertEquals(1, xceiverClient.getRefcount());
-    Assert.assertEquals(container1.getPipeline(),
+    Assertions.assertEquals(1, xceiverClient.getRefcount());
+    Assertions.assertEquals(container1.getPipeline(),
         xceiverClient.getPipeline());
     Pipeline pipeline = xceiverClient.getPipeline();
     XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
@@ -164,7 +155,7 @@ public class Test2WayCommitInRatis {
             container1.getContainerInfo().getContainerID(),
             xceiverClient.getPipeline()));
     reply.getResponse().get();
-    Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
+    Assertions.assertEquals(3, ratisClient.getCommitInfoMap().size());
     // wait for the container to be created on all the nodes
     xceiverClient.watchForCommit(reply.getLogIndex());
     for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
@@ -181,10 +172,10 @@ public class Test2WayCommitInRatis {
     xceiverClient.watchForCommit(reply.getLogIndex());
 
     // commitInfo Map will be reduced to 2 here
-    Assert.assertEquals(2, ratisClient.getCommitInfoMap().size());
+    Assertions.assertEquals(2, ratisClient.getCommitInfoMap().size());
     clientManager.releaseClient(xceiverClient, false);
-    Assert.assertTrue(logCapturer.getOutput().contains("3 way commit failed"));
-    Assert
+    Assertions.assertTrue(logCapturer.getOutput().contains("3 way commit failed"));
+    Assertions
         .assertTrue(logCapturer.getOutput().contains("Committed by majority"));
     logCapturer.stopCapturing();
     shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
@@ -37,14 +37,11 @@ import org.apache.hadoop.ozone.client.io.KeyDataStreamOutput;
 import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -57,13 +54,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 /**
  * Tests BlockDataStreamOutput class.
  */
+@Timeout(300)
 public class TestBlockDataStreamOutput {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf = new OzoneConfiguration();
   private static OzoneClient client;
@@ -83,7 +75,7 @@ public class TestBlockDataStreamOutput {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     chunkSize = 100;
     flushSize = 2 * chunkSize;
@@ -128,7 +120,7 @@ public class TestBlockDataStreamOutput {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -184,7 +176,7 @@ public class TestBlockDataStreamOutput {
         (KeyDataStreamOutput) key.getByteBufStreamOutput();
     ByteBufferStreamOutput stream =
         keyDataStreamOutput.getStreamEntries().get(0).getByteBufStreamOutput();
-    Assert.assertTrue(stream instanceof BlockDataStreamOutput);
+    Assertions.assertTrue(stream instanceof BlockDataStreamOutput);
     TestHelper.waitForContainerClose(key, cluster);
     key.write(b);
     key.close();
@@ -208,21 +200,21 @@ public class TestBlockDataStreamOutput {
         ContainerTestHelper.getFixedLengthString(keyString, dataLength)
             .getBytes(UTF_8);
     key.write(ByteBuffer.wrap(data));
-    Assert.assertTrue(
+    Assertions.assertTrue(
         metrics.getPendingContainerOpCountMetrics(ContainerProtos.Type.PutBlock)
             <= pendingPutBlockCount + 1);
     key.close();
     // Since data length is 500 , first putBlock will be at 400(flush boundary)
     // and the other at 500
-    Assert.assertTrue(
-        metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock)
-            == putBlockCount + 2);
+    Assertions.assertEquals(
+        metrics.getContainerOpCountMetrics(ContainerProtos.Type.PutBlock),
+        putBlockCount + 2);
     validateData(keyName, data);
   }
 
 
   static OzoneDataStreamOutput createKey(String keyName, ReplicationType type,
-      long size) throws Exception {
+                                         long size) throws Exception {
     return TestHelper.createStreamKey(
         keyName, type, size, objectStore, volumeName, bucketName);
   }
@@ -245,10 +237,10 @@ public class TestBlockDataStreamOutput {
             .getBytes(UTF_8);
     key.write(ByteBuffer.wrap(data));
     // minPacketSize= 100, so first write of 50 wont trigger a writeChunk
-    Assert.assertEquals(writeChunkCount,
+    Assertions.assertEquals(writeChunkCount,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
     key.write(ByteBuffer.wrap(data));
-    Assert.assertEquals(writeChunkCount + 1,
+    Assertions.assertEquals(writeChunkCount + 1,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
     // now close the stream, It will update the key length.
     key.close();
@@ -271,7 +263,7 @@ public class TestBlockDataStreamOutput {
         keyDataStreamOutput.getStreamEntries().get(0);
     key.write(ByteBuffer.wrap(data));
     key.close();
-    Assert.assertEquals(dataLength, stream.getTotalAckDataLength());
+    Assertions.assertEquals(dataLength, stream.getTotalAckDataLength());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -53,25 +53,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests Close Container Exception handling by Ozone Client.
  */
+@Timeout(300)
 public class TestCloseContainerHandlingByClient {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf = new OzoneConfiguration();
@@ -90,7 +82,7 @@ public class TestCloseContainerHandlingByClient {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     chunkSize = (int) OzoneConsts.MB;
     blockSize = 4 * chunkSize;
@@ -123,7 +115,7 @@ public class TestCloseContainerHandlingByClient {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -141,7 +133,7 @@ public class TestCloseContainerHandlingByClient {
         .getBytes(UTF_8);
     key.write(data);
 
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -156,7 +148,7 @@ public class TestCloseContainerHandlingByClient {
     // read the key from OM again and match the length.The length will still
     // be the equal to the original data size.
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
-    Assert.assertEquals(2 * data.length, keyInfo.getDataSize());
+    Assertions.assertEquals(2 * data.length, keyInfo.getDataSize());
 
     // Written the same data twice
     String dataString = new String(data, UTF_8);
@@ -174,7 +166,7 @@ public class TestCloseContainerHandlingByClient {
         .getBytes(UTF_8);
     key.write(data);
 
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -187,7 +179,7 @@ public class TestCloseContainerHandlingByClient {
     // read the key from OM again and match the length.The length will still
     // be the equal to the original data size.
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
-    Assert.assertEquals(data.length, keyInfo.getDataSize());
+    Assertions.assertEquals(data.length, keyInfo.getDataSize());
     validateData(keyName, data);
   }
 
@@ -200,15 +192,15 @@ public class TestCloseContainerHandlingByClient {
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     // With the initial size provided, it should have preallocated 4 blocks
-    Assert.assertEquals(3, keyOutputStream.getStreamEntries().size());
+    Assertions.assertEquals(3, keyOutputStream.getStreamEntries().size());
     // write data more than 1 block
     byte[] data =
         ContainerTestHelper.getFixedLengthString(keyString, (3 * blockSize))
             .getBytes(UTF_8);
-    Assert.assertEquals(data.length, 3 * blockSize);
+    Assertions.assertEquals(data.length, 3 * blockSize);
     key.write(data);
 
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -232,10 +224,10 @@ public class TestCloseContainerHandlingByClient {
     // closeContainerException and remaining data in the chunkOutputStream
     // buffer will be copied into a different allocated block and will be
     // committed.
-    Assert.assertEquals(4, keyLocationInfos.size());
-    Assert.assertEquals(4 * blockSize, keyInfo.getDataSize());
+    Assertions.assertEquals(4, keyLocationInfos.size());
+    Assertions.assertEquals(4 * blockSize, keyInfo.getDataSize());
     for (OmKeyLocationInfo locationInfo : keyLocationInfos) {
-      Assert.assertEquals(blockSize, locationInfo.getLength());
+      Assertions.assertEquals(blockSize, locationInfo.getLength());
     }
   }
 
@@ -247,9 +239,9 @@ public class TestCloseContainerHandlingByClient {
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
 
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     // With the initial size provided, it should have pre allocated 2 blocks
-    Assert.assertEquals(2, keyOutputStream.getStreamEntries().size());
+    Assertions.assertEquals(2, keyOutputStream.getStreamEntries().size());
     String dataString =
         ContainerTestHelper.getFixedLengthString(keyString, (2 * blockSize));
     byte[] data = dataString.getBytes(UTF_8);
@@ -289,7 +281,7 @@ public class TestCloseContainerHandlingByClient {
 
     String dataCommitted =
         dataString.concat(dataString2).concat(dataString3).concat(dataString4);
-    Assert.assertEquals(dataCommitted.getBytes(UTF_8).length,
+    Assertions.assertEquals(dataCommitted.getBytes(UTF_8).length,
         keyInfo.getDataSize());
     validateData(keyName, dataCommitted.getBytes(UTF_8));
   }
@@ -303,16 +295,16 @@ public class TestCloseContainerHandlingByClient {
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     // With the initial size provided, it should have preallocated 4 blocks
-    Assert.assertEquals(4, keyOutputStream.getStreamEntries().size());
+    Assertions.assertEquals(4, keyOutputStream.getStreamEntries().size());
     // write data 4 blocks and one more chunk
     byte[] writtenData =
         ContainerTestHelper.getFixedLengthString(keyString, keyLen)
             .getBytes(UTF_8);
     byte[] data = Arrays.copyOfRange(writtenData, 0, 3 * blockSize + chunkSize);
-    Assert.assertEquals(data.length, 3 * blockSize + chunkSize);
+    Assertions.assertEquals(data.length, 3 * blockSize + chunkSize);
     key.write(data);
 
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -337,7 +329,7 @@ public class TestCloseContainerHandlingByClient {
     try (OzoneInputStream inputStream = bucket.readKey(keyName)) {
       inputStream.read(readData);
     }
-    Assert.assertArrayEquals(writtenData, readData);
+    Assertions.assertArrayEquals(writtenData, readData);
 
     // Though we have written only block initially, the close will hit
     // closeContainerException and remaining data in the chunkOutputStream
@@ -347,7 +339,7 @@ public class TestCloseContainerHandlingByClient {
     for (OmKeyLocationInfo locationInfo : keyLocationInfos) {
       length += locationInfo.getLength();
     }
-    Assert.assertEquals(4 * blockSize, length);
+    Assertions.assertEquals(4 * blockSize, length);
   }
 
   private void waitForContainerClose(OzoneOutputStream outputStream)
@@ -357,7 +349,7 @@ public class TestCloseContainerHandlingByClient {
   }
 
   private OzoneOutputStream createKey(String keyName, ReplicationType type,
-      long size) throws Exception {
+                                      long size) throws Exception {
     return TestHelper
         .createKey(keyName, type, size, objectStore, volumeName, bucketName);
   }
@@ -383,7 +375,7 @@ public class TestCloseContainerHandlingByClient {
         .setKeyName(keyName)
         .build();
 
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     waitForContainerClose(key);
     // Again Write the Data. This will throw an exception which will be handled
     // and new blocks will be allocated
@@ -395,7 +387,7 @@ public class TestCloseContainerHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     String dataString = new String(data, UTF_8);
     dataString = dataString.concat(dataString);
-    Assert.assertEquals(2 * data.length, keyInfo.getDataSize());
+    Assertions.assertEquals(2 * data.length, keyInfo.getDataSize());
     validateData(keyName, dataString.getBytes(UTF_8));
   }
 
@@ -409,7 +401,7 @@ public class TestCloseContainerHandlingByClient {
             .getBytes(UTF_8);
     key.write(data1);
 
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -427,7 +419,7 @@ public class TestCloseContainerHandlingByClient {
     // read the key from OM again and match the length.The length will still
     // be the equal to the original data size.
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
-    Assert.assertEquals((long) 5 * chunkSize, keyInfo.getDataSize());
+    Assertions.assertEquals((long) 5 * chunkSize, keyInfo.getDataSize());
 
     // Written the same data twice
     String dataString = new String(data1, UTF_8);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -43,10 +44,10 @@ import org.apache.hadoop.ozone.container.TestHelper;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -84,7 +85,7 @@ public class TestContainerReplicationEndToEnd {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     path = GenericTestUtils
@@ -132,7 +133,7 @@ public class TestContainerReplicationEndToEnd {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (xceiverClientManager != null) {
@@ -151,8 +152,9 @@ public class TestContainerReplicationEndToEnd {
     String keyName = "testContainerReplication";
     OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
-            .createKey(keyName, 0, ReplicationType.RATIS,
-                ReplicationFactor.THREE, new HashMap<>());
+            .createKey(keyName, 0,
+                ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                    ReplicationFactor.THREE), new HashMap<>());
     byte[] testData = "ratis".getBytes(UTF_8);
     // First write and flush creates a container in the datanode
     key.write(testData);
@@ -161,7 +163,7 @@ public class TestContainerReplicationEndToEnd {
     KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    Assertions.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     long containerID = omKeyLocationInfo.getContainerID();
     PipelineID pipelineID =
@@ -203,9 +205,9 @@ public class TestContainerReplicationEndToEnd {
     }
     // wait for container to move to closed state in SCM
     Thread.sleep(2 * containerReportInterval);
-    Assert.assertTrue(
+    Assertions.assertSame(
         cluster.getStorageContainerManager().getContainerInfo(containerID)
-            .getState() == HddsProtos.LifeCycleState.CLOSED);
+            .getState(), HddsProtos.LifeCycleState.CLOSED);
     // shutdown the replica node
     cluster.shutdownHddsDatanode(oldReplicaNode);
     // now the container is under replicated and will be moved to a different dn
@@ -219,14 +221,14 @@ public class TestContainerReplicationEndToEnd {
       }
     }
 
-    Assert.assertNotNull(dnService);
+    Assertions.assertNotNull(dnService);
     final HddsDatanodeService newReplicaNode = dnService;
     // wait for the container to get replicated
     GenericTestUtils.waitFor(() -> {
       return newReplicaNode.getDatanodeStateMachine().getContainer()
           .getContainerSet().getContainer(containerID) != null;
     }, 500, 100000);
-    Assert.assertTrue(newReplicaNode.getDatanodeStateMachine().getContainer()
+    Assertions.assertTrue(newReplicaNode.getDatanodeStateMachine().getContainer()
         .getContainerSet().getContainer(containerID).getContainerData()
         .getBlockCommitSequenceId() > 0);
     // wait for SCM to update the replica Map

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.HddsUtils;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
@@ -91,13 +92,10 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.storage.FileInfo;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
-import static org.hamcrest.core.Is.is;
 
 import org.apache.ratis.statemachine.impl.StatemachineImplTestUtil;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.Assert;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -203,8 +201,9 @@ public class TestContainerStateMachineFailures {
 
     OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
-            .createKey("testQuasiClosed1", 1024, ReplicationType.RATIS,
-                ReplicationFactor.THREE, new HashMap<>());
+            .createKey("testQuasiClosed1", 1024,
+                ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                    ReplicationFactor.THREE), new HashMap<>());
     key.write("ratis".getBytes(UTF_8));
     key.flush();
 
@@ -212,7 +211,7 @@ public class TestContainerStateMachineFailures {
         getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    Assertions.assertEquals(1, locationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
@@ -246,9 +245,9 @@ public class TestContainerStateMachineFailures {
     for (HddsDatanodeService dn : datanodeSet) {
       LambdaTestUtils.await(20000, 1000,
           () -> (dn.getDatanodeStateMachine()
-                .getContainer().getContainerSet()
-                .getContainer(containerID)
-                .getContainerState().equals(QUASI_CLOSED)));
+              .getContainer().getContainerSet()
+              .getContainer(containerID)
+              .getContainerState().equals(QUASI_CLOSED)));
     }
     key.close();
   }
@@ -256,27 +255,29 @@ public class TestContainerStateMachineFailures {
   @Test
   public void testContainerStateMachineFailures() throws Exception {
     OzoneOutputStream key =
-            objectStore.getVolume(volumeName).getBucket(bucketName)
-                    .createKey("ratis", 1024, ReplicationType.RATIS,
-                            ReplicationFactor.ONE, new HashMap<>());
+        objectStore.getVolume(volumeName).getBucket(bucketName)
+            .createKey("ratis", 1024,
+                ReplicationConfig.fromTypeAndFactor(
+                    ReplicationType.RATIS,
+                    ReplicationFactor.ONE), new HashMap<>());
     byte[] testData = "ratis".getBytes(UTF_8);
     // First write and flush creates a container in the datanode
     key.write(testData);
     key.flush();
     key.write(testData);
     KeyOutputStream groupOutputStream =
-            (KeyOutputStream) key.getOutputStream();
+        (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
-            groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+        groupOutputStream.getLocationInfoList();
+    Assertions.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-            cluster);
+        cluster);
     // delete the container dir
     FileUtil.fullyDelete(new File(dn.getDatanodeStateMachine()
-                    .getContainer().getContainerSet()
-                    .getContainer(omKeyLocationInfo.getContainerID()).
-                    getContainerData().getContainerPath()));
+        .getContainer().getContainerSet()
+        .getContainer(omKeyLocationInfo.getContainerID()).
+        getContainerData().getContainerPath()));
     try {
       // there is only 1 datanode in the pipeline, the pipeline will be closed
       // and allocation to new pipeline will fail as there is no other dn in
@@ -287,54 +288,54 @@ public class TestContainerStateMachineFailures {
     long containerID = omKeyLocationInfo.getContainerID();
 
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(
-            dn.getDatanodeStateMachine()
-                    .getContainer().getContainerSet()
-                    .getContainer(containerID)
-                    .getContainerState()
-                    == ContainerProtos.ContainerDataProto.State.UNHEALTHY);
+    Assertions.assertSame(dn.getDatanodeStateMachine()
+        .getContainer().getContainerSet()
+        .getContainer(containerID)
+        .getContainerState(), UNHEALTHY);
     OzoneContainer ozoneContainer;
 
     // restart the hdds datanode, container should not in the regular set
     OzoneConfiguration config = dn.getConf();
     final String dir = config.get(OzoneConfigKeys.
-            DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
-            + UUID.randomUUID();
+        DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
+        + UUID.randomUUID();
     config.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR, dir);
     int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
     cluster.restartHddsDatanode(dn.getDatanodeDetails(), false);
     ozoneContainer = cluster.getHddsDatanodes().get(index)
-            .getDatanodeStateMachine().getContainer();
-    Assert.assertNull(ozoneContainer.getContainerSet().
-                    getContainer(containerID));
+        .getDatanodeStateMachine().getContainer();
+    Assertions.assertNull(ozoneContainer.getContainerSet().
+        getContainer(containerID));
   }
 
   @Test
   public void testUnhealthyContainer() throws Exception {
     OzoneOutputStream key =
-            objectStore.getVolume(volumeName).getBucket(bucketName)
-                    .createKey("ratis", 1024, ReplicationType.RATIS,
-                            ReplicationFactor.ONE, new HashMap<>());
+        objectStore.getVolume(volumeName).getBucket(bucketName)
+            .createKey("ratis", 1024,
+                ReplicationConfig.fromTypeAndFactor(
+                    ReplicationType.RATIS,
+                    ReplicationFactor.ONE), new HashMap<>());
     // First write and flush creates a container in the datanode
     key.write("ratis".getBytes(UTF_8));
     key.flush();
     key.write("ratis".getBytes(UTF_8));
     KeyOutputStream groupOutputStream = (KeyOutputStream) key
-            .getOutputStream();
+        .getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
-            groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+        groupOutputStream.getLocationInfoList();
+    Assertions.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-            cluster);
+        cluster);
     ContainerData containerData =
-            dn.getDatanodeStateMachine()
-                    .getContainer().getContainerSet()
-                    .getContainer(omKeyLocationInfo.getContainerID())
-                    .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+        dn.getDatanodeStateMachine()
+            .getContainer().getContainerSet()
+            .getContainer(omKeyLocationInfo.getContainerID())
+            .getContainerData();
+    Assertions.assertTrue(containerData instanceof KeyValueContainerData);
     KeyValueContainerData keyValueContainerData =
-            (KeyValueContainerData) containerData;
+        (KeyValueContainerData) containerData;
     // delete the container db file
     FileUtil.fullyDelete(new File(keyValueContainerData.getChunksPath()));
     try {
@@ -348,23 +349,21 @@ public class TestContainerStateMachineFailures {
     long containerID = omKeyLocationInfo.getContainerID();
 
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(
-            dn.getDatanodeStateMachine()
-                    .getContainer().getContainerSet().getContainer(containerID)
-                    .getContainerState()
-                    == ContainerProtos.ContainerDataProto.State.UNHEALTHY);
+    Assertions.assertSame(dn.getDatanodeStateMachine()
+        .getContainer().getContainerSet().getContainer(containerID)
+        .getContainerState(), UNHEALTHY);
     // Check metadata in the .container file
     File containerFile = new File(keyValueContainerData.getMetadataPath(),
-            containerID + OzoneConsts.CONTAINER_EXTENSION);
+        containerID + OzoneConsts.CONTAINER_EXTENSION);
 
     keyValueContainerData = (KeyValueContainerData) ContainerDataYaml
-            .readContainerFile(containerFile);
-    assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
+        .readContainerFile(containerFile);
+    Assertions.assertEquals(keyValueContainerData.getState(), UNHEALTHY);
 
     OzoneConfiguration config = dn.getConf();
     final String dir = config.get(OzoneConfigKeys.
-            DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
-            + UUID.randomUUID();
+        DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
+        + UUID.randomUUID();
     config.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR, dir);
     int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
     // restart the hdds datanode and see if the container is listed in the
@@ -372,114 +371,115 @@ public class TestContainerStateMachineFailures {
     cluster.restartHddsDatanode(dn.getDatanodeDetails(), false);
     // make sure the container state is still marked unhealthy after restart
     keyValueContainerData = (KeyValueContainerData) ContainerDataYaml
-            .readContainerFile(containerFile);
-    assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
+        .readContainerFile(containerFile);
+    Assertions.assertEquals(keyValueContainerData.getState(), UNHEALTHY);
 
     OzoneContainer ozoneContainer;
     HddsDatanodeService dnService = cluster.getHddsDatanodes().get(index);
     ozoneContainer = dnService
-            .getDatanodeStateMachine().getContainer();
+        .getDatanodeStateMachine().getContainer();
     HddsDispatcher dispatcher = (HddsDispatcher) ozoneContainer
-            .getDispatcher();
+        .getDispatcher();
     ContainerProtos.ContainerCommandRequestProto.Builder request =
-            ContainerProtos.ContainerCommandRequestProto.newBuilder();
+        ContainerProtos.ContainerCommandRequestProto.newBuilder();
     request.setCmdType(ContainerProtos.Type.CloseContainer);
     request.setContainerID(containerID);
     request.setCloseContainer(
-            ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
+        ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
     request.setDatanodeUuid(dnService.getDatanodeDetails().getUuidString());
-    Assert.assertEquals(ContainerProtos.Result.CONTAINER_UNHEALTHY,
-            dispatcher.dispatch(request.build(), null)
-                    .getResult());
+    Assertions.assertEquals(ContainerProtos.Result.CONTAINER_UNHEALTHY,
+        dispatcher.dispatch(request.build(), null)
+            .getResult());
   }
 
   @Test
   @Flaky("HDDS-6935")
   public void testApplyTransactionFailure() throws Exception {
     OzoneOutputStream key =
-            objectStore.getVolume(volumeName).getBucket(bucketName)
-                    .createKey("ratis", 1024, ReplicationType.RATIS,
-                            ReplicationFactor.ONE, new HashMap<>());
+        objectStore.getVolume(volumeName).getBucket(bucketName)
+            .createKey("ratis", 1024,
+                ReplicationConfig.fromTypeAndFactor(
+                    ReplicationType.RATIS,
+                    ReplicationFactor.ONE), new HashMap<>());
     // First write and flush creates a container in the datanode
     key.write("ratis".getBytes(UTF_8));
     key.flush();
     key.write("ratis".getBytes(UTF_8));
     KeyOutputStream groupOutputStream = (KeyOutputStream) key.
-            getOutputStream();
+        getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
-            groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+        groupOutputStream.getLocationInfoList();
+    Assertions.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-            cluster);
+        cluster);
     int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
     ContainerData containerData = dn.getDatanodeStateMachine()
-                    .getContainer().getContainerSet()
-                    .getContainer(omKeyLocationInfo.getContainerID())
-                    .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+        .getContainer().getContainerSet()
+        .getContainer(omKeyLocationInfo.getContainerID())
+        .getContainerData();
+    Assertions.assertTrue(containerData instanceof KeyValueContainerData);
     KeyValueContainerData keyValueContainerData =
-            (KeyValueContainerData) containerData;
+        (KeyValueContainerData) containerData;
     key.close();
     ContainerStateMachine stateMachine =
         (ContainerStateMachine) TestHelper.getStateMachine(cluster.
             getHddsDatanodes().get(index), omKeyLocationInfo.getPipeline());
     SimpleStateMachineStorage storage =
-            (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
+        (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
     stateMachine.takeSnapshot();
     final FileInfo snapshot = getSnapshotFileInfo(storage);
     final Path parentPath = snapshot.getPath();
     // Since the snapshot threshold is set to 1, since there are
     // applyTransactions, we should see snapshots
-    Assert.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
-    Assert.assertNotNull(snapshot);
+    Assertions.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
+    Assertions.assertNotNull(snapshot);
     long containerID = omKeyLocationInfo.getContainerID();
     // delete the container db file
     FileUtil.fullyDelete(new File(keyValueContainerData.getContainerPath()));
     Pipeline pipeline = cluster.getStorageContainerLocationClient()
-            .getContainerWithPipeline(containerID).getPipeline();
+        .getContainerWithPipeline(containerID).getPipeline();
     XceiverClientSpi xceiverClient =
-            xceiverClientManager.acquireClient(pipeline);
+        xceiverClientManager.acquireClient(pipeline);
     ContainerProtos.ContainerCommandRequestProto.Builder request =
-            ContainerProtos.ContainerCommandRequestProto.newBuilder();
+        ContainerProtos.ContainerCommandRequestProto.newBuilder();
     request.setDatanodeUuid(pipeline.getFirstNode().getUuidString());
     request.setCmdType(ContainerProtos.Type.CloseContainer);
     request.setContainerID(containerID);
     request.setCloseContainer(
-            ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
+        ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
     // close container transaction will fail over Ratis and will initiate
     // a pipeline close action
 
     try {
       xceiverClient.sendCommand(request.build());
-      Assert.fail("Expected exception not thrown");
+      Assertions.fail("Expected exception not thrown");
     } catch (IOException e) {
       // Exception should be thrown
     } finally {
       xceiverClientManager.releaseClient(xceiverClient, false);
     }
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(dn.getDatanodeStateMachine()
-                    .getContainer().getContainerSet().getContainer(containerID)
-                    .getContainerState()
-                    == ContainerProtos.ContainerDataProto.State.UNHEALTHY);
+    Assertions.assertSame(dn.getDatanodeStateMachine()
+        .getContainer().getContainerSet().getContainer(containerID)
+        .getContainerState(), UNHEALTHY);
     try {
       // try to take a new snapshot, ideally it should just fail
       stateMachine.takeSnapshot();
     } catch (IOException ioe) {
-      Assert.assertTrue(ioe instanceof StateMachineException);
+      Assertions.assertTrue(ioe instanceof StateMachineException);
     }
 
     if (snapshot.getPath().toFile().exists()) {
       // Make sure the latest snapshot is same as the previous one
       try {
         final FileInfo latestSnapshot = getSnapshotFileInfo(storage);
-        Assert.assertTrue(snapshot.getPath().equals(latestSnapshot.getPath()));
+        Assertions.assertEquals(snapshot.getPath(), latestSnapshot.getPath());
       } catch (Throwable e) {
-        Assert.assertFalse(snapshot.getPath().toFile().exists());
+        Assertions.assertFalse(snapshot.getPath().toFile().exists());
       }
     }
-    
+
     // when remove pipeline, group dir including snapshot will be deleted
     LambdaTestUtils.await(10000, 500,
         () -> (!snapshot.getPath().toFile().exists()));
@@ -488,68 +488,70 @@ public class TestContainerStateMachineFailures {
   @Test
   @Flaky("HDDS-6115")
   public void testApplyTransactionIdempotencyWithClosedContainer()
-          throws Exception {
+      throws Exception {
     OzoneOutputStream key =
-            objectStore.getVolume(volumeName).getBucket(bucketName)
-                    .createKey("ratis", 1024, ReplicationType.RATIS,
-                            ReplicationFactor.ONE, new HashMap<>());
+        objectStore.getVolume(volumeName).getBucket(bucketName)
+            .createKey("ratis", 1024,
+                ReplicationConfig.fromTypeAndFactor(
+                    ReplicationType.RATIS,
+                    ReplicationFactor.ONE), new HashMap<>());
     // First write and flush creates a container in the datanode
     key.write("ratis".getBytes(UTF_8));
     key.flush();
     key.write("ratis".getBytes(UTF_8));
     KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
-            groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+        groupOutputStream.getLocationInfoList();
+    Assertions.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-            cluster);
+        cluster);
     ContainerData containerData = dn.getDatanodeStateMachine()
-                    .getContainer().getContainerSet()
-                    .getContainer(omKeyLocationInfo.getContainerID())
-                    .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+        .getContainer().getContainerSet()
+        .getContainer(omKeyLocationInfo.getContainerID())
+        .getContainerData();
+    Assertions.assertTrue(containerData instanceof KeyValueContainerData);
     key.close();
     ContainerStateMachine stateMachine =
-            (ContainerStateMachine) TestHelper.getStateMachine(dn,
-                    omKeyLocationInfo.getPipeline());
+        (ContainerStateMachine) TestHelper.getStateMachine(dn,
+            omKeyLocationInfo.getPipeline());
     SimpleStateMachineStorage storage =
-            (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
+        (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
     final FileInfo snapshot = getSnapshotFileInfo(storage);
     final Path parentPath = snapshot.getPath();
     stateMachine.takeSnapshot();
-    Assert.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
-    Assert.assertNotNull(snapshot);
+    Assertions.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
+    Assertions.assertNotNull(snapshot);
     long markIndex1 = StatemachineImplTestUtil.findLatestSnapshot(storage)
         .getIndex();
     long containerID = omKeyLocationInfo.getContainerID();
     Pipeline pipeline = cluster.getStorageContainerLocationClient()
-            .getContainerWithPipeline(containerID).getPipeline();
+        .getContainerWithPipeline(containerID).getPipeline();
     XceiverClientSpi xceiverClient =
-            xceiverClientManager.acquireClient(pipeline);
+        xceiverClientManager.acquireClient(pipeline);
     ContainerProtos.ContainerCommandRequestProto.Builder request =
-            ContainerProtos.ContainerCommandRequestProto.newBuilder();
+        ContainerProtos.ContainerCommandRequestProto.newBuilder();
     request.setDatanodeUuid(pipeline.getFirstNode().getUuidString());
     request.setCmdType(ContainerProtos.Type.CloseContainer);
     request.setContainerID(containerID);
     request.setCloseContainer(
-            ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
+        ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
     try {
       xceiverClient.sendCommand(request.build());
     } catch (IOException e) {
-      Assert.fail("Exception should not be thrown");
+      Assertions.fail("Exception should not be thrown");
     }
-    Assert.assertTrue(
-            TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
-                    .getDatanodeStateMachine()
-                    .getContainer().getContainerSet().getContainer(containerID)
-                    .getContainerState()
-                    == ContainerProtos.ContainerDataProto.State.CLOSED);
-    Assert.assertTrue(stateMachine.isStateMachineHealthy());
+    Assertions.assertSame(
+        TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
+            .getDatanodeStateMachine()
+            .getContainer().getContainerSet().getContainer(containerID)
+            .getContainerState(),
+        ContainerProtos.ContainerDataProto.State.CLOSED);
+    Assertions.assertTrue(stateMachine.isStateMachineHealthy());
     try {
       stateMachine.takeSnapshot();
     } catch (IOException ioe) {
-      Assert.fail("Exception should not be thrown");
+      Assertions.fail("Exception should not be thrown");
     } finally {
       xceiverClientManager.releaseClient(xceiverClient, false);
     }
@@ -566,7 +568,7 @@ public class TestContainerStateMachineFailures {
       }
     }), 1000, 30000);
     final FileInfo latestSnapshot = getSnapshotFileInfo(storage);
-    Assert.assertFalse(snapshot.getPath().equals(latestSnapshot.getPath()));
+    Assertions.assertNotEquals(snapshot.getPath(), latestSnapshot.getPath());
   }
 
   // The test injects multiple write chunk requests along with closed container
@@ -577,60 +579,62 @@ public class TestContainerStateMachineFailures {
   // closed here.
   @Test
   public void testWriteStateMachineDataIdempotencyWithClosedContainer()
-          throws Exception {
+      throws Exception {
     OzoneOutputStream key =
-            objectStore.getVolume(volumeName).getBucket(bucketName)
-                    .createKey("ratis-1", 1024, ReplicationType.RATIS,
-                            ReplicationFactor.ONE, new HashMap<>());
+        objectStore.getVolume(volumeName).getBucket(bucketName)
+            .createKey("ratis-1", 1024,
+                ReplicationConfig.fromTypeAndFactor(
+                    ReplicationType.RATIS,
+                    ReplicationFactor.ONE), new HashMap<>());
     // First write and flush creates a container in the datanode
     key.write("ratis".getBytes(UTF_8));
     key.flush();
     key.write("ratis".getBytes(UTF_8));
     KeyOutputStream groupOutputStream = (KeyOutputStream) key
-            .getOutputStream();
+        .getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
-            groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+        groupOutputStream.getLocationInfoList();
+    Assertions.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-            cluster);
+        cluster);
     ContainerData containerData =
-            dn.getDatanodeStateMachine()
-                    .getContainer().getContainerSet()
-                    .getContainer(omKeyLocationInfo.getContainerID())
-                    .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+        dn.getDatanodeStateMachine()
+            .getContainer().getContainerSet()
+            .getContainer(omKeyLocationInfo.getContainerID())
+            .getContainerData();
+    Assertions.assertTrue(containerData instanceof KeyValueContainerData);
     key.close();
     ContainerStateMachine stateMachine =
-            (ContainerStateMachine) TestHelper.getStateMachine(dn,
-                    omKeyLocationInfo.getPipeline());
+        (ContainerStateMachine) TestHelper.getStateMachine(dn,
+            omKeyLocationInfo.getPipeline());
     SimpleStateMachineStorage storage =
-            (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
+        (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
     final FileInfo snapshot = getSnapshotFileInfo(storage);
     final Path parentPath = snapshot.getPath();
     stateMachine.takeSnapshot();
     // Since the snapshot threshold is set to 1, since there are
     // applyTransactions, we should see snapshots
-    Assert.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
-    Assert.assertNotNull(snapshot);
+    Assertions.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
+    Assertions.assertNotNull(snapshot);
     long containerID = omKeyLocationInfo.getContainerID();
     Pipeline pipeline = cluster.getStorageContainerLocationClient()
-            .getContainerWithPipeline(containerID).getPipeline();
+        .getContainerWithPipeline(containerID).getPipeline();
     XceiverClientSpi xceiverClient =
-            xceiverClientManager.acquireClient(pipeline);
+        xceiverClientManager.acquireClient(pipeline);
     CountDownLatch latch = new CountDownLatch(100);
     int count = 0;
     AtomicInteger failCount = new AtomicInteger(0);
     Runnable r1 = () -> {
       try {
         ContainerProtos.ContainerCommandRequestProto.Builder request =
-                ContainerProtos.ContainerCommandRequestProto.newBuilder();
+            ContainerProtos.ContainerCommandRequestProto.newBuilder();
         request.setDatanodeUuid(pipeline.getFirstNode().getUuidString());
         request.setCmdType(ContainerProtos.Type.CloseContainer);
         request.setContainerID(containerID);
         request.setCloseContainer(
-                ContainerProtos.CloseContainerRequestProto.
-                        getDefaultInstance());
+            ContainerProtos.CloseContainerRequestProto.
+                getDefaultInstance());
         xceiverClient.sendCommand(request.build());
       } catch (IOException e) {
         failCount.incrementAndGet();
@@ -643,20 +647,19 @@ public class TestContainerStateMachineFailures {
             ContainerTestHelper.newWriteChunkRequestBuilder(pipeline,
                 omKeyLocationInfo.getBlockID(), data.size());
         writeChunkRequest.setWriteChunk(writeChunkRequest.getWriteChunkBuilder()
-                .setData(data));
+            .setData(data));
         xceiverClient.sendCommand(writeChunkRequest.build());
         latch.countDown();
       } catch (IOException e) {
         latch.countDown();
         if (!(HddsClientUtils
-                .checkForException(e) instanceof ContainerNotOpenException)) {
+            .checkForException(e) instanceof ContainerNotOpenException)) {
           failCount.incrementAndGet();
         }
         String message = e.getMessage();
-        Assert.assertFalse(message,
-            message.contains("hello"));
-        Assert.assertTrue(message,
-            message.contains(HddsUtils.REDACTED.toStringUtf8()));
+        Assertions.assertFalse(message.contains("hello"), message);
+        Assertions.assertTrue(message.contains(
+            HddsUtils.REDACTED.toStringUtf8()), message);
       }
     };
 
@@ -679,23 +682,25 @@ public class TestContainerStateMachineFailures {
       }
 
       if (failCount.get() > 0) {
-        fail("testWriteStateMachineDataIdempotencyWithClosedContainer failed");
+        Assertions.fail(
+            "testWriteStateMachineDataIdempotencyWithClosedContainer " +
+                "failed");
       }
-      Assert.assertTrue(
+      Assertions.assertSame(
           TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
               .getDatanodeStateMachine()
               .getContainer().getContainerSet().getContainer(containerID)
-              .getContainerState()
-              == ContainerProtos.ContainerDataProto.State.CLOSED);
-      Assert.assertTrue(stateMachine.isStateMachineHealthy());
+              .getContainerState(),
+          ContainerProtos.ContainerDataProto.State.CLOSED);
+      Assertions.assertTrue(stateMachine.isStateMachineHealthy());
       try {
         stateMachine.takeSnapshot();
       } catch (IOException ioe) {
-        Assert.fail("Exception should not be thrown");
+        Assertions.fail("Exception should not be thrown");
       }
 
       final FileInfo latestSnapshot = getSnapshotFileInfo(storage);
-      Assert.assertFalse(snapshot.getPath().equals(latestSnapshot.getPath()));
+      Assertions.assertNotEquals(snapshot.getPath(), latestSnapshot.getPath());
 
       r2.run();
     } finally {
@@ -708,8 +713,9 @@ public class TestContainerStateMachineFailures {
       throws Exception {
     OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
-            .createKey("ratis1", 1024, ReplicationType.RATIS,
-                ReplicationFactor.THREE, new HashMap<>());
+            .createKey("ratis1", 1024,
+                ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                    ReplicationFactor.THREE), new HashMap<>());
 
     key.write("ratis".getBytes(UTF_8));
     key.flush();
@@ -720,7 +726,7 @@ public class TestContainerStateMachineFailures {
         getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    Assertions.assertEquals(1, locationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
@@ -733,7 +739,7 @@ public class TestContainerStateMachineFailures {
       key.close();
     } catch (Exception ioe) {
       // Should not fail..
-      Assert.fail("Exception " + ioe.getMessage());
+      Assertions.fail("Exception " + ioe.getMessage());
     }
     validateData("ratis1", 2, "ratisratisratisratis");
   }
@@ -743,8 +749,9 @@ public class TestContainerStateMachineFailures {
       throws Exception {
     OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
-            .createKey("ratis2", 1024, ReplicationType.RATIS,
-                ReplicationFactor.THREE, new HashMap<>());
+            .createKey("ratis2", 1024,
+                ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                    ReplicationFactor.THREE), new HashMap<>());
 
     key.write("ratis".getBytes(UTF_8));
     key.flush();
@@ -755,7 +762,7 @@ public class TestContainerStateMachineFailures {
         getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    Assertions.assertEquals(1, locationInfoList.size());
 
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
@@ -768,7 +775,7 @@ public class TestContainerStateMachineFailures {
       key.close();
     } catch (Exception ioe) {
       // Should not fail..
-      Assert.fail("Exception " + ioe.getMessage());
+      Assertions.fail("Exception " + ioe.getMessage());
     }
     validateData("ratis1", 2, "ratisratisratisratis");
   }
@@ -794,7 +801,7 @@ public class TestContainerStateMachineFailures {
           ContainerData containerData =
               container
                   .getContainerData();
-          Assert.assertTrue(containerData instanceof KeyValueContainerData);
+          Assertions.assertTrue(containerData instanceof KeyValueContainerData);
           KeyValueContainerData keyValueContainerData =
               (KeyValueContainerData) containerData;
           FileUtil.fullyDelete(new File(keyValueContainerData.getChunksPath()));
@@ -817,7 +824,7 @@ public class TestContainerStateMachineFailures {
     try {
       keyInfo = cluster.getOzoneManager().lookupKey(omKeyArgs);
 
-      Assert.assertEquals(locationCount,
+      Assertions.assertEquals(locationCount,
           keyInfo.getLatestVersionLocations().getLocationListCount());
       byte[] buffer = new byte[1024];
       try (OzoneInputStream o = objectStore.getVolume(volumeName)
@@ -828,9 +835,9 @@ public class TestContainerStateMachineFailures {
       String response = new String(buffer, 0,
           end,
           StandardCharsets.UTF_8);
-      Assert.assertEquals(payload, response);
+      Assertions.assertEquals(payload, response);
     } catch (IOException e) {
-      Assert.fail("Exception not expected " + e.getMessage());
+      Assertions.fail("Exception not expected " + e.getMessage());
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFlushDelay.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.client.rpc;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -38,14 +39,11 @@ import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,14 +61,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 /**
  * Tests the containerStateMachine failure handling by set flush delay.
  */
+@Timeout(300)
 public class TestContainerStateMachineFlushDelay {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf = new OzoneConfiguration();
   private OzoneClient client;
@@ -89,7 +81,7 @@ public class TestContainerStateMachineFlushDelay {
    *
    * @throws IOException
    */
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     chunkSize = 100;
     flushSize = 2 * chunkSize;
@@ -140,7 +132,7 @@ public class TestContainerStateMachineFlushDelay {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @After
+  @AfterEach
   public void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -152,14 +144,15 @@ public class TestContainerStateMachineFlushDelay {
   public void testContainerStateMachineFailures() throws Exception {
     OzoneOutputStream key =
         objectStore.getVolume(volumeName).getBucket(bucketName)
-            .createKey("ratis", 1024, ReplicationType.RATIS,
-                ReplicationFactor.ONE, new HashMap<>());
+            .createKey("ratis", 1024,
+                ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                    ReplicationFactor.ONE), new HashMap<>());
     // Now ozone.client.stream.buffer.flush.delay is currently enabled
     // by default. Here we  written data(length 110) greater than chunk
     // Size(length 100), make sure flush will sync data.
     byte[] data =
         ContainerTestHelper.getFixedLengthString(keyString, 110)
-        .getBytes(UTF_8);
+            .getBytes(UTF_8);
     // First write and flush creates a container in the datanode
     key.write(data);
     key.flush();
@@ -171,7 +164,7 @@ public class TestContainerStateMachineFlushDelay {
 
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    Assertions.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
 
     // delete the container dir
@@ -183,12 +176,12 @@ public class TestContainerStateMachineFlushDelay {
 
     key.close();
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(
+    Assertions.assertSame(
         cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
             .getContainer().getContainerSet()
             .getContainer(omKeyLocationInfo.getContainerID())
-            .getContainerState()
-            == ContainerProtos.ContainerDataProto.State.UNHEALTHY);
+            .getContainerState(),
+        ContainerProtos.ContainerDataProto.State.UNHEALTHY);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineStream.java
@@ -36,14 +36,11 @@ import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -60,14 +57,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 /**
  * Tests the containerStateMachine stream handling.
  */
+@Timeout(300)
 public class TestContainerStateMachineStream {
-
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf = new OzoneConfiguration();
   private OzoneClient client;
@@ -85,7 +76,7 @@ public class TestContainerStateMachineStream {
    *
    * @throws IOException
    */
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
 
@@ -150,7 +141,7 @@ public class TestContainerStateMachineStream {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @After
+  @AfterEach
   public void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -184,9 +175,9 @@ public class TestContainerStateMachineStream {
     long bytesUsed = dn.getDatanodeStateMachine()
         .getContainer().getContainerSet()
         .getContainer(omKeyLocationInfo.getContainerID()).
-            getContainerData().getBytesUsed();
+        getContainerData().getBytesUsed();
 
-    Assert.assertTrue(bytesUsed == size);
+    Assertions.assertEquals(bytesUsed, size);
   }
 
 
@@ -215,9 +206,9 @@ public class TestContainerStateMachineStream {
     long bytesUsed = dn.getDatanodeStateMachine()
         .getContainer().getContainerSet()
         .getContainer(omKeyLocationInfo.getContainerID()).
-            getContainerData().getBytesUsed();
+        getContainerData().getBytesUsed();
 
-    Assert.assertTrue(bytesUsed == size);
+    Assertions.assertEquals(bytesUsed, size);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDiscardPreallocatedBlocks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDiscardPreallocatedBlocks.java
@@ -49,26 +49,17 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests Close Container Exception handling by Ozone Client.
  */
+@Timeout(300)
 public class TestDiscardPreallocatedBlocks {
-
-  /**
-   * Set a timeout for each test.
-   */
-
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf = new OzoneConfiguration();
   private static OzoneClient client;
@@ -87,7 +78,7 @@ public class TestDiscardPreallocatedBlocks {
    * @throws IOException
    */
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     chunkSize = (int) OzoneConsts.MB;
     blockSize = 4 * chunkSize;
@@ -119,10 +110,10 @@ public class TestDiscardPreallocatedBlocks {
   }
 
   /**
-  * Shutdown MiniDFSCluster.
-  */
+   * Shutdown MiniDFSCluster.
+   */
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -137,14 +128,14 @@ public class TestDiscardPreallocatedBlocks {
         createKey(keyName, ReplicationType.RATIS, 2 * blockSize);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     // With the initial size provided, it should have pre allocated 2 blocks
-    Assert.assertEquals(2, keyOutputStream.getStreamEntries().size());
+    Assertions.assertEquals(2, keyOutputStream.getStreamEntries().size());
     long containerID1 = keyOutputStream.getStreamEntries().get(0)
-            .getBlockID().getContainerID();
+        .getBlockID().getContainerID();
     long containerID2 = keyOutputStream.getStreamEntries().get(1)
-            .getBlockID().getContainerID();
-    Assert.assertEquals(containerID1, containerID2);
+        .getBlockID().getContainerID();
+    Assertions.assertEquals(containerID1, containerID2);
     String dataString =
         ContainerTestHelper.getFixedLengthString(keyString, (1 * blockSize));
     byte[] data = dataString.getBytes(UTF_8);
@@ -161,28 +152,27 @@ public class TestDiscardPreallocatedBlocks {
         cluster.getStorageContainerManager().getPipelineManager()
             .getPipeline(container.getPipelineID());
     List<DatanodeDetails> datanodes = pipeline.getNodes();
-    Assert.assertEquals(3, datanodes.size());
+    Assertions.assertEquals(3, datanodes.size());
     waitForContainerClose(key);
     dataString =
         ContainerTestHelper.getFixedLengthString(keyString, (1 * blockSize));
     data = dataString.getBytes(UTF_8);
     key.write(data);
-    Assert.assertEquals(3, keyOutputStream.getStreamEntries().size());
+    Assertions.assertEquals(3, keyOutputStream.getStreamEntries().size());
     // the 1st block got written. Now all the containers are closed, so the 2nd
     // pre allocated block will be removed from the list and new block should
     // have been allocated
-    Assert.assertTrue(
-        keyOutputStream.getLocationInfoList().get(0).getBlockID()
-            .equals(locationInfos.get(0).getBlockID()));
-    Assert.assertFalse(
-        locationStreamInfos.get(1).getBlockID()
-            .equals(keyOutputStream.getLocationInfoList().get(1).getBlockID()));
+    Assertions.assertEquals(
+        keyOutputStream.getLocationInfoList().get(0).getBlockID(),
+        locationInfos.get(0).getBlockID());
+    Assertions.assertNotEquals(locationStreamInfos.get(1).getBlockID(),
+        keyOutputStream.getLocationInfoList().get(1).getBlockID());
     key.close();
 
   }
 
   private OzoneOutputStream createKey(String keyName, ReplicationType type,
-      long size) throws Exception {
+                                      long size) throws Exception {
     return TestHelper
         .createKey(keyName, type, size, objectStore, volumeName, bucketName);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -17,14 +17,14 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * Tests key output stream without zero-copy enabled.
  */
 public class TestECKeyOutputStream extends
     AbstractTestECKeyOutputStream {
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     init(false);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStreamWithZeroCopy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStreamWithZeroCopy.java
@@ -17,14 +17,14 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * Tests key output stream with zero-copy enabled.
  */
 public class TestECKeyOutputStreamWithZeroCopy extends
     AbstractTestECKeyOutputStream {
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     init(true);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -67,7 +67,7 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_NO
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -133,7 +133,7 @@ public class TestFailureHandlingByClient {
     conf.setClass(NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
         StaticMapping.class, DNSToSwitchMapping.class);
     StaticMapping.addNodeToRack(NetUtils.normalizeHostNames(
-        Collections.singleton(HddsUtils.getHostName(conf))).get(0),
+            Collections.singleton(HddsUtils.getHostName(conf))).get(0),
         "/rack1");
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(10).setTotalPipelineNumLimit(15).build();
@@ -173,16 +173,16 @@ public class TestFailureHandlingByClient {
     key.write(data);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     // assert that the exclude list's expire time equals to
     // default value 600000 ms in OzoneClientConfig.java
-    Assert.assertEquals(((KeyOutputStream) key.getOutputStream())
+    Assertions.assertEquals(((KeyOutputStream) key.getOutputStream())
         .getExcludeList().getExpiryTime(), 600000);
     KeyOutputStream groupOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertTrue(locationInfoList.size() == 1);
+    Assertions.assertEquals(1, locationInfoList.size());
     long containerId = locationInfoList.get(0).getContainerID();
     ContainerInfo container = cluster.getStorageContainerManager()
         .getContainerManager()
@@ -204,7 +204,7 @@ public class TestFailureHandlingByClient {
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
-    Assert.assertEquals(data.length, keyInfo.getDataSize());
+    Assertions.assertEquals(data.length, keyInfo.getDataSize());
     validateData(keyName, data);
 
     // Verify that the block information is updated correctly in the DB on
@@ -277,11 +277,11 @@ public class TestFailureHandlingByClient {
               .getLocalID()));
       // The first Block could have 1 or 2 chunkSize of data
       int block1NumChunks = blockData1.getChunks().size();
-      Assert.assertTrue(block1NumChunks >= 1);
+      Assertions.assertTrue(block1NumChunks >= 1);
 
-      Assert.assertEquals(chunkSize * block1NumChunks, blockData1.getSize());
-      Assert.assertEquals(1, containerData1.getBlockCount());
-      Assert.assertEquals(chunkSize * block1NumChunks,
+      Assertions.assertEquals(chunkSize * block1NumChunks, blockData1.getSize());
+      Assertions.assertEquals(1, containerData1.getBlockCount());
+      Assertions.assertEquals(chunkSize * block1NumChunks,
           containerData1.getBytesUsed());
     }
 
@@ -295,17 +295,17 @@ public class TestFailureHandlingByClient {
           containerData2.getBlockKey(locationList.get(1).getBlockID()
               .getLocalID()));
       // The second Block should have 0.5 chunkSize of data
-      Assert.assertEquals(block2ExpectedChunkCount,
+      Assertions.assertEquals(block2ExpectedChunkCount,
           blockData2.getChunks().size());
-      Assert.assertEquals(1, containerData2.getBlockCount());
+      Assertions.assertEquals(1, containerData2.getBlockCount());
       int expectedBlockSize;
       if (block2ExpectedChunkCount == 1) {
         expectedBlockSize = chunkSize / 2;
       } else {
         expectedBlockSize = chunkSize + chunkSize / 2;
       }
-      Assert.assertEquals(expectedBlockSize, blockData2.getSize());
-      Assert.assertEquals(expectedBlockSize, containerData2.getBytesUsed());
+      Assertions.assertEquals(expectedBlockSize, blockData2.getSize());
+      Assertions.assertEquals(expectedBlockSize, containerData2.getBytesUsed());
     }
   }
 
@@ -319,7 +319,7 @@ public class TestFailureHandlingByClient {
         .getFixedLengthString(keyString,  chunkSize / 2);
     key.write(data.getBytes(UTF_8));
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
@@ -347,10 +347,10 @@ public class TestFailureHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(data.getBytes(UTF_8).length,
+    Assertions.assertEquals(data.getBytes(UTF_8).length,
         keyInfo.getDataSize());
     validateData(keyName, data.getBytes(UTF_8));
   }
@@ -367,14 +367,14 @@ public class TestFailureHandlingByClient {
         .getFixedLengthString(keyString,  chunkSize);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<BlockOutputStreamEntry> streamEntryList =
         keyOutputStream.getStreamEntries();
 
     // Assert that 1 block will be preallocated
-    Assert.assertEquals(1, streamEntryList.size());
+    Assertions.assertEquals(1, streamEntryList.size());
     key.write(data.getBytes(UTF_8));
     key.flush();
     long containerId = streamEntryList.get(0).getBlockID().getContainerID();
@@ -391,11 +391,11 @@ public class TestFailureHandlingByClient {
     key.write(data.getBytes(UTF_8));
     key.flush();
 
-    Assert.assertTrue(keyOutputStream.getExcludeList().getContainerIds()
+    Assertions.assertTrue(keyOutputStream.getExcludeList().getContainerIds()
         .contains(ContainerID.valueOf(containerId)));
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getDatanodes().isEmpty());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getPipelineIds().isEmpty());
 
     // The close will just write to the buffer
@@ -408,10 +408,10 @@ public class TestFailureHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(2 * data.getBytes(UTF_8).length,
+    Assertions.assertEquals(2 * data.getBytes(UTF_8).length,
         keyInfo.getDataSize());
     validateData(keyName, data.concat(data).getBytes(UTF_8));
   }
@@ -426,14 +426,14 @@ public class TestFailureHandlingByClient {
         .getFixedLengthString(keyString,  chunkSize);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<BlockOutputStreamEntry> streamEntryList =
         keyOutputStream.getStreamEntries();
 
     // Assert that 1 block will be preallocated
-    Assert.assertEquals(1, streamEntryList.size());
+    Assertions.assertEquals(1, streamEntryList.size());
     key.write(data.getBytes(UTF_8));
     key.flush();
     long containerId = streamEntryList.get(0).getBlockID().getContainerID();
@@ -454,11 +454,11 @@ public class TestFailureHandlingByClient {
     key.write(data.getBytes(UTF_8));
     key.flush();
 
-    Assert.assertTrue(keyOutputStream.getExcludeList().getDatanodes()
+    Assertions.assertTrue(keyOutputStream.getExcludeList().getDatanodes()
         .contains(datanodes.get(0)));
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getContainerIds().isEmpty());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getPipelineIds().isEmpty());
     // The close will just write to the buffer
     key.close();
@@ -471,10 +471,10 @@ public class TestFailureHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
+    Assertions.assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName, data.concat(data).concat(data).getBytes(UTF_8));
   }
 
@@ -489,14 +489,14 @@ public class TestFailureHandlingByClient {
         .getFixedLengthString(keyString,  chunkSize);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<BlockOutputStreamEntry> streamEntryList =
         keyOutputStream.getStreamEntries();
 
     // Assert that 1 block will be preallocated
-    Assert.assertEquals(1, streamEntryList.size());
+    Assertions.assertEquals(1, streamEntryList.size());
     key.write(data.getBytes(UTF_8));
     key.flush();
     long containerId = streamEntryList.get(0).getBlockID().getContainerID();
@@ -517,11 +517,11 @@ public class TestFailureHandlingByClient {
     key.write(data.getBytes(UTF_8));
     key.write(data.getBytes(UTF_8));
     key.flush();
-    Assert.assertTrue(keyOutputStream.getExcludeList().getPipelineIds()
+    Assertions.assertTrue(keyOutputStream.getExcludeList().getPipelineIds()
         .contains(pipeline.getId()));
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getContainerIds().isEmpty());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getDatanodes().isEmpty());
     // The close will just write to the buffer
     key.close();
@@ -534,15 +534,15 @@ public class TestFailureHandlingByClient {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
+    Assertions.assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName, data.concat(data).concat(data).getBytes(UTF_8));
   }
 
   private OzoneOutputStream createKey(String keyName, ReplicationType type,
-      long size) throws Exception {
+                                      long size) throws Exception {
     return TestHelper
         .createKey(keyName, type, size, objectStore, volumeName, bucketName);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
@@ -47,13 +47,10 @@ import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -69,13 +66,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 /**
  * Tests Exception handling by Ozone Client by set flush delay.
  */
+@Timeout(300)
 public class TestFailureHandlingByClientFlushDelay {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
@@ -132,7 +124,7 @@ public class TestFailureHandlingByClientFlushDelay {
     conf.setClass(NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
         StaticMapping.class, DNSToSwitchMapping.class);
     StaticMapping.addNodeToRack(NetUtils.normalizeHostNames(
-        Collections.singleton(HddsUtils.getHostName(conf))).get(0),
+            Collections.singleton(HddsUtils.getHostName(conf))).get(0),
         "/rack1");
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(10)
@@ -160,7 +152,7 @@ public class TestFailureHandlingByClientFlushDelay {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @After
+  @AfterEach
   public void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -178,14 +170,14 @@ public class TestFailureHandlingByClientFlushDelay {
         .getFixedLengthString(keyString,  chunkSize);
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<BlockOutputStreamEntry> streamEntryList =
         keyOutputStream.getStreamEntries();
 
     // Assert that 1 block will be preallocated
-    Assert.assertEquals(1, streamEntryList.size());
+    Assertions.assertEquals(1, streamEntryList.size());
     key.write(data.getBytes(UTF_8));
     key.flush();
     long containerId = streamEntryList.get(0).getBlockID().getContainerID();
@@ -205,11 +197,11 @@ public class TestFailureHandlingByClientFlushDelay {
 
     key.write(data.getBytes(UTF_8));
     key.flush();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getContainerIds().isEmpty());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getDatanodes().isEmpty());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         keyOutputStream.getExcludeList().getDatanodes().isEmpty());
     key.write(data.getBytes(UTF_8));
     // The close will just write to the buffer
@@ -225,15 +217,15 @@ public class TestFailureHandlingByClientFlushDelay {
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
 
     // Make sure a new block is written
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().get(0)
             .getBlockID(), blockId);
-    Assert.assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
+    Assertions.assertEquals(3 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName, data.concat(data).concat(data).getBytes(UTF_8));
   }
 
   private OzoneOutputStream createKey(String keyName, ReplicationType type,
-      long size) throws Exception {
+                                      long size) throws Exception {
     return TestHelper
         .createKey(keyName, type, size, objectStore, volumeName, bucketName);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestHybridPipelineOnDatanode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestHybridPipelineOnDatanode.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
-
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -37,33 +37,23 @@ import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.HashMap;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
 
 /**
  * Tests Hybrid Pipeline Creation and IO on same set of Datanodes.
  */
+@Timeout(300)
 public class TestHybridPipelineOnDatanode {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
   private static OzoneClient client;
@@ -76,7 +66,7 @@ public class TestHybridPipelineOnDatanode {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3)
@@ -90,7 +80,7 @@ public class TestHybridPipelineOnDatanode {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -117,8 +107,9 @@ public class TestHybridPipelineOnDatanode {
 
     // Write data into a key
     OzoneOutputStream out = bucket
-        .createKey(keyName1, data.length, ReplicationType.RATIS,
-            ReplicationFactor.ONE, new HashMap<>());
+        .createKey(keyName1, data.length,
+            ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                ReplicationFactor.ONE), new HashMap<>());
     out.write(value.getBytes(UTF_8));
     out.close();
 
@@ -126,8 +117,9 @@ public class TestHybridPipelineOnDatanode {
 
     // Write data into a key
     out = bucket
-        .createKey(keyName2, data.length, ReplicationType.RATIS,
-            ReplicationFactor.THREE, new HashMap<>());
+        .createKey(keyName2, data.length,
+            ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                ReplicationFactor.THREE), new HashMap<>());
     out.write(value.getBytes(UTF_8));
     out.close();
 
@@ -151,17 +143,18 @@ public class TestHybridPipelineOnDatanode {
         cluster.getStorageContainerManager().getPipelineManager()
             .getPipeline(pipelineID1);
     List<DatanodeDetails> dns = pipeline1.getNodes();
-    Assert.assertTrue(dns.size() == 1);
+    Assertions.assertEquals(1, dns.size());
 
     Pipeline pipeline2 =
         cluster.getStorageContainerManager().getPipelineManager()
             .getPipeline(pipelineID2);
-    Assert.assertNotEquals(pipeline1, pipeline2);
-    Assert.assertTrue(pipeline1.getType() == HddsProtos.ReplicationType.RATIS);
-    Assert.assertTrue(pipeline1.getType() == pipeline2.getType());
+    Assertions.assertNotEquals(pipeline1, pipeline2);
+    Assertions.assertSame(pipeline1.getType(),
+        HddsProtos.ReplicationType.RATIS);
+    Assertions.assertSame(pipeline1.getType(), pipeline2.getType());
     // assert that the pipeline Id1 and pipelineId2 are on the same node
     // but different replication factor
-    Assert.assertTrue(pipeline2.getNodes().contains(dns.get(0)));
+    Assertions.assertTrue(pipeline2.getNodes().contains(dns.get(0)));
     byte[] b1 = new byte[data.length];
     byte[] b2 = new byte[data.length];
     // now try to read both the keys
@@ -173,8 +166,8 @@ public class TestHybridPipelineOnDatanode {
     is = bucket.readKey(keyName2);
     is.read(b2);
     is.close();
-    Assert.assertTrue(Arrays.equals(b1, data));
-    Assert.assertTrue(Arrays.equals(b1, b2));
+    Assertions.assertArrayEquals(b1, data);
+    Assertions.assertArrayEquals(b1, b2);
   }
 }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
@@ -42,20 +42,16 @@ import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
@@ -64,14 +60,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 /**
  * Tests MultiBlock Writes with Dn failures by Ozone Client.
  */
+@Timeout(300)
 public class TestMultiBlockWritesWithDnFailures {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
   private OzoneClient client;
@@ -137,7 +127,7 @@ public class TestMultiBlockWritesWithDnFailures {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @After
+  @AfterEach
   public void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -156,12 +146,12 @@ public class TestMultiBlockWritesWithDnFailures {
     key.write(data.getBytes(UTF_8));
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream groupOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
         groupOutputStream.getLocationInfoList();
-    Assert.assertTrue(locationInfoList.size() == 2);
+    Assertions.assertEquals(2, locationInfoList.size());
     long containerId = locationInfoList.get(1).getContainerID();
     ContainerInfo container = cluster.getStorageContainerManager()
         .getContainerManager()
@@ -185,7 +175,7 @@ public class TestMultiBlockWritesWithDnFailures {
         .setKeyName(keyName)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
-    Assert.assertEquals(2 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
+    Assertions.assertEquals(2 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName, data.concat(data).getBytes(UTF_8));
   }
 
@@ -201,14 +191,14 @@ public class TestMultiBlockWritesWithDnFailures {
     key.write(data.getBytes(UTF_8));
 
     // get the name of a valid container
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream =
         (KeyOutputStream) key.getOutputStream();
     List<BlockOutputStreamEntry> streamEntryList =
         keyOutputStream.getStreamEntries();
 
     // Assert that 6 block will be preallocated
-    Assert.assertEquals(6, streamEntryList.size());
+    Assertions.assertEquals(6, streamEntryList.size());
     key.write(data.getBytes(UTF_8));
     key.flush();
     long containerId = streamEntryList.get(0).getBlockID().getContainerID();
@@ -237,13 +227,13 @@ public class TestMultiBlockWritesWithDnFailures {
         .setKeyName(keyName)
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
-    Assert.assertEquals(4 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
+    Assertions.assertEquals(4 * data.getBytes(UTF_8).length, keyInfo.getDataSize());
     validateData(keyName,
         data.concat(data).concat(data).concat(data).getBytes(UTF_8));
   }
 
   private OzoneOutputStream createKey(String keyName, ReplicationType type,
-      long size) throws Exception {
+                                      long size) throws Exception {
     return TestHelper
         .createKey(keyName, type, size, objectStore, volumeName, bucketName);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -245,8 +245,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
     // So, when a part is override partNames will still be same irrespective
     // of content in ozone s3. This will make S3 Mpu completeMPU pass when
     // comparing part names and large file uploads work using aws cp.
-    Assertions.assertEquals("Part names should be same", partName,
-        partNameNew);
+    Assertions.assertEquals(partName, partNameNew, "Part names should be same");
 
     // old part bytes written needs discard and have only
     // new part bytes in quota for this bucket

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -61,15 +61,12 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -86,13 +83,14 @@ import java.util.UUID;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.client.ReplicationType.RATIS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This test verifies all the S3 multipart client apis - prefix layout.
  */
+@Timeout(300)
 public class TestOzoneClientMultipartUploadWithFSO {
 
   private static ObjectStore store = null;
@@ -100,12 +98,6 @@ public class TestOzoneClientMultipartUploadWithFSO {
   private static OzoneClient ozClient = null;
 
   private static String scmId = UUID.randomUUID().toString();
-
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(new Timeout(300000));
   private String volumeName;
   private String bucketName;
   private String keyName;
@@ -119,7 +111,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     OMRequestTestUtils.configureFSOptimizedPaths(conf, true);
@@ -129,7 +121,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
   /**
    * Close OzoneClient and shutdown MiniOzoneCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws IOException {
     shutdownCluster();
   }
@@ -142,10 +134,10 @@ public class TestOzoneClientMultipartUploadWithFSO {
    */
   static void startCluster(OzoneConfiguration conf) throws Exception {
     cluster = MiniOzoneCluster.newBuilder(conf)
-            .setNumDatanodes(5)
-            .setTotalPipelineNumLimit(10)
-            .setScmId(scmId)
-            .build();
+        .setNumDatanodes(5)
+        .setTotalPipelineNumLimit(10)
+        .setScmId(scmId)
+        .build();
     cluster.waitForClusterToBeReady();
     ozClient = OzoneClientFactory.getRpcClient(conf);
     store = ozClient.getObjectStore();
@@ -163,8 +155,8 @@ public class TestOzoneClientMultipartUploadWithFSO {
       cluster.shutdown();
     }
   }
-  
-  @Before
+
+  @BeforeEach
   public void preTest() throws Exception {
     volumeName = UUID.randomUUID().toString();
     bucketName = UUID.randomUUID().toString();
@@ -178,7 +170,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
 
   @Test
   public void testInitiateMultipartUploadWithReplicationInformationSet() throws
-          IOException {
+      IOException {
     String uploadID = initiateMultipartUpload(bucket, keyName,
         ReplicationType.RATIS, ONE);
 
@@ -186,31 +178,31 @@ public class TestOzoneClientMultipartUploadWithFSO {
     // generate a new uploadID.
     String uploadIDNew = initiateMultipartUpload(bucket, keyName,
         ReplicationType.RATIS, ONE);
-    Assert.assertNotEquals(uploadIDNew, uploadID);
+    Assertions.assertNotEquals(uploadIDNew, uploadID);
   }
 
   @Test
   public void testInitiateMultipartUploadWithDefaultReplication() throws
-          IOException {
+      IOException {
     OmMultipartInfo multipartInfo = bucket.initiateMultipartUpload(keyName);
 
-    Assert.assertNotNull(multipartInfo);
+    Assertions.assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
-    Assert.assertNotNull(multipartInfo.getUploadID());
+    Assertions.assertEquals(volumeName, multipartInfo.getVolumeName());
+    Assertions.assertEquals(bucketName, multipartInfo.getBucketName());
+    Assertions.assertEquals(keyName, multipartInfo.getKeyName());
+    Assertions.assertNotNull(multipartInfo.getUploadID());
 
     // Call initiate multipart upload for the same key again, this should
     // generate a new uploadID.
     multipartInfo = bucket.initiateMultipartUpload(keyName);
 
-    Assert.assertNotNull(multipartInfo);
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
-    Assert.assertNotEquals(multipartInfo.getUploadID(), uploadID);
-    Assert.assertNotNull(multipartInfo.getUploadID());
+    Assertions.assertNotNull(multipartInfo);
+    Assertions.assertEquals(volumeName, multipartInfo.getVolumeName());
+    Assertions.assertEquals(bucketName, multipartInfo.getBucketName());
+    Assertions.assertEquals(keyName, multipartInfo.getKeyName());
+    Assertions.assertNotEquals(multipartInfo.getUploadID(), uploadID);
+    Assertions.assertNotNull(multipartInfo.getUploadID());
   }
 
   @Test
@@ -220,15 +212,15 @@ public class TestOzoneClientMultipartUploadWithFSO {
         ReplicationType.RATIS, ONE);
 
     OzoneOutputStream ozoneOutputStream = bucket.createMultipartKey(keyName,
-            sampleData.length(), 1, uploadID);
+        sampleData.length(), 1, uploadID);
     ozoneOutputStream.write(string2Bytes(sampleData), 0, sampleData.length());
     ozoneOutputStream.close();
 
     OmMultipartCommitUploadPartInfo commitUploadPartInfo = ozoneOutputStream
-            .getCommitUploadPartInfo();
+        .getCommitUploadPartInfo();
 
-    Assert.assertNotNull(commitUploadPartInfo);
-    Assert.assertNotNull(commitUploadPartInfo.getPartName());
+    Assertions.assertNotNull(commitUploadPartInfo);
+    Assertions.assertNotNull(commitUploadPartInfo.getPartName());
   }
 
   @Test
@@ -253,13 +245,13 @@ public class TestOzoneClientMultipartUploadWithFSO {
     // So, when a part is override partNames will still be same irrespective
     // of content in ozone s3. This will make S3 Mpu completeMPU pass when
     // comparing part names and large file uploads work using aws cp.
-    Assert.assertEquals("Part names should be same", partName,
+    Assertions.assertEquals("Part names should be same", partName,
         partNameNew);
 
     // old part bytes written needs discard and have only
     // new part bytes in quota for this bucket
     long byteWritten = "name".length() * 3; // data written with replication
-    Assert.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
+    Assertions.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
         byteWritten);
   }
 
@@ -277,14 +269,14 @@ public class TestOzoneClientMultipartUploadWithFSO {
 
     String partName = uploadPart(bucket, keyName, uploadID, partNumber,
         data);
-    
+
     Map<Integer, String> partsMap = new HashMap<>();
     partsMap.put(partNumber, partName);
     bucket.completeMultipartUpload(keyName, uploadID, partsMap);
 
     long replicatedSize = QuotaUtil.getReplicatedSize(data.length,
         bucket.getReplicationConfig());
-    Assert.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
+    Assertions.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
         replicatedSize);
 
     //upload same key again
@@ -299,7 +291,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
     bucket.completeMultipartUpload(keyName, uploadID, partsMap);
 
     // used sized should remain same, overwrite previous upload
-    Assert.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
+    Assertions.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
         replicatedSize);
   }
 
@@ -316,16 +308,16 @@ public class TestOzoneClientMultipartUploadWithFSO {
     String uploadID = multipartInfo.getUploadID();
     int partNumber = 1;
     uploadPart(bucket, keyName, uploadID, partNumber, data);
-    
+
     long replicatedSize = QuotaUtil.getReplicatedSize(data.length,
         bucket.getReplicationConfig());
-    Assert.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
+    Assertions.assertEquals(volume.getBucket(bucketName).getUsedBytes(),
         replicatedSize);
 
     bucket.abortMultipartUpload(keyName, uploadID);
 
     // used size should become zero after aport upload
-    Assert.assertEquals(volume.getBucket(bucketName).getUsedBytes(), 0);
+    Assertions.assertEquals(volume.getBucket(bucketName).getUsedBytes(), 0);
   }
 
   private OzoneBucket getOzoneECBucket(String myBucket)
@@ -339,22 +331,22 @@ public class TestOzoneClientMultipartUploadWithFSO {
     volume.createBucket(myBucket, bucketArgs.build());
     return volume.getBucket(myBucket);
   }
-  
+
   @Test
   public void testMultipartUploadWithPartsLessThanMinSize() throws Exception {
     // Initiate multipart upload
     String uploadID = initiateMultipartUpload(bucket, keyName, RATIS,
-            ONE);
+        ONE);
 
     // Upload Parts
     Map<Integer, String> partsMap = new TreeMap<>();
     // Uploading part 1 with less than min size
     String partName = uploadPart(bucket, keyName, uploadID, 1,
-            "data".getBytes(UTF_8));
+        "data".getBytes(UTF_8));
     partsMap.put(1, partName);
 
     partName = uploadPart(bucket, keyName, uploadID, 2,
-            "data".getBytes(UTF_8));
+        "data".getBytes(UTF_8));
     partsMap.put(2, partName);
 
     // Complete multipart upload
@@ -389,14 +381,14 @@ public class TestOzoneClientMultipartUploadWithFSO {
     // the unused part size should be discarded from the bucket size,
     // 30000000 - 10000000 = 20000000
     long bucketSize = volume.getBucket(bucketName).getUsedBytes();
-    Assert.assertEquals(bucketSize, data.length * 2);
+    Assertions.assertEquals(bucketSize, data.length * 2);
   }
 
   @Test
   public void testMultipartUploadWithPartsMisMatchWithListSizeDifferent()
-          throws Exception {
+      throws Exception {
     String uploadID = initiateMultipartUpload(bucket, keyName, RATIS,
-            ONE);
+        ONE);
 
     // We have not uploaded any parts, but passing some list it should throw
     // error.
@@ -409,9 +401,9 @@ public class TestOzoneClientMultipartUploadWithFSO {
 
   @Test
   public void testMultipartUploadWithPartsMisMatchWithIncorrectPartName()
-          throws Exception {
+      throws Exception {
     String uploadID = initiateMultipartUpload(bucket, keyName, RATIS,
-            ONE);
+        ONE);
 
     uploadPart(bucket, keyName, uploadID, 1, "data".getBytes(UTF_8));
 
@@ -426,7 +418,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
   @Test
   public void testMultipartUploadWithMissingParts() throws Exception {
     String uploadID = initiateMultipartUpload(bucket, keyName, RATIS,
-            ONE);
+        ONE);
 
     uploadPart(bucket, keyName, uploadID, 1, "data".getBytes(UTF_8));
 
@@ -461,35 +453,35 @@ public class TestOzoneClientMultipartUploadWithFSO {
   @Test
   public void testCommitPartAfterCompleteUpload() throws Exception {
     String parentDir = "a/b/c/d/";
-    keyName = parentDir + UUID.randomUUID().toString();
+    keyName = parentDir + UUID.randomUUID();
     String uploadID = initiateMultipartUpload(bucket, keyName, RATIS, ONE);
 
-    Assert.assertEquals(volume.getBucket(bucketName).getUsedNamespace(), 4);
+    Assertions.assertEquals(volume.getBucket(bucketName).getUsedNamespace(), 4);
 
     // upload part 1.
     byte[] data = generateData(5 * 1024 * 1024,
-            (byte) RandomUtils.nextLong());
+        (byte) RandomUtils.nextLong());
     OzoneOutputStream ozoneOutputStream = bucket.createMultipartKey(keyName,
-            data.length, 1, uploadID);
+        data.length, 1, uploadID);
     ozoneOutputStream.write(data, 0, data.length);
     ozoneOutputStream.close();
 
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =
-            ozoneOutputStream.getCommitUploadPartInfo();
+        ozoneOutputStream.getCommitUploadPartInfo();
 
     // Do not close output stream for part 2.
     ozoneOutputStream = bucket.createMultipartKey(keyName,
-            data.length, 2, uploadID);
+        data.length, 2, uploadID);
     ozoneOutputStream.write(data, 0, data.length);
 
     Map<Integer, String> partsMap = new LinkedHashMap<>();
     partsMap.put(1, omMultipartCommitUploadPartInfo.getPartName());
     OmMultipartUploadCompleteInfo omMultipartUploadCompleteInfo =
-            bucket.completeMultipartUpload(keyName,
-                    uploadID, partsMap);
-    Assert.assertNotNull(omMultipartUploadCompleteInfo);
+        bucket.completeMultipartUpload(keyName,
+            uploadID, partsMap);
+    Assertions.assertNotNull(omMultipartUploadCompleteInfo);
 
-    Assert.assertNotNull(omMultipartCommitUploadPartInfo);
+    Assertions.assertNotNull(omMultipartCommitUploadPartInfo);
 
     byte[] fileContent = new byte[data.length];
     try (OzoneInputStream inputStream = bucket.readKey(keyName)) {
@@ -500,15 +492,15 @@ public class TestOzoneClientMultipartUploadWithFSO {
     // Combine all parts data, and check is it matching with get key data.
     String part1 = new String(data, UTF_8);
     sb.append(part1);
-    Assert.assertEquals(sb.toString(), new String(fileContent, UTF_8));
+    Assertions.assertEquals(sb.toString(), new String(fileContent, UTF_8));
 
     try {
       ozoneOutputStream.close();
-      Assert.fail("testCommitPartAfterCompleteUpload failed");
+      Assertions.fail("testCommitPartAfterCompleteUpload failed");
     } catch (IOException ex) {
-      Assert.assertTrue(ex instanceof OMException);
-      Assert.assertEquals(NO_SUCH_MULTIPART_UPLOAD_ERROR,
-              ((OMException) ex).getResult());
+      Assertions.assertTrue(ex instanceof OMException);
+      Assertions.assertEquals(NO_SUCH_MULTIPART_UPLOAD_ERROR,
+          ((OMException) ex).getResult());
     }
   }
 
@@ -521,7 +513,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
   @Test
   public void testAbortUploadFailWithInProgressPartUpload() throws Exception {
     String parentDir = "a/b/c/d/";
-    keyName = parentDir + UUID.randomUUID().toString();
+    keyName = parentDir + UUID.randomUUID();
 
     String uploadID = initiateMultipartUpload(bucket, keyName,
         RATIS, ONE);
@@ -548,7 +540,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
   @Test
   public void testAbortUploadSuccessWithOutAnyParts() throws Exception {
     String parentDir = "a/b/c/d/";
-    keyName = parentDir + UUID.randomUUID().toString();
+    keyName = parentDir + UUID.randomUUID();
 
     String uploadID = initiateMultipartUpload(bucket, keyName, RATIS,
         ONE);
@@ -558,7 +550,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
   @Test
   public void testAbortUploadSuccessWithParts() throws Exception {
     String parentDir = "a/b/c/d/";
-    keyName = parentDir + UUID.randomUUID().toString();
+    keyName = parentDir + UUID.randomUUID();
 
     OzoneManager ozoneManager = cluster.getOzoneManager();
     String buckKey = ozoneManager.getMetadataManager()
@@ -585,8 +577,8 @@ public class TestOzoneClientMultipartUploadWithFSO {
         metadataMgr.getOpenKeyTable(bucketLayout).get(multipartOpenKey);
     OmMultipartKeyInfo omMultipartKeyInfo =
         metadataMgr.getMultipartInfoTable().get(multipartKey);
-    Assert.assertNull(omKeyInfo);
-    Assert.assertNull(omMultipartKeyInfo);
+    Assertions.assertNull(omKeyInfo);
+    Assertions.assertNull(omMultipartKeyInfo);
 
     // Since deleteTable operation is performed via
     // batchOp - Table.putWithBatch(), which is an async operation and
@@ -616,22 +608,22 @@ public class TestOzoneClientMultipartUploadWithFSO {
     OzoneMultipartUploadPartListParts ozoneMultipartUploadPartListParts =
         bucket.listParts(keyName, uploadID, 0, 3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
         ozoneMultipartUploadPartListParts.getReplicationConfig());
 
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
         ozoneMultipartUploadPartListParts.getPartInfoList().size());
 
     verifyPartNamesInDB(partsMap,
         ozoneMultipartUploadPartListParts, uploadID);
 
-    Assert.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
+    Assertions.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
   }
 
   private void verifyPartNamesInDB(Map<Integer, String> partsMap,
-      OzoneMultipartUploadPartListParts ozoneMultipartUploadPartListParts,
-      String uploadID) throws IOException {
+                                   OzoneMultipartUploadPartListParts ozoneMultipartUploadPartListParts,
+                                   String uploadID) throws IOException {
 
     List<String> listPartNames = new ArrayList<>();
     String keyPartName = verifyPartNames(partsMap, 0,
@@ -652,7 +644,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
         keyName, uploadID);
     OmMultipartKeyInfo omMultipartKeyInfo =
         metadataMgr.getMultipartInfoTable().get(multipartKey);
-    Assert.assertNotNull(omMultipartKeyInfo);
+    Assertions.assertNotNull(omMultipartKeyInfo);
 
     for (OzoneManagerProtocolProtos.PartKeyInfo partKeyInfo :
         omMultipartKeyInfo.getPartKeyInfoMap()) {
@@ -663,21 +655,21 @@ public class TestOzoneClientMultipartUploadWithFSO {
           metadataMgr.getOzoneKey(volumeName, bucketName, keyName);
 
       // partKeyName format in DB - partKeyName + ClientID
-      Assert.assertTrue("Invalid partKeyName format in DB: " + partKeyName
-              + ", expected name:" + fullKeyPartName,
-          partKeyName.startsWith(fullKeyPartName));
+      Assertions.assertTrue(partKeyName.startsWith(fullKeyPartName),
+          "Invalid partKeyName format in DB: " + partKeyName
+              + ", expected name:" + fullKeyPartName);
 
       listPartNames.remove(partKeyName);
     }
 
-    Assert.assertTrue("Wrong partKeyName format in DB!",
-        listPartNames.isEmpty());
+    Assertions.assertTrue(listPartNames.isEmpty(),
+        "Wrong partKeyName format in DB!");
   }
 
   private String verifyPartNames(Map<Integer, String> partsMap, int index,
-      OzoneMultipartUploadPartListParts ozoneMultipartUploadPartListParts) {
+                                 OzoneMultipartUploadPartListParts ozoneMultipartUploadPartListParts) {
 
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    Assertions.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(index).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(index)
             .getPartName());
@@ -707,37 +699,37 @@ public class TestOzoneClientMultipartUploadWithFSO {
     OzoneMultipartUploadPartListParts ozoneMultipartUploadPartListParts =
         bucket.listParts(keyName, uploadID, 0, 2);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
         ozoneMultipartUploadPartListParts.getReplicationConfig());
 
-    Assert.assertEquals(2,
+    Assertions.assertEquals(2,
         ozoneMultipartUploadPartListParts.getPartInfoList().size());
 
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    Assertions.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(0).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(0)
             .getPartName());
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    Assertions.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(1).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(1)
             .getPartName());
 
     // Get remaining
-    Assert.assertTrue(ozoneMultipartUploadPartListParts.isTruncated());
+    Assertions.assertTrue(ozoneMultipartUploadPartListParts.isTruncated());
     ozoneMultipartUploadPartListParts = bucket.listParts(keyName, uploadID,
         ozoneMultipartUploadPartListParts.getNextPartNumberMarker(), 2);
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         ozoneMultipartUploadPartListParts.getPartInfoList().size());
-    Assert.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
+    Assertions.assertEquals(partsMap.get(ozoneMultipartUploadPartListParts
             .getPartInfoList().get(0).getPartNumber()),
         ozoneMultipartUploadPartListParts.getPartInfoList().get(0)
             .getPartName());
 
 
     // As we don't have any parts for this, we should get false here
-    Assert.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
+    Assertions.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
 
   }
 
@@ -745,7 +737,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
   public void testListPartsInvalidPartMarker() throws Exception {
     try {
       bucket.listParts(keyName, "random", -1, 2);
-      Assert.fail("Should throw exception as partNumber is an invalid number!");
+      Assertions.fail("Should throw exception as partNumber is an invalid number!");
     } catch (IllegalArgumentException ex) {
       GenericTestUtils.assertExceptionContains("Should be greater than or "
           + "equal to zero", ex);
@@ -756,7 +748,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
   public void testListPartsInvalidMaxParts() throws Exception {
     try {
       bucket.listParts(keyName, "random", 1, -1);
-      Assert.fail("Should throw exception as max parts is an invalid number!");
+      Assertions.fail("Should throw exception as max parts is an invalid number!");
     } catch (IllegalArgumentException ex) {
       GenericTestUtils.assertExceptionContains("Max Parts Should be greater "
           + "than zero", ex);
@@ -777,15 +769,15 @@ public class TestOzoneClientMultipartUploadWithFSO {
 
     // Should return empty
 
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         ozoneMultipartUploadPartListParts.getPartInfoList().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
         ozoneMultipartUploadPartListParts.getReplicationConfig());
 
     // As we don't have any parts with greater than partNumberMarker and list
     // is not truncated, so it should return false here.
-    Assert.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
+    Assertions.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
 
   }
 
@@ -824,53 +816,53 @@ public class TestOzoneClientMultipartUploadWithFSO {
     uploadPart(bucket, key3, uploadID3, 1, "data".getBytes(UTF_8));
 
     OzoneMultipartUploadList listMPUs = bucket.listMultipartUploads("dir1");
-    Assert.assertEquals(3, listMPUs.getUploads().size());
+    Assertions.assertEquals(3, listMPUs.getUploads().size());
     List<String> expectedList = new ArrayList<>(keys);
     for (OzoneMultipartUpload mpu : listMPUs.getUploads()) {
       expectedList.remove(mpu.getKeyName());
     }
-    Assert.assertEquals(0, expectedList.size());
+    Assertions.assertEquals(0, expectedList.size());
 
     listMPUs = bucket.listMultipartUploads("dir1/dir2");
-    Assert.assertEquals(2, listMPUs.getUploads().size());
+    Assertions.assertEquals(2, listMPUs.getUploads().size());
     expectedList = new ArrayList<>();
     expectedList.add(key2);
     expectedList.add(key3);
     for (OzoneMultipartUpload mpu : listMPUs.getUploads()) {
       expectedList.remove(mpu.getKeyName());
     }
-    Assert.assertEquals(0, expectedList.size());
+    Assertions.assertEquals(0, expectedList.size());
 
     listMPUs = bucket.listMultipartUploads("dir1/dir2/dir3");
-    Assert.assertEquals(1, listMPUs.getUploads().size());
+    Assertions.assertEquals(1, listMPUs.getUploads().size());
     expectedList = new ArrayList<>();
     expectedList.add(key3);
     for (OzoneMultipartUpload mpu : listMPUs.getUploads()) {
       expectedList.remove(mpu.getKeyName());
     }
-    Assert.assertEquals(0, expectedList.size());
+    Assertions.assertEquals(0, expectedList.size());
 
     // partial key
     listMPUs = bucket.listMultipartUploads("d");
-    Assert.assertEquals(3, listMPUs.getUploads().size());
+    Assertions.assertEquals(3, listMPUs.getUploads().size());
     expectedList = new ArrayList<>(keys);
     for (OzoneMultipartUpload mpu : listMPUs.getUploads()) {
       expectedList.remove(mpu.getKeyName());
     }
-    Assert.assertEquals(0, expectedList.size());
+    Assertions.assertEquals(0, expectedList.size());
 
     // partial key
     listMPUs = bucket.listMultipartUploads("");
-    Assert.assertEquals(3, listMPUs.getUploads().size());
+    Assertions.assertEquals(3, listMPUs.getUploads().size());
     expectedList = new ArrayList<>(keys);
     for (OzoneMultipartUpload mpu : listMPUs.getUploads()) {
       expectedList.remove(mpu.getKeyName());
     }
-    Assert.assertEquals(0, expectedList.size());
+    Assertions.assertEquals(0, expectedList.size());
   }
 
   private String verifyUploadedPart(String uploadID, String partName,
-      OMMetadataManager metadataMgr) throws IOException {
+                                    OMMetadataManager metadataMgr) throws IOException {
     OzoneManager ozoneManager = cluster.getOzoneManager();
     String buckKey = ozoneManager.getMetadataManager()
         .getBucketKey(volumeName, bucketName);
@@ -888,28 +880,28 @@ public class TestOzoneClientMultipartUploadWithFSO {
     OmMultipartKeyInfo omMultipartKeyInfo =
         metadataMgr.getMultipartInfoTable().get(multipartKey);
 
-    Assert.assertNotNull(omKeyInfo);
-    Assert.assertNotNull(omMultipartKeyInfo);
-    Assert.assertEquals(OzoneFSUtils.getFileName(keyName),
+    Assertions.assertNotNull(omKeyInfo);
+    Assertions.assertNotNull(omMultipartKeyInfo);
+    Assertions.assertEquals(OzoneFSUtils.getFileName(keyName),
         omKeyInfo.getKeyName());
-    Assert.assertEquals(uploadID, omMultipartKeyInfo.getUploadID());
+    Assertions.assertEquals(uploadID, omMultipartKeyInfo.getUploadID());
 
     for (OzoneManagerProtocolProtos.PartKeyInfo partKeyInfo :
         omMultipartKeyInfo.getPartKeyInfoMap()) {
       OmKeyInfo currentKeyPartInfo =
           OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
 
-      Assert.assertEquals(keyName, currentKeyPartInfo.getKeyName());
+      Assertions.assertEquals(keyName, currentKeyPartInfo.getKeyName());
 
       // verify dbPartName
-      Assert.assertEquals(partName, partKeyInfo.getPartName());
+      Assertions.assertEquals(partName, partKeyInfo.getPartName());
     }
     return multipartKey;
   }
 
   private String getMultipartOpenKey(String multipartUploadID,
-      String volName, String buckName, String kName,
-      OMMetadataManager omMetadataManager) throws IOException {
+                                     String volName, String buckName, String kName,
+                                     OMMetadataManager omMetadataManager) throws IOException {
 
     String fileName = OzoneFSUtils.getFileName(kName);
     final long volumeId = omMetadataManager.getVolumeId(volName);
@@ -919,13 +911,13 @@ public class TestOzoneClientMultipartUploadWithFSO {
         omMetadataManager);
 
     String multipartKey = omMetadataManager.getMultipartKey(volumeId, bucketId,
-            parentID, fileName, multipartUploadID);
+        parentID, fileName, multipartUploadID);
 
     return multipartKey;
   }
 
   private long getParentID(String volName, String buckName,
-      String kName, OMMetadataManager omMetadataManager) throws IOException {
+                           String kName, OMMetadataManager omMetadataManager) throws IOException {
     Iterator<Path> pathComponents = Paths.get(kName).iterator();
     final long volumeId = omMetadataManager.getVolumeId(volName);
     final long bucketId = omMetadataManager.getBucketId(volName,
@@ -935,17 +927,17 @@ public class TestOzoneClientMultipartUploadWithFSO {
   }
 
   private String initiateMultipartUpload(OzoneBucket oBucket, String kName,
-      ReplicationType replicationType, ReplicationFactor replicationFactor)
-          throws IOException {
+                                         ReplicationType replicationType, ReplicationFactor replicationFactor)
+      throws IOException {
     OmMultipartInfo multipartInfo = oBucket.initiateMultipartUpload(kName,
-            replicationType, replicationFactor);
+        replicationType, replicationFactor);
 
-    Assert.assertNotNull(multipartInfo);
+    Assertions.assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(kName, multipartInfo.getKeyName());
-    Assert.assertNotNull(multipartInfo.getUploadID());
+    Assertions.assertEquals(volumeName, multipartInfo.getVolumeName());
+    Assertions.assertEquals(bucketName, multipartInfo.getBucketName());
+    Assertions.assertEquals(kName, multipartInfo.getKeyName());
+    Assertions.assertNotNull(multipartInfo.getUploadID());
 
     return uploadID;
   }
@@ -954,32 +946,32 @@ public class TestOzoneClientMultipartUploadWithFSO {
       uploadID, int partNumber, byte[] data) throws IOException {
 
     OzoneOutputStream ozoneOutputStream = oBucket.createMultipartKey(kName,
-            data.length, partNumber, uploadID);
+        data.length, partNumber, uploadID);
     ozoneOutputStream.write(data, 0,
-            data.length);
+        data.length);
     ozoneOutputStream.close();
 
     OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =
-            ozoneOutputStream.getCommitUploadPartInfo();
+        ozoneOutputStream.getCommitUploadPartInfo();
 
-    Assert.assertNotNull(omMultipartCommitUploadPartInfo);
-    Assert.assertNotNull(omMultipartCommitUploadPartInfo.getPartName());
+    Assertions.assertNotNull(omMultipartCommitUploadPartInfo);
+    Assertions.assertNotNull(omMultipartCommitUploadPartInfo.getPartName());
 
     return omMultipartCommitUploadPartInfo.getPartName();
   }
 
   private void completeMultipartUpload(OzoneBucket oBucket, String kName,
-      String uploadID, Map<Integer, String> partsMap) throws Exception {
+                                       String uploadID, Map<Integer, String> partsMap) throws Exception {
     OmMultipartUploadCompleteInfo omMultipartUploadCompleteInfo = oBucket
-            .completeMultipartUpload(kName, uploadID, partsMap);
+        .completeMultipartUpload(kName, uploadID, partsMap);
 
-    Assert.assertNotNull(omMultipartUploadCompleteInfo);
-    Assert.assertEquals(omMultipartUploadCompleteInfo.getBucket(), oBucket
-            .getName());
-    Assert.assertEquals(omMultipartUploadCompleteInfo.getVolume(), oBucket
-            .getVolumeName());
-    Assert.assertEquals(omMultipartUploadCompleteInfo.getKey(), kName);
-    Assert.assertNotNull(omMultipartUploadCompleteInfo.getHash());
+    Assertions.assertNotNull(omMultipartUploadCompleteInfo);
+    Assertions.assertEquals(omMultipartUploadCompleteInfo.getBucket(), oBucket
+        .getName());
+    Assertions.assertEquals(omMultipartUploadCompleteInfo.getVolume(), oBucket
+        .getVolumeName());
+    Assertions.assertEquals(omMultipartUploadCompleteInfo.getKey(), kName);
+    Assertions.assertNotNull(omMultipartUploadCompleteInfo.getHash());
   }
 
   private byte[] generateData(int size, byte val) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
@@ -39,13 +39,13 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.UnhealthyTest;
 import org.apache.ozone.test.tag.Unhealthy;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +64,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class is to test audit logs for xxxACL APIs of Ozone Client.
@@ -75,7 +75,7 @@ import static org.junit.Assert.assertTrue;
  * all assertion based test in this class.
  */
 @NotThreadSafe
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 @Category(UnhealthyTest.class)
 @Unhealthy("Fix this after adding audit support for HA Acl code. This will " +
     "be fixed by HDDS-2038")
@@ -86,10 +86,10 @@ public class TestOzoneRpcClientForAclAuditLog {
   private static UserGroupInformation ugi;
   private static final OzoneAcl USER_ACL =
       new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER,
-      "johndoe", IAccessAuthorizer.ACLType.ALL, ACCESS);
+          "johndoe", IAccessAuthorizer.ACLType.ALL, ACCESS);
   private static final OzoneAcl USER_ACL_2 =
       new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER,
-      "jane", IAccessAuthorizer.ACLType.ALL, ACCESS);
+          "jane", IAccessAuthorizer.ACLType.ALL, ACCESS);
   private static List<OzoneAcl> aclListToAdd = new ArrayList<>();
   private static MiniOzoneCluster cluster = null;
   private static OzoneClient ozClient = null;
@@ -106,7 +106,7 @@ public class TestOzoneRpcClientForAclAuditLog {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     System.setProperty("log4j.configurationFile", "auditlog.properties");
     ugi = UserGroupInformation.getCurrentUser();
@@ -141,7 +141,7 @@ public class TestOzoneRpcClientForAclAuditLog {
   /**
    * Close OzoneClient and shutdown MiniOzoneCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void teardown() throws IOException {
     shutdownCluster();
     deleteAuditLog();
@@ -195,7 +195,7 @@ public class TestOzoneRpcClientForAclAuditLog {
     OzoneVolume retVolumeinfo = store.getVolume(volumeName);
     verifyLog(OMAction.READ_VOLUME.name(), volumeName,
         AuditEventStatus.SUCCESS.name());
-    Assert.assertTrue(retVolumeinfo.getName().equalsIgnoreCase(volumeName));
+    Assertions.assertTrue(retVolumeinfo.getName().equalsIgnoreCase(volumeName));
 
     OzoneObj volObj = new OzoneObjInfo.Builder()
         .setVolumeName(volumeName)
@@ -207,7 +207,7 @@ public class TestOzoneRpcClientForAclAuditLog {
     List<OzoneAcl> acls = store.getAcl(volObj);
     verifyLog(OMAction.GET_ACL.name(), volumeName,
         AuditEventStatus.SUCCESS.name());
-    Assert.assertTrue(acls.size() > 0);
+    Assertions.assertTrue(acls.size() > 0);
 
     //Testing addAcl
     store.addAcl(volObj, USER_ACL);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -52,15 +51,14 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.THREE;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class is to test all the public facing APIs of Ozone Client with an
@@ -117,8 +115,8 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
 
     // Write data into a key
     try (OzoneOutputStream out = bucket.createKey(keyName,
-        value.getBytes(UTF_8).length, ReplicationType.RATIS,
-        THREE, new HashMap<>())) {
+        value.getBytes(UTF_8).length, ReplicationConfig.fromTypeAndFactor(
+            ReplicationType.RATIS, THREE), new HashMap<>())) {
       out.write(value.getBytes(UTF_8));
     }
 
@@ -132,7 +130,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] b = new byte[value.getBytes(UTF_8).length];
       is.read(b);
-      Assert.assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
+      Assertions.assertArrayEquals(b, value.getBytes(UTF_8));
     } catch (OzoneChecksumException e) {
       fail("Read key should succeed");
     }
@@ -141,7 +139,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] b = new byte[value.getBytes(UTF_8).length];
       is.read(b);
-      Assert.assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
+      Assertions.assertArrayEquals(b, value.getBytes(UTF_8));
     } catch (OzoneChecksumException e) {
       fail("Read file should succeed");
     }
@@ -156,7 +154,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
       try (OzoneInputStream is = newBucket.readKey(keyName)) {
         byte[] b = new byte[value.getBytes(UTF_8).length];
         is.read(b);
-        Assert.assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
+        Assertions.assertArrayEquals(b, value.getBytes(UTF_8));
       } catch (OzoneChecksumException e) {
         fail("Read key should succeed");
       }
@@ -165,7 +163,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
       try (OzoneInputStream is = newBucket.readFile(keyName)) {
         byte[] b = new byte[value.getBytes(UTF_8).length];
         is.read(b);
-        Assert.assertTrue(Arrays.equals(b, value.getBytes(UTF_8)));
+        Assertions.assertArrayEquals(b, value.getBytes(UTF_8));
       } catch (OzoneChecksumException e) {
         fail("Read file should succeed");
       }
@@ -197,9 +195,9 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
 
     assertNotNull(multipartInfo);
     String uploadID = multipartInfo.getUploadID();
-    Assert.assertEquals(volumeName, multipartInfo.getVolumeName());
-    Assert.assertEquals(bucketName, multipartInfo.getBucketName());
-    Assert.assertEquals(keyName, multipartInfo.getKeyName());
+    Assertions.assertEquals(volumeName, multipartInfo.getVolumeName());
+    Assertions.assertEquals(bucketName, multipartInfo.getBucketName());
+    Assertions.assertEquals(keyName, multipartInfo.getKeyName());
     assertNotNull(multipartInfo.getUploadID());
 
     OzoneDataStreamOutput ozoneStreamOutput = bucket.createMultipartStreamKey(
@@ -211,11 +209,11 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     OzoneMultipartUploadPartListParts parts =
         bucket.listParts(keyName, uploadID, 0, 1);
 
-    Assert.assertEquals(parts.getPartInfoList().size(), 1);
+    Assertions.assertEquals(parts.getPartInfoList().size(), 1);
 
     OzoneMultipartUploadPartListParts.PartInfo partInfo =
         parts.getPartInfoList().get(0);
-    Assert.assertEquals(valueLength, partInfo.getSize());
+    Assertions.assertEquals(valueLength, partInfo.getSize());
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
@@ -61,10 +62,10 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_DESTRO
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.StatemachineImplTestUtil;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the containerStateMachine failure handling.
@@ -84,7 +85,7 @@ public class TestValidateBCSIDOnRestart {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
 
@@ -93,14 +94,14 @@ public class TestValidateBCSIDOnRestart {
     conf.setFromObject(clientConfig);
 
     conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,
-            TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS);
     conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 200,
-            TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS);
     conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 200,
-            TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS);
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 10, TimeUnit.SECONDS);
     conf.setTimeDuration(OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, 1,
-            TimeUnit.SECONDS);
+        TimeUnit.SECONDS);
 
     RatisClientConfig ratisClientConfig =
         conf.getObject(RatisClientConfig.class);
@@ -121,9 +122,9 @@ public class TestValidateBCSIDOnRestart {
     conf.setFromObject(raftClientConfig);
 
     cluster =
-            MiniOzoneCluster.newBuilder(conf).setNumDatanodes(2).
-                    setHbInterval(200)
-                    .build();
+        MiniOzoneCluster.newBuilder(conf).setNumDatanodes(2).
+            setHbInterval(200)
+            .build();
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 60000);
     //the easiest way to create an open container is creating a key
@@ -139,7 +140,7 @@ public class TestValidateBCSIDOnRestart {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -150,29 +151,31 @@ public class TestValidateBCSIDOnRestart {
   @Test
   public void testValidateBCSIDOnDnRestart() throws Exception {
     OzoneOutputStream key =
-            objectStore.getVolume(volumeName).getBucket(bucketName)
-                    .createKey("ratis", 1024, ReplicationType.RATIS,
-                            ReplicationFactor.ONE, new HashMap<>());
+        objectStore.getVolume(volumeName).getBucket(bucketName)
+            .createKey("ratis", 1024,
+                ReplicationConfig.fromTypeAndFactor(
+                    ReplicationType.RATIS,
+                    ReplicationFactor.ONE), new HashMap<>());
     // First write and flush creates a container in the datanode
     key.write("ratis".getBytes(UTF_8));
     key.flush();
     key.write("ratis".getBytes(UTF_8));
     KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
     List<OmKeyLocationInfo> locationInfoList =
-            groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+        groupOutputStream.getLocationInfoList();
+    Assertions.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
     HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-            cluster);
+        cluster);
     ContainerData containerData =
-            TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
-                    .getDatanodeStateMachine()
-                    .getContainer().getContainerSet()
-                    .getContainer(omKeyLocationInfo.getContainerID())
-                    .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+        TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
+            .getDatanodeStateMachine()
+            .getContainer().getContainerSet()
+            .getContainer(omKeyLocationInfo.getContainerID())
+            .getContainerData();
+    Assertions.assertTrue(containerData instanceof KeyValueContainerData);
     KeyValueContainerData keyValueContainerData =
-            (KeyValueContainerData) containerData;
+        (KeyValueContainerData) containerData;
     key.close();
 
     long containerID = omKeyLocationInfo.getContainerID();
@@ -182,49 +185,50 @@ public class TestValidateBCSIDOnRestart {
 
     HddsDatanodeService dnService = cluster.getHddsDatanodes().get(index);
     OzoneContainer ozoneContainer =
-            dnService.getDatanodeStateMachine()
-                    .getContainer();
+        dnService.getDatanodeStateMachine()
+            .getContainer();
     ozoneContainer.getContainerSet().removeContainer(containerID);
     ContainerStateMachine stateMachine =
-            (ContainerStateMachine) TestHelper.getStateMachine(cluster.
-                    getHddsDatanodes().get(index),
-                    omKeyLocationInfo.getPipeline());
+        (ContainerStateMachine) TestHelper.getStateMachine(cluster.
+                getHddsDatanodes().get(index),
+            omKeyLocationInfo.getPipeline());
     SimpleStateMachineStorage storage =
-            (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
+        (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
     stateMachine.takeSnapshot();
     final Path parentPath = StatemachineImplTestUtil.findLatestSnapshot(storage)
         .getFile().getPath();
     stateMachine.buildMissingContainerSet(parentPath.toFile());
     // Since the snapshot threshold is set to 1, since there are
     // applyTransactions, we should see snapshots
-    Assert.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
+    Assertions.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
 
     // make sure the missing containerSet is not empty
     HddsDispatcher dispatcher = (HddsDispatcher) ozoneContainer.getDispatcher();
-    Assert.assertTrue(!dispatcher.getMissingContainerSet().isEmpty());
-    Assert
-            .assertTrue(dispatcher.getMissingContainerSet()
-                    .contains(containerID));
+    Assertions.assertFalse(dispatcher.getMissingContainerSet().isEmpty());
+    Assertions
+        .assertTrue(dispatcher.getMissingContainerSet()
+            .contains(containerID));
     // write a new key
     key = objectStore.getVolume(volumeName).getBucket(bucketName)
-            .createKey("ratis", 1024, ReplicationType.RATIS,
-                    ReplicationFactor.ONE, new HashMap<>());
+        .createKey("ratis", 1024,
+            ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS,
+                ReplicationFactor.ONE), new HashMap<>());
     // First write and flush creates a container in the datanode
     key.write("ratis1".getBytes(UTF_8));
     key.flush();
     groupOutputStream = (KeyOutputStream) key.getOutputStream();
     locationInfoList = groupOutputStream.getLocationInfoList();
-    Assert.assertEquals(1, locationInfoList.size());
+    Assertions.assertEquals(1, locationInfoList.size());
     omKeyLocationInfo = locationInfoList.get(0);
     key.close();
     containerID = omKeyLocationInfo.getContainerID();
     dn = TestHelper.getDatanodeService(omKeyLocationInfo,
-            cluster);
+        cluster);
     containerData = dn.getDatanodeStateMachine()
-            .getContainer().getContainerSet()
-            .getContainer(omKeyLocationInfo.getContainerID())
-            .getContainerData();
-    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+        .getContainer().getContainerSet()
+        .getContainer(omKeyLocationInfo.getContainerID())
+        .getContainerData();
+    Assertions.assertTrue(containerData instanceof KeyValueContainerData);
     keyValueContainerData = (KeyValueContainerData) containerData;
     try (DBHandle db = BlockUtils.getDB(keyValueContainerData, conf)) {
 
@@ -239,11 +243,10 @@ public class TestValidateBCSIDOnRestart {
     index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
     cluster.restartHddsDatanode(dn.getDatanodeDetails(), true);
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(
-            cluster.getHddsDatanodes().get(index)
-                    .getDatanodeStateMachine()
-                    .getContainer().getContainerSet().getContainer(containerID)
-                    .getContainerState()
-                    == ContainerProtos.ContainerDataProto.State.UNHEALTHY);
+    Assertions.assertSame(cluster.getHddsDatanodes().get(index)
+            .getDatanodeStateMachine()
+            .getContainer().getContainerSet().getContainer(containerID)
+            .getContainerState(),
+        ContainerProtos.ContainerDataProto.State.UNHEALTHY);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -66,7 +66,7 @@ import org.apache.ozone.test.tag.Flaky;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import org.apache.ratis.protocol.exceptions.GroupMismatchException;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -183,43 +183,43 @@ public class TestWatchForCommit {
         ContainerTestHelper.getFixedLengthString(keyString, dataLength)
             .getBytes(UTF_8);
     key.write(data1);
-    Assert.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
+    Assertions.assertTrue(key.getOutputStream() instanceof KeyOutputStream);
     KeyOutputStream keyOutputStream = (KeyOutputStream)key.getOutputStream();
 
     OutputStream stream = keyOutputStream.getStreamEntries().get(0)
         .getOutputStream();
-    Assert.assertTrue(stream instanceof BlockOutputStream);
+    Assertions.assertTrue(stream instanceof BlockOutputStream);
     RatisBlockOutputStream blockOutputStream = (RatisBlockOutputStream) stream;
     // we have just written data more than flush Size(2 chunks), at this time
     // buffer pool will have 3 buffers allocated worth of chunk size
-    Assert.assertEquals(4, blockOutputStream.getBufferPool().getSize());
+    Assertions.assertEquals(4, blockOutputStream.getBufferPool().getSize());
     // writtenDataLength as well flushedDataLength will be updated here
-    Assert.assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
-    Assert.assertEquals(maxFlushSize,
+    Assertions.assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
+    Assertions.assertEquals(maxFlushSize,
         blockOutputStream.getTotalDataFlushedLength());
     // since data equals to maxBufferSize is written, this will be a blocking
     // call and hence will wait for atleast flushSize worth of data to get
     // acked by all servers right here
-    Assert.assertTrue(blockOutputStream.getTotalAckDataLength() >= flushSize);
+    Assertions.assertTrue(blockOutputStream.getTotalAckDataLength() >= flushSize);
     // watchForCommit will clean up atleast one entry from the map where each
     // entry corresponds to flushSize worth of data
-    Assert.assertTrue(
+    Assertions.assertTrue(
         blockOutputStream.getCommitIndex2flushedDataMap().size() <= 1);
     // Now do a flush. This will flush the data and update the flush length and
     // the map.
     key.flush();
     // Since the data in the buffer is already flushed, flush here will have
     // no impact on the counters and data structures
-    Assert.assertEquals(4, blockOutputStream.getBufferPool().getSize());
-    Assert.assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
-    Assert.assertEquals(dataLength,
+    Assertions.assertEquals(4, blockOutputStream.getBufferPool().getSize());
+    Assertions.assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
+    Assertions.assertEquals(dataLength,
         blockOutputStream.getTotalDataFlushedLength());
     // flush will make sure one more entry gets updated in the map
-    Assert.assertTrue(
+    Assertions.assertTrue(
         blockOutputStream.getCommitIndex2flushedDataMap().size() <= 2);
     XceiverClientRatis raftClient =
         (XceiverClientRatis) blockOutputStream.getXceiverClient();
-    Assert.assertEquals(3, raftClient.getCommitInfoMap().size());
+    Assertions.assertEquals(3, raftClient.getCommitInfoMap().size());
     Pipeline pipeline = raftClient.getPipeline();
     cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
     cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
@@ -234,15 +234,15 @@ public class TestWatchForCommit {
     // and one flush for partial chunk
     key.flush();
     // Make sure the retryCount is reset after the exception is handled
-    Assert.assertTrue(keyOutputStream.getRetryCount() == 0);
+    Assertions.assertEquals(0, keyOutputStream.getRetryCount());
     // now close the stream, It will update the ack length after watchForCommit
     key.close();
-    Assert
+    Assertions
         .assertEquals(dataLength, blockOutputStream.getTotalAckDataLength());
     // make sure the bufferPool is empty
-    Assert
+    Assertions
         .assertEquals(0, blockOutputStream.getBufferPool().computeBufferData());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         blockOutputStream.getCommitIndex2flushedDataMap().isEmpty());
     validateData(keyName, data1);
   }
@@ -257,8 +257,8 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      Assert.assertEquals(1, xceiverClient.getRefcount());
-      Assert.assertEquals(container1.getPipeline(),
+      Assertions.assertEquals(1, xceiverClient.getRefcount());
+      Assertions.assertEquals(container1.getPipeline(),
           xceiverClient.getPipeline());
       Pipeline pipeline = xceiverClient.getPipeline();
       TestHelper.createPipelineOnDatanode(pipeline, cluster);
@@ -280,18 +280,18 @@ public class TestWatchForCommit {
         // The basic idea here is just to test if its throws an exception.
         xceiverClient
             .watchForCommit(index + new Random().nextInt(100) + 10);
-        Assert.fail("expected exception not thrown");
+        Assertions.fail("expected exception not thrown");
       } catch (Exception e) {
-        Assert.assertTrue(e instanceof ExecutionException);
+        Assertions.assertTrue(e instanceof ExecutionException);
         // since the timeout value is quite long, the watch request will either
         // fail with NotReplicated exceptio, RetryFailureException or
         // RuntimeException
-        Assert.assertFalse(HddsClientUtils
+        Assertions.assertFalse(HddsClientUtils
             .checkForException(e) instanceof TimeoutException);
         // client should not attempt to watch with
         // MAJORITY_COMMITTED replication level, except the grpc IO issue
         if (!logCapturer.getOutput().contains("Connection refused")) {
-          Assert.assertFalse(
+          Assertions.assertFalse(
               e.getMessage().contains("Watch-MAJORITY_COMMITTED"));
         }
       }
@@ -310,8 +310,8 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      Assert.assertEquals(1, xceiverClient.getRefcount());
-      Assert.assertEquals(container1.getPipeline(),
+      Assertions.assertEquals(1, xceiverClient.getRefcount());
+      Assertions.assertEquals(container1.getPipeline(),
           xceiverClient.getPipeline());
       Pipeline pipeline = xceiverClient.getPipeline();
       TestHelper.createPipelineOnDatanode(pipeline, cluster);
@@ -321,7 +321,7 @@ public class TestWatchForCommit {
               container1.getContainerInfo().getContainerID(),
               xceiverClient.getPipeline()));
       reply.getResponse().get();
-      Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
+      Assertions.assertEquals(3, ratisClient.getCommitInfoMap().size());
       List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();
       for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
         // shutdown the ratis follower
@@ -338,12 +338,12 @@ public class TestWatchForCommit {
       xceiverClient.watchForCommit(reply.getLogIndex());
 
       // commitInfo Map will be reduced to 2 here
-      Assert.assertEquals(2, ratisClient.getCommitInfoMap().size());
+      Assertions.assertEquals(2, ratisClient.getCommitInfoMap().size());
       clientManager.releaseClient(xceiverClient, false);
       String output = logCapturer.getOutput();
-      Assert.assertTrue(output.contains("3 way commit failed"));
-      Assert.assertTrue(output.contains("TimeoutException"));
-      Assert.assertTrue(output.contains("Committed by majority"));
+      Assertions.assertTrue(output.contains("3 way commit failed"));
+      Assertions.assertTrue(output.contains("TimeoutException"));
+      Assertions.assertTrue(output.contains("Committed by majority"));
     }
     logCapturer.stopCapturing();
   }
@@ -356,8 +356,8 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      Assert.assertEquals(1, xceiverClient.getRefcount());
-      Assert.assertEquals(container1.getPipeline(),
+      Assertions.assertEquals(1, xceiverClient.getRefcount());
+      Assertions.assertEquals(container1.getPipeline(),
           xceiverClient.getPipeline());
       Pipeline pipeline = xceiverClient.getPipeline();
       XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
@@ -366,7 +366,7 @@ public class TestWatchForCommit {
           ContainerTestHelper.getCreateContainerRequest(containerId,
               xceiverClient.getPipeline()));
       reply.getResponse().get();
-      Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
+      Assertions.assertEquals(3, ratisClient.getCommitInfoMap().size());
       List<Pipeline> pipelineList = new ArrayList<>();
       pipelineList.add(pipeline);
       TestHelper.waitForPipelineClose(pipelineList, cluster);
@@ -377,9 +377,9 @@ public class TestWatchForCommit {
         xceiverClient
             .watchForCommit(reply.getLogIndex() +
                 new Random().nextInt(100) + 10);
-        Assert.fail("Expected exception not thrown");
+        Assertions.fail("Expected exception not thrown");
       } catch (Exception e) {
-        Assert.assertTrue(HddsClientUtils
+        Assertions.assertTrue(HddsClientUtils
             .checkForException(e) instanceof GroupMismatchException);
       }
       clientManager.releaseClient(xceiverClient, false);
@@ -387,7 +387,7 @@ public class TestWatchForCommit {
   }
 
   private OzoneOutputStream createKey(String keyName, ReplicationType type,
-      long size) throws Exception {
+                                      long size) throws Exception {
     return TestHelper
         .createKey(keyName, type, size, objectStore, volumeName, bucketName);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrating all the tests under integration-test/ozone/client to Junit5 and making sure that Junit4 is not used in any of the tests

Tested that using grep -rlE "org.junit.[A-Z]" . --include '*.java' command in hadoop-ozone/integration-test/

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9776

## How was this patch tested?

Full CI run: https://github.com/VarshaRaviCV/ozone/actions/runs/7248042617
