### PR TITLE
HDDS-9992. Add static import for assertions and mocks in ozone-s3gateway

### DIFF
--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestAuthorizationFilter.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestAuthorizationFilter.java
@@ -51,11 +51,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 
 /**
  * This class test string to sign generation.
@@ -309,21 +310,21 @@ public class TestAuthorizationFilter {
     headerMap.putSingle(X_AMAZ_DATE, date);
     headerMap.putSingle(CONTENT_TYPE, contentType);
 
-    UriInfo uriInfo = Mockito.mock(UriInfo.class);
-    ContainerRequestContext context = Mockito.mock(
+    UriInfo uriInfo = mock(UriInfo.class);
+    ContainerRequestContext context = mock(
         ContainerRequestContext.class);
-    Mockito.when(uriInfo.getQueryParameters()).thenReturn(queryMap);
-    Mockito.when(uriInfo.getRequestUri()).thenReturn(
+    when(uriInfo.getQueryParameters()).thenReturn(queryMap);
+    when(uriInfo.getRequestUri()).thenReturn(
         new URI("http://" + host + path));
 
-    Mockito.when(context.getMethod()).thenReturn(method);
-    Mockito.when(context.getUriInfo()).thenReturn(uriInfo);
-    Mockito.when(context.getHeaders()).thenReturn(headerMap);
-    Mockito.when(context.getHeaderString(AUTHORIZATION_HEADER))
+    when(context.getMethod()).thenReturn(method);
+    when(context.getUriInfo()).thenReturn(uriInfo);
+    when(context.getHeaders()).thenReturn(headerMap);
+    when(context.getHeaderString(AUTHORIZATION_HEADER))
         .thenReturn(authHeader);
-    Mockito.when(context.getUriInfo().getQueryParameters())
+    when(context.getUriInfo().getQueryParameters())
         .thenReturn(queryMap);
-    Mockito.when(context.getUriInfo().getPathParameters())
+    when(context.getUriInfo().getPathParameters())
         .thenReturn(pathParamsMap);
 
     return context;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestVirtualHostStyleFilter.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestVirtualHostStyleFilter.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.Mockito;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.SecurityContext;
@@ -35,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * This class test virtual host style mapping conversion to path style.
@@ -81,9 +81,8 @@ public class TestVirtualHostStyleFilter {
       pathStyleUri = new URI("http://" + s3HttpAddr + path + queryParams);
     }
     String httpMethod = "DELETE";
-    SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-    PropertiesDelegate propertiesDelegate = Mockito.mock(PropertiesDelegate
-        .class);
+    SecurityContext securityContext = mock(SecurityContext.class);
+    PropertiesDelegate propertiesDelegate = mock(PropertiesDelegate.class);
     ContainerRequest containerRequest;
     if (virtualHostStyle) {
       containerRequest = new ContainerRequest(baseUri, virtualHostStyleUri,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
-import org.mockito.Mockito;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -34,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -50,7 +50,7 @@ public class TestAbortMultipartUpload {
     OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket(bucket);
 
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketAcl.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketAcl.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
@@ -45,6 +44,7 @@ import static java.net.HttpURLConnection.HTTP_NOT_IMPLEMENTED;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -66,9 +66,9 @@ public class TestBucketAcl {
     client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket(BUCKET_NAME);
 
-    servletRequest = Mockito.mock(HttpServletRequest.class);
-    parameterMap = Mockito.mock(Map.class);
-    headers = Mockito.mock(HttpHeaders.class);
+    servletRequest = mock(HttpServletRequest.class);
+    parameterMap = mock(Map.class);
+    headers = mock(HttpHeaders.class);
     when(servletRequest.getParameterMap()).thenReturn(parameterMap);
 
     bucketEndpoint = new BucketEndpoint();

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
@@ -26,13 +26,13 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.jetbrains.annotations.NotNull;
-import org.mockito.Mockito;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -51,7 +51,7 @@ public class TestInitiateMultipartUpload {
     OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket(bucket);
 
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 
@@ -80,7 +80,7 @@ public class TestInitiateMultipartUpload {
     String key = OzoneConsts.KEY;
     OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket(bucket);
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     ObjectEndpoint rest = getObjectEndpoint(client, headers);
     client.getObjectStore().getS3Bucket(bucket)
         .setReplicationConfig(new ECReplicationConfig("rs-3-2-1024K"));

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -35,6 +34,7 @@ import java.io.ByteArrayInputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,7 +56,7 @@ public class TestListParts {
     OzoneClient client = new OzoneClientStub();
     client.getObjectStore().createS3Bucket(OzoneConsts.S3_BUCKET);
 
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -45,6 +44,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -62,7 +62,7 @@ public class TestMultipartUploadComplete {
     CLIENT.getObjectStore().createS3Bucket(OzoneConsts.S3_BUCKET);
 
 
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.web.utils.OzoneUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
@@ -55,6 +54,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER_RANGE;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_IF_MODIFIED_SINCE;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_IF_UNMODIFIED_SINCE;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -115,7 +115,7 @@ public class TestMultipartUploadWithCopy {
     if (sleepMs > 0) {
       Thread.sleep(sleepMs);
     }
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 
@@ -426,7 +426,7 @@ public class TestMultipartUploadWithCopy {
   }
 
   private void setHeaders(Map<String, String> additionalHeaders) {
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectDelete.java
@@ -19,6 +19,7 @@
  */
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.io.IOException;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -28,7 +29,6 @@ import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * Test delete object.
@@ -54,7 +54,7 @@ public class TestObjectDelete {
     rest.delete("b1", "key1", null);
 
     //THEN
-    Assertions.assertFalse(bucket.listKeys("").hasNext(),
+    assertFalse(bucket.listKeys("").hasNext(),
         "Bucket Should not contain any key after delete");
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_FSO_DIRECTORY_CREATION_ENABLED;
@@ -48,6 +47,8 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_HEADER;
 import static org.mockito.Mockito.doReturn;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test get object.
@@ -88,12 +89,12 @@ public class TestObjectGet {
     rest = new ObjectEndpoint();
     rest.setClient(client);
     rest.setOzoneConfiguration(new OzoneConfiguration());
-    headers = Mockito.mock(HttpHeaders.class);
+    headers = mock(HttpHeaders.class);
     rest.setHeaders(headers);
 
-    context = Mockito.mock(ContainerRequestContext.class);
-    Mockito.when(context.getUriInfo()).thenReturn(Mockito.mock(UriInfo.class));
-    Mockito.when(context.getUriInfo().getQueryParameters())
+    context = mock(ContainerRequestContext.class);
+    when(context.getUriInfo()).thenReturn(mock(UriInfo.class));
+    when(context.getUriInfo().getQueryParameters())
         .thenReturn(new MultivaluedHashMap<>());
     rest.setContext(context);
   }
@@ -154,7 +155,7 @@ public class TestObjectGet {
         CONTENT_DISPOSITION2);
     queryParameter.putSingle("response-content-encoding", CONTENT_ENCODING2);
 
-    Mockito.when(context.getUriInfo().getQueryParameters())
+    when(context.getUriInfo().getQueryParameters())
         .thenReturn(queryParameter);
     Response response = rest.get("b1", "key1", 0, null, 0, null);
 
@@ -175,14 +176,14 @@ public class TestObjectGet {
   @Test
   public void getRangeHeader() throws IOException, OS3Exception {
     Response response;
-    Mockito.when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-0");
+    when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-0");
 
     response = rest.get("b1", "key1", 0, null, 0, null);
     assertEquals("1", response.getHeaderString("Content-Length"));
     assertEquals(String.format("bytes 0-0/%s", CONTENT.length()),
         response.getHeaderString("Content-Range"));
 
-    Mockito.when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-");
+    when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-");
     response = rest.get("b1", "key1", 0, null, 0, null);
     assertEquals(String.valueOf(CONTENT.length()),
         response.getHeaderString("Content-Length"));
@@ -201,7 +202,7 @@ public class TestObjectGet {
     // https://www.rfc-editor.org/rfc/rfc7233#section-4.1
     // The 206 (Partial Content) status code indicates that the server is
     //   successfully fulfilling a range request for the target resource
-    Mockito.when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-1");
+    when(headers.getHeaderString(RANGE_HEADER)).thenReturn("bytes=0-1");
     response = rest.get("b1", "key1", 0, null, 0, null);
     assertEquals(response.getStatus(),
         Response.Status.PARTIAL_CONTENT.getStatusCode());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.DECODED_CONTENT_LENGTH_HEADER;
@@ -57,7 +56,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -91,7 +92,7 @@ public class TestObjectPut {
   @Test
   public void testPutObject() throws IOException, OS3Exception {
     //GIVEN
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     objectEndpoint.setHeaders(headers);
@@ -116,7 +117,7 @@ public class TestObjectPut {
   public void testPutObjectWithECReplicationConfig()
       throws IOException, OS3Exception {
     //GIVEN
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     objectEndpoint.setHeaders(headers);
@@ -145,7 +146,7 @@ public class TestObjectPut {
     // The contentLength specified when creating the Key should be the same as
     // the Content-Length, the key Commit will compare the Content-Length with
     // the actual length of the data written.
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     objectEndpoint.setHeaders(headers);
@@ -158,7 +159,7 @@ public class TestObjectPut {
   @Test
   public void testPutObjectContentLengthForStreaming()
       throws IOException, OS3Exception {
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     objectEndpoint.setHeaders(headers);
 
     String chunkedContent = "0a;chunk-signature=signature\r\n"
@@ -184,7 +185,7 @@ public class TestObjectPut {
   @Test
   public void testPutObjectWithSignedChunks() throws IOException, OS3Exception {
     //GIVEN
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     objectEndpoint.setHeaders(headers);
 
     String chunkedContent = "0a;chunk-signature=signature\r\n"
@@ -215,7 +216,7 @@ public class TestObjectPut {
   @Test
   public void testCopyObject() throws IOException, OS3Exception {
     // Put object in to source bucket
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     objectEndpoint.setHeaders(headers);
@@ -288,7 +289,7 @@ public class TestObjectPut {
 
   @Test
   public void testInvalidStorageType() throws IOException {
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     objectEndpoint.setHeaders(headers);
@@ -304,7 +305,7 @@ public class TestObjectPut {
 
   @Test
   public void testEmptyStorageType() throws IOException, OS3Exception {
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     objectEndpoint.setHeaders(headers);
@@ -331,16 +332,16 @@ public class TestObjectPut {
     final int partNumber = 0;
     final String uploadId = "";
     final InputStream body = null;
-    final HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    final HttpHeaders headers = mock(HttpHeaders.class);
     final ObjectEndpoint objEndpoint = new ObjectEndpoint();
     objEndpoint.setOzoneConfiguration(new OzoneConfiguration());
     objEndpoint.setHeaders(headers);
-    final OzoneClient client = Mockito.mock(OzoneClient.class);
+    final OzoneClient client = mock(OzoneClient.class);
     objEndpoint.setClient(client);
-    final ObjectStore objectStore = Mockito.mock(ObjectStore.class);
-    final OzoneVolume volume = Mockito.mock(OzoneVolume.class);
-    final OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
-    final ClientProtocol protocol = Mockito.mock(ClientProtocol.class);
+    final ObjectStore objectStore = mock(ObjectStore.class);
+    final OzoneVolume volume = mock(OzoneVolume.class);
+    final OzoneBucket bucket = mock(OzoneBucket.class);
+    final ClientProtocol protocol = mock(ClientProtocol.class);
 
     // WHEN
     when(client.getObjectStore()).thenReturn(objectStore);
@@ -354,7 +355,7 @@ public class TestObjectPut {
 
     // THEN
     assertEquals(HttpStatus.SC_OK, response.getStatus());
-    Mockito.verify(protocol).createDirectory(any(), eq(bucketName), eq(path));
+    verify(protocol).createDirectory(any(), eq(bucketName), eq(path));
   }
 
   @Test
@@ -366,16 +367,16 @@ public class TestObjectPut {
     final String uploadId = "";
     final ByteArrayInputStream body =
         new ByteArrayInputStream("content".getBytes(UTF_8));
-    final HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    final HttpHeaders headers = mock(HttpHeaders.class);
     final ObjectEndpoint objEndpoint = new ObjectEndpoint();
     objEndpoint.setOzoneConfiguration(new OzoneConfiguration());
     objEndpoint.setHeaders(headers);
-    final OzoneClient client = Mockito.mock(OzoneClient.class);
+    final OzoneClient client = mock(OzoneClient.class);
     objEndpoint.setClient(client);
-    final ObjectStore objectStore = Mockito.mock(ObjectStore.class);
-    final OzoneVolume volume = Mockito.mock(OzoneVolume.class);
-    final OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
-    final ClientProtocol protocol = Mockito.mock(ClientProtocol.class);
+    final ObjectStore objectStore = mock(ObjectStore.class);
+    final OzoneVolume volume = mock(OzoneVolume.class);
+    final OzoneBucket bucket = mock(OzoneBucket.class);
+    final ClientProtocol protocol = mock(ClientProtocol.class);
 
     // WHEN
     when(client.getObjectStore()).thenReturn(objectStore);
@@ -394,6 +395,6 @@ public class TestObjectPut {
             .put(bucketName, path, length, partNumber, uploadId, body));
     assertEquals("Conflict", exception.getCode());
     assertEquals(409, exception.getHttpCode());
-    Mockito.verify(protocol, times(1)).createDirectory(any(), any(), any());
+    verify(protocol, times(1)).createDirectory(any(), any(), any());
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -45,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -62,7 +62,7 @@ public class TestPartUpload {
     client.getObjectStore().createS3Bucket(OzoneConsts.S3_BUCKET);
 
 
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 
@@ -144,7 +144,7 @@ public class TestPartUpload {
   @Test
   public void testPartUploadStreamContentLength()
       throws IOException, OS3Exception {
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     ObjectEndpoint objectEndpoint = new ObjectEndpoint();
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setClient(client);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUploadWithStream.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUploadWithStream.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -42,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -60,7 +60,7 @@ public class TestPartUploadWithStream {
     client.getObjectStore().createS3Bucket(S3BUCKET);
 
 
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn("STANDARD");
 
     REST.setHeaders(headers);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
@@ -48,6 +47,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -73,18 +73,18 @@ public class TestPermissionCheck {
     conf = new OzoneConfiguration();
     conf.set(OzoneConfigKeys.OZONE_S3_VOLUME_NAME,
         OzoneConfigKeys.OZONE_S3_VOLUME_NAME_DEFAULT);
-    client = Mockito.mock(OzoneClient.class);
-    objectStore = Mockito.mock(ObjectStore.class);
-    bucket = Mockito.mock(OzoneBucket.class);
-    volume = Mockito.mock(OzoneVolume.class);
+    client = mock(OzoneClient.class);
+    objectStore = mock(ObjectStore.class);
+    bucket = mock(OzoneBucket.class);
+    volume = mock(OzoneVolume.class);
     when(volume.getName()).thenReturn("s3Volume");
     exception = new OMException("Permission Denied",
         OMException.ResultCodes.PERMISSION_DENIED);
-    Mockito.when(client.getObjectStore()).thenReturn(objectStore);
-    Mockito.when(client.getConfiguration()).thenReturn(conf);
-    headers = Mockito.mock(HttpHeaders.class);
-    clientProtocol = Mockito.mock(ClientProtocol.class);
-    Mockito.when(client.getProxy()).thenReturn(clientProtocol);
+    when(client.getObjectStore()).thenReturn(objectStore);
+    when(client.getConfiguration()).thenReturn(conf);
+    headers = mock(HttpHeaders.class);
+    clientProtocol = mock(ClientProtocol.class);
+    when(client.getProxy()).thenReturn(clientProtocol);
   }
 
   /**
@@ -114,7 +114,7 @@ public class TestPermissionCheck {
 
   @Test
   public void testCreateBucket() throws IOException {
-    Mockito.when(objectStore.getVolume(anyString())).thenReturn(volume);
+    when(objectStore.getVolume(anyString())).thenReturn(volume);
     doThrow(exception).when(objectStore).createS3Bucket(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
@@ -135,7 +135,7 @@ public class TestPermissionCheck {
   }
   @Test
   public void testListMultiUpload() throws IOException {
-    Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).listMultipartUploads(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
@@ -147,8 +147,8 @@ public class TestPermissionCheck {
 
   @Test
   public void testListKey() throws IOException {
-    Mockito.when(objectStore.getVolume(anyString())).thenReturn(volume);
-    Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getVolume(anyString())).thenReturn(volume);
+    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).listKeys(anyString(), isNull(),
         anyBoolean());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
@@ -162,8 +162,8 @@ public class TestPermissionCheck {
 
   @Test
   public void testDeleteKeys() throws IOException, OS3Exception {
-    Mockito.when(objectStore.getVolume(anyString())).thenReturn(volume);
-    Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getVolume(anyString())).thenReturn(volume);
+    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).deleteKey(any());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
@@ -181,12 +181,12 @@ public class TestPermissionCheck {
 
   @Test
   public void testGetAcl() throws Exception {
-    Mockito.when(objectStore.getS3Volume()).thenReturn(volume);
-    Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getS3Volume()).thenReturn(volume);
+    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).getAcls();
 
-    HttpServletRequest servletRequest = Mockito.mock(HttpServletRequest.class);
-    Map<String, String[]> parameterMap = Mockito.mock(Map.class);
+    HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+    Map<String, String[]> parameterMap = mock(Map.class);
     when(servletRequest.getParameterMap()).thenReturn(parameterMap);
 
     when(parameterMap.containsKey("acl")).thenReturn(true);
@@ -202,12 +202,12 @@ public class TestPermissionCheck {
 
   @Test
   public void testSetAcl() throws Exception {
-    Mockito.when(objectStore.getS3Volume()).thenReturn(volume);
-    Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getS3Volume()).thenReturn(volume);
+    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).addAcl(any());
 
-    HttpServletRequest servletRequest = Mockito.mock(HttpServletRequest.class);
-    Map<String, String[]> parameterMap = Mockito.mock(Map.class);
+    HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+    Map<String, String[]> parameterMap = mock(Map.class);
     when(servletRequest.getParameterMap()).thenReturn(parameterMap);
 
     when(parameterMap.containsKey("acl")).thenReturn(true);
@@ -228,7 +228,7 @@ public class TestPermissionCheck {
    */
   @Test
   public void testGetKey() throws IOException {
-    Mockito.when(client.getProxy()).thenReturn(clientProtocol);
+    when(client.getProxy()).thenReturn(clientProtocol);
     doThrow(exception).when(clientProtocol)
         .getS3KeyDetails(anyString(), anyString());
     ObjectEndpoint objectEndpoint = new ObjectEndpoint();
@@ -243,8 +243,8 @@ public class TestPermissionCheck {
 
   @Test
   public void testPutKey() throws IOException {
-    Mockito.when(objectStore.getS3Volume()).thenReturn(volume);
-    Mockito.when(volume.getBucket("bucketName")).thenReturn(bucket);
+    when(objectStore.getS3Volume()).thenReturn(volume);
+    when(volume.getBucket("bucketName")).thenReturn(bucket);
     doThrow(exception).when(clientProtocol).createKey(
             anyString(), anyString(), anyString(), anyLong(), any(), any());
     ObjectEndpoint objectEndpoint = new ObjectEndpoint();
@@ -260,7 +260,7 @@ public class TestPermissionCheck {
 
   @Test
   public void testDeleteKey() throws IOException {
-    Mockito.when(objectStore.getS3Volume()).thenReturn(volume);
+    when(objectStore.getS3Volume()).thenReturn(volume);
     doThrow(exception).when(clientProtocol).deleteKey(anyString(), anyString(),
         anyString(), anyBoolean());
     ObjectEndpoint objectEndpoint = new ObjectEndpoint();
@@ -275,7 +275,7 @@ public class TestPermissionCheck {
 
   @Test
   public void testMultiUploadKey() throws IOException {
-    Mockito.when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
+    when(objectStore.getS3Bucket(anyString())).thenReturn(bucket);
     doThrow(exception).when(bucket).initiateMultipartUpload(anyString(), any());
     ObjectEndpoint objectEndpoint = new ObjectEndpoint();
     objectEndpoint.setClient(client);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestUploadWithStream.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.HttpHeaders;
@@ -49,6 +48,7 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -68,7 +68,7 @@ public class TestUploadWithStream {
   private static ContainerRequestContext context;
 
   static {
-    HEADERS = Mockito.mock(HttpHeaders.class);
+    HEADERS = mock(HttpHeaders.class);
     when(HEADERS.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn("STANDARD");
   }
 
@@ -87,9 +87,9 @@ public class TestUploadWithStream {
         StorageUnit.BYTES);
     REST.setOzoneConfiguration(conf);
 
-    context = Mockito.mock(ContainerRequestContext.class);
-    Mockito.when(context.getUriInfo()).thenReturn(Mockito.mock(UriInfo.class));
-    Mockito.when(context.getUriInfo().getQueryParameters())
+    context = mock(ContainerRequestContext.class);
+    when(context.getUriInfo()).thenReturn(mock(UriInfo.class));
+    when(context.getUriInfo().getQueryParameters())
         .thenReturn(new MultivaluedHashMap<>());
     REST.setContext(context);
 
@@ -132,7 +132,7 @@ public class TestUploadWithStream {
     additionalHeaders
         .put(COPY_SOURCE_HEADER, S3BUCKET + "/" + S3_COPY_EXISTING_KEY);
 
-    HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.HttpHeaders;
@@ -61,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -98,15 +98,15 @@ public class TestS3GatewayMetrics {
     keyEndpoint.setClient(clientStub);
     keyEndpoint.setOzoneConfiguration(new OzoneConfiguration());
 
-    headers = Mockito.mock(HttpHeaders.class);
+    headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
     keyEndpoint.setHeaders(headers);
     metrics = bucketEndpoint.getMetrics();
 
-    context = Mockito.mock(ContainerRequestContext.class);
-    Mockito.when(context.getUriInfo()).thenReturn(Mockito.mock(UriInfo.class));
-    Mockito.when(context.getUriInfo().getQueryParameters())
+    context = mock(ContainerRequestContext.class);
+    when(context.getUriInfo()).thenReturn(mock(UriInfo.class));
+    when(context.getUriInfo().getQueryParameters())
         .thenReturn(new MultivaluedHashMap<>());
     keyEndpoint.setContext(context);
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestStringToSignProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestStringToSignProducer.java
@@ -39,12 +39,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.S3_AUTHINFO_CREATION_ERROR;
 import static org.apache.hadoop.ozone.s3.signature.SignatureProcessor.DATE_FORMATTER;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test string2sign creation.
@@ -123,15 +124,15 @@ public class TestStringToSignProducer {
       MultivaluedMap<String, String> headerMap,
       MultivaluedMap<String, String> queryMap) {
     ContainerRequestContext context =
-        Mockito.mock(ContainerRequestContext.class);
-    UriInfo uriInfo = Mockito.mock(UriInfo.class);
+        mock(ContainerRequestContext.class);
+    UriInfo uriInfo = mock(UriInfo.class);
 
-    Mockito.when(uriInfo.getRequestUri()).thenReturn(uri);
-    Mockito.when(uriInfo.getQueryParameters()).thenReturn(queryMap);
+    when(uriInfo.getRequestUri()).thenReturn(uri);
+    when(uriInfo.getQueryParameters()).thenReturn(queryMap);
 
-    Mockito.when(context.getUriInfo()).thenReturn(uriInfo);
-    Mockito.when(context.getMethod()).thenReturn(method);
-    Mockito.when(context.getHeaders()).thenReturn(headerMap);
+    when(context.getUriInfo()).thenReturn(uriInfo);
+    when(context.getMethod()).thenReturn(method);
+    when(context.getHeaders()).thenReturn(headerMap);
 
     return context;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The goal of this task is to add import static for all assertions and interactions with mocks. Replacing:
```
Assertions.assert<X>(...) -> assert<X>(...)
Assertions.fail(...) -> fail(...)
```
and
```
Mockito.mock(...) -> mock(...)
Mockito.verify(...) -> verify(...)
Mockito.when(...) -> when(...)
```
and
```
ArgumentMatchers.any() -> any()
ArgumentMatchers.eq() -> eq()
ArgumentMatchers.matches() -> matches()
// also:
// Matchers.<...>()
```
makes the code more readable (shorter lines, less wrapping).

## What is the link to the Apache JIRA
[HDDS-9992](https://issues.apache.org/jira/browse/HDDS-9992)

## CI
https://github.com/wzhallright/ozone/actions/runs/7318668302
