### PR TITLE
HDDS-9974. Add static import for assertions and mocks in hdds-client

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestContainerClientMetrics.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestContainerClientMetrics.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.UUID;
@@ -31,6 +30,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test ContainerClientMetrics.
@@ -108,7 +108,7 @@ public class TestContainerClientMetrics {
   private Pipeline createPipeline(PipelineID piplineId, UUID leaderId) {
     return Pipeline.newBuilder()
         .setId(piplineId)
-        .setReplicationConfig(Mockito.mock(ReplicationConfig.class))
+        .setReplicationConfig(mock(ReplicationConfig.class))
         .setState(Pipeline.PipelineState.OPEN)
         .setNodes(Collections.emptyList())
         .setLeaderId(leaderId)

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -35,13 +35,11 @@ import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.ratis.thirdparty.io.grpc.Status;
 import org.apache.ratis.thirdparty.io.grpc.StatusException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.EOFException;
@@ -92,7 +90,7 @@ public class TestBlockInputStream {
   @BeforeEach
   @SuppressWarnings("unchecked")
   public void setup() throws Exception {
-    refreshFunction = Mockito.mock(Function.class);
+    refreshFunction = mock(Function.class);
     BlockID blockID = new BlockID(new ContainerBlockID(1, 1));
     checksum = new Checksum(ChecksumType.NONE, CHUNK_SIZE);
     createChunkList(5);
@@ -376,7 +374,7 @@ public class TestBlockInputStream {
       subject.initialize();
 
       // WHEN
-      Assertions.assertThrows(ex.getClass(),
+      assertThrows(ex.getClass(),
           () -> subject.read(new byte[len], 0, len));
 
       // THEN

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -45,9 +45,11 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * UNIT test for BlockOutputStream.
@@ -93,8 +95,8 @@ public class TestBlockOutputStreamCorrectness {
 
     final Pipeline pipeline = MockPipeline.createRatisPipeline();
 
-    final XceiverClientManager xcm = Mockito.mock(XceiverClientManager.class);
-    Mockito.when(xcm.acquireClient(Mockito.any()))
+    final XceiverClientManager xcm = mock(XceiverClientManager.class);
+    when(xcm.acquireClient(any()))
         .thenReturn(new MockXceiverClientSpi(pipeline));
 
     OzoneClientConfig config = new OzoneClientConfig();

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestBlockInputStreamFactoryImpl.java
@@ -30,11 +30,13 @@ import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockLocationInfo;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Tests for BlockInputStreamFactoryImpl.
@@ -53,9 +55,9 @@ public class TestBlockInputStreamFactoryImpl {
     BlockExtendedInputStream stream =
         factory.create(repConfig, blockInfo, blockInfo.getPipeline(),
             blockInfo.getToken(), true, null, null);
-    Assertions.assertTrue(stream instanceof BlockInputStream);
-    Assertions.assertEquals(stream.getBlockID(), blockInfo.getBlockID());
-    Assertions.assertEquals(stream.getLength(), blockInfo.getLength());
+    assertInstanceOf(BlockInputStream.class, stream);
+    assertEquals(stream.getBlockID(), blockInfo.getBlockID());
+    assertEquals(stream.getLength(), blockInfo.getLength());
   }
 
   @Test
@@ -70,9 +72,9 @@ public class TestBlockInputStreamFactoryImpl {
     BlockExtendedInputStream stream =
         factory.create(repConfig, blockInfo, blockInfo.getPipeline(),
             blockInfo.getToken(), true, null, null);
-    Assertions.assertTrue(stream instanceof ECBlockInputStreamProxy);
-    Assertions.assertEquals(stream.getBlockID(), blockInfo.getBlockID());
-    Assertions.assertEquals(stream.getLength(), blockInfo.getLength());
+    assertInstanceOf(ECBlockInputStreamProxy.class, stream);
+    assertEquals(stream.getBlockID(), blockInfo.getBlockID());
+    assertEquals(stream.getLength(), blockInfo.getLength());
   }
 
   private BlockLocationInfo createKeyLocationInfo(ReplicationConfig repConf,

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockInputStream.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.scm.storage.BlockLocationInfo;
 import org.apache.hadoop.hdds.scm.storage.ByteReaderStrategy;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +44,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for ECBlockInputStream.
@@ -71,14 +74,14 @@ public class TestECBlockInputStream {
         .createKeyInfo(repConfig, 5, 5 * ONEMB);
     try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
         keyInfo, true, null, null, new TestBlockInputStreamFactory())) {
-      Assertions.assertTrue(ecb.hasSufficientLocations());
+      assertTrue(ecb.hasSufficientLocations());
     }
 
     // EC-3-2, very large block, so all 3 data locations are needed
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, 5, 5000 * ONEMB);
     try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
         keyInfo, true, null, null, new TestBlockInputStreamFactory())) {
-      Assertions.assertTrue(ecb.hasSufficientLocations());
+      assertTrue(ecb.hasSufficientLocations());
     }
 
     Map<DatanodeDetails, Integer> dnMap = new HashMap<>();
@@ -88,7 +91,7 @@ public class TestECBlockInputStream {
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, ONEMB - 1, dnMap);
     try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
         keyInfo, true, null, null, new TestBlockInputStreamFactory())) {
-      Assertions.assertTrue(ecb.hasSufficientLocations());
+      assertTrue(ecb.hasSufficientLocations());
     }
 
     // EC-3-2, 5MB blocks, only 2 locations passed so we do not have sufficient
@@ -98,7 +101,7 @@ public class TestECBlockInputStream {
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, 5 * ONEMB, dnMap);
     try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
         keyInfo, true, null, null, new TestBlockInputStreamFactory())) {
-      Assertions.assertFalse(ecb.hasSufficientLocations());
+      assertFalse(ecb.hasSufficientLocations());
     }
 
     // EC-3-2, 5MB blocks, only 1 data and 2 parity locations present. For now
@@ -110,7 +113,7 @@ public class TestECBlockInputStream {
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, 5 * ONEMB, dnMap);
     try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
         keyInfo, true, null, null, new TestBlockInputStreamFactory())) {
-      Assertions.assertFalse(ecb.hasSufficientLocations());
+      assertFalse(ecb.hasSufficientLocations());
     }
   }
 
@@ -127,7 +130,7 @@ public class TestECBlockInputStream {
       // We expect only 1 block stream and it should have a length passed of
       // ONEMB - 100.
       List<TestBlockInputStream> streams = streamFactory.getBlockStreams();
-      Assertions.assertEquals(ONEMB - 100, streams.get(0).getLength());
+      assertEquals(ONEMB - 100, streams.get(0).getLength());
     }
   }
 
@@ -142,8 +145,8 @@ public class TestECBlockInputStream {
         keyInfo, true, null, null, streamFactory)) {
       ecb.read(buf);
       List<TestBlockInputStream> streams = streamFactory.getBlockStreams();
-      Assertions.assertEquals(ONEMB, streams.get(0).getLength());
-      Assertions.assertEquals(100, streams.get(1).getLength());
+      assertEquals(ONEMB, streams.get(0).getLength());
+      assertEquals(100, streams.get(1).getLength());
     }
   }
 
@@ -158,9 +161,9 @@ public class TestECBlockInputStream {
         keyInfo, true, null, null, streamFactory)) {
       ecb.read(buf);
       List<TestBlockInputStream> streams = streamFactory.getBlockStreams();
-      Assertions.assertEquals(ONEMB, streams.get(0).getLength());
-      Assertions.assertEquals(ONEMB, streams.get(1).getLength());
-      Assertions.assertEquals(100, streams.get(2).getLength());
+      assertEquals(ONEMB, streams.get(0).getLength());
+      assertEquals(ONEMB, streams.get(1).getLength());
+      assertEquals(100, streams.get(2).getLength());
     }
   }
 
@@ -175,9 +178,9 @@ public class TestECBlockInputStream {
         keyInfo, true, null, null, streamFactory)) {
       ecb.read(buf);
       List<TestBlockInputStream> streams = streamFactory.getBlockStreams();
-      Assertions.assertEquals(4 * ONEMB, streams.get(0).getLength());
-      Assertions.assertEquals(3 * ONEMB + 100, streams.get(1).getLength());
-      Assertions.assertEquals(3 * ONEMB, streams.get(2).getLength());
+      assertEquals(4 * ONEMB, streams.get(0).getLength());
+      assertEquals(3 * ONEMB + 100, streams.get(1).getLength());
+      assertEquals(3 * ONEMB, streams.get(2).getLength());
     }
   }
 
@@ -192,7 +195,7 @@ public class TestECBlockInputStream {
         keyInfo, true, null, null, streamFactory)) {
       ecb.read(buf);
       List<TestBlockInputStream> streams = streamFactory.getBlockStreams();
-      Assertions.assertEquals(ONEMB, streams.get(0).getLength());
+      assertEquals(ONEMB, streams.get(0).getLength());
     }
   }
 
@@ -207,9 +210,9 @@ public class TestECBlockInputStream {
         keyInfo, true, null, null, streamFactory)) {
       ecb.read(buf);
       List<TestBlockInputStream> streams = streamFactory.getBlockStreams();
-      Assertions.assertEquals(3 * ONEMB, streams.get(0).getLength());
-      Assertions.assertEquals(3 * ONEMB, streams.get(1).getLength());
-      Assertions.assertEquals(3 * ONEMB, streams.get(2).getLength());
+      assertEquals(3 * ONEMB, streams.get(0).getLength());
+      assertEquals(3 * ONEMB, streams.get(1).getLength());
+      assertEquals(3 * ONEMB, streams.get(2).getLength());
     }
   }
 
@@ -223,12 +226,12 @@ public class TestECBlockInputStream {
       ByteBuffer buf = ByteBuffer.allocate(100);
 
       int read = ecb.read(buf);
-      Assertions.assertEquals(100, read);
+      assertEquals(100, read);
       validateBufferContents(buf, 0, 100, (byte) 0);
-      Assertions.assertEquals(100, ecb.getPos());
+      assertEquals(100, ecb.getPos());
     }
     for (TestBlockInputStream s : streamFactory.getBlockStreams()) {
-      Assertions.assertTrue(s.isClosed());
+      assertTrue(s.isClosed());
     }
   }
 
@@ -246,12 +249,12 @@ public class TestECBlockInputStream {
       ByteBuffer buf = ByteBuffer.allocate(100);
 
       int read = ecb.read(buf);
-      Assertions.assertEquals(100, read);
+      assertEquals(100, read);
       validateBufferContents(buf, 0, 100, (byte) 0);
-      Assertions.assertEquals(100, ecb.getPos());
+      assertEquals(100, ecb.getPos());
     }
     for (TestBlockInputStream s : streamFactory.getBlockStreams()) {
-      Assertions.assertTrue(s.isClosed());
+      assertTrue(s.isClosed());
     }
   }
 
@@ -265,9 +268,9 @@ public class TestECBlockInputStream {
       ByteBuffer buf = ByteBuffer.allocate(100);
 
       int read = ecb.read(buf);
-      Assertions.assertEquals(50, read);
+      assertEquals(50, read);
       read = ecb.read(buf);
-      Assertions.assertEquals(read, -1);
+      assertEquals(read, -1);
     }
   }
 
@@ -285,7 +288,7 @@ public class TestECBlockInputStream {
       // so 350
       ByteBuffer buf = ByteBuffer.allocate(350);
       int read = ecb.read(buf);
-      Assertions.assertEquals(350, read);
+      assertEquals(350, read);
 
       validateBufferContents(buf, 0, 100, (byte) 0);
       validateBufferContents(buf, 100, 200, (byte) 1);
@@ -294,7 +297,7 @@ public class TestECBlockInputStream {
 
       buf.clear();
       read = ecb.read(buf);
-      Assertions.assertEquals(350, read);
+      assertEquals(350, read);
 
       validateBufferContents(buf, 0, 50, (byte) 0);
       validateBufferContents(buf, 50, 150, (byte) 1);
@@ -303,7 +306,7 @@ public class TestECBlockInputStream {
 
     }
     for (TestBlockInputStream s : streamFactory.getBlockStreams()) {
-      Assertions.assertTrue(s.isClosed());
+      assertTrue(s.isClosed());
     }
   }
 
@@ -341,8 +344,8 @@ public class TestECBlockInputStream {
     try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
         keyInfo, true, null, null, streamFactory)) {
       ecb.seek(0);
-      Assertions.assertEquals(0, ecb.getPos());
-      Assertions.assertEquals(0, ecb.getRemaining());
+      assertEquals(0, ecb.getPos());
+      assertEquals(0, ecb.getRemaining());
     }
   }
 
@@ -355,23 +358,23 @@ public class TestECBlockInputStream {
     try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
         keyInfo, true, null, null, streamFactory)) {
       ecb.seek(ONEMB - 1);
-      Assertions.assertEquals(ONEMB - 1, ecb.getPos());
-      Assertions.assertEquals(ONEMB * 4 + 1, ecb.getRemaining());
+      assertEquals(ONEMB - 1, ecb.getPos());
+      assertEquals(ONEMB * 4 + 1, ecb.getRemaining());
       // First read should read the last byte of the first chunk
-      Assertions.assertEquals(0, ecb.read());
-      Assertions.assertEquals(ONEMB,
+      assertEquals(0, ecb.read());
+      assertEquals(ONEMB,
           streamFactory.getBlockStreams().get(0).position);
       // Second read should be the first byte of the second chunk.
-      Assertions.assertEquals(1, ecb.read());
+      assertEquals(1, ecb.read());
 
       // Seek to the end of the file minus one byte
       ecb.seek(ONEMB * 5 - 1);
-      Assertions.assertEquals(1, ecb.read());
-      Assertions.assertEquals(ONEMB * 2,
+      assertEquals(1, ecb.read());
+      assertEquals(ONEMB * 2,
           streamFactory.getBlockStreams().get(1).position);
       // Second read should be EOF as there is no data left
-      Assertions.assertEquals(-1, ecb.read());
-      Assertions.assertEquals(0, ecb.getRemaining());
+      assertEquals(-1, ecb.read());
+      assertEquals(0, ecb.getRemaining());
     }
   }
 
@@ -387,14 +390,14 @@ public class TestECBlockInputStream {
       // factory
       ByteBuffer buf = ByteBuffer.allocate(3 * ONEMB);
       int read = ecb.read(buf);
-      Assertions.assertEquals(3 * ONEMB, read);
+      assertEquals(3 * ONEMB, read);
       // Now make replication index 2 error on the next read
       streamFactory.getBlockStreams().get(1).setThrowException(true);
       buf.clear();
       BadDataLocationException e =
           assertThrows(BadDataLocationException.class, () -> ecb.read(buf));
-      Assertions.assertEquals(1, e.getFailedLocations().size());
-      Assertions.assertEquals(2,
+      assertEquals(1, e.getFailedLocations().size());
+      assertEquals(2,
           keyInfo.getPipeline().getReplicaIndex(e.getFailedLocations().get(0)));
     }
   }
@@ -418,13 +421,13 @@ public class TestECBlockInputStream {
       // factory
       ByteBuffer buf = ByteBuffer.allocate(3 * ONEMB);
       int read = ecb.read(buf);
-      Assertions.assertEquals(3 * ONEMB, read);
+      assertEquals(3 * ONEMB, read);
       // Now make replication index 1 error on the next read but as there is a
       // spare it should read from it with no errors
       streamFactory.getBlockStreams().get(0).setThrowException(true);
       buf.clear();
       read = ecb.read(buf);
-      Assertions.assertEquals(3 * ONEMB, read);
+      assertEquals(3 * ONEMB, read);
 
       // Now make the spare one error on the next read, and we should get an
       // error with two failed locations. As each stream is created, a new
@@ -439,11 +442,11 @@ public class TestECBlockInputStream {
           assertThrows(BadDataLocationException.class, () -> ecb.read(buf));
       List<DatanodeDetails> failed = e.getFailedLocations();
       // Expect 2 different DNs reported as failure
-      Assertions.assertEquals(2, failed.size());
-      Assertions.assertNotEquals(failed.get(0), failed.get(1));
+      assertEquals(2, failed.size());
+      assertNotEquals(failed.get(0), failed.get(1));
       // Both failures should map to index = 1.
       for (DatanodeDetails dn : failed) {
-        Assertions.assertEquals(1, datanodes.get(dn));
+        assertEquals(1, datanodes.get(dn));
       }
     }
   }
@@ -484,17 +487,17 @@ public class TestECBlockInputStream {
               .getPipeline();
       // Check the pipeline is built with the correct Datanode
       // with right replicaIndex.
-      Assertions.assertEquals(HddsProtos.ReplicationType.STAND_ALONE,
+      assertEquals(HddsProtos.ReplicationType.STAND_ALONE,
           pipeline.getReplicationConfig().getReplicationType());
-      Assertions.assertEquals(1, pipeline.getNodes().size());
-      Assertions.assertEquals(3, dnMap.get(pipeline.getNodes().get(0)));
+      assertEquals(1, pipeline.getNodes().size());
+      assertEquals(3, dnMap.get(pipeline.getNodes().get(0)));
     }
   }
 
   private void validateBufferContents(ByteBuffer buf, int from, int to,
       byte val) {
     for (int i = from; i < to; i++) {
-      Assertions.assertEquals(val, buf.get(i));
+      assertEquals(val, buf.get(i));
     }
   }
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockInputStreamProxy.java
@@ -24,11 +24,8 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockLocationInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -39,15 +36,14 @@ import java.util.SplittableRandom;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for the  ECBlockInputStreamProxy class.
  */
 public class TestECBlockInputStreamProxy {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestECBlockInputStreamProxy.class);
 
   private static final int ONEMB = 1024 * 1024;
   private ECReplicationConfig repConfig;
@@ -67,23 +63,23 @@ public class TestECBlockInputStreamProxy {
 
   @Test
   public void testExpectedDataLocations() {
-    Assertions.assertEquals(1,
+    assertEquals(1,
         ECBlockInputStreamProxy.expectedDataLocations(repConfig, 1));
-    Assertions.assertEquals(2,
+    assertEquals(2,
         ECBlockInputStreamProxy.expectedDataLocations(repConfig, ONEMB + 1));
-    Assertions.assertEquals(3,
+    assertEquals(3,
         ECBlockInputStreamProxy.expectedDataLocations(repConfig, 3 * ONEMB));
-    Assertions.assertEquals(3,
+    assertEquals(3,
         ECBlockInputStreamProxy.expectedDataLocations(repConfig, 10 * ONEMB));
 
     repConfig = new ECReplicationConfig(6, 3);
-    Assertions.assertEquals(1,
+    assertEquals(1,
         ECBlockInputStreamProxy.expectedDataLocations(repConfig, 1));
-    Assertions.assertEquals(2,
+    assertEquals(2,
         ECBlockInputStreamProxy.expectedDataLocations(repConfig, ONEMB + 1));
-    Assertions.assertEquals(3,
+    assertEquals(3,
         ECBlockInputStreamProxy.expectedDataLocations(repConfig, 3 * ONEMB));
-    Assertions.assertEquals(6,
+    assertEquals(6,
         ECBlockInputStreamProxy.expectedDataLocations(repConfig, 10 * ONEMB));
   }
 
@@ -93,21 +89,21 @@ public class TestECBlockInputStreamProxy {
         ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5);
     BlockLocationInfo blockInfo =
         ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
-    Assertions.assertEquals(1, ECBlockInputStreamProxy.availableDataLocations(
+    assertEquals(1, ECBlockInputStreamProxy.availableDataLocations(
         blockInfo.getPipeline(), 1));
-    Assertions.assertEquals(2, ECBlockInputStreamProxy.availableDataLocations(
+    assertEquals(2, ECBlockInputStreamProxy.availableDataLocations(
         blockInfo.getPipeline(), 2));
-    Assertions.assertEquals(3, ECBlockInputStreamProxy.availableDataLocations(
+    assertEquals(3, ECBlockInputStreamProxy.availableDataLocations(
         blockInfo.getPipeline(), 3));
 
     dnMap = ECStreamTestUtil.createIndexMap(1, 4, 5);
     blockInfo = ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
-    Assertions.assertEquals(1, ECBlockInputStreamProxy.availableDataLocations(
+    assertEquals(1, ECBlockInputStreamProxy.availableDataLocations(
         blockInfo.getPipeline(), 3));
 
     dnMap = ECStreamTestUtil.createIndexMap(2, 3, 4, 5);
     blockInfo = ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
-    Assertions.assertEquals(0, ECBlockInputStreamProxy.availableDataLocations(
+    assertEquals(0, ECBlockInputStreamProxy.availableDataLocations(
         blockInfo.getPipeline(), 1));
   }
 
@@ -122,7 +118,7 @@ public class TestECBlockInputStreamProxy {
         ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
 
     try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
-      Assertions.assertEquals(blockInfo.getBlockID(), bis.getBlockID());
+      assertEquals(blockInfo.getBlockID(), bis.getBlockID());
     }
   }
 
@@ -137,7 +133,7 @@ public class TestECBlockInputStreamProxy {
         ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
 
     try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
-      Assertions.assertEquals(1234, bis.getLength());
+      assertEquals(1234, bis.getLength());
     }
   }
 
@@ -154,11 +150,11 @@ public class TestECBlockInputStreamProxy {
     dataGenerator = new SplittableRandom(randomSeed);
     ByteBuffer readBuffer = ByteBuffer.allocate(100);
     try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
-      Assertions.assertEquals(12345, bis.getRemaining());
-      Assertions.assertEquals(0, bis.getPos());
+      assertEquals(12345, bis.getRemaining());
+      assertEquals(0, bis.getPos());
       bis.read(readBuffer);
-      Assertions.assertEquals(12345 - 100, bis.getRemaining());
-      Assertions.assertEquals(100, bis.getPos());
+      assertEquals(12345 - 100, bis.getRemaining());
+      assertEquals(100, bis.getPos());
     }
   }
 
@@ -176,8 +172,8 @@ public class TestECBlockInputStreamProxy {
     try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
       // Not all locations present, so we expect on;y the "missing=true" stream
       // to be present.
-      Assertions.assertTrue(streamFactory.getStreams().containsKey(false));
-      Assertions.assertFalse(streamFactory.getStreams().containsKey(true));
+      assertThat(streamFactory.getStreams()).containsKey(false);
+      assertThat(streamFactory.getStreams()).doesNotContainKey(true);
     }
 
     streamFactory = new TestECBlockInputStreamFactory();
@@ -188,8 +184,8 @@ public class TestECBlockInputStreamProxy {
     try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
       // Not all locations present, so we expect on;y the "missing=true" stream
       // to be present.
-      Assertions.assertFalse(streamFactory.getStreams().containsKey(false));
-      Assertions.assertTrue(streamFactory.getStreams().containsKey(true));
+      assertThat(streamFactory.getStreams()).doesNotContainKey(false);
+      assertThat(streamFactory.getStreams()).containsKey(true);
     }
   }
 
@@ -217,7 +213,7 @@ public class TestECBlockInputStreamProxy {
       }
       readBuffer.clear();
       int read = bis.read(readBuffer);
-      Assertions.assertEquals(-1, read);
+      assertEquals(-1, read);
     }
   }
 
@@ -245,7 +241,7 @@ public class TestECBlockInputStreamProxy {
       }
       readBuffer.clear();
       int read = bis.read(readBuffer);
-      Assertions.assertEquals(-1, read);
+      assertEquals(-1, read);
     }
   }
 
@@ -267,7 +263,7 @@ public class TestECBlockInputStreamProxy {
     try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
       // Perform one read to get the stream created
       int read = bis.read(readBuffer);
-      Assertions.assertEquals(100, read);
+      assertEquals(100, read);
       ECStreamTestUtil.assertBufferMatches(readBuffer, dataGenerator);
       // Setup an error to be thrown part through a read, so the dataBuffer
       // will have been advanced by 50 bytes before the error. This tests it
@@ -285,10 +281,10 @@ public class TestECBlockInputStreamProxy {
       }
       readBuffer.clear();
       read = bis.read(readBuffer);
-      Assertions.assertEquals(-1, read);
+      assertEquals(-1, read);
       // Ensure the bad location was passed into the factory to create the
       // reconstruction reader
-      Assertions.assertEquals(badDN, streamFactory.getFailedLocations().get(0));
+      assertEquals(badDN, streamFactory.getFailedLocations().get(0));
     }
   }
 
@@ -307,14 +303,14 @@ public class TestECBlockInputStreamProxy {
     try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
       // Perform one read to get the stream created
       int read = bis.read(readBuffer);
-      Assertions.assertEquals(100, read);
+      assertEquals(100, read);
 
       bis.seek(1024);
       readBuffer.clear();
       resetAndAdvanceDataGenerator(1024);
       bis.read(readBuffer);
       ECStreamTestUtil.assertBufferMatches(readBuffer, dataGenerator);
-      Assertions.assertEquals(1124, bis.getPos());
+      assertEquals(1124, bis.getPos());
 
       // Set the non-reconstruction reader to thrown an exception on seek
       streamFactory.getStreams().get(false).setShouldErrorOnSeek(true);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.scm.storage.BlockLocationInfo;
 import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +38,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.hadoop.ozone.client.io.ECStreamTestUtil.generateParity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -87,7 +87,7 @@ public class TestECBlockReconstructedInputStream {
       try (ECBlockReconstructedInputStream stream =
           new ECBlockReconstructedInputStream(repConfig, bufferPool,
               stripeStream)) {
-        Assertions.assertEquals(12345L, stream.getLength());
+        assertEquals(12345L, stream.getLength());
       }
     }
   }
@@ -101,7 +101,7 @@ public class TestECBlockReconstructedInputStream {
       try (ECBlockReconstructedInputStream stream =
           new ECBlockReconstructedInputStream(repConfig, bufferPool,
               stripeStream)) {
-        Assertions.assertEquals(new BlockID(1, 1), stream.getBlockID());
+        assertEquals(new BlockID(1, 1), stream.getBlockID());
       }
     }
   }
@@ -133,19 +133,19 @@ public class TestECBlockReconstructedInputStream {
           int expectedRead = Math.min(blockLength - totalRead, readBufferSize);
           long read = stream.read(b);
           totalRead += read;
-          Assertions.assertEquals(expectedRead, read);
+          assertEquals(expectedRead, read);
           ECStreamTestUtil.assertBufferMatches(b, dataGenerator);
           b.clear();
         }
         // Next read should be EOF
         b.clear();
         long read = stream.read(b);
-        Assertions.assertEquals(-1, read);
+        assertEquals(-1, read);
         // Seek back to zero and read again to ensure the buffers are
         // re-allocated after being freed at the end of block.
         stream.seek(0);
         read = stream.read(b);
-        Assertions.assertEquals(readBufferSize, read);
+        assertEquals(readBufferSize, read);
         dataGenerator = new SplittableRandom(randomSeed);
         ECStreamTestUtil.assertBufferMatches(b, dataGenerator);
       }
@@ -181,7 +181,7 @@ public class TestECBlockReconstructedInputStream {
           int expectedRead = Math.min(blockLength - totalRead, readBufferSize);
           long read = stream.read(b);
           totalRead += read;
-          Assertions.assertEquals(expectedRead, read);
+          assertEquals(expectedRead, read);
           ECStreamTestUtil.assertBufferMatches(b, dataGenerator);
           b.clear();
           stream.unbuffer();
@@ -189,7 +189,7 @@ public class TestECBlockReconstructedInputStream {
         // Next read should be EOF
         b.clear();
         long read = stream.read(b);
-        Assertions.assertEquals(-1, read);
+        assertEquals(-1, read);
       }
     }
   }
@@ -216,12 +216,12 @@ public class TestECBlockReconstructedInputStream {
         ByteBuffer b = ByteBuffer.allocate(readBufferSize);
         dataGenerator = new SplittableRandom(randomSeed);
         long read = stream.read(b);
-        Assertions.assertEquals(blockLength, read);
+        assertEquals(blockLength, read);
         ECStreamTestUtil.assertBufferMatches(b, dataGenerator);
         b.clear();
         // Next read should be EOF
         read = stream.read(b);
-        Assertions.assertEquals(-1, read);
+        assertEquals(-1, read);
       }
     }
   }
@@ -253,10 +253,10 @@ public class TestECBlockReconstructedInputStream {
           if (val == -1) {
             break;
           }
-          Assertions.assertEquals(dataGenerator.nextInt(255), val);
+          assertEquals(dataGenerator.nextInt(255), val);
           totalRead += 1;
         }
-        Assertions.assertEquals(blockLength, totalRead);
+        assertEquals(blockLength, totalRead);
       }
     }
   }
@@ -287,13 +287,13 @@ public class TestECBlockReconstructedInputStream {
           int expectedRead = Math.min(blockLength - totalRead, 1024);
           long read = stream.read(buf, 0, buf.length);
           totalRead += read;
-          Assertions.assertEquals(expectedRead, read);
+          assertEquals(expectedRead, read);
           ECStreamTestUtil.assertBufferMatches(
               ByteBuffer.wrap(buf, 0, (int)read), dataGenerator);
         }
         // Next read should be EOF
         long read = stream.read(buf, 0, buf.length);
-        Assertions.assertEquals(-1, read);
+        assertEquals(-1, read);
       }
     }
   }
@@ -325,7 +325,7 @@ public class TestECBlockReconstructedInputStream {
           resetAndAdvanceDataGenerator(seekPosition);
           long expectedRead = Math.min(stream.getRemaining(), readBufferSize);
           long read = stream.read(b);
-          Assertions.assertEquals(expectedRead, read);
+          assertEquals(expectedRead, read);
           ECStreamTestUtil.assertBufferMatches(b, dataGenerator);
           seekPosition = random.nextInt(blockLength);
           stream.seek(seekPosition);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.ozone.client.io.ECStreamTestUtil.TestBlockInputStreamFa
 import org.apache.hadoop.ozone.client.io.ECStreamTestUtil.TestBlockInputStream;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,7 +52,10 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.hadoop.ozone.client.io.ECStreamTestUtil.generateParity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for the ECBlockReconstructedStripeInputStream.
@@ -126,7 +128,7 @@ public class TestECBlockReconstructedStripeInputStream {
     BlockLocationInfo keyInfo = ECStreamTestUtil
         .createKeyInfo(repConfig, 1, ONEMB);
     try (ECBlockInputStream ecb = createInputStream(keyInfo)) {
-      Assertions.assertTrue(ecb.hasSufficientLocations());
+      assertTrue(ecb.hasSufficientLocations());
     }
     // Two Chunks, but missing data block 2.
     Map<DatanodeDetails, Integer> dnMap
@@ -134,16 +136,16 @@ public class TestECBlockReconstructedStripeInputStream {
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, ONEMB * 2, dnMap);
     try (ECBlockReconstructedStripeInputStream ecb =
              createInputStream(keyInfo)) {
-      Assertions.assertTrue(ecb.hasSufficientLocations());
+      assertTrue(ecb.hasSufficientLocations());
       Collection<Integer> idxs = dnMap.values();
       for (int i : idxs) {
         ecb.setRecoveryIndexes(singleton(i - 1));
-        Assertions.assertTrue(ecb.hasSufficientLocations());
+        assertTrue(ecb.hasSufficientLocations());
       }
 
       // trying to recover all
       ecb.setRecoveryIndexes(toBufferIndexes(idxs));
-      Assertions.assertFalse(ecb.hasSufficientLocations());
+      assertFalse(ecb.hasSufficientLocations());
     }
 
     // Three Chunks, but missing data block 2 and 3.
@@ -151,19 +153,19 @@ public class TestECBlockReconstructedStripeInputStream {
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, ONEMB * 3, dnMap);
     try (ECBlockReconstructedStripeInputStream ecb =
              createInputStream(keyInfo)) {
-      Assertions.assertTrue(ecb.hasSufficientLocations());
+      assertTrue(ecb.hasSufficientLocations());
       // Set a failed location
       List<DatanodeDetails> failed = new ArrayList<>();
       failed.add(keyInfo.getPipeline().getFirstNode());
       ecb.addFailedDatanodes(failed);
-      Assertions.assertFalse(ecb.hasSufficientLocations());
+      assertFalse(ecb.hasSufficientLocations());
     }
 
     // Three Chunks, but missing data block 2 and 3 and parity 1.
     dnMap = ECStreamTestUtil.createIndexMap(1, 4);
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, ONEMB * 3, dnMap);
     try (ECBlockInputStream ecb = createInputStream(keyInfo)) {
-      Assertions.assertFalse(ecb.hasSufficientLocations());
+      assertFalse(ecb.hasSufficientLocations());
     }
 
     // Three Chunks, all available but fail 3
@@ -171,7 +173,7 @@ public class TestECBlockReconstructedStripeInputStream {
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, ONEMB * 3, dnMap);
     try (ECBlockReconstructedStripeInputStream ecb =
              createInputStream(keyInfo)) {
-      Assertions.assertTrue(ecb.hasSufficientLocations());
+      assertTrue(ecb.hasSufficientLocations());
       // Set a failed location
       List<DatanodeDetails> failed = new ArrayList<>();
       for (Map.Entry<DatanodeDetails, Integer> entry : dnMap.entrySet()) {
@@ -179,7 +181,7 @@ public class TestECBlockReconstructedStripeInputStream {
         boolean expected = failed.size() < 3;
 
         ecb.addFailedDatanodes(singleton(entry.getKey()));
-        Assertions.assertEquals(expected, ecb.hasSufficientLocations());
+        assertEquals(expected, ecb.hasSufficientLocations());
       }
     }
 
@@ -190,7 +192,7 @@ public class TestECBlockReconstructedStripeInputStream {
         recover.add(i);
         ecb.setRecoveryIndexes(recover);
         boolean expected = recover.size() < 3;
-        Assertions.assertEquals(expected, ecb.hasSufficientLocations());
+        assertEquals(expected, ecb.hasSufficientLocations());
       }
     }
 
@@ -200,7 +202,7 @@ public class TestECBlockReconstructedStripeInputStream {
     dnMap = ECStreamTestUtil.createIndexMap(2, 3);
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, ONEMB, dnMap);
     try (ECBlockInputStream ecb = createInputStream(keyInfo)) {
-      Assertions.assertFalse(ecb.hasSufficientLocations());
+      assertFalse(ecb.hasSufficientLocations());
     }
   }
 
@@ -241,7 +243,7 @@ public class TestECBlockReconstructedStripeInputStream {
       // Read 3 full stripes
       for (int i = 0; i < 3; i++) {
         int read = ecb.read(bufs);
-        Assertions.assertEquals(stripeSize(), read);
+        assertEquals(stripeSize(), read);
 
         int output = 0;
         for (int j = 0; j < repConfig.getRequiredNodes(); j++) {
@@ -252,15 +254,15 @@ public class TestECBlockReconstructedStripeInputStream {
 
         // Check the underlying streams have read 1 chunk per read:
         for (TestBlockInputStream bis : streamFactory.getBlockStreams()) {
-          Assertions.assertEquals(chunkSize * (i + 1),
+          assertEquals(chunkSize * (i + 1),
               bis.getPos());
         }
-        Assertions.assertEquals(stripeSize() * (i + 1), ecb.getPos());
+        assertEquals(stripeSize() * (i + 1), ecb.getPos());
         clearBuffers(bufs);
       }
       // The next read is a partial stripe
       int read = ecb.read(bufs);
-      Assertions.assertEquals(partialStripeSize, read);
+      assertEquals(partialStripeSize, read);
       int output = 0;
       for (int j = 0; j < 2; j++) {
         if (outputIndexes.contains(j)) {
@@ -268,14 +270,14 @@ public class TestECBlockReconstructedStripeInputStream {
         }
       }
       if (outputIndexes.contains(2)) {
-        Assertions.assertEquals(0, bufs[output].remaining());
-        Assertions.assertEquals(0, bufs[output].position());
+        assertEquals(0, bufs[output].remaining());
+        assertEquals(0, bufs[output].position());
       }
 
       // A further read should give EOF
       clearBuffers(bufs);
       read = ecb.read(bufs);
-      Assertions.assertEquals(-1, read);
+      assertEquals(-1, read);
     }
   }
 
@@ -301,21 +303,21 @@ public class TestECBlockReconstructedStripeInputStream {
     try (ECBlockReconstructedStripeInputStream ecb =
         createInputStream(keyInfo)) {
       int read = ecb.read(bufs);
-      Assertions.assertEquals(blockLength, read);
+      assertEquals(blockLength, read);
       ECStreamTestUtil.assertBufferMatches(bufs[0], dataGen);
-      Assertions.assertEquals(0, bufs[1].remaining());
-      Assertions.assertEquals(0, bufs[1].position());
-      Assertions.assertEquals(0, bufs[2].remaining());
-      Assertions.assertEquals(0, bufs[2].position());
+      assertEquals(0, bufs[1].remaining());
+      assertEquals(0, bufs[1].position());
+      assertEquals(0, bufs[2].remaining());
+      assertEquals(0, bufs[2].position());
       // Check the underlying streams have been advanced by 1 blockLength:
       for (TestBlockInputStream bis : streamFactory.getBlockStreams()) {
-        Assertions.assertEquals(blockLength, bis.getPos());
+        assertEquals(blockLength, bis.getPos());
       }
-      Assertions.assertEquals(ecb.getPos(), blockLength);
+      assertEquals(ecb.getPos(), blockLength);
       clearBuffers(bufs);
       // A further read should give EOF
       read = ecb.read(bufs);
-      Assertions.assertEquals(-1, read);
+      assertEquals(-1, read);
     }
   }
 
@@ -344,18 +346,18 @@ public class TestECBlockReconstructedStripeInputStream {
       ecb.setRecoveryIndexes(Arrays.asList(3, 4));
 
       int read = ecb.read(bufs);
-      Assertions.assertEquals(blockLength, read);
+      assertEquals(blockLength, read);
       ECStreamTestUtil.assertBufferMatches(bufs[0], dataGen);
       ECStreamTestUtil.assertBufferMatches(bufs[1], dataGen);
       // Check the underlying streams have been advanced by 1 blockLength:
       for (TestBlockInputStream bis : streamFactory.getBlockStreams()) {
-        Assertions.assertEquals(blockLength, bis.getPos());
+        assertEquals(blockLength, bis.getPos());
       }
-      Assertions.assertEquals(ecb.getPos(), blockLength);
+      assertEquals(ecb.getPos(), blockLength);
       clearBuffers(bufs);
       // A further read should give EOF
       read = ecb.read(bufs);
-      Assertions.assertEquals(-1, read);
+      assertEquals(-1, read);
     }
   }
 
@@ -383,20 +385,20 @@ public class TestECBlockReconstructedStripeInputStream {
     try (ECBlockReconstructedStripeInputStream ecb =
         createInputStream(keyInfo)) {
       int read = ecb.read(bufs);
-      Assertions.assertEquals(blockLength, read);
+      assertEquals(blockLength, read);
       ECStreamTestUtil.assertBufferMatches(bufs[0], dataGen);
       ECStreamTestUtil.assertBufferMatches(bufs[1], dataGen);
-      Assertions.assertEquals(0, bufs[2].remaining());
-      Assertions.assertEquals(0, bufs[2].position());
+      assertEquals(0, bufs[2].remaining());
+      assertEquals(0, bufs[2].position());
       // Check the underlying streams have been advanced by 1 chunk:
       for (TestBlockInputStream bis : streamFactory.getBlockStreams()) {
-        Assertions.assertEquals(chunkSize, bis.getPos());
+        assertEquals(chunkSize, bis.getPos());
       }
-      Assertions.assertEquals(ecb.getPos(), blockLength);
+      assertEquals(ecb.getPos(), blockLength);
       clearBuffers(bufs);
       // A further read should give EOF
       read = ecb.read(bufs);
-      Assertions.assertEquals(-1, read);
+      assertEquals(-1, read);
     }
   }
 
@@ -440,19 +442,19 @@ public class TestECBlockReconstructedStripeInputStream {
       try (ECBlockReconstructedStripeInputStream ecb =
           createInputStream(keyInfo)) {
         int read = ecb.read(bufs);
-        Assertions.assertEquals(blockLength, read);
+        assertEquals(blockLength, read);
         ECStreamTestUtil.assertBufferMatches(bufs[0], dataGen);
         ECStreamTestUtil.assertBufferMatches(bufs[1], dataGen);
         ECStreamTestUtil.assertBufferMatches(bufs[2], dataGen);
         // Check the underlying streams have been advanced by 1 chunk:
         for (TestBlockInputStream bis : streamFactory.getBlockStreams()) {
-          Assertions.assertEquals(0, bis.getRemaining());
+          assertEquals(0, bis.getRemaining());
         }
-        Assertions.assertEquals(ecb.getPos(), blockLength);
+        assertEquals(ecb.getPos(), blockLength);
         clearBuffers(bufs);
         // A further read should give EOF
         read = ecb.read(bufs);
-        Assertions.assertEquals(-1, read);
+        assertEquals(-1, read);
       }
     }
   }
@@ -479,14 +481,8 @@ public class TestECBlockReconstructedStripeInputStream {
     BlockLocationInfo keyInfo =
         ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
     streamFactory.setCurrentPipeline(keyInfo.getPipeline());
-    try (ECBlockReconstructedStripeInputStream ecb =
-        createInputStream(keyInfo)) {
-      try {
-        ecb.read(bufs);
-        Assertions.fail("Read should have thrown an exception");
-      } catch (InsufficientLocationsException e) {
-        // expected
-      }
+    try (ECBlockReconstructedStripeInputStream ecb = createInputStream(keyInfo)) {
+      assertThrows(InsufficientLocationsException.class, () -> ecb.read(bufs));
     }
   }
 
@@ -538,19 +534,19 @@ public class TestECBlockReconstructedStripeInputStream {
       try (ECBlockReconstructedStripeInputStream ecb =
                createInputStream(keyInfo)) {
         int read = ecb.read(bufs);
-        Assertions.assertEquals(blockLength, read);
+        assertEquals(blockLength, read);
         ECStreamTestUtil.assertBufferMatches(bufs[0], dataGen);
         ECStreamTestUtil.assertBufferMatches(bufs[1], dataGen);
         ECStreamTestUtil.assertBufferMatches(bufs[2], dataGen);
         // Check the underlying streams have been advanced by 1 chunk:
         for (TestBlockInputStream bis : streamFactory.getBlockStreams()) {
-          Assertions.assertEquals(0, bis.getRemaining());
+          assertEquals(0, bis.getRemaining());
         }
-        Assertions.assertEquals(ecb.getPos(), blockLength);
+        assertEquals(ecb.getPos(), blockLength);
         clearBuffers(bufs);
         // A further read should give EOF
         read = ecb.read(bufs);
-        Assertions.assertEquals(-1, read);
+        assertEquals(-1, read);
       }
     }
   }
@@ -596,8 +592,8 @@ public class TestECBlockReconstructedStripeInputStream {
         for (int j = 0; j < bufs.length; j++) {
           validateContents(dataBufs[j], bufs[j], 0, chunkSize);
         }
-        Assertions.assertEquals(stripeSize(), read);
-        Assertions.assertEquals(dataLength - stripeSize(), ecb.getRemaining());
+        assertEquals(stripeSize(), read);
+        assertEquals(dataLength - stripeSize(), ecb.getRemaining());
 
         // Seek to 0 and read again
         clearBuffers(bufs);
@@ -606,8 +602,8 @@ public class TestECBlockReconstructedStripeInputStream {
         for (int j = 0; j < bufs.length; j++) {
           validateContents(dataBufs[j], bufs[j], 0, chunkSize);
         }
-        Assertions.assertEquals(stripeSize(), read);
-        Assertions.assertEquals(dataLength - stripeSize(), ecb.getRemaining());
+        assertEquals(stripeSize(), read);
+        assertEquals(dataLength - stripeSize(), ecb.getRemaining());
 
         // Seek to the last stripe
         // Seek to the last stripe
@@ -616,9 +612,9 @@ public class TestECBlockReconstructedStripeInputStream {
         read = ecb.read(bufs);
         validateContents(dataBufs[0], bufs[0], 3 * chunkSize, chunkSize);
         validateContents(dataBufs[1], bufs[1], 3 * chunkSize, chunkSize - 1);
-        Assertions.assertEquals(0, bufs[2].remaining());
-        Assertions.assertEquals(partialStripeSize, read);
-        Assertions.assertEquals(0, ecb.getRemaining());
+        assertEquals(0, bufs[2].remaining());
+        assertEquals(partialStripeSize, read);
+        assertEquals(0, ecb.getRemaining());
 
         // seek to the start of stripe 3
         clearBuffers(bufs);
@@ -627,8 +623,8 @@ public class TestECBlockReconstructedStripeInputStream {
         for (int j = 0; j < bufs.length; j++) {
           validateContents(dataBufs[j], bufs[j], 2 * chunkSize, chunkSize);
         }
-        Assertions.assertEquals(stripeSize(), read);
-        Assertions.assertEquals(partialStripeSize, ecb.getRemaining());
+        assertEquals(stripeSize(), read);
+        assertEquals(partialStripeSize, ecb.getRemaining());
       }
     }
   }
@@ -641,15 +637,10 @@ public class TestECBlockReconstructedStripeInputStream {
         stripeSize() * 3, dnMap);
     streamFactory.setCurrentPipeline(keyInfo.getPipeline());
 
-    try (ECBlockReconstructedStripeInputStream ecb =
-        createInputStream(keyInfo)) {
-      try {
-        ecb.seek(10);
-        Assertions.fail("Seek should have thrown an exception");
-      } catch (IOException e) {
-        Assertions.assertEquals("Requested position 10 does not align " +
-            "with a stripe offset", e.getMessage());
-      }
+    try (ECBlockReconstructedStripeInputStream ecb = createInputStream(keyInfo)) {
+      IOException e = assertThrows(IOException.class, () -> ecb.seek(10));
+      assertEquals("Requested position 10 does not align " +
+          "with a stripe offset", e.getMessage());
     }
   }
 
@@ -692,8 +683,8 @@ public class TestECBlockReconstructedStripeInputStream {
           for (int j = 0; j < bufs.length; j++) {
             validateContents(dataBufs[j], bufs[j], i * chunkSize, chunkSize);
           }
-          Assertions.assertEquals(stripeSize() * (i + 1), ecb.getPos());
-          Assertions.assertEquals(stripeSize(), read);
+          assertEquals(stripeSize() * (i + 1), ecb.getPos());
+          assertEquals(stripeSize(), read);
           clearBuffers(bufs);
           if (i == 0) {
             Integer failStream =
@@ -705,11 +696,11 @@ public class TestECBlockReconstructedStripeInputStream {
         }
         // The next read is a partial stripe
         int read = ecb.read(bufs);
-        Assertions.assertEquals(partialStripeSize, read);
+        assertEquals(partialStripeSize, read);
         validateContents(dataBufs[0], bufs[0], 3 * chunkSize, chunkSize);
         validateContents(dataBufs[1], bufs[1], 3 * chunkSize, chunkSize - 1);
-        Assertions.assertEquals(0, bufs[2].remaining());
-        Assertions.assertEquals(0, bufs[2].position());
+        assertEquals(0, bufs[2].remaining());
+        assertEquals(0, bufs[2].position());
 
         // seek back to zero and read a stripe to re-open the streams
         ecb.seek(0);
@@ -723,13 +714,8 @@ public class TestECBlockReconstructedStripeInputStream {
         Integer failStream = getRandomStreamIndex(currentStreams);
         streamFactory.getBlockStream(failStream)
             .setShouldError(true);
-        try {
-          clearBuffers(bufs);
-          ecb.read(bufs);
-          Assertions.fail("InsufficientLocationsException expected");
-        } catch (InsufficientLocationsException e) {
-          // expected
-        }
+        clearBuffers(bufs);
+        assertThrows(InsufficientLocationsException.class, () -> ecb.read(bufs));
       }
     }
   }
@@ -808,13 +794,13 @@ public class TestECBlockReconstructedStripeInputStream {
       for (int j = 0; j < bufs.length; j++) {
         ECStreamTestUtil.assertBufferMatches(bufs[j], dataGen);
       }
-      Assertions.assertEquals(stripeSize(), read);
+      assertEquals(stripeSize(), read);
 
       // Now ensure that streams with repIndexes 1, 2 and 3 have not been
       // created in the stream factory, indicating we did not read them.
       List<TestBlockInputStream> streams = streamFactory.getBlockStreams();
       for (TestBlockInputStream stream : streams) {
-        Assertions.assertTrue(stream.getEcReplicaIndex() > 2);
+        assertTrue(stream.getEcReplicaIndex() > 2);
       }
     }
   }
@@ -847,9 +833,9 @@ public class TestECBlockReconstructedStripeInputStream {
   private void validateContents(ByteBuffer src, ByteBuffer data, int offset,
       int count) {
     byte[] srcArray = src.array();
-    Assertions.assertEquals(count, data.remaining());
+    assertEquals(count, data.remaining());
     for (int i = offset; i < offset + count; i++) {
-      Assertions.assertEquals(srcArray[i], data.get(), "Element " + i);
+      assertEquals(srcArray[i], data.get(), "Element " + i);
     }
     data.flip();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add static import for assertions and mocks in `hadoop-hdds/client`.

Also replace few `assertTrue` / `assertFalase` statements with more descriptive `assertInstanceOf` / `assertThat`.

https://issues.apache.org/jira/browse/HDDS-9974

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7279062643