### PR TITLE
HDDS-10056. Silent failure in unit check

### DIFF
--- a/hadoop-hdds/annotations/pom.xml
+++ b/hadoop-hdds/annotations/pom.xml
@@ -30,4 +30,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </description>
   <name>Apache Ozone Annotation Processing</name>
   <packaging>jar</packaging>
+
+  <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+  </properties>
 </project>

--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -29,6 +29,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <packaging>jar</packaging>
 
   <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
     <skipDocs>false</skipDocs>
   </properties>
 

--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Hadoop Client dependencies</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no tests in this module -->
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Hadoop Server dependencies</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no tests in this module -->
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-hdds/hadoop-dependency-test/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-test/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Hadoop Test dependencies</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no tests in this module -->
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Admin Interface</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Client Interface</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -29,6 +29,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone HDDS Server Interface</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/hadoop-hdds/managed-rocksdb/pom.xml
+++ b/hadoop-hdds/managed-rocksdb/pom.xml
@@ -27,6 +27,10 @@
   <name>Apache Ozone HDDS Managed RocksDB</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -67,7 +67,7 @@ for i in $(seq 1 ${ITERATIONS}); do
 
   # shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
   source "${DIR}/_mvn_unit_report.sh"
-  if [[ ${irc} == 0 ]] && [[ -s "${REPORT_FILE}" ]]; then
+  if [[ ${irc} == 0 ]] && [[ -s "${REPORT_DIR}/summary.txt" ]]; then
     irc=1
   fi
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-10013 removed dependency on `junit` from modules which do not have tests.  Now `unit` check finishes with success in 1 minute instead of running unit tests:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project hdds-annotation-processing: groups/excludedGroups require TestNG, JUnit48+ or JUnit 5 (a specific engine required on classpath) on project test classpath -> [Help 1]
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project hdds-hadoop-dependency-client: groups/excludedGroups require TestNG, JUnit48+ or JUnit 5 (a specific engine required on classpath) on project test classpath -> [Help 1]
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project hdds-hadoop-dependency-server: groups/excludedGroups require TestNG, JUnit48+ or JUnit 5 (a specific engine required on classpath) on project test classpath -> [Help 1]
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project hdds-interface-client: groups/excludedGroups require TestNG, JUnit48+ or JUnit 5 (a specific engine required on classpath) on project test classpath -> [Help 1]
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project hdds-docs: groups/excludedGroups require TestNG, JUnit48+ or JUnit 5 (a specific engine required on classpath) on project test classpath -> [Help 1]
```

This change adds `maven.test.skip=true` in such modules to prevent the problem.

It also tweaks `junit.sh` (run by `unit` check) to look for errors other than test failures in Maven output to avoid silent failure of the check.

https://issues.apache.org/jira/browse/HDDS-10056

## How was this patch tested?

Ran `unit` check locally (restricted to a single test for quick results):

```
$ hadoop-ozone/dev-support/checks/unit.sh -Dtest='TestOzoneManagerDoubleBufferWithOMResponse'
```

Also verified that the fix in `junit.sh` without the POM changes catches the failure:

```
$ hadoop-ozone/dev-support/checks/unit.sh -Dtest='TestOzoneManagerDoubleBufferWithOMResponse' > /dev/null 2>&1
$ echo $?
1
$ bash hadoop-ozone/dev-support/checks/_summary.sh target/unit/summary.txt
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project hdds-annotation-processing: groups/excludedGroups require TestNG, JUnit48+ or JUnit 5 (a specific engine required on classpath) on project test classpath -> [Help 1]
$ echo $?
1
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7395145245/job/20117969381