### PR TITLE
HDDS-9971. Fix issues in allocateBlock when clientMachine is null

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -162,8 +163,11 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
             .setNumBlocks(num)
             .setType(replicationConfig.getReplicationType())
             .setOwner(owner)
-            .setClient(clientMachine)
             .setExcludeList(excludeList.getProtoBuf());
+
+    if (StringUtils.isNotEmpty(clientMachine)) {
+      requestBuilder.setClient(clientMachine);
+    }
 
     switch (replicationConfig.getReplicationType()) {
     case STAND_ALONE:

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -383,6 +384,9 @@ public class SCMBlockProtocolServer implements
   }
 
   private Node getClientNode(String clientMachine) {
+    if (StringUtils.isEmpty(clientMachine)) {
+      return null;
+    }
     List<DatanodeDetails> datanodes = scm.getScmNodeManager()
         .getNodesByAddress(clientMachine);
     return !datanodes.isEmpty() ? datanodes.get(0) :


### PR DESCRIPTION
## What changes were proposed in this pull request?

@xichen01 found NPE when running `SCMThroughputBenchmark`

<img width="1531" alt="Screenshot 2023-12-20 at 3 08 52 PM" src="https://github.com/apache/ozone/assets/36403683/8ab666d7-5df7-4ed5-a1e6-ca790afb34fc">

There were also excessive WARN logs from `SCMNodeManager#getNodesByAddress` when the `clientMachine` is empty.

This patch will the resolve the above issues.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9971

## How was this patch tested?

Existing tests.