### PR TITLE
HDDS-10028. Simplify Maven cache for dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ matrix.java }}
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup java
         uses: actions/setup-java@v3
@@ -162,12 +161,11 @@ jobs:
           git config user.email 'noreply@github.com'
           git commit --allow-empty -a -m 'workaround for HADOOP-19011'
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ matrix.java }}
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup java
         uses: actions/setup-java@v3
@@ -205,13 +203,11 @@ jobs:
           fetch-depth: 0
         if: matrix.check == 'bats'
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ matrix.check }}
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}-8
-            maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
         if: ${{ !contains('author,bats,docs', matrix.check) }}
       - name: Setup java
@@ -255,13 +251,11 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v3
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ matrix.profile }}
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}-8
-            maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup java
         uses: actions/setup-java@v3
@@ -329,14 +323,13 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v3
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.m2/repository
             !~/.m2/repository/org/apache/ozone
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Download Ozone repo
         id: download-ozone-repo
@@ -466,13 +459,11 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v3
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ matrix.profile }}
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}-8
-            maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Download Ozone repo
         id: download-ozone-repo
@@ -532,13 +523,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ github.job }}
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}-8
-            maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,16 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
+      - name: Cache for maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/ozone
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
       - name: Download Ozone repo
         id: download-ozone-repo
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,9 @@ jobs:
       - name: Cache for maven dependencies
         uses: actions/cache@v3
         with:
-          path: ~/.m2/repository
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-repo-
@@ -128,12 +130,6 @@ jobs:
           path: |
             ~/.m2/repository/org/apache/ozone
           retention-days: 1
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
   compile:
     needs:
       - build-info
@@ -163,7 +159,9 @@ jobs:
       - name: Cache for maven dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ~/.m2/repository
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-repo-
@@ -177,12 +175,6 @@ jobs:
         env:
           OZONE_WITH_COVERAGE: false
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
   basic:
     needs:
       - build-info
@@ -205,7 +197,9 @@ jobs:
       - name: Cache for maven dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ~/.m2/repository
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-repo-
@@ -230,12 +224,6 @@ jobs:
           name: ${{ matrix.check }}
           path: target/${{ matrix.check }}
         continue-on-error: true
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
   unit:
     needs:
       - build-info
@@ -253,7 +241,9 @@ jobs:
       - name: Cache for maven dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ~/.m2/repository
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-repo-
@@ -277,12 +267,6 @@ jobs:
           name: ${{ matrix.check }}
           path: target/${{ matrix.check }}
         continue-on-error: true
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
   dependency:
     needs:
       - build-info
@@ -461,7 +445,9 @@ jobs:
       - name: Cache for maven dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ~/.m2/repository
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-repo-
@@ -503,12 +489,6 @@ jobs:
           name: it-${{ matrix.profile }}
           path: target/integration
         continue-on-error: true
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
   coverage:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
@@ -525,7 +505,9 @@ jobs:
       - name: Cache for maven dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ~/.m2/repository
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-repo-
@@ -556,9 +538,3 @@ jobs:
           name: coverage
           path: target/coverage
         continue-on-error: true
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * `license` check should use Maven cache for dependencies.
 * Use explicit `cache/restore` in all checks except `build`.  This avoids the need for separate cache keys in concurrent checks, since only `build` will save cache.
 * Specify `path` exception to avoid the need to explicitly delete Ozone artifacts before cache upload.

https://issues.apache.org/jira/browse/HDDS-10028

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7355754873