### PR TITLE
HDDS-8470. Intermittent failure in TestStorageContainerManager#testContainerReportQueueTakingMoreTime.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -95,10 +95,8 @@ import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.Time;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.apache.ozone.test.FlakyTest;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.RaftServerConfigKeys;
@@ -108,7 +106,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
@@ -985,7 +982,6 @@ public class TestStorageContainerManager {
   }
 
   @Test
-  @Category(FlakyTest.class) @Flaky("HDDS-8470")
   public void testContainerReportQueueTakingMoreTime() throws Exception {
     EventQueue eventQueue = new EventQueue();
     List<BlockingQueue<SCMDatanodeHeartbeatDispatcher.ContainerReport>>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -996,7 +996,7 @@ public class TestStorageContainerManager {
     ContainerReportHandler containerReportHandler =
         Mockito.mock(ContainerReportHandler.class);
     Mockito.doAnswer((inv) -> {
-      Thread.currentThread().sleep(1000);
+      Thread.currentThread().sleep(1500);
       return null;
     }).when(containerReportHandler).onMessage(Mockito.any(),
         Mockito.eq(eventQueue));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -1016,8 +1016,8 @@ public class TestStorageContainerManager {
             containerReportHandler, queues, eventQueue,
             ContainerReportFromDatanode.class, executors,
             reportExecutorMap);
-    containerReportExecutors.setQueueWaitThreshold(1000);
-    containerReportExecutors.setExecWaitThreshold(1000);
+    containerReportExecutors.setQueueWaitThreshold(800);
+    containerReportExecutors.setExecWaitThreshold(800);
     
     eventQueue.addHandler(SCMEvents.CONTAINER_REPORT, containerReportExecutors,
         containerReportHandler);


### PR DESCRIPTION
This PR fixes the Intermittent failure in TestStorageContainerManager#testContainerReportQueueTakingMoreTime. Intermittent failure was detected in below assertion:
Assert.assertTrue(containerReportExecutors.longWaitInQueueEvents() >= 1);

This assertion statement asserts that number of container reports, waiting in event queue more than queueWaitThreshold is greater than 1. This metric of longWaitInQueue is incremented if report is waiting in event queue longer than wait threshold value of 1s set by test case. Due to timing issue, assertion use to fail intermittently and this PR fixes that with usage of semaphore. This PR also improves the test case by reducing the time needed to finish the test case.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8470

## How was this patch tested?
This patch is tested by running all test cases of TestStorageContainerManager in repeated CI flakytest workflow by running 500 iterations. Here is the green CI [link](https://github.com/devmadhuu/ozone/actions/runs/7244420268/job/19775989967) for the same. Flaky Workflow CI run passes for TestStorageContainerManager#testContainerReportQueueTakingMoreTime, failures are related to timeout for TestStorageContainerManager#testBlockDeletionTransactions for which we already have [HDDS-8492](https://issues.apache.org/jira/browse/HDDS-8492)

