### PR TITLE
HDDS-9946. Move pathComponents calculation to OMFileRequest#getParentID

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -70,11 +70,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -908,11 +905,10 @@ public class TestOzoneClientMultipartUploadWithFSO {
 
   private long getParentID(String volName, String buckName,
                            String kName, OMMetadataManager omMetadataManager) throws IOException {
-    Iterator<Path> pathComponents = Paths.get(kName).iterator();
     final long volumeId = omMetadataManager.getVolumeId(volName);
     final long bucketId = omMetadataManager.getBucketId(volName,
         buckName);
-    return OMFileRequest.getParentID(volumeId, bucketId, pathComponents,
+    return OMFileRequest.getParentID(volumeId, bucketId,
         kName, omMetadataManager);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -973,19 +973,16 @@ public final class OMFileRequest {
    *
    * @param volumeId       volume id
    * @param bucketId       bucket id
-   * @param pathComponents fie path elements
    * @param keyName        user given key name
    * @param omMetadataManager   om metadata manager
    * @return lastKnownParentID
    * @throws IOException DB failure or parent not exists in DirectoryTable
    */
   public static long getParentID(long volumeId, long bucketId,
-                                 Iterator<Path> pathComponents,
                                  String keyName,
                                  OMMetadataManager omMetadataManager)
       throws IOException {
-
-    return getParentID(volumeId, bucketId, pathComponents, keyName,
+    return getParentID(volumeId, bucketId, keyName,
             omMetadataManager, null);
   }
 
@@ -993,18 +990,17 @@ public final class OMFileRequest {
    * Get parent id for the user given path.
    *
    * @param bucketId       bucket id
-   * @param pathComponents fie path elements
    * @param keyName        user given key name
    * @param omMetadataManager   om metadata manager
    * @return lastKnownParentID
    * @throws IOException DB failure or parent not exists in DirectoryTable
    */
-  public static long getParentID(long volumeId, long bucketId,
-      Iterator<Path> pathComponents, String keyName,
+  public static long getParentID(long volumeId, long bucketId, String keyName,
       OMMetadataManager omMetadataManager, String errMsg)
       throws IOException {
 
     long lastKnownParentId = bucketId;
+    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
 
     // If no sub-dirs then bucketID is the root/parent.
     if (!pathComponents.hasNext()) {
@@ -1064,9 +1060,8 @@ public final class OMFileRequest {
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
             bucketName);
-    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
     return OMFileRequest.getParentID(volumeId, bucketId,
-            pathComponents, keyName, omMetadataManager);
+            keyName, omMetadataManager);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -51,9 +51,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -188,10 +185,9 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(
         volumeName, bucketName);
-    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
-    long parentID = OMFileRequest.getParentID(volumeId, bucketId,
-        pathComponents, keyName, omMetadataManager,
-        "Cannot recover file : " + keyName
+
+    long parentID = OMFileRequest.getParentID(volumeId, bucketId, keyName,
+        omMetadataManager, "Cannot recover file : " + keyName
             + " as parent directory doesn't exist");
     String fileName = OzoneFSUtils.getFileName(keyName);
     dbFileKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -50,10 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -215,9 +212,9 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
     final long bucketId = omMetadataManager.getBucketId(
             volumeName, bucketName);
     String fileName = OzoneFSUtils.getFileName(keyName);
-    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
+
     long parentID = OMFileRequest.getParentID(volumeId, bucketId,
-            pathComponents, keyName, omMetadataManager);
+          keyName, omMetadataManager);
     return omMetadataManager.getOpenFileName(volumeId, bucketId, parentID,
             fileName, clientID);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -50,9 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -126,7 +123,6 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
               commitKeyRequest.getClientID());
 
 
-      Iterator<Path> pathComponents = Paths.get(keyName).iterator();
       String dbOpenFileKey = null;
 
       List<OmKeyLocationInfo>
@@ -144,7 +140,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       final long bucketId = omMetadataManager.getBucketId(
               volumeName, bucketName);
       long parentID = OMFileRequest.getParentID(volumeId, bucketId,
-              pathComponents, keyName, omMetadataManager,
+              keyName, omMetadataManager,
               "Cannot create file : " + keyName
               + " as parent directory doesn't exist");
       String dbFileKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
@@ -32,9 +32,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Iterator;
 
 /**
  * Handle Multipart upload commit upload part file.
@@ -53,12 +50,12 @@ public class S3MultipartUploadCommitPartRequestWithFSO
       throws IOException {
 
     String fileName = OzoneFSUtils.getFileName(keyName);
-    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
+
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
             bucketName);
     long parentID = OMFileRequest
-        .getParentID(volumeId, bucketId, pathComponents, keyName,
+        .getParentID(volumeId, bucketId, keyName,
                 omMetadataManager);
 
     return omMetadataManager.getOpenFileName(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OMMultipartUploadUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OMMultipartUploadUtils.java
@@ -27,9 +27,6 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
@@ -115,11 +112,11 @@ public final class OMMultipartUploadUtils {
         String bucketName, String keyName, String uploadID,
         OMMetadataManager metaMgr) throws IOException {
     String fileName = OzoneFSUtils.getFileName(keyName);
-    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
+
     final long volumeId = metaMgr.getVolumeId(volumeName);
     final long bucketId = metaMgr.getBucketId(volumeName, bucketName);
     long parentID =
-        OMFileRequest.getParentID(volumeId, bucketId, pathComponents,
+        OMFileRequest.getParentID(volumeId, bucketId,
             keyName, metaMgr);
 
     String multipartKey = metaMgr.getMultipartKey(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
@@ -30,9 +30,6 @@ import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.UUID;
 
 /**
@@ -90,13 +87,11 @@ public class TestS3MultipartUploadCompleteRequestWithFSO
 
   private long getParentID(String volumeName, String bucketName,
                            String keyName) throws IOException {
-    Path keyPath = Paths.get(keyName);
-    Iterator<Path> elements = keyPath.iterator();
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
             bucketName);
     return OMFileRequest.getParentID(volumeId, bucketId,
-            elements, keyName, omMetadataManager);
+            keyName, omMetadataManager);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Move pathComponents calculation to OMFileRequest#getParentID

Please describe your PR in detail:
* PathComponets comes from key and always used with OMFileRequest#getParentID so we can Move pathComponents calculation to OMFileRequest#getParentID. 

## What is the link to the Apache JIRA

HDDS-9946. Move pathComponents calculation to OMFileRequest#getParentID

## How was this patch tested?
CI test
https://github.com/TaiJuWu/ozone/actions/runs/7307373311
