### PR TITLE
HDDS-10023. testLockViolations should fail if it does not catch RuntimeException

### DIFF
--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -171,6 +171,7 @@ public class TestOzoneManagerLock {
           try {
             resourceName = generateResourceName(resource);
             lock.acquireWriteLock(resource, resourceName);
+            fail("testLockViolations failed");
           } catch (RuntimeException ex) {
             String message = "cannot acquire " + resource.getName() + " lock " +
                 "while holding " + currentLocks + " lock(s).";


### PR DESCRIPTION
## What changes were proposed in this pull request?
testLockViolations should fail if it does not catch RuntimeException

* Insert Assertions.fail() to next line.

## What is the link to the Apache JIRA
HDDS-10023.

## How was this patch tested?
CI:  https://github.com/TaiJuWu/ozone/actions/runs/7347807688