### PR TITLE
HDDS-9927. Ozone List keys CLI should co-ordinate between max limit and listCache Size.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -301,6 +301,10 @@ public class OzoneBucket extends WithMetadata {
     return owner;
   }
 
+  public int getListCacheSize() {
+    return listCacheSize;
+  }
+
   /**
    * Builder for OmBucketInfo.
   /**
@@ -403,6 +407,10 @@ public class OzoneBucket extends WithMetadata {
   public void setReplicationConfig(ReplicationConfig replicationConfig)
       throws IOException {
     proxy.setReplicationConfig(volumeName, name, replicationConfig);
+  }
+
+  public void setListCacheSize(int listCacheSize) {
+    this.listCacheSize = listCacheSize;
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
@@ -77,10 +77,13 @@ public class ListKeyHandler extends VolumeBucketHandler {
 
     OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = vol.getBucket(bucketName);
+    int maxKeyLimit = listOptions.getLimit();
+    if (maxKeyLimit < bucket.getListCacheSize()) {
+      bucket.setListCacheSize(maxKeyLimit);
+    }
     Iterator<? extends OzoneKey> keyIterator = bucket.listKeys(
         keyPrefix, listOptions.getStartItem());
 
-    int maxKeyLimit = listOptions.getLimit();
     int counter = printAsJsonArray(keyIterator, maxKeyLimit);
 
     // More keys were returned notify about max length


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ozone List keys CLI should co-ordinate between max limit and listCache Size. 

The client should only ask the OM the user requested amount of keys (if maxLimit is set) however currently even though user requests say 10 keys (maxLimit=10), OM will give out 1000 keys (as maxCacheLimit=1000) and then while printing we only print the 10 keys. We can reduce this small performance overhead by only requesting maxLimit from OM which this PR intends to do.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9927

## How was this patch tested?
Manual