### PR TITLE
HDDS-9989. Add static import for assertions and mocks in ozone-common

### DIFF
--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -45,6 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -79,7 +80,7 @@ public class TestOmUtils {
 
   @Test
   public void createOMDirThrowsIfCannotCreate() {
-    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       File parent = folder.toFile();
       File omDir = new File(new File(parent, "sub"), "dir");
       assumeTrue(parent.setWritable(false, false));
@@ -127,7 +128,7 @@ public class TestOmUtils {
     configuration.set(OZONE_OM_SERVICE_IDS_KEY, "om2,om3");
     try {
       getOzoneManagerServiceId(configuration);
-      Assertions.fail();
+      fail();
     } catch (IOException ioEx) {
       assertTrue(ioEx.getMessage()
           .contains("Cannot find the internal service id om1 in [om2, om3]"));
@@ -145,7 +146,7 @@ public class TestOmUtils {
     configuration.set(OZONE_OM_SERVICE_IDS_KEY, "om2,om1");
     try {
       getOzoneManagerServiceId(configuration);
-      Assertions.fail();
+      fail();
     } catch (IOException ioEx) {
       assertTrue(ioEx.getMessage()
           .contains("More than 1 OzoneManager ServiceID (ozone.om.service" +
@@ -155,7 +156,7 @@ public class TestOmUtils {
 
   @Test
   public void checkMaxTransactionID() {
-    Assertions.assertEquals((long) (Math.pow(2, 54) - 2), OmUtils.MAX_TRXN_ID);
+    assertEquals((long) (Math.pow(2, 54) - 2), OmUtils.MAX_TRXN_ID);
   }
 
   @Test
@@ -173,16 +174,16 @@ public class TestOmUtils {
     conf.set(OZONE_OM_ADDRESS_KEY + "." + serviceId2 + ".om1", "om1-host");
 
     Set<String> hosts = getOmHostsFromConfig(conf, serviceId);
-    Assertions.assertEquals(3, hosts.size());
-    Assertions.assertTrue(hosts.contains("omA-host"));
-    Assertions.assertTrue(hosts.contains("omB-host"));
-    Assertions.assertTrue(hosts.contains("omC-host"));
+    assertEquals(3, hosts.size());
+    assertTrue(hosts.contains("omA-host"));
+    assertTrue(hosts.contains("omB-host"));
+    assertTrue(hosts.contains("omC-host"));
 
     hosts = getOmHostsFromConfig(conf, serviceId2);
-    Assertions.assertEquals(1, hosts.size());
-    Assertions.assertTrue(hosts.contains("om1-host"));
+    assertEquals(1, hosts.size());
+    assertTrue(hosts.contains("om1-host"));
 
-    Assertions.assertTrue(getOmHostsFromConfig(conf, "newId").isEmpty());
+    assertTrue(getOmHostsFromConfig(conf, "newId").isEmpty());
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/client/io/TestSelectorOutputStream.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/client/io/TestSelectorOutputStream.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.fs.Syncable;
 import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.function.CheckedConsumer;
 import org.apache.ratis.util.function.CheckedFunction;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -31,6 +30,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test {@link SelectorOutputStream}.
@@ -100,14 +104,14 @@ public class TestSelectorOutputStream {
 
     // checkout auto selection
     final boolean isAbove = byteToWrite > threshold;
-    Assertions.assertFalse(belowThreshold.isInitialized());
-    Assertions.assertEquals(isAbove, aboveThreshold.isInitialized());
+    assertFalse(belowThreshold.isInitialized());
+    assertEquals(isAbove, aboveThreshold.isInitialized());
 
     final boolean isBelow = !isAbove;
     if (op != null) {
       op.accept(out);
-      Assertions.assertEquals(isBelow, belowThreshold.isInitialized());
-      Assertions.assertEquals(isAbove, aboveThreshold.isInitialized());
+      assertEquals(isBelow, belowThreshold.isInitialized());
+      assertEquals(isAbove, aboveThreshold.isInitialized());
     }
   }
 
@@ -134,11 +138,11 @@ public class TestSelectorOutputStream {
 
   @Test
   public void testHflushNonSyncable() {
-    final IllegalStateException thrown = Assertions.assertThrows(
+    final IllegalStateException thrown = assertThrows(
         IllegalStateException.class,
         () -> runTestSelector(10, 2, Op.HFLUSH, false));
     LOG.info("thrown", thrown);
-    Assertions.assertTrue(thrown.getMessage().contains("not Syncable"));
+    assertTrue(thrown.getMessage().contains("not Syncable"));
   }
 
   @Test
@@ -150,10 +154,10 @@ public class TestSelectorOutputStream {
 
   @Test
   public void testHSyncNonSyncable() {
-    final IllegalStateException thrown = Assertions.assertThrows(
+    final IllegalStateException thrown = assertThrows(
         IllegalStateException.class,
         () -> runTestSelector(10, 2, Op.HSYNC, false));
     LOG.info("thrown", thrown);
-    Assertions.assertTrue(thrown.getMessage().contains("not Syncable"));
+    assertTrue(thrown.getMessage().contains("not Syncable"));
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/exceptions/TestResultCodes.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/exceptions/TestResultCodes.java
@@ -20,8 +20,10 @@ package org.apache.hadoop.ozone.om.exceptions;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test code mappping.
@@ -30,16 +32,16 @@ public class TestResultCodes {
 
   @Test
   public void codeMapping() {
-    Assertions.assertEquals(ResultCodes.values().length,
+    assertEquals(ResultCodes.values().length,
         Status.values().length);
     for (int i = 0; i < ResultCodes.values().length; i++) {
       ResultCodes codeValue = ResultCodes.values()[i];
       Status protoBufValue = Status.values()[i];
-      Assertions.assertTrue(sameName(codeValue.name(), protoBufValue.name()),
+      assertTrue(sameName(codeValue.name(), protoBufValue.name()),
           String.format("Protobuf/Enum constant name mismatch %s %s", codeValue,
               protoBufValue));
       ResultCodes converted = ResultCodes.values()[protoBufValue.ordinal()];
-      Assertions.assertEquals(codeValue, converted);
+      assertEquals(codeValue, converted);
     }
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
@@ -27,7 +27,6 @@ import java.util.StringJoiner;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -40,6 +39,9 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.
     OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.
     OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests OMFailoverProxyProvider failover behaviour.
@@ -121,10 +123,10 @@ public class TestOMFailoverProxyProvider {
     Collection<String> allNodeIds = config.getTrimmedStringCollection(ConfUtils.
         addKeySuffixes(OZONE_OM_NODES_KEY, OM_SERVICE_ID));
     allNodeIds.remove(provider.getCurrentProxyOMNodeId());
-    Assertions.assertTrue(allNodeIds.size() > 0,
+    assertTrue(allNodeIds.size() > 0,
         "This test needs at least 2 OMs");
     provider.setNextOmProxy(allNodeIds.iterator().next());
-    Assertions.assertEquals(0, provider.getWaitTime());
+    assertEquals(0, provider.getWaitTime());
   }
 
   /**
@@ -150,7 +152,7 @@ public class TestOMFailoverProxyProvider {
                                   long waitTimeAfter) {
     for (int attempt = 0; attempt < numNextNodeFailoverTimes; attempt++) {
       provider.selectNextOmProxy();
-      Assertions.assertEquals(waitTimeAfter, provider.getWaitTime());
+      assertEquals(waitTimeAfter, provider.getWaitTime());
       provider.performFailover(null);
     }
   }
@@ -162,7 +164,7 @@ public class TestOMFailoverProxyProvider {
     provider.performFailover(null);
     for (int attempt = 1; attempt <= numSameNodeFailoverTimes; attempt++) {
       provider.setNextOmProxy(provider.getCurrentProxyOMNodeId());
-      Assertions.assertEquals(attempt * waitBetweenRetries,
+      assertEquals(attempt * waitBetweenRetries,
           provider.getWaitTime());
     }
   }
@@ -175,7 +177,7 @@ public class TestOMFailoverProxyProvider {
     OzoneConfiguration ozoneConf = new OzoneConfiguration();
     ArrayList<String> nodeAddrs = new ArrayList<>(
         Arrays.asList("4.3.2.1:9862", "2.1.0.5:9862", "3.2.1.0:9862"));
-    Assertions.assertEquals(numNodes, nodeAddrs.size());
+    assertEquals(numNodes, nodeAddrs.size());
 
     StringJoiner allNodeIds = new StringJoiner(",");
     for (int i = 1; i <= numNodes; i++) {
@@ -197,7 +199,7 @@ public class TestOMFailoverProxyProvider {
 
     Collections.sort(nodeAddrs);
     String expectedDtService = String.join(",", nodeAddrs);
-    Assertions.assertEquals(expectedDtService, dtService.toString());
+    assertEquals(expectedDtService, dtService.toString());
   }
 
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketArgs.java
@@ -20,10 +20,13 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.client.ReplicationType.EC;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests for the OmBucketArgs class.
@@ -37,14 +40,14 @@ public class TestOmBucketArgs {
         .setVolumeName("volume")
         .build();
 
-    Assertions.assertFalse(bucketArgs.hasQuotaInBytes());
-    Assertions.assertFalse(bucketArgs.hasQuotaInNamespace());
+    assertFalse(bucketArgs.hasQuotaInBytes());
+    assertFalse(bucketArgs.hasQuotaInNamespace());
 
     OmBucketArgs argsFromProto = OmBucketArgs.getFromProtobuf(
         bucketArgs.getProtobuf());
 
-    Assertions.assertFalse(argsFromProto.hasQuotaInBytes());
-    Assertions.assertFalse(argsFromProto.hasQuotaInNamespace());
+    assertFalse(argsFromProto.hasQuotaInBytes());
+    assertFalse(argsFromProto.hasQuotaInNamespace());
 
     bucketArgs = OmBucketArgs.newBuilder()
         .setBucketName("bucket")
@@ -53,14 +56,14 @@ public class TestOmBucketArgs {
         .setQuotaInBytes(456)
         .build();
 
-    Assertions.assertTrue(bucketArgs.hasQuotaInBytes());
-    Assertions.assertTrue(bucketArgs.hasQuotaInNamespace());
+    assertTrue(bucketArgs.hasQuotaInBytes());
+    assertTrue(bucketArgs.hasQuotaInNamespace());
 
     argsFromProto = OmBucketArgs.getFromProtobuf(
         bucketArgs.getProtobuf());
 
-    Assertions.assertTrue(argsFromProto.hasQuotaInBytes());
-    Assertions.assertTrue(argsFromProto.hasQuotaInNamespace());
+    assertTrue(argsFromProto.hasQuotaInBytes());
+    assertTrue(argsFromProto.hasQuotaInNamespace());
   }
 
   @Test
@@ -73,7 +76,7 @@ public class TestOmBucketArgs {
     OmBucketArgs argsFromProto = OmBucketArgs.getFromProtobuf(
         bucketArgs.getProtobuf());
 
-    Assertions.assertNull(argsFromProto.getDefaultReplicationConfig());
+    assertNull(argsFromProto.getDefaultReplicationConfig());
 
     bucketArgs = OmBucketArgs.newBuilder()
         .setBucketName("bucket")
@@ -85,7 +88,7 @@ public class TestOmBucketArgs {
     argsFromProto = OmBucketArgs.getFromProtobuf(
         bucketArgs.getProtobuf());
 
-    Assertions.assertEquals(EC,
+    assertEquals(EC,
         argsFromProto.getDefaultReplicationConfig().getType());
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -26,11 +26,17 @@ import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.apache.hadoop.util.Time;
 
 import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Test BucketInfo.
@@ -47,7 +53,7 @@ public class TestOmBucketInfo {
         .setStorageType(StorageType.ARCHIVE)
         .build();
 
-    Assertions.assertEquals(bucket,
+    assertEquals(bucket,
         OmBucketInfo.getFromProtobuf(bucket.getProtobuf()));
   }
 
@@ -60,7 +66,7 @@ public class TestOmBucketInfo {
         .setSourceBucket("someBucket")
         .build();
 
-    Assertions.assertEquals(bucket,
+    assertEquals(bucket,
         OmBucketInfo.getFromProtobuf(bucket.getProtobuf()));
   }
 
@@ -82,8 +88,8 @@ public class TestOmBucketInfo {
 
     /* Clone an omBucketInfo. */
     OmBucketInfo cloneBucketInfo = omBucketInfo.copyObject();
-    Assertions.assertNotSame(omBucketInfo, cloneBucketInfo);
-    Assertions.assertEquals(omBucketInfo, cloneBucketInfo,
+    assertNotSame(omBucketInfo, cloneBucketInfo);
+    assertEquals(omBucketInfo, cloneBucketInfo,
         "Expected " + omBucketInfo + " and " + cloneBucketInfo
             + " to be equal");
 
@@ -94,14 +100,14 @@ public class TestOmBucketInfo {
         IAccessAuthorizer.ACLType.WRITE_ACL,
         OzoneAcl.AclScope.ACCESS
     )));
-    Assertions.assertNotEquals(
+    assertNotEquals(
         omBucketInfo.getAcls().get(0),
         cloneBucketInfo.getAcls().get(0));
 
     /* Clone acl & check equal. */
     cloneBucketInfo = omBucketInfo.copyObject();
-    Assertions.assertEquals(omBucketInfo, cloneBucketInfo);
-    Assertions.assertEquals(
+    assertEquals(omBucketInfo, cloneBucketInfo);
+    assertEquals(
         omBucketInfo.getAcls().get(0),
         cloneBucketInfo.getAcls().get(0));
 
@@ -112,8 +118,8 @@ public class TestOmBucketInfo {
         IAccessAuthorizer.ACLType.WRITE_ACL,
         OzoneAcl.AclScope.ACCESS
     ));
-    Assertions.assertEquals(0, omBucketInfo.getAcls().size());
-    Assertions.assertEquals(1, cloneBucketInfo.getAcls().size());
+    assertEquals(0, omBucketInfo.getAcls().size());
+    assertEquals(1, cloneBucketInfo.getAcls().size());
 
   }
 
@@ -129,11 +135,11 @@ public class TestOmBucketInfo {
                     OzoneAcl.AclScope.ACCESS))).build();
     OzoneManagerProtocolProtos.BucketInfo protobuf = omBucketInfo.getProtobuf();
     // No EC Config
-    Assertions.assertFalse(protobuf.hasDefaultReplicationConfig());
+    assertFalse(protobuf.hasDefaultReplicationConfig());
 
     // Reconstruct object from Proto
     OmBucketInfo recovered = OmBucketInfo.getFromProtobuf(protobuf);
-    Assertions.assertNull(recovered.getDefaultReplicationConfig());
+    assertNull(recovered.getDefaultReplicationConfig());
 
     // EC Config
     omBucketInfo = OmBucketInfo.newBuilder()
@@ -151,20 +157,20 @@ public class TestOmBucketInfo {
                 new ECReplicationConfig(3, 2))).build();
     protobuf = omBucketInfo.getProtobuf();
 
-    Assertions.assertTrue(protobuf.hasDefaultReplicationConfig());
-    Assertions.assertEquals(3,
+    assertTrue(protobuf.hasDefaultReplicationConfig());
+    assertEquals(3,
         protobuf.getDefaultReplicationConfig().getEcReplicationConfig()
             .getData());
-    Assertions.assertEquals(2,
+    assertEquals(2,
         protobuf.getDefaultReplicationConfig().getEcReplicationConfig()
             .getParity());
 
     // Reconstruct object from Proto
     recovered = OmBucketInfo.getFromProtobuf(protobuf);
-    Assertions.assertEquals(ReplicationType.EC,
+    assertEquals(ReplicationType.EC,
         recovered.getDefaultReplicationConfig().getType());
     ReplicationConfig config =
         recovered.getDefaultReplicationConfig().getReplicationConfig();
-    Assertions.assertEquals(new ECReplicationConfig(3, 2), config);
+    assertEquals(new ECReplicationConfig(3, 2), config);
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo.Builder;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -45,6 +44,10 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Test OmKeyInfo.
@@ -59,11 +62,11 @@ public class TestOmKeyInfo {
     OmKeyInfo keyAfterSerialization = OmKeyInfo.getFromProtobuf(
         key.getProtobuf(ClientVersion.CURRENT_VERSION));
 
-    Assertions.assertEquals(key, keyAfterSerialization);
+    assertEquals(key, keyAfterSerialization);
 
-    Assertions.assertFalse(key.isHsync());
+    assertFalse(key.isHsync());
     key.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID, "clientid");
-    Assertions.assertTrue(key.isHsync());
+    assertTrue(key.isHsync());
   }
 
   @Test
@@ -74,39 +77,39 @@ public class TestOmKeyInfo {
         key.getProtobuf(ClientVersion.CURRENT_VERSION);
 
     // No EC Config
-    Assertions.assertFalse(omKeyProto.hasEcReplicationConfig());
-    Assertions.assertEquals(THREE, omKeyProto.getFactor());
-    Assertions.assertEquals(RATIS, omKeyProto.getType());
+    assertFalse(omKeyProto.hasEcReplicationConfig());
+    assertEquals(THREE, omKeyProto.getFactor());
+    assertEquals(RATIS, omKeyProto.getType());
 
     // Reconstruct object from Proto
     OmKeyInfo recovered = OmKeyInfo.getFromProtobuf(omKeyProto);
-    Assertions.assertEquals(RATIS,
+    assertEquals(RATIS,
         recovered.getReplicationConfig().getReplicationType());
-    Assertions.assertTrue(
+    assertTrue(
         recovered.getReplicationConfig() instanceof RatisReplicationConfig);
 
     // EC Config
     key = createOmKeyInfo(new ECReplicationConfig(3, 2));
-    Assertions.assertFalse(key.isHsync());
+    assertFalse(key.isHsync());
     omKeyProto = key.getProtobuf(ClientVersion.CURRENT_VERSION);
 
-    Assertions.assertEquals(3,
+    assertEquals(3,
         omKeyProto.getEcReplicationConfig().getData());
-    Assertions.assertEquals(2,
+    assertEquals(2,
         omKeyProto.getEcReplicationConfig().getParity());
-    Assertions.assertFalse(omKeyProto.hasFactor());
-    Assertions.assertEquals(EC, omKeyProto.getType());
+    assertFalse(omKeyProto.hasFactor());
+    assertEquals(EC, omKeyProto.getType());
 
     // Reconstruct object from Proto
     recovered = OmKeyInfo.getFromProtobuf(omKeyProto);
-    Assertions.assertEquals(EC,
+    assertEquals(EC,
         recovered.getReplicationConfig().getReplicationType());
-    Assertions.assertTrue(
+    assertTrue(
         recovered.getReplicationConfig() instanceof ECReplicationConfig);
     ECReplicationConfig config =
         (ECReplicationConfig) recovered.getReplicationConfig();
-    Assertions.assertEquals(3, config.getData());
-    Assertions.assertEquals(2, config.getParity());
+    assertEquals(3, config.getData());
+    assertEquals(2, config.getParity());
   }
 
   private OmKeyInfo createOmKeyInfo(ReplicationConfig replicationConfig) {
@@ -153,10 +156,10 @@ public class TestOmKeyInfo {
 
     // OmKeyLocationInfoGroup has now implemented equals() method.
     // assertEquals should work now.
-    Assertions.assertEquals(key, cloneKey);
+    assertEquals(key, cloneKey);
 
     // Check each version content here.
-    Assertions.assertEquals(key.getKeyLocationVersions().size(),
+    assertEquals(key.getKeyLocationVersions().size(),
         cloneKey.getKeyLocationVersions().size());
 
     // Check blocks for each version.
@@ -164,16 +167,16 @@ public class TestOmKeyInfo {
       OmKeyLocationInfoGroup orig = key.getKeyLocationVersions().get(i);
       OmKeyLocationInfoGroup clone = key.getKeyLocationVersions().get(i);
 
-      Assertions.assertEquals(orig.isMultipartKey(), clone.isMultipartKey());
-      Assertions.assertEquals(orig.getVersion(), clone.getVersion());
+      assertEquals(orig.isMultipartKey(), clone.isMultipartKey());
+      assertEquals(orig.getVersion(), clone.getVersion());
 
-      Assertions.assertEquals(orig.getLocationList().size(),
+      assertEquals(orig.getLocationList().size(),
           clone.getLocationList().size());
 
       for (int j = 0; j < orig.getLocationList().size(); j++) {
         OmKeyLocationInfo origLocationInfo = orig.getLocationList().get(j);
         OmKeyLocationInfo cloneLocationInfo = clone.getLocationList().get(j);
-        Assertions.assertEquals(origLocationInfo, cloneLocationInfo);
+        assertEquals(origLocationInfo, cloneLocationInfo);
       }
     }
 
@@ -182,14 +185,14 @@ public class TestOmKeyInfo {
         IAccessAuthorizer.ACLType.WRITE, ACCESS)));
 
     // Change acls and check.
-    Assertions.assertNotEquals(key, cloneKey);
+    assertNotEquals(key, cloneKey);
 
-    Assertions.assertNotEquals(key.getAcls(), cloneKey.getAcls());
+    assertNotEquals(key.getAcls(), cloneKey.getAcls());
 
     // clone now again
     cloneKey = key.copyObject();
 
-    Assertions.assertEquals(key.getAcls(), cloneKey.getAcls());
+    assertEquals(key.getAcls(), cloneKey.getAcls());
   }
 
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
@@ -16,12 +16,13 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test OmKeyLocationInfoGroup.
@@ -33,8 +34,8 @@ public class TestOmKeyLocationInfoGroup {
     OmKeyLocationInfoGroup testInstance = createTestInstance();
     List<OmKeyLocationInfo> latestList =
         testInstance.getBlocksLatestVersionOnly();
-    Assertions.assertEquals(1, latestList.size());
-    Assertions.assertEquals(2, latestList.get(0).getCreateVersion());
+    assertEquals(1, latestList.size());
+    assertEquals(2, latestList.get(0).getCreateVersion());
   }
 
   @Test
@@ -42,7 +43,7 @@ public class TestOmKeyLocationInfoGroup {
     OmKeyLocationInfoGroup testInstance = createTestInstance();
     Collection<OmKeyLocationInfo> list = testInstance.getLocationList(
         1L);
-    Assertions.assertEquals(2, list.size());
+    assertEquals(2, list.size());
   }
 
   @Test
@@ -51,9 +52,9 @@ public class TestOmKeyLocationInfoGroup {
     List<OmKeyLocationInfo> locationInfoList = createLocationList();
     OmKeyLocationInfoGroup newInstance =
         testInstance.generateNextVersion(locationInfoList);
-    Assertions.assertEquals(1, newInstance.getLocationList().size());
+    assertEquals(1, newInstance.getLocationList().size());
     // createTestInstance is of version 2, nextVersion should be 3
-    Assertions.assertEquals(3, newInstance.getVersion());
+    assertEquals(3, newInstance.getVersion());
 
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartUpload.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartUpload.java
@@ -17,8 +17,9 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test utilities inside OmMutipartUpload.
@@ -31,9 +32,9 @@ public class TestOmMultipartUpload {
         OmMultipartUpload.getDbKey("vol1", "bucket1", "dir1/key1", "uploadId");
     OmMultipartUpload info = OmMultipartUpload.from(key1);
 
-    Assertions.assertEquals("vol1", info.getVolumeName());
-    Assertions.assertEquals("bucket1", info.getBucketName());
-    Assertions.assertEquals("dir1/key1", info.getKeyName());
-    Assertions.assertEquals("uploadId", info.getUploadId());
+    assertEquals("vol1", info.getVolumeName());
+    assertEquals("bucket1", info.getBucketName());
+    assertEquals("dir1/key1", info.getKeyName());
+    assertEquals("uploadId", info.getUploadId());
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
@@ -25,11 +25,11 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Snapsho
 
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsUtils.toProtobuf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests SnapshotInfo metadata data structure holding state info for
@@ -102,7 +102,7 @@ public class TestOmSnapshotInfo {
   public void testSnapshotStatusProtoToObject() {
     OzoneManagerProtocolProtos.SnapshotInfo snapshotInfoEntry =
         createSnapshotInfoProto();
-    Assertions.assertEquals(SNAPSHOT_STATUS,
+    assertEquals(SNAPSHOT_STATUS,
         SnapshotStatus.valueOf(snapshotInfoEntry.getSnapshotStatus()));
   }
 
@@ -114,34 +114,34 @@ public class TestOmSnapshotInfo {
 
     OzoneManagerProtocolProtos.SnapshotInfo snapshotInfoEntryActual =
         snapshotInfo.getProtobuf();
-    Assertions.assertEquals(snapshotInfoEntryExpected.getSnapshotID(),
+    assertEquals(snapshotInfoEntryExpected.getSnapshotID(),
         snapshotInfoEntryActual.getSnapshotID());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getName(),
+    assertEquals(snapshotInfoEntryExpected.getName(),
         snapshotInfoEntryActual.getName());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getVolumeName(),
+    assertEquals(snapshotInfoEntryExpected.getVolumeName(),
         snapshotInfoEntryActual.getVolumeName());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getBucketName(),
+    assertEquals(snapshotInfoEntryExpected.getBucketName(),
         snapshotInfoEntryActual.getBucketName());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getSnapshotStatus(),
+    assertEquals(snapshotInfoEntryExpected.getSnapshotStatus(),
         snapshotInfoEntryActual.getSnapshotStatus());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getDbTxSequenceNumber(),
+    assertEquals(snapshotInfoEntryExpected.getDbTxSequenceNumber(),
         snapshotInfoEntryActual.getDbTxSequenceNumber());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getDeepClean(),
+    assertEquals(snapshotInfoEntryExpected.getDeepClean(),
         snapshotInfoEntryActual.getDeepClean());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getSstFiltered(),
+    assertEquals(snapshotInfoEntryExpected.getSstFiltered(),
         snapshotInfoEntryActual.getSstFiltered());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getReferencedSize(),
+    assertEquals(snapshotInfoEntryExpected.getReferencedSize(),
         snapshotInfoEntryActual.getReferencedSize());
-    Assertions.assertEquals(
+    assertEquals(
         snapshotInfoEntryExpected.getReferencedReplicatedSize(),
         snapshotInfoEntryActual.getReferencedReplicatedSize());
-    Assertions.assertEquals(snapshotInfoEntryExpected.getExclusiveSize(),
+    assertEquals(snapshotInfoEntryExpected.getExclusiveSize(),
         snapshotInfoEntryActual.getExclusiveSize());
-    Assertions.assertEquals(
+    assertEquals(
         snapshotInfoEntryExpected.getExclusiveReplicatedSize(),
         snapshotInfoEntryActual.getExclusiveReplicatedSize());
 
-    Assertions.assertEquals(snapshotInfoEntryExpected, snapshotInfoEntryActual);
+    assertEquals(snapshotInfoEntryExpected, snapshotInfoEntryActual);
   }
 
   @Test
@@ -152,32 +152,32 @@ public class TestOmSnapshotInfo {
 
     SnapshotInfo snapshotInfoActual = SnapshotInfo
         .getFromProtobuf(snapshotInfoEntry);
-    Assertions.assertEquals(snapshotInfoExpected.getSnapshotId(),
+    assertEquals(snapshotInfoExpected.getSnapshotId(),
         snapshotInfoActual.getSnapshotId());
-    Assertions.assertEquals(snapshotInfoExpected.getName(),
+    assertEquals(snapshotInfoExpected.getName(),
         snapshotInfoActual.getName());
-    Assertions.assertEquals(snapshotInfoExpected.getVolumeName(),
+    assertEquals(snapshotInfoExpected.getVolumeName(),
         snapshotInfoActual.getVolumeName());
-    Assertions.assertEquals(snapshotInfoExpected.getBucketName(),
+    assertEquals(snapshotInfoExpected.getBucketName(),
         snapshotInfoActual.getBucketName());
-    Assertions.assertEquals(snapshotInfoExpected.getSnapshotStatus(),
+    assertEquals(snapshotInfoExpected.getSnapshotStatus(),
         snapshotInfoActual.getSnapshotStatus());
-    Assertions.assertEquals(snapshotInfoExpected.getDbTxSequenceNumber(),
+    assertEquals(snapshotInfoExpected.getDbTxSequenceNumber(),
         snapshotInfoActual.getDbTxSequenceNumber());
-    Assertions.assertEquals(snapshotInfoExpected.getDeepClean(),
+    assertEquals(snapshotInfoExpected.getDeepClean(),
         snapshotInfoActual.getDeepClean());
-    Assertions.assertEquals(snapshotInfoExpected.isSstFiltered(),
+    assertEquals(snapshotInfoExpected.isSstFiltered(),
         snapshotInfoActual.isSstFiltered());
-    Assertions.assertEquals(snapshotInfoExpected.getReferencedSize(),
+    assertEquals(snapshotInfoExpected.getReferencedSize(),
         snapshotInfoActual.getReferencedSize());
-    Assertions.assertEquals(snapshotInfoExpected.getReferencedReplicatedSize(),
+    assertEquals(snapshotInfoExpected.getReferencedReplicatedSize(),
         snapshotInfoActual.getReferencedReplicatedSize());
-    Assertions.assertEquals(snapshotInfoExpected.getExclusiveSize(),
+    assertEquals(snapshotInfoExpected.getExclusiveSize(),
         snapshotInfoActual.getExclusiveSize());
-    Assertions.assertEquals(snapshotInfoExpected.getExclusiveReplicatedSize(),
+    assertEquals(snapshotInfoExpected.getExclusiveReplicatedSize(),
         snapshotInfoActual.getExclusiveReplicatedSize());
 
-    Assertions.assertEquals(snapshotInfoExpected, snapshotInfoActual);
+    assertEquals(snapshotInfoExpected, snapshotInfoActual);
   }
 
   @Test
@@ -185,6 +185,6 @@ public class TestOmSnapshotInfo {
     // GMT: Sunday, July 10, 2022 7:56:55.001 PM
     long millis = 1657483015001L;
     String name = SnapshotInfo.generateName(millis);
-    Assertions.assertEquals("s20220710-195655.001", name);
+    assertEquals("s20220710-195655.001", name);
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
@@ -24,10 +24,11 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Class to test {@link OmVolumeArgs}.
@@ -49,7 +50,7 @@ public class TestOmVolumeArgs {
 
     OmVolumeArgs cloneVolumeArgs = omVolumeArgs.copyObject();
 
-    Assertions.assertEquals(omVolumeArgs, cloneVolumeArgs);
+    assertEquals(omVolumeArgs, cloneVolumeArgs);
 
     // add user acl to write.
     omVolumeArgs.addAcl(new OzoneAcl(
@@ -57,7 +58,7 @@ public class TestOmVolumeArgs {
         IAccessAuthorizer.ACLType.WRITE, ACCESS));
 
     // Now check clone acl
-    Assertions.assertNotEquals(cloneVolumeArgs.getAcls().get(0),
+    assertNotEquals(cloneVolumeArgs.getAcls().get(0),
         omVolumeArgs.getAcls().get(0));
 
     // Set user acl to Write_ACL.
@@ -65,14 +66,14 @@ public class TestOmVolumeArgs {
         IAccessAuthorizer.ACLIdentityType.USER, "user1",
         IAccessAuthorizer.ACLType.WRITE_ACL, ACCESS)));
 
-    Assertions.assertNotEquals(cloneVolumeArgs.getAcls().get(0),
+    assertNotEquals(cloneVolumeArgs.getAcls().get(0),
         omVolumeArgs.getAcls().get(0));
 
     // Now clone and check. It should have same as original acl.
     cloneVolumeArgs = (OmVolumeArgs) omVolumeArgs.copyObject();
 
-    Assertions.assertEquals(omVolumeArgs, cloneVolumeArgs);
-    Assertions.assertEquals(cloneVolumeArgs.getAcls().get(0),
+    assertEquals(omVolumeArgs, cloneVolumeArgs);
+    assertEquals(cloneVolumeArgs.getAcls().get(0),
         omVolumeArgs.getAcls().get(0));
 
     omVolumeArgs.removeAcl(new OzoneAcl(
@@ -80,8 +81,8 @@ public class TestOmVolumeArgs {
         IAccessAuthorizer.ACLType.WRITE_ACL, ACCESS));
 
     // Removing acl, in original omVolumeArgs it should have no acls.
-    Assertions.assertEquals(0, omVolumeArgs.getAcls().size());
-    Assertions.assertEquals(1, cloneVolumeArgs.getAcls().size());
+    assertEquals(0, omVolumeArgs.getAcls().size());
+    assertEquals(1, cloneVolumeArgs.getAcls().size());
 
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -36,8 +35,10 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 
 /**
  * Test for OzoneAcls utility class.
@@ -202,8 +203,8 @@ public class TestOzoneAclUtil {
         OzoneAcl.parseAcl("user:masstter:rw[DEFAULT]"));
 
     //[user:masstter:rwx[DEFAULT]]
-    Assertions.assertEquals(1, ozoneAcls.size());
-    Assertions.assertEquals(DEFAULT, ozoneAcls.get(0).getAclScope());
+    assertEquals(1, ozoneAcls.size());
+    assertEquals(DEFAULT, ozoneAcls.get(0).getAclScope());
 
     ozoneAcls = new ArrayList<>();
     OzoneAclUtil.addAcl(ozoneAcls,
@@ -212,8 +213,8 @@ public class TestOzoneAclUtil {
         OzoneAcl.parseAcl("user:masstter:rw[ACCESS]"));
 
     //[user:masstter:rwx[ACCESS]]
-    Assertions.assertEquals(1, ozoneAcls.size());
-    Assertions.assertEquals(ACCESS, ozoneAcls.get(0).getAclScope());
+    assertEquals(1, ozoneAcls.size());
+    assertEquals(ACCESS, ozoneAcls.get(0).getAclScope());
 
     ozoneAcls = new ArrayList<>();
     OzoneAclUtil.addAcl(ozoneAcls,
@@ -222,10 +223,10 @@ public class TestOzoneAclUtil {
         OzoneAcl.parseAcl("user:masstter:rwx[ACCESS]"));
 
     //[user:masstter:rwx[ACCESS], user:masstter:rwx[DEFAULT]]
-    Assertions.assertEquals(2, ozoneAcls.size());
-    Assertions.assertNotEquals(ozoneAcls.get(0).getAclScope(),
+    assertEquals(2, ozoneAcls.size());
+    assertNotEquals(ozoneAcls.get(0).getAclScope(),
         ozoneAcls.get(1).getAclScope());
-    Assertions.assertEquals(ozoneAcls.get(0).getAclBitSet(),
+    assertEquals(ozoneAcls.get(0).getAclBitSet(),
         ozoneAcls.get(1).getAclBitSet());
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneFsUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneFsUtils.java
@@ -18,8 +18,10 @@
 
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test OzoneFsUtils.
@@ -28,12 +30,12 @@ public class TestOzoneFsUtils {
 
   @Test
   public void testPaths() {
-    Assertions.assertTrue(OzoneFSUtils.isValidName("/a/b"));
-    Assertions.assertFalse(OzoneFSUtils.isValidName("../../../a/b"));
-    Assertions.assertFalse(OzoneFSUtils.isValidName("/./."));
-    Assertions.assertFalse(OzoneFSUtils.isValidName("/:/"));
-    Assertions.assertFalse(OzoneFSUtils.isValidName("a/b"));
-    Assertions.assertFalse(OzoneFSUtils.isValidName("/a:/b"));
-    Assertions.assertFalse(OzoneFSUtils.isValidName("/a//b"));
+    assertTrue(OzoneFSUtils.isValidName("/a/b"));
+    assertFalse(OzoneFSUtils.isValidName("../../../a/b"));
+    assertFalse(OzoneFSUtils.isValidName("/./."));
+    assertFalse(OzoneFSUtils.isValidName("/:/"));
+    assertFalse(OzoneFSUtils.isValidName("a/b"));
+    assertFalse(OzoneFSUtils.isValidName("/a:/b"));
+    assertFalse(OzoneFSUtils.isValidName("/a//b"));
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneIdentityProvider.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneIdentityProvider.java
@@ -20,11 +20,13 @@ package org.apache.hadoop.ozone.om.helpers;
 import org.apache.hadoop.ipc.CallerContext;
 import org.apache.hadoop.ipc.Schedulable;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_S3_CALLER_CONTEXT_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test class for {@link OzoneIdentityProvider}.
@@ -104,7 +106,7 @@ public class TestOzoneIdentityProvider {
     String identity = identityProvider
         .makeIdentity(CALLER_CONTEXT_SCHEDULABLE);
 
-    Assertions.assertEquals(ACCESS_ID, identity);
+    assertEquals(ACCESS_ID, identity);
   }
 
   /**
@@ -116,11 +118,11 @@ public class TestOzoneIdentityProvider {
     String identity = identityProvider
         .makeIdentity(NO_PREFIX_CALLER_CONTEXT_SCHEDULABLE);
 
-    Assertions.assertFalse(
+    assertFalse(
         NO_PREFIX_CALLER_CONTEXT_SCHEDULABLE
             .getCallerContext().getContext()
             .startsWith(OM_S3_CALLER_CONTEXT_PREFIX));
-    Assertions.assertEquals(
+    assertEquals(
         NO_PREFIX_CALLER_CONTEXT_SCHEDULABLE
             .getUserGroupInformation()
             .getShortUserName(), identity);
@@ -132,14 +134,13 @@ public class TestOzoneIdentityProvider {
 
     // DEFAULT_SCHEDULABLE doesn't override CallerContext and
     // accessing it should throw an exception.
-    UnsupportedOperationException uoex = Assertions
-        .assertThrows(UnsupportedOperationException.class,
+    UnsupportedOperationException uoex = assertThrows(UnsupportedOperationException.class,
             DEFAULT_SCHEDULABLE::getCallerContext);
-    Assertions.assertEquals("Invalid operation.",
+    assertEquals("Invalid operation.",
         uoex.getMessage());
 
     String usernameFromUGI = DEFAULT_SCHEDULABLE
         .getUserGroupInformation().getShortUserName();
-    Assertions.assertEquals(usernameFromUGI, identity);
+    assertEquals(usernameFromUGI, identity);
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestQuotaUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestQuotaUtil.java
@@ -20,12 +20,12 @@ package org.apache.hadoop.ozone.om.helpers;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for the QuotaUtil class.
@@ -39,7 +39,7 @@ public class TestQuotaUtil {
     ReplicationConfig repConfig = RatisReplicationConfig.getInstance(THREE);
     long replicatedSize =
         QuotaUtil.getReplicatedSize(123 * ONE_MB, repConfig);
-    Assertions.assertEquals(123 * ONE_MB * 3, replicatedSize);
+    assertEquals(123 * ONE_MB * 3, replicatedSize);
   }
 
   @Test
@@ -47,7 +47,7 @@ public class TestQuotaUtil {
     ReplicationConfig repConfig = RatisReplicationConfig.getInstance(ONE);
     long replicatedSize =
         QuotaUtil.getReplicatedSize(123 * ONE_MB, repConfig);
-    Assertions.assertEquals(123 * ONE_MB, replicatedSize);
+    assertEquals(123 * ONE_MB, replicatedSize);
   }
 
   @Test
@@ -55,7 +55,7 @@ public class TestQuotaUtil {
     ECReplicationConfig repConfig = new ECReplicationConfig(3, 2, RS, ONE_MB);
     long dataSize = ONE_MB * 3 * 123; // 123 full stripe
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
-    Assertions.assertEquals(dataSize + 123 * ONE_MB * 2, replicatedSize);
+    assertEquals(dataSize + 123 * ONE_MB * 2, replicatedSize);
   }
 
   @Test
@@ -64,7 +64,7 @@ public class TestQuotaUtil {
     long dataSize = ONE_MB * 3 * 123 + 10; // 123 full stripes, plus 10 bytes
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
     // Expected is 123 parity stripes, plus another 10 bytes in each parity
-    Assertions.assertEquals(dataSize + 123 * ONE_MB * 2 + 10 * 2,
+    assertEquals(dataSize + 123 * ONE_MB * 2 + 10 * 2,
         replicatedSize);
   }
 
@@ -75,7 +75,7 @@ public class TestQuotaUtil {
     long dataSize = ONE_MB * 3 * 123 + ONE_MB + 10;
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
     // Expected is 123 parity stripes, plus another 1MB in each parity
-    Assertions.assertEquals(
+    assertEquals(
         dataSize + 123 * ONE_MB * 2 + ONE_MB * 2, replicatedSize);
   }
 
@@ -85,7 +85,7 @@ public class TestQuotaUtil {
     long dataSize = 10;
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
     // Expected is 123 parity stripes, plus another 1MB in each parity
-    Assertions.assertEquals(dataSize + 10 * 2, replicatedSize);
+    assertEquals(dataSize + 10 * 2, replicatedSize);
   }
 
   @Test
@@ -94,7 +94,7 @@ public class TestQuotaUtil {
     long dataSize = 2 * ONE_MB + 10;
     long replicatedSize = QuotaUtil.getReplicatedSize(dataSize, repConfig);
     // Expected is 123 parity stripes, plus another 1MB in each parity
-    Assertions.assertEquals(dataSize + ONE_MB * 2, replicatedSize);
+    assertEquals(dataSize + ONE_MB * 2, replicatedSize);
   }
 
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestKeyPathLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestKeyPathLock.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.lock;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +30,8 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests OzoneManagerLock.Resource.KEY_PATH_LOCK.
@@ -104,14 +105,14 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
 
     // For example, threadCount = 10, iterations = 100. The expected counter
     // value is 10 * 100
-    Assertions.assertEquals(((long) threadCount) * iterations,
+    assertEquals(((long) threadCount) * iterations,
         counter.getCount());
-    Assertions.assertEquals(threadCount, listTokens.size());
+    assertEquals(threadCount, listTokens.size());
 
     // Thread-1 -> 1 * 100,
     // Thread-2 -> 2 * 100 and so on.
     for (int i = 1; i <= listTokens.size(); i++) {
-      Assertions.assertEquals(Integer.valueOf(i * iterations),
+      assertEquals(Integer.valueOf(i * iterations),
           listTokens.get(i - 1));
     }
   }
@@ -134,7 +135,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     }
 
     // Now all threads have been instantiated.
-    Assertions.assertEquals(0, countDownLatch.getCount());
+    assertEquals(0, countDownLatch.getCount());
 
     lock.acquireWriteLock(resource, sampleResourceName);
     LOG.info("Write Lock Acquired by " + Thread.currentThread().getName());
@@ -201,7 +202,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
       return true; // all threads have finished counting down.
     }, 3000, 120000); // 2 minutes
 
-    Assertions.assertEquals(0, countDown.getCount());
+    assertEquals(0, countDown.getCount());
 
     for (Thread t : threads) {
       t.join();
@@ -221,7 +222,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     // Waiting for all the threads to be instantiated/to reach
     // acquireWriteLock.
     countDown.countDown();
-    Assertions.assertEquals(1, lock.getCurrentLocks().size());
+    assertEquals(1, lock.getCurrentLocks().size());
 
     lock.releaseWriteLock(resource, sampleResourceName);
     LOG.info("Write Lock Released by " + Thread.currentThread().getName());
@@ -248,7 +249,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire " + higherResource.getName() + " lock " +
           "while holding [" + resource.getName() + "] lock(s).";
-      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
+      assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
   }
 
@@ -273,7 +274,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire " + higherResource.getName() + " lock " +
           "while holding [" + resource.getName() + "] lock(s).";
-      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
+      assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
   }
 
@@ -298,7 +299,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire " + higherResource.getName() + " lock " +
           "while holding [" + resource.getName() + "] lock(s).";
-      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
+      assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
   }
 
@@ -323,7 +324,7 @@ public class TestKeyPathLock extends TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire " + higherResource.getName() + " lock " +
           "while holding [" + resource.getName() + "] lock(s).";
-      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
+      assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -26,12 +26,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -55,7 +56,7 @@ public class TestOzoneManagerLock {
     OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
     lock.acquireWriteLock(resource, resourceName);
     lock.releaseWriteLock(resource, resourceName);
-    Assertions.assertTrue(true);
+    assertTrue(true);
   }
 
   @Test
@@ -82,17 +83,17 @@ public class TestOzoneManagerLock {
       } catch (RuntimeException ex) {
         String message = "cannot acquire " + resource.getName() + " lock " +
             "while holding [" + resource.getName() + "] lock(s).";
-        Assertions.assertTrue(ex.getMessage().contains(message),
+        assertTrue(ex.getMessage().contains(message),
             ex.getMessage());
       }
       lock.releaseWriteLock(resource, resourceName);
-      Assertions.assertTrue(true);
+      assertTrue(true);
     } else {
       lock.acquireWriteLock(resource, resourceName);
       lock.acquireWriteLock(resource, resourceName);
       lock.releaseWriteLock(resource, resourceName);
       lock.releaseWriteLock(resource, resourceName);
-      Assertions.assertTrue(true);
+      assertTrue(true);
     }
   }
 
@@ -123,7 +124,7 @@ public class TestOzoneManagerLock {
             resourceInfo.getLockName());
       }
     }
-    Assertions.assertTrue(true);
+    assertTrue(true);
   }
 
   @Test
@@ -140,7 +141,7 @@ public class TestOzoneManagerLock {
           } catch (RuntimeException ex) {
             String message = "cannot acquire " + resource.getName() + " lock " +
                 "while holding [" + higherResource.getName() + "] lock(s).";
-            Assertions.assertTrue(ex.getMessage().contains(message),
+            assertTrue(ex.getMessage().contains(message),
                 ex.getMessage());
           }
           lock.releaseWriteLock(higherResource, resourceName);
@@ -173,7 +174,7 @@ public class TestOzoneManagerLock {
           } catch (RuntimeException ex) {
             String message = "cannot acquire " + resource.getName() + " lock " +
                 "while holding " + currentLocks + " lock(s).";
-            Assertions.assertTrue(ex.getMessage().contains(message),
+            assertTrue(ex.getMessage().contains(message),
                 ex.getMessage());
           }
         }
@@ -236,7 +237,7 @@ public class TestOzoneManagerLock {
     OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
     lock.acquireMultiUserLock("user1", "user2");
     lock.releaseMultiUserLock("user1", "user2");
-    Assertions.assertTrue(true);
+    assertTrue(true);
   }
 
   @Test
@@ -249,7 +250,7 @@ public class TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire USER_LOCK lock while holding " +
           "[USER_LOCK] lock(s).";
-      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
+      assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
     lock.releaseMultiUserLock("user1", "user2");
   }
@@ -264,7 +265,7 @@ public class TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire USER_LOCK lock while holding " +
           "[USER_LOCK] lock(s).";
-      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
+      assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
     lock.releaseWriteLock(Resource.USER_LOCK, "user3");
   }
@@ -279,7 +280,7 @@ public class TestOzoneManagerLock {
     } catch (RuntimeException ex) {
       String message = "cannot acquire USER_LOCK lock while holding " +
           "[USER_LOCK] lock(s).";
-      Assertions.assertTrue(ex.getMessage().contains(message), ex.getMessage());
+      assertTrue(ex.getMessage().contains(message), ex.getMessage());
     }
     lock.releaseMultiUserLock("user1", "user2");
   }
@@ -303,13 +304,13 @@ public class TestOzoneManagerLock {
       Thread.sleep(100);
       // Since the new thread is trying to get lock on same resource,
       // it will wait.
-      Assertions.assertFalse(gotLock.get());
+      assertFalse(gotLock.get());
       lock.releaseWriteLock(resource, resourceName);
       // Since we have released the lock, the new thread should have the lock
       // now.
       // Let's give some time for the new thread to run
       Thread.sleep(100);
-      Assertions.assertTrue(gotLock.get());
+      assertTrue(gotLock.get());
     }
 
   }
@@ -329,13 +330,13 @@ public class TestOzoneManagerLock {
     Thread.sleep(100);
     // Since the new thread is trying to get lock on same resource, it will
     // wait.
-    Assertions.assertFalse(gotLock.get());
+    assertFalse(gotLock.get());
     lock.releaseMultiUserLock("user2", "user1");
     // Since we have released the lock, the new thread should have the lock
     // now.
     // Let's give some time for the new thread to run
     Thread.sleep(100);
-    Assertions.assertTrue(gotLock.get());
+    assertTrue(gotLock.get());
   }
 
   @Test
@@ -370,26 +371,26 @@ public class TestOzoneManagerLock {
     lock.releaseReadLock(resource, resourceName);
     assertEquals(0, lock.getReadHoldCount(resource, resourceName));
 
-    Assertions.assertFalse(
+    assertFalse(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(0, lock.getWriteHoldCount(resource, resourceName));
     lock.acquireWriteLock(resource, resourceName);
-    Assertions.assertTrue(
+    assertTrue(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(1, lock.getWriteHoldCount(resource, resourceName));
 
     lock.acquireWriteLock(resource, resourceName);
-    Assertions.assertTrue(
+    assertTrue(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(2, lock.getWriteHoldCount(resource, resourceName));
 
     lock.releaseWriteLock(resource, resourceName);
-    Assertions.assertTrue(
+    assertTrue(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(1, lock.getWriteHoldCount(resource, resourceName));
 
     lock.releaseWriteLock(resource, resourceName);
-    Assertions.assertFalse(
+    assertFalse(
         lock.isWriteLockedByCurrentThread(resource, resourceName));
     assertEquals(0, lock.getWriteHoldCount(resource, resourceName));
   }
@@ -432,13 +433,13 @@ public class TestOzoneManagerLock {
     }
 
     String readHeldStat = lock.getOMLockMetrics().getReadLockHeldTimeMsStat();
-    Assertions.assertTrue(readHeldStat.contains("Samples = " + threadCount),
+    assertTrue(readHeldStat.contains("Samples = " + threadCount),
         "Expected " + threadCount +
             " samples in readLockHeldTimeMsStat: " + readHeldStat);
 
     String readWaitingStat =
         lock.getOMLockMetrics().getReadLockWaitingTimeMsStat();
-    Assertions.assertTrue(readWaitingStat.contains("Samples = " + threadCount),
+    assertTrue(readWaitingStat.contains("Samples = " + threadCount),
         "Expected " + threadCount +
             " samples in readLockWaitingTimeMsStat: " + readWaitingStat);
   }
@@ -468,13 +469,13 @@ public class TestOzoneManagerLock {
     }
 
     String writeHeldStat = lock.getOMLockMetrics().getWriteLockHeldTimeMsStat();
-    Assertions.assertTrue(writeHeldStat.contains("Samples = " + threadCount),
+    assertTrue(writeHeldStat.contains("Samples = " + threadCount),
         "Expected " + threadCount +
             " samples in writeLockHeldTimeMsStat: " + writeHeldStat);
 
     String writeWaitingStat =
         lock.getOMLockMetrics().getWriteLockWaitingTimeMsStat();
-    Assertions.assertTrue(writeWaitingStat.contains("Samples = " + threadCount),
+    assertTrue(writeWaitingStat.contains("Samples = " + threadCount),
         "Expected " + threadCount +
             " samples in writeLockWaitingTimeMsStat" + writeWaitingStat);
   }
@@ -524,26 +525,26 @@ public class TestOzoneManagerLock {
     }
 
     String readHeldStat = lock.getOMLockMetrics().getReadLockHeldTimeMsStat();
-    Assertions.assertTrue(readHeldStat.contains("Samples = " + readThreadCount),
+    assertTrue(readHeldStat.contains("Samples = " + readThreadCount),
         "Expected " + readThreadCount +
             " samples in readLockHeldTimeMsStat: " + readHeldStat);
 
     String readWaitingStat =
         lock.getOMLockMetrics().getReadLockWaitingTimeMsStat();
-    Assertions.assertTrue(readWaitingStat.contains(
+    assertTrue(readWaitingStat.contains(
             "Samples = " + readThreadCount),
         "Expected " + readThreadCount +
             " samples in readLockWaitingTimeMsStat: " + readWaitingStat);
 
     String writeHeldStat = lock.getOMLockMetrics().getWriteLockHeldTimeMsStat();
-    Assertions.assertTrue(writeHeldStat.contains(
+    assertTrue(writeHeldStat.contains(
             "Samples = " + writeThreadCount),
         "Expected " + writeThreadCount +
             " samples in writeLockHeldTimeMsStat: " + writeHeldStat);
 
     String writeWaitingStat =
         lock.getOMLockMetrics().getWriteLockWaitingTimeMsStat();
-    Assertions.assertTrue(writeWaitingStat.contains(
+    assertTrue(writeWaitingStat.contains(
             "Samples = " + writeThreadCount),
         "Expected " + writeThreadCount +
             " samples in writeLockWaitingTimeMsStat" + writeWaitingStat);
@@ -555,16 +556,16 @@ public class TestOzoneManagerLock {
     try {
       MetricsCollectorImpl metricsCollector = new MetricsCollectorImpl();
       omLockMetrics.getMetrics(metricsCollector, true);
-      Assertions.assertEquals(1, metricsCollector.getRecords().size());
+      assertEquals(1, metricsCollector.getRecords().size());
 
       String omLockMetricsRecords = metricsCollector.getRecords().toString();
-      Assertions.assertTrue(omLockMetricsRecords.contains(
+      assertTrue(omLockMetricsRecords.contains(
           "ReadLockWaitingTime"), omLockMetricsRecords);
-      Assertions.assertTrue(omLockMetricsRecords.contains("ReadLockHeldTime"),
+      assertTrue(omLockMetricsRecords.contains("ReadLockHeldTime"),
           omLockMetricsRecords);
-      Assertions.assertTrue(omLockMetricsRecords.contains(
+      assertTrue(omLockMetricsRecords.contains(
           "WriteLockWaitingTime"), omLockMetricsRecords);
-      Assertions.assertTrue(omLockMetricsRecords.contains("WriteLockHeldTime"),
+      assertTrue(omLockMetricsRecords.contains("WriteLockHeldTime"),
           omLockMetricsRecords);
     } finally {
       omLockMetrics.unRegister();

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/TestS3GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/TestS3GrpcOmTransport.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
@@ -48,6 +47,8 @@ import com.google.protobuf.ServiceException;
 import org.apache.ratis.protocol.RaftPeerId;
 
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.ozone.om.OMConfigKeys
     .OZONE_OM_GRPC_MAXIMUM_RESPONSE_LENGTH;
 
@@ -165,9 +166,9 @@ public class TestS3GrpcOmTransport {
     client.startClient(channel);
 
     final OMResponse resp = client.submitRequest(omRequest);
-    Assertions.assertEquals(resp.getStatus(), org.apache.hadoop.ozone.protocol
+    assertEquals(resp.getStatus(), org.apache.hadoop.ozone.protocol
         .proto.OzoneManagerProtocolProtos.Status.OK);
-    Assertions.assertEquals(resp.getLeaderOMNodeId(), leaderOMNodeId);
+    assertEquals(resp.getLeaderOMNodeId(), leaderOMNodeId);
   }
 
   @Test
@@ -189,9 +190,9 @@ public class TestS3GrpcOmTransport {
     // failover is performed and request is internally retried
     // second invocation request to server succeeds
     final OMResponse resp = client.submitRequest(omRequest);
-    Assertions.assertEquals(resp.getStatus(), org.apache.hadoop.ozone.protocol
+    assertEquals(resp.getStatus(), org.apache.hadoop.ozone.protocol
         .proto.OzoneManagerProtocolProtos.Status.OK);
-    Assertions.assertEquals(resp.getLeaderOMNodeId(), leaderOMNodeId);
+    assertEquals(resp.getLeaderOMNodeId(), leaderOMNodeId);
   }
 
   @Test
@@ -219,7 +220,7 @@ public class TestS3GrpcOmTransport {
       final OMResponse resp = client.submitRequest(omRequest);
       fail();
     } catch (Exception e) {
-      Assertions.assertTrue(true);
+      assertTrue(true);
     }
   }
 
@@ -254,7 +255,7 @@ public class TestS3GrpcOmTransport {
       final OMResponse resp = client.submitRequest(omRequest);
       fail();
     } catch (Exception e) {
-      Assertions.assertTrue(true);
+      assertTrue(true);
     }
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/grpc/TestClientAddressClientInterceptor.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/grpc/TestClientAddressClientInterceptor.java
@@ -27,12 +27,12 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 /**
  * Test OM GRPC client interceptor to define client ip and hostname headers.
@@ -42,7 +42,7 @@ public class TestClientAddressClientInterceptor {
   @Test
   public void testClientAddressEntriesInRequestHeaders() {
     try (MockedStatic<Context> grpcContextStaticMock =
-             Mockito.mockStatic(Context.class)) {
+             mockStatic(Context.class)) {
       // given
       Context.Key<String> ipAddressContextKey = mock(Context.Key.class);
       when(ipAddressContextKey.get()).thenReturn("172.43.3.2");

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/grpc/TestClientAddressServerInterceptor.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/grpc/TestClientAddressServerInterceptor.java
@@ -27,11 +27,11 @@ import io.grpc.ServerInterceptor;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -42,7 +42,7 @@ public class TestClientAddressServerInterceptor {
   @Test
   public void testClientAddressEntriesInHeaders() {
     try (MockedStatic<Contexts> contextsMockedStatic =
-             Mockito.mockStatic(Contexts.class)) {
+             mockStatic(Contexts.class)) {
       // given
       ServerInterceptor serverInterceptor =
           new ClientAddressServerInterceptor();

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/grpc/TestClientAddressServerInterceptor.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/protocolPB/grpc/TestClientAddressServerInterceptor.java
@@ -24,7 +24,6 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
@@ -33,6 +32,7 @@ import org.mockito.Mockito;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test OM GRPC server interceptor to define client ip and hostname.
@@ -68,9 +68,9 @@ public class TestClientAddressServerInterceptor {
       );
       Context context = contextArgumentCaptor.getValue();
       context.attach();
-      Assertions.assertEquals("host.example.com",
+      assertEquals("host.example.com",
           GrpcClientConstants.CLIENT_HOSTNAME_CTX_KEY.get());
-      Assertions.assertEquals("173.56.23.4",
+      assertEquals("173.56.23.4",
           GrpcClientConstants.CLIENT_IP_ADDRESS_CTX_KEY.get());
     }
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestGDPRSymmetricKey.java
@@ -18,10 +18,12 @@ package org.apache.hadoop.ozone.security;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.security.SecureRandom;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests GDPRSymmetricKey structure.
@@ -32,11 +34,11 @@ public class TestGDPRSymmetricKey {
   public void testKeyGenerationWithDefaults() throws Exception {
     GDPRSymmetricKey gkey = new GDPRSymmetricKey(new SecureRandom());
 
-    Assertions.assertTrue(gkey.getCipher().getAlgorithm()
+    assertTrue(gkey.getCipher().getAlgorithm()
         .equalsIgnoreCase(OzoneConsts.GDPR_ALGORITHM_NAME));
 
     gkey.acceptKeyDetails(
-        (k, v) -> Assertions.assertTrue(v.length() > 0));
+        (k, v) -> assertTrue(v.length() > 0));
   }
 
   @Test
@@ -45,11 +47,11 @@ public class TestGDPRSymmetricKey {
         RandomStringUtils.randomAlphabetic(16),
         OzoneConsts.GDPR_ALGORITHM_NAME);
 
-    Assertions.assertTrue(gkey.getCipher().getAlgorithm()
+    assertTrue(gkey.getCipher().getAlgorithm()
         .equalsIgnoreCase(OzoneConsts.GDPR_ALGORITHM_NAME));
 
     gkey.acceptKeyDetails(
-        (k, v) -> Assertions.assertTrue(v.length() > 0));
+        (k, v) -> assertTrue(v.length() > 0));
   }
 
   @Test
@@ -57,9 +59,9 @@ public class TestGDPRSymmetricKey {
     try {
       new GDPRSymmetricKey(RandomStringUtils.randomAlphabetic(5),
           OzoneConsts.GDPR_ALGORITHM_NAME);
-      Assertions.fail("Expect length mismatched");
+      fail("Expect length mismatched");
     } catch (IllegalArgumentException ex) {
-      Assertions.assertTrue(ex.getMessage()
+      assertTrue(ex.getMessage()
           .equalsIgnoreCase("Secret must be exactly 16 characters"));
     }
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSelector.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSelector.java
@@ -21,13 +21,14 @@ package org.apache.hadoop.ozone.security;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.Token;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.apache.hadoop.ozone.security.OzoneTokenIdentifier.KIND_NAME;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Class to test OzoneDelegationTokenSelector.
@@ -59,7 +60,7 @@ public class TestOzoneDelegationTokenSelector {
             Collections.singletonList(tokenIdentifierToken));
 
 
-    Assertions.assertNotNull(selectedToken);
+    assertNotNull(selectedToken);
 
 
     tokenIdentifierToken.setService(new Text("om1:9863"));
@@ -67,14 +68,14 @@ public class TestOzoneDelegationTokenSelector {
         ozoneDelegationTokenSelector.selectToken(service,
             Collections.singletonList(tokenIdentifierToken));
 
-    Assertions.assertNull(selectedToken);
+    assertNull(selectedToken);
 
     service = new Text("om1:9863");
     selectedToken =
         ozoneDelegationTokenSelector.selectToken(service,
             Collections.singletonList(tokenIdentifierToken));
 
-    Assertions.assertNotNull(selectedToken);
+    assertNotNull(selectedToken);
 
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add static import for assertions and mocks in hadoop-ozone/common.
The goal of this task is to add import static for all assertions and interactions with mocks.

## What is the link to the Apache JIRA

HDDS-9989

## How was this patch tested?

CI test:
https://github.com/TaiJuWu/ozone/actions/runs/7313708292