### PR TITLE
HDDS-9986. Log if there is a failure in closing RocksDB

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -226,12 +226,12 @@ public class RDBStore implements DBStore {
     }
 
     RDBMetrics.unRegister();
-    IOUtils.closeQuietly(checkPointManager);
+    IOUtils.close(LOG, checkPointManager);
     if (rocksDBCheckpointDiffer != null) {
       RocksDBCheckpointDifferHolder
           .invalidateCacheEntry(rocksDBCheckpointDiffer.getMetadataDir());
     }
-    IOUtils.closeQuietly(db);
+    IOUtils.close(LOG, db);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotCache.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotCache.java
@@ -169,8 +169,8 @@ public class SnapshotCache implements ReferenceCountedCallback {
     // does not exist, and increment the reference count on the instance.
     ReferenceCounted<IOmMetadataReader, SnapshotCache> rcOmSnapshot =
         dbMap.compute(key, (k, v) -> {
-          LOG.info("Loading snapshot. Table key: {}", k);
           if (v == null) {
+            LOG.info("Loading snapshot. Table key: {}", k);
             try {
               v = new ReferenceCounted<>(cacheLoader.load(k), false, this);
             } catch (OMException omEx) {
@@ -317,7 +317,7 @@ public class SnapshotCache implements ReferenceCountedCallback {
       Preconditions.checkState(rcOmSnapshot == result,
           "Cache map entry removal failure. The cache is in an inconsistent "
               + "state. Expected OmSnapshot instance: " + rcOmSnapshot
-              + ", actual: " + result);
+              + ", actual: " + result + " for key: " + key);
 
       pendingEvictionList.remove(result);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to log failure if there is any problem in closing RocksDB instance to investigate to memory leak like
```
2023-12-18 19:21:06,485 WARN [Finalizer]-org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils: Checkpoint is not closed properly
2023-12-18 19:21:06,486 WARN [Finalizer]-org.apache.hadoop.ozone.om.OmSnapshot: org.apache.hadoop.hdds.utils.db.RDBStore@4e5ac786 is not closed properly. snapshotName: snap-5griw
```


## What is the link to the Apache JIRA
HDDS-9986

## How was this patch tested?
Existing unit tests.
