### PR TITLE
HDDS-9990. Add static import for assertions and mocks in ozone-client

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneClient.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.ozone.test.LambdaTestUtils.VoidCallable;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +47,11 @@ import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Real unit test for OzoneClient.
@@ -65,9 +69,9 @@ public class TestOzoneClient {
       throws Exception {
     try {
       eval.call();
-      Assertions.fail("OMException is expected");
+      fail("OMException is expected");
     } catch (OMException ex) {
-      Assertions.assertEquals(code, ex.getResult());
+      assertEquals(code, ex.getResult());
     }
   }
 
@@ -108,7 +112,7 @@ public class TestOzoneClient {
     String volumeName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
-    Assertions.assertNotNull(volume);
+    assertNotNull(volume);
     store.deleteVolume(volumeName);
     expectOmException(ResultCodes.VOLUME_NOT_FOUND,
         () -> store.getVolume(volumeName));
@@ -124,11 +128,11 @@ public class TestOzoneClient {
         .build();
     store.createVolume(volumeName, volumeArgs);
     OzoneVolume volume = store.getVolume(volumeName);
-    Assertions.assertEquals(OzoneConsts.QUOTA_RESET,
+    assertEquals(OzoneConsts.QUOTA_RESET,
         volume.getQuotaInNamespace());
-    Assertions.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
-    Assertions.assertEquals("val1", volume.getMetadata().get("key1"));
-    Assertions.assertEquals(volumeName, volume.getName());
+    assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
+    assertEquals("val1", volume.getMetadata().get("key1"));
+    assertEquals(volumeName, volume.getName());
   }
 
   @Test
@@ -141,9 +145,9 @@ public class TestOzoneClient {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    Assertions.assertEquals(bucketName, bucket.getName());
-    Assertions.assertFalse(bucket.getCreationTime().isBefore(testStartTime));
-    Assertions.assertFalse(volume.getCreationTime().isBefore(testStartTime));
+    assertEquals(bucketName, bucket.getName());
+    assertFalse(bucket.getCreationTime().isBefore(testStartTime));
+    assertFalse(volume.getCreationTime().isBefore(testStartTime));
   }
 
   @Test
@@ -161,14 +165,14 @@ public class TestOzoneClient {
       out.write(value.getBytes(UTF_8));
       out.close();
       OzoneKey key = bucket.getKey(keyName);
-      Assertions.assertEquals(keyName, key.getName());
+      assertEquals(keyName, key.getName());
       OzoneInputStream is = bucket.readKey(keyName);
       byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-      Assertions.assertEquals(value.length(), is.read(fileContent));
+      assertEquals(value.length(), is.read(fileContent));
       is.close();
-      Assertions.assertEquals(value, new String(fileContent, UTF_8));
-      Assertions.assertFalse(key.getCreationTime().isBefore(testStartTime));
-      Assertions.assertFalse(key.getModificationTime().isBefore(testStartTime));
+      assertEquals(value, new String(fileContent, UTF_8));
+      assertFalse(key.getCreationTime().isBefore(testStartTime));
+      assertFalse(key.getModificationTime().isBefore(testStartTime));
     }
   }
 
@@ -218,7 +222,7 @@ public class TestOzoneClient {
         out.write(value.getBytes(UTF_8));
       }
       OzoneKey key = bucket.getKey(keyName);
-      Assertions.assertEquals(keyName, key.getName());
+      assertEquals(keyName, key.getName());
     }
   }
 
@@ -240,7 +244,7 @@ public class TestOzoneClient {
           value.getBytes(UTF_8).length, ReplicationType.RATIS, ONE,
           new HashMap<>());
       out1.write(value.substring(0, value.length() - 1).getBytes(UTF_8));
-      Assertions.assertThrows(IllegalStateException.class, out1::close,
+      assertThrows(IllegalStateException.class, out1::close,
           "Expected IllegalArgumentException due to size mismatch.");
 
       // Simulating second mismatch: Write more data than expected
@@ -249,7 +253,7 @@ public class TestOzoneClient {
           new HashMap<>());
       value += "1";
       out2.write(value.getBytes(UTF_8));
-      Assertions.assertThrows(IllegalStateException.class, out2::close,
+      assertThrows(IllegalStateException.class, out2::close,
           "Expected IllegalArgumentException due to size mismatch.");
     } finally {
       client.getProxy().setIsS3Request(false);

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -49,7 +49,6 @@ import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -66,6 +65,11 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Real unit test for OzoneECClient.
@@ -146,7 +150,7 @@ public class TestOzoneECClient {
   public void testPutECKeyAndCheckDNStoredData() throws IOException {
     OzoneBucket bucket = writeIntoECKey(inputChunks, keyName, null);
     OzoneKey key = bucket.getKey(keyName);
-    Assertions.assertEquals(keyName, key.getName());
+    assertEquals(keyName, key.getName());
     Map<DatanodeDetails, MockDatanodeStorage> storages =
         factoryStub.getStorages();
     DatanodeDetails[] dnDetails =
@@ -154,10 +158,10 @@ public class TestOzoneECClient {
     Arrays.sort(dnDetails);
     for (int i = 0; i < inputChunks.length; i++) {
       MockDatanodeStorage datanodeStorage = storages.get(dnDetails[i]);
-      Assertions.assertEquals(1, datanodeStorage.getAllBlockData().size());
+      assertEquals(1, datanodeStorage.getAllBlockData().size());
       ByteString content =
           datanodeStorage.getAllBlockData().values().iterator().next();
-      Assertions.assertEquals(new String(inputChunks[i], UTF_8),
+      assertEquals(new String(inputChunks[i], UTF_8),
           content.toStringUtf8());
     }
   }
@@ -175,7 +179,7 @@ public class TestOzoneECClient {
     }
     encoder.encode(dataBuffers, parityBuffers);
     OzoneKey key = bucket.getKey(keyName);
-    Assertions.assertEquals(keyName, key.getName());
+    assertEquals(keyName, key.getName());
     Map<DatanodeDetails, MockDatanodeStorage> storages =
         factoryStub.getStorages();
     DatanodeDetails[] dnDetails =
@@ -184,10 +188,10 @@ public class TestOzoneECClient {
 
     for (int i = dataBlocks; i < parityBlocks + dataBlocks; i++) {
       MockDatanodeStorage datanodeStorage = storages.get(dnDetails[i]);
-      Assertions.assertEquals(1, datanodeStorage.getAllBlockData().size());
+      assertEquals(1, datanodeStorage.getAllBlockData().size());
       ByteString content =
           datanodeStorage.getAllBlockData().values().iterator().next();
-      Assertions.assertEquals(
+      assertEquals(
           new String(parityBuffers[i - dataBlocks].array(), UTF_8),
           content.toStringUtf8());
     }
@@ -198,15 +202,15 @@ public class TestOzoneECClient {
   public void testPutECKeyAndReadContent() throws IOException {
     OzoneBucket bucket = writeIntoECKey(inputChunks, keyName, null);
     OzoneKey key = bucket.getKey(keyName);
-    Assertions.assertEquals(keyName, key.getName());
+    assertEquals(keyName, key.getName());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks; i++) {
-        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assertions.assertArrayEquals(fileContent, inputChunks[i]);
+        assertEquals(inputChunks[i].length, is.read(fileContent));
+        assertArrayEquals(fileContent, inputChunks[i]);
       }
       // A further read should give EOF
-      Assertions.assertEquals(-1, is.read(fileContent));
+      assertEquals(-1, is.read(fileContent));
     }
   }
 
@@ -221,7 +225,7 @@ public class TestOzoneECClient {
     // create key without mentioning replication config. Since we set EC
     // replication in bucket, key should be EC key.
     try (OzoneOutputStream out = bucket.createKey("mykey", inputSize)) {
-      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       for (int i = 0; i < inputChunks.length; i++) {
         out.write(inputChunks[i]);
       }
@@ -299,11 +303,11 @@ public class TestOzoneECClient {
   private void validateContent(int offset, int length, byte[] inputData,
                                OzoneBucket bucket,
       OzoneKey key) throws IOException {
-    Assertions.assertEquals(keyName, key.getName());
+    assertEquals(keyName, key.getName());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[length];
-      Assertions.assertEquals(length, is.read(fileContent));
-      Assertions.assertEquals(new String(Arrays.copyOfRange(inputData, offset,
+      assertEquals(length, is.read(fileContent));
+      assertEquals(new String(Arrays.copyOfRange(inputData, offset,
                       offset + length),
                       UTF_8),
           new String(fileContent, UTF_8));
@@ -341,7 +345,7 @@ public class TestOzoneECClient {
         keyLocations.getBlockID().getContainerBlockID().getContainerID(),
         keyLocations.getBlockID().getContainerBlockID().getLocalID()));
 
-    Assertions.assertArrayEquals(
+    assertArrayEquals(
         firstSmallChunk, firstBlockData.getBytes(UTF_8));
 
     final ByteBuffer[] dataBuffers = new ByteBuffer[dataBlocks];
@@ -365,8 +369,8 @@ public class TestOzoneECClient {
           keyLocations.getBlockID().getContainerBlockID().getLocalID()));
       String expected =
           new String(parityBuffers[i - dataBlocks].array(), UTF_8);
-      Assertions.assertEquals(expected, parityBlockData);
-      Assertions.assertEquals(expected.length(), parityBlockData.length());
+      assertEquals(expected, parityBlockData);
+      assertEquals(expected.length(), parityBlockData.length());
 
     }
   }
@@ -375,12 +379,12 @@ public class TestOzoneECClient {
   public void testPutBlockHasBlockGroupLen() throws IOException {
     OzoneBucket bucket = writeIntoECKey(inputChunks, keyName, null);
     OzoneKey key = bucket.getKey(keyName);
-    Assertions.assertEquals(keyName, key.getName());
+    assertEquals(keyName, key.getName());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks; i++) {
-        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assertions.assertArrayEquals(fileContent, inputChunks[i]);
+        assertEquals(inputChunks[i].length, is.read(fileContent));
+        assertArrayEquals(fileContent, inputChunks[i]);
       }
 
       Map<DatanodeDetails, MockDatanodeStorage> storages =
@@ -411,7 +415,7 @@ public class TestOzoneECClient {
                 .equals(OzoneConsts.BLOCK_GROUP_LEN_KEY_IN_PUT_BLOCK))
                 .collect(Collectors.toList());
 
-        Assertions.assertEquals(3L * chunkSize,
+        assertEquals(3L * chunkSize,
             Long.parseLong(metadataList.get(0).getValue()));
       }
     }
@@ -463,7 +467,7 @@ public class TestOzoneECClient {
     // create key without mentioning replication config. Since we set EC
     // replication in bucket, key should be EC key.
     try (OzoneOutputStream out = bucket.createKey("mykey", 6 * inputSize)) {
-      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       // Block Size is 2kb, so to create 3 blocks we need 6 iterations here
       for (int j = 0; j < 6; j++) {
         for (int i = 0; i < inputChunks.length; i++) {
@@ -475,20 +479,20 @@ public class TestOzoneECClient {
         transportStub.getKeys().get(volumeName).get(bucketName).get("mykey")
             .getKeyLocationListList().get(0);
 
-    Assertions.assertEquals(3, blockList.getKeyLocationsCount());
+    assertEquals(3, blockList.getKeyLocationsCount());
     // As the mock allocator allocates block with id's increasing sequentially
     // from 1. Therefore the block should be in the order with id starting 1, 2
     // and then 3.
     for (int i = 0; i < 3; i++) {
       long localId = blockList.getKeyLocationsList().get(i).getBlockID()
           .getContainerBlockID().getLocalID();
-      Assertions.assertEquals(i + 1, localId);
+      assertEquals(i + 1, localId);
     }
 
-    Assertions.assertEquals(1,
+    assertEquals(1,
         transportStub.getKeys().get(volumeName).get(bucketName).get("mykey")
             .getKeyLocationListCount());
-    Assertions.assertEquals(inputChunks[0].length * 3 * 6,
+    assertEquals(inputChunks[0].length * 3 * 6,
         transportStub.getKeys().get(volumeName).get(bucketName).get("mykey")
             .getDataSize());
   }
@@ -560,13 +564,13 @@ public class TestOzoneECClient {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < 2; i++) {
-        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i], fileContent);
+        assertEquals(inputChunks[i].length, is.read(fileContent));
+        assertArrayEquals(inputChunks[i], fileContent);
       }
-      Assertions.assertEquals(lastChunk.length, is.read(fileContent));
-      Assertions.assertArrayEquals(lastChunk, Arrays.copyOf(fileContent, lastChunk.length));
+      assertEquals(lastChunk.length, is.read(fileContent));
+      assertArrayEquals(lastChunk, Arrays.copyOf(fileContent, lastChunk.length));
       // A further read should give EOF
-      Assertions.assertEquals(-1, is.read(fileContent));
+      assertEquals(-1, is.read(fileContent));
     }
   }
 
@@ -600,8 +604,8 @@ public class TestOzoneECClient {
 
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
-      Assertions.assertEquals(inSize, is.read(fileContent));
-      Assertions.assertArrayEquals(partialChunk, Arrays.copyOf(fileContent, inSize));
+      assertEquals(inSize, is.read(fileContent));
+      assertArrayEquals(partialChunk, Arrays.copyOf(fileContent, inSize));
     }
   }
 
@@ -646,7 +650,7 @@ public class TestOzoneECClient {
         nodesIndexesToMarkFailure);
     // It should have used 3rd block group also. So, total initialized nodes
     // count should be clusterSize.
-    Assertions.assertEquals(clusterSize, factoryStub.getStorages().size());
+    assertEquals(clusterSize, factoryStub.getStorages().size());
   }
 
   @Test
@@ -666,7 +670,7 @@ public class TestOzoneECClient {
         nodesIndexesToMarkFailure);
     // It should have used 3rd block group also. So, total initialized nodes
     // count should be clusterSize.
-    Assertions.assertEquals(clusterSize, factoryStub.getStorages().size());
+    assertEquals(clusterSize, factoryStub.getStorages().size());
   }
 
   // The mocked impl throws IllegalStateException when there are not enough
@@ -683,7 +687,7 @@ public class TestOzoneECClient {
     }
     // Mocked MultiNodePipelineBlockAllocator#allocateBlock implementation can
     // not pick new block group as all nodes in cluster marked as bad.
-    Assertions.assertThrows(IllegalStateException.class, () ->
+    assertThrows(IllegalStateException.class, () ->
         testStripeWriteRetriesOnFailures(con, clusterSize,
             nodesIndexesToMarkFailure));
   }
@@ -708,11 +712,11 @@ public class TestOzoneECClient {
       // OZONE_CLIENT_MAX_EC_STRIPE_WRITE_RETRIES_ON_FAILURE(here it was
       // configured as 3). So, it should fail as we have marked 3 nodes as bad.
       testStripeWriteRetriesOnFailures(con, 20, nodesIndexesToMarkFailure);
-      Assertions.fail(
+      fail(
           "Expecting it to fail as retries should exceed the max allowed times:"
               + " " + 3);
     } catch (IOException e) {
-      Assertions.assertEquals(
+      assertEquals(
           "Completed max allowed retries 3 on stripe failures.",
           e.getMessage());
     }
@@ -738,7 +742,7 @@ public class TestOzoneECClient {
         out.write(inputChunks[i]);
       }
       waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
-      Assertions.assertEquals(5, factoryStub.getStorages().size());
+      assertEquals(5, factoryStub.getStorages().size());
       List<DatanodeDetails> failedDNs = new ArrayList<>();
       List<HddsProtos.DatanodeDetailsProto> dns = blkAllocator.getClusterDns();
 
@@ -760,16 +764,16 @@ public class TestOzoneECClient {
     // failures after first stripe, the second stripe data should have been
     // written into new blockgroup. So, we should have 2 block groups. That
     // means two keyLocations.
-    Assertions.assertEquals(2, key.getOzoneKeyLocations().size());
+    assertEquals(2, key.getOzoneKeyLocations().size());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks; i++) {
-        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i], fileContent);
+        assertEquals(inputChunks[i].length, is.read(fileContent));
+        assertArrayEquals(inputChunks[i], fileContent);
       }
       for (int i = 0; i < numChunksToWriteAfterFailure; i++) {
-        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i], fileContent);
+        assertEquals(inputChunks[i].length, is.read(fileContent));
+        assertArrayEquals(inputChunks[i], fileContent);
       }
     }
   }
@@ -810,18 +814,17 @@ public class TestOzoneECClient {
     // failures after first stripe, the second stripe data should have been
     // written into new block group. So, we should have numExpectedBlockGrps.
     // That means two keyLocations.
-    Assertions
-        .assertEquals(numExpectedBlockGrps, key.getOzoneKeyLocations().size());
+    assertEquals(numExpectedBlockGrps, key.getOzoneKeyLocations().size());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks; i++) {
-        Assertions.assertEquals(inputChunks[i].length, is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i], fileContent);
+        assertEquals(inputChunks[i].length, is.read(fileContent));
+        assertArrayEquals(inputChunks[i], fileContent);
       }
       for (int i = 0; i < numChunksToWriteAfterFailure; i++) {
-        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
+        assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
+        assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
       }
     }
   }
@@ -860,7 +863,7 @@ public class TestOzoneECClient {
     try (OzoneOutputStream out = bucket.createKey(keyName,
         2L * dataBlocks * chunkSize, repConfig, new HashMap<>())) {
 
-      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       ECKeyOutputStream ecKeyOut = (ECKeyOutputStream) out.getOutputStream();
 
       List<HddsProtos.DatanodeDetailsProto> dns = blkAllocator.getClusterDns();
@@ -889,7 +892,7 @@ public class TestOzoneECClient {
       waitForFlushingThreadToFinish((ECKeyOutputStream) out.getOutputStream());
 
       // Assert excludeList only includes failedDNs
-      Assertions.assertArrayEquals(failedDNs.toArray(new DatanodeDetails[0]),
+      assertArrayEquals(failedDNs.toArray(new DatanodeDetails[0]),
           ecKeyOut.getExcludeList().getDatanodes()
               .toArray(new DatanodeDetails[0]));
     }
@@ -953,19 +956,18 @@ public class TestOzoneECClient {
     // failures after first stripe, the second stripe data should have been
     // written into new block group. So, we should have numExpectedBlockGrps.
     // That means two keyLocations.
-    Assertions
-        .assertEquals(numExpectedBlockGrps, key.getOzoneKeyLocations().size());
+    assertEquals(numExpectedBlockGrps, key.getOzoneKeyLocations().size());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks * numFullStripesBeforeFailure; i++) {
-        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
+        assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
+        assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
       }
       for (int i = 0; i < numChunksToWriteAfterFailure; i++) {
-        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
+        assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
+        assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
       }
     }
   }
@@ -1020,17 +1022,16 @@ public class TestOzoneECClient {
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < numFullChunks; i++) {
-        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
+        assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
+        assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
       }
 
       byte[] partialChunkToRead = new byte[partialChunkSize];
-      Assertions
-          .assertEquals(partialChunkToRead.length, is.read(partialChunkToRead));
-      Assertions.assertArrayEquals(partialChunk, partialChunkToRead);
+      assertEquals(partialChunkToRead.length, is.read(partialChunkToRead));
+      assertArrayEquals(partialChunk, partialChunkToRead);
 
-      Assertions.assertEquals(-1, is.read(partialChunkToRead));
+      assertEquals(-1, is.read(partialChunkToRead));
     }
   }
 
@@ -1064,10 +1065,10 @@ public class TestOzoneECClient {
         new ECReplicationConfig(dataBlocks, parityBlocks,
             ECReplicationConfig.EcCodec.RS,
             chunkSize), new HashMap<>())) {
-      Assertions.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
+      assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       ECKeyOutputStream kos = (ECKeyOutputStream) out.getOutputStream();
       List<OmKeyLocationInfo> blockInfos = getAllLocationInfoList(kos);
-      Assertions.assertEquals(1, blockInfos.size());
+      assertEquals(1, blockInfos.size());
 
       // Mock some pre-allocated blocks to the key,
       // should be > maxRetries
@@ -1115,20 +1116,20 @@ public class TestOzoneECClient {
       } catch (IOException e) {
         // If we don't discard pre-allocated blocks,
         // retries should exceed the maxRetries and write will fail.
-        Assertions.fail("Max retries exceeded");
+        fail("Max retries exceeded");
       }
     }
 
     final OzoneKeyDetails key = bucket.getKey(keyName);
-    Assertions.assertEquals(numExpectedBlockGrps,
+    assertEquals(numExpectedBlockGrps,
         key.getOzoneKeyLocations().size());
 
     try (OzoneInputStream is = bucket.readKey(keyName)) {
       byte[] fileContent = new byte[chunkSize];
       for (int i = 0; i < dataBlocks * numStripesTotal; i++) {
-        Assertions.assertEquals(inputChunks[i % dataBlocks].length,
+        assertEquals(inputChunks[i % dataBlocks].length,
             is.read(fileContent));
-        Assertions.assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
+        assertArrayEquals(inputChunks[i % dataBlocks], fileContent);
       }
     }
   }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -56,7 +56,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -75,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * Unit tests for ReplicatedFileChecksumHelper class.
@@ -143,7 +143,7 @@ public class TestReplicatedFileChecksumHelper {
         .setAcls(null)
         .build();
 
-    when(om.lookupKey(ArgumentMatchers.any())).thenReturn(omKeyInfo);
+    when(om.lookupKey(any())).thenReturn(omKeyInfo);
 
     OzoneVolume mockVolume = mock(OzoneVolume.class);
     when(mockVolume.getName()).thenReturn("vol1");
@@ -197,7 +197,7 @@ public class TestReplicatedFileChecksumHelper {
           }
         };
     XceiverClientFactory factory = mock(XceiverClientFactory.class);
-    when(factory.acquireClientForReadData(ArgumentMatchers.any())).
+    when(factory.acquireClientForReadData(any())).
         thenReturn(xceiverClientGrpc);
 
     when(mockRpcClient.getXceiverClientManager()).thenReturn(factory);
@@ -229,7 +229,7 @@ public class TestReplicatedFileChecksumHelper {
         .setAcls(null)
         .build();
 
-    when(om.lookupKey(ArgumentMatchers.any())).thenReturn(omKeyInfo);
+    when(om.lookupKey(any())).thenReturn(omKeyInfo);
 
     OzoneVolume mockVolume = mock(OzoneVolume.class);
     when(mockVolume.getName()).thenReturn("vol1");
@@ -265,7 +265,7 @@ public class TestReplicatedFileChecksumHelper {
         .setAcls(null)
         .setFileChecksum(cachedChecksum)
         .build();
-    when(om.lookupKey(ArgumentMatchers.any())).
+    when(om.lookupKey(any())).
         thenReturn(omKeyInfoWithChecksum);
 
     helper = new ReplicatedFileChecksumHelper(

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -75,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit tests for ReplicatedFileChecksumHelper class.
@@ -123,9 +123,9 @@ public class TestReplicatedFileChecksumHelper {
   @Test
   public void testEmptyBlock() throws IOException {
     // test the file checksum of a file with an empty block.
-    RpcClient mockRpcClient = Mockito.mock(RpcClient.class);
+    RpcClient mockRpcClient = mock(RpcClient.class);
 
-    OzoneManagerProtocol om = Mockito.mock(OzoneManagerProtocol.class);
+    OzoneManagerProtocol om = mock(OzoneManagerProtocol.class);
     when(mockRpcClient.getOzoneManagerClient()).thenReturn(om);
 
     OmKeyInfo omKeyInfo = new OmKeyInfo.Builder()
@@ -145,9 +145,9 @@ public class TestReplicatedFileChecksumHelper {
 
     when(om.lookupKey(ArgumentMatchers.any())).thenReturn(omKeyInfo);
 
-    OzoneVolume mockVolume = Mockito.mock(OzoneVolume.class);
+    OzoneVolume mockVolume = mock(OzoneVolume.class);
     when(mockVolume.getName()).thenReturn("vol1");
-    OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
+    OzoneBucket bucket = mock(OzoneBucket.class);
     when(bucket.getName()).thenReturn("bucket1");
 
     OzoneClientConfig.ChecksumCombineMode combineMode =
@@ -173,7 +173,7 @@ public class TestReplicatedFileChecksumHelper {
     // test the file checksum of a file with one block.
     OzoneConfiguration conf = new OzoneConfiguration();
 
-    RpcClient mockRpcClient = Mockito.mock(RpcClient.class);
+    RpcClient mockRpcClient = mock(RpcClient.class);
 
     List<DatanodeDetails> dns = Arrays.asList(
         DatanodeDetails.newBuilder().setUuid(UUID.randomUUID()).build());
@@ -196,13 +196,13 @@ public class TestReplicatedFileChecksumHelper {
             return buildValidResponse();
           }
         };
-    XceiverClientFactory factory = Mockito.mock(XceiverClientFactory.class);
+    XceiverClientFactory factory = mock(XceiverClientFactory.class);
     when(factory.acquireClientForReadData(ArgumentMatchers.any())).
         thenReturn(xceiverClientGrpc);
 
     when(mockRpcClient.getXceiverClientManager()).thenReturn(factory);
 
-    OzoneManagerProtocol om = Mockito.mock(OzoneManagerProtocol.class);
+    OzoneManagerProtocol om = mock(OzoneManagerProtocol.class);
     when(mockRpcClient.getOzoneManagerClient()).thenReturn(om);
 
     BlockID blockID = new BlockID(1, 1);
@@ -231,9 +231,9 @@ public class TestReplicatedFileChecksumHelper {
 
     when(om.lookupKey(ArgumentMatchers.any())).thenReturn(omKeyInfo);
 
-    OzoneVolume mockVolume = Mockito.mock(OzoneVolume.class);
+    OzoneVolume mockVolume = mock(OzoneVolume.class);
     when(mockVolume.getName()).thenReturn("vol1");
-    OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
+    OzoneBucket bucket = mock(OzoneBucket.class);
     when(bucket.getName()).thenReturn("bucket1");
 
     OzoneClientConfig.ChecksumCombineMode combineMode =

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyInputStreamEC.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyInputStreamEC.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -43,6 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test KeyInputStream with EC keys.
@@ -74,7 +74,7 @@ public class TestKeyInputStreamEC {
         null, true,  null, mockStreamFactory)) {
       byte[] buf = new byte[100];
       int readBytes = kis.read(buf, 0, 100);
-      Assertions.assertEquals(100, readBytes);
+      assertEquals(100, readBytes);
     }
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestRpcClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/TestRpcClient.java
@@ -22,7 +22,6 @@ package org.apache.hadoop.ozone.client.rpc;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -31,7 +30,7 @@ import java.util.List;
 
 import static org.apache.hadoop.ozone.client.rpc.RpcClient.validateOmVersion;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Run RPC Client tests.
  */
@@ -206,7 +205,7 @@ public class TestRpcClient {
       b2.setOmVersion(testCase.om2Version);
       serviceInfoList.add(b2.build());
     }
-    Assertions.assertEquals(testCase.validation,
+    assertEquals(testCase.validation,
         validateOmVersion(testCase.expectedVersion, serviceInfoList),
         "Running test " + testCase);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add static import for assertions and mocks in hadoop-ozone/client.
The goal of this task is to add import static for all assertions and interactions with mocks.

## What is the link to the Apache JIRA
HDDS-9990

## How was this patch tested?
CI test: https://github.com/TaiJuWu/ozone/actions/runs/7377357085