### PR TITLE
HDDS-9622. Disk Usage Legend Labels are large then UI is breaking

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
@@ -23,7 +23,8 @@ import * as Plotly from 'plotly.js';
 
 interface ChartState {
     windowWidth: number;
-    windowHeight: number; 
+    windowHeight: number;
+    labelLengthOverflow: boolean;
 }
 
 interface ChartProps{
@@ -40,7 +41,8 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
         super(props);
         this.state = {
             windowWidth: window.innerWidth,
-            windowHeight: window.innerHeight
+            windowHeight: window.innerHeight,
+            labelLengthOverflow: false
         };
     }
 
@@ -63,17 +65,16 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
 
     componentDidMount(): void {
         window.addEventListener('resize', this.updateWindowSize);
-        // this.props.plotData.forEach((data, idx) => {
-        //     if (data && Object.keys(data).length !== 0){
-        //         let wrappedLabels = data["labels"].map((label: string) => {
-        //             if (label.length < 50)
-        //                 return label
-        //             else
-        //                 return this.parseLabels(label, 50)
-        //         })
-        //         this.props.plotData[idx]["labels"] = wrappedLabels;
-        //     }
-        // })
+        this.props.plotData.forEach((data) => {
+            if (data && Object.keys(data).length !== 0){
+                if (data["labels"].some((label: string) =>{ return label.length > 35 })){
+                    this.setState({
+                        ...this.state,
+                        labelLengthOverflow: true
+                    })
+                }
+            }
+        });
     }
 
     componentWillUnmount(): void {
@@ -81,7 +82,7 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
     }
 
     render() {
-        const { windowHeight, windowWidth } = this.state;
+        const { windowHeight, windowWidth, labelLengthOverflow } = this.state;
         let layoutProps: Partial<Plotly.Legend> = 
         {
             width: windowWidth * 0.8,
@@ -103,8 +104,9 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
                 }
             },
             margin: {
-                l: windowWidth * 0.3
-            }
+                l: labelLengthOverflow ? windowWidth * 0.3 : 0
+            },
+            paper_bgcolor: "#FFFFFF"
         }
         if (windowWidth < 1200) {
             // We are now almost at tablet/small size screen

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
@@ -104,7 +104,8 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
                 }
             },
             margin: {
-                l: labelLengthOverflow ? windowWidth * 0.3 : 0
+                l: labelLengthOverflow ? windowWidth * 0.3 : 0,
+                r: (labelLengthOverflow && windowWidth < 1200) ? windowWidth * 0.2 : 0
             },
             paper_bgcolor: "#FFFFFF"
         }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
@@ -117,7 +117,6 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
             layoutProps["width"] = windowWidth * 0.7
             layoutProps["height"] = windowHeight * 0.9
             layoutProps["legend"]["orientation"] = "h"
-            // layoutProps["width"] = windowWidth * 
             layoutProps["legend"]["x"] = 0.4;
             layoutProps["legend"]["xanchor"] = "center";
             layoutProps["legend"]["y"] = (- windowHeight);

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import Plot from 'react-plotly.js';
+import * as Plotly from 'plotly.js';
+
+
+interface ChartState {
+    windowWidth: number;
+    windowHeight: number; 
+}
+
+interface ChartProps{
+    plotData: Plotly.Data[];
+    plotOnClickHandler?: ((event: Readonly<Plotly.PlotMouseEvent>) => void) | undefined;
+    title: string;
+}
+
+export class PieChartComponent extends React.Component<ChartProps, ChartState> {
+    constructor(props = {
+        plotData: [],
+        title: ""
+    }) {
+        super(props);
+        this.state = {
+            windowWidth: window.innerWidth,
+            windowHeight: window.innerHeight
+        };
+    }
+
+    updateWindowSize = () => {
+        this.setState({
+            ...this.state,
+            windowHeight: window.innerHeight,
+            windowWidth: window.innerWidth
+        });
+    }
+
+    parseLabels = (label: string, charlen: number) => {
+        let res = "";
+        while(label.length > 0){
+            res += label.substring(0, charlen) + "<br>";
+            label = label.substring(charlen)
+        }
+        return res;
+    }
+
+    componentDidMount(): void {
+        window.addEventListener('resize', this.updateWindowSize);
+        // this.props.plotData.forEach((data, idx) => {
+        //     if (data && Object.keys(data).length !== 0){
+        //         let wrappedLabels = data["labels"].map((label: string) => {
+        //             if (label.length < 50)
+        //                 return label
+        //             else
+        //                 return this.parseLabels(label, 50)
+        //         })
+        //         this.props.plotData[idx]["labels"] = wrappedLabels;
+        //     }
+        // })
+    }
+
+    componentWillUnmount(): void {
+        window.removeEventListener('resize', this.updateWindowSize);
+    }
+
+    render() {
+        const { windowHeight, windowWidth } = this.state;
+        let layoutProps: Partial<Plotly.Legend> = 
+        {
+            width: windowWidth * 0.8,
+            height: windowHeight - 200,
+            font: {
+                family: 'Roboto, sans-serif',
+                size: windowWidth * 0.009
+            },
+            showlegend: true,
+            legend: {
+                font: {
+                    size: windowWidth * 0.008
+                }
+            },
+            title: {
+                text: this.props.title,
+                font: {
+                    size: 20
+                }
+            },
+            margin: {
+                l: windowWidth * 0.3
+            }
+        }
+        if (windowWidth < 1200) {
+            // We are now almost at tablet/small size screen
+            layoutProps["width"] = windowWidth * 0.7
+            layoutProps["height"] = windowHeight * 0.9
+            layoutProps["legend"]["orientation"] = "h"
+            // layoutProps["width"] = windowWidth * 
+            layoutProps["legend"]["x"] = 0.4;
+            layoutProps["legend"]["xanchor"] = "center";
+            layoutProps["legend"]["y"] = (- windowHeight);
+            layoutProps["legend"]["yanchor"] = "bottom";
+            layoutProps["legend"]["font"]["size"] = windowWidth * 0.009;
+            layoutProps["margin"]["b"] = windowHeight * 0.01
+        }
+
+        return (
+            <Plot
+                data={this.props.plotData}
+                layout={
+                    layoutProps
+                }
+                onClick={this.props.plotOnClickHandler}/>
+        );
+    }
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/chartComponent/pieChartComponent.tsx
@@ -67,7 +67,7 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
         window.addEventListener('resize', this.updateWindowSize);
         this.props.plotData.forEach((data) => {
             if (data && Object.keys(data).length !== 0){
-                if (data["labels"].some((label: string) =>{ return label.length > 35 })){
+                if (data["labels"].some((label: string) => { return label.length > 35 })){
                     this.setState({
                         ...this.state,
                         labelLengthOverflow: true
@@ -86,16 +86,18 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
         let layoutProps: Partial<Plotly.Legend> = 
         {
             width: windowWidth * 0.8,
-            height: windowHeight - 200,
+            height: windowHeight - 100,
             font: {
                 family: 'Roboto, sans-serif',
-                size: windowWidth * 0.009
+                size: windowWidth * 0.008
             },
             showlegend: true,
             legend: {
                 font: {
-                    size: windowWidth * 0.008
-                }
+                    size: windowWidth * 0.009
+                },
+                y: - windowHeight - 300,
+                yanchor: "bottom"
             },
             title: {
                 text: this.props.title,
@@ -105,7 +107,8 @@ export class PieChartComponent extends React.Component<ChartProps, ChartState> {
             },
             margin: {
                 l: labelLengthOverflow ? windowWidth * 0.3 : 0,
-                r: (labelLengthOverflow && windowWidth < 1200) ? windowWidth * 0.2 : 0
+                r: (labelLengthOverflow && windowWidth < 1200) ? windowWidth * 0.2 : 0,
+                b: 100
             },
             paper_bgcolor: "#FFFFFF"
         }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
@@ -38,10 +38,10 @@
     margin-right: 25px;
   }
 
-  .legendtext {
+  text.legendtext {
     fill: rgba(0, 0, 0, 0.65) !important;
     line-height: 1.5;
-    font-size: 16px !important;
+    // font-size: 0.7vw !important;
     font-feature-settings: 'tnum', "tnum";
     font-variant: tabular-nums;
   }
@@ -56,10 +56,6 @@
 
   .slicetext {
     fill: rgba(0, 0, 0, 0.60) !important;
-    font-size: 17px !important;
-    line-height: 1.5;
-    font-feature-settings: 'tnum', "tnum";
-    font-variant: tabular-nums;
   }
 }
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.less
@@ -41,7 +41,6 @@
   text.legendtext {
     fill: rgba(0, 0, 0, 0.65) !important;
     line-height: 1.5;
-    // font-size: 0.7vw !important;
     font-feature-settings: 'tnum', "tnum";
     font-variant: tabular-nums;
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -17,13 +17,12 @@
  */
 
 import React from 'react';
-import Plot from 'react-plotly.js';
 import {Row, Col, Icon, Button, Input, Menu, Dropdown, Tooltip} from 'antd';
 import {DetailPanel} from 'components/rightDrawer/rightDrawer';
-import * as Plotly from 'plotly.js';
 import {byteToSize, showDataFetchError} from 'utils/common';
 import './diskUsage.less';
 import moment from 'moment';
+import { PieChartComponent } from 'components/chartComponent/pieChartComponent';
 import { AxiosGetHelper, cancelRequests } from 'utils/axiosRequestHelper';
 
 const DEFAULT_DISPLAY_LIMIT = 10;
@@ -563,26 +562,17 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
               </Row>
               <Row>
                 {(duResponse.size > 0) ?
-                  <div style={{height: 1000}}>
-                    <Plot
-                      data={plotData}
-                      layout={
-                        {
-                          width: 1200,
-                          height: 750,
-                          font: {
-                            family: 'Roboto, sans-serif',
-                            size: 15
-                          },
-                          showlegend: true,
-                          legend: {
-                            "x": 1.2,
-                            "xanchor": "right"
-                          },
-                          title: 'Disk Usage for ' + returnPath + ' (Total Size: ' + byteToSize(duResponse.size, 1) + ')'
-                        }
+                  <div style={{height: "90vh"}}>
+                    <PieChartComponent
+                      plotData={plotData}
+                      plotOnClickHandler={
+                        (duResponse.subPathCount === 0)
+                        ? undefined
+                        : e => this.clickPieSection(e, returnPath)
                       }
-                      onClick={(duResponse.subPathCount === 0) ? undefined : e => this.clickPieSection(e, returnPath)}/>
+                      title={
+                        'Disk Usage for ' + returnPath + ' (Total Size: ' + byteToSize(duResponse.size, 1) + ')'
+                      }/>
                   </div>
                     :
                   <div style={{height: 800}} className='metadatainformation'><br/>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9622. Added responsive functionality for Disk Usage chart

Please describe your PR in detail:
* Currently we have a Disk Usage page in Ozone Recon, which displays the space occupied by various keys, buckets and volumes.
* However when we these entity names are very large, the label overlaps the Pie Chart that is rendered as a part of the UI to show the usage.
* This change will introduce a more responsive approach to displaying the labels, where we change the layout based on the window size (height and width).
* If we are having a large display size, we should be able to display the information beside the chart, else we should break the labels down to the next row.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9622


## How was this patch tested?
This was a UI related patch and was tested manually.
* When we have small-medium label lengths:
<img width="1711" alt="Screenshot 2023-12-19 at 17 52 03" src="https://github.com/apache/ozone/assets/43001336/434845ba-ce78-4380-8022-bdaa2c3fbcc0">
<img width="1728" alt="Screenshot 2023-12-19 at 17 52 44" src="https://github.com/apache/ozone/assets/43001336/a472a9ea-c5bc-43c3-a70c-64d1dfc4bacd">

* When we are having larger label lengths:

https://github.com/apache/ozone/assets/43001336/c5d6c74a-3661-43cc-9912-f86a70490868




