### PR TITLE
HDDS-10036. OzoneManagerRatisServer.getServer() should return Division.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -221,8 +221,12 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
   @Override
   public void restartOzoneManager() throws IOException {
-    for (OzoneManager ozoneManager : omhaService.getActiveServices()) {
-      stopOM(ozoneManager);
+    for (OzoneManager ozoneManager : omhaService.getServices()) {
+      try {
+        stopOM(ozoneManager);
+      } catch (Exception e) {
+        LOG.warn("Failed to stop OM: {}", ozoneManager.getOMServiceId());
+      }
     }
     omhaService.inactiveServices().forEachRemaining(omhaService::activate);
     for (OzoneManager ozoneManager : omhaService.getServices()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -48,6 +50,8 @@ import org.apache.hadoop.util.StringUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.grpc.server.GrpcLogAppender;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.leader.FollowerInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -124,6 +128,13 @@ public class TestAddRemoveOzoneManager {
     }
   }
 
+  static List<String> getCurrentPeersFromRaftConf(OzoneManagerRatisServer omRatisServer) {
+    return omRatisServer.getServerDivision().getRaftConf().getCurrentPeers().stream()
+        .map(RaftPeer::getId)
+        .map(RaftPeerId::toString)
+        .collect(Collectors.toList());
+  }
+
   private void assertNewOMExistsInPeerList(String nodeId) throws Exception {
     // Check that new peer exists in all OMs peers list and also in their Ratis
     // server's peer list
@@ -132,7 +143,7 @@ public class TestAddRemoveOzoneManager {
           + " not present in Peer list of OM " + om.getOMNodeId());
       assertTrue(om.getOmRatisServer().doesPeerExist(nodeId), "New OM node " + nodeId
           + " not present in Peer list of OM " + om.getOMNodeId() + " RatisServer");
-      assertThat(om.getOmRatisServer().getCurrentPeersFromRaftConf())
+      assertThat(getCurrentPeersFromRaftConf(om.getOmRatisServer()))
           .withFailMessage("New OM node " + nodeId + " not present in " + om.getOMNodeId() + "'s RaftConf")
           .contains(nodeId);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -461,7 +461,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneManagerRatisServer ozoneManagerRatisServer =
         getCluster().getOzoneManager(currentLeaderNodeId).getOmRatisServer();
 
-    RaftServer raftServer = ozoneManagerRatisServer.getServer();
+    final RaftServer raftServer = ozoneManagerRatisServer.getServerDivision().getRaftServer();
 
     ClientId clientId = ClientId.randomId();
     long callId = 2000L;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -387,7 +387,8 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
     final RaftProperties p = getCluster()
         .getOzoneManager()
         .getOmRatisServer()
-        .getServer()
+        .getServerDivision()
+        .getRaftServer()
         .getProperties();
     final TimeDuration t = RaftServerConfigKeys.Log.Appender.waitTimeMin(p);
     assertEquals(TimeDuration.ZERO, t,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -341,7 +341,7 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
   private boolean logFilesPresentInRatisPeer(OzoneManager om) {
     final RaftServer.Division server = om.getOmRatisServer().getServerDivision();
     final String ratisDir = server.getRaftServer().getProperties().get("raft.server.storage.dir");
-    final String groupIdDirName = server.getGroup().getGroupId().toString();
+    final String groupIdDirName = server.getGroup().getGroupId().getUuid().toString();
     File logDir = Paths.get(ratisDir, groupIdDirName, "current")
         .toFile();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Prepare
 import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Slow;
 import org.apache.ozone.test.tag.Unhealthy;
+import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
@@ -338,11 +339,9 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
   }
 
   private boolean logFilesPresentInRatisPeer(OzoneManager om) {
-    String ratisDir = om.getOmRatisServer().getServer().getProperties()
-        .get("raft.server.storage.dir");
-    String groupIdDirName =
-        om.getOmRatisServer().getServer().getGroupIds().iterator()
-            .next().getUuid().toString();
+    final RaftServer.Division server = om.getOmRatisServer().getServerDivision();
+    final String ratisDir = server.getRaftServer().getProperties().get("raft.server.storage.dir");
+    final String groupIdDirName = server.getGroup().getGroupId().toString();
     File logDir = Paths.get(ratisDir, groupIdDirName, "current")
         .toFile();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestTransferLeadershipShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestTransferLeadershipShell.java
@@ -25,8 +25,6 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
-import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -135,13 +133,10 @@ public class TestTransferLeadershipShell {
     assertSCMResetPriorities();
   }
 
-  private void assertOMResetPriorities() throws IOException {
-    OzoneManagerRatisServer ratisServer = cluster.getOMLeader()
-        .getOmRatisServer();
-    RaftGroupId raftGroupId = ratisServer.getRaftGroupId();
-    Collection<RaftPeer> raftPeers = ratisServer
-        .getServer()
-        .getDivision(raftGroupId)
+  private void assertOMResetPriorities() {
+    final Collection<RaftPeer> raftPeers = cluster.getOMLeader()
+        .getOmRatisServer()
+        .getServerDivision()
         .getGroup()
         .getPeers();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -31,15 +31,17 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -86,8 +88,8 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
-import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.LifeCycle;
+import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.StringUtils;
 import org.apache.ratis.util.TimeDuration;
@@ -104,12 +106,11 @@ import static org.apache.hadoop.util.MetricUtil.captureLatencyNs;
  * Creates a Ratis server endpoint for OM.
  */
 public final class OzoneManagerRatisServer {
-  private static final Logger LOG = LoggerFactory
-      .getLogger(OzoneManagerRatisServer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OzoneManagerRatisServer.class);
 
   private final int port;
-  private final InetSocketAddress omRatisAddress;
   private final RaftServer server;
+  private final Supplier<RaftServer.Division> serverDivision;
   private final RaftGroupId raftGroupId;
   private final RaftGroup raftGroup;
   private final RaftPeerId raftPeerId;
@@ -144,7 +145,6 @@ public final class OzoneManagerRatisServer {
       SecurityConfig secConfig, CertificateClient certClient)
       throws IOException {
     this.ozoneManager = om;
-    this.omRatisAddress = addr;
     this.port = addr.getPort();
     this.ratisStorageDir = OzoneManagerRatisUtils.getOMRatisDirectory(conf);
     final RaftProperties serverProperties = newRaftProperties(
@@ -166,7 +166,7 @@ public final class OzoneManagerRatisServer {
         raftPeersStr.append(", ").append(peer.getAddress());
       }
       LOG.info("Instantiating OM Ratis server with groupID: {} and peers: {}",
-          raftGroupIdStr, raftPeersStr.toString().substring(2));
+          raftGroupIdStr, raftPeersStr.substring(2));
     }
     this.omStateMachine = getStateMachine(conf);
 
@@ -179,6 +179,13 @@ public final class OzoneManagerRatisServer {
         .setStateMachine(omStateMachine)
         .setOption(RaftStorage.StartupOption.RECOVER)
         .build();
+    this.serverDivision = MemoizedSupplier.valueOf(() -> {
+      try {
+        return server.getDivision(raftGroupId);
+      } catch (IOException e) {
+        throw new IllegalStateException("Failed to getDivision for " + raftGroupId, e);
+      }
+    });
     this.perfMetrics = om.getPerfMetrics();
   }
 
@@ -287,10 +294,9 @@ public final class OzoneManagerRatisServer {
   }
 
   private RaftClientRequest createRaftRequest(OMRequest omRequest) {
-    RaftClientRequest raftClientRequest = captureLatencyNs(
+    return captureLatencyNs(
         perfMetrics.getCreateRatisRequestLatencyNs(),
         () -> createRaftRequestImpl(omRequest));
-    return raftClientRequest;
   }
 
   /**
@@ -341,8 +347,7 @@ public final class OzoneManagerRatisServer {
             " new OM peer {} to the Ratis group {}", ozoneManager.getOMNodeId(),
         newRaftPeer, raftGroup);
 
-    List<RaftPeer> newPeersList = new ArrayList<>();
-    newPeersList.addAll(raftPeerMap.values());
+    final List<RaftPeer> newPeersList = new ArrayList<>(raftPeerMap.values());
     newPeersList.add(newRaftPeer);
 
     checkLeaderStatus();
@@ -373,9 +378,10 @@ public final class OzoneManagerRatisServer {
             "remove OM peer {} from Ratis group {}", ozoneManager.getOMNodeId(),
         removeNodeId, raftGroup);
 
-    List<RaftPeer> newPeersList = new ArrayList<>();
-    newPeersList.addAll(raftPeerMap.values());
-    newPeersList.remove(raftPeerMap.get(removeNodeId));
+    final List<RaftPeer> newPeersList = raftPeerMap.entrySet().stream()
+        .filter(e -> !e.getKey().equals(removeNodeId))
+        .map(Map.Entry::getValue)
+        .collect(Collectors.toList());
 
     checkLeaderStatus();
     SetConfigurationRequest request = new SetConfigurationRequest(clientId,
@@ -397,10 +403,8 @@ public final class OzoneManagerRatisServer {
   /**
    * Return a list of peer NodeIds.
    */
-  public List<String> getPeerIds() {
-    List<String> peerIds = new ArrayList<>();
-    peerIds.addAll(raftPeerMap.keySet());
-    return peerIds;
+  public Set<String> getPeerIds() {
+    return Collections.unmodifiableSet(raftPeerMap.keySet());
   }
 
   /**
@@ -555,8 +559,8 @@ public final class OzoneManagerRatisServer {
   }
 
   @VisibleForTesting
-  public RaftServer getServer() {
-    return server;
+  public RaftServer.Division getServerDivision() {
+    return serverDivision.get();
   }
 
   /**
@@ -767,25 +771,18 @@ public final class OzoneManagerRatisServer {
         .getPropsMatchPrefixAndTrimPrefix(OZONE_OM_HA_PREFIX + ".");
   }
 
-  public RaftPeer getLeader() {
-    try {
-      RaftServer.Division division = server.getDivision(raftGroupId);
-      if (division != null) {
-        if (division.getInfo().isLeader()) {
-          return division.getPeer();
-        } else {
-          ByteString leaderId = division.getInfo().getRoleInfoProto()
-                  .getFollowerInfo().getLeaderInfo().getId().getId();
-          return leaderId.isEmpty() ? null :
-                  division.getRaftConf().getPeer(RaftPeerId.valueOf(leaderId));
-        }
-      }
-    } catch (IOException e) {
-      // In this case we return not a leader.
-      LOG.error("Fail to get RaftServer impl and therefore it's not clear " +
-          "whether it's leader. ", e);
+  public RaftPeerId getLeaderId() {
+    return getServerDivision().getInfo().getLeaderId();
+  }
+
+  public OMNotLeaderException newOMNotLeaderException() {
+    final RaftPeerId leaderId = getLeaderId();
+    final RaftPeer leader = leaderId == null ? null : getServerDivision().getRaftConf().getPeer(leaderId);
+    if (leader == null) {
+      return new OMNotLeaderException(raftPeerId);
     }
-    return null;
+    final String leaderAddress = getRaftLeaderAddress(leader);
+    return new OMNotLeaderException(raftPeerId, leader.getId(), leaderAddress);
   }
 
   /**
@@ -803,40 +800,15 @@ public final class OzoneManagerRatisServer {
    * @return RaftServerStatus.
    */
   public RaftServerStatus checkLeaderStatus() {
-    try {
-      RaftServer.Division division = server.getDivision(raftGroupId);
-      if (division != null) {
-        if (!division.getInfo().isLeader()) {
-          return RaftServerStatus.NOT_LEADER;
-        } else if (division.getInfo().isLeaderReady()) {
-          return RaftServerStatus.LEADER_AND_READY;
-        } else {
-          return RaftServerStatus.LEADER_AND_NOT_READY;
-        }
-      }
-    } catch (IOException ioe) {
-      // In this case we return not a leader.
-      LOG.error("Fail to get RaftServer impl and therefore it's not clear " +
-          "whether it's leader. ", ioe);
-    }
-    return RaftServerStatus.NOT_LEADER;
-  }
-
-  /**
-   * Get list of peer NodeIds from Ratis.
-   * @return List of Peer NodeId's.
-   */
-  @VisibleForTesting
-  public List<String> getCurrentPeersFromRaftConf() throws IOException {
-    try {
-      Collection<RaftPeer> currentPeers =
-          server.getDivision(raftGroupId).getRaftConf().getCurrentPeers();
-      List<String> currentPeerList = new ArrayList<>();
-      currentPeers.forEach(e -> currentPeerList.add(e.getId().toString()));
-      return currentPeerList;
-    } catch (IOException e) {
-      // In this case we return not a leader.
-      throw new IOException("Failed to get peer information from Ratis.", e);
+    final RaftServer.Division division = getServerDivision();
+    if (division == null) {
+      return RaftServerStatus.NOT_LEADER;
+    } else if (!division.getInfo().isLeader()) {
+      return RaftServerStatus.NOT_LEADER;
+    } else if (division.getInfo().isLeaderReady()) {
+      return RaftServerStatus.LEADER_AND_READY;
+    } else {
+      return RaftServerStatus.LEADER_AND_NOT_READY;
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -237,7 +237,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     case SUCCESS:
     case SNAPSHOT_UNAVAILABLE:
       // Currently, only trigger for the one who installed snapshot
-      if (ozoneManager.getOmRatisServer().getServer().getPeer().equals(peer)) {
+      if (ozoneManager.getOmRatisServer().getServerDivision().getPeer().equals(peer)) {
         ozoneManager.getOmSnapshotProvider().init();
       }
       break;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -99,9 +99,7 @@ public class OMPrepareRequest extends OMClientRequest {
       doubleBuffer.add(response, termIndex);
 
       OzoneManagerRatisServer omRatisServer = ozoneManager.getOmRatisServer();
-      RaftServer.Division division =
-          omRatisServer.getServer()
-              .getDivision(omRatisServer.getRaftGroup().getGroupId());
+      final RaftServer.Division division = omRatisServer.getServerDivision();
 
       // Wait for outstanding double buffer entries to flush to disk,
       // so they will not be purged from the log before being persisted to


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OzoneManagerRatisServer` has a specific raftGroup. The `getServer()` method should return the division specific to that group. Otherwise, callers have to get groupId and then get the division with try-catch.

## What is the link to the Apache JIRA

HDDS-10036

## How was this patch tested?

By updating existing tests.