### PR TITLE
HDDS-10002. TestRocksDBCheckpointDiffer leaves artifacts in project root dir

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -225,7 +225,7 @@ public class TestRocksDBCheckpointDiffer {
     deleteDirectory(metadataDirDir);
     deleteDirectory(activeDbDir);
 
-    for (File dir:cpDirList){
+    for (File dir : cpDirList) {
       deleteDirectory(dir);
     }
   }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -121,6 +121,8 @@ public class TestRocksDBCheckpointDiffer {
   private static final String CP_PATH_PREFIX = "rocksdb-cp-";
   private final List<DifferSnapshotInfo> snapshots = new ArrayList<>();
 
+  private final List<File> cpDirList = new ArrayList<>();
+
   private final List<List<ColumnFamilyHandle>> colHandles = new ArrayList<>();
 
   private final String activeDbDirName = "./rocksdb-data";
@@ -222,6 +224,10 @@ public class TestRocksDBCheckpointDiffer {
     deleteDirectory(sstBackUpDir);
     deleteDirectory(metadataDirDir);
     deleteDirectory(activeDbDir);
+
+    for (File dir:cpDirList){
+      deleteDirectory(dir);
+    }
   }
 
   /**
@@ -605,6 +611,7 @@ public class TestRocksDBCheckpointDiffer {
     if (dir.exists()) {
       deleteDirectory(dir);
     }
+    cpDirList.add(dir);
 
     createCheckPoint(activeDbDirName, cpPath, rocksDB);
     final UUID snapshotId = UUID.randomUUID();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Clean up artifacts in hadoop-hdds/rocksdb-checkpoint-differ directory.

Add a list to record cp directory and we can delete these directories when clean up.

## What is the link to the Apache JIRA
HDDS-10002.

## How was this patch tested?
CI test: https://github.com/TaiJuWu/ozone/actions/runs/7376016275