### PR TITLE
HDDS-9834. Migrate simple freon integration tests to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidate.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 import java.time.Duration;
@@ -76,10 +76,10 @@ public abstract class TestDataValidate {
         "--validate-writes"
     );
 
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
-    Assert.assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    Assertions.assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
   }
 
   @Test
@@ -95,14 +95,14 @@ public abstract class TestDataValidate {
         "--validate-writes"
     );
 
-    Assert.assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
-    Assert.assertTrue(randomKeyGenerator.getValidateWrites());
-    Assert.assertNotEquals(0, randomKeyGenerator.getTotalKeysValidated());
-    Assert.assertNotEquals(0, randomKeyGenerator
+    Assertions.assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
+    Assertions.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
+    Assertions.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
+    Assertions.assertTrue(randomKeyGenerator.getValidateWrites());
+    Assertions.assertNotEquals(0, randomKeyGenerator.getTotalKeysValidated());
+    Assertions.assertNotEquals(0, randomKeyGenerator
         .getSuccessfulValidationCount());
-    Assert.assertEquals(0, randomKeyGenerator
+    Assertions.assertEquals(0, randomKeyGenerator
         .getUnsuccessfulValidationCount());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithDummyContainers.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithDummyContainers.java
@@ -21,33 +21,28 @@ package org.apache.hadoop.ozone.freon;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 
 /**
  * Tests Freon with MiniOzoneCluster and ChunkManagerDummyImpl.
  * Data validation is disabled in RandomKeyGenerator.
  */
+
+@Timeout(value = 300, unit = TimeUnit.SECONDS)
 public class TestDataValidateWithDummyContainers
     extends TestDataValidate {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
   private static final Logger LOG =
       LoggerFactory.getLogger(TestDataValidateWithDummyContainers.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA, false);
@@ -67,7 +62,7 @@ public class TestDataValidateWithDummyContainers
     LOG.info("Skipping validateWriteTest for non-persistent containers.");
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     shutdownCluster();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithSafeByteOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithSafeByteOperations.java
@@ -20,23 +20,18 @@ package org.apache.hadoop.ozone.freon;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests Freon, with MiniOzoneCluster and validate data.
  */
-public class TestDataValidateWithSafeByteOperations extends TestDataValidate {
 
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
+@Timeout(value = 300, unit = TimeUnit.SECONDS)
+public class TestDataValidateWithSafeByteOperations extends TestDataValidate {
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -44,7 +39,7 @@ public class TestDataValidateWithSafeByteOperations extends TestDataValidate {
    * Ozone is made active by setting OZONE_ENABLED = true
    *
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OzoneConfigKeys.OZONE_UNSAFEBYTEOPERATIONS_ENABLED,
@@ -55,7 +50,7 @@ public class TestDataValidateWithSafeByteOperations extends TestDataValidate {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     shutdownCluster();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithUnsafeByteOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithUnsafeByteOperations.java
@@ -20,23 +20,16 @@ package org.apache.hadoop.ozone.freon;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests Freon, with MiniOzoneCluster and validate data.
  */
+@Timeout(value = 300, unit = TimeUnit.SECONDS)
 public class TestDataValidateWithUnsafeByteOperations extends TestDataValidate {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -44,7 +37,7 @@ public class TestDataValidateWithUnsafeByteOperations extends TestDataValidate {
    * Ozone is made active by setting OZONE_ENABLED = true
    *
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OzoneConfigKeys.OZONE_UNSAFEBYTEOPERATIONS_ENABLED,
@@ -55,7 +48,7 @@ public class TestDataValidateWithUnsafeByteOperations extends TestDataValidate {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     shutdownCluster();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithDatanodeFastRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithDatanodeFastRestart.java
@@ -27,28 +27,22 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import picocli.CommandLine;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests Freon with Datanode restarts without waiting for pipeline to close.
  */
+@Timeout(value = 300, unit = TimeUnit.SECONDS)
 public class TestFreonWithDatanodeFastRestart {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
 
@@ -58,7 +52,7 @@ public class TestFreonWithDatanodeFastRestart {
    * Ozone is made active by setting OZONE_ENABLED = true
    *
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf)
@@ -72,7 +66,7 @@ public class TestFreonWithDatanodeFastRestart {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -94,14 +88,14 @@ public class TestFreonWithDatanodeFastRestart {
     String expectedSnapFile =
         storage.getSnapshotFile(termIndexBeforeRestart.getTerm(),
             termIndexBeforeRestart.getIndex()).getAbsolutePath();
-    Assert.assertEquals(expectedSnapFile,
+    Assertions.assertEquals(expectedSnapFile,
         snapshotInfo.getFile().getPath().toString());
-    Assert.assertEquals(termInSnapshot, termIndexBeforeRestart);
+    Assertions.assertEquals(termInSnapshot, termIndexBeforeRestart);
 
     // After restart the term index might have progressed to apply pending
     // transactions.
     TermIndex termIndexAfterRestart = sm.getLastAppliedTermIndex();
-    Assert.assertTrue(termIndexAfterRestart.getIndex() >=
+    Assertions.assertTrue(termIndexAfterRestart.getIndex() >=
         termIndexBeforeRestart.getIndex());
     // TODO: fix me
     // Give some time for the datanode to register again with SCM.
@@ -127,10 +121,10 @@ public class TestFreonWithDatanodeFastRestart {
         "--validate-writes"
     );
 
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
-    Assert.assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    Assertions.assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
   }
 
   private StateMachine getStateMachine() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithPipelineDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithPipelineDestroy.java
@@ -30,10 +30,10 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 import java.time.Duration;
@@ -54,7 +54,7 @@ public class TestFreonWithPipelineDestroy {
    * Ozone is made active by setting OZONE_ENABLED = true
    *
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT,
@@ -85,7 +85,7 @@ public class TestFreonWithPipelineDestroy {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -114,10 +114,10 @@ public class TestFreonWithPipelineDestroy {
         "--validate-writes"
     );
 
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assert.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    Assertions.assertEquals(0,
         randomKeyGenerator.getUnsuccessfulValidationCount());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -34,9 +34,9 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -60,7 +60,7 @@ public class TestHadoopDirTreeGenerator {
           LoggerFactory.getLogger(TestHadoopDirTreeGenerator.class);
   private OzoneClient client;
 
-  @Before
+  @BeforeEach
   public void setup() {
     path = GenericTestUtils
             .getTempPath(TestHadoopDirTreeGenerator.class.getSimpleName());
@@ -157,8 +157,7 @@ public class TestHadoopDirTreeGenerator {
       int actualDepth =
           traverseToLeaf(fileSystem, fileStatus.getPath(), 1, depth, span,
               fileCount, StorageSize.parse(perFileSize, StorageUnit.BYTES));
-      Assert.assertEquals("Mismatch depth in a path",
-              depth, actualDepth);
+      Assertions.assertEquals(depth, actualDepth, "Mismatch depth in a path");
     }
   }
 
@@ -180,19 +179,16 @@ public class TestHadoopDirTreeGenerator {
         return traverseToLeaf(fs, fileStatus.getPath(), depth, expectedDepth,
                 expectedSpanCnt, expectedFileCnt, perFileSize);
       } else {
-        Assert.assertEquals("Mismatches file len", perFileSize.toBytes(),
-            fileStatus.getLen());
+        Assertions.assertEquals(perFileSize.toBytes(), fileStatus.getLen(), "Mismatches file len");
         String fName = fileStatus.getPath().getName();
-        Assert.assertFalse("actualNumFiles:" + actualNumFiles +
-                        ", fName:" + fName + ", expectedFileCnt:" +
-                        expectedFileCnt + ", depth:" + depth,
-                files.contains(fName));
+        Assertions.assertFalse(files.contains(fName), actualNumFiles + "actualNumFiles:" + fName +
+                ", fName:" + expectedFileCnt + ", expectedFileCnt:" + depth
+                + ", depth:");
         files.add(fName);
         actualNumFiles++;
       }
     }
-    Assert.assertEquals("Mismatches files count in a directory",
-            expectedFileCnt, actualNumFiles);
+    Assertions.assertEquals(expectedFileCnt, actualNumFiles, "Mismatches files count in a directory");
     return depth;
   }
 
@@ -204,8 +200,7 @@ public class TestHadoopDirTreeGenerator {
         ++actualSpan;
       }
     }
-    Assert.assertEquals("Mismatches subdirs count in a directory",
-            expectedSpanCnt, actualSpan);
+    Assertions.assertEquals(expectedSpanCnt, actualSpan, "Mismatches subdirs count in a directory");
     return actualSpan;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
@@ -32,9 +32,9 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
 import java.util.LinkedList;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -59,7 +59,7 @@ public class TestHadoopNestedDirGenerator {
           LoggerFactory.getLogger(TestHadoopNestedDirGenerator.class);
   private OzoneClient client;
 
-  @Before
+  @BeforeEach
     public void setup() {
     path = getTempPath(TestHadoopNestedDirGenerator.class.getSimpleName());
     GenericTestUtils.setLogLevel(RaftLog.LOG, Level.DEBUG);
@@ -142,8 +142,7 @@ public class TestHadoopNestedDirGenerator {
       // verify the num of peer directories and span directories
       p = depthBFS(fileSystem, fileStatuses, span, actualDepth);
       int actualSpan = spanCheck(fileSystem, span, p);
-      Assert.assertEquals("Mismatch span in a path",
-              span, actualSpan);
+      Assertions.assertEquals(span, actualSpan, "Mismatch span in a path");
     }
   }
 
@@ -183,8 +182,7 @@ public class TestHadoopNestedDirGenerator {
         p = f.getPath().getParent();
       }
     }
-    Assert.assertEquals("Mismatch depth in a path",
-            depth, actualDepth);
+    Assertions.assertEquals(depth, actualDepth, "Mismatch depth in a path");
     return p;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
@@ -34,9 +34,9 @@ import org.apache.hadoop.ozone.om.lock.OMLockMetrics;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -59,7 +59,7 @@ public class TestOmBucketReadWriteFileOps {
       LoggerFactory.getLogger(TestOmBucketReadWriteFileOps.class);
   private OzoneClient client;
 
-  @Before
+  @BeforeEach
   public void setup() {
     path = GenericTestUtils
         .getTempPath(TestOmBucketReadWriteFileOps.class.getSimpleName());
@@ -207,7 +207,7 @@ public class TestOmBucketReadWriteFileOps {
         }
       }
     }
-    Assert.assertEquals("Mismatch Count!", expectedCount, actual);
+    Assertions.assertEquals(expectedCount, actual, "Mismatch Count!");
   }
 
   private void verifyOMLockMetrics(OMLockMetrics omLockMetrics) {
@@ -218,8 +218,7 @@ public class TestOmBucketReadWriteFileOps {
         omLockMetrics.getLongestReadLockWaitingTimeMs());
     int readWaitingSamples =
         Integer.parseInt(readLockWaitingTimeMsStat.split(" ")[2]);
-    Assert.assertTrue("Read Lock Waiting Samples should be positive",
-        readWaitingSamples > 0);
+    Assertions.assertTrue(readWaitingSamples > 0, "Read Lock Waiting Samples should be positive");
 
     String readLockHeldTimeMsStat = omLockMetrics.getReadLockHeldTimeMsStat();
     LOG.info("Read Lock Held Time Stat: " + readLockHeldTimeMsStat);
@@ -227,8 +226,7 @@ public class TestOmBucketReadWriteFileOps {
         omLockMetrics.getLongestReadLockHeldTimeMs());
     int readHeldSamples =
         Integer.parseInt(readLockHeldTimeMsStat.split(" ")[2]);
-    Assert.assertTrue("Read Lock Held Samples should be positive",
-        readHeldSamples > 0);
+    Assertions.assertTrue(readHeldSamples > 0, "Read Lock Held Samples should be positive");
 
     String writeLockWaitingTimeMsStat =
         omLockMetrics.getWriteLockWaitingTimeMsStat();
@@ -237,8 +235,7 @@ public class TestOmBucketReadWriteFileOps {
         omLockMetrics.getLongestWriteLockWaitingTimeMs());
     int writeWaitingSamples =
         Integer.parseInt(writeLockWaitingTimeMsStat.split(" ")[2]);
-    Assert.assertTrue("Write Lock Waiting Samples should be positive",
-        writeWaitingSamples > 0);
+    Assertions.assertTrue(writeWaitingSamples > 0, "Write Lock Waiting Samples should be positive");
 
     String writeLockHeldTimeMsStat = omLockMetrics.getWriteLockHeldTimeMsStat();
     LOG.info("Write Lock Held Time Stat: " + writeLockHeldTimeMsStat);
@@ -246,8 +243,7 @@ public class TestOmBucketReadWriteFileOps {
         omLockMetrics.getLongestWriteLockHeldTimeMs());
     int writeHeldSamples =
         Integer.parseInt(writeLockHeldTimeMsStat.split(" ")[2]);
-    Assert.assertTrue("Write Lock Held Samples should be positive",
-        writeHeldSamples > 0);
+    Assertions.assertTrue(writeHeldSamples > 0, "Write Lock Held Samples should be positive");
   }
 
   private static class ParameterBuilder {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
@@ -33,9 +33,9 @@ import org.apache.hadoop.ozone.om.lock.OMLockMetrics;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -61,7 +61,7 @@ public class TestOmBucketReadWriteKeyOps {
       LoggerFactory.getLogger(TestOmBucketReadWriteKeyOps.class);
   private OzoneClient client;
 
-  @Before
+  @BeforeEach
   public void setup() {
     path = GenericTestUtils
         .getTempPath(TestHadoopDirTreeGenerator.class.getSimpleName());
@@ -193,7 +193,7 @@ public class TestOmBucketReadWriteKeyOps {
       ozoneKeyIterator.next();
       ++actual;
     }
-    Assert.assertEquals("Mismatch Count!", expectedCount, actual);
+    Assertions.assertEquals(expectedCount, actual, "Mismatch Count!");
   }
 
   private void verifyOMLockMetrics(OMLockMetrics omLockMetrics) {
@@ -204,8 +204,7 @@ public class TestOmBucketReadWriteKeyOps {
         omLockMetrics.getLongestReadLockWaitingTimeMs());
     int readWaitingSamples =
         Integer.parseInt(readLockWaitingTimeMsStat.split(" ")[2]);
-    Assert.assertTrue("Read Lock Waiting Samples should be positive",
-        readWaitingSamples > 0);
+    Assertions.assertTrue(readWaitingSamples > 0, "Read Lock Waiting Samples should be positive");
 
     String readLockHeldTimeMsStat = omLockMetrics.getReadLockHeldTimeMsStat();
     LOG.info("Read Lock Held Time Stat: " + readLockHeldTimeMsStat);
@@ -213,8 +212,7 @@ public class TestOmBucketReadWriteKeyOps {
         omLockMetrics.getLongestReadLockHeldTimeMs());
     int readHeldSamples =
         Integer.parseInt(readLockHeldTimeMsStat.split(" ")[2]);
-    Assert.assertTrue("Read Lock Held Samples should be positive",
-        readHeldSamples > 0);
+    Assertions.assertTrue(readHeldSamples > 0, "Read Lock Held Samples should be positive");
 
     String writeLockWaitingTimeMsStat =
         omLockMetrics.getWriteLockWaitingTimeMsStat();
@@ -223,8 +221,7 @@ public class TestOmBucketReadWriteKeyOps {
         omLockMetrics.getLongestWriteLockWaitingTimeMs());
     int writeWaitingSamples =
         Integer.parseInt(writeLockWaitingTimeMsStat.split(" ")[2]);
-    Assert.assertTrue("Write Lock Waiting Samples should be positive",
-        writeWaitingSamples > 0);
+    Assertions.assertTrue(writeWaitingSamples > 0, "Write Lock Waiting Samples should be positive");
 
     String writeLockHeldTimeMsStat = omLockMetrics.getWriteLockHeldTimeMsStat();
     LOG.info("Write Lock Held Time Stat: " + writeLockHeldTimeMsStat);
@@ -232,8 +229,7 @@ public class TestOmBucketReadWriteKeyOps {
         omLockMetrics.getLongestWriteLockHeldTimeMs());
     int writeHeldSamples =
         Integer.parseInt(writeLockHeldTimeMsStat.split(" ")[2]);
-    Assert.assertTrue("Write Lock Held Samples should be positive",
-        writeHeldSamples > 0);
+    Assertions.assertTrue(writeHeldSamples > 0, "Write Lock Held Samples should be positive");
   }
 
   private static class ParameterBuilder {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrated the following classes to JUnit5 as per the task of the parent jira HDDS-6729

hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidate.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithDummyContainers.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithDatanodeFastRestart.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithPipelineDestroy.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithSafeByteOperations.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidateWithUnsafeByteOperations.java

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9834

## How was this patch tested?
Ran unit tests
