### PR TITLE
HDDS-10001. Options not closed properly in rocksdb-checkpoint-differ

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/SstFileSetReader.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/SstFileSetReader.java
@@ -78,9 +78,10 @@ public class SstFileSetReader {
 
       try (ManagedOptions options = new ManagedOptions()) {
         for (String sstFile : sstFiles) {
-          SstFileReader fileReader = new SstFileReader(options);
-          fileReader.open(sstFile);
-          estimatedSize += fileReader.getTableProperties().getNumEntries();
+          try (SstFileReader fileReader = new SstFileReader(options)) {
+            fileReader.open(sstFile);
+            estimatedSize += fileReader.getTableProperties().getNumEntries();
+          }
         }
       }
       estimatedTotalKeys = estimatedSize;

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -629,16 +629,18 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
       filename += SST_FILE_EXTENSION;
     }
 
-    Options option = new Options();
-    SstFileReader reader = new SstFileReader(option);
+    try (
+        ManagedOptions option = new ManagedOptions();
+        SstFileReader reader = new SstFileReader(option)) {
 
-    reader.open(getAbsoluteSstFilePath(filename));
+      reader.open(getAbsoluteSstFilePath(filename));
 
-    TableProperties properties = reader.getTableProperties();
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("{} has {} keys", filename, properties.getNumEntries());
+      TableProperties properties = reader.getTableProperties();
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("{} has {} keys", filename, properties.getNumEntries());
+      }
+      return properties.getNumEntries();
     }
-    return properties.getNumEntries();
   }
 
   private String getAbsoluteSstFilePath(String filename)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Close some RocksDB objects that were left open in `rocksdb-checkpoint-differ` module.

https://issues.apache.org/jira/browse/HDDS-10001

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7359160284