### PR TITLE
HDDS-10024. Fix typo in ContainerStateMachine log message

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -284,7 +284,7 @@ public class ContainerStateMachine extends BaseStateMachine {
       throws IOException {
     if (snapshot == null) {
       TermIndex empty = TermIndex.valueOf(0, RaftLog.INVALID_LOG_INDEX);
-      LOG.info("{}: The snapshot info is null. Setting the last applied index" +
+      LOG.info("{}: The snapshot info is null. Setting the last applied index " +
               "to:{}", gid, empty);
       setLastAppliedTermIndex(empty);
       return empty.getIndex();


### PR DESCRIPTION
## What changes were proposed in this pull request?
In ContainerStateMachine, some wrong symbols will be recorded to the log file. The purpose of this PR is to fix it.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10024

## How was this patch tested?
For testing, there’s not much pressure.
