### PR TITLE
HDDS-10007. Rename ManagedSstFileReader in rocksdb-checkpoint-differ

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -177,17 +177,20 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=false
 }
 
-@test "native test in other module" {
-  run dev-support/ci/selective_ci_checks.sh 7d01cc14a6
-
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","native","unit"]'
-  assert_output -p needs-build=true
-  assert_output -p needs-compile=true
-  assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
-  assert_output -p needs-integration-tests=false
-  assert_output -p needs-kubernetes-tests=false
-}
+# disabled, because this test fails if
+# hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdb/util/TestManagedSstFileReader.java
+# is not present in the current tree (i.e. if file is renamed, moved or deleted)
+#@test "native test in other module" {
+#  run dev-support/ci/selective_ci_checks.sh 7d01cc14a6
+#
+#  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","native","unit"]'
+#  assert_output -p needs-build=true
+#  assert_output -p needs-compile=true
+#  assert_output -p needs-compose-tests=false
+#  assert_output -p needs-dependency-check=false
+#  assert_output -p needs-integration-tests=false
+#  assert_output -p needs-kubernetes-tests=false
+#}
 
 @test "kubernetes only" {
   run dev-support/ci/selective_ci_checks.sh 5336bb9bd

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/SstFileSetReader.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/SstFileSetReader.java
@@ -46,16 +46,16 @@ import java.util.stream.StreamSupport;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * ManagedSstFileReader provides an abstraction layer using which we can
- * iterate over multiple underlying SST files transparently.
+ * Provides an abstraction layer using which we can iterate over multiple
+ * underlying SST files transparently.
  */
-public class ManagedSstFileReader {
+public class SstFileSetReader {
 
   private final Collection<String> sstFiles;
 
   private volatile long estimatedTotalKeys = -1;
 
-  public ManagedSstFileReader(final Collection<String> sstFiles) {
+  public SstFileSetReader(final Collection<String> sstFiles) {
     this.sstFiles = sstFiles;
   }
 

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdb/util/TestSstFileSetReader.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdb/util/TestSstFileSetReader.java
@@ -58,7 +58,7 @@ import static org.apache.hadoop.hdds.utils.NativeConstants.ROCKS_TOOLS_NATIVE_LI
 /**
  * ManagedSstFileReader tests.
  */
-class TestManagedSstFileReader {
+class TestSstFileSetReader {
 
   @TempDir
   private File tempDir;
@@ -146,7 +146,7 @@ class TestManagedSstFileReader {
                 .collect(Collectors.toMap(Map.Entry::getKey,
                     Map.Entry::getValue));
         try (Stream<String> keyStream =
-                 new ManagedSstFileReader(files).getKeyStream(
+                 new SstFileSetReader(files).getKeyStream(
                      lowerBound.orElse(null), upperBound.orElse(null))) {
           keyStream.forEach(key -> {
             Assertions.assertEquals(1, keysInBoundary.get(key));
@@ -194,7 +194,7 @@ class TestManagedSstFileReader {
                           .orElse(true))
                   .collect(Collectors.toMap(Map.Entry::getKey,
                       Map.Entry::getValue));
-          try (Stream<String> keyStream = new ManagedSstFileReader(files)
+          try (Stream<String> keyStream = new SstFileSetReader(files)
               .getKeyStreamWithTombstone(sstDumpTool, lowerBound.orElse(null),
                   upperBound.orElse(null))) {
             keyStream.forEach(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -56,7 +56,7 @@ import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
 import org.apache.hadoop.util.ClosableIterator;
 import org.apache.logging.log4j.util.Strings;
-import org.apache.ozone.rocksdb.util.ManagedSstFileReader;
+import org.apache.ozone.rocksdb.util.SstFileSetReader;
 import org.apache.ozone.rocksdb.util.RdbUtil;
 import org.apache.ozone.rocksdiff.DifferSnapshotInfo;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
@@ -1083,7 +1083,7 @@ public class SnapshotDiffManager implements AutoCloseable {
     String tablePrefix = getTablePrefix(tablePrefixes, fsTable.getName());
     boolean isDirectoryTable =
         fsTable.getName().equals(DIRECTORY_TABLE);
-    ManagedSstFileReader sstFileReader = new ManagedSstFileReader(deltaFiles);
+    SstFileSetReader sstFileReader = new SstFileSetReader(deltaFiles);
     validateEstimatedKeyChangesAreInLimits(sstFileReader);
     String sstFileReaderLowerBound = tablePrefix;
     String sstFileReaderUpperBound = null;
@@ -1204,7 +1204,7 @@ public class SnapshotDiffManager implements AutoCloseable {
   }
 
   private void validateEstimatedKeyChangesAreInLimits(
-      ManagedSstFileReader sstFileReader
+      SstFileSetReader sstFileReader
   ) throws RocksDBException, IOException {
     if (sstFileReader.getEstimatedTotalKeys() >
         maxAllowedKeyChangesForASnapDiff) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -63,7 +63,7 @@ import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.ClosableIterator;
 import org.apache.hadoop.util.ExitUtil;
-import org.apache.ozone.rocksdb.util.ManagedSstFileReader;
+import org.apache.ozone.rocksdb.util.SstFileSetReader;
 import org.apache.ozone.rocksdb.util.RdbUtil;
 import org.apache.ozone.rocksdiff.DifferSnapshotInfo;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
@@ -651,8 +651,8 @@ public class TestSnapshotDiffManager {
         .map(i -> (i + 100) + "/key" + i).collect(Collectors.toSet());
 
     // Mocking SSTFileReader functions to return the above keys list.
-    try (MockedConstruction<ManagedSstFileReader> mockedSSTFileReader =
-             Mockito.mockConstruction(ManagedSstFileReader.class,
+    try (MockedConstruction<SstFileSetReader> mockedSSTFileReader =
+             Mockito.mockConstruction(SstFileSetReader.class,
                  (mock, context) -> {
                    when(mock.getKeyStreamWithTombstone(any(), any(), any()))
                        .thenReturn(keysIncludingTombstones.stream());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename `ManagedSstFileReader` in `rocksdb-checkpoint-differ` to avoid confusion with the "real" `ManagedSstFileReader` from `hdds-managed-rocksdb`.

https://github.com/apache/ozone/blob/f9167a359e7ff6f54eafc8a7b1c3fd165050160f/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedSstFileReader.java#L23-L26

https://github.com/apache/ozone/blob/f9167a359e7ff6f54eafc8a7b1c3fd165050160f/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/ManagedSstFileReader.java#L48-L52

I think `SstFileSetReader` would be a better name.

https://issues.apache.org/jira/browse/HDDS-10007

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7309005071