### PR TITLE
HDDS-5604. Intermittent failure in TestPipelineClose.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -207,7 +207,6 @@ public class TestPipelineClose {
   }
 
   @Test
-  @Flaky("HDDS-5604")
   public void testPipelineCloseWithLogFailure()
       throws IOException, TimeoutException {
     EventQueue eventQ = (EventQueue) scm.getEventQueue();
@@ -244,12 +243,6 @@ public class TestPipelineClose {
      * This is expected to trigger an immediate pipeline actions report to SCM
      */
     xceiverRatis.handleNodeLogFailure(groupId, null);
-
-    // verify SCM receives a pipeline action report "immediately"
-    /*Mockito.verify(pipelineActionTest, Mockito.timeout(1500))
-        .onMessage(
-            actionCaptor.capture(),
-            Mockito.any(EventPublisher.class));*/
     Mockito.verify(pipelineActionTest, Mockito.timeout(1500).atLeastOnce())
         .onMessage(
             actionCaptor.capture(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -48,7 +48,6 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -210,7 +210,7 @@ public class TestPipelineClose {
   @Flaky("HDDS-5604")
   public void testPipelineCloseWithLogFailure()
       throws IOException, TimeoutException {
-
+    Mockito.reset();
     EventQueue eventQ = (EventQueue) scm.getEventQueue();
     PipelineActionHandler pipelineActionTest =
         Mockito.mock(PipelineActionHandler.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -210,7 +210,6 @@ public class TestPipelineClose {
   @Flaky("HDDS-5604")
   public void testPipelineCloseWithLogFailure()
       throws IOException, TimeoutException {
-    Mockito.reset();
     EventQueue eventQ = (EventQueue) scm.getEventQueue();
     PipelineActionHandler pipelineActionTest =
         Mockito.mock(PipelineActionHandler.class);
@@ -247,7 +246,11 @@ public class TestPipelineClose {
     xceiverRatis.handleNodeLogFailure(groupId, null);
 
     // verify SCM receives a pipeline action report "immediately"
-    Mockito.verify(pipelineActionTest, Mockito.timeout(2000))
+    /*Mockito.verify(pipelineActionTest, Mockito.timeout(1500))
+        .onMessage(
+            actionCaptor.capture(),
+            Mockito.any(EventPublisher.class));*/
+    Mockito.verify(pipelineActionTest, Mockito.timeout(1500).atLeastOnce())
         .onMessage(
             actionCaptor.capture(),
             Mockito.any(EventPublisher.class));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -247,7 +247,7 @@ public class TestPipelineClose {
     xceiverRatis.handleNodeLogFailure(groupId, null);
 
     // verify SCM receives a pipeline action report "immediately"
-    Mockito.verify(pipelineActionTest, Mockito.timeout(100))
+    Mockito.verify(pipelineActionTest, Mockito.timeout(1000))
         .onMessage(
             actionCaptor.capture(),
             Mockito.any(EventPublisher.class));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -117,7 +117,6 @@ public class TestPipelineClose {
     if (cluster != null) {
       cluster.shutdown();
     }
-    Mockito.reset();
   }
 
   @Test
@@ -248,7 +247,7 @@ public class TestPipelineClose {
     xceiverRatis.handleNodeLogFailure(groupId, null);
 
     // verify SCM receives a pipeline action report "immediately"
-    Mockito.verify(pipelineActionTest, Mockito.timeout(1000))
+    Mockito.verify(pipelineActionTest, Mockito.timeout(2000))
         .onMessage(
             actionCaptor.capture(),
             Mockito.any(EventPublisher.class));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -117,6 +117,7 @@ public class TestPipelineClose {
     if (cluster != null) {
       cluster.shutdown();
     }
+    Mockito.reset();
   }
 
   @Test


### PR DESCRIPTION
This PR fixes the  Intermittent failure in `TestPipelineClose#testPipelineCloseWithLogFailure`. Test case was earlier verifying if `org.apache.hadoop.hdds.scm.pipeline.PipelineActionHandler#onMessage` gets called immediately with timeout f 100 ms after calling `org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis#handleNodeLogFailure` , this was failing intermittently as the number of times `PipelineActionHandler#onMessage`  get called may vary due to timing issue from all 3 DNs, so this PR fixes this problem by changing the calling count at least once for `PipelineActionHandler#onMessage` method.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5604

## How was this patch tested?
This patch was tested using existing integration test by running using flaky workflow. Here is the green CI [link](https://github.com/devmadhuu/ozone/actions/runs/7244179623).
