### PR TITLE
HDDS-9955. Simplify assertions in integration tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -72,8 +72,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -261,9 +259,12 @@ public class TestOzoneFileInterfaces {
         o3fs.pathToKey(path));
 
     // verify prefix directories and the file, do not already exist
-    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(lev1key));
-    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(lev2key));
-    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(fileKey));
+    assertTrue(
+        metadataManager.getKeyTable(getBucketLayout()).get(lev1key) == null);
+    assertTrue(
+        metadataManager.getKeyTable(getBucketLayout()).get(lev2key) == null);
+    assertTrue(
+        metadataManager.getKeyTable(getBucketLayout()).get(fileKey) == null);
 
     try (FSDataOutputStream stream = fs.create(path)) {
       stream.writeBytes(data);
@@ -375,16 +376,19 @@ public class TestOzoneFileInterfaces {
         o3fs.pathToKey(leaf));
 
     // verify prefix directories and the leaf, do not already exist
-    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(lev1key));
-    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(lev2key));
-    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(leafKey));
+    assertTrue(
+        metadataManager.getKeyTable(getBucketLayout()).get(lev1key) == null);
+    assertTrue(
+        metadataManager.getKeyTable(getBucketLayout()).get(lev2key) == null);
+    assertTrue(
+        metadataManager.getKeyTable(getBucketLayout()).get(leafKey) == null);
 
     assertTrue("Makedirs returned with false for the path " + leaf,
         fs.mkdirs(leaf));
 
     // verify the leaf directory got created.
     leafstatus = getDirectoryStat(leaf);
-    assertNotNull(leafstatus);
+    assertTrue(leafstatus != null);
 
     FileStatus lev1status;
     FileStatus lev2status;
@@ -405,7 +409,7 @@ public class TestOzoneFileInterfaces {
 
     // check the root directory
     rootstatus = getDirectoryStat(createPath("/"));
-    assertNotNull(rootstatus);
+    assertTrue(rootstatus != null);
 
     // root directory listing should contain the lev1 prefix directory
     FileStatus[] statusList = fs.listStatus(createPath("/"));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -72,6 +72,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -259,12 +261,9 @@ public class TestOzoneFileInterfaces {
         o3fs.pathToKey(path));
 
     // verify prefix directories and the file, do not already exist
-    assertTrue(
-        metadataManager.getKeyTable(getBucketLayout()).get(lev1key) == null);
-    assertTrue(
-        metadataManager.getKeyTable(getBucketLayout()).get(lev2key) == null);
-    assertTrue(
-        metadataManager.getKeyTable(getBucketLayout()).get(fileKey) == null);
+    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(lev1key));
+    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(lev2key));
+    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(fileKey));
 
     try (FSDataOutputStream stream = fs.create(path)) {
       stream.writeBytes(data);
@@ -376,19 +375,16 @@ public class TestOzoneFileInterfaces {
         o3fs.pathToKey(leaf));
 
     // verify prefix directories and the leaf, do not already exist
-    assertTrue(
-        metadataManager.getKeyTable(getBucketLayout()).get(lev1key) == null);
-    assertTrue(
-        metadataManager.getKeyTable(getBucketLayout()).get(lev2key) == null);
-    assertTrue(
-        metadataManager.getKeyTable(getBucketLayout()).get(leafKey) == null);
+    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(lev1key));
+    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(lev2key));
+    assertNull(metadataManager.getKeyTable(getBucketLayout()).get(leafKey));
 
     assertTrue("Makedirs returned with false for the path " + leaf,
         fs.mkdirs(leaf));
 
     // verify the leaf directory got created.
     leafstatus = getDirectoryStat(leaf);
-    assertTrue(leafstatus != null);
+    assertNotNull(leafstatus);
 
     FileStatus lev1status;
     FileStatus lev2status;
@@ -409,7 +405,7 @@ public class TestOzoneFileInterfaces {
 
     // check the root directory
     rootstatus = getDirectoryStat(createPath("/"));
-    assertTrue(rootstatus != null);
+    assertNotNull(rootstatus);
 
     // root directory listing should contain the lev1 prefix directory
     FileStatus[] statusList = fs.listStatus(createPath("/"));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1886,9 +1886,9 @@ public class TestRootedOzoneFileSystem {
       ContractTestUtils.touch(fs, childFolderFile);
     }
 
-    assertTrue(fs.listStatus(grandparent).length == 1);
-    assertTrue(fs.listStatus(parent).length == 9);
-    assertTrue(fs.listStatus(childFolder).length == 8);
+    assertEquals(1, fs.listStatus(grandparent).length);
+    assertEquals(9, fs.listStatus(parent).length);
+    assertEquals(8, fs.listStatus(childFolder).length);
 
     Boolean successResult = fs.delete(grandparent, true);
     assertTrue(successResult);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -201,7 +201,7 @@ public class TestRootedOzoneFileSystemWithFSO
     assertTrue(getFs().delete(bucketPath2, true));
     assertTrue(getFs().delete(volumePath1, false));
     long deletes = getOMMetrics().getNumKeyDeletes();
-    assertTrue(deletes == prevDeletes + 1);
+    assertEquals(prevDeletes + 1, deletes);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
@@ -94,9 +94,9 @@ public class TestLeaderChoosePolicy {
       leaderCount.put(leader, leaderCount.get(leader) + 1);
     }
 
-    assertEquals(leaderCount.size(), dnNum);
+    assertEquals(dnNum, leaderCount.size());
     for (Map.Entry<UUID, Integer> entry: leaderCount.entrySet()) {
-      assertEquals(leaderCount.get(entry.getKey()), leaderNumOfEachDn);
+      assertEquals(leaderNumOfEachDn, leaderCount.get(entry.getKey()));
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
@@ -94,9 +94,9 @@ public class TestLeaderChoosePolicy {
       leaderCount.put(leader, leaderCount.get(leader) + 1);
     }
 
-    assertTrue(leaderCount.size() == dnNum);
+    assertEquals(leaderCount.size(), dnNum);
     for (Map.Entry<UUID, Integer> entry: leaderCount.entrySet()) {
-      assertTrue(leaderCount.get(entry.getKey()) == leaderNumOfEachDn);
+      assertEquals(leaderCount.get(entry.getKey()), leaderNumOfEachDn);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -63,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for Pipeline Closing.
@@ -229,7 +230,7 @@ public class TestPipelineClose {
     try {
       pipelineManager.getPipeline(openPipeline.getId());
     } catch (PipelineNotFoundException e) {
-      assertTrue(false, "pipeline should exist");
+      fail("pipeline should exist");
     }
 
     DatanodeDetails datanodeDetails = openPipeline.getNodes().get(0);
@@ -275,6 +276,6 @@ public class TestPipelineClose {
     }
 
     assertTrue(found, "SCM did not receive a Close action for the Pipeline");
-    return found;
+    return true;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -634,7 +634,7 @@ public abstract class TestOzoneRpcClientAbstract {
     volume.createBucket(bucketName, builder.build());
     OzoneBucket bucket = volume.getBucket(bucketName);
     assertEquals(bucketName, bucket.getName());
-    assertEquals(true, bucket.getVersioning());
+    assertTrue(bucket.getVersioning());
   }
 
   @Test
@@ -708,7 +708,7 @@ public abstract class TestOzoneRpcClientAbstract {
     volume.createBucket(bucketName, builder.build());
     OzoneBucket bucket = volume.getBucket(bucketName);
     assertEquals(bucketName, bucket.getName());
-    assertEquals(true, bucket.getVersioning());
+    assertTrue(bucket.getVersioning());
     assertEquals(StorageType.SSD, bucket.getStorageType());
     assertTrue(bucket.getAcls().contains(userAcl));
     assertEquals(repConfig, bucket.getReplicationConfig());
@@ -812,7 +812,7 @@ public abstract class TestOzoneRpcClientAbstract {
     bucket.setVersioning(true);
     OzoneBucket newBucket = volume.getBucket(bucketName);
     assertEquals(bucketName, newBucket.getName());
-    assertEquals(true, newBucket.getVersioning());
+    assertTrue(newBucket.getVersioning());
   }
 
   @Test
@@ -830,7 +830,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
     OzoneBucket newBucket = volume.getBucket(bucketName);
     assertEquals(bucketName, newBucket.getName());
-    assertEquals(true, newBucket.getVersioning());
+    assertTrue(newBucket.getVersioning());
 
     List<OzoneAcl> aclsAfterSet = newBucket.getAcls();
     assertEquals(currentAcls, aclsAfterSet);
@@ -3796,7 +3796,7 @@ public abstract class TestOzoneRpcClientAbstract {
     assertTrue(latestVersionLocations.isMultipartKey());
     latestVersionLocations.getBlocksLatestVersionOnly()
         .forEach(omKeyLocationInfo ->
-            assertTrue(omKeyLocationInfo.getPartNumber() != -1));
+            assertNotEquals(omKeyLocationInfo.getPartNumber(), -1));
   }
 
   private String initiateMultipartUpload(OzoneBucket bucket, String keyName,
@@ -3996,7 +3996,7 @@ public abstract class TestOzoneRpcClientAbstract {
     assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
     assertEquals("AES",
         key.getMetadata().get(OzoneConsts.GDPR_ALGORITHM));
-    assertTrue(key.getMetadata().get(OzoneConsts.GDPR_SECRET) != null);
+    assertNotNull(key.getMetadata().get(OzoneConsts.GDPR_SECRET));
 
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       assertInputStreamContent(text, is);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -3796,7 +3796,7 @@ public abstract class TestOzoneRpcClientAbstract {
     assertTrue(latestVersionLocations.isMultipartKey());
     latestVersionLocations.getBlocksLatestVersionOnly()
         .forEach(omKeyLocationInfo ->
-            assertNotEquals(omKeyLocationInfo.getPartNumber(), -1));
+            assertNotEquals(-1, omKeyLocationInfo.getPartNumber()));
   }
 
   private String initiateMultipartUpload(OzoneBucket bucket, String keyName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientForAclAuditLog.java
@@ -64,6 +64,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -287,7 +288,7 @@ public class TestOzoneRpcClientForAclAuditLog {
     try {
       // When log entry is expected, the log file will contain one line and
       // that must be equal to the expected string
-      assertTrue(lines.size() != 0);
+      assertNotEquals(0, lines.size());
       for (String exp: expected) {
         assertTrue(lines.get(0).contains(exp));
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -143,7 +143,7 @@ public class TestOmBlockVersioning {
     List<OmKeyLocationInfo> locationInfoList =
         openKey.getKeyInfo().getLatestVersionLocations()
             .getBlocksLatestVersionOnly();
-    assertEquals(locationInfoList.size(), 1);
+    assertEquals(1, locationInfoList.size());
     locationInfoList.add(locationInfo);
     keyArgs.setLocationInfoList(locationInfoList);
     writeClient.commitKey(keyArgs, openKey.getId());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -39,7 +39,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -144,7 +143,7 @@ public class TestOmBlockVersioning {
     List<OmKeyLocationInfo> locationInfoList =
         openKey.getKeyInfo().getLatestVersionLocations()
             .getBlocksLatestVersionOnly();
-    assertTrue(locationInfoList.size() == 1);
+    assertEquals(locationInfoList.size(), 1);
     locationInfoList.add(locationInfo);
     keyArgs.setLocationInfoList(locationInfoList);
     writeClient.commitKey(keyArgs, openKey.getId());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumesSecure.java
@@ -294,7 +294,7 @@ public class TestOzoneManagerListVolumesSecure {
                            Callable<Boolean> callable) {
     // Some thread (eg: HeartbeatEndpointTask) will use the login ugi,
     // so we could not use loginUserFromKeytabAndReturnUGI to switch user.
-    assertEquals(true, ugi.doAs((PrivilegedAction<Boolean>) () -> {
+    assertTrue(ugi.doAs((PrivilegedAction<Boolean>) () -> {
       try {
         return callable.call();
       } catch (Throwable ex) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -272,7 +272,7 @@ public class TestScmSafeMode {
     scm = cluster.getStorageContainerManager();
     assertTrue(scm.isInSafeMode());
     assertFalse(logCapturer.getOutput().contains("SCM exiting safe mode."));
-    assertTrue(scm.getCurrentContainerThreshold() == 0);
+    assertEquals(0, scm.getCurrentContainerThreshold());
     for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
       dn.start();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotDeletingService.java
@@ -407,7 +407,7 @@ public class TestSnapshotDeletingService {
           RepeatedOmKeyInfo activeDBDeleted = next.getValue();
           OMMetadataManager metadataManager =
               cluster.getOzoneManager().getMetadataManager();
-          assertEquals(activeDBDeleted.getOmKeyInfoList().size(), 1);
+          assertEquals(1, activeDBDeleted.getOmKeyInfoList().size());
           OmKeyInfo activeDbDeletedKeyInfo =
               activeDBDeleted.getOmKeyInfoList().get(0);
           long volumeId = metadataManager

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerReportWithKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerReportWithKeys.java
@@ -140,9 +140,8 @@ public class TestContainerReportWithKeys {
     Set<ContainerReplica> replicas =
         scm.getContainerManager().getContainerReplicas(
             ContainerID.valueOf(keyInfo.getContainerID()));
-    Assert.assertTrue(replicas.size() == 1);
-    replicas.stream().forEach(rp ->
-        Assert.assertTrue(rp.getDatanodeDetails().getParent() != null));
+    Assert.assertEquals(1, replicas.size());
+    replicas.stream().forEach(rp -> Assert.assertNotNull(rp.getDatanodeDetails().getParent()));
 
     LOG.info("SCM Container Info keyCount: {} usedBytes: {}",
         cinfo.getNumberOfKeys(), cinfo.getUsedBytes());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
@@ -115,7 +115,7 @@ public class TestFailoverWithSCMHA {
     scmClientConfig.setRetryCount(1);
     scmClientConfig.setRetryInterval(100);
     scmClientConfig.setMaxRetryTimeout(1500);
-    assertEquals(scmClientConfig.getRetryCount(), 15);
+    assertEquals(15, scmClientConfig.getRetryCount());
     conf.setFromObject(scmClientConfig);
     StorageContainerManager scm = getLeader(cluster);
     assertNotNull(scm);
@@ -161,7 +161,7 @@ public class TestFailoverWithSCMHA {
     scmClientConfig.setRetryCount(1);
     scmClientConfig.setRetryInterval(100);
     scmClientConfig.setMaxRetryTimeout(1500);
-    assertEquals(scmClientConfig.getRetryCount(), 15);
+    assertEquals(15, scmClientConfig.getRetryCount());
     conf.setFromObject(scmClientConfig);
     StorageContainerManager scm = getLeader(cluster);
     assertNotNull(scm);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMMXBean.java
@@ -159,12 +159,12 @@ public class TestSCMMXBean {
 
     containerStateCount.forEach((k, v) -> {
       if (k.equals(HddsProtos.LifeCycleState.CLOSING.toString())) {
-        assertEquals((int)v, 5);
+        assertEquals(5, (int)v);
       } else if (k.equals(HddsProtos.LifeCycleState.CLOSED.toString())) {
-        assertEquals((int)v, 5);
+        assertEquals(5, (int)v);
       } else  {
         // Remaining all container state count should be zero.
-        assertEquals((int)v, 0);
+        assertEquals(0, (int)v);
       }
     });
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -1073,7 +1073,7 @@ public class TestStorageContainerManager {
     eventQueue.fireEvent(SCMEvents.INCREMENTAL_CONTAINER_REPORT, dndata);
     eventQueue.fireEvent(SCMEvents.INCREMENTAL_CONTAINER_REPORT, dndata);
     eventQueue.fireEvent(SCMEvents.INCREMENTAL_CONTAINER_REPORT, dndata);
-    Assert.assertTrue(containerReportExecutors.droppedEvents() == 0);
+    Assert.assertEquals(0, containerReportExecutors.droppedEvents());
     Thread.currentThread().sleep(3000);
     Assert.assertEquals(containerReportExecutors.scheduledEvents(),
         containerReportExecutors.queuedEvents());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -117,7 +117,7 @@ public class TestXceiverClientManager {
       clientManager.releaseClient(client1, true);
       clientManager.releaseClient(client2, true);
       clientManager.releaseClient(client3, true);
-      Assertions.assertTrue(clientManager.getClientCache().size() == 0);
+      Assertions.assertEquals(0, clientManager.getClientCache().size());
     }
   }
 
@@ -159,7 +159,7 @@ public class TestXceiverClientManager {
       XceiverClientSpi nonExistent1 = cache.getIfPresent(
           container1.getContainerInfo().getPipelineID().getId().toString()
               + container1.getContainerInfo().getReplicationType());
-      Assertions.assertEquals(null, nonExistent1);
+      Assertions.assertNull(nonExistent1);
       // However container call should succeed because of refcount on the client
       ContainerProtocolCalls.createContainer(client1,
           container1.getContainerInfo().getContainerID(), null);
@@ -218,7 +218,7 @@ public class TestXceiverClientManager {
       XceiverClientSpi nonExistent = cache.getIfPresent(
           container1.getContainerInfo().getPipelineID().getId().toString()
               + container1.getContainerInfo().getReplicationType());
-      Assertions.assertEquals(null, nonExistent);
+      Assertions.assertNull(nonExistent);
 
       // Any container operation should now fail
       Throwable t = Assertions.assertThrows(IOException.class,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -109,7 +109,7 @@ public class TestSCMPipelineMetrics {
     Pipeline pipeline = block.getPipeline();
     long numBlocksAllocated = getLongCounter(
         SCMPipelineMetrics.getBlockAllocationMetricName(pipeline), metrics);
-    Assertions.assertEquals(numBlocksAllocated, 1);
+    Assertions.assertEquals(1, numBlocksAllocated);
 
     // destroy the pipeline
     Assertions.assertDoesNotThrow(() ->


### PR DESCRIPTION
## What changes were proposed in this pull request?
Assertions in the form:  
``` 
assertTrue(<x> == <y>)   
assertEquals(null, <x>) or assertTrue(<x> == null)
assertTrue(<x> != null)
assertEquals(<boolean>, <x>)
```
can be simplified to:   
```
assertEquals(<x>, <y>)
assertNotNull(<x>)
assertTrue/assertFalse(<x>)
assertNull(<x>)
```
Not only are these simpler, some of them also provide more information in case of failure.

This PR updates such assertions in hadoop-ozone/integration-test.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9955
## CI
https://github.com/wzhallright/ozone/actions/runs/7284783456
