### PR TITLE
HDDS-10027. NPE in VolumeInfoMetrics.getCommitted()

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -79,7 +79,7 @@ public class HddsVolume extends StorageVolume {
   private final VolumeIOStats volumeIOStats;
   private final VolumeInfoMetrics volumeInfoMetrics;
 
-  private final AtomicLong committedBytes; // till Open containers become full
+  private final AtomicLong committedBytes = new AtomicLong(); // till Open containers become full
 
   // Mentions the type of volume
   private final VolumeType type = VolumeType.DATA_VOLUME;
@@ -121,7 +121,6 @@ public class HddsVolume extends StorageVolume {
           this.getStorageDir().toString());
       this.volumeInfoMetrics =
           new VolumeInfoMetrics(b.getVolumeRootStr(), this);
-      this.committedBytes = new AtomicLong(0);
 
       LOG.info("Creating HddsVolume: {} of storage type : {} capacity : {}",
           getStorageDir(), b.getStorageType(),
@@ -134,7 +133,6 @@ public class HddsVolume extends StorageVolume {
       this.setState(VolumeState.FAILED);
       volumeIOStats = null;
       volumeInfoMetrics = new VolumeInfoMetrics(b.getVolumeRootStr(), this);
-      committedBytes = null;
     }
 
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
@@ -510,6 +510,7 @@ public class TestHddsVolume {
       assertEquals(0, volumeInfoMetrics.getCapacity());
       assertEquals(0, volumeInfoMetrics.getReserved());
       assertEquals(0, volumeInfoMetrics.getTotalCapacity());
+      assertEquals(0, volumeInfoMetrics.getCommitted());
     } finally {
       // Shutdown the volume.
       volume.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix NPE in `HddsVolume.getCommitted()`, which can happen for failed volumes.

https://issues.apache.org/jira/browse/HDDS-10027

## How was this patch tested?

Added assertion unit test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/7355440841