### PR TITLE
HDDS-10003. [hsync] Cache serialized block token in output stream to reduce heap consumption

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -131,6 +131,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
   //number of buffers used before doing a flush/putBlock.
   private int flushPeriod;
   private final Token<? extends TokenIdentifier> token;
+  private final String tokenString;
   private final DataStreamOutput out;
   private CompletableFuture<DataStreamReply> dataStreamCloseReply;
   private List<CompletableFuture<DataStreamReply>> futures = new ArrayList<>();
@@ -168,6 +169,8 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
     this.xceiverClient =
         (XceiverClientRatis)xceiverClientManager.acquireClient(pipeline, true);
     this.token = token;
+    this.tokenString = (this.token == null) ? null :
+        this.token.encodeToUrlString();
     // Alternatively, stream setup can be delayed till the first chunk write.
     this.out = setupStream(pipeline);
     this.bufferList = bufferList;
@@ -207,8 +210,8 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
             .setContainerID(blockID.get().getContainerID())
             .setDatanodeUuid(id).setWriteChunk(writeChunkRequest);
 
-    if (token != null) {
-      builder.setEncodedToken(token.encodeToUrlString());
+    if (tokenString != null) {
+      builder.setEncodedToken(tokenString);
     }
 
     ContainerCommandRequestMessage message =
@@ -420,7 +423,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
     if (close) {
       final ContainerCommandRequestProto putBlockRequest
           = ContainerProtocolCalls.getPutBlockRequest(
-              xceiverClient.getPipeline(), blockData, true, token);
+              xceiverClient.getPipeline(), blockData, true, tokenString);
       dataStreamCloseReply = executePutBlockClose(putBlockRequest,
           PUT_BLOCK_REQUEST_LENGTH_MAX, out);
       dataStreamCloseReply.whenComplete((reply, e) -> {
@@ -437,7 +440,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
 
     try {
       XceiverClientReply asyncReply =
-          putBlockAsync(xceiverClient, blockData, close, token);
+          putBlockAsync(xceiverClient, blockData, close, tokenString);
       final CompletableFuture<ContainerCommandResponseProto> flushFuture
           = asyncReply.getResponse().thenApplyAsync(e -> {
             try {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -167,7 +167,7 @@ public class BlockOutputStream extends OutputStream {
     this.xceiverClient = xceiverClientManager.acquireClient(pipeline);
     this.bufferPool = bufferPool;
     this.token = token;
-    this.tokenString = (this.token == null) ? null:
+    this.tokenString = (this.token == null) ? null :
         this.token.encodeToUrlString();
 
     //number of buffers used before doing a flush

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -124,6 +124,7 @@ public class BlockOutputStream extends OutputStream {
   //current buffer allocated to write
   private ChunkBuffer currentBuffer;
   private final Token<? extends TokenIdentifier> token;
+  private final String tokenString;
   private int replicationIndex;
   private Pipeline pipeline;
   private final ContainerClientMetrics clientMetrics;
@@ -166,6 +167,7 @@ public class BlockOutputStream extends OutputStream {
     this.xceiverClient = xceiverClientManager.acquireClient(pipeline);
     this.bufferPool = bufferPool;
     this.token = token;
+    this.tokenString = this.token.encodeToUrlString();
 
     //number of buffers used before doing a flush
     refreshCurrentBuffer();
@@ -466,7 +468,7 @@ public class BlockOutputStream extends OutputStream {
     try {
       BlockData blockData = containerBlockData.build();
       XceiverClientReply asyncReply =
-          putBlockAsync(xceiverClient, blockData, close, token);
+          putBlockAsync(xceiverClient, blockData, close, tokenString);
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future =
           asyncReply.getResponse();
       flushFuture = future.thenApplyAsync(e -> {
@@ -724,7 +726,7 @@ public class BlockOutputStream extends OutputStream {
 
     try {
       XceiverClientReply asyncReply = writeChunkAsync(xceiverClient, chunkInfo,
-          blockID.get(), data, token, replicationIndex);
+          blockID.get(), data, tokenString, replicationIndex);
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
           respFuture = asyncReply.getResponse();
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto>

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -247,8 +247,8 @@ public class BlockOutputStream extends OutputStream {
     return this.pipeline;
   }
 
-  Token<? extends TokenIdentifier> getToken() {
-    return this.token;
+  protected String getTokenString() {
+    return this.tokenString;
   }
 
   ExecutorService getResponseExecutor() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -167,7 +167,8 @@ public class BlockOutputStream extends OutputStream {
     this.xceiverClient = xceiverClientManager.acquireClient(pipeline);
     this.bufferPool = bufferPool;
     this.token = token;
-    this.tokenString = this.token.encodeToUrlString();
+    this.tokenString = (this.token == null) ? null:
+        this.token.encodeToUrlString();
 
     //number of buffers used before doing a flush
     refreshCurrentBuffer();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -228,7 +228,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
     try {
       ContainerProtos.BlockData blockData = getContainerBlockData().build();
       XceiverClientReply asyncReply =
-          putBlockAsync(getXceiverClient(), blockData, close, getToken());
+          putBlockAsync(getXceiverClient(), blockData, close, getTokenString());
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future =
           asyncReply.getResponse();
       flushFuture = future.thenApplyAsync(e -> {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -248,52 +248,14 @@ public final class ContainerProtocolCalls  {
    *
    * @param xceiverClient client to perform call
    * @param containerBlockData block data to identify container
-   * @param token a token for this block (may be null)
-   * @return putBlockResponse
-   * @throws IOException if there is an I/O error while performing the call
-   */
-  public static ContainerProtos.PutBlockResponseProto putBlock(
-      XceiverClientSpi xceiverClient, BlockData containerBlockData,
-      Token<OzoneBlockTokenIdentifier> token)
-      throws IOException {
-    PutBlockRequestProto.Builder createBlockRequest =
-        PutBlockRequestProto.newBuilder().setBlockData(containerBlockData);
-    String id = xceiverClient.getPipeline().getFirstNode().getUuidString();
-    ContainerCommandRequestProto.Builder builder =
-        ContainerCommandRequestProto.newBuilder().setCmdType(Type.PutBlock)
-            .setContainerID(containerBlockData.getBlockID().getContainerID())
-            .setDatanodeUuid(id)
-            .setPutBlock(createBlockRequest);
-    if (token != null) {
-      builder.setEncodedToken(token.encodeToUrlString());
-    }
-    ContainerCommandRequestProto request = builder.build();
-    ContainerCommandResponseProto response =
-        xceiverClient.sendCommand(request, getValidatorList());
-    return response.getPutBlock();
-  }
-
-  /**
-   * Calls the container protocol to put a container block.
-   *
-   * @param xceiverClient client to perform call
-   * @param containerBlockData block data to identify container
    * @param eof whether this is the last putBlock for the same block
-   * @param token a token for this block (may be null)
+   * @param tokenString a serialized token for this block (may be null)
    * @return putBlockResponse
    * @throws IOException if there is an error while performing the call
    */
-  public static XceiverClientReply putBlockAsync(XceiverClientSpi xceiverClient,
-      BlockData containerBlockData, boolean eof,
-      Token<? extends TokenIdentifier> token)
-      throws IOException, InterruptedException, ExecutionException {
-    final ContainerCommandRequestProto request = getPutBlockRequest(
-        xceiverClient.getPipeline(), containerBlockData, eof, token);
-    return xceiverClient.sendCommandAsync(request);
-  }
-
   static XceiverClientReply putBlockAsync(XceiverClientSpi xceiverClient,
-                                                 BlockData containerBlockData, boolean eof,
+                                                 BlockData containerBlockData,
+                                                 boolean eof,
                                                  String tokenString)
       throws IOException, InterruptedException, ExecutionException {
     final ContainerCommandRequestProto request = getPutBlockRequest(
@@ -316,25 +278,6 @@ public final class ContainerProtocolCalls  {
             .setPutBlock(createBlockRequest);
     if (tokenString != null) {
       builder.setEncodedToken(tokenString);
-    }
-    return builder.build();
-  }
-
-  public static ContainerCommandRequestProto getPutBlockRequest(
-      Pipeline pipeline, BlockData containerBlockData, boolean eof,
-      Token<? extends TokenIdentifier> token) throws IOException {
-    PutBlockRequestProto.Builder createBlockRequest =
-        PutBlockRequestProto.newBuilder()
-            .setBlockData(containerBlockData)
-            .setEof(eof);
-    final String id = pipeline.getFirstNode().getUuidString();
-    ContainerCommandRequestProto.Builder builder =
-        ContainerCommandRequestProto.newBuilder().setCmdType(Type.PutBlock)
-            .setContainerID(containerBlockData.getBlockID().getContainerID())
-            .setDatanodeUuid(id)
-            .setPutBlock(createBlockRequest);
-    if (token != null) {
-      builder.setEncodedToken(token.encodeToUrlString());
     }
     return builder.build();
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -253,7 +253,7 @@ public final class ContainerProtocolCalls  {
    * @return putBlockResponse
    * @throws IOException if there is an error while performing the call
    */
-  static XceiverClientReply putBlockAsync(XceiverClientSpi xceiverClient,
+  public static XceiverClientReply putBlockAsync(XceiverClientSpi xceiverClient,
                                                  BlockData containerBlockData,
                                                  boolean eof,
                                                  String tokenString)

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -408,9 +408,19 @@ public final class ContainerProtocolCalls  {
     }
   }
 
-  private static ContainerCommandRequestProto.Builder writeChunkAsyncCommon(
+  /**
+   * Calls the container protocol to write a chunk.
+   *
+   * @param xceiverClient client to perform call
+   * @param chunk information about chunk to write
+   * @param blockID ID of the block
+   * @param data the data of the chunk to write
+   * @param tokenString serialized block token
+   * @throws IOException if there is an I/O error while performing the call
+   */
+  public static XceiverClientReply writeChunkAsync(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
-      ByteString data, int replicationIndex)
+      ByteString data, String tokenString, int replicationIndex)
       throws IOException, ExecutionException, InterruptedException {
     WriteChunkRequestProto.Builder writeChunkRequest =
         WriteChunkRequestProto.newBuilder()
@@ -430,47 +440,6 @@ public final class ContainerProtocolCalls  {
             .setDatanodeUuid(id)
             .setWriteChunk(writeChunkRequest);
 
-    return builder;
-
-  }
-
-  /**
-   * Calls the container protocol to write a chunk.
-   *
-   * @param xceiverClient client to perform call
-   * @param chunk information about chunk to write
-   * @param blockID ID of the block
-   * @param data the data of the chunk to write
-   * @param token token
-   * @throws IOException if there is an I/O error while performing the call
-   */
-  public static XceiverClientReply writeChunkAsync(
-      XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
-      ByteString data, Token<? extends TokenIdentifier> token,
-      int replicationIndex, BlockData blockData
-  )
-      throws IOException, ExecutionException, InterruptedException {
-
-    ContainerCommandRequestProto.Builder builder =
-        writeChunkAsyncCommon(xceiverClient, chunk, blockID, data,
-            replicationIndex);
-    if (token != null) {
-      builder.setEncodedToken(token.encodeToUrlString());
-    }
-    ContainerCommandRequestProto request = builder.build();
-    return xceiverClient.sendCommandAsync(request);
-  }
-
-  public static XceiverClientReply writeChunkAsync(
-      XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
-      ByteString data, String tokenString,
-      int replicationIndex, BlockData blockData
-  )
-      throws IOException, ExecutionException, InterruptedException {
-
-    ContainerCommandRequestProto.Builder builder =
-        writeChunkAsyncCommon(xceiverClient, chunk, blockID, data,
-            replicationIndex);
     if (tokenString != null) {
       builder.setEncodedToken(tokenString);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Block token is serialized for every output stream client request. Cache it to avoid the waste.

Please describe your PR in detail:
The profiler report found that a noticeable amount of heap allocation is attributed to block token serialization. Because the block token is never updated, we can cache the serialized block token once and it use it repeatedly.

The change is applicable in both WriteChunk and PutBlock request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10003

## How was this patch tested?

Verified on a real cluster that the heap allocation is removed.