### PR TITLE
HDDS-9975. Add static import for assertions and mocks in hdds-server-framework

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import com.google.gson.Gson;
 import org.apache.hadoop.http.HttpServer2;
@@ -30,7 +32,6 @@ import org.apache.hadoop.util.XMLUtils;
 import org.eclipse.jetty.util.ajax.JSON;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
-import org.mockito.Mockito;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -75,10 +76,10 @@ public class TestHddsConfServlet {
     verifyMap.put("application/xml", HddsConfServlet.FORMAT_XML);
     verifyMap.put("application/json", HddsConfServlet.FORMAT_JSON);
 
-    HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
     for (Map.Entry<String, String> entry : verifyMap.entrySet()) {
       String contenTypeActual = entry.getValue();
-      Mockito.when(request.getHeader(HttpHeaders.ACCEPT))
+      when(request.getHeader(HttpHeaders.ACCEPT))
           .thenReturn(entry.getKey());
       assertEquals(contenTypeActual,
           HddsConfServlet.parseAcceptHeader(request));
@@ -202,10 +203,9 @@ public class TestHddsConfServlet {
       // response request
       service.doGet(request, response);
       if (cmd.equals("illegal")) {
-        Mockito.verify(response)
-            .sendError(
-                Mockito.eq(HttpServletResponse.SC_NOT_FOUND),
-                Mockito.eq("illegal is not a valid command."));
+        verify(response).sendError(
+            eq(HttpServletResponse.SC_NOT_FOUND),
+            eq("illegal is not a valid command."));
       }
       String result = sw.toString().trim();
       return result;
@@ -269,10 +269,10 @@ public class TestHddsConfServlet {
         } else {
           // if property name is not empty, and it's not in configuration
           // expect proper error code and error message is set to the response
-          Mockito.verify(response)
+          verify(response)
               .sendError(
-                  Mockito.eq(HttpServletResponse.SC_NOT_FOUND),
-                  Mockito.eq("Property " + propertyName + " not found"));
+                  eq(HttpServletResponse.SC_NOT_FOUND),
+                  eq("Property " + propertyName + " not found"));
         }
       }
     } finally {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/exceptions/TestSCMExceptionResultCodes.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/exceptions/TestSCMExceptionResultCodes.java
@@ -17,10 +17,9 @@
  */
 package org.apache.hadoop.hdds.scm.exceptions;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes;
-import org.apache.hadoop.hdds.protocol.proto.
-    ScmBlockLocationProtocolProtos.Status;
-import org.junit.jupiter.api.Assertions;
+import org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.Status;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,16 +31,16 @@ public class TestSCMExceptionResultCodes {
   public void codeMapping() {
     // ResultCode = SCMException definition
     // Status = protobuf definition
-    Assertions.assertEquals(ResultCodes.values().length,
+    assertEquals(ResultCodes.values().length,
         Status.values().length);
     for (int i = 0; i < ResultCodes.values().length; i++) {
       ResultCodes codeValue = ResultCodes.values()[i];
       Status protoBufValue = Status.values()[i];
-      Assertions.assertEquals(codeValue.name(), protoBufValue.name(),
+      assertEquals(codeValue.name(), protoBufValue.name(),
           String.format("Protobuf/Enum constant name mismatch %s %s",
               codeValue, protoBufValue));
       ResultCodes converted = ResultCodes.values()[protoBufValue.ordinal()];
-      Assertions.assertEquals(codeValue, converted);
+      assertEquals(codeValue, converted);
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestPemFileBasedKeyStoresFactory.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestPemFileBasedKeyStoresFactory.java
@@ -40,7 +40,6 @@ import org.apache.ratis.thirdparty.io.grpc.netty.NettyServerBuilder;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.ClientAuth;
 import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,6 +52,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test PemFileBasedKeyStoresFactory.
@@ -76,9 +77,9 @@ public class TestPemFileBasedKeyStoresFactory {
         secConf, caClient);
     try {
       keyStoresFactory.init(KeyStoresFactory.Mode.CLIENT, clientAuth);
-      Assertions.assertEquals(clientAuth, keyStoresFactory.getKeyManagers()[0]
+      assertEquals(clientAuth, keyStoresFactory.getKeyManagers()[0]
           instanceof ReloadingX509KeyManager);
-      Assertions.assertTrue(keyStoresFactory.getTrustManagers()[0]
+      assertTrue(keyStoresFactory.getTrustManagers()[0]
           instanceof ReloadingX509TrustManager);
     } finally {
       keyStoresFactory.destroy();
@@ -86,9 +87,9 @@ public class TestPemFileBasedKeyStoresFactory {
 
     try {
       keyStoresFactory.init(KeyStoresFactory.Mode.SERVER, clientAuth);
-      Assertions.assertTrue(keyStoresFactory.getKeyManagers()[0]
+      assertTrue(keyStoresFactory.getKeyManagers()[0]
           instanceof ReloadingX509KeyManager);
-      Assertions.assertTrue(keyStoresFactory.getTrustManagers()[0]
+      assertTrue(keyStoresFactory.getTrustManagers()[0]
           instanceof ReloadingX509TrustManager);
     } finally {
       keyStoresFactory.destroy();
@@ -117,7 +118,7 @@ public class TestPemFileBasedKeyStoresFactory {
 
       // send command
       ContainerCommandResponseProto responseProto = sendRequest(asyncStub);
-      Assertions.assertEquals(SUCCESS, responseProto.getResult());
+      assertEquals(SUCCESS, responseProto.getResult());
 
       // Renew certificate
       caClient.renewKey();
@@ -125,7 +126,7 @@ public class TestPemFileBasedKeyStoresFactory {
 
       // send command again
       responseProto = sendRequest(asyncStub);
-      Assertions.assertEquals(SUCCESS, responseProto.getResult());
+      assertEquals(SUCCESS, responseProto.getResult());
     } finally {
       if (channel != null) {
         channel.shutdownNow();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
@@ -21,13 +21,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.security.cert.X509Certificate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItemInArray;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,8 +53,7 @@ public class TestReloadingX509TrustManager {
         (ReloadingX509TrustManager) caClient.getServerKeyStoresFactory()
             .getTrustManagers()[0];
     X509Certificate cert1 = caClient.getRootCACertificate();
-    assertThat(tm.getAcceptedIssuers(),
-        Matchers.arrayContaining(cert1));
+    assertThat(tm.getAcceptedIssuers(), arrayContaining(cert1));
 
     caClient.renewRootCA();
     caClient.renewKey();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestLocalKeyStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestLocalKeyStore.java
@@ -50,7 +50,6 @@ import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.params.provider.Arguments.of;
 
 /**
  * Test cases for {@link LocalSecretKeyStore}.
@@ -71,13 +70,13 @@ class TestLocalKeyStore {
   static Stream<Arguments> saveAndLoadTestCases() throws Exception {
     return Stream.of(
         // empty
-        of(ImmutableList.of()),
+        Arguments.of(ImmutableList.of()),
         // single secret keys.
-        of(newArrayList(
+        Arguments.of(newArrayList(
             generateKey("HmacSHA256")
         )),
         // multiple secret keys.
-        of(newArrayList(
+        Arguments.of(newArrayList(
             generateKey("HmacSHA1"),
             generateKey("HmacSHA256")
         ))

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestLocalKeyStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestLocalKeyStore.java
@@ -50,6 +50,7 @@ import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
 /**
  * Test cases for {@link LocalSecretKeyStore}.
@@ -70,13 +71,13 @@ class TestLocalKeyStore {
   static Stream<Arguments> saveAndLoadTestCases() throws Exception {
     return Stream.of(
         // empty
-        Arguments.of(ImmutableList.of()),
+        of(ImmutableList.of()),
         // single secret keys.
-        Arguments.of(newArrayList(
+        of(newArrayList(
             generateKey("HmacSHA256")
         )),
         // multiple secret keys.
-        Arguments.of(newArrayList(
+        of(newArrayList(
             generateKey("HmacSHA1"),
             generateKey("HmacSHA256")
         ))

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestSecretKeyManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestSecretKeyManager.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -40,6 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,7 +56,7 @@ public class TestSecretKeyManager {
 
   @BeforeEach
   private void setup() {
-    mockedKeyStore = Mockito.mock(SecretKeyStore.class);
+    mockedKeyStore = mock(SecretKeyStore.class);
   }
 
   public static Stream<Arguments> loadSecretKeysTestCases() throws Exception {
@@ -160,7 +161,7 @@ public class TestSecretKeyManager {
     // Set the initial state.
     state.updateKeys(initialKeys);
     ManagedSecretKey initialCurrentKey = state.getCurrentKey();
-    Mockito.reset(mockedKeyStore);
+    reset(mockedKeyStore);
 
     assertEquals(expectRotate, lifeCycleManager.checkAndRotate(false));
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenIdentifier.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenIdentifier.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.security.symmetric.SecretKeyTestUtil;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +34,7 @@ import java.util.EnumSet;
 
 import static java.time.Duration.ofDays;
 import static java.time.Instant.now;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -93,8 +93,8 @@ public class TestOzoneBlockTokenIdentifier {
     decodedTokenId.readFields(new DataInputStream(
         new ByteArrayInputStream(decodedToken.getIdentifier())));
 
-    Assertions.assertEquals(tokenId, decodedTokenId);
-    Assertions.assertEquals(maxLength, decodedTokenId.getMaxLength());
+    assertEquals(tokenId, decodedTokenId);
+    assertEquals(maxLength, decodedTokenId.getMaxLength());
 
     // Verify a decoded signed Token
     assertTrue(secretKey.isValidSignature(decodedTokenId,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -55,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -85,9 +85,9 @@ public class TestOzoneBlockTokenSecretManager {
     secretKey = generateValidSecretKey();
     secretKeyId = secretKey.getId();
 
-    secretKeyClient = Mockito.mock(SecretKeyVerifierClient.class);
+    secretKeyClient = mock(SecretKeyVerifierClient.class);
     SecretKeySignerClient secretKeySignerClient =
-        Mockito.mock(SecretKeySignerClient.class);
+        mock(SecretKeySignerClient.class);
     when(secretKeySignerClient.getCurrentSecretKey()).thenReturn(secretKey);
     when(secretKeyClient.getSecretKey(secretKeyId)).thenReturn(secretKey);
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,7 +119,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
 
     Instant past = Instant.now().minus(Duration.ofHours(1));
     ManagedSecretKey expiredSecretKey = new ManagedSecretKey(UUID.randomUUID(),
-        past, past, Mockito.mock(SecretKey.class));
+        past, past, mock(SecretKey.class));
 
     when(secretKeyClient.getSecretKey(SECRET_KEY_ID))
         .thenReturn(expiredSecretKey);
@@ -181,7 +180,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
       throws IOException {
     SecretKeyVerifierClient secretKeyClient =
         mock(SecretKeyVerifierClient.class);
-    ManagedSecretKey validSecretKey = Mockito.mock(ManagedSecretKey.class);
+    ManagedSecretKey validSecretKey = mock(ManagedSecretKey.class);
     when(secretKeyClient.getSecretKey(SECRET_KEY_ID))
         .thenReturn(validSecretKey);
     when(validSecretKey.isValidSignature((TokenIdentifier) any(), any()))
@@ -259,7 +258,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
 
     MockTokenManager() {
       super(TimeUnit.HOURS.toMillis(1),
-          Mockito.mock(SecretKeySignerClient.class));
+          mock(SecretKeySignerClient.class));
     }
 
     @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateSignRequest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateSignRequest.java
@@ -37,7 +37,6 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.PKCSException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -53,6 +52,10 @@ import java.util.UUID;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getDistinguishedNameFormat;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getPkcs9Extensions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Certificate Signing Request.
@@ -91,33 +94,32 @@ public class TestCertificateSignRequest {
     // Check the Subject Name is in the expected format.
     String dnName = String.format(getDistinguishedNameFormat(),
         subject, scmID, clusterID);
-    Assertions.assertEquals(dnName, csr.getSubject().toString());
+    assertEquals(dnName, csr.getSubject().toString());
 
     // Verify the public key info match
     byte[] encoded = keyPair.getPublic().getEncoded();
     SubjectPublicKeyInfo subjectPublicKeyInfo =
         SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(encoded));
     SubjectPublicKeyInfo csrPublicKeyInfo = csr.getSubjectPublicKeyInfo();
-    Assertions.assertEquals(subjectPublicKeyInfo, csrPublicKeyInfo);
+    assertEquals(subjectPublicKeyInfo, csrPublicKeyInfo);
 
     // Verify CSR with attribute for extensions
-    Assertions.assertEquals(1, csr.getAttributes().length);
+    assertEquals(1, csr.getAttributes().length);
     Extensions extensions = getPkcs9Extensions(csr);
 
     // Verify key usage extension
     Extension keyUsageExt = extensions.getExtension(Extension.keyUsage);
-    Assertions.assertTrue(keyUsageExt.isCritical());
+    assertTrue(keyUsageExt.isCritical());
 
 
     // Verify San extension not set
-    Assertions.assertNull(
-        extensions.getExtension(Extension.subjectAlternativeName));
+    assertNull(extensions.getExtension(Extension.subjectAlternativeName));
 
     // Verify signature in CSR
     ContentVerifierProvider verifierProvider =
         new JcaContentVerifierProviderBuilder().setProvider(securityConfig
             .getProvider()).build(csr.getSubjectPublicKeyInfo());
-    Assertions.assertTrue(csr.isSignatureValid(verifierProvider));
+    assertTrue(csr.isSignatureValid(verifierProvider));
   }
 
   @Test
@@ -151,22 +153,22 @@ public class TestCertificateSignRequest {
     // Check the Subject Name is in the expected format.
     String dnName = String.format(getDistinguishedNameFormat(),
         subject, scmID, clusterID);
-    Assertions.assertEquals(dnName, csr.getSubject().toString());
+    assertEquals(dnName, csr.getSubject().toString());
 
     // Verify the public key info match
     byte[] encoded = keyPair.getPublic().getEncoded();
     SubjectPublicKeyInfo subjectPublicKeyInfo =
         SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(encoded));
     SubjectPublicKeyInfo csrPublicKeyInfo = csr.getSubjectPublicKeyInfo();
-    Assertions.assertEquals(subjectPublicKeyInfo, csrPublicKeyInfo);
+    assertEquals(subjectPublicKeyInfo, csrPublicKeyInfo);
 
     // Verify CSR with attribute for extensions
-    Assertions.assertEquals(1, csr.getAttributes().length);
+    assertEquals(1, csr.getAttributes().length);
     Extensions extensions = getPkcs9Extensions(csr);
 
     // Verify key usage extension
     Extension sanExt = extensions.getExtension(Extension.keyUsage);
-    Assertions.assertTrue(sanExt.isCritical());
+    assertTrue(sanExt.isCritical());
 
     verifyServiceId(extensions);
 
@@ -174,7 +176,7 @@ public class TestCertificateSignRequest {
     ContentVerifierProvider verifierProvider =
         new JcaContentVerifierProviderBuilder().setProvider(securityConfig
             .getProvider()).build(csr.getSubjectPublicKeyInfo());
-    Assertions.assertTrue(csr.isSignatureValid(verifierProvider));
+    assertTrue(csr.isSignatureValid(verifierProvider));
   }
 
   @Test
@@ -198,7 +200,7 @@ public class TestCertificateSignRequest {
     try {
       builder.setKey(null);
       builder.build();
-      Assertions.fail("Null Key should have failed.");
+      fail("Null Key should have failed.");
     } catch (NullPointerException | IllegalArgumentException e) {
       builder.setKey(keyPair);
     }
@@ -207,7 +209,7 @@ public class TestCertificateSignRequest {
     try {
       builder.setSubject(null);
       builder.build();
-      Assertions.fail("Null/Blank Subject should have thrown.");
+      fail("Null/Blank Subject should have thrown.");
     } catch (IllegalArgumentException e) {
       builder.setSubject(subject);
     }
@@ -215,7 +217,7 @@ public class TestCertificateSignRequest {
     try {
       builder.setSubject("");
       builder.build();
-      Assertions.fail("Null/Blank Subject should have thrown.");
+      fail("Null/Blank Subject should have thrown.");
     } catch (IllegalArgumentException e) {
       builder.setSubject(subject);
     }
@@ -224,7 +226,7 @@ public class TestCertificateSignRequest {
     try {
       builder.addIpAddress("255.255.255.*");
       builder.build();
-      Assertions.fail("Invalid ip address");
+      fail("Invalid ip address");
     } catch (IllegalArgumentException e) {
     }
 
@@ -233,17 +235,17 @@ public class TestCertificateSignRequest {
     // Check the Subject Name is in the expected format.
     String dnName = String.format(getDistinguishedNameFormat(),
         subject, scmID, clusterID);
-    Assertions.assertEquals(dnName, csr.getSubject().toString());
+    assertEquals(dnName, csr.getSubject().toString());
 
     // Verify the public key info match
     byte[] encoded = keyPair.getPublic().getEncoded();
     SubjectPublicKeyInfo subjectPublicKeyInfo =
         SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(encoded));
     SubjectPublicKeyInfo csrPublicKeyInfo = csr.getSubjectPublicKeyInfo();
-    Assertions.assertEquals(subjectPublicKeyInfo, csrPublicKeyInfo);
+    assertEquals(subjectPublicKeyInfo, csrPublicKeyInfo);
 
     // Verify CSR with attribute for extensions
-    Assertions.assertEquals(1, csr.getAttributes().length);
+    assertEquals(1, csr.getAttributes().length);
   }
 
   @Test
@@ -269,7 +271,7 @@ public class TestCertificateSignRequest {
 
     // Verify de-serialized CSR matches with the original CSR
     PKCS10CertificationRequest dsCsr = new PKCS10CertificationRequest(csrBytes);
-    Assertions.assertEquals(csr, dsCsr);
+    assertEquals(csr, dsCsr);
   }
 
   private void verifyServiceId(Extensions extensions) {
@@ -285,11 +287,11 @@ public class TestCertificateSignRequest {
           Object o = iterator.next();
           if (o instanceof ASN1ObjectIdentifier) {
             String oid = o.toString();
-            Assertions.assertEquals("2.16.840.1.113730.3.1.34", oid);
+            assertEquals("2.16.840.1.113730.3.1.34", oid);
           }
           if (o instanceof DERTaggedObject) {
             String serviceName = ((DERTaggedObject)o).getObject().toString();
-            Assertions.assertEquals("OzoneMarketingCluster003", serviceName);
+            assertEquals("OzoneMarketingCluster003", serviceName);
           }
         }
       }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCertificate.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestRootCertificate.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,6 +43,12 @@ import java.util.Date;
 import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test Class for Root Certificate generation.
@@ -82,35 +87,30 @@ public class TestRootCertificate {
     X509CertificateHolder certificateHolder = builder.build();
 
     //Assert that we indeed have a self signed certificate.
-    Assertions.assertEquals(certificateHolder.getIssuer(),
+    assertEquals(certificateHolder.getIssuer(),
         certificateHolder.getSubject());
 
 
     // Make sure that NotBefore is before the current Date
     Date invalidDate = Date.from(
         notBefore.minusDays(1).atZone(ZoneId.systemDefault()).toInstant());
-    Assertions.assertFalse(
-        certificateHolder.getNotBefore()
-            .before(invalidDate));
+    assertFalse(certificateHolder.getNotBefore().before(invalidDate));
 
     //Make sure the end date is honored.
     invalidDate = Date.from(
         notAfter.plusDays(1).atZone(ZoneId.systemDefault()).toInstant());
-    Assertions.assertFalse(
-        certificateHolder.getNotAfter()
-            .after(invalidDate));
+    assertFalse(certificateHolder.getNotAfter().after(invalidDate));
 
     // Check the Subject Name and Issuer Name is in the expected format.
     String dnName = String.format(SelfSignedCertificate.getNameFormat(),
         subject, scmID, clusterID, certificateHolder.getSerialNumber());
-    Assertions.assertEquals(dnName, certificateHolder.getIssuer().toString());
-    Assertions.assertEquals(dnName, certificateHolder.getSubject().toString());
+    assertEquals(dnName, certificateHolder.getIssuer().toString());
+    assertEquals(dnName, certificateHolder.getSubject().toString());
 
     // We did not ask for this Certificate to be a CertificateServer
     // certificate, hence that
     // extension should be null.
-    Assertions.assertNull(
-        certificateHolder.getExtension(Extension.basicConstraints));
+    assertNull(certificateHolder.getExtension(Extension.basicConstraints));
 
     // Extract the Certificate and verify that certificate matches the public
     // key.
@@ -149,13 +149,12 @@ public class TestRootCertificate {
     Extension basicExt =
         certificateHolder.getExtension(Extension.basicConstraints);
 
-    Assertions.assertNotNull(basicExt);
-    Assertions.assertTrue(basicExt.isCritical());
+    assertNotNull(basicExt);
+    assertTrue(basicExt.isCritical());
 
     // Since this code assigns ONE for the root certificate, we check if the
     // serial number is the expected number.
-    Assertions.assertEquals(BigInteger.ONE,
-        certificateHolder.getSerialNumber());
+    assertEquals(BigInteger.ONE, certificateHolder.getSerialNumber());
 
     CertificateCodec codec = new CertificateCodec(securityConfig, "scm");
     String pemString = CertificateCodec.getPEMEncodedString(certificateHolder);
@@ -165,8 +164,8 @@ public class TestRootCertificate {
 
     X509CertificateHolder loadedCert =
         codec.getTargetCertHolder(basePath, "pemcertificate.crt");
-    Assertions.assertNotNull(loadedCert);
-    Assertions.assertEquals(certificateHolder.getSerialNumber(),
+    assertNotNull(loadedCert);
+    assertEquals(certificateHolder.getSerialNumber(),
         loadedCert.getSerialNumber());
   }
 
@@ -194,7 +193,7 @@ public class TestRootCertificate {
     try {
       builder.setKey(null);
       builder.build();
-      Assertions.fail("Null Key should have failed.");
+      fail("Null Key should have failed.");
     } catch (NullPointerException | IllegalArgumentException e) {
       builder.setKey(keyPair);
     }
@@ -203,7 +202,7 @@ public class TestRootCertificate {
     try {
       builder.setSubject("");
       builder.build();
-      Assertions.fail("Null/Blank Subject should have thrown.");
+      fail("Null/Blank Subject should have thrown.");
     } catch (IllegalArgumentException e) {
       builder.setSubject(subject);
     }
@@ -212,7 +211,7 @@ public class TestRootCertificate {
     try {
       builder.setScmID(null);
       builder.build();
-      Assertions.fail("Null/Blank SCM ID should have thrown.");
+      fail("Null/Blank SCM ID should have thrown.");
     } catch (IllegalArgumentException e) {
       builder.setScmID(scmID);
     }
@@ -222,7 +221,7 @@ public class TestRootCertificate {
     try {
       builder.setClusterID(null);
       builder.build();
-      Assertions.fail("Null/Blank Cluster ID should have thrown.");
+      fail("Null/Blank Cluster ID should have thrown.");
     } catch (IllegalArgumentException e) {
       builder.setClusterID(clusterID);
     }
@@ -234,7 +233,7 @@ public class TestRootCertificate {
       builder.setBeginDate(notAfter);
       builder.setEndDate(notBefore);
       builder.build();
-      Assertions.fail("Illegal dates should have thrown.");
+      fail("Illegal dates should have thrown.");
     } catch (IllegalArgumentException e) {
       builder.setBeginDate(notBefore);
       builder.setEndDate(notAfter);
@@ -248,12 +247,12 @@ public class TestRootCertificate {
       X509Certificate cert =
           new JcaX509CertificateConverter().getCertificate(certificateHolder);
       cert.verify(wrongKey.getPublic());
-      Assertions.fail("Invalid Key, should have thrown.");
+      fail("Invalid Key, should have thrown.");
     } catch (SCMSecurityException | CertificateException
         | SignatureException | InvalidKeyException e) {
       builder.setKey(keyPair);
     }
     // Assert that we can create a certificate with all sane params.
-    Assertions.assertNotNull(builder.build());
+    assertNotNull(builder.build());
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestHDDSKeyGenerator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestHDDSKeyGenerator.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.keys;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
@@ -29,7 +30,6 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -58,11 +58,10 @@ public class TestHDDSKeyGenerator {
       throws NoSuchProviderException, NoSuchAlgorithmException {
     HDDSKeyGenerator keyGen = new HDDSKeyGenerator(config);
     KeyPair keyPair = keyGen.generateKey();
-    Assertions.assertEquals(config.getKeyAlgo(),
-        keyPair.getPrivate().getAlgorithm());
+    assertEquals(config.getKeyAlgo(), keyPair.getPrivate().getAlgorithm());
     PKCS8EncodedKeySpec keySpec =
         new PKCS8EncodedKeySpec(keyPair.getPrivate().getEncoded());
-    Assertions.assertEquals("PKCS#8", keySpec.getFormat());
+    assertEquals("PKCS#8", keySpec.getFormat());
   }
 
   /**
@@ -80,8 +79,7 @@ public class TestHDDSKeyGenerator {
     KeyPair keyPair = keyGen.generateKey(4096);
     PublicKey publicKey = keyPair.getPublic();
     if (publicKey instanceof RSAPublicKey) {
-      Assertions.assertEquals(4096,
-          ((RSAPublicKey)(publicKey)).getModulus().bitLength());
+      assertEquals(4096, ((RSAPublicKey)(publicKey)).getModulus().bitLength());
     }
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestKeyCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestKeyCodec.java
@@ -20,6 +20,8 @@
 package org.apache.hadoop.hdds.security.x509.keys;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,7 +45,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.SecurityConfig;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -88,29 +89,29 @@ public class TestKeyCodec {
 
     // Assert that locations have been created.
     Path keyLocation = pemWriter.getSecurityConfig().getKeyLocation(component);
-    Assertions.assertTrue(keyLocation.toFile().exists());
+    assertTrue(keyLocation.toFile().exists());
 
     // Assert that locations are created in the locations that we specified
     // using the Config.
-    Assertions.assertTrue(keyLocation.toString().startsWith(prefix));
+    assertTrue(keyLocation.toString().startsWith(prefix));
     Path privateKeyPath = Paths.get(keyLocation.toString(),
         pemWriter.getSecurityConfig().getPrivateKeyFileName());
-    Assertions.assertTrue(privateKeyPath.toFile().exists());
+    assertTrue(privateKeyPath.toFile().exists());
     Path publicKeyPath = Paths.get(keyLocation.toString(),
         pemWriter.getSecurityConfig().getPublicKeyFileName());
-    Assertions.assertTrue(publicKeyPath.toFile().exists());
+    assertTrue(publicKeyPath.toFile().exists());
 
     // Read the private key and test if the expected String in the PEM file
     // format exists.
     byte[] privateKey = Files.readAllBytes(privateKeyPath);
     String privateKeydata = new String(privateKey, StandardCharsets.UTF_8);
-    Assertions.assertTrue(privateKeydata.contains("PRIVATE KEY"));
+    assertTrue(privateKeydata.contains("PRIVATE KEY"));
 
     // Read the public key and test if the expected String in the PEM file
     // format exists.
     byte[] publicKey = Files.readAllBytes(publicKeyPath);
     String publicKeydata = new String(publicKey, StandardCharsets.UTF_8);
-    Assertions.assertTrue(publicKeydata.contains("PUBLIC KEY"));
+    assertTrue(publicKeydata.contains("PUBLIC KEY"));
 
     // Let us decode the PEM file and parse it back into binary.
     KeyFactory kf = KeyFactory.getInstance(
@@ -128,7 +129,7 @@ public class TestKeyCodec {
     byte[] keyBytes = Base64.decodeBase64(privateKeydata);
     PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
     PrivateKey privateKeyDecoded = kf.generatePrivate(spec);
-    Assertions.assertNotNull(privateKeyDecoded,
+    assertNotNull(privateKeyDecoded,
         "Private Key should not be null");
 
     // Let us decode the public key and veriy that we can parse it back into
@@ -141,28 +142,28 @@ public class TestKeyCodec {
     keyBytes = Base64.decodeBase64(publicKeydata);
     X509EncodedKeySpec pubKeyspec = new X509EncodedKeySpec(keyBytes);
     PublicKey publicKeyDecoded = kf.generatePublic(pubKeyspec);
-    Assertions.assertNotNull(publicKeyDecoded, "Public Key should not be null");
+    assertNotNull(publicKeyDecoded, "Public Key should not be null");
 
     // Now let us assert the permissions on the Directories and files are as
     // expected.
     Set<PosixFilePermission> expectedSet = pemWriter.getFilePermissionSet();
     Set<PosixFilePermission> currentSet =
         Files.getPosixFilePermissions(privateKeyPath);
-    Assertions.assertEquals(expectedSet.size(), currentSet.size());
+    assertEquals(expectedSet.size(), currentSet.size());
     currentSet.removeAll(expectedSet);
-    Assertions.assertEquals(0, currentSet.size());
+    assertEquals(0, currentSet.size());
 
     currentSet =
         Files.getPosixFilePermissions(publicKeyPath);
     currentSet.removeAll(expectedSet);
-    Assertions.assertEquals(0, currentSet.size());
+    assertEquals(0, currentSet.size());
 
     expectedSet = pemWriter.getDirPermissionSet();
     currentSet =
         Files.getPosixFilePermissions(keyLocation);
-    Assertions.assertEquals(expectedSet.size(), currentSet.size());
+    assertEquals(expectedSet.size(), currentSet.size());
     currentSet.removeAll(expectedSet);
-    Assertions.assertEquals(0, currentSet.size());
+    assertEquals(0, currentSet.size());
   }
 
   /**
@@ -228,6 +229,6 @@ public class TestKeyCodec {
     keycodec.writeKey(kp);
 
     PublicKey pubKey = keycodec.readPublicKey();
-    Assertions.assertNotNull(pubKey);
+    assertNotNull(pubKey);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
@@ -17,10 +17,11 @@
  */
 package org.apache.hadoop.hdds.server.events;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -67,7 +68,7 @@ public class TestEventQueue {
 
     queue.fireEvent(EVENT1, 11L);
     queue.processAll(1000);
-    Assertions.assertEquals(11, result[0]);
+    assertEquals(11, result[0]);
 
   }
 
@@ -105,20 +106,20 @@ public class TestEventQueue {
 
     // As it is fixed threadpool executor with 10 threads, all should be
     // scheduled.
-    Assertions.assertEquals(11, eventExecutor.queuedEvents());
+    assertEquals(11, eventExecutor.queuedEvents());
     Thread.currentThread().sleep(500);
 
     // As we don't see all 10 events scheduled.
-    Assertions.assertTrue(eventExecutor.scheduledEvents() >= 1 &&
+    assertTrue(eventExecutor.scheduledEvents() >= 1 &&
         eventExecutor.scheduledEvents() <= 10);
 
     queue.processAll(60000);
 
-    Assertions.assertEquals(11, eventExecutor.scheduledEvents());
+    assertEquals(11, eventExecutor.scheduledEvents());
 
-    Assertions.assertEquals(166, eventTotal.intValue());
+    assertEquals(166, eventTotal.intValue());
 
-    Assertions.assertEquals(11, eventExecutor.successfulEvents());
+    assertEquals(11, eventExecutor.successfulEvents());
     eventTotal.set(0);
     eventExecutor.close();
   }
@@ -147,8 +148,8 @@ public class TestEventQueue {
 
     queue.fireEvent(EVENT2, 23L);
     queue.processAll(1000);
-    Assertions.assertEquals(23, result[0]);
-    Assertions.assertEquals(23, result[1]);
+    assertEquals(23, result[0]);
+    assertEquals(23, result[1]);
 
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventWatcher.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventWatcher.java
@@ -16,11 +16,13 @@
  */
 package org.apache.hadoop.hdds.server.events;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.hadoop.hdds.HddsIdFactory;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.lease.LeaseManager;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -79,7 +81,7 @@ public class TestEventWatcher {
     queue.fireEvent(WATCH_UNDER_REPLICATED,
         new UnderreplicatedEvent(id2, "C2"));
 
-    Assertions.assertEquals(0,
+    assertEquals(0,
         underReplicatedEvents.getReceivedEvents().size());
 
     Thread.sleep(1000);
@@ -87,16 +89,16 @@ public class TestEventWatcher {
     queue.fireEvent(REPLICATION_COMPLETED,
         new ReplicationCompletedEvent(id1, "C2", "D1"));
 
-    Assertions.assertEquals(0,
+    assertEquals(0,
         underReplicatedEvents.getReceivedEvents().size());
 
     Thread.sleep(1500);
 
     queue.processAll(1000L);
 
-    Assertions.assertEquals(1,
+    assertEquals(1,
         underReplicatedEvents.getReceivedEvents().size());
-    Assertions.assertEquals(id2,
+    assertEquals(id2,
         underReplicatedEvents.getReceivedEvents().get(0).id);
 
   }
@@ -132,15 +134,14 @@ public class TestEventWatcher {
     List<UnderreplicatedEvent> c1todo = replicationWatcher
         .getTimeoutEvents(e -> e.containerId.equalsIgnoreCase("C1"));
 
-    Assertions.assertEquals(2, c1todo.size());
-    Assertions.assertTrue(replicationWatcher.contains(event1));
+    assertEquals(2, c1todo.size());
+    assertTrue(replicationWatcher.contains(event1));
     Thread.sleep(1500L);
 
     c1todo = replicationWatcher
         .getTimeoutEvents(e -> e.containerId.equalsIgnoreCase("C1"));
-    Assertions.assertEquals(0, c1todo.size());
-    Assertions.assertFalse(replicationWatcher.contains(event1));
-
+    assertEquals(0, c1todo.size());
+    assertFalse(replicationWatcher.contains(event1));
   }
 
   @Test
@@ -195,17 +196,17 @@ public class TestEventWatcher {
     EventWatcherMetrics metrics = replicationWatcher.getMetrics();
 
     //3 events are received
-    Assertions.assertEquals(3, metrics.getTrackedEvents().value());
+    assertEquals(3, metrics.getTrackedEvents().value());
 
     //completed + timed out = all messages
-    Assertions.assertEquals(metrics.getTrackedEvents().value(),
+    assertEquals(metrics.getTrackedEvents().value(),
         metrics.getCompletedEvents().value() +
             metrics.getTimedOutEvents().value(),
         "number of timed out and completed messages should be the same as the"
             + " all messages");
 
     //_at least_ two are timed out.
-    Assertions.assertTrue(metrics.getTimedOutEvents().value() >= 2,
+    assertTrue(metrics.getTimedOutEvents().value() >= 2,
         "At least two events should be timed out.");
 
     DefaultMetricsSystem.shutdown();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdds.server.http;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -95,13 +95,13 @@ public class TestBaseHttpServer {
 
     conf.set("addresskey", "0.0.0.0:1234");
 
-    Assertions.assertEquals("/0.0.0.0:1234", baseHttpServer
+    assertEquals("/0.0.0.0:1234", baseHttpServer
         .getBindAddress("bindhostkey", "addresskey",
             "default", 65).toString());
 
     conf.set("bindhostkey", "1.2.3.4");
 
-    Assertions.assertEquals("/1.2.3.4:1234", baseHttpServer
+    assertEquals("/1.2.3.4:1234", baseHttpServer
         .getBindAddress("bindhostkey", "addresskey",
             "default", 65).toString());
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHtmlQuoting.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHtmlQuoting.java
@@ -20,13 +20,14 @@ package org.apache.hadoop.hdds.server.http;
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 /**
  * Testing HTML Quoting.
@@ -76,24 +77,24 @@ public class TestHtmlQuoting {
 
   @Test
   public void testRequestQuoting() throws Exception {
-    HttpServletRequest mockReq = Mockito.mock(HttpServletRequest.class);
+    HttpServletRequest mockReq = mock(HttpServletRequest.class);
     HttpServer2.QuotingInputFilter.RequestQuoter quoter =
         new HttpServer2.QuotingInputFilter.RequestQuoter(mockReq);
 
-    Mockito.doReturn("a<b").when(mockReq).getParameter("x");
+    doReturn("a<b").when(mockReq).getParameter("x");
     assertEquals("a&lt;b", quoter.getParameter("x"),
         "Test simple param quoting");
 
-    Mockito.doReturn(null).when(mockReq).getParameter("x");
+    doReturn(null).when(mockReq).getParameter("x");
     assertNull(quoter.getParameter("x"),
         "Test that missing parameters dont cause NPE");
 
-    Mockito.doReturn(new String[] {"a<b", "b"}).when(mockReq)
+    doReturn(new String[] {"a<b", "b"}).when(mockReq)
         .getParameterValues("x");
     assertArrayEquals(new String[] {"a&lt;b", "b"},
         quoter.getParameterValues("x"), "Test escaping of an array");
 
-    Mockito.doReturn(null).when(mockReq).getParameterValues("x");
+    doReturn(null).when(mockReq).getParameterValues("x");
     assertNull(quoter.getParameterValues("x"),
         "Test that missing parameters dont cause NPE for array");
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2Metrics.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2Metrics.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.Random;
 
@@ -50,8 +49,8 @@ public class TestHttpServer2Metrics {
 
   @BeforeEach
   public void setup() {
-    threadPool = Mockito.mock(QueuedThreadPool.class);
-    metricsCollector = Mockito.mock(MetricsCollector.class);
+    threadPool = mock(QueuedThreadPool.class);
+    metricsCollector = mock(MetricsCollector.class);
     recorder = mock(MetricsRecordBuilder.class);
   }
 
@@ -65,10 +64,10 @@ public class TestHttpServer2Metrics {
     int threadQueueWaitingTaskCount = random.nextInt();
     String name = "s3g";
 
-    Mockito.when(threadPool.getThreads()).thenReturn(threadCount);
-    Mockito.when(threadPool.getMaxThreads()).thenReturn(maxThreadCount);
-    Mockito.when(threadPool.getIdleThreads()).thenReturn(idleThreadCount);
-    Mockito.when(threadPool.getQueueSize())
+    when(threadPool.getThreads()).thenReturn(threadCount);
+    when(threadPool.getMaxThreads()).thenReturn(maxThreadCount);
+    when(threadPool.getIdleThreads()).thenReturn(idleThreadCount);
+    when(threadPool.getQueueSize())
             .thenReturn(threadQueueWaitingTaskCount);
     when(recorder.addGauge(any(MetricsInfo.class), anyInt()))
         .thenReturn(recorder);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdds.server.http;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.hadoop.hdds.server.http.ProfileServlet.Event;
 import org.apache.hadoop.hdds.server.http.ProfileServlet.Output;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,22 +41,22 @@ public class TestProfileServlet {
 
   @Test
   public void testNameValidationWithNewLine() {
-    Assertions.assertThrows(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> ProfileServlet.validateFileName("test\n" +
             ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
                 Event.ALLOC)));
-    Assertions.assertThrows(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> ProfileServlet.validateFileName("test\n" +
             ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC)));
   }
 
   @Test
   public void testNameValidationWithSlash() {
-    Assertions.assertThrows(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> ProfileServlet.validateFileName("../" +
             ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
                 Event.ALLOC)));
-    Assertions.assertThrows(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> ProfileServlet.validateFileName("../" +
             ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC)));
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsIntegration.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsIntegration.java
@@ -18,6 +18,9 @@
 package org.apache.hadoop.hdds.server.http;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,7 +38,6 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -101,7 +103,7 @@ public class TestPrometheusMetricsIntegration {
     String writtenMetrics = waitForMetricsToPublish("test_metrics_num");
 
     //THEN
-    Assertions.assertTrue(
+    assertTrue(
         writtenMetrics.contains(
             "test_metrics_num_bucket_create_fails{context=\"dfs\""),
         "The expected metric line is missing from prometheus metrics output"
@@ -125,11 +127,11 @@ public class TestPrometheusMetricsIntegration {
     String writtenMetrics = waitForMetricsToPublish("rpc_metrics_counter");
 
     // THEN
-    Assertions.assertTrue(
+    assertTrue(
         writtenMetrics.contains("rpc_metrics_counter{port=\"2345\""),
         "The expected metric line is missing from prometheus metrics output");
 
-    Assertions.assertTrue(
+    assertTrue(
         writtenMetrics.contains("rpc_metrics_counter{port=\"1234\""),
         "The expected metric line is missing from prometheus metrics output");
 
@@ -152,14 +154,14 @@ public class TestPrometheusMetricsIntegration {
     String writtenMetrics = waitForMetricsToPublish("same_name_counter");
 
     // THEN
-    Assertions.assertEquals(1, StringUtils.countMatches(writtenMetrics,
+    assertEquals(1, StringUtils.countMatches(writtenMetrics,
         "# TYPE same_name_counter"));
 
     // both metrics should be present
-    Assertions.assertTrue(
+    assertTrue(
         writtenMetrics.contains("same_name_counter{port=\"1234\""),
         "The expected metric line is present in prometheus metrics output");
-    Assertions.assertTrue(
+    assertTrue(
         writtenMetrics.contains("same_name_counter{port=\"2345\""),
         "The expected metric line is present in prometheus metrics output");
 
@@ -198,10 +200,10 @@ public class TestPrometheusMetricsIntegration {
 
     // THEN
     // The first metric shouldn't be present
-    Assertions.assertFalse(
+    assertFalse(
         writtenMetrics.contains("stale_metric_counter{port=\"1234\""),
         "The expected metric line is present in prometheus metrics output");
-    Assertions.assertTrue(
+    assertTrue(
         writtenMetrics.contains("some_metric_counter{port=\"4321\""),
         "The expected metric line is present in prometheus metrics output");
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
@@ -31,10 +31,10 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.metrics.SegmentedRaftLogMetrics;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.ratis.server.metrics.SegmentedRaftLogMetrics.RAFT_LOG_SYNC_TIME;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test RatisDropwizardRexporter.
@@ -73,7 +73,7 @@ public class TestRatisDropwizardExports {
 
     System.out.println(writer);
 
-    Assertions.assertFalse(writer.toString()
+    assertFalse(writer.toString()
             .contains("ratis_core_ratis_log_worker_instance_syncTime"),
         "Instance name is not moved to be a tag");
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
@@ -22,11 +22,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
@@ -98,9 +98,9 @@ public class TestRatisNameRewrite {
     String cleanName = new RatisNameRewriteSampleBuilder()
         .normalizeRatisMetric(originalName, names, values);
 
-    Assertions.assertEquals(expectedName, cleanName);
-    Assertions.assertEquals(Arrays.asList(expectedTagNames), names);
-    Assertions.assertEquals(Arrays.asList(expectedTagValues), values);
+    assertEquals(expectedName, cleanName);
+    assertEquals(Arrays.asList(expectedTagNames), names);
+    assertEquals(Arrays.asList(expectedTagValues), values);
 
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestCollectionUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestCollectionUtils.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.utils;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -33,6 +32,7 @@ import static java.util.Collections.reverseOrder;
 import static java.util.Collections.singletonList;
 import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test for {@link CollectionUtils}. */
 public class TestCollectionUtils {
@@ -90,7 +90,7 @@ public class TestCollectionUtils {
       List<List<T>> listOfLists) {
     List<T> actual = new ArrayList<>();
     CollectionUtils.newIterator(listOfLists).forEachRemaining(actual::add);
-    Assertions.assertEquals(expected, actual);
+    assertEquals(expected, actual);
   }
 
   @Test
@@ -141,7 +141,7 @@ public class TestCollectionUtils {
 
   private static <T> void assertTopN(List<T> items, Comparator<T> comparator,
       Predicate<T> filter, List<T> sorted, int limit) {
-    Assertions.assertEquals(
+    assertEquals(
         sorted.stream().filter(filter).limit(limit).collect(toList()),
         CollectionUtils.findTopN(items, limit, comparator, filter));
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestDecayRpcSchedulerUtil.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestDecayRpcSchedulerUtil.java
@@ -21,11 +21,12 @@ package org.apache.hadoop.hdds.utils;
 
 import java.util.Optional;
 import org.apache.hadoop.metrics2.MetricsTag;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test class for DecayRpcSchedulerUtil.
@@ -86,7 +87,7 @@ public class TestDecayRpcSchedulerUtil {
         DecayRpcSchedulerUtil.createUsernameTag(username);
 
     // THEN
-    Assertions.assertFalse(optionalMetricsTag.isPresent());
+    assertFalse(optionalMetricsTag.isPresent());
   }
 
   @Test
@@ -99,10 +100,10 @@ public class TestDecayRpcSchedulerUtil {
         DecayRpcSchedulerUtil.createUsernameTag(username);
 
     // THEN
-    Assertions.assertTrue(optionalMetricsTag.isPresent());
-    Assertions.assertEquals(username, optionalMetricsTag.get().value());
-    Assertions.assertEquals(username, optionalMetricsTag.get().name());
-    Assertions.assertEquals("caller username",
+    assertTrue(optionalMetricsTag.isPresent());
+    assertEquals(username, optionalMetricsTag.get().value());
+    assertEquals(username, optionalMetricsTag.get().name());
+    assertEquals("caller username",
         optionalMetricsTag.get().description());
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestPrometheusMetricsSinkUtil.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestPrometheusMetricsSinkUtil.java
@@ -17,12 +17,15 @@
  */
 package org.apache.hadoop.hdds.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.metrics2.MetricsTag;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -49,7 +52,7 @@ class TestPrometheusMetricsSinkUtil {
         username, servername, unmodifiableMetricTags);
 
     // THEN
-    Assertions.assertFalse(metricsTags.stream()
+    assertFalse(metricsTags.stream()
         .anyMatch(metricsTag -> metricsTag.name().equals(USERNAME_TAG_NAME) ||
             metricsTag.description().equals(USERNAME_TAG_DESCRIPTION)));
   }
@@ -68,7 +71,7 @@ class TestPrometheusMetricsSinkUtil {
         username, servername, unmodifiableMetricTags);
 
     // THEN
-    Assertions.assertFalse(metricsTags.stream()
+    assertFalse(metricsTags.stream()
         .anyMatch(metricsTag -> metricsTag.name().equals(USERNAME_TAG_NAME) ||
             metricsTag.description().equals(USERNAME_TAG_DESCRIPTION)));
   }
@@ -87,7 +90,7 @@ class TestPrometheusMetricsSinkUtil {
         username, servername, unmodifiableMetricTags);
 
     // THEN
-    Assertions.assertTrue(metricsTags.stream()
+    assertTrue(metricsTags.stream()
         .anyMatch(metricsTag -> metricsTag.name().equals(USERNAME_TAG_NAME) &&
             metricsTag.description().equals(USERNAME_TAG_DESCRIPTION)));
   }
@@ -106,7 +109,7 @@ class TestPrometheusMetricsSinkUtil {
         username, servername, unmodifiableMetricTags);
 
     // THEN
-    Assertions.assertFalse(metricsTags.stream()
+    assertFalse(metricsTags.stream()
         .anyMatch(metricsTag -> metricsTag.name().equals(SERVERNAME_TAG_NAME) ||
             metricsTag.description().equals(SERVERNAME_TAG_DESCRIPTION)));
   }
@@ -125,7 +128,7 @@ class TestPrometheusMetricsSinkUtil {
         username, servername, unmodifiableMetricTags);
 
     // THEN
-    Assertions.assertTrue(metricsTags.stream()
+    assertTrue(metricsTags.stream()
         .anyMatch(metricsTag -> metricsTag.name().equals(SERVERNAME_TAG_NAME) &&
             metricsTag.description().equals(SERVERNAME_TAG_DESCRIPTION)));
   }
@@ -144,22 +147,22 @@ class TestPrometheusMetricsSinkUtil {
         username, servername, unmodifiableMetricTags);
 
     // THEN
-    Assertions.assertTrue(metricsTags.stream()
+    assertTrue(metricsTags.stream()
         .anyMatch(metricsTag -> metricsTag.name().equals(USERNAME_TAG_NAME)));
-    Assertions.assertTrue(metricsTags.stream()
+    assertTrue(metricsTags.stream()
         .anyMatch(metricsTag -> metricsTag.name().equals(SERVERNAME_TAG_NAME)));
   }
 
   @Test
   void testNamingCamelCase() {
     //THEN
-    Assertions.assertEquals("rpc_time_some_metrics",
+    assertEquals("rpc_time_some_metrics",
         PrometheusMetricsSinkUtil.prometheusName("RpcTime", "SomeMetrics"));
 
-    Assertions.assertEquals("om_rpc_time_om_info_keys",
+    assertEquals("om_rpc_time_om_info_keys",
         PrometheusMetricsSinkUtil.prometheusName("OMRpcTime", "OMInfoKeys"));
 
-    Assertions.assertEquals("rpc_time_small",
+    assertEquals("rpc_time_small",
         PrometheusMetricsSinkUtil.prometheusName("RpcTime", "small"));
   }
 
@@ -167,7 +170,7 @@ class TestPrometheusMetricsSinkUtil {
   void testNamingRocksDB() {
     //RocksDB metrics are handled differently.
     // THEN
-    Assertions.assertEquals("rocksdb_om_db_num_open_connections",
+    assertEquals("rocksdb_om_db_num_open_connections",
         PrometheusMetricsSinkUtil.prometheusName("Rocksdb_om.db",
             "num_open_connections"));
   }
@@ -180,7 +183,7 @@ class TestPrometheusMetricsSinkUtil {
         + "RATIS-THREE-47659e3d-40c9-43b3-9792-4982fc279aba";
 
     // THEN
-    Assertions.assertEquals(
+    assertEquals(
         "scm_pipeline_metrics_" + "num_blocks_allocated_"
             + "ratis_three_47659e3d_40c9_43b3_9792_4982fc279aba",
         PrometheusMetricsSinkUtil.prometheusName(recordName, metricName));
@@ -193,7 +196,7 @@ class TestPrometheusMetricsSinkUtil {
     String metricName = "GcTimeMillisG1 Young Generation";
 
     // THEN
-    Assertions.assertEquals(
+    assertEquals(
         "jvm_metrics_gc_time_millis_g1_young_generation",
         PrometheusMetricsSinkUtil.prometheusName(recordName, metricName));
   }
@@ -209,7 +212,7 @@ class TestPrometheusMetricsSinkUtil {
         metricName);
 
     // THEN
-    Assertions.assertEquals(metricName, newMetricName);
+    assertEquals(metricName, newMetricName);
   }
 
   @Test
@@ -223,7 +226,7 @@ class TestPrometheusMetricsSinkUtil {
         metricName);
 
     // THEN
-    Assertions.assertNull(username);
+    assertNull(username);
   }
 
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -228,7 +227,7 @@ public class TestRDBSnapshotProvider {
       throws IOException {
     try (Table<byte[], byte[]> firstTable = dbStore.getTable(families.
         get(familyIndex))) {
-      Assertions.assertNotNull(firstTable, "Table cannot be null");
+      assertNotNull(firstTable, "Table cannot be null");
       for (int x = 0; x < 100; x++) {
         byte[] key =
             RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestUgiMetricsUtil.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestUgiMetricsUtil.java
@@ -18,9 +18,11 @@
 
 package org.apache.hadoop.hdds.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
 import org.apache.hadoop.metrics2.MetricsTag;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,7 +41,7 @@ class TestUgiMetricsUtil {
         UgiMetricsUtil.createServernameTag(key, servername);
 
     // THEN
-    Assertions.assertFalse(optionalMetricsTag.isPresent());
+    assertFalse(optionalMetricsTag.isPresent());
   }
 
   @Test
@@ -53,10 +55,10 @@ class TestUgiMetricsUtil {
         UgiMetricsUtil.createServernameTag(key, servername);
 
     // THEN
-    Assertions.assertTrue(optionalMetricsTag.isPresent());
-    Assertions.assertEquals(servername, optionalMetricsTag.get().value());
-    Assertions.assertEquals(servername, optionalMetricsTag.get().name());
-    Assertions.assertEquals("name of the server",
+    assertTrue(optionalMetricsTag.isPresent());
+    assertEquals(servername, optionalMetricsTag.get().value());
+    assertEquals(servername, optionalMetricsTag.get().name());
+    assertEquals("name of the server",
         optionalMetricsTag.get().description());
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -21,7 +21,6 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
 import com.google.protobuf.ByteString;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.slf4j.Logger;
@@ -36,6 +35,11 @@ import java.util.function.Consumer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.utils.db.CodecTestUtil.gc;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test {@link Codec} implementations.
@@ -72,9 +76,9 @@ public final class TestCodec {
   static void runTestShorts(short original) {
     final ShortCodec codec = ShortCodec.get();
     final byte[] bytes = Shorts.toByteArray(original);
-    Assertions.assertArrayEquals(bytes, codec.toPersistedFormat(original));
-    Assertions.assertEquals(original, Shorts.fromByteArray(bytes));
-    Assertions.assertEquals(original, codec.fromPersistedFormat(bytes));
+    assertArrayEquals(bytes, codec.toPersistedFormat(original));
+    assertEquals(original, Shorts.fromByteArray(bytes));
+    assertEquals(original, codec.fromPersistedFormat(bytes));
   }
 
   @Test
@@ -101,9 +105,9 @@ public final class TestCodec {
   static void runTestInts(int original) {
     final IntegerCodec codec = IntegerCodec.get();
     final byte[] bytes = Ints.toByteArray(original);
-    Assertions.assertArrayEquals(bytes, codec.toPersistedFormat(original));
-    Assertions.assertEquals(original, Ints.fromByteArray(bytes));
-    Assertions.assertEquals(original, codec.fromPersistedFormat(bytes));
+    assertArrayEquals(bytes, codec.toPersistedFormat(original));
+    assertEquals(original, Ints.fromByteArray(bytes));
+    assertEquals(original, codec.fromPersistedFormat(bytes));
   }
 
   @Test
@@ -130,27 +134,27 @@ public final class TestCodec {
   static void runTestLongs(long original) {
     final LongCodec codec = LongCodec.get();
     final byte[] bytes = Longs.toByteArray(original);
-    Assertions.assertArrayEquals(bytes, codec.toPersistedFormat(original));
-    Assertions.assertEquals(original, Longs.fromByteArray(bytes));
-    Assertions.assertEquals(original, codec.fromPersistedFormat(bytes));
+    assertArrayEquals(bytes, codec.toPersistedFormat(original));
+    assertEquals(original, Longs.fromByteArray(bytes));
+    assertEquals(original, codec.fromPersistedFormat(bytes));
   }
 
   @Test
   public void testStringCodec() throws Exception {
-    Assertions.assertFalse(StringCodec.get().isFixedLength());
+    assertFalse(StringCodec.get().isFixedLength());
     runTestStringCodec("");
 
     for (int i = 0; i < NUM_LOOPS; i++) {
       final String original = "test" + ThreadLocalRandom.current().nextLong();
       final int serializedSize = runTestStringCodec(original);
-      Assertions.assertEquals(original.length(), serializedSize);
+      assertEquals(original.length(), serializedSize);
     }
 
     final String alphabets = "AbcdEfghIjklmnOpqrstUvwxyz";
     for (int i = 0; i < NUM_LOOPS; i++) {
       final String original = i == 0 ? alphabets : alphabets.substring(0, i);
       final int serializedSize = runTestStringCodec(original);
-      Assertions.assertEquals(original.length(), serializedSize);
+      assertEquals(original.length(), serializedSize);
     }
 
     final String[] docs = {
@@ -160,7 +164,7 @@ public final class TestCodec {
     };
     for (String original : docs) {
       final int serializedSize = runTestStringCodec(original);
-      Assertions.assertTrue(original.length() < serializedSize);
+      assertTrue(original.length() < serializedSize);
     }
 
     final String multiByteChars = "官方发行包包括了源代码包和二进制代码包";
@@ -168,7 +172,7 @@ public final class TestCodec {
       final String original = i == 0 ? multiByteChars
           : multiByteChars.substring(0, i);
       final int serializedSize = runTestStringCodec(original);
-      Assertions.assertEquals(3 * original.length(), serializedSize);
+      assertEquals(3 * original.length(), serializedSize);
     }
 
     gc();
@@ -182,7 +186,7 @@ public final class TestCodec {
 
   @Test
   public void testFixedLengthStringCodec() throws Exception {
-    Assertions.assertTrue(FixedLengthStringCodec.get().isFixedLength());
+    assertTrue(FixedLengthStringCodec.get().isFixedLength());
     runTestFixedLengthStringCodec("");
 
     for (int i = 0; i < NUM_LOOPS; i++) {
@@ -198,9 +202,9 @@ public final class TestCodec {
 
 
     final String multiByteChars = "Ozone 是 Hadoop 的分布式对象存储系统，具有易扩展和冗余存储的特点。";
-    Assertions.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         tryCatch(() -> runTestFixedLengthStringCodec(multiByteChars)));
-    Assertions.assertThrows(IllegalStateException.class,
+    assertThrows(IllegalStateException.class,
         tryCatch(() -> FixedLengthStringCodec.string2Bytes(multiByteChars)));
 
     gc();
@@ -210,7 +214,7 @@ public final class TestCodec {
   public void testByteStringCodec() throws Exception {
     for (int i = 0; i < 2; i++) {
       try (CodecBuffer empty = CodecBuffer.getEmptyBuffer()) {
-        Assertions.assertTrue(empty.isDirect());
+        assertTrue(empty.isDirect());
       }
     }
 
@@ -297,9 +301,9 @@ public final class TestCodec {
         CodecBuffer.Allocator.HEAP)) {
       final Bytes fromBuffer = new Bytes(buffer);
 
-      Assertions.assertEquals(fromArray.hashCode(), fromBuffer.hashCode());
-      Assertions.assertEquals(fromArray, fromBuffer);
-      Assertions.assertEquals(fromBuffer, fromArray);
+      assertEquals(fromArray.hashCode(), fromBuffer.hashCode());
+      assertEquals(fromArray, fromBuffer);
+      assertEquals(fromBuffer, fromArray);
     }
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodecRegistry.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodecRegistry.java
@@ -17,8 +17,9 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.protobuf.ByteString;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +38,8 @@ public final class TestCodecRegistry {
     final Codec<T> codec = registry.getCodec(object);
     LOG.info("object {}", object.getClass());
     LOG.info("codec {}", codec.getClass());
-    Assertions.assertTrue(expectedCodecClass.isInstance(codec));
-    Assertions.assertSame(expectedCodecClass, codec.getClass());
+    assertTrue(expectedCodecClass.isInstance(codec));
+    assertSame(expectedCodecClass, codec.getClass());
   }
 
   @Test
@@ -55,7 +56,7 @@ public final class TestCodecRegistry {
     final Codec<T> codec = registry.getCodecFromClass(format);
     LOG.info("format {}", format);
     LOG.info("codec {}", codec.getClass());
-    Assertions.assertSame(expectedCodecClass, codec.getClass());
+    assertSame(expectedCodecClass, codec.getClass());
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBConfigFromFile.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.utils.db;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -42,6 +41,9 @@ import java.util.List;
 import org.apache.hadoop.hdds.StringUtils;
 
 import static org.apache.hadoop.hdds.utils.db.DBConfigFromFile.getOptionsFileNameFromDB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * DBConf tests.
@@ -84,10 +86,10 @@ public class TestDBConfigFromFile {
 
     // Some Random Values Defined in the test.db.ini, we verify that we are
     // able to get values that are defined in the test.db.ini.
-    Assertions.assertNotNull(options);
-    Assertions.assertEquals(551615L, options.maxManifestFileSize());
-    Assertions.assertEquals(1000L, options.keepLogFileNum());
-    Assertions.assertEquals(1048576, options.writableFileMaxBufferSize());
+    assertNotNull(options);
+    assertEquals(551615L, options.maxManifestFileSize());
+    assertEquals(1000L, options.keepLogFileNum());
+    assertEquals(1048576, options.writableFileMaxBufferSize());
   }
 
   @Test
@@ -109,6 +111,6 @@ public class TestDBConfigFromFile {
         columnFamilyDescriptors);
 
     // This has to return a Null, since we have config defined for badfile.db
-    Assertions.assertNull(options);
+    assertNull(options);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -49,6 +48,13 @@ import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
 
 import static org.apache.hadoop.ozone.OzoneConsts.ROCKSDB_SST_SUFFIX;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * RDBStore Tests.
@@ -106,7 +112,7 @@ public class TestRDBStore {
       throws IOException {
     try (Table<byte[], byte[]> firstTable = dbStore.getTable(families.
         get(familyIndex))) {
-      Assertions.assertNotNull(firstTable, "Table cannot be null");
+      assertNotNull(firstTable, "Table cannot be null");
       for (int x = 0; x < 100; x++) {
         byte[] key =
           RandomStringUtils.random(10).getBytes(StandardCharsets.UTF_8);
@@ -121,7 +127,7 @@ public class TestRDBStore {
 
   @Test
   public void compactDB() throws Exception {
-    Assertions.assertNotNull(rdbStore, "DB Store cannot be null");
+    assertNotNull(rdbStore, "DB Store cannot be null");
     for (int i = 0; i < 2; i++) {
       for (int j = 0; j <= 10; j++) {
         insertRandomData(rdbStore, i);
@@ -133,25 +139,25 @@ public class TestRDBStore {
     rdbStore.compactDB();
     int metaSizeAfterCompact = rdbStore.getDb().getLiveFilesMetaDataSize();
 
-    Assertions.assertTrue(metaSizeAfterCompact < metaSizeBeforeCompact);
-    Assertions.assertEquals(metaSizeAfterCompact, 2);
+    assertTrue(metaSizeAfterCompact < metaSizeBeforeCompact);
+    assertEquals(metaSizeAfterCompact, 2);
 
   }
 
   @Test
   public void close() throws Exception {
-    Assertions.assertNotNull(rdbStore, "DBStore cannot be null");
+    assertNotNull(rdbStore, "DBStore cannot be null");
     // This test does not assert anything if there is any error this test
     // will throw and fail.
     rdbStore.close();
-    Assertions.assertTrue(rdbStore.isClosed());
+    assertTrue(rdbStore.isClosed());
   }
 
   @Test
   public void closeUnderlyingDB() throws Exception {
-    Assertions.assertNotNull(rdbStore, "DBStore cannot be null");
+    assertNotNull(rdbStore, "DBStore cannot be null");
     rdbStore.getDb().close();
-    Assertions.assertTrue(rdbStore.isClosed());
+    assertTrue(rdbStore.isClosed());
   }
 
   @Test
@@ -168,12 +174,12 @@ public class TestRDBStore {
         rdbStore.move(key, firstTable, secondTable);
         byte[] newvalue = secondTable.get(key);
         // Make sure we have value in the second table
-        Assertions.assertNotNull(newvalue);
+        assertNotNull(newvalue);
         //and it is same as what we wrote to the FirstTable
-        Assertions.assertArrayEquals(value, newvalue);
+        assertArrayEquals(value, newvalue);
       }
       // After move this key must not exist in the first table.
-      Assertions.assertNull(firstTable.get(key));
+      assertNull(firstTable.get(key));
     }
   }
 
@@ -193,10 +199,10 @@ public class TestRDBStore {
         rdbStore.move(key, nextValue, firstTable, secondTable);
         byte[] newvalue = secondTable.get(key);
         // Make sure we have value in the second table
-        Assertions.assertNotNull(newvalue);
+        assertNotNull(newvalue);
         //and it is not same as what we wrote to the FirstTable, and equals
         // the new value.
-        Assertions.assertArrayEquals(nextValue, newvalue);
+        assertArrayEquals(nextValue, newvalue);
       }
     }
 
@@ -204,7 +210,7 @@ public class TestRDBStore {
 
   @Test
   public void getEstimatedKeyCount() throws Exception {
-    Assertions.assertNotNull(rdbStore, "DB Store cannot be null");
+    assertNotNull(rdbStore, "DB Store cannot be null");
 
     // Write 100 keys to the first table.
     insertRandomData(rdbStore, 1);
@@ -213,7 +219,7 @@ public class TestRDBStore {
     insertRandomData(rdbStore, 2);
 
     // Let us make sure that our estimate is not off by 10%
-    Assertions.assertTrue(rdbStore.getEstimatedKeyCount() > 180
+    assertTrue(rdbStore.getEstimatedKeyCount() > 180
         || rdbStore.getEstimatedKeyCount() < 220);
   }
 
@@ -221,17 +227,17 @@ public class TestRDBStore {
   public void getTable() throws Exception {
     for (String tableName : families) {
       try (Table table = rdbStore.getTable(tableName)) {
-        Assertions.assertNotNull(table, tableName + "is null");
+        assertNotNull(table, tableName + "is null");
       }
     }
-    Assertions.assertThrows(IOException.class,
+    assertThrows(IOException.class,
         () -> rdbStore.getTable("ATableWithNoName"));
   }
 
   @Test
   public void listTables() throws Exception {
     List<Table> tableList = rdbStore.listTables();
-    Assertions.assertNotNull(tableList, "Table list cannot be null");
+    assertNotNull(tableList, "Table list cannot be null");
     Map<String, Table> hashTable = new HashMap<>();
 
     for (Table t : tableList) {
@@ -241,27 +247,27 @@ public class TestRDBStore {
     int count = families.size();
     // Assert that we have all the tables in the list and no more.
     for (String name : families) {
-      Assertions.assertTrue(hashTable.containsKey(name));
+      assertTrue(hashTable.containsKey(name));
       count--;
     }
-    Assertions.assertEquals(0, count);
+    assertEquals(0, count);
   }
 
   @Test
   public void testRocksDBCheckpoint() throws Exception {
-    Assertions.assertNotNull(rdbStore, "DB Store cannot be null");
+    assertNotNull(rdbStore, "DB Store cannot be null");
 
     insertRandomData(rdbStore, 1);
     DBCheckpoint checkpoint =
         rdbStore.getCheckpoint(true);
-    Assertions.assertNotNull(checkpoint);
+    assertNotNull(checkpoint);
 
     RDBStore restoredStoreFromCheckPoint =
         newRDBStore(checkpoint.getCheckpointLocation().toFile(),
             options, configSet, MAX_DB_UPDATES_SIZE_THRESHOLD);
 
     // Let us make sure that our estimate is not off by 10%
-    Assertions.assertTrue(
+    assertTrue(
         restoredStoreFromCheckPoint.getEstimatedKeyCount() > 90
         || restoredStoreFromCheckPoint.getEstimatedKeyCount() < 110);
     checkpoint.cleanupCheckpoint();
@@ -269,17 +275,17 @@ public class TestRDBStore {
 
   @Test
   public void testRocksDBCheckpointCleanup() throws Exception {
-    Assertions.assertNotNull(rdbStore, "DB Store cannot be null");
+    assertNotNull(rdbStore, "DB Store cannot be null");
 
     insertRandomData(rdbStore, 1);
     DBCheckpoint checkpoint =
         rdbStore.getCheckpoint(true);
-    Assertions.assertNotNull(checkpoint);
+    assertNotNull(checkpoint);
 
-    Assertions.assertTrue(Files.exists(
+    assertTrue(Files.exists(
         checkpoint.getCheckpointLocation()));
     checkpoint.cleanupCheckpoint();
-    Assertions.assertFalse(Files.exists(
+    assertFalse(Files.exists(
         checkpoint.getCheckpointLocation()));
   }
 
@@ -296,10 +302,10 @@ public class TestRDBStore {
           org.apache.commons.codec.binary.StringUtils
               .getBytesUtf16("Value2"));
     }
-    Assertions.assertEquals(2, rdbStore.getDb().getLatestSequenceNumber());
+    assertEquals(2, rdbStore.getDb().getLatestSequenceNumber());
 
     DBUpdatesWrapper dbUpdatesSince = rdbStore.getUpdatesSince(0);
-    Assertions.assertEquals(2, dbUpdatesSince.getData().size());
+    assertEquals(2, dbUpdatesSince.getData().size());
   }
 
   @Test
@@ -327,11 +333,11 @@ public class TestRDBStore {
           org.apache.commons.codec.binary.StringUtils
               .getBytesUtf16("Value5"));
     }
-    Assertions.assertEquals(5, rdbStore.getDb().getLatestSequenceNumber());
+    assertEquals(5, rdbStore.getDb().getLatestSequenceNumber());
 
     DBUpdatesWrapper dbUpdatesSince = rdbStore.getUpdatesSince(0, 5);
-    Assertions.assertEquals(2, dbUpdatesSince.getData().size());
-    Assertions.assertEquals(2, dbUpdatesSince.getCurrentSequenceNumber());
+    assertEquals(2, dbUpdatesSince.getData().size());
+    assertEquals(2, dbUpdatesSince.getCurrentSequenceNumber());
   }
 
   @Test
@@ -365,9 +371,9 @@ public class TestRDBStore {
         MAX_DB_UPDATES_SIZE_THRESHOLD);
     for (String family : familiesMinusOne) {
       try (Table table = rdbStore.getTable(family)) {
-        Assertions.assertNotNull(table, family + "is null");
+        assertNotNull(table, family + "is null");
         Object val = table.get(family.getBytes(StandardCharsets.UTF_8));
-        Assertions.assertNotNull(val);
+        assertNotNull(val);
       }
     }
 
@@ -375,9 +381,9 @@ public class TestRDBStore {
     // we do not use it.
     String extraFamily = families.get(families.size() - 1);
     try (Table table = rdbStore.getTable(extraFamily)) {
-      Assertions.assertNotNull(table, extraFamily + "is null");
+      assertNotNull(table, extraFamily + "is null");
       Object val = table.get(extraFamily.getBytes(StandardCharsets.UTF_8));
-      Assertions.assertNotNull(val);
+      assertNotNull(val);
     }
   }
 
@@ -425,7 +431,7 @@ public class TestRDBStore {
       File fileInCk2 = new File(checkpoint2.getAbsoluteFile(), name);
       long length1 = fileInCk1.length();
       long length2 = fileInCk2.length();
-      Assertions.assertEquals(length1, length2, name);
+      assertEquals(length1, length2, name);
 
       try (InputStream fileStream1 = new FileInputStream(fileInCk1);
            InputStream fileStream2 = new FileInputStream(fileInCk2)) {
@@ -433,7 +439,7 @@ public class TestRDBStore {
         byte[] content2 = new byte[fileStream2.available()];
         fileStream1.read(content1);
         fileStream2.read(content2);
-        Assertions.assertArrayEquals(content1, content2);
+        assertArrayEquals(content1, content2);
       }
     }
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreByteArrayIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreByteArrayIterator.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -97,7 +98,7 @@ public class TestRDBStoreByteArrayIterator {
     iter.forEachRemaining(consumerStub);
 
     ArgumentCaptor<RawKeyValue.ByteArray> capture =
-        ArgumentCaptor.forClass(RawKeyValue.ByteArray.class);
+        forClass(RawKeyValue.ByteArray.class);
     verify(consumerStub, times(3)).accept(capture.capture());
     assertArrayEquals(
         new byte[]{0x00}, capture.getAllValues().get(0).getKey());

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -29,6 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,7 +54,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
@@ -255,8 +256,8 @@ public class TestTypedRDBTableStore {
 
   @Test
   public void testIteratorOnException() throws Exception {
-    RDBTable rdbTable = Mockito.mock(RDBTable.class);
-    Mockito.when(rdbTable.iterator((CodecBuffer) null))
+    RDBTable rdbTable = mock(RDBTable.class);
+    when(rdbTable.iterator((CodecBuffer) null))
         .thenThrow(new IOException());
     try (Table<String, String> testTable = new TypedTable<>(rdbTable,
         codecRegistry, String.class, String.class)) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -19,6 +19,16 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,7 +49,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -105,12 +114,12 @@ public class TestTypedRDBTableStore {
           RandomStringUtils.random(10);
       String value = RandomStringUtils.random(10);
       testTable.put(key, value);
-      Assertions.assertFalse(testTable.isEmpty());
+      assertFalse(testTable.isEmpty());
       String readValue = testTable.get(key);
-      Assertions.assertEquals(value, readValue);
+      assertEquals(value, readValue);
     }
     try (Table secondTable = rdbStore.getTable("Second")) {
-      Assertions.assertTrue(secondTable.isEmpty());
+      assertTrue(secondTable.isEmpty());
     }
   }
 
@@ -152,11 +161,11 @@ public class TestTypedRDBTableStore {
       }
 
       for (int x = 0; x < validKeys.size(); x++) {
-        Assertions.assertNotNull(testTable.get(validKeys.get(0)));
+        assertNotNull(testTable.get(validKeys.get(0)));
       }
 
       for (int x = 0; x < deletedKeys.size(); x++) {
-        Assertions.assertNull(testTable.get(deletedKeys.get(0)));
+        assertNull(testTable.get(deletedKeys.get(0)));
       }
     }
   }
@@ -178,7 +187,7 @@ public class TestTypedRDBTableStore {
       rdbStore.commitBatchOperation(batch);
 
       //then
-      Assertions.assertNotNull(testTable.get(key));
+      assertNotNull(testTable.get(key));
     }
   }
 
@@ -200,16 +209,16 @@ public class TestTypedRDBTableStore {
       rdbStore.commitBatchOperation(batch);
 
       //then
-      Assertions.assertNull(testTable.get(key));
+      assertNull(testTable.get(key));
     }
   }
 
   private static boolean consume(Table.KeyValue keyValue) {
     count++;
     try {
-      Assertions.assertNotNull(keyValue.getKey());
+      assertNotNull(keyValue.getKey());
     } catch (IOException ex) {
-      Assertions.fail(ex.toString());
+      fail(ex.toString());
     }
     return true;
   }
@@ -235,10 +244,10 @@ public class TestTypedRDBTableStore {
           localCount++;
         }
 
-        Assertions.assertEquals(iterCount, localCount);
+        assertEquals(iterCount, localCount);
         iter.seekToFirst();
         iter.forEachRemaining(TestTypedRDBTableStore::consume);
-        Assertions.assertEquals(iterCount, count);
+        assertEquals(iterCount, count);
 
       }
     }
@@ -251,7 +260,7 @@ public class TestTypedRDBTableStore {
         .thenThrow(new IOException());
     try (Table<String, String> testTable = new TypedTable<>(rdbTable,
         codecRegistry, String.class, String.class)) {
-      Assertions.assertThrows(IOException.class, testTable::iterator);
+      assertThrows(IOException.class, testTable::iterator);
     }
   }
 
@@ -271,7 +280,7 @@ public class TestTypedRDBTableStore {
       // As we have added to cache, so get should return value even if it
       // does not exist in DB.
       for (int x = 0; x < iterCount; x++) {
-        Assertions.assertEquals(Integer.toString(1),
+        assertEquals(Integer.toString(1),
             testTable.get(Integer.toString(1)));
       }
 
@@ -301,10 +310,10 @@ public class TestTypedRDBTableStore {
       // does not exist in DB.
       for (int x = 0; x < iterCount; x++) {
         if (x % 2 == 0) {
-          Assertions.assertEquals(Integer.toString(x),
+          assertEquals(Integer.toString(x),
               testTable.get(Integer.toString(x)));
         } else {
-          Assertions.assertNull(testTable.get(Integer.toString(x)));
+          assertNull(testTable.get(Integer.toString(x)));
         }
       }
 
@@ -322,10 +331,10 @@ public class TestTypedRDBTableStore {
       //Check remaining values
       for (int x = 6; x < iterCount; x++) {
         if (x % 2 == 0) {
-          Assertions.assertEquals(Integer.toString(x),
+          assertEquals(Integer.toString(x),
               testTable.get(Integer.toString(x)));
         } else {
-          Assertions.assertNull(testTable.get(Integer.toString(x)));
+          assertNull(testTable.get(Integer.toString(x)));
         }
       }
 
@@ -341,13 +350,13 @@ public class TestTypedRDBTableStore {
           RandomStringUtils.random(10);
       String value = RandomStringUtils.random(10);
       testTable.put(key, value);
-      Assertions.assertTrue(testTable.isExist(key));
+      assertTrue(testTable.isExist(key));
 
       String invalidKey = key + RandomStringUtils.random(1);
-      Assertions.assertFalse(testTable.isExist(invalidKey));
+      assertFalse(testTable.isExist(invalidKey));
 
       testTable.delete(key);
-      Assertions.assertFalse(testTable.isExist(key));
+      assertFalse(testTable.isExist(key));
     }
   }
 
@@ -359,13 +368,13 @@ public class TestTypedRDBTableStore {
           RandomStringUtils.random(10);
       String value = RandomStringUtils.random(10);
       testTable.put(key, value);
-      Assertions.assertNotNull(testTable.getIfExist(key));
+      assertNotNull(testTable.getIfExist(key));
 
       String invalidKey = key + RandomStringUtils.random(1);
-      Assertions.assertNull(testTable.getIfExist(invalidKey));
+      assertNull(testTable.getIfExist(invalidKey));
 
       testTable.delete(key);
-      Assertions.assertNull(testTable.getIfExist(key));
+      assertNull(testTable.getIfExist(key));
     }
   }
 
@@ -378,11 +387,11 @@ public class TestTypedRDBTableStore {
       String value = RandomStringUtils.random(10);
       testTable.addCacheEntry(new CacheKey<>(key),
           CacheValue.get(1L, value));
-      Assertions.assertTrue(testTable.isExist(key));
+      assertTrue(testTable.isExist(key));
 
       testTable.addCacheEntry(new CacheKey<>(key),
           CacheValue.get(1L));
-      Assertions.assertFalse(testTable.isExist(key));
+      assertFalse(testTable.isExist(key));
     }
   }
 
@@ -400,7 +409,7 @@ public class TestTypedRDBTableStore {
       }
       long keyCount = testTable.getEstimatedKeyCount();
       // The result should be larger than zero but not exceed(?) numKeys
-      Assertions.assertTrue(keyCount > 0 && keyCount <= numKeys);
+      assertTrue(keyCount > 0 && keyCount <= numKeys);
     }
   }
 
@@ -414,11 +423,11 @@ public class TestTypedRDBTableStore {
       byte[] value = new byte[] {4, 5, 6};
       testTable.put(key, value);
       byte[] actualValue = testTable.get(key);
-      Assertions.assertArrayEquals(value, testTable.get(key));
-      Assertions.assertNotSame(value, actualValue);
+      assertArrayEquals(value, testTable.get(key));
+      assertNotSame(value, actualValue);
       testTable.addCacheEntry(new CacheKey<>(key),
               CacheValue.get(1L, value));
-      Assertions.assertSame(value, testTable.get(key));
+      assertSame(value, testTable.get(key));
     }
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -19,12 +19,15 @@
 
 package org.apache.hadoop.hdds.utils.db.cache;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -64,7 +67,7 @@ public class TestTableCache {
 
 
     for (int i = 0; i < 10; i++) {
-      Assertions.assertEquals(Integer.toString(i),
+      assertEquals(Integer.toString(i),
           tableCache.get(new CacheKey<>(Integer.toString(i))).getCacheValue());
     }
 
@@ -78,7 +81,7 @@ public class TestTableCache {
     tableCache.evictCache(epochs);
 
     for (int i = 5; i < 10; i++) {
-      Assertions.assertEquals(Integer.toString(i),
+      assertEquals(Integer.toString(i),
           tableCache.get(new CacheKey<>(Integer.toString(i))).getCacheValue());
     }
 
@@ -90,9 +93,9 @@ public class TestTableCache {
                            long expectedMisses,
                            long expectedIterations) {
     CacheStats stats = cache.getStats();
-    Assertions.assertEquals(expectedHits, stats.getCacheHits());
-    Assertions.assertEquals(expectedMisses, stats.getCacheMisses());
-    Assertions.assertEquals(expectedIterations, stats.getIterationTimes());
+    assertEquals(expectedHits, stats.getCacheHits());
+    assertEquals(expectedMisses, stats.getCacheMisses());
+    assertEquals(expectedIterations, stats.getIterationTimes());
   }
 
   @ParameterizedTest
@@ -111,17 +114,17 @@ public class TestTableCache {
 
     // Epoch entries should be like (long, (key1, key2, ...))
     // (0, (0A, 0B))  (1, (1A, 1B))  (2, (2A, 1B))
-    Assertions.assertEquals(3, tableCache.getEpochEntries().size());
-    Assertions.assertEquals(2, tableCache.getEpochEntries().get(0L).size());
+    assertEquals(3, tableCache.getEpochEntries().size());
+    assertEquals(2, tableCache.getEpochEntries().get(0L).size());
     
     // Cache should be like (key, (cacheValue, long))
     // (0A, (null, 0))   (0B, (0, 0))
     // (1A, (null, 1))   (1B, (0, 1))
     // (2A, (null, 2))   (2B, (0, 2))
     for (int i = 0; i < 3; i++) {
-      Assertions.assertNull(tableCache.get(new CacheKey<>(
+      assertNull(tableCache.get(new CacheKey<>(
           Integer.toString(i).concat("A"))).getCacheValue());
-      Assertions.assertEquals(Integer.toString(i),
+      assertEquals(Integer.toString(i),
           tableCache.get(new CacheKey<>(Integer.toString(i).concat("B")))
               .getCacheValue());
     }
@@ -135,12 +138,12 @@ public class TestTableCache {
 
     tableCache.evictCache(epochs);
 
-    Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+    assertEquals(0, tableCache.getEpochEntries().size());
 
     if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
-      Assertions.assertEquals(0, tableCache.size());
+      assertEquals(0, tableCache.size());
     } else {
-      Assertions.assertEquals(3, tableCache.size());
+      assertEquals(3, tableCache.size());
     }
 
     verifyStats(tableCache, 6, 0, 0);
@@ -168,7 +171,7 @@ public class TestTableCache {
       totalCount++;
     }
 
-    Assertions.assertEquals(totalCount, tableCache.size());
+    assertEquals(totalCount, tableCache.size());
 
     tableCache.evictCache(epochs);
 
@@ -176,22 +179,22 @@ public class TestTableCache {
 
     // If cleanup policy is manual entries should have been removed.
     if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
-      Assertions.assertEquals(count - epochs.size(), tableCache.size());
+      assertEquals(count - epochs.size(), tableCache.size());
 
       // Check remaining entries exist or not and deleted entries does not
       // exist.
       for (long i = 0; i < insertedCount; i += 2) {
         if (!epochs.contains(i)) {
-          Assertions.assertEquals(Long.toString(i),
+          assertEquals(Long.toString(i),
               tableCache.get(new CacheKey<>(Long.toString(i))).getCacheValue());
         } else {
-          Assertions.assertNull(
+          assertNull(
               tableCache.get(new CacheKey<>(Long.toString(i))));
         }
       }
     } else {
       for (long i = 0; i < insertedCount; i += 2) {
-        Assertions.assertEquals(Long.toString(i),
+        assertEquals(Long.toString(i),
             tableCache.get(new CacheKey<>(Long.toString(i))).getCacheValue());
       }
     }
@@ -223,9 +226,9 @@ public class TestTableCache {
 
 
 
-    Assertions.assertEquals(3, tableCache.size());
+    assertEquals(3, tableCache.size());
     // It will have 2 additional entries because we have 2 override entries.
-    Assertions.assertEquals(3 + 2,
+    assertEquals(3 + 2,
         tableCache.getEpochEntries().size());
 
     // Now remove
@@ -241,9 +244,9 @@ public class TestTableCache {
 
       tableCache.evictCache(epochs);
 
-      Assertions.assertEquals(0, tableCache.size());
+      assertEquals(0, tableCache.size());
 
-      Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+      assertEquals(0, tableCache.getEpochEntries().size());
     }
 
     // Add a new entry.
@@ -255,10 +258,10 @@ public class TestTableCache {
     if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       tableCache.evictCache(epochs);
 
-      Assertions.assertEquals(0, tableCache.size());
+      assertEquals(0, tableCache.size());
 
       // Overridden entries would have been deleted.
-      Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+      assertEquals(0, tableCache.getEpochEntries().size());
     }
 
     verifyStats(tableCache, 0, 0, 0);
@@ -297,9 +300,9 @@ public class TestTableCache {
     // 0-5, 1-6, 2-2
 
 
-    Assertions.assertEquals(3, tableCache.size());
+    assertEquals(3, tableCache.size());
     // It will have 4 additional entries because we have 4 override entries.
-    Assertions.assertEquals(3 + 4,
+    assertEquals(3 + 4,
         tableCache.getEpochEntries().size());
 
     // Now remove
@@ -317,16 +320,16 @@ public class TestTableCache {
     if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       tableCache.evictCache(epochs);
 
-      Assertions.assertEquals(0, tableCache.size());
+      assertEquals(0, tableCache.size());
 
-      Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+      assertEquals(0, tableCache.getEpochEntries().size());
     } else {
       tableCache.evictCache(epochs);
 
-      Assertions.assertEquals(1, tableCache.size());
+      assertEquals(1, tableCache.size());
 
       // Epoch entries which are overridden also will be cleaned up.
-      Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+      assertEquals(0, tableCache.getEpochEntries().size());
     }
 
     // Add a new entry, now old override entries will be cleaned up.
@@ -339,19 +342,19 @@ public class TestTableCache {
     if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       tableCache.evictCache(epochs);
 
-      Assertions.assertEquals(0, tableCache.size());
+      assertEquals(0, tableCache.size());
 
       // Epoch entries which are overridden now would have been deleted.
-      Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+      assertEquals(0, tableCache.getEpochEntries().size());
     } else {
       tableCache.evictCache(epochs);
 
       // 2 entries will be in cache, as 2 are not deleted.
-      Assertions.assertEquals(2, tableCache.size());
+      assertEquals(2, tableCache.size());
 
       // Epoch entries which are not marked for delete will also be cleaned up.
       // As they are override entries in full cache.
-      Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+      assertEquals(0, tableCache.getEpochEntries().size());
     }
 
     verifyStats(tableCache, 0, 0, 0);
@@ -370,12 +373,12 @@ public class TestTableCache {
           try {
             return writeToCache(10, 1, 0);
           } catch (InterruptedException ex) {
-            Assertions.fail("writeToCache got interrupt exception");
+            fail("writeToCache got interrupt exception");
           }
           return 0;
         });
     int value = future.get();
-    Assertions.assertEquals(10, value);
+    assertEquals(10, value);
 
     totalCount += value;
 
@@ -384,20 +387,20 @@ public class TestTableCache {
           try {
             return writeToCache(10, 11, 100);
           } catch (InterruptedException ex) {
-            Assertions.fail("writeToCache got interrupt exception");
+            fail("writeToCache got interrupt exception");
           }
           return 0;
         });
 
     // Check we have first 10 entries in cache.
     for (int i = 1; i <= 10; i++) {
-      Assertions.assertEquals(Integer.toString(i),
+      assertEquals(Integer.toString(i),
           tableCache.get(new CacheKey<>(Integer.toString(i))).getCacheValue());
     }
 
 
     value = future.get();
-    Assertions.assertEquals(10, value);
+    assertEquals(10, value);
 
     totalCount += value;
 
@@ -415,10 +418,10 @@ public class TestTableCache {
       tableCache.evictCache(epochs);
 
       // We should totalCount - deleted entries in cache.
-      Assertions.assertEquals(totalCount - deleted, tableCache.size());
+      assertEquals(totalCount - deleted, tableCache.size());
       // Check if we have remaining entries.
       for (int i = 6; i <= totalCount; i++) {
-        Assertions.assertEquals(Integer.toString(i), tableCache.get(
+        assertEquals(Integer.toString(i), tableCache.get(
             new CacheKey<>(Integer.toString(i))).getCacheValue());
       }
 
@@ -430,14 +433,14 @@ public class TestTableCache {
       tableCache.evictCache(epochs);
 
       // Cleaned up all entries, so cache size should be zero.
-      Assertions.assertEquals(0, tableCache.size());
+      assertEquals(0, tableCache.size());
     } else {
       ArrayList<Long> epochs = new ArrayList<>();
       for (long i = 0; i <= totalCount; i++) {
         epochs.add(i);
       }
       tableCache.evictCache(epochs);
-      Assertions.assertEquals(totalCount, tableCache.size());
+      assertEquals(totalCount, tableCache.size());
     }
   }
 
@@ -467,8 +470,8 @@ public class TestTableCache {
 
     tableCache.evictCache(epochs);
 
-    Assertions.assertEquals(0, tableCache.size());
-    Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+    assertEquals(0, tableCache.size());
+    assertEquals(0, tableCache.getEpochEntries().size());
 
     verifyStats(tableCache, 0, 0, 0);
   }
@@ -502,15 +505,15 @@ public class TestTableCache {
 
     tableCache.evictCache(epochs);
 
-    Assertions.assertEquals(2, tableCache.size());
-    Assertions.assertEquals(2, tableCache.getEpochEntries().size());
+    assertEquals(2, tableCache.size());
+    assertEquals(2, tableCache.getEpochEntries().size());
 
-    Assertions.assertNotNull(tableCache.get(new CacheKey<>(Long.toString(0))));
-    Assertions.assertEquals(2,
+    assertNotNull(tableCache.get(new CacheKey<>(Long.toString(0))));
+    assertEquals(2,
         tableCache.get(new CacheKey<>(Long.toString(0))).getEpoch());
 
-    Assertions.assertNotNull(tableCache.get(new CacheKey<>(Long.toString(1))));
-    Assertions.assertEquals(4,
+    assertNotNull(tableCache.get(new CacheKey<>(Long.toString(1))));
+    assertEquals(4,
         tableCache.get(new CacheKey<>(Long.toString(1))).getEpoch());
 
     // now evict 2,4
@@ -521,21 +524,21 @@ public class TestTableCache {
     tableCache.evictCache(epochs);
 
     if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
-      Assertions.assertEquals(0, tableCache.size());
-      Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+      assertEquals(0, tableCache.size());
+      assertEquals(0, tableCache.getEpochEntries().size());
     } else {
-      Assertions.assertEquals(2, tableCache.size());
-      Assertions.assertEquals(0, tableCache.getEpochEntries().size());
+      assertEquals(2, tableCache.size());
+      assertEquals(0, tableCache.getEpochEntries().size());
 
       // Entries should exist, as the entries are not delete entries
-      Assertions.assertNotNull(
+      assertNotNull(
           tableCache.get(new CacheKey<>(Long.toString(0))));
-      Assertions.assertEquals(2,
+      assertEquals(2,
           tableCache.get(new CacheKey<>(Long.toString(0))).getEpoch());
 
-      Assertions.assertNotNull(
+      assertNotNull(
           tableCache.get(new CacheKey<>(Long.toString(1))));
-      Assertions.assertEquals(4,
+      assertEquals(4,
           tableCache.get(new CacheKey<>(Long.toString(1))).getEpoch());
     }
   }
@@ -551,11 +554,11 @@ public class TestTableCache {
     tableCache.put(new CacheKey<>("1"),
         CacheValue.get(1, "1"));
 
-    Assertions.assertNotNull(tableCache.get(new CacheKey<>("0")));
-    Assertions.assertNotNull(tableCache.get(new CacheKey<>("0")));
-    Assertions.assertNotNull(tableCache.get(new CacheKey<>("1")));
-    Assertions.assertNull(tableCache.get(new CacheKey<>("2")));
-    Assertions.assertNull(tableCache.get(new CacheKey<>("3")));
+    assertNotNull(tableCache.get(new CacheKey<>("0")));
+    assertNotNull(tableCache.get(new CacheKey<>("0")));
+    assertNotNull(tableCache.get(new CacheKey<>("1")));
+    assertNull(tableCache.get(new CacheKey<>("2")));
+    assertNull(tableCache.get(new CacheKey<>("3")));
 
     tableCache.iterator();
     tableCache.iterator();


### PR DESCRIPTION
## What changes were proposed in this pull request?
The goal of this task is to add import static for all assertions and interactions with mocks. Replacing:
```
Assertions.assert<X>(...) -> assert<X>(...)
Assertions.fail(...) -> fail(...)
```
and
```
Mockito.mock(...) -> mock(...)
Mockito.verify(...) -> verify(...)
Mockito.when(...) -> when(...)
```
and
```
ArgumentMatchers.any() -> any()
ArgumentMatchers.eq() -> eq()
ArgumentMatchers.matches() -> matches()
// also:
// Matchers.<...>()
```
makes the code more readable (shorter lines, less wrapping).


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9975

## CI
https://github.com/wzhallright/ozone/actions/runs/7286857379
