### PR TITLE
HDDS-9948. Compose annotation for tests parameterized with ContainerLayoutVersion

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -29,11 +29,8 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,6 +40,7 @@ import java.util.UUID;
 
 import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_CHUNK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -67,10 +65,6 @@ public class TestContainerDataYaml {
 
   private void setLayoutVersion(ContainerLayoutVersion layoutVersion) {
     this.layoutVersion = layoutVersion;
-  }
-
-  private static Iterable<Object[]> layoutVersion() {
-    return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
   /**
@@ -111,8 +105,7 @@ public class TestContainerDataYaml {
     FileUtil.fullyDelete(new File(testRoot));
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testCreateContainerFile(ContainerLayoutVersion layout)
       throws IOException {
     setLayoutVersion(layout);
@@ -179,8 +172,7 @@ public class TestContainerDataYaml {
         kvData.getDataScanTimestamp().longValue());
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testCreateContainerFileWithoutReplicaIndex(
       ContainerLayoutVersion layout) throws IOException {
     setLayoutVersion(layout);
@@ -191,14 +183,13 @@ public class TestContainerDataYaml {
     final String content =
         FileUtils.readFileToString(containerFile, Charset.defaultCharset());
 
-    Assertions.assertFalse(content.contains("replicaIndex"),
+    assertFalse(content.contains("replicaIndex"),
         "ReplicaIndex shouldn't be persisted if zero");
     cleanup();
   }
 
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testIncorrectContainerFile(ContainerLayoutVersion layout)
       throws IOException {
     setLayoutVersion(layout);
@@ -216,8 +207,7 @@ public class TestContainerDataYaml {
   }
 
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testCheckBackWardCompatibilityOfContainerFile(
       ContainerLayoutVersion layout) {
     setLayoutVersion(layout);
@@ -258,8 +248,7 @@ public class TestContainerDataYaml {
   /**
    * Test to verify {@link ContainerUtils#verifyChecksum(ContainerData)}.
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testChecksumInContainerFile(ContainerLayoutVersion layout)
       throws IOException {
     setLayoutVersion(layout);
@@ -278,8 +267,7 @@ public class TestContainerDataYaml {
   /**
    * Test to verify {@link ContainerUtils#verifyChecksum(ContainerData)}.
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testChecksumInContainerFileWithReplicaIndex(
       ContainerLayoutVersion layout) throws IOException {
     setLayoutVersion(layout);
@@ -306,8 +294,7 @@ public class TestContainerDataYaml {
   /**
    * Test to verify incorrect checksum is detected.
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testIncorrectChecksum(ContainerLayoutVersion layout) {
     setLayoutVersion(layout);
     try {
@@ -323,8 +310,7 @@ public class TestContainerDataYaml {
   /**
    * Test to verify disabled checksum with incorrect checksum.
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testDisabledChecksum(ContainerLayoutVersion layout)
       throws IOException {
     setLayoutVersion(layout);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.ozone.container.common.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -41,10 +44,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.common.impl.BlockDeletingService.ContainerBlockInfo;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 /**
@@ -66,10 +66,6 @@ public class TestContainerDeletionChoosingPolicy {
     this.layoutVersion = layout;
   }
 
-  private static Iterable<Object[]> layoutVersion() {
-    return ContainerLayoutTestInfo.containerLayoutParameters();
-  }
-
   @BeforeEach
   public void init() throws Throwable {
     conf = new OzoneConfiguration();
@@ -77,8 +73,7 @@ public class TestContainerDeletionChoosingPolicy {
         .getTempPath(TestContainerDeletionChoosingPolicy.class.getSimpleName());
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testRandomChoosingPolicy(ContainerLayoutVersion layout)
       throws IOException {
     setLayoutVersion(layout);
@@ -86,7 +81,7 @@ public class TestContainerDeletionChoosingPolicy {
     if (containerDir.exists()) {
       FileUtils.deleteDirectory(new File(path));
     }
-    Assertions.assertTrue(containerDir.mkdirs());
+    assertTrue(containerDir.mkdirs());
 
     conf.set(
         ScmConfigKeys.OZONE_SCM_KEY_VALUE_CONTAINER_DELETION_CHOOSING_POLICY,
@@ -105,7 +100,7 @@ public class TestContainerDeletionChoosingPolicy {
       data.closeContainer();
       KeyValueContainer container = new KeyValueContainer(data, conf);
       containerSet.addContainer(container);
-      Assertions.assertTrue(
+      assertTrue(
           containerSet.getContainerMapCopy()
               .containsKey(data.getContainerID()));
     }
@@ -121,7 +116,7 @@ public class TestContainerDeletionChoosingPolicy {
     for (ContainerBlockInfo pr : result0) {
       totPendingBlocks += pr.getNumBlocksToDelete();
     }
-    Assertions.assertTrue(totPendingBlocks >= blockLimitPerInterval);
+    assertTrue(totPendingBlocks >= blockLimitPerInterval);
 
     // test random choosing. We choose 100 times the 3 datanodes twice.
     //We expect different order at least once.
@@ -138,12 +133,11 @@ public class TestContainerDeletionChoosingPolicy {
         }
       }
     }
-    Assertions.fail("Chosen container results were same 100 times");
+    fail("Chosen container results were same 100 times");
 
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testTopNOrderedChoosingPolicy(ContainerLayoutVersion layout)
       throws IOException {
     setLayoutVersion(layout);
@@ -151,7 +145,7 @@ public class TestContainerDeletionChoosingPolicy {
     if (containerDir.exists()) {
       FileUtils.deleteDirectory(new File(path));
     }
-    Assertions.assertTrue(containerDir.mkdirs());
+    assertTrue(containerDir.mkdirs());
 
     conf.set(
         ScmConfigKeys.OZONE_SCM_KEY_VALUE_CONTAINER_DELETION_CHOOSING_POLICY,
@@ -182,7 +176,7 @@ public class TestContainerDeletionChoosingPolicy {
       KeyValueContainer container = new KeyValueContainer(data, conf);
       data.closeContainer();
       containerSet.addContainer(container);
-      Assertions.assertTrue(
+      assertTrue(
           containerSet.getContainerMapCopy().containsKey(containerId));
     }
     numberOfBlocks.sort(Collections.reverseOrder());
@@ -196,7 +190,7 @@ public class TestContainerDeletionChoosingPolicy {
     for (ContainerBlockInfo pr : result0) {
       totPendingBlocks += pr.getNumBlocksToDelete();
     }
-    Assertions.assertTrue(totPendingBlocks >= blockLimitPerInterval);
+    assertTrue(totPendingBlocks >= blockLimitPerInterval);
 
 
     List<ContainerBlockInfo> result1 = blockDeletingService
@@ -211,7 +205,7 @@ public class TestContainerDeletionChoosingPolicy {
         break;
       }
     }
-    Assertions.assertEquals(containerCount, result1.size());
+    assertEquals(containerCount, result1.size());
 
     // verify the order of return list
     int initialName2CountSize = name2Count.size();
@@ -220,11 +214,11 @@ public class TestContainerDeletionChoosingPolicy {
       int currentCount =
           name2Count.remove(data.getContainerData().getContainerID());
       // previous count should not smaller than next one
-      Assertions.assertTrue(currentCount > 0 && currentCount <= lastCount);
+      assertTrue(currentCount > 0 && currentCount <= lastCount);
       lastCount = currentCount;
     }
     // ensure all the container data are compared
-    Assertions.assertEquals(result1.size(),
+    assertEquals(result1.size(),
         initialName2CountSize - name2Count.size());
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -30,8 +30,6 @@ import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -65,12 +63,7 @@ public class TestContainerSet {
     this.layoutVersion = layoutVersion;
   }
 
-  private static Iterable<Object[]> layoutVersion() {
-    return ContainerLayoutTestInfo.containerLayoutParameters();
-  }
-
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testAddGetRemoveContainer(ContainerLayoutVersion layout)
       throws StorageContainerException {
     setLayoutVersion(layout);
@@ -112,8 +105,7 @@ public class TestContainerSet {
     assertFalse(containerSet.removeContainer(1000L));
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testIteratorsAndCount(ContainerLayoutVersion layout)
       throws StorageContainerException {
     setLayoutVersion(layout);
@@ -159,8 +151,7 @@ public class TestContainerSet {
 
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testIteratorPerVolume(ContainerLayoutVersion layout)
       throws StorageContainerException {
     setLayoutVersion(layout);
@@ -205,8 +196,7 @@ public class TestContainerSet {
     assertEquals(5, count2);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void iteratorIsOrderedByScanTime(ContainerLayoutVersion layout)
       throws StorageContainerException {
     setLayoutVersion(layout);
@@ -259,8 +249,7 @@ public class TestContainerSet {
     assertEquals(containerCount, containersToBeScanned);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testGetContainerReport(ContainerLayoutVersion layout)
       throws IOException {
     setLayoutVersion(layout);
@@ -273,9 +262,7 @@ public class TestContainerSet {
     assertEquals(10, containerReportsRequestProto.getReportsList().size());
   }
 
-
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testListContainer(ContainerLayoutVersion layout)
       throws StorageContainerException {
     setLayoutVersion(layout);
@@ -289,8 +276,7 @@ public class TestContainerSet {
     assertContainerIds(startId, count, result);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testListContainerFromFirstKey(ContainerLayoutVersion layout)
       throws StorageContainerException {
     setLayoutVersion(layout);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -63,8 +63,6 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,12 +101,7 @@ public class TestHddsDispatcher {
       c -> {
       };
 
-  private static Iterable<Object[]> layoutVersion() {
-    return ContainerLayoutTestInfo.containerLayoutParameters();
-  }
-
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testContainerCloseActionWhenFull(
       ContainerLayoutVersion layout) throws IOException {
 
@@ -166,8 +159,7 @@ public class TestHddsDispatcher {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testContainerCloseActionWhenVolumeFull(
       ContainerLayoutVersion layoutVersion) throws Exception {
     String testDir = GenericTestUtils.getTempPath(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
@@ -35,8 +35,6 @@ import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -77,10 +75,6 @@ public class TestCloseContainerCommandHandler {
     init();
   }
 
-  private static Iterable<Object[]> layoutVersion() {
-    return ContainerLayoutTestInfo.containerLayoutParameters();
-  }
-
   private void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     context = ContainerTestUtils.getMockContext(randomDatanodeDetails(), conf);
@@ -109,8 +103,7 @@ public class TestCloseContainerCommandHandler {
         .thenReturn(false);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void closeContainerWithPipeline(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);
@@ -125,8 +118,7 @@ public class TestCloseContainerCommandHandler {
         .quasiCloseContainer(eq(container), any());
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void closeContainerWithoutPipeline(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);
@@ -144,8 +136,7 @@ public class TestCloseContainerCommandHandler {
         .quasiCloseContainer(eq(container), any());
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void closeContainerWithForceFlagSet(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);
@@ -159,8 +150,7 @@ public class TestCloseContainerCommandHandler {
     verify(containerHandler).closeContainer(container);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void forceCloseQuasiClosedContainer(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);
@@ -177,8 +167,7 @@ public class TestCloseContainerCommandHandler {
         .closeContainer(container);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void forceCloseOpenContainer(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);
@@ -194,8 +183,7 @@ public class TestCloseContainerCommandHandler {
         .closeContainer(container);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void forceCloseOpenContainerWithPipeline(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);
@@ -213,8 +201,7 @@ public class TestCloseContainerCommandHandler {
         .closeContainer(container);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void closeAlreadyClosedContainer(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);
@@ -238,8 +225,7 @@ public class TestCloseContainerCommandHandler {
         .submitRequest(any(), any());
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void closeNonExistenceContainer(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);
@@ -253,8 +239,7 @@ public class TestCloseContainerCommandHandler {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void closeMissingContainer(ContainerLayoutVersion layout)
       throws Exception {
     initLayoutVerison(layout);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerLayoutTestInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerLayoutTestInfo.java
@@ -24,8 +24,14 @@ import org.apache.hadoop.ozone.container.keyvalue.impl.FilePerBlockStrategy;
 import org.apache.hadoop.ozone.container.keyvalue.impl.FilePerChunkStrategy;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA;
@@ -120,5 +126,16 @@ public enum ContainerLayoutTestInfo {
     return ContainerLayoutVersion.getAllVersions().stream()
         .map(each -> new Object[] {each})
         .collect(toList());
+  }
+
+  /**
+   * Composite annotation for tests parameterized with {@link  ContainerLayoutTestInfo}.
+   */
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @ParameterizedTest
+  @MethodSource("org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo#containerLayoutParameters")
+  public @interface ContainerTest {
+    // composite annotation
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerLayoutTestInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ContainerLayoutTestInfo.java
@@ -33,7 +33,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_LAYOUT_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,19 +121,13 @@ public enum ContainerLayoutTestInfo {
     assertEquals(count, files.length);
   }
 
-  public static Iterable<Object[]> containerLayoutParameters() {
-    return ContainerLayoutVersion.getAllVersions().stream()
-        .map(each -> new Object[] {each})
-        .collect(toList());
-  }
-
   /**
    * Composite annotation for tests parameterized with {@link  ContainerLayoutTestInfo}.
    */
   @Target(ElementType.METHOD)
   @Retention(RetentionPolicy.RUNTIME)
   @ParameterizedTest
-  @MethodSource("org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo#containerLayoutParameters")
+  @MethodSource("org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion#getAllVersions")
   public @interface ContainerTest {
     // composite annotation
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
@@ -28,11 +28,8 @@ import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingP
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +44,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Con
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -76,10 +74,6 @@ public class TestKeyValueContainerMarkUnhealthy {
   private void initTestData(ContainerLayoutVersion layoutVersion) throws Exception {
     this.layout = layoutVersion;
     setup();
-  }
-
-  private static Iterable<Object[]> layoutVersion() {
-    return ContainerLayoutTestInfo.containerLayoutParameters();
   }
 
   public void setup() throws Exception {
@@ -125,8 +119,7 @@ public class TestKeyValueContainerMarkUnhealthy {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testMarkContainerUnhealthy(ContainerLayoutVersion layoutVersion) throws Exception {
     initTestData(layoutVersion);
     assertThat(keyValueContainerData.getState(), is(OPEN));
@@ -146,12 +139,11 @@ public class TestKeyValueContainerMarkUnhealthy {
    *
    * @throws IOException
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testCloseUnhealthyContainer(ContainerLayoutVersion layoutVersion) throws Exception {
     initTestData(layoutVersion);
     keyValueContainer.markContainerUnhealthy();
-    Assertions.assertThrows(StorageContainerException.class, () ->
+    assertThrows(StorageContainerException.class, () ->
         keyValueContainer.markContainerForClose());
 
   }
@@ -159,8 +151,7 @@ public class TestKeyValueContainerMarkUnhealthy {
   /**
    * Attempting to mark a closed container as unhealthy should succeed.
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testMarkClosedContainerAsUnhealthy(ContainerLayoutVersion layoutVersion) throws Exception {
     initTestData(layoutVersion);
     // We need to create the container so the compact-on-close operation
@@ -174,8 +165,7 @@ public class TestKeyValueContainerMarkUnhealthy {
   /**
    * Attempting to mark a quasi-closed container as unhealthy should succeed.
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testMarkQuasiClosedContainerAsUnhealthy(ContainerLayoutVersion layoutVersion) throws Exception {
     initTestData(layoutVersion);
     // We need to create the container so the sync-on-quasi-close operation
@@ -189,8 +179,7 @@ public class TestKeyValueContainerMarkUnhealthy {
   /**
    * Attempting to mark a closing container as unhealthy should succeed.
    */
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testMarkClosingContainerAsUnhealthy(ContainerLayoutVersion layoutVersion) throws Exception {
     initTestData(layoutVersion);
     keyValueContainer.markContainerForClose();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -64,10 +64,7 @@ import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
@@ -80,6 +77,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status.DONE;
 import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.fromSources;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.LOW;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.NORMAL;
@@ -112,10 +111,6 @@ public class TestReplicationSupervisor {
   private TestClock clock;
   private DatanodeDetails datanode;
 
-  private static Iterable<Object[]> layoutVersion() {
-    return ContainerLayoutTestInfo.containerLayoutParameters();
-  }
-
   @BeforeEach
   public void setUp() throws Exception {
     clock = new TestClock(Instant.now(), ZoneId.systemDefault());
@@ -136,8 +131,7 @@ public class TestReplicationSupervisor {
     replicatorRef.set(null);
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void normal(ContainerLayoutVersion layout) {
     this.layoutVersion = layout;
     // GIVEN
@@ -152,24 +146,23 @@ public class TestReplicationSupervisor {
       supervisor.addTask(createTask(2L));
       supervisor.addTask(createTask(5L));
 
-      Assertions.assertEquals(3, supervisor.getReplicationRequestCount());
-      Assertions.assertEquals(3, supervisor.getReplicationSuccessCount());
-      Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
-      Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
-      Assertions.assertEquals(0, supervisor.getQueueSize());
-      Assertions.assertEquals(3, set.containerCount());
+      assertEquals(3, supervisor.getReplicationRequestCount());
+      assertEquals(3, supervisor.getReplicationSuccessCount());
+      assertEquals(0, supervisor.getReplicationFailureCount());
+      assertEquals(0, supervisor.getTotalInFlightReplications());
+      assertEquals(0, supervisor.getQueueSize());
+      assertEquals(3, set.containerCount());
 
       MetricsCollectorImpl metricsCollector = new MetricsCollectorImpl();
       metrics.getMetrics(metricsCollector, true);
-      Assertions.assertEquals(1, metricsCollector.getRecords().size());
+      assertEquals(1, metricsCollector.getRecords().size());
     } finally {
       metrics.unRegister();
       supervisor.stop();
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void duplicateMessage(ContainerLayoutVersion layout) {
     this.layoutVersion = layout;
     // GIVEN
@@ -184,20 +177,19 @@ public class TestReplicationSupervisor {
       supervisor.addTask(createTask(6L));
 
       //THEN
-      Assertions.assertEquals(4, supervisor.getReplicationRequestCount());
-      Assertions.assertEquals(1, supervisor.getReplicationSuccessCount());
-      Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
-      Assertions.assertEquals(3, supervisor.getReplicationSkippedCount());
-      Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
-      Assertions.assertEquals(0, supervisor.getQueueSize());
-      Assertions.assertEquals(1, set.containerCount());
+      assertEquals(4, supervisor.getReplicationRequestCount());
+      assertEquals(1, supervisor.getReplicationSuccessCount());
+      assertEquals(0, supervisor.getReplicationFailureCount());
+      assertEquals(3, supervisor.getReplicationSkippedCount());
+      assertEquals(0, supervisor.getTotalInFlightReplications());
+      assertEquals(0, supervisor.getQueueSize());
+      assertEquals(1, set.containerCount());
     } finally {
       supervisor.stop();
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void failureHandling(ContainerLayoutVersion layout) {
     this.layoutVersion = layout;
     // GIVEN
@@ -210,20 +202,19 @@ public class TestReplicationSupervisor {
       supervisor.addTask(task);
 
       //THEN
-      Assertions.assertEquals(1, supervisor.getReplicationRequestCount());
-      Assertions.assertEquals(0, supervisor.getReplicationSuccessCount());
-      Assertions.assertEquals(1, supervisor.getReplicationFailureCount());
-      Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
-      Assertions.assertEquals(0, supervisor.getQueueSize());
-      Assertions.assertEquals(0, set.containerCount());
-      Assertions.assertEquals(ReplicationTask.Status.FAILED, task.getStatus());
+      assertEquals(1, supervisor.getReplicationRequestCount());
+      assertEquals(0, supervisor.getReplicationSuccessCount());
+      assertEquals(1, supervisor.getReplicationFailureCount());
+      assertEquals(0, supervisor.getTotalInFlightReplications());
+      assertEquals(0, supervisor.getQueueSize());
+      assertEquals(0, set.containerCount());
+      assertEquals(ReplicationTask.Status.FAILED, task.getStatus());
     } finally {
       supervisor.stop();
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void stalledDownload() {
     // GIVEN
     ReplicationSupervisor supervisor = supervisorWith(__ -> noopReplicator,
@@ -238,23 +229,22 @@ public class TestReplicationSupervisor {
       supervisor.addTask(createECTask(5L));
 
       //THEN
-      Assertions.assertEquals(0, supervisor.getReplicationRequestCount());
-      Assertions.assertEquals(0, supervisor.getReplicationSuccessCount());
-      Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
-      Assertions.assertEquals(5, supervisor.getTotalInFlightReplications());
-      Assertions.assertEquals(3, supervisor.getInFlightReplications(
+      assertEquals(0, supervisor.getReplicationRequestCount());
+      assertEquals(0, supervisor.getReplicationSuccessCount());
+      assertEquals(0, supervisor.getReplicationFailureCount());
+      assertEquals(5, supervisor.getTotalInFlightReplications());
+      assertEquals(3, supervisor.getInFlightReplications(
           ReplicationTask.class));
-      Assertions.assertEquals(2, supervisor.getInFlightReplications(
+      assertEquals(2, supervisor.getInFlightReplications(
           ECReconstructionCoordinatorTask.class));
-      Assertions.assertEquals(0, supervisor.getQueueSize());
-      Assertions.assertEquals(0, set.containerCount());
+      assertEquals(0, supervisor.getQueueSize());
+      assertEquals(0, set.containerCount());
     } finally {
       supervisor.stop();
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void slowDownload() {
     // GIVEN
     ReplicationSupervisor supervisor = supervisorWith(__ -> slowReplicator,
@@ -268,22 +258,21 @@ public class TestReplicationSupervisor {
       supervisor.addTask(createTask(3L));
 
       //THEN
-      Assertions.assertEquals(3, supervisor.getTotalInFlightReplications());
-      Assertions.assertEquals(2, supervisor.getQueueSize());
+      assertEquals(3, supervisor.getTotalInFlightReplications());
+      assertEquals(2, supervisor.getQueueSize());
       // Sleep 4s, wait all tasks processed
       try {
         Thread.sleep(4000);
       } catch (InterruptedException e) {
       }
-      Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
-      Assertions.assertEquals(0, supervisor.getQueueSize());
+      assertEquals(0, supervisor.getTotalInFlightReplications());
+      assertEquals(0, supervisor.getQueueSize());
     } finally {
       supervisor.stop();
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testDownloadAndImportReplicatorFailure() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
 
@@ -322,14 +311,13 @@ public class TestReplicationSupervisor {
         .captureLogs(DownloadAndImportReplicator.LOG);
 
     supervisor.addTask(createTask(1L));
-    Assertions.assertEquals(1, supervisor.getReplicationFailureCount());
-    Assertions.assertEquals(0, supervisor.getReplicationSuccessCount());
-    Assertions.assertTrue(logCapturer.getOutput()
+    assertEquals(1, supervisor.getReplicationFailureCount());
+    assertEquals(0, supervisor.getReplicationSuccessCount());
+    assertTrue(logCapturer.getOutput()
         .contains("Container 1 replication was unsuccessful."));
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testTaskBeyondDeadline(ContainerLayoutVersion layout) {
     this.layoutVersion = layout;
     ReplicationSupervisor supervisor =
@@ -352,18 +340,17 @@ public class TestReplicationSupervisor {
     supervisor.addTask(task2);
     supervisor.addTask(task3);
 
-    Assertions.assertEquals(3, supervisor.getReplicationRequestCount());
-    Assertions.assertEquals(2, supervisor.getReplicationSuccessCount());
-    Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
-    Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
-    Assertions.assertEquals(0, supervisor.getQueueSize());
-    Assertions.assertEquals(1, supervisor.getReplicationTimeoutCount());
-    Assertions.assertEquals(2, set.containerCount());
+    assertEquals(3, supervisor.getReplicationRequestCount());
+    assertEquals(2, supervisor.getReplicationSuccessCount());
+    assertEquals(0, supervisor.getReplicationFailureCount());
+    assertEquals(0, supervisor.getTotalInFlightReplications());
+    assertEquals(0, supervisor.getQueueSize());
+    assertEquals(1, supervisor.getReplicationTimeoutCount());
+    assertEquals(2, set.containerCount());
 
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testDatanodeOutOfService(ContainerLayoutVersion layout) {
     this.layoutVersion = layout;
     ReplicationSupervisor supervisor =
@@ -379,17 +366,16 @@ public class TestReplicationSupervisor {
     supervisor.addTask(new ReplicationTask(pushCmd, replicatorRef.get()));
     supervisor.addTask(new ReplicationTask(pullCmd, replicatorRef.get()));
 
-    Assertions.assertEquals(2, supervisor.getReplicationRequestCount());
-    Assertions.assertEquals(1, supervisor.getReplicationSuccessCount());
-    Assertions.assertEquals(0, supervisor.getReplicationFailureCount());
-    Assertions.assertEquals(0, supervisor.getTotalInFlightReplications());
-    Assertions.assertEquals(0, supervisor.getQueueSize());
-    Assertions.assertEquals(0, supervisor.getReplicationTimeoutCount());
-    Assertions.assertEquals(1, set.containerCount());
+    assertEquals(2, supervisor.getReplicationRequestCount());
+    assertEquals(1, supervisor.getReplicationSuccessCount());
+    assertEquals(0, supervisor.getReplicationFailureCount());
+    assertEquals(0, supervisor.getTotalInFlightReplications());
+    assertEquals(0, supervisor.getQueueSize());
+    assertEquals(0, supervisor.getReplicationTimeoutCount());
+    assertEquals(1, set.containerCount());
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void taskWithObsoleteTermIsDropped(ContainerLayoutVersion layout) {
     this.layoutVersion = layout;
     final long newTerm = 2;
@@ -399,12 +385,11 @@ public class TestReplicationSupervisor {
     context.setTermOfLeaderSCM(newTerm);
     supervisor.addTask(createTask(1L));
 
-    Assertions.assertEquals(1, supervisor.getReplicationRequestCount());
-    Assertions.assertEquals(0, supervisor.getReplicationSuccessCount());
+    assertEquals(1, supervisor.getReplicationRequestCount());
+    assertEquals(0, supervisor.getReplicationSuccessCount());
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testPriorityOrdering(ContainerLayoutVersion layout)
       throws InterruptedException {
     this.layoutVersion = layout;
@@ -458,19 +443,19 @@ public class TestReplicationSupervisor {
     // Before unblocking the queue, check the queue count for the OrderedTask.
     // We loaded 3 High / normal priority and 2 low. The counter should not
     // include the low counts.
-    Assertions.assertEquals(3,
+    assertEquals(3,
         supervisor.getInFlightReplications(OrderedTask.class));
-    Assertions.assertEquals(1,
+    assertEquals(1,
         supervisor.getInFlightReplications(BlockingTask.class));
 
     // Unblock the queue
     completeRunning.countDown();
     // Wait for all tasks to complete
     tasksCompleteLatch.await();
-    Assertions.assertEquals(expectedOrder, completionOrder);
-    Assertions.assertEquals(0,
+    assertEquals(expectedOrder, completionOrder);
+    assertEquals(0,
         supervisor.getInFlightReplications(OrderedTask.class));
-    Assertions.assertEquals(0,
+    assertEquals(0,
         supervisor.getInFlightReplications(BlockingTask.class));
   }
 
@@ -610,7 +595,7 @@ public class TestReplicationSupervisor {
       }
 
       // assumes same-thread execution
-      Assertions.assertEquals(1, supervisor.getTotalInFlightReplications());
+      assertEquals(1, supervisor.getTotalInFlightReplications());
 
       KeyValueContainerData kvcd =
           new KeyValueContainerData(task.getContainerId(),
@@ -623,7 +608,7 @@ public class TestReplicationSupervisor {
         set.addContainer(kvc);
         task.setStatus(DONE);
       } catch (Exception e) {
-        Assertions.fail("Unexpected error: " + e.getMessage());
+        fail("Unexpected error: " + e.getMessage());
       }
     }
   }
@@ -665,8 +650,7 @@ public class TestReplicationSupervisor {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void poolSizeCanBeIncreased() {
     datanode.setPersistedOpState(IN_SERVICE);
     ReplicationSupervisor subject = ReplicationSupervisor.newBuilder()
@@ -680,8 +664,7 @@ public class TestReplicationSupervisor {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void poolSizeCanBeDecreased() {
     datanode.setPersistedOpState(IN_MAINTENANCE);
     ReplicationSupervisor subject = ReplicationSupervisor.newBuilder()
@@ -695,8 +678,7 @@ public class TestReplicationSupervisor {
     }
   }
 
-  @ParameterizedTest
-  @MethodSource("layoutVersion")
+  @ContainerLayoutTestInfo.ContainerTest
   public void testMaxQueueSize() {
     List<DatanodeDetails> datanodes = new ArrayList<>();
     datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -724,22 +706,22 @@ public class TestReplicationSupervisor {
 
     // in progress task will be limited by max. queue size,
     // since all tasks are discarded by the executor, none of them complete
-    Assertions.assertEquals(maxQueueSize, rs.getTotalInFlightReplications());
+    assertEquals(maxQueueSize, rs.getTotalInFlightReplications());
 
     // queue size is doubled
     rs.nodeStateUpdated(HddsProtos.NodeOperationalState.DECOMMISSIONING);
-    Assertions.assertEquals(2 * maxQueueSize, rs.getMaxQueueSize());
-    Assertions.assertEquals(2 * replicationMaxStreams, threadPoolSize.get());
+    assertEquals(2 * maxQueueSize, rs.getMaxQueueSize());
+    assertEquals(2 * replicationMaxStreams, threadPoolSize.get());
 
     // can schedule more tasks
     scheduleTasks(datanodes, rs);
-    Assertions.assertEquals(
+    assertEquals(
         2 * maxQueueSize, rs.getTotalInFlightReplications());
 
     // queue size is restored
     rs.nodeStateUpdated(IN_SERVICE);
-    Assertions.assertEquals(maxQueueSize, rs.getMaxQueueSize());
-    Assertions.assertEquals(replicationMaxStreams, threadPoolSize.get());
+    assertEquals(maxQueueSize, rs.getMaxQueueSize());
+    assertEquals(replicationMaxStreams, threadPoolSize.get());
   }
 
   //schedule 10 container replication

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.client.rpc.read;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
 
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
@@ -27,10 +26,8 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.om.TestBucket;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -41,16 +38,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 class TestChunkInputStream extends TestInputStreamBase {
 
-  private static List<ContainerLayoutVersion> layouts() {
-    return ContainerLayoutVersion.getAllVersions();
-  }
-
   /**
    * Run the tests as a single test method to avoid needing a new mini-cluster
    * for each test.
    */
-  @ParameterizedTest
-  @MethodSource("layouts")
+  @ContainerLayoutTestInfo.ContainerTest
   void testAll(ContainerLayoutVersion layout) throws Exception {
     try (MiniOzoneCluster cluster = newCluster(layout)) {
       cluster.waitForClusterToBeReady();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.om.TestBucket;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -63,10 +64,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * Tests {@link KeyInputStream}.
  */
 class TestKeyInputStream extends TestInputStreamBase {
-
-  private static List<ContainerLayoutVersion> layouts() {
-    return ContainerLayoutVersion.getAllVersions();
-  }
 
   /**
    * This method does random seeks and reads and validates the reads are
@@ -124,8 +121,7 @@ class TestKeyInputStream extends TestInputStreamBase {
    * This test runs the others as a single test, so to avoid creating a new
    * mini-cluster for each test.
    */
-  @ParameterizedTest
-  @MethodSource("layouts")
+  @ContainerLayoutTestInfo.ContainerTest
   void testNonReplicationReads(ContainerLayoutVersion layout) throws Exception {
     try (MiniOzoneCluster cluster = newCluster(layout)) {
       cluster.waitForClusterToBeReady();


### PR DESCRIPTION
## What changes were proposed in this pull request?
ContainerLayoutVersion is used in several classes to parameterize test methods.

- replace repeated @ParameterizedTest and @MethodSource

- delete the local method used as source in the test class    
   
https://issues.apache.org/jira/browse/HDDS-9948

## How was this patch tested?
CI: https://github.com/wzhallright/ozone/actions/runs/7274471363