### PR TITLE
HDDS-9996. Add static import for assertions and mocks in ozone-recon

### DIFF
--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconCodecs.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconCodecs.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.ozone.recon;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.IOException;
 
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.spi.impl.ContainerKeyPrefixCodec;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.IntegerCodec;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,10 +40,10 @@ public class TestReconCodecs {
 
     Codec<ContainerKeyPrefix> codec = ContainerKeyPrefixCodec.get();
     byte[] persistedFormat = codec.toPersistedFormat(containerKeyPrefix);
-    Assertions.assertNotNull(persistedFormat);
+    assertNotNull(persistedFormat);
     ContainerKeyPrefix fromPersistedFormat =
         codec.fromPersistedFormat(persistedFormat);
-    Assertions.assertEquals(containerKeyPrefix, fromPersistedFormat);
+    assertEquals(containerKeyPrefix, fromPersistedFormat);
   }
 
   @Test
@@ -50,9 +51,9 @@ public class TestReconCodecs {
     Integer i = 1000;
     Codec<Integer> codec = IntegerCodec.get();
     byte[] persistedFormat = codec.toPersistedFormat(i);
-    Assertions.assertNotNull(persistedFormat);
+    assertNotNull(persistedFormat);
     Integer fromPersistedFormat =
         codec.fromPersistedFormat(persistedFormat);
-    Assertions.assertEquals(i, fromPersistedFormat);
+    assertEquals(i, fromPersistedFormat);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestBlocksEndPoint.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
@@ -56,6 +55,8 @@ import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -154,17 +155,17 @@ public class TestBlocksEndPoint {
         containerStateBlockInfoListMap =
         (Map<String, List<ContainerBlocksInfoWrapper>>)
             blocksPendingDeletion.getEntity();
-    Assertions.assertNotNull(containerStateBlockInfoListMap);
-    Assertions.assertEquals(1, containerStateBlockInfoListMap.size());
+    assertNotNull(containerStateBlockInfoListMap);
+    assertEquals(1, containerStateBlockInfoListMap.size());
     List<ContainerBlocksInfoWrapper> containerBlocksInfoWrappers =
         containerStateBlockInfoListMap.get("OPEN");
     ContainerBlocksInfoWrapper containerBlocksInfoWrapper =
         containerBlocksInfoWrappers.get(0);
-    Assertions.assertEquals(100, containerBlocksInfoWrapper.getContainerID());
-    Assertions.assertEquals(4, containerBlocksInfoWrapper.getLocalIDCount());
-    Assertions.assertEquals(4,
+    assertEquals(100, containerBlocksInfoWrapper.getContainerID());
+    assertEquals(4, containerBlocksInfoWrapper.getLocalIDCount());
+    assertEquals(4,
         containerBlocksInfoWrapper.getLocalIDList().size());
-    Assertions.assertEquals(1, containerBlocksInfoWrapper.getTxID());
+    assertEquals(1, containerBlocksInfoWrapper.getTxID());
   }
 
   @Test
@@ -195,17 +196,17 @@ public class TestBlocksEndPoint {
         containerStateBlockInfoListMap =
         (Map<String, List<ContainerBlocksInfoWrapper>>)
             blocksPendingDeletion.getEntity();
-    Assertions.assertNotNull(containerStateBlockInfoListMap);
-    Assertions.assertEquals(1, containerStateBlockInfoListMap.size());
+    assertNotNull(containerStateBlockInfoListMap);
+    assertEquals(1, containerStateBlockInfoListMap.size());
     List<ContainerBlocksInfoWrapper> containerBlocksInfoWrappers =
         containerStateBlockInfoListMap.get("OPEN");
     ContainerBlocksInfoWrapper containerBlocksInfoWrapper =
         containerBlocksInfoWrappers.get(0);
-    Assertions.assertEquals(100, containerBlocksInfoWrapper.getContainerID());
-    Assertions.assertEquals(4, containerBlocksInfoWrapper.getLocalIDCount());
-    Assertions.assertEquals(4,
+    assertEquals(100, containerBlocksInfoWrapper.getContainerID());
+    assertEquals(4, containerBlocksInfoWrapper.getLocalIDCount());
+    assertEquals(4,
         containerBlocksInfoWrapper.getLocalIDList().size());
-    Assertions.assertEquals(1, containerBlocksInfoWrapper.getTxID());
+    assertEquals(1, containerBlocksInfoWrapper.getTxID());
   }
 
   @Test
@@ -236,31 +237,31 @@ public class TestBlocksEndPoint {
         containerStateBlockInfoListMap =
         (Map<String, List<ContainerBlocksInfoWrapper>>)
             blocksPendingDeletion.getEntity();
-    Assertions.assertNotNull(containerStateBlockInfoListMap);
-    Assertions.assertEquals(1, containerStateBlockInfoListMap.size());
+    assertNotNull(containerStateBlockInfoListMap);
+    assertEquals(1, containerStateBlockInfoListMap.size());
     List<ContainerBlocksInfoWrapper> containerBlocksInfoWrappers =
         containerStateBlockInfoListMap.get("OPEN");
     ContainerBlocksInfoWrapper containerBlocksInfoWrapper =
         containerBlocksInfoWrappers.get(0);
-    Assertions.assertEquals(101, containerBlocksInfoWrapper.getContainerID());
-    Assertions.assertEquals(4, containerBlocksInfoWrapper.getLocalIDCount());
-    Assertions.assertEquals(4,
+    assertEquals(101, containerBlocksInfoWrapper.getContainerID());
+    assertEquals(4, containerBlocksInfoWrapper.getLocalIDCount());
+    assertEquals(4,
         containerBlocksInfoWrapper.getLocalIDList().size());
-    Assertions.assertEquals(3, containerBlocksInfoWrapper.getTxID());
+    assertEquals(3, containerBlocksInfoWrapper.getTxID());
 
     blocksPendingDeletion =
         blocksEndPoint.getBlocksPendingDeletion(1, 3);
     containerStateBlockInfoListMap =
         (Map<String, List<ContainerBlocksInfoWrapper>>)
             blocksPendingDeletion.getEntity();
-    Assertions.assertEquals(0, containerStateBlockInfoListMap.size());
+    assertEquals(0, containerStateBlockInfoListMap.size());
 
     blocksPendingDeletion =
         blocksEndPoint.getBlocksPendingDeletion(1, 4);
     containerStateBlockInfoListMap =
         (Map<String, List<ContainerBlocksInfoWrapper>>)
             blocksPendingDeletion.getEntity();
-    Assertions.assertEquals(0, containerStateBlockInfoListMap.size());
+    assertEquals(0, containerStateBlockInfoListMap.size());
   }
 
   protected ContainerWithPipeline getTestContainer(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerStateCounts.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,6 +51,7 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -134,12 +134,9 @@ public class TestContainerStateCounts extends AbstractReconSqlDBTest {
     int expectedDeletedContainers = NUM_DELETED_CONTAINERS;
 
     // Verify counts using assertions
-    Assertions.assertEquals(expectedTotalContainers,
-        clusterStateResponse1.getContainers());
-    Assertions.assertEquals(expectedOpenContainers,
-        clusterStateResponse1.getOpenContainers());
-    Assertions.assertEquals(expectedDeletedContainers,
-        clusterStateResponse1.getDeletedContainers());
+    assertEquals(expectedTotalContainers, clusterStateResponse1.getContainers());
+    assertEquals(expectedOpenContainers, clusterStateResponse1.getOpenContainers());
+    assertEquals(expectedDeletedContainers, clusterStateResponse1.getDeletedContainers());
   }
 
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -97,7 +97,6 @@ import org.hadoop.ozone.recon.schema.tables.pojos.ContainerCountBySize;
 import org.hadoop.ozone.recon.schema.tables.pojos.FileCountBySize;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -116,6 +115,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -406,7 +406,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
       // Process all events in the event queue
       reconScm.getEventQueue().processAll(1000);
     } catch (Exception ex) {
-      Assertions.fail(ex.getMessage());
+      fail(ex.getMessage());
     }
     // Write Data to OM
     // A sample volume (sampleVol) and a bucket (bucketOne) is already created
@@ -517,47 +517,47 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
   private void testDatanodeResponse(DatanodeMetadata datanodeMetadata)
       throws IOException {
     // Check NodeState and NodeOperationalState field existence
-    Assertions.assertEquals(NodeState.HEALTHY, datanodeMetadata.getState());
-    Assertions.assertEquals(NodeOperationalState.IN_SERVICE,
+    assertEquals(NodeState.HEALTHY, datanodeMetadata.getState());
+    assertEquals(NodeOperationalState.IN_SERVICE,
         datanodeMetadata.getOperationalState());
 
     String hostname = datanodeMetadata.getHostname();
     switch (hostname) {
     case HOST1:
-      Assertions.assertEquals(75000,
+      assertEquals(75000,
           datanodeMetadata.getDatanodeStorageReport().getCapacity());
-      Assertions.assertEquals(15400,
+      assertEquals(15400,
           datanodeMetadata.getDatanodeStorageReport().getRemaining());
-      Assertions.assertEquals(35000,
+      assertEquals(35000,
           datanodeMetadata.getDatanodeStorageReport().getUsed());
 
-      Assertions.assertEquals(1, datanodeMetadata.getPipelines().size());
-      Assertions.assertEquals(pipelineId,
+      assertEquals(1, datanodeMetadata.getPipelines().size());
+      assertEquals(pipelineId,
           datanodeMetadata.getPipelines().get(0).getPipelineID().toString());
-      Assertions.assertEquals(pipeline.getReplicationConfig().getReplication(),
+      assertEquals(pipeline.getReplicationConfig().getReplication(),
           datanodeMetadata.getPipelines().get(0).getReplicationFactor());
-      Assertions.assertEquals(pipeline.getType().toString(),
+      assertEquals(pipeline.getType().toString(),
           datanodeMetadata.getPipelines().get(0).getReplicationType());
-      Assertions.assertEquals(pipeline.getLeaderNode().getHostName(),
+      assertEquals(pipeline.getLeaderNode().getHostName(),
           datanodeMetadata.getPipelines().get(0).getLeaderNode());
-      Assertions.assertEquals(1, datanodeMetadata.getLeaderCount());
+      assertEquals(1, datanodeMetadata.getLeaderCount());
       break;
     case HOST2:
-      Assertions.assertEquals(130000,
+      assertEquals(130000,
           datanodeMetadata.getDatanodeStorageReport().getCapacity());
-      Assertions.assertEquals(17800,
+      assertEquals(17800,
           datanodeMetadata.getDatanodeStorageReport().getRemaining());
-      Assertions.assertEquals(80000,
+      assertEquals(80000,
           datanodeMetadata.getDatanodeStorageReport().getUsed());
 
-      Assertions.assertEquals(0, datanodeMetadata.getPipelines().size());
-      Assertions.assertEquals(0, datanodeMetadata.getLeaderCount());
+      assertEquals(0, datanodeMetadata.getPipelines().size());
+      assertEquals(0, datanodeMetadata.getLeaderCount());
       break;
     default:
-      Assertions.fail(String.format("Datanode %s not registered",
+      fail(String.format("Datanode %s not registered",
           hostname));
     }
-    Assertions.assertEquals(HDDSLayoutVersionManager.maxLayoutVersion(),
+    assertEquals(HDDSLayoutVersionManager.maxLayoutVersion(),
         datanodeMetadata.getLayoutVersion());
   }
 
@@ -566,14 +566,14 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     Response response = nodeEndpoint.getDatanodes();
     DatanodesResponse datanodesResponse =
         (DatanodesResponse) response.getEntity();
-    Assertions.assertEquals(2, datanodesResponse.getTotalCount());
-    Assertions.assertEquals(2, datanodesResponse.getDatanodes().size());
+    assertEquals(2, datanodesResponse.getTotalCount());
+    assertEquals(2, datanodesResponse.getDatanodes().size());
 
     datanodesResponse.getDatanodes().forEach(datanodeMetadata -> {
       try {
         testDatanodeResponse(datanodeMetadata);
       } catch (IOException e) {
-        Assertions.fail(e.getMessage());
+        fail(e.getMessage());
       }
     });
 
@@ -635,20 +635,20 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     Response response = pipelineEndpoint.getPipelines();
     PipelinesResponse pipelinesResponse =
         (PipelinesResponse) response.getEntity();
-    Assertions.assertEquals(1, pipelinesResponse.getTotalCount());
-    Assertions.assertEquals(1, pipelinesResponse.getPipelines().size());
+    assertEquals(1, pipelinesResponse.getTotalCount());
+    assertEquals(1, pipelinesResponse.getPipelines().size());
     PipelineMetadata pipelineMetadata =
         pipelinesResponse.getPipelines().iterator().next();
-    Assertions.assertEquals(1, pipelineMetadata.getDatanodes().size());
-    Assertions.assertEquals(pipeline.getType().toString(),
+    assertEquals(1, pipelineMetadata.getDatanodes().size());
+    assertEquals(pipeline.getType().toString(),
         pipelineMetadata.getReplicationType());
-    Assertions.assertEquals(pipeline.getReplicationConfig().getReplication(),
+    assertEquals(pipeline.getReplicationConfig().getReplication(),
         pipelineMetadata.getReplicationFactor());
-    Assertions.assertEquals(datanodeDetails.getHostName(),
+    assertEquals(datanodeDetails.getHostName(),
         pipelineMetadata.getLeaderNode());
-    Assertions.assertEquals(pipeline.getId().getId(),
+    assertEquals(pipeline.getId().getId(),
         pipelineMetadata.getPipelineId());
-    Assertions.assertEquals(5, pipelineMetadata.getLeaderElections());
+    assertEquals(5, pipelineMetadata.getLeaderElections());
 
     waitAndCheckConditionAfterHeartbeat(() -> {
       Response response1 = pipelineEndpoint.getPipelines();
@@ -698,13 +698,13 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     ClusterStateResponse clusterStateResponse =
         (ClusterStateResponse) response.getEntity();
 
-    Assertions.assertEquals(1, clusterStateResponse.getPipelines());
-    Assertions.assertEquals(0, clusterStateResponse.getVolumes());
-    Assertions.assertEquals(0, clusterStateResponse.getBuckets());
-    Assertions.assertEquals(0, clusterStateResponse.getKeys());
-    Assertions.assertEquals(2, clusterStateResponse.getTotalDatanodes());
-    Assertions.assertEquals(2, clusterStateResponse.getHealthyDatanodes());
-    Assertions.assertEquals(0, clusterStateResponse.getMissingContainers());
+    assertEquals(1, clusterStateResponse.getPipelines());
+    assertEquals(0, clusterStateResponse.getVolumes());
+    assertEquals(0, clusterStateResponse.getBuckets());
+    assertEquals(0, clusterStateResponse.getKeys());
+    assertEquals(2, clusterStateResponse.getTotalDatanodes());
+    assertEquals(2, clusterStateResponse.getHealthyDatanodes());
+    assertEquals(0, clusterStateResponse.getMissingContainers());
 
     waitAndCheckConditionAfterHeartbeat(() -> {
       Response response1 = clusterStateEndpoint.getClusterState();
@@ -719,15 +719,15 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     assertTrue(result.getRight());
     response = clusterStateEndpoint.getClusterState();
     clusterStateResponse = (ClusterStateResponse) response.getEntity();
-    Assertions.assertEquals(2, clusterStateResponse.getVolumes());
-    Assertions.assertEquals(3, clusterStateResponse.getBuckets());
-    Assertions.assertEquals(3, clusterStateResponse.getKeys());
+    assertEquals(2, clusterStateResponse.getVolumes());
+    assertEquals(3, clusterStateResponse.getBuckets());
+    assertEquals(3, clusterStateResponse.getKeys());
     // Since a single RepeatedOmKeyInfo can contain multiple deleted keys with
     // the same name, the total count of pending deletion keys is determined by
     // summing the count of the keyInfoList. Each keyInfoList comprises
     // OmKeyInfo objects that represent the deleted keys.
-    Assertions.assertEquals(6, clusterStateResponse.getKeysPendingDeletion());
-    Assertions.assertEquals(3, clusterStateResponse.getDeletedDirs());
+    assertEquals(6, clusterStateResponse.getKeysPendingDeletion());
+    assertEquals(3, clusterStateResponse.getDeletedDirs());
   }
 
   @Test
@@ -928,12 +928,12 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
       } else if (acl.getAclList().get(0).equals("READ")) {
         assertEquals("WRITE", acl.getAclList().get(1));
       } else {
-        Assertions.fail(String.format("ACL %s is not recognized",
+        fail(String.format("ACL %s is not recognized",
             acl.getAclList().get(0)));
       }
       break;
     default:
-      Assertions.fail(String.format("Volume %s not registered",
+      fail(String.format("Volume %s not registered",
           volumeName));
     }
 
@@ -942,17 +942,17 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
   @Test
   public void testGetVolumes() throws Exception {
     Response response = volumeEndpoint.getVolumes(10, "");
-    Assertions.assertEquals(200, response.getStatus());
+    assertEquals(200, response.getStatus());
     VolumesResponse volumesResponse =
         (VolumesResponse) response.getEntity();
-    Assertions.assertEquals(2, volumesResponse.getTotalCount());
-    Assertions.assertEquals(2, volumesResponse.getVolumes().size());
+    assertEquals(2, volumesResponse.getTotalCount());
+    assertEquals(2, volumesResponse.getVolumes().size());
 
     volumesResponse.getVolumes().forEach(volumeMetadata -> {
       try {
         testVolumeResponse(volumeMetadata);
       } catch (IOException e) {
-        Assertions.fail(e.getMessage());
+        fail(e.getMessage());
       }
     });
   }
@@ -961,21 +961,21 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
   public void testGetVolumesWithPrevKeyAndLimit() throws IOException {
     // Test limit
     Response responseWithLimit = volumeEndpoint.getVolumes(1, null);
-    Assertions.assertEquals(200, responseWithLimit.getStatus());
+    assertEquals(200, responseWithLimit.getStatus());
     VolumesResponse volumesResponseWithLimit =
         (VolumesResponse) responseWithLimit.getEntity();
-    Assertions.assertEquals(1, volumesResponseWithLimit.getTotalCount());
-    Assertions.assertEquals(1, volumesResponseWithLimit.getVolumes().size());
+    assertEquals(1, volumesResponseWithLimit.getTotalCount());
+    assertEquals(1, volumesResponseWithLimit.getVolumes().size());
 
     // Test prevKey
     Response responseWithPrevKey = volumeEndpoint.getVolumes(1, "sampleVol");
-    Assertions.assertEquals(200, responseWithPrevKey.getStatus());
+    assertEquals(200, responseWithPrevKey.getStatus());
     VolumesResponse volumesResponseWithPrevKey =
         (VolumesResponse) responseWithPrevKey.getEntity();
 
-    Assertions.assertEquals(1, volumesResponseWithPrevKey.getTotalCount());
-    Assertions.assertEquals(1, volumesResponseWithPrevKey.getVolumes().size());
-    Assertions.assertEquals("sampleVol2",
+    assertEquals(1, volumesResponseWithPrevKey.getTotalCount());
+    assertEquals(1, volumesResponseWithPrevKey.getVolumes().size());
+    assertEquals("sampleVol2",
         volumesResponseWithPrevKey.getVolumes().stream()
             .findFirst().get().getVolume());
 
@@ -1029,7 +1029,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
       assertEquals("READ", acl2.getAclList().get(0));
       break;
     default:
-      Assertions.fail(String.format("Bucket %s not registered",
+      fail(String.format("Bucket %s not registered",
           bucketName));
     }
 
@@ -1039,32 +1039,32 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
   public void testGetBuckets() throws Exception {
     // Normal bucket under a volume
     Response response = bucketEndpoint.getBuckets("sampleVol2", 10, null);
-    Assertions.assertEquals(200, response.getStatus());
+    assertEquals(200, response.getStatus());
     BucketsResponse bucketUnderVolumeResponse =
         (BucketsResponse) response.getEntity();
-    Assertions.assertEquals(2, bucketUnderVolumeResponse.getTotalCount());
-    Assertions.assertEquals(2,
+    assertEquals(2, bucketUnderVolumeResponse.getTotalCount());
+    assertEquals(2,
         bucketUnderVolumeResponse.getBuckets().size());
 
     bucketUnderVolumeResponse.getBuckets().forEach(bucketMetadata -> {
       try {
         testBucketResponse(bucketMetadata);
       } catch (IOException e) {
-        Assertions.fail(e.getMessage());
+        fail(e.getMessage());
       }
     });
 
     // Listing all buckets
     Response response3 = bucketEndpoint.getBuckets(null, 10, null);
-    Assertions.assertEquals(200, response3.getStatus());
+    assertEquals(200, response3.getStatus());
     BucketsResponse allBucketsResponse =
         (BucketsResponse) response3.getEntity();
 
     // Include bucketOne under sampleVol in
     // A sample volume (sampleVol) and a bucket (bucketOne) is already created
     // in initializeNewOmMetadataManager.
-    Assertions.assertEquals(3, allBucketsResponse.getTotalCount());
-    Assertions.assertEquals(3, allBucketsResponse.getBuckets().size());
+    assertEquals(3, allBucketsResponse.getTotalCount());
+    assertEquals(3, allBucketsResponse.getBuckets().size());
   }
 
   @Test
@@ -1073,32 +1073,32 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     // Test limit
     Response responseLimitWithoutVolume = bucketEndpoint.getBuckets(null,
         1, null);
-    Assertions.assertEquals(200, responseLimitWithoutVolume.getStatus());
+    assertEquals(200, responseLimitWithoutVolume.getStatus());
 
     BucketsResponse bucketsResponseLimitWithoutVolume =
         (BucketsResponse) responseLimitWithoutVolume.getEntity();
-    Assertions.assertEquals(1,
+    assertEquals(1,
         bucketsResponseLimitWithoutVolume.getTotalCount());
-    Assertions.assertEquals(1,
+    assertEquals(1,
         bucketsResponseLimitWithoutVolume.getBuckets().size());
 
     // Test prevKey (it should be ignored)
     Response responsePrevKeyWithoutVolume = bucketEndpoint.getBuckets(
         null, 3, "bucketOne");
 
-    Assertions.assertEquals(200,
+    assertEquals(200,
         responsePrevKeyWithoutVolume.getStatus());
 
     BucketsResponse bucketResponsePrevKeyWithoutVolume =
         (BucketsResponse) responsePrevKeyWithoutVolume.getEntity();
-    Assertions.assertEquals(3,
+    assertEquals(3,
         bucketResponsePrevKeyWithoutVolume.getTotalCount());
-    Assertions.assertEquals(3,
+    assertEquals(3,
         bucketResponsePrevKeyWithoutVolume.getBuckets().size());
-    Assertions.assertEquals("sampleVol",
+    assertEquals("sampleVol",
         bucketResponsePrevKeyWithoutVolume.getBuckets()
             .stream().findFirst().get().getVolumeName());
-    Assertions.assertEquals("bucketOne",
+    assertEquals("bucketOne",
         bucketResponsePrevKeyWithoutVolume.getBuckets()
             .stream().findFirst().get().getName());
 
@@ -1107,31 +1107,31 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     Response responseLimitWithVolume = bucketEndpoint.getBuckets(
         "sampleVol2", 1, null);
 
-    Assertions.assertEquals(200, responseLimitWithVolume.getStatus());
+    assertEquals(200, responseLimitWithVolume.getStatus());
 
     BucketsResponse bucketResponseLimitWithVolume =
         (BucketsResponse) responseLimitWithVolume.getEntity();
-    Assertions.assertEquals(1,
+    assertEquals(1,
         bucketResponseLimitWithVolume.getTotalCount());
-    Assertions.assertEquals(1,
+    assertEquals(1,
         bucketResponseLimitWithVolume.getBuckets().size());
 
     // Case 3: Test prevKey (it should not be ignored)
     Response responsePrevKeyWithVolume = bucketEndpoint.getBuckets(
         "sampleVol2", 1, "bucketOne");
 
-    Assertions.assertEquals(200, responsePrevKeyWithVolume.getStatus());
+    assertEquals(200, responsePrevKeyWithVolume.getStatus());
 
     BucketsResponse bucketPrevKeyResponseWithVolume =
         (BucketsResponse) responsePrevKeyWithVolume.getEntity();
-    Assertions.assertEquals(1,
+    assertEquals(1,
         bucketPrevKeyResponseWithVolume.getTotalCount());
-    Assertions.assertEquals(1,
+    assertEquals(1,
         bucketPrevKeyResponseWithVolume.getBuckets().size());
-    Assertions.assertEquals("sampleVol2",
+    assertEquals("sampleVol2",
         bucketPrevKeyResponseWithVolume.getBuckets()
             .stream().findFirst().get().getVolumeName());
-    Assertions.assertEquals("bucketTwo",
+    assertEquals("bucketTwo",
         bucketPrevKeyResponseWithVolume.getBuckets()
             .stream().findFirst().get().getName());
 
@@ -1139,13 +1139,13 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     Response responseVolumeNotExist = bucketEndpoint.getBuckets(
         "sampleVol3", 100, "bucketOne");
 
-    Assertions.assertEquals(200, responseVolumeNotExist.getStatus());
+    assertEquals(200, responseVolumeNotExist.getStatus());
 
     BucketsResponse bucketVolumeNotExistResponse  =
         (BucketsResponse) responseVolumeNotExist.getEntity();
-    Assertions.assertEquals(0,
+    assertEquals(0,
         bucketVolumeNotExistResponse.getTotalCount());
-    Assertions.assertEquals(0,
+    assertEquals(0,
         bucketVolumeNotExistResponse.getBuckets().size());
 
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestFeaturesEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestFeaturesEndPoint.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
@@ -41,6 +40,9 @@ import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HEATMAP_E
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_HEATMAP_PROVIDER_KEY;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -97,9 +99,9 @@ public class TestFeaturesEndPoint {
     Response disabledFeatures = featuresEndPoint.getDisabledFeatures();
     List<FeatureProvider.Feature> allDisabledFeatures =
         (List<FeatureProvider.Feature>) disabledFeatures.getEntity();
-    Assertions.assertNotNull(allDisabledFeatures);
-    Assertions.assertTrue(allDisabledFeatures.size() > 0);
-    Assertions.assertEquals(FeatureProvider.Feature.HEATMAP.getFeatureName(),
+    assertNotNull(allDisabledFeatures);
+    assertTrue(allDisabledFeatures.size() > 0);
+    assertEquals(FeatureProvider.Feature.HEATMAP.getFeatureName(),
         allDisabledFeatures.get(0).getFeatureName());
   }
 
@@ -112,8 +114,8 @@ public class TestFeaturesEndPoint {
     Response disabledFeatures = featuresEndPoint.getDisabledFeatures();
     List<FeatureProvider.Feature> allDisabledFeatures =
         (List<FeatureProvider.Feature>) disabledFeatures.getEntity();
-    Assertions.assertNotNull(allDisabledFeatures);
-    Assertions.assertEquals(0, allDisabledFeatures.size());
+    assertNotNull(allDisabledFeatures);
+    assertEquals(0, allDisabledFeatures.size());
   }
 
   @Test
@@ -125,9 +127,9 @@ public class TestFeaturesEndPoint {
     Response disabledFeatures = featuresEndPoint.getDisabledFeatures();
     List<FeatureProvider.Feature> allDisabledFeatures =
         (List<FeatureProvider.Feature>) disabledFeatures.getEntity();
-    Assertions.assertNotNull(allDisabledFeatures);
-    Assertions.assertTrue(allDisabledFeatures.size() > 0);
-    Assertions.assertEquals(FeatureProvider.Feature.HEATMAP.getFeatureName(),
+    assertNotNull(allDisabledFeatures);
+    assertTrue(allDisabledFeatures.size() > 0);
+    assertEquals(FeatureProvider.Feature.HEATMAP.getFeatureName(),
         allDisabledFeatures.get(0).getFeatureName());
   }
 
@@ -140,7 +142,7 @@ public class TestFeaturesEndPoint {
     Response disabledFeatures = featuresEndPoint.getDisabledFeatures();
     List<FeatureProvider.Feature> allDisabledFeatures =
         (List<FeatureProvider.Feature>) disabledFeatures.getEntity();
-    Assertions.assertNotNull(allDisabledFeatures);
-    Assertions.assertEquals(0, allDisabledFeatures.size());
+    assertNotNull(allDisabledFeatures);
+    assertEquals(0, allDisabledFeatures.size());
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -48,7 +48,6 @@ import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
@@ -70,6 +69,9 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandom
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -221,13 +223,13 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     OmKeyInfo omKeyInfo1 =
         reconOMMetadataManager.getOpenKeyTable(getBucketLayout())
             .get("/sampleVol/bucketOne/key_one");
-    Assertions.assertEquals("key_one", omKeyInfo1.getKeyName());
+    assertEquals("key_one", omKeyInfo1.getKeyName());
     Response openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeyInfo(-1, "", true, true);
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals("key_one",
+    assertNotNull(keyInsightInfoResp);
+    assertEquals("key_one",
         keyInsightInfoResp.getNonFSOKeyInfoList().get(0).getPath());
   }
 
@@ -252,16 +254,16 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
     Response openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeySummary();
-    Assertions.assertNotNull(openKeyInfoResp);
+    assertNotNull(openKeyInfoResp);
 
     Map<String, Long> openKeysSummary =
         (Map<String, Long>) openKeyInfoResp.getEntity();
     // Assert that the key prefix format is accepted in the global stats
-    Assertions.assertEquals(6L,
+    assertEquals(6L,
         openKeysSummary.get("totalOpenKeys"));
-    Assertions.assertEquals(300L,
+    assertEquals(300L,
         openKeysSummary.get("totalReplicatedDataSize"));
-    Assertions.assertEquals(100L,
+    assertEquals(100L,
         openKeysSummary.get("totalUnreplicatedDataSize"));
 
     // Delete the previous records and Update the new value for valid key prefix
@@ -280,16 +282,16 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
     openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeySummary();
-    Assertions.assertNotNull(openKeyInfoResp);
+    assertNotNull(openKeyInfoResp);
 
     openKeysSummary =
         (Map<String, Long>) openKeyInfoResp.getEntity();
     // Assert that the key format is not accepted in the global stats
-    Assertions.assertEquals(0L,
+    assertEquals(0L,
         openKeysSummary.get("totalOpenKeys"));
-    Assertions.assertEquals(0L,
+    assertEquals(0L,
         openKeysSummary.get("totalReplicatedDataSize"));
-    Assertions.assertEquals(0L,
+    assertEquals(0L,
         openKeysSummary.get("totalUnreplicatedDataSize"));
   }
 
@@ -319,31 +321,31 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     // Call the API of Open keys to get the response
     Response openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeySummary();
-    Assertions.assertNotNull(openKeyInfoResp);
+    assertNotNull(openKeyInfoResp);
 
     Map<String, Long> openKeysSummary =
         (Map<String, Long>) openKeyInfoResp.getEntity();
 
-    Assertions.assertEquals(60L,
+    assertEquals(60L,
         openKeysSummary.get("totalReplicatedDataSize"));
-    Assertions.assertEquals(20L,
+    assertEquals(20L,
         openKeysSummary.get("totalUnreplicatedDataSize"));
-    Assertions.assertEquals(6L,
+    assertEquals(6L,
         openKeysSummary.get("totalOpenKeys"));
 
     // Call the API of Deleted keys to get the response
     Response deletedKeyInfoResp =
         omdbInsightEndpoint.getDeletedKeySummary();
-    Assertions.assertNotNull(deletedKeyInfoResp);
+    assertNotNull(deletedKeyInfoResp);
 
     Map<String, Long> deletedKeysSummary = (Map<String, Long>)
         deletedKeyInfoResp.getEntity();
 
-    Assertions.assertEquals(30L,
+    assertEquals(30L,
         deletedKeysSummary.get("totalReplicatedDataSize"));
-    Assertions.assertEquals(10L,
+    assertEquals(10L,
         deletedKeysSummary.get("totalUnreplicatedDataSize"));
-    Assertions.assertEquals(3L,
+    assertEquals(3L,
         deletedKeysSummary.get("totalDeletedKeys"));
   }
 
@@ -373,25 +375,25 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         omdbInsightEndpoint.getOpenKeyInfo(2, "", true, true);
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(2,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(2,
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
-    Assertions.assertEquals(0, keyInsightInfoResp.getFsoKeyInfoList().size());
-    Assertions.assertEquals(2, keyInsightInfoResp.getFsoKeyInfoList().size() +
+    assertEquals(0, keyInsightInfoResp.getFsoKeyInfoList().size());
+    assertEquals(2, keyInsightInfoResp.getFsoKeyInfoList().size() +
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
-    Assertions.assertEquals("key_three",
+    assertEquals("key_three",
         keyInsightInfoResp.getNonFSOKeyInfoList().get(1).getPath());
 
     openKeyInfoResp = omdbInsightEndpoint.getOpenKeyInfo(3, "", true, true);
     keyInsightInfoResp =
         (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(2,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(2,
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
-    Assertions.assertEquals(1, keyInsightInfoResp.getFsoKeyInfoList().size());
-    Assertions.assertEquals(3, keyInsightInfoResp.getFsoKeyInfoList().size() +
+    assertEquals(1, keyInsightInfoResp.getFsoKeyInfoList().size());
+    assertEquals(3, keyInsightInfoResp.getFsoKeyInfoList().size() +
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
-    Assertions.assertEquals("key_three",
+    assertEquals("key_three",
         keyInsightInfoResp.getNonFSOKeyInfoList().get(1).getPath());
   }
 
@@ -436,10 +438,10 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         omdbInsightEndpoint.getOpenKeyInfo(10, "", true, false);
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(4,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(4,
         keyInsightInfoResp.getFsoKeyInfoList().size());
-    Assertions.assertEquals(0,
+    assertEquals(0,
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
 
     // CASE 2 :- Display only Non-FSO keys in response
@@ -447,10 +449,10 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeyInfo(10, "", false, true);
     keyInsightInfoResp = (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(0,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(0,
         keyInsightInfoResp.getFsoKeyInfoList().size());
-    Assertions.assertEquals(3,
+    assertEquals(3,
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
 
     // CASE 3 :- Display both FSO and Non-FSO keys in response
@@ -458,10 +460,10 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeyInfo(10, "", true, true);
     keyInsightInfoResp = (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(4,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(4,
         keyInsightInfoResp.getFsoKeyInfoList().size());
-    Assertions.assertEquals(3,
+    assertEquals(3,
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
 
     // CASE 4 :- Don't Display both FSO and Non-FSO keys in response
@@ -469,10 +471,10 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     openKeyInfoResp =
         omdbInsightEndpoint.getOpenKeyInfo(10, "", false, false);
     keyInsightInfoResp = (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(0,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(0,
         keyInsightInfoResp.getFsoKeyInfoList().size());
-    Assertions.assertEquals(0,
+    assertEquals(0,
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
   }
 
@@ -496,15 +498,15 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
             true, true);
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) openKeyInfoResp.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(1,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(1,
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
-    Assertions.assertEquals(1, keyInsightInfoResp.getFsoKeyInfoList().size());
-    Assertions.assertEquals(2, keyInsightInfoResp.getFsoKeyInfoList().size() +
+    assertEquals(1, keyInsightInfoResp.getFsoKeyInfoList().size());
+    assertEquals(2, keyInsightInfoResp.getFsoKeyInfoList().size() +
         keyInsightInfoResp.getNonFSOKeyInfoList().size());
-    Assertions.assertEquals("key_three",
+    assertEquals("key_three",
         keyInsightInfoResp.getNonFSOKeyInfoList().get(0).getPath());
-    Assertions.assertEquals("key_two",
+    assertEquals("key_two",
         keyInsightInfoResp.getFsoKeyInfoList().get(0).getPath());
   }
 
@@ -527,12 +529,12 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     OmKeyInfo omKeyInfoCopy =
         reconOMMetadataManager.getKeyTable(getBucketLayout())
             .get("/sampleVol/bucketOne/key_one");
-    Assertions.assertEquals("key_one", omKeyInfoCopy.getKeyName());
+    assertEquals("key_one", omKeyInfoCopy.getKeyName());
     RepeatedOmKeyInfo repeatedOmKeyInfo1 = new RepeatedOmKeyInfo(omKeyInfoCopy);
 
     reconOMMetadataManager.getDeletedTable()
         .put("/sampleVol/bucketOne/key_one", repeatedOmKeyInfo1);
-    Assertions.assertEquals("key_one",
+    assertEquals("key_one",
         repeatedOmKeyInfo1.getOmKeyInfoList().get(0).getKeyName());
 
     RepeatedOmKeyInfo repeatedOmKeyInfo2 = new RepeatedOmKeyInfo(omKeyInfo2);
@@ -545,10 +547,10 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     Response deletedKeyInfo = omdbInsightEndpoint.getDeletedKeyInfo(2, "");
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) deletedKeyInfo.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(2,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(2,
         keyInsightInfoResp.getRepeatedOmKeyInfoList().size());
-    Assertions.assertEquals("key_two",
+    assertEquals("key_two",
         keyInsightInfoResp.getRepeatedOmKeyInfoList().get(1).getOmKeyInfoList()
             .get(0).getKeyName());
   }
@@ -577,8 +579,8 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "/sampleVol/bucketOne/key_one");
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) deletedKeyInfo.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(2,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(2,
         keyInsightInfoResp.getRepeatedOmKeyInfoList().size());
 
     List<String> pendingDeleteKeys =
@@ -587,7 +589,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
                 repeatedOmKeyInfo -> repeatedOmKeyInfo.getOmKeyInfoList().get(0)
                     .getKeyName())
             .collect(Collectors.toList());
-    Assertions.assertFalse(pendingDeleteKeys.contains("key_one"));
+    assertFalse(pendingDeleteKeys.contains("key_one"));
   }
 
   @Test
@@ -599,20 +601,20 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         .put("/sampleVol/bucketOne/key_one", omKeyInfo);
     OmKeyInfo omKeyInfo1 = reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_one");
-    Assertions.assertEquals("key_one", omKeyInfo1.getKeyName());
+    assertEquals("key_one", omKeyInfo1.getKeyName());
     RepeatedOmKeyInfo repeatedOmKeyInfo = new RepeatedOmKeyInfo(omKeyInfo);
     reconOMMetadataManager.getDeletedTable()
         .put("/sampleVol/bucketOne/key_one", repeatedOmKeyInfo);
     RepeatedOmKeyInfo repeatedOmKeyInfo1 =
         reconOMMetadataManager.getDeletedTable()
             .get("/sampleVol/bucketOne/key_one");
-    Assertions.assertEquals("key_one",
+    assertEquals("key_one",
         repeatedOmKeyInfo1.getOmKeyInfoList().get(0).getKeyName());
     Response deletedKeyInfo = omdbInsightEndpoint.getDeletedKeyInfo(-1, "");
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) deletedKeyInfo.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals("key_one",
+    assertNotNull(keyInsightInfoResp);
+    assertEquals("key_one",
         keyInsightInfoResp.getRepeatedOmKeyInfoList().get(0).getOmKeyInfoList()
             .get(0).getKeyName());
   }
@@ -650,15 +652,15 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     OmKeyInfo omKeyInfoCopy =
         reconOMMetadataManager.getDeletedDirTable()
             .get("/sampleVol/bucketOne/dir_one");
-    Assertions.assertEquals("dir_one", omKeyInfoCopy.getKeyName());
+    assertEquals("dir_one", omKeyInfoCopy.getKeyName());
 
     Response deletedDirInfo = omdbInsightEndpoint.getDeletedDirInfo(2, "");
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(2,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(2,
         keyInsightInfoResp.getDeletedDirInfoList().size());
-    Assertions.assertEquals("/sampleVol/bucketOne/dir_one",
+    assertEquals("/sampleVol/bucketOne/dir_one",
         keyInsightInfoResp.getDeletedDirInfoList().get(0).getKey());
   }
 
@@ -681,18 +683,18 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     OmKeyInfo omKeyInfoCopy =
         reconOMMetadataManager.getDeletedDirTable()
             .get("/sampleVol/bucketOne/dir_one");
-    Assertions.assertEquals("dir_one", omKeyInfoCopy.getKeyName());
+    assertEquals("dir_one", omKeyInfoCopy.getKeyName());
 
     Response deletedDirInfo = omdbInsightEndpoint.getDeletedDirInfo(2,
         "/sampleVol/bucketOne/dir_one");
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(2,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(2,
         keyInsightInfoResp.getDeletedDirInfoList().size());
-    Assertions.assertEquals("/sampleVol/bucketOne/dir_three",
+    assertEquals("/sampleVol/bucketOne/dir_three",
         keyInsightInfoResp.getDeletedDirInfoList().get(0).getKey());
-    Assertions.assertEquals("/sampleVol/bucketOne/dir_two",
+    assertEquals("/sampleVol/bucketOne/dir_two",
         keyInsightInfoResp.getLastKey());
   }
 
@@ -715,17 +717,17 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     OmKeyInfo omKeyInfoCopy =
         reconOMMetadataManager.getDeletedDirTable()
             .get("/sampleVol/bucketOne/dir_one");
-    Assertions.assertEquals("dir_one", omKeyInfoCopy.getKeyName());
+    assertEquals("dir_one", omKeyInfoCopy.getKeyName());
 
     Response deletedDirInfo = omdbInsightEndpoint.getDeletedDirInfo(-1, "");
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(3,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(3,
         keyInsightInfoResp.getDeletedDirInfoList().size());
-    Assertions.assertEquals("/sampleVol/bucketOne/dir_one",
+    assertEquals("/sampleVol/bucketOne/dir_one",
         keyInsightInfoResp.getDeletedDirInfoList().get(0).getKey());
-    Assertions.assertEquals("/sampleVol/bucketOne/dir_two",
+    assertEquals("/sampleVol/bucketOne/dir_two",
         keyInsightInfoResp.getLastKey());
   }
 
@@ -760,21 +762,21 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     Response deletedDirInfo = omdbInsightEndpoint.getDeletedDirInfo(-1, "");
     KeyInsightInfoResponse keyInsightInfoResp =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
-    Assertions.assertNotNull(keyInsightInfoResp);
-    Assertions.assertEquals(3,
+    assertNotNull(keyInsightInfoResp);
+    assertEquals(3,
         keyInsightInfoResp.getDeletedDirInfoList().size());
     // Assert the total size under directory dir1 is 5L
-    Assertions.assertEquals(5L,
+    assertEquals(5L,
         keyInsightInfoResp.getDeletedDirInfoList().get(0).getSize());
     // Assert the total size under directory dir2 is 6L
-    Assertions.assertEquals(6L,
+    assertEquals(6L,
         keyInsightInfoResp.getDeletedDirInfoList().get(1).getSize());
     // Assert the total size under directory dir3 is 7L
-    Assertions.assertEquals(7L,
+    assertEquals(7L,
         keyInsightInfoResp.getDeletedDirInfoList().get(2).getSize());
 
     // Assert the total of all the deleted directories is 18L
-    Assertions.assertEquals(18L, keyInsightInfoResp.getUnreplicatedDataSize());
+    assertEquals(18L, keyInsightInfoResp.getUnreplicatedDataSize());
   }
 
   private NSSummary getNsSummary(long size) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -67,6 +66,8 @@ import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayo
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -329,7 +330,7 @@ public class TestOpenContainerCount {
       // Process all events in the event queue
       reconScm.getEventQueue().processAll(1000);
     } catch (Exception ex) {
-      Assertions.fail(ex.getMessage());
+      fail(ex.getMessage());
     }
   }
 
@@ -352,7 +353,7 @@ public class TestOpenContainerCount {
       --expectedCnt;
       closeContainer(id);
       DatanodeMetadata metadata = getDatanodeMetadata();
-      Assertions.assertEquals(expectedCnt, metadata.getOpenContainers());
+      assertEquals(expectedCnt, metadata.getOpenContainers());
     }
   }
 
@@ -421,7 +422,7 @@ public class TestOpenContainerCount {
       // Process all events in the event queue
       reconScm.getEventQueue().processAll(1000);
     } catch (Exception ex) {
-      Assertions.fail(ex.getMessage());
+      fail(ex.getMessage());
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTaskStatusService.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTaskStatusService.java
@@ -18,13 +18,13 @@
 
 package org.apache.hadoop.ozone.recon.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 
 import org.apache.hadoop.ozone.recon.persistence.AbstractReconSqlDBTest;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.ReconTaskStatus;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -67,11 +67,10 @@ public class TestTaskStatusService extends AbstractReconSqlDBTest {
     List<ReconTaskStatus> responseList = (List<ReconTaskStatus>)
         response.getEntity();
 
-    Assertions.assertEquals(resultList.size(), responseList.size());
+    assertEquals(resultList.size(), responseList.size());
     for (ReconTaskStatus r : responseList) {
-      Assertions.assertEquals(reconTaskStatusRecord.getTaskName(),
-          r.getTaskName());
-      Assertions.assertEquals(reconTaskStatusRecord.getLastUpdatedTimestamp(),
+      assertEquals(reconTaskStatusRecord.getTaskName(), r.getTaskName());
+      assertEquals(reconTaskStatusRecord.getLastUpdatedTimestamp(),
           r.getLastUpdatedTimestamp());
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.io.TempDir;
 
 import javax.ws.rs.core.Response;
@@ -59,6 +58,7 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializ
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconUtils.createTarFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -148,7 +148,7 @@ public class TestTriggerDBSyncEndpoint {
     TriggerDBSyncEndpoint triggerDBSyncEndpoint
         = reconTestInjector.getInstance(TriggerDBSyncEndpoint.class);
     Response response = triggerDBSyncEndpoint.triggerOMDBSync();
-    Assertions.assertEquals(200, response.getStatus());
-    Assertions.assertEquals(true, response.getEntity());
+    assertEquals(200, response.getStatus());
+    assertEquals(true, response.getEntity());
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/filters/TestAdminFilter.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/filters/TestAdminFilter.java
@@ -17,6 +17,11 @@
  */
 package org.apache.hadoop.ozone.recon.api.filters;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.recon.ReconConfigKeys;
@@ -30,9 +35,7 @@ import org.apache.hadoop.ozone.recon.api.TaskStatusService;
 import org.apache.hadoop.ozone.recon.api.TriggerDBSyncEndpoint;
 import org.apache.hadoop.ozone.recon.api.UtilizationEndpoint;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
@@ -64,7 +67,7 @@ public class TestAdminFilter {
     Set<Class<?>> allEndpoints =
         reflections.getTypesAnnotatedWith(Path.class);
 
-    Assertions.assertFalse(allEndpoints.isEmpty());
+    assertFalse(allEndpoints.isEmpty());
 
     // If an endpoint is added, it must be explicitly added to this set or be
     // marked with @AdminOnly for this test to pass.
@@ -77,19 +80,19 @@ public class TestAdminFilter {
     nonAdminEndpoints.add(TaskStatusService.class);
     nonAdminEndpoints.add(TriggerDBSyncEndpoint.class);
 
-    Assertions.assertTrue(allEndpoints.containsAll(nonAdminEndpoints));
+    assertTrue(allEndpoints.containsAll(nonAdminEndpoints));
 
     Set<Class<?>> adminEndpoints = Sets.difference(allEndpoints,
         nonAdminEndpoints);
 
     for (Class<?> endpoint: nonAdminEndpoints) {
-      Assertions.assertFalse(endpoint.isAnnotationPresent(AdminOnly.class),
+      assertFalse(endpoint.isAnnotationPresent(AdminOnly.class),
           String.format("Endpoint class %s has been declared as non admin " +
               "in this test, but is marked as @AdminOnly.", endpoint));
     }
 
     for (Class<?> endpoint: adminEndpoints) {
-      Assertions.assertTrue(endpoint.isAnnotationPresent(AdminOnly.class),
+      assertTrue(endpoint.isAnnotationPresent(AdminOnly.class),
           String.format("Endpoint class %s must be marked as @AdminOnly " +
               "or explicitly declared as non admin in this test.", endpoint));
     }
@@ -164,21 +167,21 @@ public class TestAdminFilter {
 
   private void testAdminFilterWithPrincipal(OzoneConfiguration conf,
       String principalToUse, boolean shouldPass) throws Exception {
-    Principal mockPrincipal = Mockito.mock(Principal.class);
-    Mockito.when(mockPrincipal.getName()).thenReturn(principalToUse);
-    HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
-    Mockito.when(mockRequest.getUserPrincipal()).thenReturn(mockPrincipal);
+    Principal mockPrincipal = mock(Principal.class);
+    when(mockPrincipal.getName()).thenReturn(principalToUse);
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    when(mockRequest.getUserPrincipal()).thenReturn(mockPrincipal);
 
-    HttpServletResponse mockResponse = Mockito.mock(HttpServletResponse.class);
-    FilterChain mockFilterChain = Mockito.mock(FilterChain.class);
+    HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+    FilterChain mockFilterChain = mock(FilterChain.class);
 
     new ReconAdminFilter(conf).doFilter(mockRequest, mockResponse,
         mockFilterChain);
 
     if (shouldPass) {
-      Mockito.verify(mockFilterChain).doFilter(mockRequest, mockResponse);
+      verify(mockFilterChain).doFilter(mockRequest, mockResponse);
     } else {
-      Mockito.verify(mockResponse).setStatus(HttpServletResponse.SC_FORBIDDEN);
+      verify(mockResponse).setStatus(HttpServletResponse.SC_FORBIDDEN);
     }
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
@@ -29,13 +29,14 @@ import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacem
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +61,7 @@ public class TestContainerHealthStatus {
     when(container.containerID()).thenReturn(ContainerID.valueOf(123456));
     when(container.getContainerID()).thenReturn((long)123456);
     when(placementPolicy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+        anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 1, 1));
   }
 
@@ -163,7 +164,7 @@ public class TestContainerHealthStatus {
         ContainerReplicaProto.State.CLOSED,
         ContainerReplicaProto.State.CLOSED);
     when(placementPolicy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+        anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 2, 5));
     ContainerHealthStatus status =
         new ContainerHealthStatus(container, replicas, placementPolicy,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.recon.fsck;
 import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_UNHEALTHY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -59,7 +60,6 @@ import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.hadoop.ozone.recon.schema.tables.daos.UnhealthyContainersDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.ReconTaskStatus;
 import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -137,7 +137,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
         .thenReturn(Collections.emptySet());
 
     List<UnhealthyContainers> all = unHealthyContainersTableHandle.findAll();
-    Assertions.assertTrue(all.isEmpty());
+    assertTrue(all.isEmpty());
 
     long currentTime = System.currentTimeMillis();
     ReconTaskStatusDao reconTaskStatusDao = getDao(ReconTaskStatusDao.class);
@@ -192,7 +192,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
 
     ReconTaskStatus taskStatus =
         reconTaskStatusDao.findById(containerHealthTask.getTaskName());
-    Assertions.assertTrue(taskStatus.getLastUpdatedTimestamp() >
+    assertTrue(taskStatus.getLastUpdatedTimestamp() >
         currentTime);
 
     // Now run the job again, to check that relevant records are updated or
@@ -300,7 +300,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
         .thenReturn(new ContainerWithPipeline(mockContainers.get(0), null));
 
     List<UnhealthyContainers> all = unHealthyContainersTableHandle.findAll();
-    Assertions.assertTrue(all.isEmpty());
+    assertTrue(all.isEmpty());
 
     long currentTime = System.currentTimeMillis();
     ReconTaskStatusDao reconTaskStatusDao = getDao(ReconTaskStatusDao.class);
@@ -328,7 +328,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
 
     ReconTaskStatus taskStatus =
         reconTaskStatusDao.findById(containerHealthTask.getTaskName());
-    Assertions.assertTrue(taskStatus.getLastUpdatedTimestamp() >
+    assertTrue(taskStatus.getLastUpdatedTimestamp() >
         currentTime);
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
@@ -31,7 +31,6 @@ import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
 import org.hadoop.ozone.recon.schema.tables.records.UnhealthyContainersRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +48,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -85,7 +86,7 @@ public class TestContainerHealthTaskRecordGenerator {
     when(emptyContainer.containerID()).thenReturn(ContainerID.valueOf(345678));
     when(emptyContainer.getContainerID()).thenReturn((long) 345678);
     when(placementPolicy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+        anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 1, 1));
   }
 
@@ -195,7 +196,7 @@ public class TestContainerHealthTaskRecordGenerator {
     Set<ContainerReplica> replicas =
         generateReplicas(container, CLOSED, CLOSED, CLOSED);
     when(placementPolicy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+        anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(2, 3, 5));
     ContainerHealthStatus status =
         new ContainerHealthStatus(container, replicas, placementPolicy,
@@ -222,7 +223,7 @@ public class TestContainerHealthTaskRecordGenerator {
 
     // Container is now placed OK - should be removed.
     when(placementPolicy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+        anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(3, 3, 5));
     status = new ContainerHealthStatus(container, replicas, placementPolicy,
         reconContainerMetadataManager);
@@ -306,7 +307,7 @@ public class TestContainerHealthTaskRecordGenerator {
     replicas =
         generateReplicas(container, CLOSED, CLOSED);
     when(placementPolicy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+        anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 2, 5));
     status =
         new ContainerHealthStatus(container, replicas, placementPolicy,
@@ -354,7 +355,7 @@ public class TestContainerHealthTaskRecordGenerator {
     // it is mis-replicated too
     replicas.clear();
     when(placementPolicy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+        anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 2, 5));
     status =
         new ContainerHealthStatus(container, replicas, placementPolicy,
@@ -486,7 +487,7 @@ public class TestContainerHealthTaskRecordGenerator {
     // Under and Mis-Replicated
     replicas = generateReplicas(container, CLOSED, CLOSED);
     when(placementPolicy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+        anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 2, 5));
     status = new ContainerHealthStatus(container, replicas, placementPolicy,
         reconContainerMetadataManager);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImp
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -46,6 +45,9 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -759,24 +761,17 @@ public class TestHeatMapInfo {
         Arrays.stream(entities).collect(Collectors.toList());
     EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
         heatMapUtil.generateHeatMap(entityMetaDataList);
-    Assertions.assertTrue(
-        entityReadAccessHeatMapResponse.getChildren().size() > 0);
-    Assertions.assertEquals(12,
-        entityReadAccessHeatMapResponse.getChildren().size());
-    Assertions.assertEquals(25600, entityReadAccessHeatMapResponse.
-        getSize());
-    Assertions.assertEquals(2924, entityReadAccessHeatMapResponse.
-        getMinAccessCount());
-    Assertions.assertEquals(155074, entityReadAccessHeatMapResponse.
-        getMaxAccessCount());
-    Assertions.assertEquals("root", entityReadAccessHeatMapResponse.
-        getLabel());
-    Assertions.assertEquals(0.0,
-        entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
-    Assertions.assertEquals(0.442,
+    assertTrue(entityReadAccessHeatMapResponse.getChildren().size() > 0);
+    assertEquals(12, entityReadAccessHeatMapResponse.getChildren().size());
+    assertEquals(25600, entityReadAccessHeatMapResponse.getSize());
+    assertEquals(2924, entityReadAccessHeatMapResponse.getMinAccessCount());
+    assertEquals(155074, entityReadAccessHeatMapResponse.getMaxAccessCount());
+    assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
+    assertEquals(0.0, entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
+    assertEquals(0.442,
         entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
             .get(0).getChildren().get(1).getColor());
-    Assertions.assertEquals(0.058,
+    assertEquals(0.058,
         entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
             .get(1).getChildren().get(3).getColor());
   }
@@ -875,22 +870,15 @@ public class TestHeatMapInfo {
       //}
       EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
           heatMapUtil.generateHeatMap(entityMetaDataList);
-      Assertions.assertTrue(
-          entityReadAccessHeatMapResponse.getChildren().size() > 0);
-      Assertions.assertEquals(2,
-          entityReadAccessHeatMapResponse.getChildren().size());
-      Assertions.assertEquals(512, entityReadAccessHeatMapResponse.
-          getSize());
-      Assertions.assertEquals(8590, entityReadAccessHeatMapResponse.
-          getMinAccessCount());
-      Assertions.assertEquals(19263, entityReadAccessHeatMapResponse.
-          getMaxAccessCount());
-      Assertions.assertEquals(1.0,
-          entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
-      Assertions.assertEquals("root", entityReadAccessHeatMapResponse.
-          getLabel());
+      assertTrue(entityReadAccessHeatMapResponse.getChildren().size() > 0);
+      assertEquals(2, entityReadAccessHeatMapResponse.getChildren().size());
+      assertEquals(512, entityReadAccessHeatMapResponse.getSize());
+      assertEquals(8590, entityReadAccessHeatMapResponse.getMinAccessCount());
+      assertEquals(19263, entityReadAccessHeatMapResponse.getMaxAccessCount());
+      assertEquals(1.0, entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
+      assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
     } else {
-      Assertions.assertNull(entities);
+      assertNull(entities);
     }
   }
 
@@ -1110,18 +1098,18 @@ public class TestHeatMapInfo {
       //}
       EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
           heatMapUtil.generateHeatMap(entityMetaDataList);
-      Assertions.assertTrue(
+      assertTrue(
           entityReadAccessHeatMapResponse.getChildren().size() > 0);
-      Assertions.assertEquals(2,
+      assertEquals(2,
           entityReadAccessHeatMapResponse.getChildren().size());
-      Assertions.assertEquals(0.0,
+      assertEquals(0.0,
           entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
       String path =
           entityReadAccessHeatMapResponse.getChildren().get(1).getChildren()
               .get(0).getPath();
-      Assertions.assertEquals("/testnewvol2/fsobuck11", path);
+      assertEquals("/testnewvol2/fsobuck11", path);
     } else {
-      Assertions.assertNull(entities);
+      assertNull(entities);
     }
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/AbstractReconSqlDBTest.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.recon.persistence;
 
 import static org.hadoop.ozone.recon.codegen.SqlDbUtils.DERBY_DRIVER_CLASS;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +39,6 @@ import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 
 import com.google.inject.AbstractModule;
@@ -65,7 +65,7 @@ public class AbstractReconSqlDBTest {
           new DerbyDataSourceConfigurationProvider(Files.createDirectory(
               temporaryFolder.resolve("Config")).toFile());
     } catch (IOException e) {
-      Assertions.fail();
+      fail();
     }
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestStatsSchemaDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestStatsSchemaDefinition.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -33,6 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hadoop.ozone.recon.schema.StatsSchemaDefinition.GLOBAL_STATS_TABLE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Class used to test StatsSchemaDefinition.
@@ -61,8 +62,8 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
           resultSet.getInt("DATA_TYPE")));
     }
 
-    Assertions.assertEquals(3, actualPairs.size());
-    Assertions.assertEquals(expectedPairs, actualPairs);
+    assertEquals(3, actualPairs.size());
+    assertEquals(expectedPairs, actualPairs);
   }
 
   @Test
@@ -74,7 +75,7 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
         GLOBAL_STATS_TABLE_NAME, null);
 
     while (resultSet.next()) {
-      Assertions.assertEquals(GLOBAL_STATS_TABLE_NAME,
+      assertEquals(GLOBAL_STATS_TABLE_NAME,
           resultSet.getString("TABLE_NAME"));
     }
 
@@ -97,15 +98,15 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
     // Read
     GlobalStats dbRecord = dao.findById("key1");
 
-    Assertions.assertEquals("key1", dbRecord.getKey());
-    Assertions.assertEquals(Long.valueOf(500), dbRecord.getValue());
-    Assertions.assertEquals(new Timestamp(now),
+    assertEquals("key1", dbRecord.getKey());
+    assertEquals(Long.valueOf(500), dbRecord.getValue());
+    assertEquals(new Timestamp(now),
         dbRecord.getLastUpdatedTimestamp());
 
     dbRecord = dao.findById("key2");
-    Assertions.assertEquals("key2", dbRecord.getKey());
-    Assertions.assertEquals(Long.valueOf(10), dbRecord.getValue());
-    Assertions.assertEquals(new Timestamp(now + 1000L),
+    assertEquals("key2", dbRecord.getKey());
+    assertEquals(Long.valueOf(10), dbRecord.getValue());
+    assertEquals(new Timestamp(now + 1000L),
         dbRecord.getLastUpdatedTimestamp());
 
     // Update
@@ -116,9 +117,9 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
     // Read updated
     dbRecord = dao.findById("key2");
 
-    Assertions.assertEquals(new Timestamp(now + 2000L),
+    assertEquals(new Timestamp(now + 2000L),
         dbRecord.getLastUpdatedTimestamp());
-    Assertions.assertEquals(Long.valueOf(100L), dbRecord.getValue());
+    assertEquals(Long.valueOf(100L), dbRecord.getValue());
 
     // Delete
     dao.deleteById("key1");
@@ -126,6 +127,6 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
     // Verify
     dbRecord = dao.findById("key1");
 
-    Assertions.assertNull(dbRecord);
+    assertNull(dbRecord);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -56,7 +56,6 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 /**
  * Test Recon ICR handler.
@@ -87,11 +86,10 @@ public class TestReconIncrementalContainerReportHandler
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
     EventQueue eventQueue = new EventQueue();
     SCMStorageConfig storageConfig = new SCMStorageConfig(conf);
-    this.versionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
-    Mockito.when(versionManager.getMetadataLayoutVersion())
+    this.versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion())
         .thenReturn(maxLayoutVersion());
-    Mockito.when(versionManager.getSoftwareLayoutVersion())
+    when(versionManager.getSoftwareLayoutVersion())
         .thenReturn(maxLayoutVersion());
 
     NodeManager nodeManager = new SCMNodeManager(conf, storageConfig,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -65,9 +65,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Class to test Recon Pipeline Manager.
@@ -131,11 +131,10 @@ public class TestReconPipelineManager {
 
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
     EventQueue eventQueue = new EventQueue();
-    this.versionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
-    Mockito.when(versionManager.getMetadataLayoutVersion())
+    this.versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion())
         .thenReturn(maxLayoutVersion());
-    Mockito.when(versionManager.getSoftwareLayoutVersion())
+    when(versionManager.getSoftwareLayoutVersion())
         .thenReturn(maxLayoutVersion());
     NodeManager nodeManager = new SCMNodeManager(conf, scmStorageConfig,
         eventQueue, clusterMap, SCMContext.emptyContext(), versionManager);
@@ -149,7 +148,7 @@ public class TestReconPipelineManager {
                  scmhaManager,
                  scmContext)) {
       StorageContainerManager mock = mock(StorageContainerManager.class);
-      Mockito.when(mock.getScmNodeDetails())
+      when(mock.getScmNodeDetails())
           .thenReturn(mock(SCMNodeDetails.class));
       scmContext = new SCMContext.Builder().setIsInSafeMode(true)
               .setLeader(true).setIsPreCheckComplete(true)
@@ -185,11 +184,10 @@ public class TestReconPipelineManager {
     Pipeline pipeline = getRandomPipeline();
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
     EventQueue eventQueue = new EventQueue();
-    this.versionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
-    Mockito.when(versionManager.getMetadataLayoutVersion())
+    this.versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion())
         .thenReturn(maxLayoutVersion());
-    Mockito.when(versionManager.getSoftwareLayoutVersion())
+    when(versionManager.getSoftwareLayoutVersion())
         .thenReturn(maxLayoutVersion());
     NodeManager nodeManager = new SCMNodeManager(conf, scmStorageConfig,
         eventQueue, clusterMap, SCMContext.emptyContext(), versionManager);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.recon.ReconTestInjector;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +38,10 @@ import java.util.Set;
 
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for NSSummary manager.
@@ -84,31 +87,29 @@ public class TestReconNamespaceSummaryManagerImpl {
     NSSummary summary = reconNamespaceSummaryManager.getNSSummary(1L);
     NSSummary summary2 = reconNamespaceSummaryManager.getNSSummary(2L);
     NSSummary summary3 = reconNamespaceSummaryManager.getNSSummary(3L);
-    Assertions.assertEquals(1, summary.getNumOfFiles());
-    Assertions.assertEquals(2, summary.getSizeOfFiles());
-    Assertions.assertEquals(3, summary2.getNumOfFiles());
-    Assertions.assertEquals(4, summary2.getSizeOfFiles());
-    Assertions.assertEquals(5, summary3.getNumOfFiles());
-    Assertions.assertEquals(6, summary3.getSizeOfFiles());
+    assertEquals(1, summary.getNumOfFiles());
+    assertEquals(2, summary.getSizeOfFiles());
+    assertEquals(3, summary2.getNumOfFiles());
+    assertEquals(4, summary2.getSizeOfFiles());
+    assertEquals(5, summary3.getNumOfFiles());
+    assertEquals(6, summary3.getSizeOfFiles());
 
-    Assertions.assertEquals("dir1", summary.getDirName());
-    Assertions.assertEquals("dir2", summary2.getDirName());
-    Assertions.assertEquals("dir3", summary3.getDirName());
+    assertEquals("dir1", summary.getDirName());
+    assertEquals("dir2", summary2.getDirName());
+    assertEquals("dir3", summary3.getDirName());
 
     // test child dir is written
-    Assertions.assertEquals(3, summary.getChildDir().size());
+    assertEquals(3, summary.getChildDir().size());
     // non-existent key
-    Assertions.assertNull(reconNamespaceSummaryManager.getNSSummary(0L));
+    assertNull(reconNamespaceSummaryManager.getNSSummary(0L));
   }
 
   @Test
   public void testInitNSSummaryTable() throws IOException {
     putThreeNSMetadata();
-    Assertions.assertFalse(
-            reconNamespaceSummaryManager.getNSSummaryTable().isEmpty());
+    assertFalse(reconNamespaceSummaryManager.getNSSummaryTable().isEmpty());
     reconNamespaceSummaryManager.clearNSSummaryTable();
-    Assertions.assertTrue(
-            reconNamespaceSummaryManager.getNSSummaryTable().isEmpty());
+    assertTrue(reconNamespaceSummaryManager.getNSSummaryTable().isEmpty());
   }
 
   private void putThreeNSMetadata() throws IOException {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestStorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestStorageContainerServiceProviderImpl.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,7 +36,6 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -74,7 +74,7 @@ public class TestStorageContainerServiceProviderImpl {
               toInstance(conf);
           bind(ReconUtils.class).toInstance(reconUtils);
         } catch (Exception e) {
-          Assertions.fail();
+          fail();
         }
       }
     });

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
@@ -33,7 +33,6 @@ import org.jooq.DSLContext;
 import org.jooq.Record3;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.AdditionalAnswers;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,6 +46,7 @@ import static org.hadoop.ozone.recon.schema.tables.FileCountBySizeTable.FILE_COU
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalAnswers.returnsElementsOf;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -309,16 +309,16 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .thenReturn(keyTableFso);
 
     when(mockKeyIterLegacy.hasNext())
-        .thenAnswer(AdditionalAnswers.returnsElementsOf(hasNextAnswer));
+        .thenAnswer(returnsElementsOf(hasNextAnswer));
     when(mockKeyIterFso.hasNext())
-        .thenAnswer(AdditionalAnswers.returnsElementsOf(hasNextAnswer));
+        .thenAnswer(returnsElementsOf(hasNextAnswer));
     when(mockKeyIterLegacy.next()).thenReturn(mockKeyValueLegacy);
     when(mockKeyIterFso.next()).thenReturn(mockKeyValueFso);
 
     when(mockKeyValueLegacy.getValue())
-        .thenAnswer(AdditionalAnswers.returnsElementsOf(omKeyInfoList));
+        .thenAnswer(returnsElementsOf(omKeyInfoList));
     when(mockKeyValueFso.getValue())
-        .thenAnswer(AdditionalAnswers.returnsElementsOf(omKeyInfoList));
+        .thenAnswer(returnsElementsOf(omKeyInfoList));
 
     Pair<String, Boolean> result =
         fileSizeCountTask.reprocess(omMetadataManager);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -41,7 +40,9 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializ
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.PUT;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
@@ -96,7 +97,7 @@ public class TestOmUpdateEventValidator {
         mock(SnapshotInfo.class), "key1", PUT));
 
     // Verify that no log message is printed
-    verify(logger, Mockito.never()).warn(Mockito.anyString());
+    verify(logger, never()).warn(anyString());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add static import for assertions and mocks in hadoop-ozone/recon
The goal of this task is to add import static for all assertions and interactions with mocks. Replacing:
```
Assertions.assert<X>(...) -> assert<X>(...)
Assertions.fail(...) -> fail(...)
```
and
```
Mockito.mock(...) -> mock(...)
Mockito.verify(...) -> verify(...)
Mockito.when(...) -> when(...)
```
and
```
ArgumentMatchers.any() -> any()
ArgumentMatchers.eq() -> eq()
ArgumentMatchers.matches() -> matches()
// also:
// Matchers.<...>()
```
makes the code more readable (shorter lines, less wrapping).

## What is the link to the Apache JIRA
[HDDS-9996](https://issues.apache.org/jira/browse/HDDS-9996)

## CI
https://github.com/wzhallright/ozone/actions/runs/7321501158
