### PR TITLE
HDDS-10047. Add number of datanodes, total capacity/used space to SCMNodeMetrics

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1044,6 +1044,8 @@ public class SCMNodeManager implements NodeManager {
         nodeInfo.put(s.label + stat.name(), 0L);
       }
     }
+    nodeInfo.put("TotalCapacity", 0L);
+    nodeInfo.put("TotalUsed", 0L);
 
     for (DatanodeInfo node : nodeStateManager.getAllNodes()) {
       String keyPrefix = "";
@@ -1078,6 +1080,8 @@ public class SCMNodeManager implements NodeManager {
           nodeInfo.compute(keyPrefix + UsageMetrics.SSDUsed.name(),
               (k, v) -> v + reportProto.getScmUsed());
         }
+        nodeInfo.compute("TotalCapacity", (k, v) -> v + reportProto.getCapacity());
+        nodeInfo.compute("TotalUsed", (k, v) -> v + reportProto.getScmUsed());
       }
     }
     return nodeInfo;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
@@ -135,6 +135,7 @@ public final class SCMNodeMetrics implements MetricsSource {
   public void getMetrics(MetricsCollector collector, boolean all) {
     Map<String, Map<String, Integer>> nodeCount = managerMXBean.getNodeCount();
     Map<String, Long> nodeInfo = managerMXBean.getNodeInfo();
+    int totalNodeCount = 0;
     /**
      * Loop over the Node map and create a metric for the cross product of all
      * Operational and health states, ie:
@@ -152,8 +153,11 @@ public final class SCMNodeMetrics implements MetricsSource {
                 StringUtils.camelize(e.getKey() + "_" + h.getKey() + "_nodes"),
                 "Number of " + e.getKey() + " " + h.getKey() + " datanodes"),
             h.getValue());
+        totalNodeCount += h.getValue();
       }
     }
+    metrics.addGauge(
+        Interns.info("AllNodes", "Number of datanodes"), totalNodeCount);
 
     for (Map.Entry<String, Long> e : nodeInfo.entrySet()) {
       metrics.addGauge(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -1982,6 +1982,10 @@ public class TestSCMNodeManager {
     assertEquals(2000, stats.get("MaintenanceDiskCapacity").longValue());
     assertEquals(100, stats.get("MaintenanceDiskUsed").longValue());
     assertEquals(1900, stats.get("MaintenanceDiskRemaining").longValue());
+
+    // All nodes
+    assertEquals(12000, stats.get("TotalCapacity").longValue());
+    assertEquals(600, stats.get("TotalUsed").longValue());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
@@ -253,6 +253,12 @@ public class TestSCMNodeMetrics {
         getMetrics(SCMNodeMetrics.class.getSimpleName()));
     assertGauge("DecommissionedSSDRemaining", 0L,
         getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("AllNodes", 1,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("TotalCapacity", 100L,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("TotalUsed", 10L,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
 
     LayoutVersionManager versionManager = nodeManager.getLayoutVersionManager();
     LayoutVersionProto layoutInfo = LayoutVersionProto.newBuilder()


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added three new metrics to the `SCMNodeMetrics`:

- Number of datanodes
- Total cluster installed capacity
- Total current Ozone utilization

With this change these metrics will be available in the SCM's JMX endpoint. This is an addition to the already existing SCMNodeMetrics, which will be useful when we want to gather information about the overall state of the cluster.

https://issues.apache.org/jira/browse/HDDS-10047

## How was this patch tested?

I added the new metrics to the already existing tests, green CI: https://github.com/dombizita/ozone/actions/runs/7387348419
