### PR TITLE
HDDS-9982. Improve assertTrue assertions in hdds-server-framework

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.conf;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -113,7 +114,7 @@ public class TestHddsConfServlet {
     assertEquals(result, tags);
     // cmd is getPropertyByTag
     result = getResultWithCmd(conf, "getPropertyByTag");
-    assertTrue(result.contains("ozone.test.test.key"));
+    assertThat(result).contains("ozone.test.test.key");
     // cmd is illegal
     getResultWithCmd(conf, "illegal");
   }
@@ -254,13 +255,12 @@ public class TestHddsConfServlet {
       // in the response
       if (Strings.isNullOrEmpty(propertyName)) {
         for (Map.Entry<String, String> entry : TEST_PROPERTIES.entrySet()) {
-          assertTrue(result.contains(entry.getKey()) &&
-                  result.contains(entry.getValue()));
+          assertThat(result).contains(entry.getKey(), entry.getValue());
         }
       } else {
         if (conf.get(propertyName) != null) {
           // if property name is not empty and property is found
-          assertTrue(result.contains(propertyName));
+          assertThat(result).contains(propertyName);
           for (Map.Entry<String, String> entry : TEST_PROPERTIES.entrySet()) {
             if (!entry.getKey().equals(propertyName)) {
               assertFalse(result.contains(entry.getKey()));

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.conf;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
@@ -263,7 +262,7 @@ public class TestHddsConfServlet {
           assertThat(result).contains(propertyName);
           for (Map.Entry<String, String> entry : TEST_PROPERTIES.entrySet()) {
             if (!entry.getKey().equals(propertyName)) {
-              assertFalse(result.contains(entry.getKey()));
+              assertThat(result).doesNotContain(entry.getKey());
             }
           }
         } else {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestPemFileBasedKeyStoresFactory.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestPemFileBasedKeyStoresFactory.java
@@ -52,8 +52,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test PemFileBasedKeyStoresFactory.
@@ -79,18 +79,15 @@ public class TestPemFileBasedKeyStoresFactory {
       keyStoresFactory.init(KeyStoresFactory.Mode.CLIENT, clientAuth);
       assertEquals(clientAuth, keyStoresFactory.getKeyManagers()[0]
           instanceof ReloadingX509KeyManager);
-      assertTrue(keyStoresFactory.getTrustManagers()[0]
-          instanceof ReloadingX509TrustManager);
+      assertInstanceOf(ReloadingX509TrustManager.class, keyStoresFactory.getTrustManagers()[0]);
     } finally {
       keyStoresFactory.destroy();
     }
 
     try {
       keyStoresFactory.init(KeyStoresFactory.Mode.SERVER, clientAuth);
-      assertTrue(keyStoresFactory.getKeyManagers()[0]
-          instanceof ReloadingX509KeyManager);
-      assertTrue(keyStoresFactory.getTrustManagers()[0]
-          instanceof ReloadingX509TrustManager);
+      assertInstanceOf(ReloadingX509KeyManager.class, keyStoresFactory.getKeyManagers()[0]);
+      assertInstanceOf(ReloadingX509TrustManager.class, keyStoresFactory.getTrustManagers()[0]);
     } finally {
       keyStoresFactory.destroy();
     }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509KeyManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509KeyManager.java
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.Test;
 import javax.net.ssl.KeyManager;
 import java.security.PrivateKey;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test ReloadingX509KeyManager.
@@ -61,8 +61,7 @@ public class TestReloadingX509KeyManager {
     assertEquals(privateKey2, ((ReloadingX509KeyManager)km).getPrivateKey(
         caClient.getComponentName() + "_key"));
 
-    assertTrue(reloaderLog.getOutput().contains(
-        "ReloadingX509KeyManager is reloaded"));
+    assertThat(reloaderLog.getOutput()).contains("ReloadingX509KeyManager is reloaded");
 
     // Make sure there is two reloads happened, one for server, one for client
     assertEquals(2, StringUtils.countMatches(reloaderLog.getOutput(),

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestSecretKeyManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestSecretKeyManager.java
@@ -34,10 +34,10 @@ import java.util.stream.Stream;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -110,8 +110,7 @@ public class TestSecretKeyManager {
       // expect the current key is newly generated.
       assertFalse(savedSecretKey.contains(state.getCurrentKey()));
       assertEquals(1, state.getSortedKeys().size());
-      assertTrue(state.getSortedKeys().contains(
-          state.getCurrentKey()));
+      assertThat(state.getSortedKeys()).contains(state.getCurrentKey());
     }
   }
 
@@ -119,7 +118,7 @@ public class TestSecretKeyManager {
                                      Collection<ManagedSecretKey> actual) {
     assertEquals(expected.size(), actual.size());
     for (ManagedSecretKey expectedKey : expected) {
-      assertTrue(actual.contains(expectedKey));
+      assertThat(actual).contains(expectedKey);
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestSecretKeyManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/symmetric/TestSecretKeyManager.java
@@ -36,7 +36,6 @@ import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.mockito.Mockito.mock;
@@ -108,7 +107,7 @@ public class TestSecretKeyManager {
       assertSameKeys(expectedLoadedKeys, allKeys);
     } else {
       // expect the current key is newly generated.
-      assertFalse(savedSecretKey.contains(state.getCurrentKey()));
+      assertThat(savedSecretKey).doesNotContain(state.getCurrentKey());
       assertEquals(1, state.getSortedKeys().size());
       assertThat(state.getSortedKeys()).contains(state.getCurrentKey());
     }
@@ -170,7 +169,7 @@ public class TestSecretKeyManager {
       // 1. A new key is generated as current key.
       ManagedSecretKey currentKey = state.getCurrentKey();
       assertNotEquals(initialCurrentKey, currentKey);
-      assertFalse(initialKeys.contains(currentKey));
+      assertThat(initialKeys).doesNotContain(currentKey);
 
       // 2. keys are correctly rotated, expired ones are excluded.
       List<ManagedSecretKey> expectedAllKeys = expectedRetainedKeys;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -73,6 +73,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.OM;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_CA_CERT_STORAGE_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_CA_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -130,7 +131,7 @@ public class TestDefaultCAServer {
     } catch (IllegalStateException e) {
       // This also is a runtime exception. Hence not caught by junit expected
       // exception.
-      assertTrue(e.toString().contains("Missing Root Certs"));
+      assertThat(e.toString()).contains("Missing Root Certs");
     }
   }
 
@@ -151,7 +152,7 @@ public class TestDefaultCAServer {
     } catch (IllegalStateException e) {
       // This also is a runtime exception. Hence not caught by junit expected
       // exception.
-      assertTrue(e.toString().contains("Missing Keys"));
+      assertThat(e.toString()).contains("Missing Keys");
     }
   }
 
@@ -296,8 +297,7 @@ public class TestDefaultCAServer {
               CRLReason.lookup(CRLReason.keyCompromise), now);
           result.get();
         });
-    assertTrue(execution.getCause().getMessage()
-        .contains("Certificates cannot be null"));
+    assertThat(execution.getCause().getMessage()).contains("Certificates cannot be null");
   }
 
   @Test
@@ -331,8 +331,8 @@ public class TestDefaultCAServer {
                   String.valueOf(System.nanoTime()));
           holder.get();
         });
-    assertTrue(execution.getCause().getMessage()
-        .contains("ScmId and ClusterId in CSR subject are incorrect"));
+    assertThat(execution.getCause().getMessage())
+        .contains("ScmId and ClusterId in CSR subject are incorrect");
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -297,7 +297,8 @@ public class TestDefaultCAServer {
               CRLReason.lookup(CRLReason.keyCompromise), now);
           result.get();
         });
-    assertThat(execution.getCause().getMessage()).contains("Certificates cannot be null");
+    assertThat(execution.getCause().getMessage())
+        .contains("Certificates cannot be null");
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -68,6 +68,7 @@ import static org.apache.hadoop.hdds.security.x509.certificate.client.Certificat
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -186,7 +187,7 @@ public class TestDefaultCertificateClient {
     cert = dnCertClient.getCertificate(
         x509Certificate.getSerialNumber().toString());
     assertNotNull(cert);
-    assertTrue(cert.getEncoded().length > 0);
+    assertThat(cert.getEncoded().length).isGreaterThan(0);
     assertEquals(x509Certificate, cert);
 
     // TODO: test verifyCertificate once implemented.
@@ -213,8 +214,8 @@ public class TestDefaultCertificateClient {
     // Expect error when there is no private key to sign.
     IOException ioException = assertThrows(IOException.class,
         () -> dnCertClient.signData(data.getBytes(UTF_8)));
-    assertTrue(ioException.getMessage()
-        .contains("Error while signing the stream"));
+    assertThat(ioException.getMessage())
+        .contains("Error while signing the stream");
 
     generateKeyPairFiles();
     byte[] sign = dnCertClient.signData(data.getBytes(UTF_8));
@@ -288,17 +289,17 @@ public class TestDefaultCertificateClient {
     CertificateException certException = assertThrows(
         CertificateException.class,
         () -> dnCertClient.getCertificate(cert1.getSerialNumber().toString()));
-    assertTrue(certException.getMessage()
-        .contains("Error while getting certificate"));
+    assertThat(certException.getMessage())
+        .contains("Error while getting certificate");
     certException = assertThrows(CertificateException.class,
         () -> dnCertClient.getCertificate(cert2.getSerialNumber().toString()));
-    assertTrue(certException.getMessage()
-        .contains("Error while getting certificate"));
+    assertThat(certException.getMessage())
+        .contains("Error while getting certificate");
     certException = assertThrows(CertificateException.class,
         () -> dnCertClient.getCertificate(cert3.getSerialNumber()
             .toString()));
-    assertTrue(certException.getMessage()
-        .contains("Error while getting certificate"));
+    assertThat(certException.getMessage())
+        .contains("Error while getting certificate");
     codec.writeCertificate(certPath, "1.crt",
         getPEMEncodedString(cert1));
     codec.writeCertificate(certPath, "2.crt",
@@ -334,11 +335,11 @@ public class TestDefaultCertificateClient {
         .toString()));
 
     assertEquals(2, dnCertClient.getAllCaCerts().size());
-    assertTrue(dnCertClient.getAllCaCerts().contains(subCa1));
-    assertTrue(dnCertClient.getAllCaCerts().contains(subCa2));
+    assertThat(dnCertClient.getAllCaCerts()).contains(subCa1);
+    assertThat(dnCertClient.getAllCaCerts()).contains(subCa2);
     assertEquals(2, dnCertClient.getAllRootCaCerts().size());
-    assertTrue(dnCertClient.getAllRootCaCerts().contains(rootCa1));
-    assertTrue(dnCertClient.getAllRootCaCerts().contains(rootCa2));
+    assertThat(dnCertClient.getAllRootCaCerts()).contains(rootCa1);
+    assertThat(dnCertClient.getAllRootCaCerts()).contains(rootCa2);
   }
 
   @Test
@@ -399,7 +400,7 @@ public class TestDefaultCertificateClient {
 
     // Check for DN.
     assertEquals(FAILURE, dnCertClient.init());
-    assertTrue(dnClientLog.getOutput().contains("Keypair validation failed"));
+    assertThat(dnClientLog.getOutput()).contains("Keypair validation failed");
     dnClientLog.clearOutput();
 
     // Case 2. Expect failure when certificate is generated from different
@@ -415,7 +416,7 @@ public class TestDefaultCertificateClient {
         x509Certificate.getEncoded()));
     // Check for DN.
     assertEquals(FAILURE, dnCertClient.init());
-    assertTrue(dnClientLog.getOutput().contains("Keypair validation failed"));
+    assertThat(dnClientLog.getOutput()).contains("Keypair validation failed");
     dnClientLog.clearOutput();
 
     // Case 3. Expect failure when certificate is generated from different
@@ -430,8 +431,8 @@ public class TestDefaultCertificateClient {
 
     // Check for DN.
     assertEquals(FAILURE, dnCertClient.init());
-    assertTrue(dnClientLog.getOutput()
-        .contains("Stored certificate is generated with different"));
+    assertThat(dnClientLog.getOutput())
+        .contains("Stored certificate is generated with different");
     dnClientLog.clearOutput();
 
     // Case 4. Failure when public key recovery fails.
@@ -442,7 +443,7 @@ public class TestDefaultCertificateClient {
 
     // Check for DN.
     assertEquals(FAILURE, dnCertClient.init());
-    assertTrue(dnClientLog.getOutput().contains("Can't recover public key"));
+    assertThat(dnClientLog.getOutput()).contains("Can't recover public key");
   }
 
   @Test
@@ -464,8 +465,8 @@ public class TestDefaultCertificateClient {
     dnCertClient.storeCertificate(
         getPEMEncodedString(cert), CAType.SUBORDINATE);
     duration = dnCertClient.timeBeforeExpiryGracePeriod(cert);
-    assertTrue(duration.toMillis() < Duration.ofDays(1).toMillis() &&
-        duration.toMillis() > Duration.ofHours(23).plusMinutes(59).toMillis());
+    assertThat(duration.toMillis()).isLessThan(Duration.ofDays(1).toMillis())
+        .isGreaterThan(Duration.ofHours(23).plusMinutes(59).toMillis());
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestRootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestRootCaRotationPoller.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -167,12 +168,12 @@ public class TestRootCaRotationPoller {
     //Then the first run encounters an error
     poller.pollRootCas();
     processingResult.join();
-    assertTrue(logCapturer.getOutput().contains(
-        "There was a caught exception when trying to sign the certificate"));
+    assertThat(logCapturer.getOutput()).contains(
+        "There was a caught exception when trying to sign the certificate");
     //And then the second clean run is successful.
     poller.pollRootCas();
-    assertTrue(logCapturer.getOutput().contains(
-        "Certificate processing was successful."));
+    assertThat(logCapturer.getOutput()).contains(
+        "Certificate processing was successful.");
   }
 
   private X509Certificate generateX509Cert(

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCRLCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCRLCodec.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.utils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -204,8 +205,8 @@ public class TestCRLCodec {
     // Verify header and footer of PEM encoded String
     String header = "-----BEGIN X509 CRL-----";
     String footer = "-----END X509 CRL-----";
-    assertTrue(pemEncodedString.contains(header));
-    assertTrue(pemEncodedString.contains(footer));
+    assertThat(pemEncodedString).contains(header);
+    assertThat(pemEncodedString).contains(footer);
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestKeyCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestKeyCodec.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.keys;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -105,13 +106,13 @@ public class TestKeyCodec {
     // format exists.
     byte[] privateKey = Files.readAllBytes(privateKeyPath);
     String privateKeydata = new String(privateKey, StandardCharsets.UTF_8);
-    assertTrue(privateKeydata.contains("PRIVATE KEY"));
+    assertThat(privateKeydata).contains("PRIVATE KEY");
 
     // Read the public key and test if the expected String in the PEM file
     // format exists.
     byte[] publicKey = Files.readAllBytes(publicKeyPath);
     String publicKeydata = new String(publicKey, StandardCharsets.UTF_8);
-    assertTrue(publicKeydata.contains("PUBLIC KEY"));
+    assertThat(publicKeydata).contains("PUBLIC KEY");
 
     // Let us decode the PEM file and parse it back into binary.
     KeyFactory kf = KeyFactory.getInstance(
@@ -182,15 +183,15 @@ public class TestKeyCodec {
     // Assert that rewriting of keys throws exception with valid messages.
     IOException ioException = assertThrows(IOException.class,
             () -> pemWriter.writeKey(kp));
-    assertTrue(ioException.getMessage()
-        .contains("Private Key file already exists."));
+    assertThat(ioException.getMessage())
+        .contains("Private Key file already exists.");
     FileUtils.deleteQuietly(Paths.get(
         secConfig.getKeyLocation(component).toString() + "/" + secConfig
             .getPrivateKeyFileName()).toFile());
     ioException = assertThrows(IOException.class,
             () -> pemWriter.writeKey(kp));
-    assertTrue(ioException.getMessage()
-        .contains("Public Key file already exists."));
+    assertThat(ioException.getMessage())
+        .contains("Public Key file already exists.");
     FileUtils.deleteQuietly(Paths.get(
         secConfig.getKeyLocation(component).toString() + "/" + secConfig
             .getPublicKeyFileName()).toFile());
@@ -215,8 +216,8 @@ public class TestKeyCodec {
     // Assert key rewrite fails in non Posix file system.
     IOException ioException = assertThrows(IOException.class,
             () -> pemWriter.writeKey(kp));
-    assertTrue(ioException.getMessage()
-        .contains("Unsupported File System for pem file."));
+    assertThat(ioException.getMessage())
+        .contains("Unsupported File System for pem file.");
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.client.OzoneQuota;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -46,7 +47,8 @@ public class TestJsonUtils {
   }
 
   private static void assertContains(String str, String part) {
-    assertTrue(str.contains(part),
-        "Expected JSON to contain '" + part + "', but didn't: " + str);
+    assertThat(str)
+        .withFailMessage("Expected JSON to contain '" + part + "', but didn't: " + str)
+        .contains(part);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test the json object printer.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
@@ -46,8 +46,6 @@ public class TestJsonUtils {
   }
 
   private static void assertContains(String str, String part) {
-    assertThat(str)
-        .withFailMessage("Expected JSON to contain '" + part + "', but didn't: " + str)
-        .contains(part);
+    assertThat(str).contains(part);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdds.server.events;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.AfterEach;
@@ -110,8 +110,8 @@ public class TestEventQueue {
     Thread.currentThread().sleep(500);
 
     // As we don't see all 10 events scheduled.
-    assertTrue(eventExecutor.scheduledEvents() >= 1 &&
-        eventExecutor.scheduledEvents() <= 10);
+    assertThat(eventExecutor.scheduledEvents()).isGreaterThanOrEqualTo(1)
+        .isLessThanOrEqualTo(10);
 
     queue.processAll(60000);
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventWatcher.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventWatcher.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.hdds.server.events;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -206,8 +207,9 @@ public class TestEventWatcher {
             + " all messages");
 
     //_at least_ two are timed out.
-    assertTrue(metrics.getTimedOutEvents().value() >= 2,
-        "At least two events should be timed out.");
+    assertThat(metrics.getTimedOutEvents().value())
+        .withFailMessage("At least two events should be timed out.")
+        .isGreaterThanOrEqualTo(2);
 
     DefaultMetricsSystem.shutdown();
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsIntegration.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsIntegration.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdds.server.http;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -103,11 +103,9 @@ public class TestPrometheusMetricsIntegration {
     String writtenMetrics = waitForMetricsToPublish("test_metrics_num");
 
     //THEN
-    assertTrue(
-        writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\""),
-        "The expected metric line is missing from prometheus metrics output"
-    );
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is missing from prometheus metrics output")
+        .contains("test_metrics_num_bucket_create_fails{context=\"dfs\"");
 
     metrics.unregisterSource("TestMetrics");
   }
@@ -127,13 +125,13 @@ public class TestPrometheusMetricsIntegration {
     String writtenMetrics = waitForMetricsToPublish("rpc_metrics_counter");
 
     // THEN
-    assertTrue(
-        writtenMetrics.contains("rpc_metrics_counter{port=\"2345\""),
-        "The expected metric line is missing from prometheus metrics output");
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is missing from prometheus metrics output")
+        .contains("rpc_metrics_counter{port=\"2345\"");
 
-    assertTrue(
-        writtenMetrics.contains("rpc_metrics_counter{port=\"1234\""),
-        "The expected metric line is missing from prometheus metrics output");
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is missing from prometheus metrics output")
+        .contains("rpc_metrics_counter{port=\"1234\"");
 
     metrics.unregisterSource("FooBar");
   }
@@ -158,12 +156,12 @@ public class TestPrometheusMetricsIntegration {
         "# TYPE same_name_counter"));
 
     // both metrics should be present
-    assertTrue(
-        writtenMetrics.contains("same_name_counter{port=\"1234\""),
-        "The expected metric line is present in prometheus metrics output");
-    assertTrue(
-        writtenMetrics.contains("same_name_counter{port=\"2345\""),
-        "The expected metric line is present in prometheus metrics output");
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is present in prometheus metrics output")
+        .contains("same_name_counter{port=\"1234\"");
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is present in prometheus metrics output")
+        .contains("same_name_counter{port=\"2345\"");
 
     metrics.unregisterSource("SameName");
   }
@@ -203,9 +201,9 @@ public class TestPrometheusMetricsIntegration {
     assertFalse(
         writtenMetrics.contains("stale_metric_counter{port=\"1234\""),
         "The expected metric line is present in prometheus metrics output");
-    assertTrue(
-        writtenMetrics.contains("some_metric_counter{port=\"4321\""),
-        "The expected metric line is present in prometheus metrics output");
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is present in prometheus metrics output")
+        .contains("some_metric_counter{port=\"4321\"");
 
     metrics.unregisterSource("SomeMetric");
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsIntegration.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsIntegration.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.server.http;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -198,9 +197,9 @@ public class TestPrometheusMetricsIntegration {
 
     // THEN
     // The first metric shouldn't be present
-    assertFalse(
-        writtenMetrics.contains("stale_metric_counter{port=\"1234\""),
-        "The expected metric line is present in prometheus metrics output");
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is present in prometheus metrics output")
+        .doesNotContain("stale_metric_counter{port=\"1234\"");
     assertThat(writtenMetrics)
         .withFailMessage("The expected metric line is present in prometheus metrics output")
         .contains("some_metric_counter{port=\"4321\"");

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
@@ -34,7 +34,7 @@ import org.apache.ratis.server.metrics.SegmentedRaftLogMetrics;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.ratis.server.metrics.SegmentedRaftLogMetrics.RAFT_LOG_SYNC_TIME;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test RatisDropwizardRexporter.
@@ -73,9 +73,9 @@ public class TestRatisDropwizardExports {
 
     System.out.println(writer);
 
-    assertFalse(writer.toString()
-            .contains("ratis_core_ratis_log_worker_instance_syncTime"),
-        "Instance name is not moved to be a tag");
+    assertThat(writer.toString())
+        .withFailMessage("Instance name is not moved to be a tag")
+        .doesNotContain("ratis_core_ratis_log_worker_instance_syncTime");
   }
 
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/TestRDBSnapshotProvider.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.writeDBCheckpointToStream;
 import static org.apache.hadoop.hdds.utils.db.TestRDBStore.newRDBStore;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -160,8 +161,8 @@ public class TestRDBSnapshotProvider {
     checkpoint = rdbSnapshotProvider.downloadDBSnapshotFromLeader(leaderId);
     int second = HAUtils.getExistingSstFiles(
         rdbSnapshotProvider.getCandidateDir()).size();
-    assertTrue(second > first, "The second snapshot should" +
-        " have more SST files");
+    assertThat(second).withFailMessage("The second snapshot should have more SST files")
+        .isGreaterThan(first);
     DBCheckpoint latestCheckpoint = latestCK.get();
     compareDB(latestCheckpoint.getCheckpointLocation().toFile(),
         checkpoint.getCheckpointLocation().toFile(), numUsedCF);
@@ -170,8 +171,8 @@ public class TestRDBSnapshotProvider {
     checkpoint = rdbSnapshotProvider.downloadDBSnapshotFromLeader(leaderId);
     int third = HAUtils.getExistingSstFiles(
         rdbSnapshotProvider.getCandidateDir()).size();
-    assertTrue(third > second, "The third snapshot should" +
-        " have more SST files");
+    assertThat(third).withFailMessage("The third snapshot should have more SST files")
+        .isGreaterThan(second);
     compareDB(latestCK.get().getCheckpointLocation().toFile(),
         checkpoint.getCheckpointLocation().toFile(), numUsedCF);
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestCodec.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.utils.db.CodecTestUtil.gc;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -164,7 +165,7 @@ public final class TestCodec {
     };
     for (String original : docs) {
       final int serializedSize = runTestStringCodec(original);
-      assertTrue(original.length() < serializedSize);
+      assertThat(original.length()).isLessThan(serializedSize);
     }
 
     final String multiByteChars = "官方发行包包括了源代码包和二进制代码包";

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -207,7 +208,7 @@ public class TestDBStoreBuilder {
 
     try (DBStore dbStore = DBStoreBuilder.newBuilder(conf, sampleDB)
         .setName("SampleStore").setPath(newFolder.toPath()).build()) {
-      assertTrue(dbStore instanceof RDBStore);
+      assertInstanceOf(RDBStore.class, dbStore);
 
       RDBStore rdbStore = (RDBStore) dbStore;
       Collection<RocksDatabase.ColumnFamily> cfFamilies =
@@ -273,7 +274,7 @@ public class TestDBStoreBuilder {
             .setName("SampleStore")
             .disableDefaultCFAutoCompaction(disableAutoCompaction)
             .setPath(newFolder.toPath()).build()) {
-      assertTrue(dbStore instanceof RDBStore);
+      assertInstanceOf(RDBStore.class, dbStore);
 
       RDBStore rdbStore = (RDBStore) dbStore;
       Collection<RocksDatabase.ColumnFamily> cfFamilies =

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -48,6 +48,7 @@ import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
 
 import static org.apache.hadoop.ozone.OzoneConsts.ROCKSDB_SST_SUFFIX;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -139,7 +140,7 @@ public class TestRDBStore {
     rdbStore.compactDB();
     int metaSizeAfterCompact = rdbStore.getDb().getLiveFilesMetaDataSize();
 
-    assertTrue(metaSizeAfterCompact < metaSizeBeforeCompact);
+    assertThat(metaSizeAfterCompact).isLessThan(metaSizeBeforeCompact);
     assertEquals(metaSizeAfterCompact, 2);
 
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreByteArrayIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreByteArrayIterator.java
@@ -33,8 +33,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -300,7 +302,7 @@ public class TestRDBStoreByteArrayIterator {
       iter.seekToLast();
       fail("Prefixed iterator does not support seekToLast");
     } catch (Exception e) {
-      assertTrue(e instanceof UnsupportedOperationException);
+      assertInstanceOf(UnsupportedOperationException.class, e);
     }
 
     iter.close();
@@ -327,6 +329,6 @@ public class TestRDBStoreByteArrayIterator {
     }
     String expectedTrace = sb.toString();
     String fromObjectInit = iterator.getStackTrace();
-    assertTrue(fromObjectInit.contains(expectedTrace));
+    assertThat(fromObjectInit).contains(expectedTrace);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreCodecBufferIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreCodecBufferIterator.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -361,7 +362,7 @@ public class TestRDBStoreCodecBufferIterator {
         i.seekToLast();
         fail("Prefixed iterator does not support seekToLast");
       } catch (Exception e) {
-        assertTrue(e instanceof UnsupportedOperationException);
+        assertInstanceOf(UnsupportedOperationException.class, e);
       }
     }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -46,8 +46,10 @@ import org.rocksdb.StatsLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -472,7 +474,7 @@ public class TestRDBTableStore {
       }
       long keyCount = testTable.getEstimatedKeyCount();
       // The result should be larger than zero but not exceed(?) numKeys
-      assertTrue(keyCount > 0 && keyCount <= numKeys);
+      assertThat(keyCount).isGreaterThan(0).isLessThanOrEqualTo(numKeys);
     }
   }
 
@@ -692,7 +694,7 @@ public class TestRDBTableStore {
 
       // check dump file exist
       assertTrue(dumpFile.exists());
-      assertTrue(dumpFile.length() != 0);
+      assertNotEquals(1, dumpFile.length());
     }
 
     // load dump file into another table

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -694,7 +694,7 @@ public class TestRDBTableStore {
 
       // check dump file exist
       assertTrue(dumpFile.exists());
-      assertNotEquals(1, dumpFile.length());
+      assertNotEquals(0, dumpFile.length());
     }
 
     // load dump file into another table

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -410,7 +411,7 @@ public class TestTypedRDBTableStore {
       }
       long keyCount = testTable.getEstimatedKeyCount();
       // The result should be larger than zero but not exceed(?) numKeys
-      assertTrue(keyCount > 0 && keyCount <= numKeys);
+      assertThat(keyCount).isGreaterThan(0).isLessThanOrEqualTo(numKeys);
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -183,11 +183,11 @@ public class TestOzoneAuditLogger {
   @Test
   public void messageIncludesAllParts() {
     String message = WRITE_FAIL_MSG.getFormattedMessage();
-    assertThat(message).withFailMessage(message).contains(USER);
-    assertThat(message).withFailMessage(message).contains(IP_ADDRESS);
-    assertThat(message).withFailMessage(message).contains(DummyAction.CREATE_VOLUME.name());
-    assertThat(message).withFailMessage(message).contains(PARAMS.toString());
-    assertThat(message).withFailMessage(message).contains(FAILURE.getStatus());
+    assertThat(message).contains(USER);
+    assertThat(message).contains(IP_ADDRESS);
+    assertThat(message).contains(DummyAction.CREATE_VOLUME.name());
+    assertThat(message).contains(PARAMS.toString());
+    assertThat(message).contains(FAILURE.getStatus());
   }
 
   /**

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -36,9 +36,9 @@ import java.util.stream.Collectors;
 import static org.apache.hadoop.ozone.audit.AuditEventStatus.FAILURE;
 import static org.apache.hadoop.ozone.audit.AuditEventStatus.SUCCESS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 
@@ -183,11 +183,11 @@ public class TestOzoneAuditLogger {
   @Test
   public void messageIncludesAllParts() {
     String message = WRITE_FAIL_MSG.getFormattedMessage();
-    assertTrue(message.contains(USER), message);
-    assertTrue(message.contains(IP_ADDRESS), message);
-    assertTrue(message.contains(DummyAction.CREATE_VOLUME.name()), message);
-    assertTrue(message.contains(PARAMS.toString()), message);
-    assertTrue(message.contains(FAILURE.getStatus()), message);
+    assertThat(message).withFailMessage(message).contains(USER);
+    assertThat(message).withFailMessage(message).contains(IP_ADDRESS);
+    assertThat(message).withFailMessage(message).contains(DummyAction.CREATE_VOLUME.name());
+    assertThat(message).withFailMessage(message).contains(PARAMS.toString());
+    assertThat(message).withFailMessage(message).contains(FAILURE.getStatus());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improve assertTrue assertions in hadoop-hdds/framework
Assertions in the form:
```
assertTrue(<string>.contains(...))
```
do not provide any information about the actual value, if the assertion fails.
```
AssertionFailedError: expected: <true> but was: <false>
```
This can be improved by replacing them with:
```
import static org.assertj.core.api.Assertions.assertThat;
assertThat(<string>).contains(...)
```
which gives us more info in the form:
```
AssertionError: 

Expecting:
 <"actual string">
to contain:
 <"part"> 
```
Similarly, assertions about inequality relations, e.g.:
```
assertTrue(<x> > <y>)
```
can be replaced with:
```
assertThat(<x>).isGreaterThan(<y>);
```
The goal of this task is to find and replace such assertTrue assertions.


## What is the link to the Apache JIRA
[HDDS-9982](https://issues.apache.org/jira/browse/HDDS-9982?filter=-1)


## CI
https://github.com/wzhallright/ozone/actions/runs/7318537019

