### PR TITLE
HDDS-10011. Improve assertTrue assertions in hdds-container-service

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
@@ -50,6 +50,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -149,7 +150,7 @@ public class TestHddsDatanodeService {
     StorageVolume volume = volumeSet.getVolumesList().get(0);
 
     // Check instanceof and typecast
-    assertTrue(volume instanceof HddsVolume);
+    assertInstanceOf(HddsVolume.class, volume);
     HddsVolume hddsVolume = (HddsVolume) volume;
 
     StorageVolumeUtil.checkVolume(hddsVolume, clusterId,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -53,6 +53,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_CHECK_
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -177,8 +179,7 @@ public class TestHddsSecureDatanodeInit {
     Assertions.assertNotNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNull(client.getCertificate());
-    Assertions.assertTrue(dnLogs.getOutput()
-        .contains("Init response: GETCERT"));
+    assertThat(dnLogs.getOutput()).contains("Init response: GETCERT");
   }
 
   @Test
@@ -188,13 +189,13 @@ public class TestHddsSecureDatanodeInit {
     RuntimeException rteException = Assertions.assertThrows(
         RuntimeException.class,
         () -> service.initializeCertificateClient(client));
-    Assertions.assertTrue(rteException.getMessage()
-        .contains("DN security initialization failed"));
+    assertThat(rteException.getMessage())
+        .contains("DN security initialization failed");
     Assertions.assertNull(client.getPrivateKey());
     Assertions.assertNull(client.getPublicKey());
     Assertions.assertNotNull(client.getCertificate());
-    Assertions.assertTrue(dnLogs.getOutput()
-        .contains("Init response: FAILURE"));
+    assertThat(dnLogs.getOutput())
+        .contains("Init response: FAILURE");
   }
 
   @Test
@@ -204,13 +205,13 @@ public class TestHddsSecureDatanodeInit {
     RuntimeException rteException = Assertions.assertThrows(
         RuntimeException.class,
         () -> service.initializeCertificateClient(client));
-    Assertions.assertTrue(rteException.getMessage()
-        .contains("DN security initialization failed"));
+    assertThat(rteException.getMessage())
+        .contains("DN security initialization failed");
     Assertions.assertNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNull(client.getCertificate());
-    Assertions.assertTrue(dnLogs.getOutput()
-        .contains("Init response: FAILURE"));
+    assertThat(dnLogs.getOutput())
+        .contains("Init response: FAILURE");
   }
 
   @Test
@@ -221,13 +222,13 @@ public class TestHddsSecureDatanodeInit {
     RuntimeException rteException = Assertions.assertThrows(
         RuntimeException.class,
         () -> service.initializeCertificateClient(client));
-    Assertions.assertTrue(rteException.getMessage()
-        .contains("DN security initialization failed"));
+    assertThat(rteException.getMessage())
+        .contains("DN security initialization failed");
     Assertions.assertNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNotNull(client.getCertificate());
-    Assertions.assertTrue(dnLogs.getOutput()
-        .contains("Init response: FAILURE"));
+    assertThat(dnLogs.getOutput())
+        .contains("Init response: FAILURE");
   }
 
   @Test
@@ -253,8 +254,8 @@ public class TestHddsSecureDatanodeInit {
     Assertions.assertNotNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNotNull(client.getCertificate());
-    Assertions.assertTrue(dnLogs.getOutput()
-        .contains("Init response: GETCERT"));
+    assertThat(dnLogs.getOutput())
+        .contains("Init response: GETCERT");
     dnLogs.clearOutput();
     // reset scmClient behavior
     when(scmClient.getDataNodeCertificateChain(anyObject(), anyString()))
@@ -270,8 +271,8 @@ public class TestHddsSecureDatanodeInit {
     Assertions.assertNotNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNotNull(client.getCertificate());
-    Assertions.assertTrue(dnLogs.getOutput()
-        .contains("Init response: SUCCESS"));
+    assertThat(dnLogs.getOutput())
+        .contains("Init response: SUCCESS");
   }
 
   @Test
@@ -284,8 +285,8 @@ public class TestHddsSecureDatanodeInit {
     Assertions.assertNotNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNull(client.getCertificate());
-    Assertions.assertTrue(dnLogs.getOutput()
-        .contains("Init response: GETCERT"));
+    assertThat(dnLogs.getOutput())
+        .contains("Init response: GETCERT");
   }
 
   @Test
@@ -299,8 +300,8 @@ public class TestHddsSecureDatanodeInit {
     Assertions.assertNotNull(client.getPrivateKey());
     Assertions.assertNotNull(client.getPublicKey());
     Assertions.assertNotNull(client.getCertificate());
-    Assertions.assertTrue(dnLogs.getOutput()
-        .contains("Init response: SUCCESS"));
+    assertThat(dnLogs.getOutput())
+        .contains("Init response: SUCCESS");
   }
 
   /**
@@ -426,7 +427,7 @@ public class TestHddsSecureDatanodeInit {
     try {
       client.getCertificate().checkValidity();
     } catch (Exception e) {
-      Assertions.assertTrue(e instanceof CertificateExpiredException);
+      assertInstanceOf(CertificateExpiredException.class, e);
     }
 
     // provide a new valid SCMGetCertResponseProto

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -107,6 +107,7 @@ import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.create
 import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_BLOCK;
 import static org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask.LOG;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -591,7 +592,7 @@ public class TestBlockDeletingService {
 
       // Container contains 3 blocks. So, space used by the container
       // should be greater than zero.
-      assertTrue(containerSpace > 0);
+      assertThat(containerSpace).isGreaterThan(0);
 
       // An interval will delete 1 * 2 blocks
       deleteAndWait(svc, 1);
@@ -602,7 +603,7 @@ public class TestBlockDeletingService {
       // After first interval 2 blocks will be deleted. Hence, current space
       // used by the container should be less than the space used by the
       // container initially(before running deletion services).
-      assertTrue(containerData.get(0).getBytesUsed() < containerSpace);
+      assertThat(containerData.get(0).getBytesUsed()).isLessThan(containerSpace);
       assertEquals(2,
           deletingServiceMetrics.getSuccessCount()
               - deleteSuccessCount);
@@ -864,8 +865,8 @@ public class TestBlockDeletingService {
 
       // The block deleting successfully and shouldn't catch timed
       // out warning log.
-      assertFalse(newLog.getOutput().contains(
-          "Background task executes timed out, retrying in next interval"));
+      assertThat(newLog.getOutput())
+          .doesNotContain("Background task executes timed out, retrying in next interval");
     }
     svc.shutdown();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -67,8 +67,8 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -201,7 +201,7 @@ public class TestSchemaOneBackwardsCompatibility {
                   cData.containerPrefix());
 
       for (Table.KeyValue<String, ChunkInfoList> kv: deletedBlocks) {
-        assertFalse(kv.getKey().contains(prefix));
+        assertThat(kv.getKey()).doesNotContain(prefix);
       }
 
       // Test sequentialRangeKVs.
@@ -209,7 +209,7 @@ public class TestSchemaOneBackwardsCompatibility {
           100, cData.containerPrefix());
 
       for (Table.KeyValue<String, ChunkInfoList> kv: deletedBlocks) {
-        assertFalse(kv.getKey().contains(prefix));
+        assertThat(kv.getKey()).doesNotContain(prefix);
       }
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -183,7 +183,8 @@ public class TestContainerDataYaml {
     final String content =
         FileUtils.readFileToString(containerFile, Charset.defaultCharset());
 
-    assertThat(content).withFailMessage("ReplicaIndex shouldn't be persisted if zero")
+    assertThat(content)
+        .withFailMessage("ReplicaIndex shouldn't be persisted if zero")
         .doesNotContain("replicaIndex");
     cleanup();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -41,7 +41,6 @@ import java.util.UUID;
 import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion.FILE_PER_CHUNK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -184,8 +183,8 @@ public class TestContainerDataYaml {
     final String content =
         FileUtils.readFileToString(containerFile, Charset.defaultCharset());
 
-    assertFalse(content.contains("replicaIndex"),
-        "ReplicaIndex shouldn't be persisted if zero");
+    assertThat(content).withFailMessage("ReplicaIndex shouldn't be persisted if zero")
+        .doesNotContain("replicaIndex");
     cleanup();
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.container.common.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -100,9 +101,9 @@ public class TestContainerDeletionChoosingPolicy {
       data.closeContainer();
       KeyValueContainer container = new KeyValueContainer(data, conf);
       containerSet.addContainer(container);
-      assertTrue(
-          containerSet.getContainerMapCopy()
-              .containsKey(data.getContainerID()));
+      assertThat(
+          containerSet.getContainerMapCopy())
+              .containsKey(data.getContainerID());
     }
     blockDeletingService = getBlockDeletingService();
 
@@ -116,7 +117,7 @@ public class TestContainerDeletionChoosingPolicy {
     for (ContainerBlockInfo pr : result0) {
       totPendingBlocks += pr.getNumBlocksToDelete();
     }
-    assertTrue(totPendingBlocks >= blockLimitPerInterval);
+    assertThat(totPendingBlocks).isGreaterThanOrEqualTo(blockLimitPerInterval);
 
     // test random choosing. We choose 100 times the 3 datanodes twice.
     //We expect different order at least once.
@@ -176,8 +177,8 @@ public class TestContainerDeletionChoosingPolicy {
       KeyValueContainer container = new KeyValueContainer(data, conf);
       data.closeContainer();
       containerSet.addContainer(container);
-      assertTrue(
-          containerSet.getContainerMapCopy().containsKey(containerId));
+      assertThat(containerSet.getContainerMapCopy())
+          .containsKey(containerId);
     }
     numberOfBlocks.sort(Collections.reverseOrder());
     int blockLimitPerInterval = 5;
@@ -190,7 +191,7 @@ public class TestContainerDeletionChoosingPolicy {
     for (ContainerBlockInfo pr : result0) {
       totPendingBlocks += pr.getNumBlocksToDelete();
     }
-    assertTrue(totPendingBlocks >= blockLimitPerInterval);
+    assertThat(totPendingBlocks).isGreaterThanOrEqualTo(blockLimitPerInterval);
 
 
     List<ContainerBlockInfo> result1 = blockDeletingService
@@ -214,7 +215,7 @@ public class TestContainerDeletionChoosingPolicy {
       int currentCount =
           name2Count.remove(data.getContainerData().getContainerID());
       // previous count should not smaller than next one
-      assertTrue(currentCount > 0 && currentCount <= lastCount);
+      assertThat(currentCount).isGreaterThan(0).isLessThanOrEqualTo(lastCount);
       lastCount = currentCount;
     }
     // ensure all the container data are compared

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -177,8 +177,7 @@ public class TestContainerDeletionChoosingPolicy {
       KeyValueContainer container = new KeyValueContainer(data, conf);
       data.closeContainer();
       containerSet.addContainer(container);
-      assertThat(containerSet.getContainerMapCopy())
-          .containsKey(containerId);
+      assertThat(containerSet.getContainerMapCopy()).containsKey(containerId);
     }
     numberOfBlocks.sort(Collections.reverseOrder());
     int blockLimitPerInterval = 5;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -91,6 +91,7 @@ import org.junit.jupiter.api.Assertions;
 
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -225,8 +226,7 @@ public class TestContainerPersistence {
     initSchemaAndVersionInfo(versionInfo);
     long testContainerID = getTestContainerID();
     addContainer(containerSet, testContainerID);
-    Assertions.assertTrue(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID));
+    assertThat(containerSet.getContainerMapCopy()).containsKey(testContainerID);
     KeyValueContainerData kvData =
         (KeyValueContainerData) containerSet.getContainer(testContainerID)
             .getContainerData();
@@ -274,14 +274,13 @@ public class TestContainerPersistence {
         addContainer(containerSet, testContainerID);
     container.close();
 
-    Assertions.assertTrue(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID));
+    assertThat(containerSet.getContainerMapCopy())
+        .containsKey(testContainerID);
 
     KeyValueContainerUtil.removeContainer(container.getContainerData(), conf);
     container.delete();
     containerSet.removeContainer(testContainerID);
-    Assertions.assertFalse(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID));
+    assertThat(containerSet.getContainerMapCopy()).doesNotContainKey(testContainerID);
 
     // Adding block to a deleted container should fail.
     BlockID blockID = ContainerTestHelper.getTestBlockID(testContainerID);
@@ -302,8 +301,8 @@ public class TestContainerPersistence {
         addContainer(containerSet, testContainerID);
     container.close();
 
-    Assertions.assertTrue(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID));
+    assertThat(containerSet.getContainerMapCopy())
+        .containsKey(testContainerID);
 
     // Deleting a non-empty container should fail.
     BlockID blockID = ContainerTestHelper.getTestBlockID(testContainerID);
@@ -324,8 +323,8 @@ public class TestContainerPersistence {
     Exception exception = Assertions.assertThrows(
         StorageContainerException.class,
         () -> kvHandler.deleteContainer(container, false));
-    Assertions.assertTrue(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID));
+    assertThat(containerSet.getContainerMapCopy())
+        .containsKey(testContainerID);
     assertThat(exception.getMessage(),
         Matchers.containsString(
             "Non-force deletion of non-empty container is not allowed."));
@@ -341,8 +340,8 @@ public class TestContainerPersistence {
         testContainerID);
     BlockID blockID = addBlockToContainer(container);
     container.close();
-    Assertions.assertTrue(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID));
+    assertThat(containerSet.getContainerMapCopy())
+        .containsKey(testContainerID);
     KeyValueContainerData containerData = container.getContainerData();
 
     // Block data and metadata tables should have data.
@@ -353,8 +352,8 @@ public class TestContainerPersistence {
         container.getContainerData().getVolume().getConf());
     container.delete();
     containerSet.removeContainer(testContainerID);
-    Assertions.assertFalse(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID));
+    assertThat(containerSet.getContainerMapCopy())
+        .doesNotContainKey(testContainerID);
 
     // Block data and metadata tables should be cleared.
     assertContainerNotInSchema3DB(containerData, blockID);
@@ -446,10 +445,10 @@ public class TestContainerPersistence {
     KeyValueContainerData container2Data = container2.getContainerData();
     assertContainerInSchema3DB(container2Data, container2Block);
 
-    Assertions.assertTrue(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID1));
-    Assertions.assertTrue(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID2));
+    assertThat(containerSet.getContainerMapCopy())
+        .containsKey(testContainerID1);
+    assertThat(containerSet.getContainerMapCopy())
+        .containsKey(testContainerID2);
 
     // Since this test only uses one volume, both containers will reside in
     // the same volume.
@@ -479,10 +478,10 @@ public class TestContainerPersistence {
 
     File container1Dir = KeyValueContainerUtil.getTmpDirectoryPath(
         container1Data, hddsVolume).toFile();
-    Assertions.assertTrue(deleteDirFiles.contains(container1Dir));
+    assertThat(deleteDirFiles).contains(container1Dir);
     File container2Dir = KeyValueContainerUtil.getTmpDirectoryPath(
         container2Data, hddsVolume).toFile();
-    Assertions.assertTrue(deleteDirFiles.contains(container2Dir));
+    assertThat(deleteDirFiles).contains(container2Dir);
 
     // Delete container1 from the disk. Container2 should remain in the
     // deleted containers directory.
@@ -510,10 +509,10 @@ public class TestContainerPersistence {
     // Remove containers from containerSet
     containerSet.removeContainer(testContainerID1);
     containerSet.removeContainer(testContainerID2);
-    Assertions.assertFalse(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID1));
-    Assertions.assertFalse(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID2));
+    assertThat(containerSet.getContainerMapCopy())
+        .doesNotContainKey(testContainerID1);
+    assertThat(containerSet.getContainerMapCopy())
+        .doesNotContainKey(testContainerID2);
 
     // Deleted containers directory should now be empty.
     deleteDirFilesArray = deletedContainerDir.listFiles();
@@ -584,7 +583,7 @@ public class TestContainerPersistence {
       long nextKey = results.get(results.size() - 1).getContainerID();
 
       //Assert that container is returning results in a sorted fashion.
-      Assertions.assertTrue(prevKey < nextKey);
+      assertThat(prevKey).isLessThan(nextKey);
       prevKey = nextKey + 1;
       results.clear();
     }
@@ -908,8 +907,8 @@ public class TestContainerPersistence {
     container.update(newMetadata, false);
 
     assertEquals(1, containerSet.getContainerMapCopy().size());
-    Assertions.assertTrue(containerSet.getContainerMapCopy()
-        .containsKey(testContainerID));
+    assertThat(containerSet.getContainerMapCopy())
+        .containsKey(testContainerID);
 
     // Verify in-memory map
     KeyValueContainerData actualNewData = (KeyValueContainerData)

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerSet.java
@@ -227,9 +227,9 @@ public class TestContainerSet {
       if (prevScanTime.isPresent()) {
         if (scanTime.isPresent()) {
           int result = scanTime.get().compareTo(prevScanTime.get());
-          assertTrue(result >= 0);
+          assertThat(result).isGreaterThanOrEqualTo(0);
           if (result == 0) {
-            assertTrue(prevContainerID < data.getContainerID());
+            assertThat(prevContainerID).isLessThan(data.getContainerID());
           }
         } else {
           fail("Containers not yet scanned should be sorted before " +

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -83,6 +83,7 @@ import static org.apache.hadoop.hdds.fs.MockSpaceUsageSource.fixed;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getContainerCommandResponse;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.COMMIT_STAGE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -319,9 +320,9 @@ public class TestHddsDispatcher {
       assertEquals(
           ContainerProtos.Result.CONTAINER_NOT_FOUND, response.getResult());
 
-      assertTrue(logCapturer.getOutput().contains(
+      assertThat(logCapturer.getOutput()).contains(
           "ContainerID " + writeChunkRequest.getContainerID()
-              + " does not exist"));
+              + " does not exist");
     } finally {
       ContainerMetrics.remove();
       FileUtils.deleteDirectory(new File(testDir));
@@ -356,9 +357,9 @@ public class TestHddsDispatcher {
       // send write chunk request without sending create container
       mockDispatcher.dispatch(writeChunkRequest, null);
       // verify the error log
-      assertTrue(logCapturer.getOutput()
+      assertThat(logCapturer.getOutput())
           .contains("ContainerID " + writeChunkRequest.getContainerID()
-              + " creation failed , Result: DISK_OUT_OF_SPACE"));
+              + " creation failed , Result: DISK_OUT_OF_SPACE");
     } finally {
       ContainerMetrics.remove();
       FileUtils.deleteDirectory(new File(testDir));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/interfaces/TestHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/interfaces/TestHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.container.common.interfaces;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import java.util.Map;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -85,7 +86,7 @@ public class TestHandler {
     Handler kvHandler = dispatcher.getHandler(
         ContainerProtos.ContainerType.KeyValueContainer);
 
-    Assertions.assertTrue((kvHandler instanceof KeyValueHandler),
+    assertInstanceOf(KeyValueHandler.class, kvHandler,
         "getHandlerForContainerType returned incorrect handler");
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -51,6 +51,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETE_COMMAND_WORKER_INTERVAL;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.commandhandler.DeleteBlocksCommandHandler.DeleteBlockTransactionExecutionResult;
@@ -134,7 +135,7 @@ public class TestDeleteBlocksCommandHandler {
   public void testDeleteBlocksCommandHandler(
       ContainerTestVersionInfo versionInfo) throws Exception {
     prepareTest(versionInfo);
-    Assertions.assertTrue(containerSet.containerCount() > 0);
+    assertThat(containerSet.containerCount()).isGreaterThan(0);
     Container<?> container = containerSet.getContainerIterator(volume1).next();
     DeletedBlocksTransaction transaction = createDeletedBlocksTransaction(1,
         container.getContainerData().getContainerID());
@@ -160,7 +161,7 @@ public class TestDeleteBlocksCommandHandler {
   public void testDeleteBlocksCommandHandlerWithTimeoutFailed(
       ContainerTestVersionInfo versionInfo) throws Exception {
     prepareTest(versionInfo);
-    Assertions.assertTrue(containerSet.containerCount() >= 2);
+    assertThat(containerSet.containerCount()).isGreaterThanOrEqualTo(2);
     Iterator<Container<?>> iterator =
         containerSet.getContainerIterator(volume1);
     Container<?> lockedContainer = iterator.next();
@@ -208,7 +209,7 @@ public class TestDeleteBlocksCommandHandler {
   public void testDeleteBlocksCommandHandlerSuccessfulAfterFirstTimeout(
       ContainerTestVersionInfo versionInfo) throws Exception {
     prepareTest(versionInfo);
-    Assertions.assertTrue(containerSet.containerCount() > 0);
+    assertThat(containerSet.containerCount()).isGreaterThan(0);
     Container<?> lockedContainer =
         containerSet.getContainerIterator(volume1).next();
     DeletedBlocksTransaction transaction = createDeletedBlocksTransaction(1,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.container.common.states.datanode;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates.SHUTDOWN;
 import static org.mockito.Mockito.when;
 
@@ -69,7 +70,7 @@ public class TestRunningDatanodeState {
     long startTime = Time.monotonicNow();
     state.await(500, TimeUnit.MILLISECONDS);
     long endTime = Time.monotonicNow();
-    Assertions.assertTrue((endTime - startTime) >= 500);
+    assertThat(endTime - startTime).isGreaterThanOrEqualTo(500);
 
     futureOne.complete(SHUTDOWN);
 
@@ -83,7 +84,7 @@ public class TestRunningDatanodeState {
     startTime = Time.monotonicNow();
     state.await(500, TimeUnit.MILLISECONDS);
     endTime = Time.monotonicNow();
-    Assertions.assertTrue((endTime - startTime) < 500);
+    assertThat(endTime - startTime).isLessThan(500);
 
     executorService.shutdown();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -234,7 +234,7 @@ public class TestHeartbeatEndpointTask {
     Assertions.assertTrue(heartbeat.hasDatanodeDetails());
     Assertions.assertFalse(heartbeat.hasNodeReport());
     Assertions.assertFalse(heartbeat.hasContainerReport());
-    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
+    Assertions.assertNotEquals(0, heartbeat.getCommandStatusReportsCount());
     Assertions.assertFalse(heartbeat.hasContainerActions());
   }
 
@@ -313,7 +313,7 @@ public class TestHeartbeatEndpointTask {
     Assertions.assertTrue(heartbeat.hasDatanodeDetails());
     Assertions.assertTrue(heartbeat.hasNodeReport());
     Assertions.assertTrue(heartbeat.hasContainerReport());
-    Assertions.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
+    Assertions.assertNotEquals(0, heartbeat.getCommandStatusReportsCount());
     Assertions.assertTrue(heartbeat.hasContainerActions());
     Assertions.assertTrue(heartbeat.hasCommandQueueReport());
     CommandQueueReportProto queueCount = heartbeat.getCommandQueueReport();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -40,8 +40,8 @@ import java.util.Map;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link CapacityVolumeChoosingPolicy}.
@@ -120,10 +120,8 @@ public class TestCapacityVolumeChoosingPolicy {
       chooseCount.put(volume, chooseCount.get(volume) + 1);
     }
 
-    Assertions.assertTrue(chooseCount.get(hddsVolume3) >
-        chooseCount.get(hddsVolume1));
-    Assertions.assertTrue(chooseCount.get(hddsVolume3) >
-        chooseCount.get(hddsVolume2));
+    assertThat(chooseCount.get(hddsVolume3)).isGreaterThan(chooseCount.get(hddsVolume1));
+    assertThat(chooseCount.get(hddsVolume3)).isGreaterThan(chooseCount.get(hddsVolume2));
   }
 
   @Test
@@ -132,10 +130,9 @@ public class TestCapacityVolumeChoosingPolicy {
         () -> policy.chooseVolume(volumes, 500));
 
     String msg = e.getMessage();
-    assertTrue(
-        msg.contains("No volumes have enough space for a new container.  " +
-            "Most available space: 250 bytes"),
-        msg);
+    assertThat(msg)
+        .contains("No volumes have enough space for a new container.  " +
+            "Most available space: 250 bytes");
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -112,10 +112,8 @@ public class TestRoundRobinVolumeChoosingPolicy {
         () -> policy.chooseVolume(volumes, 300));
 
     String msg = e.getMessage();
-    assertTrue(
-        msg.contains("No volumes have enough space for a new container.  " +
-            "Most available space: 150 bytes"),
-        msg);
+    assertThat(msg).contains("No volumes have enough space for a new container.  " +
+        "Most available space: 150 bytes");
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeHealthChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeHealthChecks.java
@@ -36,8 +36,8 @@ import java.nio.file.Paths;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for StorageVolume health checks using Real volume instances with
@@ -166,8 +166,8 @@ public class TestStorageVolumeHealthChecks {
     CONF.clear();
     DatanodeConfiguration dnConf = CONF.getObject(DatanodeConfiguration.class);
     // Make sure default values are not invalid.
-    assertTrue(dnConf.getVolumeIOFailureTolerance() <
-        dnConf.getVolumeIOTestCount());
+    assertThat(dnConf.getVolumeIOFailureTolerance())
+        .isLessThan(dnConf.getVolumeIOTestCount());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeIOStatsWithPrometheusSink.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeIOStatsWithPrometheusSink.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hdds.server.http.PrometheusMetricsSink;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -64,18 +64,12 @@ public class TestVolumeIOStatsWithPrometheusSink {
     String writtenMetrics = publishMetricsAndGetOutput();
 
     //THEN
-    Assertions.assertTrue(
-        writtenMetrics.contains("storagedirectory=\"" +
-            volumeIOStats1.getStorageDirectory() + "\""),
-        "The expected metric line is missing from prometheus" +
-            " metrics output"
-    );
-    Assertions.assertTrue(
-        writtenMetrics.contains("storagedirectory=\"" +
-            volumeIOStat2.getStorageDirectory() + "\""),
-        "The expected metric line is missing from prometheus" +
-            " metrics output"
-    );
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is missing from prometheus metrics output")
+        .contains("storagedirectory=\"" + volumeIOStats1.getStorageDirectory() + "\"");
+    assertThat(writtenMetrics)
+        .withFailMessage("The expected metric line is missing from prometheus metrics output")
+        .contains("storagedirectory=\"" + volumeIOStat2.getStorageDirectory() + "\"");
   }
 
   private String publishMetricsAndGetOutput() throws IOException {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
@@ -35,6 +35,7 @@ import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.ozone.container.common.volume.HddsVolume
     .HDDS_VOLUME_DIR;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -153,7 +154,7 @@ public class TestVolumeSet {
         "Failed Volume list did not match");
 
     // Failed volume should not exist in VolumeMap
-    assertFalse(volumeSet.getVolumeMap().containsKey(volume1));
+    assertThat(volumeSet.getVolumeMap()).doesNotContainKey(volume1);
   }
 
   @Test
@@ -173,9 +174,7 @@ public class TestVolumeSet {
     assertEquals(1, volumeSet.getVolumesList().size());
     String expectedLogMessage = "Volume : " +
         HddsVolumeUtil.getHddsRoot(volume1) + " does not exist in VolumeSet";
-    assertTrue(logs.getOutput().contains(expectedLogMessage),
-        "Log output does not contain expected log message: " +
-            expectedLogMessage);
+    assertThat(logs.getOutput()).contains(expectedLogMessage);
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -93,6 +93,7 @@ import static org.apache.ratis.util.Preconditions.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -419,7 +420,7 @@ public class TestKeyValueContainer {
         container.importContainerData(fis, packer);
         fail("Container import should fail");
       } catch (Exception ex) {
-        assertTrue(ex instanceof IOException);
+        assertInstanceOf(IOException.class, ex);
       } finally {
         File directory =
             new File(container.getContainerData().getContainerPath());
@@ -744,7 +745,7 @@ public class TestKeyValueContainer {
     try (DBHandle db1 =
              BlockUtils.getDB(keyValueContainer.getContainerData(), CONF)) {
       DatanodeStore store1 = db1.getStore();
-      Assertions.assertTrue(store1 instanceof AbstractDatanodeStore);
+      assertInstanceOf(AbstractDatanodeStore.class, store1);
       outProfile1 = ((AbstractDatanodeStore) store1).getDbProfile();
     }
 
@@ -765,7 +766,7 @@ public class TestKeyValueContainer {
     try (DBHandle db2 =
         BlockUtils.getDB(keyValueContainer.getContainerData(), otherConf)) {
       DatanodeStore store2 = db2.getStore();
-      Assertions.assertTrue(store2 instanceof AbstractDatanodeStore);
+      assertInstanceOf(AbstractDatanodeStore.class, store2);
       outProfile2 = ((AbstractDatanodeStore) store2).getDbProfile();
     }
 
@@ -901,7 +902,7 @@ public class TestKeyValueContainer {
       Thread.sleep(7000);
       List<LiveFileMetaData> fileMetaDataList2 =
           ((RDBStore)(dnStore.getStore())).getDb().getLiveFilesMetaData();
-      assertTrue(fileMetaDataList2.size() < fileMetaDataList1.size());
+      assertThat(fileMetaDataList2.size()).isLessThan(fileMetaDataList1.size());
     } catch (Exception e) {
       Fail.fail("TestAutoCompactionSmallSstFile failed");
     } finally {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScannerConfiguration
 import java.io.File;
 import java.io.RandomAccessFile;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -118,7 +119,7 @@ public class TestKeyValueContainerCheck
       File chunkFile = getChunkLayout()
           .getChunkFile(containerData, blockID, chunkInfo);
       long length = chunkFile.length();
-      assertTrue(length > 0);
+      assertThat(length).isGreaterThan(0);
       // forcefully truncate the file to induce failure.
       try (RandomAccessFile file = new RandomAccessFile(chunkFile, "rws")) {
         file.setLength(length / 2);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.ozone.test.GenericTestUtils.toLog4j;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -538,8 +539,9 @@ public class TestKeyValueContainerMetadataInspector
 
   private void containsAllStrings(String logOutput, String[] expectedMessages) {
     for (String expectedMessage : expectedMessages) {
-      assertTrue(logOutput.contains(expectedMessage),
-          "Log output did not contain \"" + expectedMessage + "\"");
+      assertThat(logOutput)
+          .withFailMessage("Log output did not contain \"" + expectedMessage + "\"")
+          .contains(expectedMessage);
     }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -62,7 +62,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -410,7 +409,7 @@ public class TestKeyValueHandler {
       try {
         kvHandler.deleteContainer(container, true);
       } catch (StorageContainerException sce) {
-        assertTrue(sce.getMessage().contains("Failed to move container"));
+        assertThat(sce.getMessage()).contains("Failed to move container");
       }
       Mockito.verify(volumeSet).checkVolumeAsync(hddsVolume);
       // cleanup
@@ -426,7 +425,7 @@ public class TestKeyValueHandler {
       String expectedLog =
           "Delete container issued on containerID 2 which is " +
               "in a failed volume";
-      assertTrue(kvHandlerLogs.getOutput().contains(expectedLog));
+      assertThat(kvHandlerLogs.getOutput()).contains(expectedLog);
     } finally {
       FileUtils.deleteDirectory(new File(testDir));
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -58,6 +58,7 @@ import static java.nio.file.Files.newInputStream;
 import static java.nio.file.Files.newOutputStream;
 import static org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker.CONTAINER_FILE_NAME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test the tar/untar for a given container.
@@ -207,7 +208,7 @@ public class TestTarContainerPacker {
         entries.put(entry.getName(), entry);
       }
 
-      Assertions.assertTrue(entries.containsKey(CONTAINER_FILE_NAME));
+      assertThat(entries).containsKey(CONTAINER_FILE_NAME);
     } finally {
       if (tarStream != null) {
         tarStream.close();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -48,6 +48,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_CHUNK;
 
 import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -233,12 +234,12 @@ class TestChunkUtils {
 
       // large file
       final int large = 10 << 20; // 10MB
-      Assertions.assertTrue(large > MAPPED_BUFFER_THRESHOLD);
+      assertThat(large).isGreaterThan(MAPPED_BUFFER_THRESHOLD);
       runTestReadFile(large, dir, true);
 
       // small file
       final int small = 30 << 10; // 30KB
-      Assertions.assertTrue(small <= MAPPED_BUFFER_THRESHOLD);
+      assertThat(small).isLessThanOrEqualTo(MAPPED_BUFFER_THRESHOLD);
       runTestReadFile(small, dir, false);
 
       // boundary case

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -39,7 +39,6 @@ import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.WRITE_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -68,7 +67,7 @@ public abstract class CommonChunkManagerTestCases extends AbstractTestChunkManag
     KeyValueContainer container = getKeyValueContainer();
     int tooLarge = OZONE_SCM_CHUNK_MAX_SIZE + 1;
     byte[] array = RandomStringUtils.randomAscii(tooLarge).getBytes(UTF_8);
-    assertTrue(array.length >= tooLarge);
+    assertThat(array.length).isGreaterThanOrEqualTo(tooLarge);
 
     BlockID blockID = getBlockID();
     ChunkInfo chunkInfo = new ChunkInfo(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestKeyValueStreamDataChannel.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestKeyValueStreamDataChannel.java
@@ -62,6 +62,7 @@ import static org.apache.hadoop.hdds.scm.storage.BlockDataStreamOutput.getProtoL
 import static org.apache.hadoop.ozone.container.keyvalue.impl.KeyValueStreamDataChannel.closeBuffers;
 import static org.apache.hadoop.ozone.container.keyvalue.impl.KeyValueStreamDataChannel.readPutBlockRequest;
 import static org.apache.hadoop.ozone.container.keyvalue.impl.KeyValueStreamDataChannel.writeBuffers;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** For testing {@link KeyValueStreamDataChannel}. */
 public class TestKeyValueStreamDataChannel {
@@ -138,7 +139,7 @@ public class TestKeyValueStreamDataChannel {
 
   static void runTestBuffers(int dataSize, int max, int seed, String name)
       throws Exception {
-    Assertions.assertTrue(max >= PUT_BLOCK_PROTO_SIZE);
+    assertThat(max).isGreaterThanOrEqualTo(PUT_BLOCK_PROTO_SIZE);
 
     // random data
     final byte[] data = new byte[dataSize];

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -66,6 +66,7 @@ import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.create
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test ContainerReader class which loads containers from disks.
@@ -414,8 +415,8 @@ public class TestContainerReader {
       }
     }
     Assertions.assertEquals(1, exist);
-    Assertions.assertTrue(paths.contains(Paths.get(
-        containerSet.getContainer(0).getContainerData().getContainerPath())));
+    assertThat(paths).contains(Paths.get(
+        containerSet.getContainer(0).getContainerData().getContainerPath()));
 
     // For conflict1, the one with the larger BCSID should win, which is
     // conflict11.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.fromSources;
@@ -121,7 +120,6 @@ public class ReplicationSupervisorScheduling {
     System.out.println(executionTime);
     assertThat(executionTime)
         .withFailMessage("Execution was too slow : " + executionTime + " ms")
-        .isLessThan(100_000
-    );
+        .isLessThan(100_000);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.fromSources;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Helper to check scheduling efficiency.
@@ -118,7 +119,9 @@ public class ReplicationSupervisorScheduling {
     rs.shutdownAfterFinish();
     final long executionTime = System.currentTimeMillis() - start;
     System.out.println(executionTime);
-    Assertions.assertTrue(executionTime < 100_000,
-        "Execution was too slow : " + executionTime + " ms");
+    assertThat(executionTime)
+        .withFailMessage("Execution was too slow : " + executionTime + " ms")
+        .isLessThan(100_000
+    );
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerImporter.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerImporter.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -90,7 +90,7 @@ class TestContainerImporter {
             null, NO_COMPRESSION));
     Assertions.assertEquals(ContainerProtos.Result.CONTAINER_EXISTS,
         ex.getResult());
-    assertTrue(ex.getMessage().contains("Container already exists"));
+    assertThat(ex.getMessage()).contains("Container already exists");
   }
 
   @Test
@@ -133,7 +133,7 @@ class TestContainerImporter {
             null, NO_COMPRESSION));
     Assertions.assertEquals(ContainerProtos.Result.CONTAINER_EXISTS,
         ex.getResult());
-    assertTrue(ex.getMessage().contains("import in progress"));
+    assertThat(ex.getMessage()).contains("import in progress");
     semaphore.release();
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.forTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test replicator metric measurement.
@@ -93,10 +94,12 @@ public class TestMeasuredReplicator {
     //even containers should be failed
     long successTime = measuredReplicator.getSuccessTime().value();
     long failureTime = measuredReplicator.getFailureTime().value();
-    Assertions.assertTrue(successTime >= 300L,
-        "Measured time should be at least 300 ms but was " + successTime);
-    Assertions.assertTrue(failureTime >= 300L,
-        "Measured time should be at least 300 ms but was " + failureTime);
+    assertThat(successTime)
+        .withFailMessage("Measured time should be at least 300 ms but was " + successTime)
+        .isGreaterThanOrEqualTo(300L);
+    assertThat(failureTime)
+        .withFailMessage("Measured time should be at least 300 ms but was " + failureTime)
+        .isGreaterThanOrEqualTo(300L);
   }
 
   @Test
@@ -134,6 +137,6 @@ public class TestMeasuredReplicator {
     };
     measuredReplicator.replicate(task);
     // There might be some deviation, so we use >= 1000 here.
-    Assertions.assertTrue(measuredReplicator.getQueueTime().value() >= 1000);
+    assertThat(measuredReplicator.getQueueTime().value()).isGreaterThanOrEqualTo(1000);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -77,8 +77,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.ozone.container.replication.AbstractReplicationTask.Status.DONE;
 import static org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand.fromSources;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.LOW;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority.NORMAL;
@@ -313,8 +313,8 @@ public class TestReplicationSupervisor {
     supervisor.addTask(createTask(1L));
     assertEquals(1, supervisor.getReplicationFailureCount());
     assertEquals(0, supervisor.getReplicationSuccessCount());
-    assertTrue(logCapturer.getOutput()
-        .contains("Container 1 replication was unsuccessful."));
+    assertThat(logCapturer.getOutput())
+        .contains("Container 1 replication was unsuccessful.");
   }
 
   @ContainerLayoutTestInfo.ContainerTest

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerRequestHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSendContainerRequestHandler.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -68,7 +69,7 @@ class TestSendContainerRequestHandler {
     StreamObserver observer = mock(StreamObserver.class);
     doAnswer(invocation -> {
       Object arg = invocation.getArgument(0);
-      Assertions.assertTrue(arg instanceof StorageContainerException);
+      assertInstanceOf(StorageContainerException.class, arg);
       Assertions.assertEquals(ContainerProtos.Result.CONTAINER_EXISTS,
           ((StorageContainerException) arg).getResult());
       return null;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
 /**
@@ -177,8 +178,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
     DbVolume dbVolume = (DbVolume) dsm.getContainer().getDbVolumeSet()
         .getVolumesList().get(0);
     Assertions.assertEquals(dbVolume, dataVolume.getDbVolume());
-    Assertions.assertTrue(
-        dbVolume.getHddsVolumeIDs().contains(dataVolume.getStorageID()));
+    assertThat(dbVolume.getHddsVolumeIDs()).contains(dataVolume.getStorageID());
     File dbFile = new File(dbVolume.getStorageDir().getAbsolutePath() + "/" +
         dbVolume.getClusterID() + "/" + dataVolume.getStorageID());
     Assertions.assertTrue(dbFile.exists());
@@ -570,8 +570,8 @@ public class TestDatanodeUpgradeToSchemaV3 {
     KeyValueContainerData data =
         (KeyValueContainerData) dsm.getContainer().getContainerSet()
             .getContainer(containerID).getContainerData();
-    Assertions.assertTrue(data.getChunksPath().contains(expectedID));
-    Assertions.assertTrue(data.getMetadataPath().contains(expectedID));
+    assertThat(data.getChunksPath()).contains(expectedID);
+    assertThat(data.getMetadataPath()).contains(expectedID);
   }
 
   public List<File> getHddsSubdirs(File volume) {
@@ -628,9 +628,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
     if (exactMatch) {
       Assertions.assertEquals(expectedMlv, mlv);
     } else {
-      Assertions.assertTrue(expectedMlv <= mlv,
-          "Expected minimum mlv(" + expectedMlv
-              + ") is smaller than mlv(" + mlv + ").");
+      assertThat(expectedMlv).isLessThanOrEqualTo(mlv);
     }
 
     callVersionEndpointTask();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -66,6 +66,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests upgrading a single datanode from pre-SCM HA volume format that used
@@ -422,8 +423,8 @@ public class TestDatanodeUpgradeToScmHA {
     KeyValueContainerData data =
         (KeyValueContainerData) dsm.getContainer().getContainerSet()
             .getContainer(containerID).getContainerData();
-    Assertions.assertTrue(data.getChunksPath().contains(expectedID));
-    Assertions.assertTrue(data.getMetadataPath().contains(expectedID));
+    assertThat(data.getChunksPath()).contains(expectedID);
+    assertThat(data.getMetadataPath()).contains(expectedID);
   }
 
   public void checkFinalizedVolumePathID(File volume, String scmID,
@@ -440,10 +441,10 @@ public class TestDatanodeUpgradeToScmHA {
       Assertions.assertEquals(2, subdirs.size());
 
       File scmIDDir = new File(hddsRoot, scmID);
-      Assertions.assertTrue(subdirs.contains(scmIDDir));
+      assertThat(subdirs).contains(scmIDDir);
 
       File clusterIDDir = new File(hddsRoot, CLUSTER_ID);
-      Assertions.assertTrue(subdirs.contains(clusterIDDir));
+      assertThat(subdirs).contains(clusterIDDir);
       Assertions.assertTrue(Files.isSymbolicLink(clusterIDDir.toPath()));
       Path symlinkTarget = Files.readSymbolicLink(clusterIDDir.toPath());
       Assertions.assertEquals(scmID, symlinkTarget.toString());
@@ -477,7 +478,7 @@ public class TestDatanodeUpgradeToScmHA {
     // Volume should only have the specified ID directory.
     Assertions.assertEquals(1, subdirs.size());
     File idDir = new File(hddsRoot, expectedID);
-    Assertions.assertTrue(subdirs.contains(idDir));
+    assertThat(subdirs).contains(idDir);
   }
 
   public List<File> getHddsSubdirs(File volume) {
@@ -533,9 +534,7 @@ public class TestDatanodeUpgradeToScmHA {
     if (exactMatch) {
       Assertions.assertEquals(expectedMlv, mlv);
     } else {
-      Assertions.assertTrue(expectedMlv <= mlv,
-          "Expected minimum mlv(" + expectedMlv
-          + ") is smaller than mlv(" + mlv + ").");
+      assertThat(expectedMlv).isLessThanOrEqualTo(mlv);
     }
 
     callVersionEndpointTask();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improve assertTrue/assertFalse assertions in hadoop-hdds/container-service.   
Assertions in the form:
```
assertTrue(<string>.contains(...))
```
do not provide any information about the actual value, if the assertion fails.
```
AssertionFailedError: expected: <true> but was: <false>
```
This can be improved by replacing them with:
```
import static org.assertj.core.api.Assertions.assertThat;
assertThat(<string>).contains(...)
```
which gives us more info in the form:
```
AssertionError: 

Expecting:
 <"actual string">
to contain:
 <"part"> 
```
Similarly, assertions about inequality relations, e.g.:
```
assertTrue(<x> > <y>)
```
can be replaced with:
```
assertThat(<x>).isGreaterThan(<y>);
```
The goal of this task is to find and replace such assertTrue assertions.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10011

## CI
https://github.com/wzhallright/ozone/actions/runs/7334614535
