### PR TITLE
HDDS-9836. Migrate simple recon integration tests to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmHASnapshot.java
@@ -20,30 +20,23 @@ package org.apache.hadoop.ozone.recon;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY;
 
 /**
  * Test Recon SCM HA Snapshot Download implementation.
  */
+@Timeout(100)
 public class TestReconScmHASnapshot {
-
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(100));
   private OzoneConfiguration conf;
   private MiniOzoneCluster ozoneCluster = null;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.setBoolean(OZONE_SCM_HA_ENABLE_KEY, true);
@@ -63,7 +56,7 @@ public class TestReconScmHASnapshot {
     TestReconScmSnapshot.testSnapshot(ozoneCluster);
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws Exception {
     if (ozoneCluster != null) {
       ozoneCluster.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
@@ -27,33 +27,26 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Recon SCM Snapshot Download implementation.
  */
+@Timeout(100)
 public class TestReconScmSnapshot {
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(100));
   private OzoneConfiguration conf;
   private MiniOzoneCluster ozoneCluster = null;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.setBoolean(
@@ -126,7 +119,7 @@ public class TestReconScmSnapshot {
     assertEquals(keyCountAfter, keyCountBefore);
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws Exception {
     if (ozoneCluster != null) {
       ozoneCluster.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
@@ -17,6 +17,9 @@
 package org.apache.hadoop.ozone.recon;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.UUID;
 
@@ -40,34 +43,25 @@ import org.apache.hadoop.ozone.recon.api.types.EntityType;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
 
 import javax.ws.rs.core.Response;
 
 /**
  * Test Ozone Recon.
  */
+@Timeout(300)
 public class TestReconWithOzoneManagerFSO {
 
   private static OzoneClient client;
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
   private static MiniOzoneCluster cluster = null;
   private static OzoneConfiguration conf;
   private static ObjectStore store;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
@@ -84,7 +78,7 @@ public class TestReconWithOzoneManagerFSO {
     store = client.getObjectStore();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -134,13 +128,13 @@ public class TestReconWithOzoneManagerFSO {
     Response basicInfo = endpoint.getBasicInfo("/vol1/bucket1/dir1");
     NamespaceSummaryResponse entity =
             (NamespaceSummaryResponse) basicInfo.getEntity();
-    Assert.assertSame(entity.getEntityType(), EntityType.DIRECTORY);
-    Assert.assertEquals(1, entity.getCountStats().getNumTotalKey());
-    Assert.assertEquals(0, entity.getCountStats().getNumTotalDir());
-    Assert.assertEquals(-1, entity.getCountStats().getNumVolume());
-    Assert.assertEquals(-1, entity.getCountStats().getNumBucket());
+    assertSame(entity.getEntityType(), EntityType.DIRECTORY);
+    assertEquals(1, entity.getCountStats().getNumTotalKey());
+    assertEquals(0, entity.getCountStats().getNumTotalDir());
+    assertEquals(-1, entity.getCountStats().getNumVolume());
+    assertEquals(-1, entity.getCountStats().getNumBucket());
     for (int i = 0; i < 10; i++) {
-      Assert.assertNotNull(impl.getOMMetadataManagerInstance()
+      assertNotNull(impl.getOMMetadataManagerInstance()
               .getVolumeTable().get("/vol" + i));
     }
     addKeys(10, 12, "dir");
@@ -148,7 +142,7 @@ public class TestReconWithOzoneManagerFSO {
 
     // test Recon is sync'ed with OM.
     for (int i = 10; i < 12; i++) {
-      Assert.assertNotNull(impl.getOMMetadataManagerInstance()
+      assertNotNull(impl.getOMMetadataManagerInstance()
               .getVolumeTable().getSkipCache("/vol" + i));
     }
 
@@ -156,12 +150,12 @@ public class TestReconWithOzoneManagerFSO {
     Response rootBasicRes = endpoint.getBasicInfo("/");
     NamespaceSummaryResponse rootBasicEntity =
             (NamespaceSummaryResponse) rootBasicRes.getEntity();
-    Assert.assertSame(EntityType.ROOT, rootBasicEntity.getEntityType());
+    assertSame(EntityType.ROOT, rootBasicEntity.getEntityType());
     // one additional dummy volume at creation
-    Assert.assertEquals(13, rootBasicEntity.getCountStats().getNumVolume());
-    Assert.assertEquals(12, rootBasicEntity.getCountStats().getNumBucket());
-    Assert.assertEquals(12, rootBasicEntity.getCountStats().getNumTotalDir());
-    Assert.assertEquals(12, rootBasicEntity.getCountStats().getNumTotalKey());
+    assertEquals(13, rootBasicEntity.getCountStats().getNumVolume());
+    assertEquals(12, rootBasicEntity.getCountStats().getNumBucket());
+    assertEquals(12, rootBasicEntity.getCountStats().getNumTotalDir());
+    assertEquals(12, rootBasicEntity.getCountStats().getNumTotalKey());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
@@ -110,9 +110,9 @@ public class TestReconWithOzoneManagerHA {
       ozoneManager.set(om);
       return om != null;
     }, 100, 120000);
-    assertNotNull(ozoneManager,"Timed out waiting OM leader election to finish: "
+    assertNotNull(ozoneManager, "Timed out waiting OM leader election to finish: "
         + "no leader or more than one leader.");
-    assertTrue(ozoneManager.get().isLeaderReady(),"Should have gotten the leader!");
+    assertTrue(ozoneManager.get().isLeaderReady(), "Should have gotten the leader!");
 
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
         cluster.getReconServer().getOzoneManagerServiceProvider();
@@ -124,8 +124,7 @@ public class TestReconWithOzoneManagerHA {
         ozoneManager.get().getHttpServer().getHttpAddress().getPort() +
         OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
     String snapshotUrl = impl.getOzoneManagerSnapshotUrl();
-    assertEquals("OM Snapshot should be requested from the leader.",
-        expectedUrl, snapshotUrl);
+    assertEquals(expectedUrl, snapshotUrl);
     // Write some data
     String keyPrefix = "ratis";
     OzoneOutputStream key = objectStore.getVolume(VOL_NAME)
@@ -148,7 +147,7 @@ public class TestReconWithOzoneManagerHA {
             (Table.KeyValue<ContainerKeyPrefix, Integer>) iterator.next();
         reconKeyPrefix = keyValue.getKey().getKeyPrefix();
       }
-      assertEquals("Container data should be synced to recon.",
+      assertEquals(
           String.format("/%s/%s/%s", VOL_NAME, VOL_NAME, keyPrefix),
           reconKeyPrefix);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
@@ -17,13 +17,6 @@
  */
 package org.apache.hadoop.ozone.recon;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
-
-import java.util.HashMap;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -45,21 +38,25 @@ import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * This class sets up a MiniOzoneOMHACluster to test with Recon.
  */
+@Timeout(300)
 public class TestReconWithOzoneManagerHA {
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   private MiniOzoneHAClusterImpl cluster;
   private ObjectStore objectStore;
@@ -67,7 +64,7 @@ public class TestReconWithOzoneManagerHA {
   private static final String VOL_NAME = "testrecon";
   private OzoneClient client;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, Boolean.TRUE.toString());
@@ -96,7 +93,7 @@ public class TestReconWithOzoneManagerHA {
             .build());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -113,10 +110,9 @@ public class TestReconWithOzoneManagerHA {
       ozoneManager.set(om);
       return om != null;
     }, 100, 120000);
-    Assert.assertNotNull("Timed out waiting OM leader election to finish: "
-        + "no leader or more than one leader.", ozoneManager);
-    Assert.assertTrue("Should have gotten the leader!",
-        ozoneManager.get().isLeaderReady());
+    assertNotNull(ozoneManager,"Timed out waiting OM leader election to finish: "
+        + "no leader or more than one leader.");
+    assertTrue(ozoneManager.get().isLeaderReady(),"Should have gotten the leader!");
 
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
         cluster.getReconServer().getOzoneManagerServiceProvider();
@@ -128,7 +124,7 @@ public class TestReconWithOzoneManagerHA {
         ozoneManager.get().getHttpServer().getHttpAddress().getPort() +
         OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
     String snapshotUrl = impl.getOzoneManagerSnapshotUrl();
-    Assert.assertEquals("OM Snapshot should be requested from the leader.",
+    assertEquals("OM Snapshot should be requested from the leader.",
         expectedUrl, snapshotUrl);
     // Write some data
     String keyPrefix = "ratis";
@@ -152,7 +148,7 @@ public class TestReconWithOzoneManagerHA {
             (Table.KeyValue<ContainerKeyPrefix, Integer>) iterator.next();
         reconKeyPrefix = keyValue.getKey().getKeyPrefix();
       }
-      Assert.assertEquals("Container data should be synced to recon.",
+      assertEquals("Container data should be synced to recon.",
           String.format("/%s/%s/%s", VOL_NAME, VOL_NAME, keyPrefix),
           reconKeyPrefix);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9836. Migrate simple recon integration tests to JUnit5

- Updated test annotations `@Before`, `@After`, `@BeforeClass`, `@AfterClass`, `@Timeout` with JUnit 5 equivalents.
- Replaced JUnit 4 assert methods and Timeout rule with JUnit 5 equivalents.
- Modified imported classes for JUnit 5 compatibility.
- Affected files:
  - TestReconScmHASnapshot.java
  - TestReconScmSnapshot.java
  - TestReconWithOzoneManagerFSO.java
  - TestReconWithOzoneManagerHA.java
- According to the description in https://issues.apache.org/jira/browse/HDDS-9836, one more class TestReconWithOzoneManager.java is also needed to change, but it is already migrated to JUnit 5, so it is skipped in this PR. 
- These changes ensure compatibility with JUnit 5 and leverage its updated testing features. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9836

## How was this patch tested?
All the modified tests are passed locally with below mvn command:
`mvn -Dskip.installnpm -Dskip.installnpx -Dskip.installyarn -Dskip.npm -Dskip.npx -Dskip.yarn -DskipShade -am -pl :ozone-integration-test clean test -Dtest="TestRecon.*"`
