### PR TITLE
HDDS-9921. Migrate TestRootedOzoneFileSystem to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
@@ -118,10 +118,6 @@
     <Bug pattern="DLS_DEAD_LOCAL_STORE" />
   </Match>
   <Match>
-    <Class name="org.apache.hadoop.fs.ozone.TestRootedOzoneFileSystem"/>
-    <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
-  </Match>
-  <Match>
     <Class name="org.apache.hadoop.fs.ozone.TestOzoneFileSystemMissingParent"/>
     <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
   </Match>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -172,7 +172,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @BeforeEach
-  public void createVolumeAndBucket() throws IOException {
+  void createVolumeAndBucket() throws IOException {
     // create a volume and a bucket to be used by RootedOzoneFileSystem (OFS)
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(client, bucketLayout);
@@ -183,7 +183,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @AfterEach
-  public void cleanup() throws IOException {
+  void cleanup() throws IOException {
     fs.delete(bucketPath, true);
     fs.delete(volumePath, false);
   }
@@ -293,7 +293,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testOzoneFsServiceLoader() throws IOException {
+  void testOzoneFsServiceLoader() throws IOException {
     assumeFalse(isBucketFSOptimized);
 
     OzoneConfiguration confTestLoader = new OzoneConfiguration();
@@ -303,7 +303,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testCreateDoesNotAddParentDirKeys() throws Exception {
+  void testCreateDoesNotAddParentDirKeys() throws Exception {
     Path grandparent = new Path(bucketPath,
         "testCreateDoesNotAddParentDirKeys");
     Path parent = new Path(grandparent, "parent");
@@ -330,7 +330,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testListStatusWithIntermediateDirWithECEnabled()
+  void testListStatusWithIntermediateDirWithECEnabled()
           throws Exception {
     String key = "object-dir/object-name1";
 
@@ -367,7 +367,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testDeleteCreatesFakeParentDir() throws Exception {
+  void testDeleteCreatesFakeParentDir() throws Exception {
     // TODO: Request for comment.
     //  If possible, improve this to test when FS Path is enabled.
     assumeTrue(!enabledFileSystemPaths, "FS Path is enabled. Skipping this test as it is not " +
@@ -403,7 +403,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testListStatus() throws Exception {
+  void testListStatus() throws Exception {
     Path parent = new Path(bucketPath, "testListStatus");
     Path file1 = new Path(parent, "key1");
     Path file2 = new Path(parent, "key2");
@@ -441,7 +441,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Tests listStatusIterator operation on a directory.
    */
   @Test
-  public void testListStatusIteratorWithDir() throws Exception {
+  void testListStatusIteratorWithDir() throws Exception {
     Path parent = new Path(bucketPath, "testListStatus");
     Path file1 = new Path(parent, "key1");
     Path file2 = new Path(parent, "key2");
@@ -493,7 +493,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Test listStatusIterator operation in a bucket.
    */
   @Test
-  public void testListStatusIteratorInBucket() throws Exception {
+  void testListStatusIteratorInBucket() throws Exception {
     Path root = new Path("/" + volumeName + "/" + bucketName);
     Path dir1 = new Path(root, "dir1");
     Path dir12 = new Path(dir1, "dir12");
@@ -525,7 +525,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testListStatusIteratorWithPathNotFound() throws Exception {
+  void testListStatusIteratorWithPathNotFound() throws Exception {
     Path path = new Path("/test/test1/test2");
     try {
       ofs.listStatusIterator(path);
@@ -540,7 +540,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * numbers of numDir.
    */
   @Test
-  public void testListStatusIteratorOnPageSize() throws Exception {
+  void testListStatusIteratorOnPageSize() throws Exception {
     OzoneFileSystemTests.listStatusIteratorOnPageSize(conf,
         "/" + volumeName + "/" + bucketName);
   }
@@ -549,7 +549,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Tests listStatusIterator on a path with subdirs.
    */
   @Test
-  public void testListStatusIteratorOnSubDirs() throws Exception {
+  void testListStatusIteratorOnSubDirs() throws Exception {
     // Create the following key structure
     //      /dir1/dir11/dir111
     //      /dir1/dir12
@@ -623,7 +623,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * OFS: Test mkdir on volume, bucket and dir that doesn't exist.
    */
   @Test
-  public void testMkdirOnNonExistentVolumeBucketDir() throws Exception {
+  void testMkdirOnNonExistentVolumeBucketDir() throws Exception {
     // TODO: Request for comment.
     //  If possible, improve this to test when FS Path is enabled.
     assumeTrue(!enabledFileSystemPaths, "FS Path is enabled. Skipping this test as it is not " +
@@ -669,7 +669,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * OFS: Test mkdir on a volume and bucket that doesn't exist.
    */
   @Test
-  public void testMkdirNonExistentVolumeBucket() throws Exception {
+  void testMkdirNonExistentVolumeBucket() throws Exception {
     String volumeNameLocal = getRandomNonExistVolumeName();
     String bucketNameLocal = "bucket-" + RandomStringUtils.randomNumeric(5);
     Path newVolBucket = new Path(
@@ -700,7 +700,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * OFS: Test mkdir on a volume that doesn't exist.
    */
   @Test
-  public void testMkdirNonExistentVolume() throws Exception {
+  void testMkdirNonExistentVolume() throws Exception {
     assumeFalse(isBucketFSOptimized);
 
     String volumeNameLocal = getRandomNonExistVolumeName();
@@ -724,7 +724,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * OFS: Test getFileStatus on root.
    */
   @Test
-  public void testGetFileStatusRoot() throws Exception {
+  void testGetFileStatusRoot() throws Exception {
     Path root = new Path("/");
     FileStatus fileStatus = fs.getFileStatus(root);
     assertNotNull(fileStatus);
@@ -737,7 +737,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Test listStatus operation in a bucket.
    */
   @Test
-  public void testListStatusInBucket() throws Exception {
+  void testListStatusInBucket() throws Exception {
     Path root = new Path("/" + volumeName + "/" + bucketName);
     Path dir1 = new Path(root, "dir1");
     Path dir12 = new Path(dir1, "dir12");
@@ -769,7 +769,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Tests listStatus operation on root directory.
    */
   @Test
-  public void testListStatusOnLargeDirectory() throws Exception {
+  void testListStatusOnLargeDirectory() throws Exception {
     Path root = new Path("/" + volumeName + "/" + bucketName);
     Set<String> paths = new TreeSet<>();
     int numDirs = LISTING_PAGE_SIZE + LISTING_PAGE_SIZE / 2;
@@ -799,7 +799,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Tests listStatus on a path with subdirs.
    */
   @Test
-  public void testListStatusOnSubDirs() throws Exception {
+  void testListStatusOnSubDirs() throws Exception {
     // Create the following key structure
     //      /dir1/dir11/dir111
     //      /dir1/dir12
@@ -838,7 +838,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testNonExplicitlyCreatedPathExistsAfterItsLeafsWereRemoved()
+  void testNonExplicitlyCreatedPathExistsAfterItsLeafsWereRemoved()
       throws Exception {
     Path source = new Path(bucketPath, "source");
     Path interimPath = new Path(source, "interimPath");
@@ -869,7 +869,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * OFS: Try to rename a key to a different bucket. The attempt should fail.
    */
   @Test
-  public void testRenameToDifferentBucket() throws IOException {
+  void testRenameToDifferentBucket() throws IOException {
     Path source = new Path(bucketPath, "source");
     Path interimPath = new Path(source, "interimPath");
     Path leafInsideInterimPath = new Path(interimPath, "leaf");
@@ -949,7 +949,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * and test the owner on listStatus.
    */
   @Test
-  public void testListStatusWithDifferentBucketOwner() throws IOException {
+  void testListStatusWithDifferentBucketOwner() throws IOException {
     String volName = getRandomNonExistVolumeName();
     objectStore.createVolume(volName);
     OzoneVolume ozoneVolume = objectStore.getVolume(volName);
@@ -981,7 +981,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * OFS: Test non-recursive listStatus on root and volume.
    */
   @Test
-  public void testListStatusRootAndVolumeNonRecursive() throws Exception {
+  void testListStatusRootAndVolumeNonRecursive() throws Exception {
     // Get owner and group of the user running this test
     final UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     final String ownerShort = ugi.getShortUserName();
@@ -1086,7 +1086,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * OFS: Test recursive listStatus on root and volume.
    */
   @Test
-  public void testListStatusRootAndVolumeRecursive() throws IOException {
+  void testListStatusRootAndVolumeRecursive() throws IOException {
     assumeFalse(isBucketFSOptimized);
 
     Path bucketPath1 = createRandomVolumeBucketWithDirs();
@@ -1133,7 +1133,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testListStatusRootAndVolumeContinuation() throws IOException {
+  void testListStatusRootAndVolumeContinuation() throws IOException {
     // TODO: Request for comment.
     //  If possible, improve this to test when FS Path is enabled.
     assumeTrue(!enabledFileSystemPaths, "FS Path is enabled. Skipping this test as it is not " +
@@ -1181,7 +1181,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testSharedTmpDir() throws IOException {
+  void testSharedTmpDir() throws IOException {
     // Prep
     conf.setBoolean(OZONE_OM_ENABLE_OFS_SHARED_TMP_DIR, true);
     // Use ClientProtocol to pass in volume ACL, ObjectStore won't do it
@@ -1298,7 +1298,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * OFS: Test /tmp mount behavior.
    */
   @Test
-  public void testTempMount() throws IOException {
+  void testTempMount() throws IOException {
     assumeFalse(isBucketFSOptimized);
 
     // Prep
@@ -1387,7 +1387,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
   /**
    * Helper function. Delete a path non-recursively and expect failure.
    * @param f Path to delete.
-   * @throws IOException
    */
   private void deleteNonRecursivelyAndFail(Path f) throws IOException {
     try {
@@ -1398,7 +1397,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testDeleteEmptyVolume() throws IOException {
+  void testDeleteEmptyVolume() throws IOException {
     assumeFalse(isBucketFSOptimized);
 
     // Create volume
@@ -1415,7 +1414,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testDeleteVolumeAndBucket() throws IOException {
+  void testDeleteVolumeAndBucket() throws IOException {
     // Create volume and bucket
     String volumeStr2 = getRandomNonExistVolumeName();
     Path volumePath2 = new Path(OZONE_URI_DELIMITER + volumeStr2);
@@ -1437,7 +1436,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testDeleteVolumeBucketAndKey() throws IOException {
+  void testDeleteVolumeBucketAndKey() throws IOException {
     // Create test volume, bucket and key
     String volumeStr3 = getRandomNonExistVolumeName();
     Path volumePath3 = new Path(OZONE_URI_DELIMITER + volumeStr3);
@@ -1479,7 +1478,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testSymlinkList() throws Exception {
+  void testSymlinkList() throws Exception {
     OzoneFsShell shell = new OzoneFsShell(conf);
     // setup symlink, destVol/destBucket -> srcVol/srcBucket
     String srcVolume = getRandomNonExistVolumeName();
@@ -1540,7 +1539,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testSymlinkPosixDelete() throws Exception {
+  void testSymlinkPosixDelete() throws Exception {
     OzoneFsShell shell = new OzoneFsShell(conf);
     // setup symlink, destVol/destBucket -> srcVol/srcBucket
     String srcVolume = getRandomNonExistVolumeName();
@@ -1601,7 +1600,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
         assertEquals(srcBucket, objectStore.getVolume(destVolume)
             .getBucket(srcBucket).getName());
-        assertEquals(true, objectStore.getVolume(destVolume)
+        assertTrue(objectStore.getVolume(destVolume)
             .getBucket(srcBucket).isLink());
         assertEquals(srcBucket, objectStore.getVolume(srcVolume)
             .getBucket(srcBucket).getName());
@@ -1650,7 +1649,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testDeleteBucketLink() throws Exception {
+  void testDeleteBucketLink() throws Exception {
     // Create test volume, bucket, directory
     String volumeStr1 = getRandomNonExistVolumeName();
     Path volumePath1 = new Path(OZONE_URI_DELIMITER + volumeStr1);
@@ -1682,7 +1681,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     fs.delete(linkVolumePath, false);
 
     // confirm vol1 data is unaffected
-    assertTrue(dir1Status.equals(fs.getFileStatus(dirPath1)));
+    assertEquals(dir1Status, fs.getFileStatus(dirPath1));
 
     // confirm link is gone
     FileNotFoundException exception = assertThrows(FileNotFoundException.class,
@@ -1696,7 +1695,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testFailToDeleteRoot() throws IOException {
+  void testFailToDeleteRoot() throws IOException {
     // rm root should always fail for OFS
     assertFalse(fs.delete(new Path("/"), false));
     assertFalse(fs.delete(new Path("/"), true));
@@ -1732,7 +1731,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Test getTrashRoots() in OFS. Different from the existing test for o3fs.
    */
   @Test
-  public void testGetTrashRoots() throws IOException {
+  void testGetTrashRoots() throws IOException {
     String username = UserGroupInformation.getCurrentUser().getShortUserName();
     OzoneVolume volume1 = objectStore.getVolume(volumeName);
     String prevOwner = volume1.getOwner();
@@ -1829,7 +1828,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testFileDelete() throws Exception {
+  void testFileDelete() throws Exception {
     Path grandparent = new Path(bucketPath, "testBatchDelete");
     Path parent = new Path(grandparent, "parent");
     Path childFolder = new Path(parent, "childFolder");
@@ -1847,33 +1846,30 @@ abstract class AbstractRootedOzoneFileSystemTest {
     assertEquals(9, fs.listStatus(parent).length);
     assertEquals(8, fs.listStatus(childFolder).length);
 
-    Boolean successResult = fs.delete(grandparent, true);
-    assertTrue(successResult);
-    assertTrue(!ofs.exists(grandparent));
+    assertTrue(fs.delete(grandparent, true));
+    assertFalse(ofs.exists(grandparent));
     for (int i = 0; i < 8; i++) {
       Path childFile = new Path(parent, "child" + i);
       // Make sure all keys under testBatchDelete/parent should be deleted
-      assertTrue(!ofs.exists(childFile));
+      assertFalse(ofs.exists(childFile));
 
       // Test to recursively delete child folder, make sure all keys under
       // testBatchDelete/parent/childFolder should be deleted.
       Path childFolderFile = new Path(childFolder, "child" + i);
-      assertTrue(!ofs.exists(childFolderFile));
+      assertFalse(ofs.exists(childFolderFile));
     }
     // Will get: WARN  ozone.BasicOzoneFileSystem delete: Path does not exist.
     // This will return false.
-    Boolean falseResult = fs.delete(parent, true);
-    assertFalse(falseResult);
+    assertFalse(fs.delete(parent, true));
   }
 
   /**
    * 1.Move a Key to Trash
    * 2.Verify that the key gets deleted by the trash emptier.
    * 3.Create a second Key in different bucket and verify deletion.
-   * @throws Exception
    */
   @Test
-  public void testTrash() throws Exception {
+  void testTrash() throws Exception {
     String testKeyName = "keyToBeDeleted";
     Path keyPath1 = new Path(bucketPath, testKeyName);
     try (FSDataOutputStream stream = fs.create(keyPath1)) {
@@ -1987,7 +1983,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testCreateWithInvalidPaths() throws Exception {
+  void testCreateWithInvalidPaths() {
     assumeFalse(isBucketFSOptimized);
 
     // Test for path with ..
@@ -2012,7 +2008,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
 
   @Test
-  public void testRenameFile() throws Exception {
+  void testRenameFile() throws Exception {
     final String dir = "/dir" + new Random().nextInt(1000);
     Path dirPath = new Path(getBucketPath() + dir);
     Path file1Source = new Path(getBucketPath() + dir
@@ -2038,7 +2034,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Rename file to an existed directory.
    */
   @Test
-  public void testRenameFileToDir() throws Exception {
+  void testRenameFileToDir() throws Exception {
     final String dir = "/dir" + new Random().nextInt(1000);
     Path dirPath = new Path(getBucketPath() + dir);
     getFs().mkdirs(dirPath);
@@ -2062,7 +2058,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Expected result : /root_dir/file1.
    */
   @Test
-  public void testRenameToParentDir() throws Exception {
+  void testRenameToParentDir() throws Exception {
     final String root = "/root_dir";
     final String dir1 = root + "/dir1";
     final String dir2 = dir1 + "/dir2";
@@ -2097,7 +2093,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    *  Cannot rename a directory to its own subdirectory.
    */
   @Test
-  public void testRenameDirToItsOwnSubDir() throws Exception {
+  void testRenameDirToItsOwnSubDir() throws Exception {
     final String root = "/root";
     final String dir1 = root + "/dir1";
     final Path dir1Path = new Path(getBucketPath() + dir1);
@@ -2127,7 +2123,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
    * Fails if the (a) parent of dst does not exist or (b) parent is a file.
    */
   @Test
-  public void testRenameDestinationParentDoesntExist() throws Exception {
+  void testRenameDestinationParentDoesNotExist() throws Exception {
     final String root = "/root_dir";
     final String dir1 = root + "/dir1";
     final String dir2 = dir1 + "/dir2";
@@ -2158,7 +2154,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testBucketDefaultsShouldNotBeInheritedToFileForNonEC()
+  void testBucketDefaultsShouldNotBeInheritedToFileForNonEC()
       throws Exception {
     BucketArgs.Builder builder = BucketArgs.newBuilder();
     builder.setStorageType(StorageType.DISK);
@@ -2187,7 +2183,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testBucketDefaultsShouldBeInheritedToFileForEC()
+  void testBucketDefaultsShouldBeInheritedToFileForEC()
       throws Exception {
     BucketArgs.Builder builder = BucketArgs.newBuilder();
     builder.setStorageType(StorageType.DISK);
@@ -2215,7 +2211,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testGetFileStatus() throws Exception {
+  void testGetFileStatus() throws Exception {
     String volumeNameLocal = getRandomNonExistVolumeName();
     String bucketNameLocal = RandomStringUtils.randomNumeric(5);
     Path volume = new Path("/" + volumeNameLocal);
@@ -2227,7 +2223,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testUnbuffer() throws IOException {
+  void testUnbuffer() throws IOException {
     String testKeyName = "testKey2";
     Path path = new Path(bucketPath, testKeyName);
     try (FSDataOutputStream stream = fs.create(path)) {
@@ -2243,7 +2239,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
 
   @Test
-  public void testCreateAndCheckECFileDiskUsage() throws Exception {
+  void testCreateAndCheckECFileDiskUsage() throws Exception {
     String key = "eckeytest";
     Path volPathTest = new Path(OZONE_URI_DELIMITER, volumeName);
     Path bucketPathTest = new Path(volPathTest, bucketName);
@@ -2269,7 +2265,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
 
   @Test
-  public void testCreateAndCheckRatisFileDiskUsage() throws Exception {
+  void testCreateAndCheckRatisFileDiskUsage() throws Exception {
     String key = "ratiskeytest";
     Path volPathTest = new Path(OZONE_URI_DELIMITER, volumeName);
     Path bucketPathTest = new Path(volPathTest, bucketName);
@@ -2295,8 +2291,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
     ofs.delete(filePathTest, true);
   }
 
-
-  public void testNonPrivilegedUserMkdirCreateBucket() throws IOException {
+  @Test
+  void testNonPrivilegedUserMkdirCreateBucket() throws IOException {
     // This test is only meaningful when ACL is enabled
     assumeTrue(enableAcl, "ACL is not enabled. Skipping this test as it requires " +
             "ACL to be enabled to be meaningful.");
@@ -2349,7 +2345,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testSnapshotRead() throws Exception {
+  void testSnapshotRead() throws Exception {
     if (useOnlyCache) {
       return;
     }
@@ -2391,14 +2387,14 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testFileSystemDeclaresCapability() throws Throwable {
+  void testFileSystemDeclaresCapability() throws Throwable {
     assertHasPathCapabilities(fs, getBucketPath(), FS_ACLS);
     assertHasPathCapabilities(fs, getBucketPath(), FS_CHECKSUMS);
   }
 
 
   @Test
-  public void testSnapshotDiff() throws Exception {
+  void testSnapshotDiff() throws Exception {
     if (useOnlyCache) {
       return;
     }
@@ -2463,7 +2459,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   }
 
   @Test
-  public void testSetTimes() throws Exception {
+  void testSetTimes() throws Exception {
     // Create a file
     OzoneBucket bucket1 =
         TestDataUtil.createVolumeAndBucket(client, bucketLayout);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTestWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTestWithFSO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -58,7 +58,7 @@ abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOz
    */
   @Override
   @Test
-  public void testRenameDestinationParentDoesntExist() throws Exception {
+  void testRenameDestinationParentDoesNotExist() throws Exception {
     final String root = "/root_dir";
     final String dir1 = root + "/dir1";
     final String dir2 = dir1 + "/dir2";
@@ -79,7 +79,7 @@ abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOz
   }
 
   @Test
-  public void testKeyRenameToBucketLevel() throws IOException {
+  void testKeyRenameToBucketLevel() throws IOException {
     final String dir = "dir1";
     final String key = dir + "/key1";
     final Path source = new Path(getBucketPath(), key);
@@ -94,10 +94,10 @@ abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOz
   }
 
   @Test
-  public void testRenameDir() throws Exception {
+  void testRenameDir() throws Exception {
     final String dir = "dir1";
     final Path source = new Path(getBucketPath(), dir);
-    final Path dest = new Path(source.toString() + ".renamed");
+    final Path dest = new Path(source + ".renamed");
     // Add a sub-dir to the directory to be moved.
     final Path subdir = new Path(source, "sub_dir1");
     getFs().mkdirs(subdir);
@@ -106,7 +106,7 @@ abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOz
     getFs().rename(source, dest);
     assertTrue(getFs().exists(dest), "Directory rename failed");
     // Verify that the subdir is also renamed i.e. keys corresponding to the
-    // sub-directories of the renamed directory have also been renamed.
+    // subdirectories of the renamed directory have also been renamed.
     assertTrue(getFs().exists(new Path(dest, "sub_dir1")),
         "Keys under the renamed directory not renamed");
     // cleanup
@@ -117,7 +117,7 @@ abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOz
    */
   @Override
   @Test
-  public void testRenameDirToItsOwnSubDir() throws Exception {
+  void testRenameDirToItsOwnSubDir() throws Exception {
     final String root = "/root";
     final String dir1 = root + "/dir1";
     final Path dir1Path = new Path(getBucketPath() + dir1);
@@ -137,7 +137,7 @@ abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOz
 
   @Override
   @Test
-  public void testDeleteVolumeAndBucket() throws IOException {
+  void testDeleteVolumeAndBucket() throws IOException {
     String volumeStr1 = getRandomNonExistVolumeName();
     Path volumePath1 = new Path(OZONE_URI_DELIMITER + volumeStr1);
     String bucketStr2 = "bucket3";
@@ -186,7 +186,7 @@ abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOz
    * Test the consistency of listStatusFSO with TableCache present.
    */
   @Test
-  public void testListStatusFSO() throws Exception {
+  void testListStatusFSO() throws Exception {
     // list keys batch size is 1024. Creating keys greater than the
     // batch size to test batch listing of the keys.
     int valueGreaterBatchSize = 1200;
@@ -208,7 +208,7 @@ abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOz
   }
 
   @Test
-  public void testLeaseRecoverable() throws Exception {
+  void testLeaseRecoverable() throws Exception {
     // Create a file
     final String dir = "dir1";
     final String key = dir + "/key1";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTestWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTestWithFSO.java
@@ -24,53 +24,31 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests to verify ofs with prefix enabled cases.
  */
-@RunWith(Parameterized.class)
-public class TestRootedOzoneFileSystemWithFSO
-    extends TestRootedOzoneFileSystem {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractRootedOzoneFileSystemTestWithFSO extends AbstractRootedOzoneFileSystemTest {
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(TestRootedOzoneFileSystemWithFSO.class);
+      LoggerFactory.getLogger(AbstractRootedOzoneFileSystemTestWithFSO.class);
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[]{true, true, false, false},
-        new Object[]{true, false, false, false},
-        new Object[]{true, true, false, true},
-        new Object[]{true, false, false, true}
-    );
-  }
-
-  public TestRootedOzoneFileSystemWithFSO(boolean setDefaultFs,
-      boolean enableOMRatis, boolean isAclEnabled, boolean noFlush) {
-    super(setDefaultFs, enableOMRatis, isAclEnabled, noFlush);
-  }
-
-  @BeforeClass
-  public static void init()
-      throws IOException, InterruptedException, TimeoutException {
-    setIsBucketFSOptimized(true);
+  AbstractRootedOzoneFileSystemTestWithFSO(boolean enableOMRatis, boolean isAclEnabled, boolean noFlush) {
+    super(BucketLayout.FILE_SYSTEM_OPTIMIZED, true, enableOMRatis, isAclEnabled, noFlush);
   }
 
   /**
@@ -109,8 +87,8 @@ public class TestRootedOzoneFileSystemWithFSO
     final Path dest = new Path(String.valueOf(getBucketPath()));
     LOG.info("Will move {} to {}", source, dest);
     getFs().rename(source, getBucketPath());
-    assertTrue("Key rename failed",
-        getFs().exists(new Path(getBucketPath(), "key1")));
+    assertTrue(getFs().exists(new Path(getBucketPath(), "key1")),
+        "Key rename failed");
     // cleanup
     getFs().delete(dest, true);
   }
@@ -126,11 +104,11 @@ public class TestRootedOzoneFileSystemWithFSO
     LOG.info("Created dir {}", subdir);
     LOG.info("Will move {} to {}", source, dest);
     getFs().rename(source, dest);
-    assertTrue("Directory rename failed", getFs().exists(dest));
+    assertTrue(getFs().exists(dest), "Directory rename failed");
     // Verify that the subdir is also renamed i.e. keys corresponding to the
     // sub-directories of the renamed directory have also been renamed.
-    assertTrue("Keys under the renamed directory not renamed",
-        getFs().exists(new Path(dest, "sub_dir1")));
+    assertTrue(getFs().exists(new Path(dest, "sub_dir1")),
+        "Keys under the renamed directory not renamed");
     // cleanup
     getFs().delete(dest, true);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFS.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFS extends AbstractRootedOzoneFileSystemTest {
+  TestOFS() {
+    super(BucketLayout.LEGACY, false, false, false, false);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithCacheOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithCacheOnly.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithCacheOnly extends AbstractRootedOzoneFileSystemTest {
+  TestOFSWithCacheOnly() {
+    super(BucketLayout.LEGACY, false, false, false, true);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSO.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithFSO extends AbstractRootedOzoneFileSystemTestWithFSO {
+  TestOFSWithFSO() {
+    super(false, false, false);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSOAndCacheOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSOAndCacheOnly.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithFSOAndCacheOnly extends AbstractRootedOzoneFileSystemTestWithFSO {
+  TestOFSWithFSOAndCacheOnly() {
+    super(false, false, true);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSOAndOMRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSOAndOMRatis.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithFSOAndOMRatis extends AbstractRootedOzoneFileSystemTestWithFSO {
+  TestOFSWithFSOAndOMRatis() {
+    super(true, false, false);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSOAndOMRatisAndCacheOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSOAndOMRatisAndCacheOnly.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithFSOAndOMRatisAndCacheOnly extends AbstractRootedOzoneFileSystemTestWithFSO {
+  TestOFSWithFSOAndOMRatisAndCacheOnly() {
+    super(true, false, true);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSPaths.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSPaths.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithFSPaths extends AbstractRootedOzoneFileSystemTest {
+  TestOFSWithFSPaths() {
+    super(BucketLayout.LEGACY, true, false, false, false);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSPathsAndOMRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSPathsAndOMRatis.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithFSPathsAndOMRatis extends AbstractRootedOzoneFileSystemTest {
+  TestOFSWithFSPathsAndOMRatis() {
+    super(BucketLayout.LEGACY, true, true, false, false);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSPathsAndOMRatisAndACL.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSPathsAndOMRatisAndACL.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithFSPathsAndOMRatisAndACL extends AbstractRootedOzoneFileSystemTest {
+  TestOFSWithFSPathsAndOMRatisAndACL() {
+    super(BucketLayout.LEGACY, true, true, true, false);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSPathsAndOMRatisAndCacheOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithFSPathsAndOMRatisAndCacheOnly.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithFSPathsAndOMRatisAndCacheOnly extends AbstractRootedOzoneFileSystemTest {
+  TestOFSWithFSPathsAndOMRatisAndCacheOnly() {
+    super(BucketLayout.LEGACY, true, true, false, true);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithOMRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOFSWithOMRatis.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestOFSWithOMRatis extends AbstractRootedOzoneFileSystemTest {
+  TestOFSWithOMRatis() {
+    super(BucketLayout.LEGACY, false, true, false, false);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate `TestRootedOzoneFileSystem` and its subclass `TestRootedOzoneFileSystemWithFSO` to JUnit5.

https://issues.apache.org/jira/browse/HDDS-9921

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7331919110/job/19965565932