### PR TITLE
HDDS-10012. Improve assertTrue assertions in hdds-server-scm

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -52,6 +52,7 @@ import java.util.stream.IntStream;
 
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageTypeProto.DISK;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -419,8 +420,8 @@ public class TestSCMCommonPlacementPolicy {
             .collect(Collectors.groupingBy(Function.identity(),
                     Collectors.counting()));
     Assertions.assertEquals(replicasToRemove.size(), 2);
-    Assertions.assertTrue(Sets.newHashSet(1L, 2L).contains(
-            removedReplicasRackCntMap.get(dummyPlacementPolicy.racks.get(0))));
+    assertThat(Sets.newHashSet(1L, 2L)).contains(
+            removedReplicasRackCntMap.get(dummyPlacementPolicy.racks.get(0)));
     Assertions.assertEquals(
             removedReplicasRackCntMap.get(dummyPlacementPolicy.racks.get(1)),
             removedReplicasRackCntMap.get(dummyPlacementPolicy.racks.get(0))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -87,6 +87,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests for SCM Block Manager.
  */
@@ -239,8 +241,7 @@ public class TestBlockManager {
         .allocateBlock(DEFAULT_BLOCK_SIZE, replicationConfig, OzoneConsts.OZONE,
             excludeList);
     Assertions.assertNotNull(block);
-    Assertions.assertTrue(
-        excludeList.getPipelineIds().contains(block.getPipeline().getId()));
+    assertThat(excludeList.getPipelineIds()).contains(block.getPipeline().getId());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -82,6 +82,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys
     .OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
@@ -168,7 +169,7 @@ public class TestDeletedBlockLog {
       for (Map.Entry<ContainerID, Long> e : map.entrySet()) {
         ContainerInfo info = containers.get(e.getKey().getId());
         try {
-          Assertions.assertTrue(e.getValue() > info.getDeleteTransactionId());
+          assertThat(e.getValue()).isGreaterThan(info.getDeleteTransactionId());
         } catch (AssertionError err) {
           throw new Exception("New TxnId " + e.getValue() + " < " + info
               .getDeleteTransactionId());
@@ -345,7 +346,7 @@ public class TestDeletedBlockLog {
     mockContainerHealthResult(true);
     Assertions.assertEquals(30 * THREE, getAllTransactions().size());
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
-      Assertions.assertTrue(containerInfo.getDeleteTransactionId() > 0);
+      assertThat(containerInfo.getDeleteTransactionId()).isGreaterThan(0);
     }
   }
 
@@ -531,7 +532,7 @@ public class TestDeletedBlockLog {
       Set<DeletedBlocksTransaction> txSet1 = new HashSet<>(entry.getValue());
       Set<DeletedBlocksTransaction> txSet2 = new HashSet<>(map2.get(dnId));
 
-      Assertions.assertTrue(txSet1.containsAll(txSet2));
+      assertThat(txSet1).containsAll(txSet2);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/command/TestCommandStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/command/TestCommandStatusReportHandler.java
@@ -43,8 +43,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test for command status report handler.
@@ -68,15 +67,15 @@ public class TestCommandStatusReportHandler implements EventPublisher {
     CommandStatusReportFromDatanode report = this.getStatusReport(Collections
         .emptyList());
     cmdStatusReportHandler.onMessage(report, this);
-    assertFalse(logCapturer.getOutput().contains("Delete_Block_Status"));
-    assertFalse(logCapturer.getOutput().contains("Replicate_Command_Status"));
+    assertThat(logCapturer.getOutput()).doesNotContain("Delete_Block_Status");
+    assertThat(logCapturer.getOutput()).doesNotContain("Replicate_Command_Status");
 
     report = this.getStatusReport(this.getCommandStatusList());
     cmdStatusReportHandler.onMessage(report, this);
-    assertTrue(logCapturer.getOutput().contains("firing event of type " +
-        "Delete_Block_Status"));
-    assertTrue(logCapturer.getOutput().contains("type: " +
-        "deleteBlocksCommand"));
+    assertThat(logCapturer.getOutput()).contains("firing event of type " +
+        "Delete_Block_Status");
+    assertThat(logCapturer.getOutput()).contains("type: " +
+        "deleteBlocksCommand");
 
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -46,8 +46,8 @@ import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.DATANODE_COMMAND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -156,7 +156,7 @@ public class TestCloseContainerEventHandler {
     closeHandler.onMessage(container.containerID(), eventPublisher);
     Mockito.verify(mockLeaseManager, atLeastOnce())
         .acquire(any(), anyLong(), any());
-    assertTrue(leaseList.size() > 0);
+    assertThat(leaseList.size()).isGreaterThan(0);
     // immediate check if event is published
     Mockito.verify(eventPublisher, never())
         .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
@@ -215,7 +215,7 @@ public class TestCloseContainerEventHandler {
         .map(d -> d.getUuid())
         .collect(Collectors.toSet());
     for (CommandForDatanode c : cmds) {
-      assertTrue(pipelineDNs.contains(c.getDatanodeId()));
+      assertThat(pipelineDNs).contains(c.getDatanodeId());
       pipelineDNs.remove(c.getDatanodeId());
       CloseContainerCommand ccc = (CloseContainerCommand)c.getCommand();
       assertEquals(container.getContainerID(), ccc.getContainerID());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -45,6 +45,7 @@ import org.slf4j.event.Level;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_NODE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -258,7 +259,7 @@ public class TestContainerBalancer {
     Thread balancingThread = containerBalancer.getCurrentBalancingThread();
     GenericTestUtils.waitFor(
         () -> balancingThread.getState() == Thread.State.TIMED_WAITING, 2, 20);
-    Assertions.assertTrue(logCapturer.getOutput().contains(expectedLog));
+    assertThat(logCapturer.getOutput()).contains(expectedLog);
     stopBalancer();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -79,6 +79,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -343,12 +344,11 @@ public class TestContainerBalancerTask {
 
     int number = percent * numberOfNodes / 100;
     ContainerBalancerMetrics metrics = containerBalancerTask.getMetrics();
-    Assertions.assertFalse(
-        containerBalancerTask.getCountDatanodesInvolvedPerIteration() > number);
-    Assertions.assertTrue(
-        metrics.getNumDatanodesInvolvedInLatestIteration() > 0);
-    Assertions.assertFalse(
-        metrics.getNumDatanodesInvolvedInLatestIteration() > number);
+    assertThat(containerBalancerTask.getCountDatanodesInvolvedPerIteration())
+        .isLessThanOrEqualTo(number);
+    assertThat(metrics.getNumDatanodesInvolvedInLatestIteration()).isGreaterThan(0);
+    assertThat(metrics.getNumDatanodesInvolvedInLatestIteration())
+        .isLessThanOrEqualTo(number);
     stopBalancer();
   }
 
@@ -444,14 +444,13 @@ public class TestContainerBalancerTask {
     startBalancer(balancerConfiguration);
 
     // balancer should not have moved more size than the limit
-    Assertions.assertFalse(
-        containerBalancerTask.getSizeScheduledForMoveInLatestIteration() >
-        10 * STORAGE_UNIT);
+    assertThat(containerBalancerTask.getSizeScheduledForMoveInLatestIteration())
+        .isLessThanOrEqualTo(10 * STORAGE_UNIT);
 
     long size = containerBalancerTask.getMetrics()
         .getDataSizeMovedGBInLatestIteration();
-    Assertions.assertTrue(size > 0);
-    Assertions.assertFalse(size > 10);
+    assertThat(size).isGreaterThan(0);
+    assertThat(size).isLessThanOrEqualTo(10);
     stopBalancer();
   }
 
@@ -604,7 +603,7 @@ public class TestContainerBalancerTask {
         balancerConfiguration.getExcludeContainers();
     for (ContainerID container :
         containerBalancerTask.getContainerToSourceMap().keySet()) {
-      Assertions.assertFalse(excludeContainers.contains(container));
+      assertThat(excludeContainers).doesNotContain(container);
     }
   }
 
@@ -684,7 +683,7 @@ public class TestContainerBalancerTask {
         .isEmpty());
     Assertions.assertFalse(containerBalancerTask.getContainerToSourceMap()
         .isEmpty());
-    Assertions.assertTrue(0 !=
+    Assertions.assertNotEquals(0,
         containerBalancerTask.getSizeScheduledForMoveInLatestIteration());
   }
 
@@ -714,11 +713,10 @@ public class TestContainerBalancerTask {
     Assertions.assertEquals(determineExpectedUnBalancedNodes(
             balancerConfiguration.getThreshold()).size(),
         metrics.getNumDatanodesUnbalanced());
-    Assertions.assertTrue(metrics.getDataSizeMovedGBInLatestIteration() <= 6);
-    Assertions.assertTrue(metrics.getDataSizeMovedGB() > 0);
+    assertThat(metrics.getDataSizeMovedGBInLatestIteration()).isLessThanOrEqualTo(6);
+    assertThat(metrics.getDataSizeMovedGB()).isGreaterThan(0);
     Assertions.assertEquals(1, metrics.getNumIterations());
-    Assertions.assertTrue(
-        metrics.getNumContainerMovesScheduledInLatestIteration() > 0);
+    assertThat(metrics.getNumContainerMovesScheduledInLatestIteration()).isGreaterThan(0);
     Assertions.assertEquals(metrics.getNumContainerMovesScheduled(),
         metrics.getNumContainerMovesScheduledInLatestIteration());
     Assertions.assertEquals(metrics.getNumContainerMovesScheduled(),
@@ -915,8 +913,8 @@ public class TestContainerBalancerTask {
     Assertions.assertEquals(1,
         containerBalancerTask.getMetrics()
             .getNumContainerMovesCompletedInLatestIteration());
-    Assertions.assertTrue(containerBalancerTask.getMetrics()
-            .getNumContainerMovesTimeoutInLatestIteration() > 1);
+    assertThat(containerBalancerTask.getMetrics()
+            .getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(1);
     stopBalancer();
 
     /*
@@ -938,8 +936,8 @@ public class TestContainerBalancerTask {
     Assertions.assertEquals(1,
         containerBalancerTask.getMetrics()
             .getNumContainerMovesCompletedInLatestIteration());
-    Assertions.assertTrue(containerBalancerTask.getMetrics()
-        .getNumContainerMovesTimeoutInLatestIteration() > 1);
+    assertThat(containerBalancerTask.getMetrics()
+        .getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(1);
     stopBalancer();
   }
 
@@ -968,8 +966,8 @@ public class TestContainerBalancerTask {
     rmConf.setEnableLegacy(true);
     startBalancer(balancerConfiguration);
 
-    Assertions.assertTrue(containerBalancerTask.getMetrics()
-        .getNumContainerMovesTimeoutInLatestIteration() > 0);
+    assertThat(containerBalancerTask.getMetrics()
+        .getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(0);
     Assertions.assertEquals(0, containerBalancerTask.getMetrics()
         .getNumContainerMovesCompletedInLatestIteration());
     stopBalancer();
@@ -984,8 +982,8 @@ public class TestContainerBalancerTask {
 
     rmConf.setEnableLegacy(false);
     startBalancer(balancerConfiguration);
-    Assertions.assertTrue(containerBalancerTask.getMetrics()
-        .getNumContainerMovesTimeoutInLatestIteration() > 0);
+    assertThat(containerBalancerTask.getMetrics()
+        .getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(0);
     Assertions.assertEquals(0, containerBalancerTask.getMetrics()
         .getNumContainerMovesCompletedInLatestIteration());
     stopBalancer();
@@ -1027,9 +1025,8 @@ public class TestContainerBalancerTask {
     Assertions.assertEquals(
         ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
-    Assertions.assertTrue(
-        containerBalancerTask.getMetrics()
-            .getNumContainerMovesFailed() >= 3);
+    assertThat(containerBalancerTask.getMetrics().getNumContainerMovesFailed())
+        .isGreaterThanOrEqualTo(3);
     stopBalancer();
 
     /*
@@ -1053,9 +1050,8 @@ public class TestContainerBalancerTask {
     Assertions.assertEquals(
         ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
-    Assertions.assertTrue(
-        containerBalancerTask.getMetrics()
-            .getNumContainerMovesFailed() >= 3);
+    assertThat(containerBalancerTask.getMetrics().getNumContainerMovesFailed())
+        .isGreaterThanOrEqualTo(3);
     stopBalancer();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
@@ -155,9 +156,9 @@ public class TestSCMContainerPlacementCapacity {
     }
 
     //datanode 6 has more space than datanode 3 and datanode 4.
-    Assertions.assertTrue(selectedCount.get(datanodes.get(3)) < selectedCount
-        .get(datanodes.get(6)));
-    Assertions.assertTrue(selectedCount.get(datanodes.get(4)) < selectedCount
-        .get(datanodes.get(6)));
+    assertThat(selectedCount.get(datanodes.get(3)))
+        .isLessThan(selectedCount.get(datanodes.get(6)));
+    assertThat(selectedCount.get(datanodes.get(4)))
+        .isLessThan(selectedCount.get(datanodes.get(6)));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -58,6 +58,7 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -339,8 +340,8 @@ public class TestSCMContainerPlacementRackAware {
     // verify metrics
     Assertions.assertEquals(totalRequest, nodeNum);
     Assertions.assertEquals(successCount, nodeNum);
-    Assertions.assertTrue(tryCount > nodeNum);
-    Assertions.assertTrue(compromiseCount >= 1);
+    assertThat(tryCount).isGreaterThan(nodeNum);
+    assertThat(compromiseCount).isGreaterThanOrEqualTo(1);
   }
 
   @ParameterizedTest
@@ -365,8 +366,10 @@ public class TestSCMContainerPlacementRackAware {
     long compromiseCount = metrics.getDatanodeChooseFallbackCount();
 
     Assertions.assertEquals(nodeNum, totalRequest);
-    Assertions.assertTrue(successCount >= 1, "Not enough success count");
-    Assertions.assertTrue(tryCount >= 1, "Not enough try count");
+    assertThat(successCount).withFailMessage("Not enough success count")
+        .isGreaterThanOrEqualTo(1);
+    assertThat(tryCount).withFailMessage("Not enough try count")
+        .isGreaterThanOrEqualTo(1);
     Assertions.assertEquals(0, compromiseCount);
   }
 
@@ -434,7 +437,7 @@ public class TestSCMContainerPlacementRackAware {
 
     Assertions.assertEquals(totalRequest, nodeNum);
     Assertions.assertEquals(successCount, 0);
-    Assertions.assertTrue(tryCount >= nodeNum, "Not enough try");
+    assertThat(tryCount).withFailMessage("Not enough try").isGreaterThanOrEqualTo(nodeNum);
     Assertions.assertEquals(compromiseCount, 0);
   }
 
@@ -793,8 +796,10 @@ public class TestSCMContainerPlacementRackAware {
     long compromiseCount = metrics.getDatanodeChooseFallbackCount();
 
     Assertions.assertEquals(nodeNum, totalRequest);
-    Assertions.assertTrue(successCount >= 1, "Not enough success count");
-    Assertions.assertTrue(tryCount >= 1, "Not enough try count");
+    assertThat(successCount).withFailMessage("Not enough success count")
+        .isGreaterThanOrEqualTo(1);
+    assertThat(tryCount).withFailMessage("Not enough try count")
+        .isGreaterThanOrEqualTo(1);
     Assertions.assertEquals(0, compromiseCount);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -66,6 +66,7 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -474,7 +475,7 @@ public class TestSCMContainerPlacementRackScatter {
 
     Assertions.assertEquals(totalRequest, nodeNum);
     Assertions.assertEquals(successCount, 0);
-    Assertions.assertTrue(tryCount >= nodeNum, "Not enough try");
+    assertThat(tryCount).withFailMessage("Not enough try").isGreaterThanOrEqualTo(nodeNum);
     Assertions.assertEquals(compromiseCount, 0);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.ADD;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.DELETE;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for ContainerReplicaPendingOps.
@@ -114,9 +115,9 @@ public class TestContainerReplicaPendingOps {
     }
     List<DatanodeDetails> allDns = ops.stream()
         .map(ContainerReplicaOp::getTarget).collect(Collectors.toList());
-    Assertions.assertTrue(allDns.contains(dn1));
-    Assertions.assertTrue(allDns.contains(dn2));
-    Assertions.assertTrue(allDns.contains(dn3));
+    assertThat(allDns).contains(dn1);
+    assertThat(allDns).contains(dn2);
+    assertThat(allDns).contains(dn3);
 
     ops = pendingOps.getPendingOps(new ContainerID(2));
     Assertions.assertEquals(1, ops.size());
@@ -141,9 +142,9 @@ public class TestContainerReplicaPendingOps {
     }
     List<DatanodeDetails> allDns = ops.stream()
         .map(ContainerReplicaOp::getTarget).collect(Collectors.toList());
-    Assertions.assertTrue(allDns.contains(dn1));
-    Assertions.assertTrue(allDns.contains(dn2));
-    Assertions.assertTrue(allDns.contains(dn3));
+    assertThat(allDns).contains(dn1);
+    assertThat(allDns).contains(dn2);
+    assertThat(allDns).contains(dn3);
 
     ops = pendingOps.getPendingOps(new ContainerID(2));
     Assertions.assertEquals(1, ops.size());
@@ -239,9 +240,9 @@ public class TestContainerReplicaPendingOps {
     List<DatanodeDetails> dns = ops.stream()
         .map(ContainerReplicaOp::getTarget)
         .collect(Collectors.toList());
-    Assertions.assertFalse(dns.contains(dn1));
-    Assertions.assertTrue(dns.contains(dn2));
-    Assertions.assertTrue(dns.contains(dn3));
+    assertThat(dns).doesNotContain(dn1);
+    assertThat(dns).contains(dn2);
+    assertThat(dns).contains(dn3);
 
     clock.fastForward(1000);
     pendingOps.removeExpiredEntries();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
@@ -45,6 +45,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.UNHEALTHY;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for EcContainerReplicaCounts.
@@ -282,7 +283,7 @@ public class TestECContainerReplicaCount {
     Assertions.assertEquals(4, rcnt.additionalMaintenanceCopiesNeeded(false));
     Set<Integer> maintenanceOnly = rcnt.maintenanceOnlyIndexes(false);
     for (int i = 1; i <= repConfig.getRequiredNodes(); i++) {
-      Assertions.assertTrue(maintenanceOnly.contains(i));
+      assertThat(maintenanceOnly).contains(i);
     }
 
     // include pending adds but still have insufficient replication
@@ -320,7 +321,7 @@ public class TestECContainerReplicaCount {
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
     Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
-    Assertions.assertTrue(rcnt.maintenanceOnlyIndexes(false).contains(5));
+    assertThat(rcnt.maintenanceOnlyIndexes(false)).contains(5);
   }
 
   @Test
@@ -341,8 +342,8 @@ public class TestECContainerReplicaCount {
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
     Assertions.assertEquals(2, rcnt.maintenanceOnlyIndexes(false).size());
-    Assertions.assertTrue(rcnt.maintenanceOnlyIndexes(false).contains(1));
-    Assertions.assertTrue(rcnt.maintenanceOnlyIndexes(false).contains(5));
+    assertThat(rcnt.maintenanceOnlyIndexes(false)).contains(1);
+    assertThat(rcnt.maintenanceOnlyIndexes(false)).contains(5);
   }
 
   @Test
@@ -372,7 +373,7 @@ public class TestECContainerReplicaCount {
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
     Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
-    Assertions.assertTrue(rcnt.maintenanceOnlyIndexes(false).contains(5));
+    assertThat(rcnt.maintenanceOnlyIndexes(false)).contains(5);
   }
 
   @Test
@@ -417,8 +418,8 @@ public class TestECContainerReplicaCount {
     Assertions.assertEquals(0, rcnt.maintenanceOnlyIndexes(false).size());
 
     Assertions.assertEquals(2, rcnt.unavailableIndexes(true).size());
-    Assertions.assertTrue(rcnt.unavailableIndexes(true).contains(4));
-    Assertions.assertTrue(rcnt.unavailableIndexes(true).contains(5));
+    assertThat(rcnt.unavailableIndexes(true)).contains(4);
+    assertThat(rcnt.unavailableIndexes(true)).contains(5);
   }
 
   @Test
@@ -441,7 +442,7 @@ public class TestECContainerReplicaCount {
 
     Set<Integer> maintenanceOnly = rcnt.maintenanceOnlyIndexes(true);
     Assertions.assertEquals(1, maintenanceOnly.size());
-    Assertions.assertTrue(maintenanceOnly.contains(5));
+    assertThat(maintenanceOnly).contains(5);
   }
 
   @Test
@@ -483,8 +484,8 @@ public class TestECContainerReplicaCount {
     Assertions.assertFalse(rcnt.isOverReplicated(true));
 
     Assertions.assertEquals(2, rcnt.unavailableIndexes(true).size());
-    Assertions.assertTrue(rcnt.unavailableIndexes(true).contains(1));
-    Assertions.assertTrue(rcnt.unavailableIndexes(true).contains(5));
+    assertThat(rcnt.unavailableIndexes(true)).contains(1);
+    assertThat(rcnt.unavailableIndexes(true)).contains(5);
   }
 
   @Test
@@ -504,9 +505,7 @@ public class TestECContainerReplicaCount {
     Assertions.assertEquals(3, rcnt.additionalMaintenanceCopiesNeeded(true));
     Set<Integer> maintenanceOnly = rcnt.maintenanceOnlyIndexes(true);
     Assertions.assertEquals(4, maintenanceOnly.size());
-    Assertions.assertTrue(
-        maintenanceOnly.contains(2) && maintenanceOnly.contains(3) &&
-            maintenanceOnly.contains(4) && maintenanceOnly.contains(5));
+    assertThat(maintenanceOnly).contains(2, 3, 4, 5);
 
     Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -62,9 +62,9 @@ import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaO
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -357,7 +357,7 @@ public class TestECOverReplicationHandler {
     );
 
     index2commandNum.keySet().forEach(i -> {
-      assertTrue(index2excessNum.containsKey(i));
+      assertThat(index2excessNum).containsKey(i);
       assertEquals(index2commandNum.get(i), index2excessNum.get(i));
     });
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -81,6 +81,7 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -297,7 +298,7 @@ public class TestECUnderReplicationHandler {
       List<DatanodeDetails> usedNodes) {
     assertEquals(replicas.size(), usedNodes.size());
     for (ContainerReplica r : replicas) {
-      assertTrue(usedNodes.contains(r.getDatanodeDetails()));
+      assertThat(usedNodes).contains(r.getDatanodeDetails());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
@@ -55,6 +55,7 @@ import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProt
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -206,8 +207,8 @@ public abstract class TestMisReplicationHandler {
               .thenAnswer(invocation -> {
                 List<DatanodeDetails> datanodeDetails =
                         invocation.getArgument(0);
-                Assertions.assertTrue(remainingReplicasAfterCopy
-                        .containsAll(datanodeDetails));
+                assertThat(remainingReplicasAfterCopy)
+                    .containsAll(datanodeDetails);
                 return targetNodes;
               });
     }
@@ -228,8 +229,8 @@ public abstract class TestMisReplicationHandler {
             container.getContainerID());
         DatanodeDetails replicateSrcDn = pair.getKey();
         DatanodeDetails target = replicateContainerCommand.getTargetDatanode();
-        Assertions.assertTrue(sourceDns.contains(replicateSrcDn));
-        Assertions.assertTrue(targetNodes.contains(target));
+        assertThat(sourceDns).contains(replicateSrcDn);
+        assertThat(targetNodes).contains(target);
         int replicaIndex = replicateContainerCommand.getReplicaIndex();
         assertReplicaIndex(replicaIndexMap, replicateSrcDn, replicaIndex);
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -57,10 +57,9 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicasWithSameOrigin;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -340,7 +339,7 @@ public class TestRatisOverReplicationHandler {
         replicas, Collections.emptyList(), getOverReplicatedHealthResult(), 2);
     Set<DatanodeDetails> datanodes =
         commands.stream().map(Pair::getKey).collect(Collectors.toSet());
-    assertTrue(datanodes.contains(quasiClosedReplica.getDatanodeDetails()));
+    assertThat(datanodes).contains(quasiClosedReplica.getDatanodeDetails());
   }
 
   @Test
@@ -363,10 +362,8 @@ public class TestRatisOverReplicationHandler {
         replicas, Collections.emptyList(), getOverReplicatedHealthResult(), 1);
     Set<DatanodeDetails> datanodes =
         commands.stream().map(Pair::getKey).collect(Collectors.toSet());
-    assertFalse(
-        datanodes.contains(decommissioningReplica.getDatanodeDetails()));
-    assertFalse(
-        datanodes.contains(maintenanceReplica.getDatanodeDetails()));
+    assertThat(datanodes).doesNotContain(decommissioningReplica.getDatanodeDetails());
+    assertThat(datanodes).doesNotContain(maintenanceReplica.getDatanodeDetails());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -61,6 +61,7 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -517,12 +518,12 @@ public class TestRatisUnderReplicationHandler {
     List<DatanodeDetails> usedNodes = usedNodesCaptor.getValue();
     List<DatanodeDetails> excludedNodes = excludedNodesCaptor.getValue();
 
-    assertTrue(usedNodes.contains(good.getDatanodeDetails()));
-    assertTrue(usedNodes.contains(maintenance.getDatanodeDetails()));
-    assertTrue(usedNodes.contains(pendingAdd));
-    assertTrue(excludedNodes.contains(unhealthy.getDatanodeDetails()));
-    assertTrue(excludedNodes.contains(decommissioning.getDatanodeDetails()));
-    assertTrue(excludedNodes.contains(pendingRemove));
+    assertThat(usedNodes).contains(good.getDatanodeDetails());
+    assertThat(usedNodes).contains(maintenance.getDatanodeDetails());
+    assertThat(usedNodes).contains(pendingAdd);
+    assertThat(excludedNodes).contains(unhealthy.getDatanodeDetails());
+    assertThat(excludedNodes).contains(decommissioning.getDatanodeDetails());
+    assertThat(excludedNodes).contains(pendingRemove);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -84,6 +84,7 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicasWithSameOrigin;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.getNoNodesTestPlacementPolicy;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1214,12 +1215,12 @@ public class TestReplicationManager {
     }
     assertEquals(2, cmdTargets.size());
     for (DatanodeDetails dn : targetNodes) {
-      assertTrue(cmdTargets.contains(dn));
+      assertThat(cmdTargets).contains(dn);
     }
 
     assertEquals(2, cmdIndexes.size());
     for (int i : missingIndexes) {
-      assertTrue(cmdIndexes.contains(i));
+      assertThat(cmdIndexes).contains(i);
     }
     assertEquals(1, replicationManager.getMetrics()
         .getEcReconstructionCmdsSentTotal());
@@ -1594,7 +1595,7 @@ public class TestReplicationManager {
     assertEquals(1, excluded.size());
     // dn 3 was at the limit already, so should be added when filtering the
     // nodes
-    assertTrue(excluded.contains(dn3));
+    assertThat(excluded).contains(dn3);
 
     // Trigger an update for dn3, but it should stay in the excluded list as its
     // count is still at the limit.
@@ -1616,7 +1617,7 @@ public class TestReplicationManager {
     excluded = replicationManager.getExcludedNodes();
     assertEquals(1, excluded.size());
     // dn 2 reached the limit from the reconstruction command
-    assertTrue(excluded.contains(dn2));
+    assertThat(excluded).contains(dn2);
 
     // Update received for DN2, it should be cleared from the excluded list.
     replicationManager.datanodeCommandCountUpdated(dn2);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -41,8 +41,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainer;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for ReplicationManagerUtil.
@@ -118,22 +118,22 @@ public class TestReplicationManagerUtil {
             replicationManager);
 
     assertEquals(3, excludedAndUsedNodes.getUsedNodes().size());
-    assertTrue(excludedAndUsedNodes.getUsedNodes()
-        .contains(good.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getUsedNodes()
-        .contains(maintenance.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getUsedNodes()
-        .contains(pendingAdd));
+    assertThat(excludedAndUsedNodes.getUsedNodes())
+        .contains(good.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getUsedNodes())
+        .contains(maintenance.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getUsedNodes())
+        .contains(pendingAdd);
 
     assertEquals(4, excludedAndUsedNodes.getExcludedNodes().size());
-    assertTrue(excludedAndUsedNodes.getExcludedNodes()
-        .contains(unhealthy.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getExcludedNodes()
-        .contains(decommissioning.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getExcludedNodes()
-        .contains(remove.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getExcludedNodes()
-        .contains(pendingDelete));
+    assertThat(excludedAndUsedNodes.getExcludedNodes())
+        .contains(unhealthy.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getExcludedNodes())
+        .contains(decommissioning.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getExcludedNodes())
+        .contains(remove.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getExcludedNodes())
+        .contains(pendingDelete);
   }
 
   @Test
@@ -202,23 +202,23 @@ public class TestReplicationManagerUtil {
             replicationManager);
 
     assertEquals(4, excludedAndUsedNodes.getUsedNodes().size());
-    assertTrue(excludedAndUsedNodes.getUsedNodes()
-        .contains(good.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getUsedNodes()
-        .contains(maintenance.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getUsedNodes()
-        .contains(pendingAdd));
-    assertTrue(excludedAndUsedNodes.getUsedNodes().contains(unhealthyWithUniqueOrigin.getDatanodeDetails()));
+    assertThat(excludedAndUsedNodes.getUsedNodes())
+        .contains(good.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getUsedNodes())
+        .contains(maintenance.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getUsedNodes())
+        .contains(pendingAdd);
+    assertThat(excludedAndUsedNodes.getUsedNodes()).contains(unhealthyWithUniqueOrigin.getDatanodeDetails());
 
     assertEquals(4, excludedAndUsedNodes.getExcludedNodes().size());
-    assertTrue(excludedAndUsedNodes.getExcludedNodes()
-        .contains(unhealthyWithNonUniqueOrigin.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getExcludedNodes()
-        .contains(decommissioning.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getExcludedNodes()
-        .contains(remove.getDatanodeDetails()));
-    assertTrue(excludedAndUsedNodes.getExcludedNodes()
-        .contains(pendingDelete));
+    assertThat(excludedAndUsedNodes.getExcludedNodes())
+        .contains(unhealthyWithNonUniqueOrigin.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getExcludedNodes())
+        .contains(decommissioning.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getExcludedNodes())
+        .contains(remove.getDatanodeDetails());
+    assertThat(excludedAndUsedNodes.getExcludedNodes())
+        .contains(pendingDelete);
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerAttribute.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Test ContainerAttribute management.
  */
@@ -38,7 +40,7 @@ public class TestContainerAttribute {
     containerAttribute.insert(1, id);
     Assertions.assertEquals(1,
         containerAttribute.getCollection(1).size());
-    Assertions.assertTrue(containerAttribute.getCollection(1).contains(id));
+    assertThat(containerAttribute.getCollection(1)).contains(id);
 
     // Insert again and verify that the new ContainerId is inserted.
     ContainerID newId =
@@ -46,7 +48,7 @@ public class TestContainerAttribute {
     containerAttribute.insert(1, newId);
     Assertions.assertEquals(1,
         containerAttribute.getCollection(1).size());
-    Assertions.assertTrue(containerAttribute.getCollection(1).contains(newId));
+    assertThat(containerAttribute.getCollection(1)).contains(newId);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
@@ -34,6 +34,8 @@ import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests on {@link org.apache.hadoop.hdds.scm.metadata.Replicate}.
  */
@@ -128,7 +130,7 @@ public class TestReplicationAnnotation {
       Assertions.fail("Cannot reach here: should have seen a IOException");
     } catch (IOException e) {
       Assertions.assertNotNull(e.getMessage());
-      Assertions.assertTrue(e.getMessage().contains("submitRequest is called"));
+      assertThat(e.getMessage()).contains("submitRequest is called");
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -55,8 +55,8 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -150,12 +150,12 @@ class TestSCMHAManagerImpl {
       IOException ex;
       ex = assertThrows(IOException.class, () ->
           scm2.removePeerFromHARing(randomScmId));
-      assertTrue(ex.getMessage().contains("Peer"));
+      assertThat(ex.getMessage()).contains("Peer");
 
       // try removing leader scm from ratis ring
       ex = assertThrows(IOException.class, () ->
           scm2.removePeerFromHARing(scm2.getScmId()));
-      assertTrue(ex.getMessage().contains("leader"));
+      assertThat(ex.getMessage()).contains("leader");
     } finally {
       scm2.getScmHAManager().getRatisServer().stop();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisResponse.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.ha;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
@@ -75,7 +76,7 @@ public class TestSCMRatisResponse {
         .build();
     SCMRatisResponse response = SCMRatisResponse.decode(reply);
     Assertions.assertFalse(response.isSuccess());
-    Assertions.assertTrue(response.getException() instanceof RaftException);
+    assertInstanceOf(RaftException.class, response.getException());
     Assertions.assertNull(response.getResult());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -101,31 +102,30 @@ public class TestNodeDecommissionManager {
         decom.decommissionNodes(
             singletonList(dns.get(1).getIpAddress() + ":10"));
     assertEquals(1, error.size());
-    assertTrue(error.get(0).getHostname().contains(dns.get(1).getIpAddress()));
+    assertThat(error.get(0).getHostname()).contains(dns.get(1).getIpAddress());
 
     // Try to decommission a host that does not exist
     error = decom.decommissionNodes(singletonList("123.123.123.123"));
     assertEquals(1, error.size());
-    assertTrue(error.get(0).getHostname().contains("123.123.123.123"));
+    assertThat(error.get(0).getHostname()).contains("123.123.123.123");
 
     // Try to decommission a host that does exist and a host that does not
     error  = decom.decommissionNodes(Arrays.asList(dns.get(1).getIpAddress(),
         "123,123,123,123"));
     assertEquals(1, error.size());
-    assertTrue(error.get(0).getHostname().contains("123,123,123,123"));
+    assertThat(error.get(0).getHostname()).contains("123,123,123,123");
 
     // Try to decommission a host with many DNs on the address with no port
     error = decom.decommissionNodes(singletonList(dns.get(0).getIpAddress()));
     assertEquals(1, error.size());
-    assertTrue(error.get(0).getHostname().contains(dns.get(0).getIpAddress()));
+    assertThat(error.get(0).getHostname()).contains(dns.get(0).getIpAddress());
 
     // Try to decommission a host with many DNs on the address with a port
     // that does not exist
     error = decom.decommissionNodes(singletonList(dns.get(0).getIpAddress()
         + ":10"));
     assertEquals(1, error.size());
-    assertTrue(error.get(0).getHostname().contains(dns.get(0).getIpAddress()
-        + ":10"));
+    assertThat(error.get(0).getHostname()).contains(dns.get(0).getIpAddress() + ":10");
 
     // Try to decommission 2 hosts with address that does not exist
     // Both should return error
@@ -220,7 +220,7 @@ public class TestNodeDecommissionManager {
     List<DatanodeAdminError> error =
         decom.decommissionNodes(singletonList(extraDN.getIpAddress()));
     assertEquals(1, error.size());
-    assertTrue(error.get(0).getHostname().contains(extraDN.getIpAddress()));
+    assertThat(error.get(0).getHostname()).contains(extraDN.getIpAddress());
 
     // Now try the one with the unique port
     decom.decommissionNodes(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -50,6 +49,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
@@ -291,14 +291,14 @@ public class TestNodeStateManager {
 
     Set<ContainerID> containerSet = nsm.getContainers(dn.getUuid());
     assertEquals(2, containerSet.size());
-    Assertions.assertTrue(containerSet.contains(ContainerID.valueOf(1)));
-    Assertions.assertTrue(containerSet.contains(ContainerID.valueOf(2)));
+    assertThat(containerSet).contains(ContainerID.valueOf(1));
+    assertThat(containerSet).contains(ContainerID.valueOf(2));
 
     nsm.removeContainer(dn.getUuid(), ContainerID.valueOf(2));
     containerSet = nsm.getContainers(dn.getUuid());
     assertEquals(1, containerSet.size());
-    Assertions.assertTrue(containerSet.contains(ContainerID.valueOf(1)));
-    Assertions.assertFalse(containerSet.contains(ContainerID.valueOf(2)));
+    assertThat(containerSet).contains(ContainerID.valueOf(1));
+    assertThat(containerSet).doesNotContain(ContainerID.valueOf(2));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStatus.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStatus.java
@@ -29,8 +29,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY
 import static org.apache.hadoop.hdds.scm.node.NodeStatus.inServiceDead;
 import static org.apache.hadoop.hdds.scm.node.NodeStatus.inServiceHealthy;
 import static org.apache.hadoop.hdds.scm.node.NodeStatus.inServiceStale;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link NodeStatus}.
@@ -46,21 +46,21 @@ class TestNodeStatus {
 
   @Test
   void healthyFirst() {
-    assertTrue(0 > inServiceHealthy().compareTo(inServiceStale()));
-    assertTrue(0 < inServiceDead().compareTo(inServiceHealthy()));
-    assertTrue(0 > new NodeStatus(ENTERING_MAINTENANCE, HEALTHY).compareTo(
+    assertThat(0).isGreaterThan(inServiceHealthy().compareTo(inServiceStale()));
+    assertThat(0).isLessThan(inServiceDead().compareTo(inServiceHealthy()));
+    assertThat(0).isGreaterThan(new NodeStatus(ENTERING_MAINTENANCE, HEALTHY).compareTo(
         inServiceStale()
     ));
-    assertTrue(0 < inServiceStale().compareTo(
+    assertThat(0).isLessThan(inServiceStale().compareTo(
         new NodeStatus(DECOMMISSIONING, HEALTHY)
     ));
   }
 
   @Test
   void inServiceFirst() {
-    assertTrue(0 > inServiceHealthy().compareTo(
+    assertThat(0).isGreaterThan(inServiceHealthy().compareTo(
         new NodeStatus(ENTERING_MAINTENANCE, HEALTHY)));
-    assertTrue(0 < new NodeStatus(DECOMMISSIONING, HEALTHY).compareTo(
+    assertThat(0).isLessThan(new NodeStatus(DECOMMISSIONING, HEALTHY).compareTo(
         inServiceHealthy()
     ));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -469,8 +469,8 @@ public class TestSCMNodeManager {
       scm.getPipelineManager().createPipeline(ratisThree);
       fail("3 nodes should not have been found for a pipeline.");
     } catch (SCMException ex) {
-      assertTrue(ex.getMessage().contains("Required 3. Found " +
-          actualNodeCount));
+      assertThat(ex.getMessage()).contains("Required 3. Found " +
+          actualNodeCount);
     }
   }
 
@@ -865,8 +865,9 @@ public class TestSCMNodeManager {
       // Step 3 : wait for 1 iteration of health check
       try {
         schedFuture.get();
-        assertTrue(nodeManager.getSkippedHealthChecks() > 0,
-            "We did not skip any heartbeat checks");
+        assertThat(nodeManager.getSkippedHealthChecks())
+            .withFailMessage("We did not skip any heartbeat checks")
+            .isGreaterThan(0);
       } catch (ExecutionException e) {
         fail("Unexpected exception waiting for Scheduled Health Check");
       }
@@ -937,8 +938,8 @@ public class TestSCMNodeManager {
             .setMetadataLayoutVersion(scmMlv + 1)
             .setSoftwareLayoutVersion(scmSlv + 1)
             .build());
-    assertTrue(logCapturer.getOutput()
-        .contains("Invalid data node in the cluster"));
+    assertThat(logCapturer.getOutput())
+        .contains("Invalid data node in the cluster");
     nodeManager.close();
   }
 
@@ -1433,8 +1434,8 @@ public class TestSCMNodeManager {
       // Assert all healthy nodes are healthy now, this has to be a greater
       // than check since Stale nodes can be healthy when we check the state.
 
-      assertTrue(nodeManager.getNodeCount(NodeStatus.inServiceHealthy())
-          >= healthyCount);
+      assertThat(nodeManager.getNodeCount(NodeStatus.inServiceHealthy()))
+          .isGreaterThanOrEqualTo(healthyCount);
 
       assertEquals(deadCount,
           nodeManager.getNodeCount(NodeStatus.inServiceDead()));
@@ -1443,7 +1444,7 @@ public class TestSCMNodeManager {
           nodeManager.getNodes(NodeStatus.inServiceDead());
 
       for (DatanodeDetails node : deadList) {
-        assertTrue(deadNodeList.contains(node));
+        assertThat(deadNodeList).contains(node);
       }
 
 
@@ -1816,7 +1817,7 @@ public class TestSCMNodeManager {
       List<SCMCommand> command =
           nodemanager.processHeartbeat(datanodeDetails, layoutInfo);
       // With dh registered, SCM will send create pipeline command to dn
-      assertTrue(command.size() >= 1);
+      assertThat(command.size()).isGreaterThanOrEqualTo(1);
       assertTrue(command.get(0).getClass().equals(
           CloseContainerCommand.class) ||
           command.get(1).getClass().equals(CloseContainerCommand.class));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -52,6 +52,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.DEAD;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.ALLOCATED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -147,7 +148,7 @@ public class TestECPipelineProvider {
     List<DatanodeDetails> nodes = pipeline.getNodes();
     Assertions.assertEquals(replicas.size() - deadNodes.size(), nodes.size());
     for (DatanodeDetails d : deadNodes) {
-      Assertions.assertFalse(nodes.contains(d));
+      assertThat(nodes).doesNotContain(d);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -91,7 +91,9 @@ import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.ALLOCAT
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.OPEN;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.ratis.util.Preconditions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -711,9 +713,9 @@ public class TestPipelineManagerImpl {
     Assertions.assertTrue(pipelineStore.get(pipelineID).isClosed());
     pipelineManager.addContainerToPipelineSCMStart(pipelineID,
             ContainerID.valueOf(2));
-    assertTrue(logCapturer.getOutput().contains("Container " +
+    assertThat(logCapturer.getOutput()).contains("Container " +
             ContainerID.valueOf(2) + " in open state for pipeline=" +
-            pipelineID + " in closed state"));
+            pipelineID + " in closed state");
   }
 
   @Test
@@ -761,12 +763,12 @@ public class TestPipelineManagerImpl {
     String pipelineExpectedOutput =
         "Pipeline " + pipelineID + " moved to CLOSED state";
     String logOutput = logCapturer.getOutput();
-    assertTrue(logOutput.contains(containerExpectedOutput));
-    assertTrue(logOutput.contains(pipelineExpectedOutput));
+    assertThat(logOutput).contains(containerExpectedOutput);
+    assertThat(logOutput).contains(pipelineExpectedOutput);
 
     int containerLogIdx = logOutput.indexOf(containerExpectedOutput);
     int pipelineLogIdx = logOutput.indexOf(pipelineExpectedOutput);
-    assertTrue(containerLogIdx < pipelineLogIdx);
+    assertThat(containerLogIdx).isLessThan(pipelineLogIdx);
   }
 
   @Test
@@ -938,8 +940,9 @@ public class TestPipelineManagerImpl {
     verify(pipelineManagerSpy, times(1))
         .waitOnePipelineReady(captor.capture(), anyLong());
     Collection<PipelineID> coll = captor.getValue();
-    Assertions.assertTrue(coll.contains(allocatedPipeline.getId()),
-               "waitOnePipelineReady() was called on allocated pipeline");
+    assertThat(coll)
+        .withFailMessage("waitOnePipelineReady() was called on allocated pipeline")
+        .contains(allocatedPipeline.getId());
     pipelineManager.close();
   }
 
@@ -955,7 +958,7 @@ public class TestPipelineManagerImpl {
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE), replicas);
     Assertions.assertEquals(3, pipeline.getNodes().size());
     for (DatanodeDetails dn : pipeline.getNodes())  {
-      Assertions.assertTrue(dns.contains(dn));
+      assertThat(dns).contains(dn);
     }
   }
 
@@ -1007,6 +1010,6 @@ public class TestPipelineManagerImpl {
   private static void assertFailsNotLeader(CheckedRunnable<?> block) {
     SCMException e = Assertions.assertThrows(SCMException.class, block::run);
     Assertions.assertEquals(ResultCodes.SCM_NOT_LEADER, e.getResult());
-    Assertions.assertTrue(e.getCause() instanceof NotLeaderException);
+    assertInstanceOf(NotLeaderException.class, e.getCause());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -75,6 +75,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_L
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for PipelinePlacementPolicy.
@@ -163,7 +164,7 @@ public class TestPipelinePlacementPolicy {
   public void testChooseNodeBasedOnNetworkTopology() {
     DatanodeDetails anchor = placementPolicy.chooseNode(nodesWithRackAwareness);
     // anchor should be removed from healthyNodes after being chosen.
-    Assertions.assertFalse(nodesWithRackAwareness.contains(anchor));
+    assertThat(nodesWithRackAwareness).doesNotContain(anchor);
 
     List<DatanodeDetails> excludedNodes =
         new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT);
@@ -173,7 +174,7 @@ public class TestPipelinePlacementPolicy {
         nodeManager.getClusterNetworkTopologyMap(), anchor);
     //DatanodeDetails nextNode = placementPolicy.chooseNodeFromNetworkTopology(
     //    nodeManager.getClusterNetworkTopologyMap(), anchor, excludedNodes);
-    Assertions.assertFalse(excludedNodes.contains(nextNode));
+    assertThat(excludedNodes).doesNotContain(nextNode);
     // next node should not be the same as anchor.
     Assertions.assertNotSame(anchor.getUuid(), nextNode.getUuid());
     // next node should be on the same rack based on topology.
@@ -250,7 +251,7 @@ public class TestPipelinePlacementPolicy {
           0, 10 * OzoneConsts.TB);
       Assertions.fail("SCMException should have been thrown.");
     } catch (SCMException ex) {
-      Assertions.assertTrue(ex.getMessage().contains(expectedMessageSubstring));
+      assertThat(ex.getMessage()).contains(expectedMessageSubstring);
     }
 
     try {
@@ -260,7 +261,7 @@ public class TestPipelinePlacementPolicy {
           0);
       Assertions.fail("SCMException should have been thrown.");
     } catch (SCMException ex) {
-      Assertions.assertTrue(ex.getMessage().contains(expectedMessageSubstring));
+      assertThat(ex.getMessage()).contains(expectedMessageSubstring);
     }
   }
 
@@ -297,8 +298,8 @@ public class TestPipelinePlacementPolicy {
     int averageLoadOnNode = maxPipelineCount *
         HddsProtos.ReplicationFactor.THREE.getNumber() / healthyNodes.size();
     for (DatanodeDetails node : healthyNodes) {
-      Assertions.assertTrue(nodeManager.getPipelinesCount(node)
-          >= averageLoadOnNode);
+      assertThat(nodeManager.getPipelinesCount(node))
+          .isGreaterThanOrEqualTo(averageLoadOnNode);
     }
     
     // Should max out pipeline usage.
@@ -563,9 +564,9 @@ public class TestPipelinePlacementPolicy {
         new ArrayList<>(), new ArrayList<>(), nodesRequired, 0, 0);
 
     Assertions.assertEquals(3, pickedDns.size());
-    Assertions.assertTrue(pickedDns.contains(dns.get(1)));
-    Assertions.assertTrue(pickedDns.contains(dns.get(2)));
-    Assertions.assertTrue(pickedDns.contains(dns.get(3)));
+    assertThat(pickedDns).contains(dns.get(1));
+    assertThat(pickedDns).contains(dns.get(2));
+    assertThat(pickedDns).contains(dns.get(3));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -54,6 +54,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Test for PipelineStateManagerImpl.
  */
@@ -118,7 +120,7 @@ public class TestPipelineStateManagerImpl {
         () -> stateManager.addPipeline(createDummyPipeline(0)
             .getProtobufMessage(ClientVersion.CURRENT_VERSION)));
     // replication factor and number of nodes in the pipeline do not match
-    Assertions.assertTrue(e.getMessage().contains("do not match"));
+    assertThat(e.getMessage()).contains("do not match");
 
     // add a pipeline
     Pipeline pipeline = createDummyPipeline(1);
@@ -131,7 +133,7 @@ public class TestPipelineStateManagerImpl {
       // Cannot add a pipeline twice
       e = Assertions.assertThrows(SCMException.class,
           () -> stateManager.addPipeline(pipelineProto));
-      Assertions.assertTrue(e.getMessage().contains("Duplicate pipeline ID"));
+      assertThat(e.getMessage()).contains("Duplicate pipeline ID");
 
       // verify pipeline returned is same
       Assertions.assertEquals(pipeline.getId(),
@@ -324,7 +326,7 @@ public class TestPipelineStateManagerImpl {
       Assertions.fail("Container should not have been added");
     } catch (IOException e) {
       // Can not add a container to removed pipeline
-      Assertions.assertTrue(e.getMessage().contains("not found"));
+      assertThat(e.getMessage()).contains("not found");
     }
   }
 
@@ -344,7 +346,7 @@ public class TestPipelineStateManagerImpl {
       Assertions.fail("Pipeline should not have been removed");
     } catch (IOException e) {
       // can not remove a pipeline which already has containers
-      Assertions.assertTrue(e.getMessage().contains("not yet closed"));
+      assertThat(e.getMessage()).contains("not yet closed");
     }
 
     // close the pipeline

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -63,8 +63,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -147,9 +147,8 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     // New pipeline should not overlap with the previous created pipeline
-    assertTrue(
-        intersection(pipeline.getNodes(), pipeline1.getNodes())
-            .size() < factor.getNumber());
+    assertThat(intersection(pipeline.getNodes(), pipeline1.getNodes()).size())
+        .isLessThan(factor.getNumber());
     if (pipeline.getReplicationConfig().getRequiredNodes() == 3) {
       assertNotEquals(pipeline.getNodeSet(), pipeline1.getNodeSet());
     }
@@ -310,7 +309,7 @@ public class TestRatisPipelineProvider {
         excludedNodes, Collections.EMPTY_LIST);
 
     for (DatanodeDetails dn : pipeline1.getNodes()) {
-      assertFalse(excludedNodes.contains(dn));
+      assertThat(excludedNodes).doesNotContain(dn);
     }
   }
 
@@ -351,7 +350,7 @@ public class TestRatisPipelineProvider {
         Assertions.fail("Expected SCMException for large container size with " +
             "replication factor " + factor.toString());
       } catch (SCMException ex) {
-        Assertions.assertTrue(ex.getMessage().contains(expectedErrorSubstring));
+        assertThat(ex.getMessage()).contains(expectedErrorSubstring);
       }
     }
 
@@ -367,7 +366,7 @@ public class TestRatisPipelineProvider {
         Assertions.fail("Expected SCMException for large metadata size with " +
             "replication factor " + factor.toString());
       } catch (SCMException ex) {
-        Assertions.assertTrue(ex.getMessage().contains(expectedErrorSubstring));
+        assertThat(ex.getMessage()).contains(expectedErrorSubstring);
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -61,13 +61,12 @@ import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.CLOSED;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -188,8 +187,9 @@ public class TestWritableECContainerProvider {
     for (int i = 0; i < n; i++) {
       ContainerInfo container =
           provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-      assertFalse(allocatedContainers.contains(container),
-          "Provided existing container for request " + i);
+      assertThat(allocatedContainers)
+          .withFailMessage("Provided existing container for request " + i)
+          .doesNotContain(container);
       allocatedContainers.add(container);
     }
     return allocatedContainers;
@@ -200,8 +200,9 @@ public class TestWritableECContainerProvider {
     for (int i = 0; i < 3 * n; i++) {
       ContainerInfo container =
           provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-      assertTrue(existing.contains(container),
-          "Provided new container for request " + i);
+      assertThat(existing)
+          .withFailMessage("Provided new container for request " + i)
+          .contains(container);
     }
   }
 
@@ -226,7 +227,7 @@ public class TestWritableECContainerProvider {
 
     ContainerInfo c = provider.getContainer(1, repConfig, OWNER, exclude);
     assertNotEquals(excludedID, c.getPipelineID());
-    assertTrue(allocatedContainers.contains(c));
+    assertThat(allocatedContainers).contains(c);
   }
 
   @ParameterizedTest
@@ -370,13 +371,13 @@ public class TestWritableECContainerProvider {
         provider.getContainer(50 * 1024 * 1024, repConfig, OWNER,
             new ExcludeList());
     assertNotNull(newContainer);
-    assertTrue(allocatedContainers.contains(newContainer));
+    assertThat(allocatedContainers).contains(newContainer);
     // Now get a new container where there is not enough space in the existing
     // and ensure a new container gets created.
     newContainer = provider.getContainer(
         128 * 1024 * 1024, repConfig, OWNER, new ExcludeList());
     assertNotNull(newContainer);
-    assertFalse(allocatedContainers.contains(newContainer));
+    assertThat(allocatedContainers).doesNotContain(newContainer);
     // The original pipelines should all be closed, triggered by the lack of
     // space.
     for (ContainerInfo c : allocatedContainers) {
@@ -410,7 +411,7 @@ public class TestWritableECContainerProvider {
     ContainerInfo newContainer =
         provider.getContainer(1, repConfig, OWNER, new ExcludeList());
     assertNotNull(newContainer);
-    assertFalse(allocatedContainers.contains(newContainer));
+    assertThat(allocatedContainers).doesNotContain(newContainer);
   }
 
   @ParameterizedTest
@@ -430,7 +431,7 @@ public class TestWritableECContainerProvider {
     ContainerInfo newContainer =
         provider.getContainer(1, repConfig, OWNER, new ExcludeList());
     assertNotNull(newContainer);
-    assertFalse(allocatedContainers.contains(newContainer));
+    assertThat(allocatedContainers).doesNotContain(newContainer);
 
     // Ensure all the existing pipelines are closed
     for (ContainerInfo c : allocatedContainers) {
@@ -451,7 +452,7 @@ public class TestWritableECContainerProvider {
     for (int i = 0; i < providerConf.getMinimumPipelines(); i++) {
       ContainerInfo container = provider.getContainer(
           1, repConfig, OWNER, new ExcludeList());
-      assertFalse(allocatedContainers.contains(container));
+      assertThat(allocatedContainers).doesNotContain(container);
       allocatedContainers.add(container);
       // Remove the container from the pipeline to simulate closing it
       pipelineManager.removeContainerFromPipeline(
@@ -459,7 +460,7 @@ public class TestWritableECContainerProvider {
     }
     ContainerInfo newContainer = provider.getContainer(
         1, repConfig, OWNER, new ExcludeList());
-    assertFalse(allocatedContainers.contains(newContainer));
+    assertThat(allocatedContainers).doesNotContain(newContainer);
     for (ContainerInfo c : allocatedContainers) {
       Pipeline pipeline = pipelineManager.getPipeline(c.getPipelineID());
       assertEquals(CLOSED, pipeline.getPipelineState());
@@ -496,7 +497,7 @@ public class TestWritableECContainerProvider {
     // expecting a new container to be created
     ContainerInfo containerInfo = provider.getContainer(1, repConfig, OWNER,
         excludeList);
-    assertFalse(allocated.contains(containerInfo));
+    assertThat(allocated).doesNotContain(containerInfo);
     for (ContainerInfo c : allocated) {
       Pipeline pipeline = pipelineManager.getPipeline(c.getPipelineID());
       assertEquals(CLOSED, pipeline.getPipelineState());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestCRLStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestCRLStatusReportHandler.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 
 /**
@@ -100,8 +101,7 @@ public class TestCRLStatusReportHandler implements EventPublisher {
         getCRLStatusReport(dn2, pendingCRLIds2, 2L);
     crlStatusReportHandler.onMessage(reportFromDatanode1, this);
     CRLStatus crlStatus = certificateStore.getCRLStatusForDN(dn1.getUuid());
-    Assertions.assertTrue(
-        crlStatus.getPendingCRLIds().containsAll(pendingCRLIds1));
+    assertThat(crlStatus.getPendingCRLIds()).containsAll(pendingCRLIds1);
     Assertions.assertEquals(5L, crlStatus.getReceivedCRLId());
 
     pendingCRLIds1.remove(0);
@@ -115,8 +115,7 @@ public class TestCRLStatusReportHandler implements EventPublisher {
 
     crlStatusReportHandler.onMessage(reportFromDatanode2, this);
     crlStatus = certificateStore.getCRLStatusForDN(dn2.getUuid());
-    Assertions.assertTrue(
-        crlStatus.getPendingCRLIds().containsAll(pendingCRLIds2));
+    assertThat(crlStatus.getPendingCRLIds()).containsAll(pendingCRLIds2);
     Assertions.assertEquals(2L, crlStatus.getReceivedCRLId());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -65,7 +64,9 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_EXPIRED_CERTIFICAT
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -160,7 +161,7 @@ public class TestRootCARotationManager {
       rootCARotationManager = new RootCARotationManager(scm);
       fail("Should fail");
     } catch (Exception e) {
-      Assertions.assertTrue(e instanceof DateTimeParseException);
+      assertInstanceOf(DateTimeParseException.class, e);
     }
 
     // check interval should be less than grace period
@@ -169,8 +170,8 @@ public class TestRootCARotationManager {
       rootCARotationManager = new RootCARotationManager(scm);
       fail("Should fail");
     } catch (Exception e) {
-      Assertions.assertTrue(e instanceof IllegalArgumentException);
-      Assertions.assertTrue(e.getMessage().contains("should be smaller than"));
+      assertInstanceOf(IllegalArgumentException.class, e);
+      assertThat(e.getMessage()).contains("should be smaller than");
     }
 
     // invalid time of day format
@@ -180,9 +181,8 @@ public class TestRootCARotationManager {
       rootCARotationManager = new RootCARotationManager(scm);
       fail("Should fail");
     } catch (Exception e) {
-      Assertions.assertTrue(e instanceof IllegalArgumentException);
-      Assertions.assertTrue(
-          e.getMessage().contains("should follow the hh:mm:ss format"));
+      assertInstanceOf(IllegalArgumentException.class, e);
+      assertThat(e.getMessage()).contains("should follow the hh:mm:ss format");
     }
 
     // valid properties

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
@@ -60,6 +60,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.DATANODE
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.OM;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore.CertType.VALID_CERTS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -143,8 +144,9 @@ public class TestSCMCertStore {
 
     assertNotNull(certInfo);
     assertNotNull(certInfo.getX509Certificate());
-    assertTrue(certInfo.getTimestamp() > 0L,
-        "Timestamp should be greater than 0");
+    assertThat(certInfo.getTimestamp())
+        .withFailMessage("Timestamp should be greater than 0")
+        .isGreaterThan(0L);
 
     long crlId = scmCertStore.getLatestCrlId();
     assertEquals(sequenceId.get().longValue(), crlId);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/update/server/TestSCMUpdateServiceGrpcServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/update/server/TestSCMUpdateServiceGrpcServer.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Tests for SCM update Service.
  */
@@ -182,9 +184,9 @@ public class TestSCMUpdateServiceGrpcServer {
       server.notifyCrlUpdate();
       GenericTestUtils.waitFor(() -> client.getUpdateCount() > 1,
           100, 2000);
-      Assertions.assertTrue(2 <= client.getUpdateCount());
+      assertThat(2L).isLessThanOrEqualTo(client.getUpdateCount());
       Assertions.assertEquals(0, client.getErrorCount());
-      Assertions.assertTrue(1 >= client.getClientCRLStore()
+      assertThat(1).isGreaterThanOrEqualTo(client.getClientCRLStore()
           .getPendingCrlIds().size());
 
       GenericTestUtils.waitFor(() -> client.getPendingCrlRemoveCount() == 1,
@@ -286,7 +288,7 @@ public class TestSCMUpdateServiceGrpcServer {
 
       GenericTestUtils.waitFor(() -> client.getUpdateCount() > 6,
           100, 2000);
-      Assertions.assertTrue(client.getUpdateCount() >= 6);
+      assertThat(client.getUpdateCount()).isGreaterThanOrEqualTo(6);
       Assertions.assertEquals(2, client.getErrorCount());
       Assertions.assertEquals(6, clientCRLStore.getLatestCrlId());
     } catch (Exception e) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -80,6 +80,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -253,9 +255,9 @@ public class TestEndPoint {
       List<HddsVolume> volumesList = StorageVolumeUtil.getHddsVolumesList(
           ozoneContainer.getVolumeSet().getFailedVolumesList());
       Assertions.assertEquals(1, volumesList.size());
-      Assertions.assertTrue(logCapturer.getOutput()
+      assertThat(logCapturer.getOutput())
           .contains("org.apache.hadoop.ozone.common" +
-              ".InconsistentStorageStateException: Mismatched ClusterIDs"));
+              ".InconsistentStorageStateException: Mismatched ClusterIDs");
       Assertions.assertEquals(0,
           ozoneContainer.getVolumeSet().getVolumesList().size());
       Assertions.assertEquals(1,
@@ -367,7 +369,7 @@ public class TestEndPoint {
       EndpointStateMachine.EndPointStates newState = versionTask.call();
       long end = Time.monotonicNow();
       scmServerImpl.setRpcResponseDelay(0);
-      Assertions.assertTrue(end - start <= rpcTimeout + tolerance);
+      assertThat(end - start).isLessThanOrEqualTo(rpcTimeout + tolerance);
       Assertions.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
           newState);
     }
@@ -488,7 +490,7 @@ public class TestEndPoint {
     registerTaskHelper(serverAddress, 1000, false).close();
     long end = Time.monotonicNow();
     scmServerImpl.setRpcResponseDelay(0);
-    Assertions.assertTrue(end - start <= rpcTimeout + tolerance);
+    assertThat(end - start).isLessThanOrEqualTo(rpcTimeout + tolerance);
   }
 
   @Test
@@ -539,7 +541,7 @@ public class TestEndPoint {
       Map<Long, CommandStatus> map = stateContext.getCommandStatusMap();
       Assertions.assertNotNull(map);
       Assertions.assertEquals(1, map.size(), "Should have 1 objects");
-      Assertions.assertTrue(map.containsKey(3L));
+      assertThat(map).containsKey(3L);
       Assertions.assertEquals(Type.deleteBlocksCommand, map.get(3L).getType());
       Assertions.assertEquals(Status.PENDING, map.get(3L).getStatus());
 
@@ -640,7 +642,7 @@ public class TestEndPoint {
     long end = Time.monotonicNow();
     scmServerImpl.setRpcResponseDelay(0);
     // 6s is introduced by DeleteBlocksCommandHandler#stop
-    Assertions.assertTrue(end - start <= rpcTimeout + tolerance + 6000);
+    assertThat(end - start).isLessThanOrEqualTo(rpcTimeout + tolerance + 6000);
   }
 
   private OzoneContainer createVolume(OzoneConfiguration conf)
@@ -658,7 +660,7 @@ public class TestEndPoint {
     StorageVolume volume = volumeSet.getVolumesList().get(0);
 
     // Check instanceof and typecast
-    Assertions.assertTrue(volume instanceof HddsVolume);
+    assertInstanceOf(HddsVolume.class, volume);
     return ozoneContainer;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestContainerPlacement.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
@@ -111,15 +111,14 @@ public class TestContainerPlacement {
     // This is a very bold claim, and needs large number of I/O operations.
     // The claim in this assertion is that we improved the data distribution
     // of this cluster in relation to the start state of the cluster.
-    Assertions.assertTrue(beforeCapacity.getStandardDeviation() >
-        postCapacity.getStandardDeviation());
+    assertThat(beforeCapacity.getStandardDeviation())
+        .isGreaterThan(postCapacity.getStandardDeviation());
 
     // This asserts that Capacity placement yields a better placement
     // algorithm than random placement, since both cluster started at an
     // identical state.
-
-    Assertions.assertTrue(postRandom.getStandardDeviation() >
-        postCapacity.getStandardDeviation());
+    assertThat(postRandom.getStandardDeviation())
+        .isGreaterThan(postCapacity.getStandardDeviation());
   }
 
   private void deleteContainer(MockNodeManager nodeManager,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Improve assertTrue assertions in hdds-server-scm
Assertions in the form:
```
assertTrue(<string>.contains(...))
```
do not provide any information about the actual value, if the assertion fails.
```
AssertionFailedError: expected: <true> but was: <false>
```
This can be improved by replacing them with:
```
import static org.assertj.core.api.Assertions.assertThat;
assertThat(<string>).contains(...)
```
which gives us more info in the form:
```
AssertionError: 

Expecting:
 <"actual string">
to contain:
 <"part"> 
```
Similarly, assertions about inequality relations, e.g.:
```
assertTrue(<x> > <y>)
```
can be replaced with:
```
assertThat(<x>).isGreaterThan(<y>);
```
The goal of this task is to find and replace such assertTrue assertions.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10012

## CI
https://github.com/wzhallright/ozone/actions/runs/7336068853
