### PR TITLE
HDDS-10049. Migrate remaining integration tests to JUnit5

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadBucket.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadBucket.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +39,9 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Bucket to perform read/write & delete ops.
@@ -174,11 +176,10 @@ public class LoadBucket {
     void doFsOp(Path p) throws IOException {
       if (readDir) {
         FileStatus status = fs.getFileStatus(p);
-        Assert.assertTrue(status.isDirectory());
-        Assert.assertEquals(p,
-            Path.getPathWithoutSchemeAndAuthority(status.getPath()));
+        assertTrue(status.isDirectory());
+        assertEquals(p, Path.getPathWithoutSchemeAndAuthority(status.getPath()));
       } else {
-        Assert.assertTrue(fs.mkdirs(p));
+        assertTrue(fs.mkdirs(p));
       }
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/OzoneFileSystemTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/OzoneFileSystemTests.java
@@ -30,8 +30,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Common test cases for Ozone file systems.
@@ -89,12 +89,10 @@ final class OzoneFileSystemTests {
         FileStatus fileStatus = iterator.next();
         iCount++;
         String filename = fileStatus.getPath().getName();
-        assertTrue(filename + " not found", paths.contains(filename));
+        assertThat(paths).contains(filename);
       }
     }
 
-    assertEquals(
-        "Total directories listed do not match the existing directories",
-        total, iCount);
+    assertEquals(total, iCount);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
@@ -41,9 +41,9 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.Assert;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * The contract of Ozone: only enabled if the test bucket is provided.
@@ -142,7 +142,7 @@ class OzoneContract extends AbstractFSContract {
   @Override
   public FileSystem getTestFileSystem() throws IOException {
     //assumes cluster is not null
-    Assert.assertNotNull("cluster not created", client);
+    assertNotNull(client);
 
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(client);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/rooted/RootedOzoneContract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/rooted/RootedOzoneContract.java
@@ -34,9 +34,8 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 
-import org.junit.Assert;
-
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * The contract of Rooted Ozone FileSystem (OFS).
@@ -96,7 +95,7 @@ class RootedOzoneContract extends AbstractFSContract {
   @Override
   public FileSystem getTestFileSystem() throws IOException {
     //assumes cluster is not null
-    Assert.assertNotNull("cluster not created", cluster);
+    assertNotNull(cluster);
 
     String uri = String.format("%s://localhost:%s/",
         OzoneConsts.OZONE_OFS_URI_SCHEME,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -106,7 +106,6 @@ import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
 import static org.apache.ozone.test.GenericTestUtils.PortAllocator.localhostWithFreePort;
 
 import org.hadoop.ozone.recon.codegen.ReconSqlDbConfig;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -981,9 +980,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     protected void configureRecon() throws IOException {
       ConfigurationProvider.resetConfiguration();
 
-      TemporaryFolder tempFolder = new TemporaryFolder();
-      tempFolder.create();
-      File tempNewFolder = tempFolder.newFolder();
+      File tempNewFolder = new File(path, "recon");
       conf.set(OZONE_RECON_DB_DIR,
           tempNewFolder.getAbsolutePath());
       conf.set(OZONE_RECON_OM_SNAPSHOT_DB_DIR, tempNewFolder

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -27,9 +27,9 @@ import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadResponse;
 import org.apache.hadoop.ozone.s3.endpoint.MultipartUploadInitiateResponse;
 import org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,8 +50,8 @@ import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 /**
@@ -76,7 +76,7 @@ public class TestMultipartObjectGet {
 
   private static final ObjectEndpoint REST = new ObjectEndpoint();
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     clusterId = UUID.randomUUID().toString();
@@ -118,7 +118,7 @@ public class TestMultipartObjectGet {
     cluster.waitForClusterToBeReady();
   }
 
-  @AfterClass
+  @AfterAll
   public static void stop() {
     IOUtils.close(LOG, client);
     if (cluster != null) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -31,21 +31,11 @@ import org.apache.hadoop.ozone.s3.S3GatewayConfigKeys;
 import java.util.Arrays;
 
 import org.apache.hadoop.ozone.s3secret.S3SecretConfigKeys;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
 
 /**
  * Tests if configuration constants documented in ozone-defaults.xml.
  */
 public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   @Override
   public void initializeMemberVariables() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -55,7 +55,6 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine;
 import org.apache.hadoop.ozone.om.ratis.metrics.OzoneManagerStateMachineMetrics;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -63,11 +62,11 @@ import org.junit.jupiter.api.Test;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.THREE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class is to test all the public facing APIs of Ozone Client with an
@@ -80,8 +79,6 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
    * Ozone is made active by setting OZONE_ENABLED = true.
    * Ozone OM Ratis server is made active by setting
    * OZONE_OM_RATIS_ENABLE = true;
-   *
-   * @throws IOException
    */
   @BeforeAll
   public static void init() throws Exception {
@@ -108,10 +105,9 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
 
   /**
    * Tests get the information of key with network topology awareness enabled.
-   * @throws IOException
    */
   @Test
-  public void testGetKeyAndFileWithNetworkTopology() throws IOException {
+  void testGetKeyAndFileWithNetworkTopology() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
@@ -355,8 +351,7 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
           ReplicationType.RATIS, ONE, new HashMap<>());
     }
 
-    Assert.assertTrue(
-        omSMLog.getOutput().contains("Failed to write, Exception occurred"));
+    assertThat(omSMLog.getOutput()).contains("Failed to write, Exception occurred");
     GenericTestUtils.waitFor(() -> metrics.getApplyTransactionMapSize() == 0,
         100, 5000);
   }
@@ -386,13 +381,13 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     }
 
     @Override
-    public void resume() throws IOException {
+    public void resume() {
       // Make sure injector pauses before resuming.
       try {
         ready.await();
       } catch (InterruptedException e) {
         e.printStackTrace();
-        assertTrue(fail("resume interrupted"));
+        fail("resume interrupted");
       }
       wait.countDown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OMUpgradeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/OMUpgradeTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Assert;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus.PREPARE_COMPLETED;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_DONE;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Utility class to help test OM upgrade scenarios.
@@ -80,7 +80,7 @@ public final class OMUpgradeTestUtils {
             statusAndMessages.msgs());
         return statusAndMessages.status().equals(FINALIZATION_DONE);
       } catch (IOException e) {
-        Assert.fail(e.getMessage());
+        fail(e.getMessage());
       }
       return false;
     }, 2000, 20000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmContainerLocationCache.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmContainerLocationCache.java
@@ -73,18 +73,14 @@ import org.apache.ratis.thirdparty.io.grpc.StatusException;
 import org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException;
 import org.apache.ratis.util.ExitUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Rule;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
@@ -104,6 +100,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.NO_REPLICA_FOUND;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -125,13 +122,9 @@ import static org.mockito.Mockito.when;
  * This integration verifies clients and OM using mocked Datanode and SCM
  * protocols.
  */
+@Timeout(300)
 public class TestOmContainerLocationCache {
 
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
   private static ScmBlockLocationProtocol mockScmBlockLocationProtocol;
   private static StorageContainerLocationProtocol mockScmContainerClient;
   private static OzoneConfiguration conf;
@@ -291,7 +284,7 @@ public class TestOmContainerLocationCache {
     try (InputStream is = key1.getContent()) {
       byte[] read = new byte[(int) key1.getDataSize()];
       IOUtils.read(is, read);
-      Assertions.assertArrayEquals(data, read);
+      assertArrayEquals(data, read);
     }
 
     // Create keyName2 in the same container to reuse the cache
@@ -304,7 +297,7 @@ public class TestOmContainerLocationCache {
     try (InputStream is = key2.getContent()) {
       byte[] read = new byte[(int) key2.getDataSize()];
       IOUtils.read(is, read);
-      Assertions.assertArrayEquals(data, read);
+      assertArrayEquals(data, read);
     }
     // Ensure SCM is not called once again.
     verify(mockScmContainerClient, times(1))
@@ -369,7 +362,7 @@ public class TestOmContainerLocationCache {
 
       byte[] read = new byte[(int) key1.getDataSize()];
       IOUtils.read(is, read);
-      Assertions.assertArrayEquals(data, read);
+      assertArrayEquals(data, read);
     }
 
     // verify SCM is called one more time to refresh.
@@ -418,7 +411,7 @@ public class TestOmContainerLocationCache {
 
       byte[] read = new byte[(int) key1.getDataSize()];
       IOUtils.read(is, read);
-      Assertions.assertArrayEquals(data, read);
+      assertArrayEquals(data, read);
     }
 
     // verify SCM is called one more time to refresh.
@@ -562,7 +555,7 @@ public class TestOmContainerLocationCache {
     try (InputStream is = updatedKey1.getContent()) {
       byte[] read = new byte[(int) key1.getDataSize()];
       IOUtils.read(is, read);
-      Assertions.assertArrayEquals(data, read);
+      assertArrayEquals(data, read);
     }
     // verify SCM is called one more time to refetch the container pipeline..
     verify(mockScmContainerClient, times(2))

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRocksDBLogging.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRocksDBLogging.java
@@ -26,32 +26,27 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test RocksDB logging for Ozone Manager.
  */
+@Timeout(100)
 public class TestOzoneManagerRocksDBLogging {
   private MiniOzoneCluster cluster = null;
   private OzoneConfiguration conf;
   private RocksDBConfiguration dbConf;
 
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(100));
-
   private static GenericTestUtils.LogCapturer logCapturer =
       GenericTestUtils.LogCapturer.captureLogs(DBStoreBuilder.ROCKS_DB_LOGGER);
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     dbConf = conf.getObject(RocksDBConfiguration.class);
@@ -64,7 +59,7 @@ public class TestOzoneManagerRocksDBLogging {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @After
+  @AfterEach
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -73,12 +68,8 @@ public class TestOzoneManagerRocksDBLogging {
 
   @Test
   public void testOMRocksDBLoggingEnabled() throws Exception {
-    try {
-      waitForRocksDbLog();
-      Assert.fail("Unexpected RocksDB log: " + logCapturer.getOutput());
-    } catch (TimeoutException ex) {
-      assertThat(ex.getMessage()).contains("Timed out");
-    }
+    Exception ex = assertThrows(TimeoutException.class, () -> waitForRocksDbLog());
+    assertThat(ex.getMessage()).contains("Timed out");
 
     enableRocksDbLogging(true);
     cluster.restartOzoneManager();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -96,19 +96,14 @@ import org.apache.hadoop.util.Time;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.JUnit5AwareTimeout;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -145,7 +140,16 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_C
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils.setInternalState;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.mockRemoteUser;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -154,35 +158,25 @@ import static org.mockito.Mockito.verify;
 /**
  * Test class that exercises the StorageContainerManager.
  */
+@Timeout(900)
 public class TestStorageContainerManager {
   private static XceiverClientManager xceiverClientManager;
   private static final Logger LOG = LoggerFactory.getLogger(
             TestStorageContainerManager.class);
-  /**
-   * Set the timeout for every test.
-   */
-  @Rule
-  public TestRule testTimeout = new JUnit5AwareTimeout(Timeout.seconds(900));
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     xceiverClientManager = new XceiverClientManager(new OzoneConfiguration());
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() {
     if (xceiverClientManager != null) {
       xceiverClientManager.close();
     }
   }
 
-  @After
+  @AfterEach
   public void cleanupDefaults() {
     DefaultConfigManager.clearDefaultConfigs();
   }
@@ -236,7 +230,7 @@ public class TestStorageContainerManager {
       } else {
         // If passes permission check, it should fail with
         // container not exist exception.
-        Assert.assertTrue(e instanceof ContainerNotFoundException);
+        assertInstanceOf(ContainerNotFoundException.class, e);
       }
     }
 
@@ -247,7 +241,7 @@ public class TestStorageContainerManager {
       if (expectPermissionDenied) {
         fail("Operation should fail, expecting an IOException here.");
       } else {
-        Assert.assertEquals(1, container2.getPipeline().getNodes().size());
+        assertEquals(1, container2.getPipeline().getNodes().size());
       }
     } catch (Exception e) {
       verifyPermissionDeniedException(e, fakeRemoteUsername);
@@ -263,7 +257,7 @@ public class TestStorageContainerManager {
       } else {
         // If passes permission check, it should fail with
         // key not exist exception.
-        Assert.assertTrue(e instanceof ContainerNotFoundException);
+        assertInstanceOf(ContainerNotFoundException.class, e);
       }
     }
   }
@@ -271,8 +265,8 @@ public class TestStorageContainerManager {
   private void verifyPermissionDeniedException(Exception e, String userName) {
     String expectedErrorMessage = "Access denied for user "
         + userName + ". " + "SCM superuser privilege is required.";
-    Assert.assertTrue(e instanceof IOException);
-    Assert.assertEquals(expectedErrorMessage, e.getMessage());
+    assertInstanceOf(IOException.class, e);
+    assertEquals(expectedErrorMessage, e.getMessage());
   }
 
   @Test
@@ -305,7 +299,7 @@ public class TestStorageContainerManager {
     try {
       DeletedBlockLog delLog = cluster.getStorageContainerManager()
           .getScmBlockManager().getDeletedBlockLog();
-      Assert.assertEquals(0, delLog.getNumOfValidTransactions());
+      assertEquals(0, delLog.getNumOfValidTransactions());
 
       // Create {numKeys} random names keys.
       TestStorageContainerManagerHelper helper =
@@ -323,7 +317,7 @@ public class TestStorageContainerManager {
           delLog, keyLocations, helper);
 
       // Verify a few TX gets created in the TX log.
-      Assert.assertTrue(delLog.getNumOfValidTransactions() > 0);
+      assertTrue(delLog.getNumOfValidTransactions() > 0);
 
       // Once TXs are written into the log, SCM starts to fetch TX
       // entries from the log and schedule block deletions in HB interval,
@@ -341,7 +335,7 @@ public class TestStorageContainerManager {
           return false;
         }
       }, 1000, 10000);
-      Assert.assertTrue(helper.verifyBlocksWithTxnTable(containerBlocks));
+      assertTrue(helper.verifyBlocksWithTxnTable(containerBlocks));
       // Continue the work, add some TXs that with known container names,
       // but unknown block IDs.
       for (Long containerID : containerBlocks.keySet()) {
@@ -356,7 +350,7 @@ public class TestStorageContainerManager {
       }
 
       // Verify a few TX gets created in the TX log.
-      Assert.assertTrue(delLog.getNumOfValidTransactions() > 0);
+      assertTrue(delLog.getNumOfValidTransactions() > 0);
 
       // These blocks cannot be found in the container, skip deleting them
       // eventually these TX will success.
@@ -399,13 +393,13 @@ public class TestStorageContainerManager {
       scm = HddsTestUtils.getScmSimple(scm.getConfiguration());
 
       DatanodeStateMachine dsm = datanode.getDatanodeStateMachine();
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
+      assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
           dsm.getContext().getState());
       // DN Endpoint State has already gone through GetVersion and Register,
       // so it will be in HEARTBEAT state.
       for (EndpointStateMachine endpoint : dsm.getConnectionManager()
           .getValues()) {
-        Assert.assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
+        assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
             endpoint.getState());
       }
       GenericTestUtils.LogCapturer scmDnHBDispatcherLog =
@@ -417,12 +411,12 @@ public class TestStorageContainerManager {
       GenericTestUtils.LogCapturer versionEndPointTaskLog =
           GenericTestUtils.LogCapturer.captureLogs(VersionEndpointTask.LOG);
       // Initially empty
-      Assert.assertTrue(scmDnHBDispatcherLog.getOutput().isEmpty());
-      Assert.assertTrue(versionEndPointTaskLog.getOutput().isEmpty());
+      assertTrue(scmDnHBDispatcherLog.getOutput().isEmpty());
+      assertTrue(versionEndPointTaskLog.getOutput().isEmpty());
       // start the new SCM
       scm.start();
       // Initially DatanodeStateMachine will be in Running state
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
+      assertEquals(DatanodeStateMachine.DatanodeStates.RUNNING,
           dsm.getContext().getState());
       // DN heartbeats to new SCM, SCM doesn't recognize the node, sends the
       // command to DN to re-register. Wait for SCM to send re-register command
@@ -446,9 +440,9 @@ public class TestStorageContainerManager {
           100, 5000);
       GenericTestUtils.waitFor(() -> dsm.getContext().getShutdownOnError(), 100,
           5000);
-      Assert.assertEquals(DatanodeStateMachine.DatanodeStates.SHUTDOWN,
+      assertEquals(DatanodeStateMachine.DatanodeStates.SHUTDOWN,
           dsm.getContext().getState());
-      Assert.assertTrue(versionEndPointTaskLog.getOutput().contains(
+      assertTrue(versionEndPointTaskLog.getOutput().contains(
           "org.apache.hadoop.ozone.common" +
               ".InconsistentStorageStateException: Mismatched ClusterIDs"));
     } finally {
@@ -482,7 +476,7 @@ public class TestStorageContainerManager {
     try {
       DeletedBlockLog delLog = cluster.getStorageContainerManager()
           .getScmBlockManager().getDeletedBlockLog();
-      Assert.assertEquals(0, delLog.getNumOfValidTransactions());
+      assertEquals(0, delLog.getNumOfValidTransactions());
 
       int limitSize = 1;
       // Reset limit value to 1, so that we only allow one TX is dealt per
@@ -505,7 +499,7 @@ public class TestStorageContainerManager {
       createDeleteTXLog(cluster.getStorageContainerManager(),
           delLog, keyLocations, helper);
       // Verify a few TX gets created in the TX log.
-      Assert.assertTrue(delLog.getNumOfValidTransactions() > 0);
+      assertTrue(delLog.getNumOfValidTransactions() > 0);
 
       // Verify the size in delete commands is expected.
       GenericTestUtils.waitFor(() -> {
@@ -559,8 +553,8 @@ public class TestStorageContainerManager {
     for (OmKeyInfo info : keyLocations.values()) {
       totalCreatedBlocks += info.getKeyLocationVersions().size();
     }
-    Assert.assertTrue(totalCreatedBlocks > 0);
-    Assert.assertEquals(totalCreatedBlocks,
+    assertTrue(totalCreatedBlocks > 0);
+    assertEquals(totalCreatedBlocks,
         helper.getAllBlocks(containerNames).size());
 
     // Create a deletion TX for each key.
@@ -598,12 +592,12 @@ public class TestStorageContainerManager {
     StorageContainerManager.scmInit(conf, testClusterId);
 
     SCMStorageConfig scmStore = new SCMStorageConfig(conf);
-    Assert.assertEquals(NodeType.SCM, scmStore.getNodeType());
-    Assert.assertEquals(testClusterId, scmStore.getClusterID());
+    assertEquals(NodeType.SCM, scmStore.getNodeType());
+    assertEquals(testClusterId, scmStore.getClusterID());
     StorageContainerManager.scmInit(conf, testClusterId);
-    Assert.assertEquals(NodeType.SCM, scmStore.getNodeType());
-    Assert.assertEquals(testClusterId, scmStore.getClusterID());
-    Assert.assertTrue(scmStore.isSCMHAEnabled());
+    assertEquals(NodeType.SCM, scmStore.getNodeType());
+    assertEquals(testClusterId, scmStore.getClusterID());
+    assertTrue(scmStore.isSCMHAEnabled());
   }
 
   @Test
@@ -620,7 +614,7 @@ public class TestStorageContainerManager {
     // This will initialize SCM
     StorageContainerManager.scmInit(conf, clusterId.toString());
     SCMStorageConfig scmStore = new SCMStorageConfig(conf);
-    Assert.assertTrue(scmStore.isSCMHAEnabled());
+    assertTrue(scmStore.isSCMHAEnabled());
     validateRatisGroupExists(conf, clusterId.toString());
   }
 
@@ -641,8 +635,8 @@ public class TestStorageContainerManager {
       // This will initialize SCM
       StorageContainerManager.scmInit(conf, clusterId.toString());
       SCMStorageConfig scmStore = new SCMStorageConfig(conf);
-      Assert.assertNotEquals(clusterId.toString(), scmStore.getClusterID());
-      Assert.assertTrue(scmStore.isSCMHAEnabled());
+      assertNotEquals(clusterId.toString(), scmStore.getClusterID());
+      assertTrue(scmStore.isSCMHAEnabled());
     } finally {
       cluster.shutdown();
     }
@@ -662,13 +656,13 @@ public class TestStorageContainerManager {
 
     StorageContainerManager.scmInit(conf, clusterId.toString());
     SCMStorageConfig scmStore = new SCMStorageConfig(conf);
-    Assert.assertEquals(clusterId.toString(), scmStore.getClusterID());
-    Assert.assertFalse(scmStore.isSCMHAEnabled());
+    assertEquals(clusterId.toString(), scmStore.getClusterID());
+    assertFalse(scmStore.isSCMHAEnabled());
 
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     StorageContainerManager.scmInit(conf, clusterId.toString());
     scmStore = new SCMStorageConfig(conf);
-    Assert.assertTrue(scmStore.isSCMHAEnabled());
+    assertTrue(scmStore.isSCMHAEnabled());
     validateRatisGroupExists(conf, clusterId.toString());
 
   }
@@ -733,7 +727,7 @@ public class TestStorageContainerManager {
       // validate there is no ratis group pre existing
       try {
         validateRatisGroupExists(conf, clusterId);
-        Assert.fail();
+        fail();
       } catch (IOException ioe) {
         // Exception is expected here
       }
@@ -745,24 +739,22 @@ public class TestStorageContainerManager {
       // Ratis group with cluster id exists now
       validateRatisGroupExists(conf, clusterId);
       SCMStorageConfig scmStore = new SCMStorageConfig(conf);
-      Assert.assertTrue(scmStore.isSCMHAEnabled());
+      assertTrue(scmStore.isSCMHAEnabled());
     } finally {
       cluster.shutdown();
     }
   }
 
   @Test
-  public void testSCMInitializationFailure()
-      throws IOException, AuthenticationException {
+  void testSCMInitializationFailure() {
     OzoneConfiguration conf = new OzoneConfiguration();
     final String path =
         GenericTestUtils.getTempPath(UUID.randomUUID().toString());
     Path scmPath = Paths.get(path, "scm-meta");
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, scmPath.toString());
-    exception.expect(SCMException.class);
-    exception.expectMessage(
-        "SCM not initialized due to storage config failure");
-    HddsTestUtils.getScmSimple(conf);
+
+    Exception e = assertThrows(SCMException.class, () -> HddsTestUtils.getScmSimple(conf));
+    assertThat(e).hasMessageContaining("SCM not initialized due to storage config failure");
   }
 
   @Test
@@ -783,12 +775,12 @@ public class TestStorageContainerManager {
       StorageContainerManager scm = HddsTestUtils.getScmSimple(conf);
       //Reads the SCM Info from SCM instance
       ScmInfo scmInfo = scm.getClientProtocolServer().getScmInfo();
-      Assert.assertEquals(clusterId, scmInfo.getClusterId());
-      Assert.assertEquals(scmId, scmInfo.getScmId());
+      assertEquals(clusterId, scmInfo.getClusterId());
+      assertEquals(scmId, scmInfo.getScmId());
 
       String expectedVersion = HddsVersionInfo.HDDS_VERSION_INFO.getVersion();
       String actualVersion = scm.getSoftwareVersion();
-      Assert.assertEquals(expectedVersion, actualVersion);
+      assertEquals(expectedVersion, actualVersion);
     } finally {
       FileUtils.deleteQuietly(new File(path));
     }
@@ -826,14 +818,14 @@ public class TestStorageContainerManager {
       Thread.sleep(heartbeatCheckerIntervalMs * 2);
 
       List<DatanodeDetails> allNodes = scm.getScmNodeManager().getAllNodes();
-      Assert.assertEquals(datanodeNum, allNodes.size());
+      assertEquals(datanodeNum, allNodes.size());
       for (DatanodeDetails node : allNodes) {
         DatanodeInfo datanodeInfo = (DatanodeInfo) scm.getScmNodeManager()
             .getNodeByUuid(node.getUuidString());
-        Assert.assertTrue(datanodeInfo.getLastHeartbeatTime() > start);
-        Assert.assertEquals(datanodeInfo.getUuidString(),
+        assertTrue(datanodeInfo.getLastHeartbeatTime() > start);
+        assertEquals(datanodeInfo.getUuidString(),
             datanodeInfo.getNetworkName());
-        Assert.assertEquals("/rack1", datanodeInfo.getNetworkLocation());
+        assertEquals("/rack1", datanodeInfo.getNetworkLocation());
       }
     } finally {
       cluster.shutdown();
@@ -874,7 +866,7 @@ public class TestStorageContainerManager {
       StorageContainerManager scm = cluster.getStorageContainerManager();
       List<ContainerInfo> containers = cluster.getStorageContainerManager()
           .getContainerManager().getContainers();
-      Assert.assertNotNull(containers);
+      assertNotNull(containers);
       ContainerInfo selectedContainer = containers.iterator().next();
 
       // Stop processing HB
@@ -974,9 +966,9 @@ public class TestStorageContainerManager {
     eventQueue.fireEvent(SCMEvents.CONTAINER_REPORT, dndata);
     eventQueue.fireEvent(SCMEvents.CONTAINER_REPORT, dndata);
     eventQueue.fireEvent(SCMEvents.CONTAINER_REPORT, dndata);
-    Assert.assertTrue(containerReportExecutors.droppedEvents() > 1);
+    assertTrue(containerReportExecutors.droppedEvents() > 1);
     Thread.currentThread().sleep(1000);
-    Assert.assertEquals(containerReportExecutors.droppedEvents()
+    assertEquals(containerReportExecutors.droppedEvents()
             + containerReportExecutors.scheduledEvents(),
         containerReportExecutors.queuedEvents());
     containerReportExecutors.close();
@@ -1031,8 +1023,8 @@ public class TestStorageContainerManager {
         = new ContainerReportFromDatanode(dn, report);
     eventQueue.fireEvent(SCMEvents.CONTAINER_REPORT, dndata2);
     semaphore.acquire(2);
-    Assert.assertTrue(containerReportExecutors.longWaitInQueueEvents() >= 1);
-    Assert.assertTrue(containerReportExecutors.longTimeExecutionEvents() >= 1);
+    assertTrue(containerReportExecutors.longWaitInQueueEvents() >= 1);
+    assertTrue(containerReportExecutors.longTimeExecutionEvents() >= 1);
     containerReportExecutors.close();
     semaphore.release(2);
   }
@@ -1075,9 +1067,9 @@ public class TestStorageContainerManager {
     eventQueue.fireEvent(SCMEvents.INCREMENTAL_CONTAINER_REPORT, dndata);
     eventQueue.fireEvent(SCMEvents.INCREMENTAL_CONTAINER_REPORT, dndata);
     eventQueue.fireEvent(SCMEvents.INCREMENTAL_CONTAINER_REPORT, dndata);
-    Assert.assertEquals(0, containerReportExecutors.droppedEvents());
+    assertEquals(0, containerReportExecutors.droppedEvents());
     Thread.currentThread().sleep(3000);
-    Assert.assertEquals(containerReportExecutors.scheduledEvents(),
+    assertEquals(containerReportExecutors.scheduledEvents(),
         containerReportExecutors.queuedEvents());
     containerReportExecutors.close();
   }
@@ -1095,8 +1087,8 @@ public class TestStorageContainerManager {
         .build()) {
       final StorageContainerManager nonRatisSCM = cluster
           .getStorageContainerManager();
-      Assert.assertNull(nonRatisSCM.getScmHAManager().getRatisServer());
-      Assert.assertFalse(nonRatisSCM.getScmStorageConfig().isSCMHAEnabled());
+      assertNull(nonRatisSCM.getScmHAManager().getRatisServer());
+      assertFalse(nonRatisSCM.getScmStorageConfig().isSCMHAEnabled());
       nonRatisSCM.stop();
       nonRatisSCM.join();
 
@@ -1107,8 +1099,8 @@ public class TestStorageContainerManager {
 
       final StorageContainerManager ratisSCM = cluster
           .getStorageContainerManager();
-      Assert.assertNotNull(ratisSCM.getScmHAManager().getRatisServer());
-      Assert.assertTrue(ratisSCM.getScmStorageConfig().isSCMHAEnabled());
+      assertNotNull(ratisSCM.getScmHAManager().getRatisServer());
+      assertTrue(ratisSCM.getScmStorageConfig().isSCMHAEnabled());
 
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHelper.java
@@ -50,22 +50,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
 
 /**
  * A helper class used by {@link TestStorageContainerManager} to generate
  * some keys and helps to verify containers and blocks locations.
  */
 public class TestStorageContainerManagerHelper {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   private final MiniOzoneCluster cluster;
   private final OzoneConfiguration conf;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate integration tests not covered by HDDS-9835 to JUnit5.

https://issues.apache.org/jira/browse/HDDS-10049

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7389637226