### PR TITLE
HDDS-10054. Reduce DataNode token verification heap allocation cost.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenIdentifier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenIdentifier.java
@@ -81,16 +81,17 @@ public class ContainerTokenIdentifier extends ShortLivedTokenIdentifier {
     }
     ContainerTokenSecretProto proto =
         ContainerTokenSecretProto.parseFrom((DataInputStream) in);
-    setSecretKeyId(ProtobufUtils.fromProtobuf(proto.getSecretKeyId()));
-    setExpiry(Instant.ofEpochMilli(proto.getExpiryDate()));
-    setOwnerId(proto.getOwnerId());
-    this.containerID = ContainerID.getFromProtobuf(proto.getContainerId());
+    readFromProto(proto);
   }
 
   @Override
   public void readFromByteArray(byte[] bytes) throws IOException {
     ContainerTokenSecretProto proto =
         ContainerTokenSecretProto.parseFrom(bytes);
+    readFromProto(proto);
+  }
+
+  private void readFromProto(ContainerTokenSecretProto proto) {
     setSecretKeyId(ProtobufUtils.fromProtobuf(proto.getSecretKeyId()));
     setExpiry(Instant.ofEpochMilli(proto.getExpiryDate()));
     setOwnerId(proto.getOwnerId());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenIdentifier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenIdentifier.java
@@ -64,13 +64,18 @@ public class ContainerTokenIdentifier extends ShortLivedTokenIdentifier {
 
   @Override
   public void write(DataOutput out) throws IOException {
+    out.write(getBytes());
+  }
+
+  @Override
+  public byte[] getBytes() {
     ContainerTokenSecretProto.Builder builder = ContainerTokenSecretProto
         .newBuilder()
         .setOwnerId(getOwnerId())
         .setSecretKeyId(ProtobufUtils.toProtobuf(getSecretKeyId()))
         .setExpiryDate(getExpiry().toEpochMilli())
         .setContainerId(containerID.getProtobuf());
-    out.write(builder.build().toByteArray());
+    return builder.build().toByteArray();
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenIdentifier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenIdentifier.java
@@ -88,6 +88,16 @@ public class ContainerTokenIdentifier extends ShortLivedTokenIdentifier {
   }
 
   @Override
+  public void readFromByteArray(byte[] bytes) throws IOException {
+    ContainerTokenSecretProto proto =
+        ContainerTokenSecretProto.parseFrom(bytes);
+    setSecretKeyId(ProtobufUtils.fromProtobuf(proto.getSecretKeyId()));
+    setExpiry(Instant.ofEpochMilli(proto.getExpiryDate()));
+    setOwnerId(proto.getOwnerId());
+    this.containerID = ContainerID.getFromProtobuf(proto.getContainerId());
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/OzoneBlockTokenIdentifier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/OzoneBlockTokenIdentifier.java
@@ -133,18 +133,17 @@ public class OzoneBlockTokenIdentifier extends ShortLivedTokenIdentifier {
     }
     BlockTokenSecretProto token =
         BlockTokenSecretProto.parseFrom((DataInputStream) in);
-    setOwnerId(token.getOwnerId());
-    setExpiry(Instant.ofEpochMilli(token.getExpiryDate()));
-    setSecretKeyId(ProtobufUtils.fromProtobuf(token.getSecretKeyId()));
-    this.blockId = token.getBlockId();
-    this.modes = EnumSet.copyOf(token.getModesList());
-    this.maxLength = token.getMaxLength();
+    readFromProto(token);
   }
 
   @Override
   public void readFromByteArray(byte[] bytes) throws IOException {
     BlockTokenSecretProto token =
         BlockTokenSecretProto.parseFrom(bytes);
+    readFromProto(token);
+  }
+
+  private void readFromProto(BlockTokenSecretProto token) {
     setOwnerId(token.getOwnerId());
     setExpiry(Instant.ofEpochMilli(token.getExpiryDate()));
     setSecretKeyId(ProtobufUtils.fromProtobuf(token.getSecretKeyId()));

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/OzoneBlockTokenIdentifier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/OzoneBlockTokenIdentifier.java
@@ -168,17 +168,7 @@ public class OzoneBlockTokenIdentifier extends ShortLivedTokenIdentifier {
 
   @Override
   public void write(DataOutput out) throws IOException {
-    BlockTokenSecretProto.Builder builder = BlockTokenSecretProto.newBuilder()
-        .setBlockId(blockId)
-        .setOwnerId(getOwnerId())
-        .setSecretKeyId(ProtobufUtils.toProtobuf(getSecretKeyId()))
-        .setExpiryDate(getExpiryDate())
-        .setMaxLength(maxLength);
-    // Add access mode allowed
-    for (AccessModeProto mode : modes) {
-      builder.addModes(AccessModeProto.valueOf(mode.name()));
-    }
-    out.write(builder.build().toByteArray());
+    out.write(getBytes());
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenIdentifier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenIdentifier.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.TokenIdentifier;
 
+import java.io.DataInput;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
@@ -82,6 +84,8 @@ public abstract class ShortLivedTokenIdentifier extends TokenIdentifier {
   public UUID getSecretKeyId() {
     return secretKeyId;
   }
+
+  public abstract void readFromByteArray(byte[] bytes) throws IOException;
 
   @Override
   public boolean equals(Object o) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenIdentifier.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenIdentifier.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.TokenIdentifier;
 
-import java.io.DataInput;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Objects;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenVerifier.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenVerifier.java
@@ -23,14 +23,10 @@ import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.symmetric.ManagedSecretKey;
 import org.apache.hadoop.hdds.security.symmetric.SecretKeyVerifierClient;
-import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Objects;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenVerifier.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenVerifier.java
@@ -23,12 +23,14 @@ import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.symmetric.ManagedSecretKey;
 import org.apache.hadoop.hdds.security.symmetric.SecretKeyVerifierClient;
+import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -75,8 +77,7 @@ public abstract class
 
     T tokenId = createTokenIdentifier();
     try {
-      tokenId.readFields(new DataInputStream(new ByteArrayInputStream(
-          token.getIdentifier())));
+      tokenId.readFromByteArray(token.getIdentifier());
     } catch (IOException ex) {
       throw new BlockTokenException("Failed to decode token : " + token);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove unnecessary heap allocation associated with block token verification in DataNode.

Please describe your PR in detail:
Rewrite part of token verification code to use the underlying byte array directly. Avoid certain input/output stream objects that internally allocates sizable heap (4KB) each.

(I wanted to get rid of or optimize Token.decodeFromUrlString too, because BaseNCodec.ensureBufferSize allocates a 8192 byte buffer, which is overkill for this use case. This is another 1.x% overhead but I haven't find a way to remove it)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10054

## How was this patch tested?

Ran with freon hsync workload and verified the change does remove heap allocation using profiler.