### PR TITLE
HDDS-9828. Do not use Files.createTempFile in tests

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestLocalKeyStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestLocalKeyStore.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.security.symmetric;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,17 +54,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test cases for {@link LocalSecretKeyStore}.
  */
-public class TestLocalKeyStore {
+class TestLocalKeyStore {
   private SecretKeyStore secretKeyStore;
   private Path testSecretFile;
 
+  @TempDir
+  private Path tempDir;
+
   @BeforeEach
-  private void setup() throws Exception {
-    testSecretFile = Files.createTempFile("key-strore-test", ".json");
+  void setup() throws IOException {
+    testSecretFile = Files.createFile(tempDir.resolve("key-store-test.json"));
     secretKeyStore = new LocalSecretKeyStore(testSecretFile);
   }
 
-  public static Stream<Arguments> saveAndLoadTestCases() throws Exception {
+  static Stream<Arguments> saveAndLoadTestCases() throws Exception {
     return Stream.of(
         // empty
         Arguments.of(ImmutableList.of()),
@@ -81,7 +85,7 @@ public class TestLocalKeyStore {
 
   @ParameterizedTest
   @MethodSource("saveAndLoadTestCases")
-  public void testSaveAndLoad(List<ManagedSecretKey> keys) throws IOException {
+  void testSaveAndLoad(List<ManagedSecretKey> keys) throws IOException {
     secretKeyStore.save(keys);
 
     // Ensure the intended file exists and is readable and writeable to
@@ -100,7 +104,7 @@ public class TestLocalKeyStore {
    * Verifies that secret keys are overwritten by subsequent writes.
    */
   @Test
-  public void testOverwrite() throws Exception {
+  void testOverwrite() throws Exception {
     List<ManagedSecretKey> initialKeys =
         newArrayList(generateKey("HmacSHA256"));
     secretKeyStore.save(initialKeys);
@@ -123,7 +127,7 @@ public class TestLocalKeyStore {
    * test fails, instead, analyse the backward-compatibility of the change.
    */
   @Test
-  public void testLoadExistingFile() throws Exception {
+  void testLoadExistingFile() throws Exception {
     // copy test file content to the backing file.
     String testJson = "[\n" +
         "  {\n" +

--- a/hadoop-hdds/rocks-native/src/test/java/org/apache/hadoop/hdds/utils/TestNativeLibraryLoader.java
+++ b/hadoop-hdds/rocks-native/src/test/java/org/apache/hadoop/hdds/utils/TestNativeLibraryLoader.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.utils;
 
 import org.apache.ozone.test.tag.Native;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
@@ -27,7 +28,7 @@ import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -42,10 +43,11 @@ import static org.mockito.ArgumentMatchers.same;
  */
 public class TestNativeLibraryLoader {
 
-  private static Stream<String> nativeLibraryDirectoryLocations()
-      throws IOException {
-    return Stream.of("", File.createTempFile("prefix", "suffix")
-        .getParentFile().getAbsolutePath(), null);
+  @TempDir
+  private static Path tempDir;
+
+  private static Stream<String> nativeLibraryDirectoryLocations() {
+    return Stream.of("", tempDir.toAbsolutePath().toString(), null);
   }
 
   @Native(ROCKS_TOOLS_NATIVE_LIBRARY_NAME)

--- a/hadoop-hdds/rocks-native/src/test/java/org/apache/hadoop/hdds/utils/db/managed/TestManagedSSTDumpIterator.java
+++ b/hadoop-hdds/rocks-native/src/test/java/org/apache/hadoop/hdds/utils/db/managed/TestManagedSSTDumpIterator.java
@@ -28,6 +28,7 @@ import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,6 +41,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,10 +64,12 @@ import static org.apache.hadoop.hdds.utils.NativeConstants.ROCKS_TOOLS_NATIVE_LI
  */
 class TestManagedSSTDumpIterator {
 
+  @TempDir
+  private Path tempDir;
+
   private File createSSTFileWithKeys(
       TreeMap<Pair<String, Integer>, String> keys) throws Exception {
-    File file = File.createTempFile("tmp_sst_file", ".sst");
-    file.deleteOnExit();
+    File file = Files.createFile(tempDir.resolve("tmp_sst_file.sst")).toFile();
     try (ManagedEnvOptions envOptions = new ManagedEnvOptions();
          ManagedOptions managedOptions = new ManagedOptions();
          ManagedSstFileWriter sstFileWriter = new ManagedSstFileWriter(
@@ -252,7 +257,7 @@ class TestManagedSSTDumpIterator {
     ByteArrayInputStream byteArrayInputStream =
         new ByteArrayInputStream(inputBytes);
     ManagedSSTDumpTool tool = Mockito.mock(ManagedSSTDumpTool.class);
-    File file = File.createTempFile("tmp", ".sst");
+    File file = Files.createFile(tempDir.resolve("tmp_file.sst")).toFile();
     Future future = Mockito.mock(Future.class);
     Mockito.when(future.isDone()).thenReturn(false);
     Mockito.when(future.get()).thenReturn(0);

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdb/util/TestManagedSstFileReader.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdb/util/TestManagedSstFileReader.java
@@ -31,6 +31,7 @@ import org.apache.ozone.test.tag.Native;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.rocksdb.RocksDBException;
@@ -58,6 +59,9 @@ import static org.apache.hadoop.hdds.utils.NativeConstants.ROCKS_TOOLS_NATIVE_LI
  */
 class TestManagedSstFileReader {
 
+  @TempDir
+  private File tempDir;
+
   // Key prefix containing all characters, to check if all characters can be
   // written & read from rocksdb through SSTDumptool
   private static final String KEY_PREFIX = IntStream.range(0, 256).boxed()
@@ -65,9 +69,8 @@ class TestManagedSstFileReader {
       .collect(Collectors.joining(""));
 
   private String createRandomSSTFile(TreeMap<String, Integer> keys)
-      throws IOException, RocksDBException {
-    File file = File.createTempFile("tmp_sst_file", ".sst");
-    file.deleteOnExit();
+      throws RocksDBException {
+    File file = new File(tempDir, "tmp_sst_file.sst");
 
     try (ManagedOptions managedOptions = new ManagedOptions();
          ManagedEnvOptions managedEnvOptions = new ManagedEnvOptions();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcProtocolService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcProtocolService.java
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.when;
  *
  * @see <a href="https://issues.apache.org/jira/browse/HDDS-8901">HDDS-8901</a>
  */
-public class TestInterSCMGrpcProtocolService {
+class TestInterSCMGrpcProtocolService {
 
   private static final String CP_FILE_NAME = "cpFile";
   private static final String CP_CONTENTS = "Hello world!";
@@ -89,7 +89,7 @@ public class TestInterSCMGrpcProtocolService {
   private Path temp;
 
   @Test
-  public void testMTLSOnInterScmGrpcProtocolServiceAccess() throws Exception {
+  void testMTLSOnInterScmGrpcProtocolServiceAccess() throws Exception {
     int port = new Random().nextInt(1000) + 45000;
     OzoneConfiguration conf = setupConfiguration(port);
     SCMCertificateClient
@@ -100,7 +100,7 @@ public class TestInterSCMGrpcProtocolService {
 
     InterSCMGrpcClient client =
         new InterSCMGrpcClient("localhost", port, conf, scmCertClient);
-    Path tempFile = Files.createTempFile(temp, CP_FILE_NAME, "");
+    Path tempFile = temp.resolve(CP_FILE_NAME);
     CompletableFuture<Path> res = client.download(tempFile);
     Path downloaded = res.get();
 
@@ -182,7 +182,7 @@ public class TestInterSCMGrpcProtocolService {
   }
 
   private DBCheckpoint checkPoint() throws IOException {
-    Path checkPointLocation = Files.createTempDirectory(temp, "cpDir");
+    Path checkPointLocation = Files.createDirectory(temp.resolve("cpDir"));
     Path cpFile = Paths.get(checkPointLocation.toString(), CP_FILE_NAME);
     Files.write(cpFile, CP_CONTENTS.getBytes(UTF_8));
     DBCheckpoint checkpoint = mock(DBCheckpoint.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -60,14 +61,14 @@ import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
  * Setting a timeout for every test method to 300 seconds.
  */
 @Timeout(value = 300)
-public class TestOzoneFsSnapshot {
+class TestOzoneFsSnapshot {
 
   private static MiniOzoneCluster cluster;
   private static final String OM_SERVICE_ID = "om-service-test1";
   private static OzoneManager ozoneManager;
   private static OzoneFsShell shell;
   private static final String VOLUME =
-      "vol-" + RandomStringUtils.randomNumeric(5);;
+      "vol-" + RandomStringUtils.randomNumeric(5);
   private static final String BUCKET =
       "buck-" + RandomStringUtils.randomNumeric(5);
   private static final String KEY =
@@ -80,7 +81,7 @@ public class TestOzoneFsSnapshot {
       BUCKET_PATH + OM_KEY_PREFIX + KEY;
 
   @BeforeAll
-  public static void initClass() throws Exception {
+  static void initClass() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     // Enable filesystem snapshot feature for the test regardless of the default
     conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
@@ -106,7 +107,7 @@ public class TestOzoneFsSnapshot {
   }
 
   @AfterAll
-  public static void shutdown() throws IOException {
+  static void shutdown() throws IOException {
     shell.close();
     if (cluster != null) {
       cluster.shutdown();
@@ -129,7 +130,7 @@ public class TestOzoneFsSnapshot {
   }
 
   @Test
-  public void testCreateSnapshotDuplicateName() throws Exception {
+  void testCreateSnapshotDuplicateName() throws Exception {
     String snapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
 
     int res = ToolRunner.run(shell,
@@ -144,7 +145,7 @@ public class TestOzoneFsSnapshot {
   }
 
   @Test
-  public void testCreateSnapshotWithSubDirInput() throws Exception {
+  void testCreateSnapshotWithSubDirInput() throws Exception {
     // Test that:
     // $ ozone fs -createSnapshot ofs://om/vol1/buck2/dir3/ snap1
     //
@@ -185,7 +186,7 @@ public class TestOzoneFsSnapshot {
   @ValueSource(strings = {"snap-1",
       "snap75795657617173401188448010125899089001363595171500499231286",
       "sn1"})
-  public void testCreateSnapshotSuccess(String snapshotName)
+  void testCreateSnapshotSuccess(String snapshotName)
       throws Exception {
     int res = ToolRunner.run(shell,
         new String[]{"-createSnapshot", BUCKET_PATH, snapshotName});
@@ -241,7 +242,7 @@ public class TestOzoneFsSnapshot {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("createSnapshotFailureScenarios")
-  public void testCreateSnapshotFailure(String description,
+  void testCreateSnapshotFailure(String description,
                                         String paramBucketPath,
                                         String snapshotName,
                                         String expectedMessage,
@@ -258,12 +259,12 @@ public class TestOzoneFsSnapshot {
    * Test list snapshot and snapshot keys with "ozone fs -ls".
    */
   @Test
-  public void testFsLsSnapshot() throws Exception {
+  void testFsLsSnapshot(@TempDir Path tempDir) throws Exception {
     String newKey = "key-" + RandomStringUtils.randomNumeric(5);
     String newKeyPath = BUCKET_PATH + OM_KEY_PREFIX + newKey;
 
     // Write a non-zero byte key.
-    Path tempFile = Files.createTempFile("testFsLsSnapshot-", "any-suffix");
+    Path tempFile = tempDir.resolve("testFsLsSnapshot-any-suffix");
     FileUtils.write(tempFile.toFile(), "random data", UTF_8);
     execShellCommandAndGetOutput(0,
         new String[]{"-put", tempFile.toString(), newKeyPath});
@@ -294,7 +295,7 @@ public class TestOzoneFsSnapshot {
   }
 
   @Test
-  public void testDeleteBucketWithSnapshot() throws Exception {
+  void testDeleteBucketWithSnapshot() throws Exception {
     String snapshotName = createSnapshot();
 
     String snapshotPath = BUCKET_WITH_SNAPSHOT_INDICATOR_PATH
@@ -326,7 +327,7 @@ public class TestOzoneFsSnapshot {
   }
 
   @Test
-  public void testSnapshotDeleteSuccess() throws Exception {
+  void testSnapshotDeleteSuccess() throws Exception {
     String snapshotName = createSnapshot();
     // Delete the created snapshot
     int res = ToolRunner.run(shell,
@@ -372,7 +373,7 @@ public class TestOzoneFsSnapshot {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("deleteSnapshotFailureScenarios")
-  public void testSnapshotDeleteFailure(String description,
+  void testSnapshotDeleteFailure(String description,
                                         String paramBucketPath,
                                         String snapshotName,
                                         String expectedMessage,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
@@ -25,11 +25,12 @@ import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +45,6 @@ import org.apache.hadoop.hdds.utils.DBCheckpointServlet;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 
-import org.apache.commons.io.FileUtils;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConsts.MULTIPART_FORM_DATA_BOUNDARY;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -154,67 +155,66 @@ public class TestSCMDbCheckpointServlet {
 
   @ParameterizedTest
   @MethodSource("getHttpMethods")
-  public void testEndpoint(String httpMethod)
+  void testEndpoint(String httpMethod, @TempDir Path tempDir)
       throws ServletException, IOException, InterruptedException {
     this.method = httpMethod;
 
-    File tempFile = null;
-    try {
-      List<String> toExcludeList = new ArrayList<>();
-      toExcludeList.add("sstFile1.sst");
-      toExcludeList.add("sstFile2.sst");
+    List<String> toExcludeList = new ArrayList<>();
+    toExcludeList.add("sstFile1.sst");
+    toExcludeList.add("sstFile2.sst");
 
-      setupHttpMethod(toExcludeList);
+    setupHttpMethod(toExcludeList);
 
-      doNothing().when(responseMock).setContentType("application/x-tgz");
-      doNothing().when(responseMock).setHeader(Mockito.anyString(),
-          Mockito.anyString());
+    doNothing().when(responseMock).setContentType("application/x-tgz");
+    doNothing().when(responseMock).setHeader(Mockito.anyString(),
+        Mockito.anyString());
 
-      tempFile = File.createTempFile("testEndpoint_" + System
-          .currentTimeMillis(), ".tar");
+    final Path outputPath = tempDir.resolve("testEndpoint.tar");
+    when(responseMock.getOutputStream()).thenReturn(
+        new ServletOutputStream() {
+          private final OutputStream fileOutputStream = Files.newOutputStream(outputPath);
 
-      FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
-      when(responseMock.getOutputStream()).thenReturn(
-          new ServletOutputStream() {
-            @Override
-            public boolean isReady() {
-              return true;
-            }
+          @Override
+          public boolean isReady() {
+            return true;
+          }
 
-            @Override
-            public void setWriteListener(WriteListener writeListener) {
-            }
+          @Override
+          public void setWriteListener(WriteListener writeListener) {
+          }
 
-            @Override
-            public void write(int b) throws IOException {
-              fileOutputStream.write(b);
-            }
-          });
+          @Override
+          public void close() throws IOException {
+            fileOutputStream.close();
+            super.close();
+          }
 
-      when(scmDbCheckpointServletMock.getBootstrapStateLock()).thenReturn(
-          new DBCheckpointServlet.Lock());
-      scmDbCheckpointServletMock.init();
-      long initialCheckpointCount =
-          scmMetrics.getDBCheckpointMetrics().getNumCheckpoints();
+          @Override
+          public void write(int b) throws IOException {
+            fileOutputStream.write(b);
+          }
+        });
 
-      doEndpoint();
+    when(scmDbCheckpointServletMock.getBootstrapStateLock()).thenReturn(
+        new DBCheckpointServlet.Lock());
+    scmDbCheckpointServletMock.init();
+    long initialCheckpointCount =
+        scmMetrics.getDBCheckpointMetrics().getNumCheckpoints();
 
-      Assertions.assertTrue(tempFile.length() > 0);
-      Assertions.assertTrue(
-          scmMetrics.getDBCheckpointMetrics().
-              getLastCheckpointCreationTimeTaken() > 0);
-      Assertions.assertTrue(
-          scmMetrics.getDBCheckpointMetrics().
-              getLastCheckpointStreamingTimeTaken() > 0);
-      Assertions.assertTrue(scmMetrics.getDBCheckpointMetrics().
-          getNumCheckpoints() > initialCheckpointCount);
+    doEndpoint();
 
-      Mockito.verify(scmDbCheckpointServletMock).writeDbDataToStream(any(),
-          any(), any(), eq(toExcludeList), any(), any());
-    } finally {
-      FileUtils.deleteQuietly(tempFile);
-    }
+    Assertions.assertTrue(outputPath.toFile().length() > 0);
+    Assertions.assertTrue(
+        scmMetrics.getDBCheckpointMetrics().
+            getLastCheckpointCreationTimeTaken() > 0);
+    Assertions.assertTrue(
+        scmMetrics.getDBCheckpointMetrics().
+            getLastCheckpointStreamingTimeTaken() > 0);
+    Assertions.assertTrue(scmMetrics.getDBCheckpointMetrics().
+        getNumCheckpoints() > initialCheckpointCount);
 
+    Mockito.verify(scmDbCheckpointServletMock).writeDbDataToStream(any(),
+        any(), any(), eq(toExcludeList), any(), any());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -67,7 +67,6 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.security.UserGroupInformation;
 
-import org.apache.commons.io.FileUtils;
 
 import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME;
@@ -141,9 +140,11 @@ public class TestOMDbCheckpointServlet {
   private Path compactionDirPath;
   private DBCheckpoint dbCheckpoint;
   private String method;
+  @TempDir
   private File folder;
   private static final String FABRICATED_FILE_NAME = "fabricatedFile.sst";
   private FileOutputStream fileOutputStream;
+
   /**
    * Create a MiniDFSCluster for testing.
    * <p>
@@ -152,12 +153,10 @@ public class TestOMDbCheckpointServlet {
    * @throws Exception
    */
   @BeforeEach
-  public void init(@TempDir File tempDir) throws Exception {
-    folder = tempDir;
+  void init() throws Exception {
     conf = new OzoneConfiguration();
 
-    tempFile = File.createTempFile("temp_" + System
-        .currentTimeMillis(), ".tar");
+    tempFile = new File(folder, "temp.tar");
 
     fileOutputStream = new FileOutputStream(tempFile);
 
@@ -186,7 +185,6 @@ public class TestOMDbCheckpointServlet {
     if (cluster != null) {
       cluster.shutdown();
     }
-    FileUtils.deleteQuietly(tempFile);
   }
 
   private void setupCluster() throws Exception {
@@ -557,7 +555,7 @@ public class TestOMDbCheckpointServlet {
         .thenReturn(null);
 
     // Get the tarball.
-    Path tmpdir = Files.createTempDirectory("bootstrapData");
+    Path tmpdir = folder.toPath().resolve("bootstrapData");
     try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
       omDbCheckpointServletMock.writeDbDataToStream(dbCheckpoint, requestMock,
           fileOutputStream, new ArrayList<>(), new ArrayList<>(), tmpdir);
@@ -604,7 +602,7 @@ public class TestOMDbCheckpointServlet {
         .thenReturn(null);
 
     // Get the tarball.
-    Path tmpdir = Files.createTempDirectory("bootstrapData");
+    Path tmpdir = folder.toPath().resolve("bootstrapData");
     try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
       omDbCheckpointServletMock.writeDbDataToStream(dbCheckpoint, requestMock,
           fileOutputStream, toExcludeList, excludedList, tmpdir);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -202,7 +202,7 @@ public class TestOMRatisSnapshots {
   @ValueSource(ints = {100})
   // tried up to 1000 snapshots and this test works, but some of the
   //  timeouts have to be increased.
-  public void testInstallSnapshot(int numSnapshotsToCreate) throws Exception {
+  void testInstallSnapshot(int numSnapshotsToCreate, @TempDir Path tempDir) throws Exception {
     // Get the leader OM
     String leaderOMNodeId = OmFailoverProxyUtil
         .getFailoverProxyProvider(objectStore.getClientProxy())
@@ -221,7 +221,7 @@ public class TestOMRatisSnapshots {
     FaultInjector faultInjector =
         new SnapshotMaxSizeInjector(leaderOM,
             followerOM.getOmSnapshotProvider().getSnapshotDir(),
-            sstSetList);
+            sstSetList, tempDir);
     followerOM.getOmSnapshotProvider().setInjector(faultInjector);
 
     // Create some snapshots, each with new keys
@@ -1186,11 +1186,11 @@ public class TestOMRatisSnapshots {
     private final List<Set<String>> sstSetList;
     private final Path tempDir;
     SnapshotMaxSizeInjector(OzoneManager om, File snapshotDir,
-                            List<Set<String>> sstSetList) throws IOException {
+                            List<Set<String>> sstSetList, Path tempDir) {
       this.om = om;
       this.snapshotDir = snapshotDir;
       this.sstSetList = sstSetList;
-      this.tempDir = Files.createTempDirectory("tmpDirPrefix");
+      this.tempDir = tempDir;
       init();
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 
@@ -65,7 +64,7 @@ public class TestOzoneManagerRatisRequest {
   public void testRequestWithNonExistentBucket() throws Exception {
     ozoneManager = Mockito.mock(OzoneManager.class);
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        Files.createTempDirectory(folder, "om").toString());
+        folder.resolve("om").toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
@@ -106,7 +105,7 @@ public class TestOzoneManagerRatisRequest {
 
     ozoneManager = Mockito.mock(OzoneManager.class);
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        Files.createTempDirectory(folder, "om").toString());
+        folder.resolve("om").toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
         ozoneManager);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
@@ -59,7 +59,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -188,7 +187,7 @@ public class TestRangerBGSyncService {
 
     omMetrics = OMMetrics.create();
     conf.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        Files.createTempDirectory(folder.toAbsolutePath(), "om").toString());
+        folder.resolve("om").toAbsolutePath().toString());
     // No need to conf.set(OzoneConfigKeys.OZONE_ADMINISTRATORS, ...) here
     //  as we did the trick earlier with mockito.
     omMetadataManager = new OmMetadataManagerImpl(conf, ozoneManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -101,7 +101,6 @@ import org.rocksdb.RocksIterator;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -207,6 +206,8 @@ public class TestSnapshotDiffManager {
   private final OMMetrics omMetrics = OMMetrics.create();
   @TempDir
   private File dbDir;
+  @TempDir
+  private File snapDiffDir;
   @Mock
   private RocksDBCheckpointDiffer differ;
   @Mock
@@ -431,7 +432,7 @@ public class TestSnapshotDiffManager {
     UUID snap1 = UUID.randomUUID();
     UUID snap2 = UUID.randomUUID();
 
-    String diffDir = Files.createTempDirectory("snapdiff_dir").toString();
+    String diffDir = snapDiffDir.getAbsolutePath();
     Set<String> randomStrings = IntStream.range(0, numberOfFiles)
         .mapToObj(i -> RandomStringUtils.randomAlphabetic(10))
         .collect(Collectors.toSet());
@@ -526,8 +527,7 @@ public class TestSnapshotDiffManager {
           toSnapshotInfo,
           false,
           Collections.emptyMap(),
-          Files.createTempDirectory("snapdiff_dir").toAbsolutePath()
-              .toString());
+          snapDiffDir.getAbsolutePath());
       assertEquals(deltaStrings, deltaFiles);
     }
   }
@@ -591,8 +591,7 @@ public class TestSnapshotDiffManager {
           toSnapshotInfo,
           false,
           Collections.emptyMap(),
-          Files.createTempDirectory("snapdiff_dir").toAbsolutePath()
-              .toString());
+          snapDiffDir.getAbsolutePath());
       assertEquals(deltaStrings, deltaFiles);
 
       rcFromSnapshot.close();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace `createTempFile` and `createTempDir` usage in tests with `@TempDir`.

Only one usage in Recon unit tests is left, which requires a bigger refactoring.

https://issues.apache.org/jira/browse/HDDS-9828

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7252513711