### PR TITLE
HDDS-9962. Intermittent timeout in TestBlockDeletion.testBlockDeletion

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -237,10 +237,12 @@ public class SCMBlockDeletingService extends BackgroundService
   public void notifyStatusChanged() {
     serviceLock.lock();
     try {
-      if (scmContext.isLeaderReady() && !scmContext.isInSafeMode() &&
-          serviceStatus != ServiceStatus.RUNNING) {
-        safemodeExitMillis = clock.millis();
-        serviceStatus = ServiceStatus.RUNNING;
+      if (scmContext.isLeaderReady() && !scmContext.isInSafeMode()) {
+        if (serviceStatus != ServiceStatus.RUNNING) {
+          LOG.info("notifyStatusChanged" + ":" + ServiceStatus.RUNNING);
+          safemodeExitMillis = clock.millis();
+          serviceStatus = ServiceStatus.RUNNING;
+        }
       } else {
         serviceStatus = ServiceStatus.PAUSING;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -168,6 +168,7 @@ public class TestBlockDeletion {
         0,
         TimeUnit.MILLISECONDS);
     conf.setInt("hdds.datanode.block.delete.threads.max", 5);
+    conf.setInt("hdds.datanode.block.delete.queue.limit", 32);
     ReplicationManager.ReplicationManagerConfiguration replicationConf = conf
         .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
     replicationConf.setInterval(Duration.ofSeconds(300));
@@ -293,11 +294,6 @@ public class TestBlockDeletion {
     Assertions.assertFalse(containerIdsWithDeletedBlocks.isEmpty());
     // Containers in the DN and SCM should have same delete transactionIds
     matchContainerTransactionIds();
-    // Containers in the DN and SCM should have same delete transactionIds
-    // after DN restart. The assertion is just to verify that the state of
-    // containerInfos in dn and scm is consistent after dn restart.
-    cluster.restartHddsDatanode(0, true);
-    matchContainerTransactionIds();
 
     // Verify transactions committed
     GenericTestUtils.waitFor(() -> {
@@ -309,6 +305,13 @@ public class TestBlockDeletion {
         return false;
       }
     }, 500, 10000);
+
+    // Containers in the DN and SCM should have same delete transactionIds
+    // after DN restart. The assertion is just to verify that the state of
+    // containerInfos in dn and scm is consistent after dn restart.
+    cluster.restartHddsDatanode(0, true);
+    matchContainerTransactionIds();
+
     Assertions.assertEquals(metrics.getNumBlockDeletionTransactionCreated(),
         metrics.getNumBlockDeletionTransactionCompleted());
     Assertions.assertTrue(metrics.getNumBlockDeletionCommandSent() >=


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix unstable integration tests.

Multiple tests have uncovered a number of things that can cause `TestBlockDeletion` to fail
1. `hdds.datanode.block.delete.queue.limit` defaults to 5, which may cause tasks to be discarded if they can't be added to the queue, thus causing the test to time out.  (fix by https://github.com/apache/ozone/pull/5845)
2. `restartHddsDatanode` in `TestBlockDeletion.testBlockDeletion` can sometimes cause the DN to be restarted before sending the `DeleteBlockTransactionResult` to the SCM.
https://github.com/apache/ozone/blob/4eca52b6b76b0737bfb2d6ed94097969a0737a45/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java#L299-L310

3. `SCMBlockDeletingService#notifyStatusChanged` in `SCMBlockDeletingService` may be executed several times, resulting in the `serviceStatus` being set from `RUNNING` to `PAUSING`, which leads to `SCMBlockDeletingService` does not work.
```bash
2023-12-28 10:42:20,496 [EventQueue-OpenPipelineForHealthyPipelineSafeModeRule] INFO  safemode.SCMSafeModeManager (SCMSafeModeManager.java:exitSafeMode(244)) - SCM exiting safe mode.  <<--- First
2023-12-28 10:42:20,496 [EventQueue-OpenPipelineForHealthyPipelineSafeModeRule] INFO  ha.SCMContext (SCMContext.java:updateSafeModeStatus(230)) - Update SafeModeStatus from SafeModeStatus{safeModeStatus=true, preCheckPassed=true} to SafeModeStatus{safeModeStatus=false, preCheckPassed=true}.
//...
2023-12-28 10:42:20,497 [EventQueue-OpenPipelineForHealthyPipelineSafeModeRule] DEBUG ha.SCMServiceManager (SCMServiceManager.java:notifyStatusChanged(51)) - Notify service:SCMBlockDeletingService.
//...
2023-12-28 10:42:20,499 [EventQueue-PipelineReportForOneReplicaPipelineSafeModeRule] INFO  safemode.SCMSafeModeManager (SCMSafeModeManager.java:validateSafeModeExitRules(215)) - ScmSafeModeManager, all rules are successfully validated
2023-12-28 10:42:20,499 [EventQueue-PipelineReportForOneReplicaPipelineSafeModeRule] INFO  safemode.SCMSafeModeManager (SCMSafeModeManager.java:exitSafeMode(244)) - SCM exiting safe mode.   <<--- Second
2023-12-28 10:42:20,499 [EventQueue-PipelineReportForOneReplicaPipelineSafeModeRule] INFO  ha.SCMContext (SCMContext.java:updateSafeModeStatus(230)) - Update SafeModeStatus from SafeModeStatus{safeModeStatus=false, preCheckPassed=true} to SafeModeStatus{safeModeStatus=false, preCheckPassed=true}.
//...
2023-12-28 10:42:20,500 [EventQueue-PipelineReportForOneReplicaPipelineSafeModeRule] DEBUG ha.SCMServiceManager (SCMServiceManager.java:notifyStatusChanged(51)) - Notify service:SCMBlockDeletingService.
//...
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9962

## How was this patch tested?

Existing Test.
Twice 25 * 15 Tests all successful
https://github.com/xichen01/ozone/actions/runs/7353980620/attempts/1
https://github.com/xichen01/ozone/actions/runs/7353980620

