### PR TITLE
HDDS-10037. Reduce the number of buffer copying in OMRatisHelper.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/io/ByteBufferInputStream.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/io/ByteBufferInputStream.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils.io;
+
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/** Warp a {@link ByteBuffer} as an {@link InputStream}. */
+public class ByteBufferInputStream extends InputStream {
+  private final ByteBuffer buffer;
+
+  public ByteBufferInputStream(ByteBuffer buffer) {
+    this.buffer = buffer.asReadOnlyBuffer();
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (!buffer.hasRemaining()) {
+      return -1;
+    }
+    return buffer.get() & 0xFF;
+  }
+
+  @Override
+  public int read(@Nonnull byte[] array, int offset, int length) throws IOException {
+    assertArrayIndex(array, offset, length);
+
+    if (length == 0) {
+      return 0;
+    }
+    final int remaining = buffer.remaining();
+    if (remaining <= 0) {
+      return -1;
+    }
+    final int min = Math.min(remaining, length);
+    buffer.get(array, offset, min);
+    return min;
+  }
+
+  static void assertArrayIndex(@Nonnull byte[] array, int offset, int length) {
+    Objects.requireNonNull(array, "array == null");
+    if (offset < 0) {
+      throw new ArrayIndexOutOfBoundsException("offset = " + offset + " < 0");
+    } else if (length < 0) {
+      throw new ArrayIndexOutOfBoundsException("length = " + length + " < 0");
+    }
+    final int end = offset + length;
+    if (end < 0) {
+      throw new ArrayIndexOutOfBoundsException(
+          "Overflow: offset+length > Integer.MAX_VALUE, offset=" + offset + ", length=" + length);
+    } else if (end > array.length) {
+      throw new ArrayIndexOutOfBoundsException(
+          "offset+length > array.length = " + array.length + ", offset=" + offset + ", length=" + length);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.ratis;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.ServiceException;
 
 import java.io.File;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -522,7 +522,7 @@ public final class OzoneManagerRatisServer {
 
     try {
       return OMRatisHelper.getOMResponseFromRaftClientReply(reply);
-    } catch (InvalidProtocolBufferException ex) {
+    } catch (IOException ex) {
       if (ex.getMessage() != null) {
         throw new ServiceException(ex.getMessage(), ex);
       } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `OMRatisHelper`, the helper methods uses a `byte[]` to do the conversion.  It can be improved by using `ByteBuffer` for reducing the number of buffer copying.

## What is the link to the Apache JIRA

HDDS-10037

## How was this patch tested?

By existing tests.