### PR TITLE
HDDS-9993. Add static import for assertions and mocks in hdds-server-scm

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,8 +53,10 @@ import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProt
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageTypeProto.DISK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -83,7 +84,7 @@ public class TestSCMCommonPlacementPolicy {
     List<DatanodeDetails> list = nodeManager.getAllNodes();
     List<DatanodeDetails> result = dummyPlacementPolicy.getResultSet(3, list);
     Set<DatanodeDetails> resultSet = new HashSet<>(result);
-    Assertions.assertNotEquals(1, resultSet.size());
+    assertNotEquals(1, resultSet.size());
   }
 
   private Set<ContainerReplica> testReplicasToFixMisreplication(
@@ -104,7 +105,7 @@ public class TestSCMCommonPlacementPolicy {
           Map<Node, Integer> expectedNumberOfCopyOperationFromRack) {
     Set<ContainerReplica> replicasToCopy = placementPolicy
             .replicasToCopyToFixMisreplication(replicas);
-    Assertions.assertEquals(expectedNumberOfReplicasToCopy,
+    assertEquals(expectedNumberOfReplicasToCopy,
             replicasToCopy.size());
     Map<Node, Long> rackCopyMap =
             replicasToCopy.stream().collect(Collectors.groupingBy(
@@ -116,7 +117,7 @@ public class TestSCMCommonPlacementPolicy {
             .map(placementPolicy::getPlacementGroup)
             .collect(Collectors.toSet());
     for (Node rack: racks) {
-      Assertions.assertEquals(
+      assertEquals(
               expectedNumberOfCopyOperationFromRack.getOrDefault(rack, 0),
               rackCopyMap.getOrDefault(rack, 0L).intValue());
     }
@@ -278,7 +279,7 @@ public class TestSCMCommonPlacementPolicy {
     Map<ContainerReplica, Boolean> replicaMap = replicas.stream().distinct()
             .collect(Collectors.toMap(Function.identity(), r -> false));
     replicaMap.put(replicas.get(0), true);
-    Assertions.assertEquals(testReplicasToFixMisreplication(replicaMap,
+    assertEquals(testReplicasToFixMisreplication(replicaMap,
             dummyPlacementPolicy, 1,
             ImmutableMap.of(racks.get(0), 1)),
             Sets.newHashSet(replicas.get(0)));
@@ -298,7 +299,7 @@ public class TestSCMCommonPlacementPolicy {
                     .collect(Collectors.toMap(Function.identity(), r -> true));
     Set<ContainerReplica> replicasToCopy = dummyPlacementPolicy
             .replicasToCopyToFixMisreplication(replicas);
-    Assertions.assertEquals(0, replicasToCopy.size());
+    assertEquals(0, replicasToCopy.size());
   }
 
   @Test
@@ -318,8 +319,8 @@ public class TestSCMCommonPlacementPolicy {
 
     Set<ContainerReplica> replicasToRemove = dummyPlacementPolicy
             .replicasToRemoveToFixOverreplication(replicas, 1);
-    Assertions.assertEquals(replicasToRemove.size(), 1);
-    Assertions.assertEquals(replicasToRemove.toArray()[0], replica);
+    assertEquals(1, replicasToRemove.size());
+    assertEquals(replicasToRemove.toArray()[0], replica);
   }
 
   @Test
@@ -339,8 +340,8 @@ public class TestSCMCommonPlacementPolicy {
 
     Set<ContainerReplica> replicasToRemove = dummyPlacementPolicy
             .replicasToRemoveToFixOverreplication(replicas, 1);
-    Assertions.assertEquals(replicasToRemove.size(), 2);
-    Assertions.assertEquals(replicasToRemove, replicasToBeRemoved);
+    assertEquals(2, replicasToRemove.size());
+    assertEquals(replicasToRemove, replicasToBeRemoved);
   }
 
   @Test
@@ -365,8 +366,8 @@ public class TestSCMCommonPlacementPolicy {
 
     Set<ContainerReplica> replicasToRemove = dummyPlacementPolicy
             .replicasToRemoveToFixOverreplication(replicas, 2);
-    Assertions.assertEquals(replicasToRemove.size(), 2);
-    Assertions.assertEquals(replicasToRemove, replicasToBeRemoved);
+    assertEquals(2, replicasToRemove.size());
+    assertEquals(replicasToRemove, replicasToBeRemoved);
   }
 
   @Test
@@ -380,10 +381,10 @@ public class TestSCMCommonPlacementPolicy {
 
     Set<ContainerReplica> replicasToRemove = dummyPlacementPolicy
             .replicasToRemoveToFixOverreplication(replicas, 3);
-    Assertions.assertEquals(replicasToRemove.size(), 2);
+    assertEquals(2, replicasToRemove.size());
     Set<Node> racksToBeRemoved = Arrays.asList(0, 1).stream()
             .map(dummyPlacementPolicy.racks::get).collect(Collectors.toSet());
-    Assertions.assertEquals(replicasToRemove.stream()
+    assertEquals(replicasToRemove.stream()
             .map(ContainerReplica::getDatanodeDetails)
             .map(dummyPlacementPolicy::getPlacementGroup)
             .collect(Collectors.toSet()), racksToBeRemoved);
@@ -419,10 +420,10 @@ public class TestSCMCommonPlacementPolicy {
             .map(dummyPlacementPolicy::getPlacementGroup)
             .collect(Collectors.groupingBy(Function.identity(),
                     Collectors.counting()));
-    Assertions.assertEquals(replicasToRemove.size(), 2);
+    assertEquals(2, replicasToRemove.size());
     assertThat(Sets.newHashSet(1L, 2L)).contains(
             removedReplicasRackCntMap.get(dummyPlacementPolicy.racks.get(0)));
-    Assertions.assertEquals(
+    assertEquals(
             removedReplicasRackCntMap.get(dummyPlacementPolicy.racks.get(1)),
             removedReplicasRackCntMap.get(dummyPlacementPolicy.racks.get(0))
                     == 2 ? 0 : 1);
@@ -439,7 +440,7 @@ public class TestSCMCommonPlacementPolicy {
 
     Set<ContainerReplica> replicasToRemove = dummyPlacementPolicy
             .replicasToRemoveToFixOverreplication(replicas, 1);
-    Assertions.assertEquals(replicasToRemove.size(), 0);
+    assertEquals(replicasToRemove.size(), 0);
   }
 
   @Test
@@ -461,7 +462,7 @@ public class TestSCMCommonPlacementPolicy {
     dummyPlacementPolicy.chooseDatanodes(null, null, 1, 1, 1);
     assertFalse(usedNodesIdentity.get());
     dummyPlacementPolicy.chooseDatanodes(null, null, null, 1, 1, 1);
-    Assertions.assertTrue(usedNodesIdentity.get());
+    assertTrue(usedNodesIdentity.get());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -36,10 +36,11 @@ import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test http server os SCM with various HTTP option.
@@ -95,15 +96,15 @@ public class TestStorageContainerManagerHttpServer {
       server = new StorageContainerManagerHttpServer(conf, null);
       server.start();
 
-      Assertions.assertTrue(implies(policy.isHttpEnabled(),
+      assertTrue(implies(policy.isHttpEnabled(),
           canAccess("http", server.getHttpAddress())));
-      Assertions.assertTrue(implies(policy.isHttpEnabled() &&
+      assertTrue(implies(policy.isHttpEnabled() &&
               !policy.isHttpsEnabled(),
           !canAccess("https", server.getHttpsAddress())));
 
-      Assertions.assertTrue(implies(policy.isHttpsEnabled(),
+      assertTrue(implies(policy.isHttpsEnabled(),
           canAccess("https", server.getHttpsAddress())));
-      Assertions.assertTrue(implies(policy.isHttpsEnabled() &&
+      assertTrue(implies(policy.isHttpsEnabled() &&
               !policy.isHttpEnabled(),
           !canAccess("http", server.getHttpAddress())));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -83,7 +83,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.AfterEach;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -79,9 +79,14 @@ import org.apache.ozone.test.GenericTestUtils;
 
 import static org.apache.hadoop.ozone.OzoneConsts.GB;
 import static org.apache.hadoop.ozone.OzoneConsts.MB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -210,7 +215,7 @@ public class TestBlockManager {
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
     AllocatedBlock block = blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,
         replicationConfig, OzoneConsts.OZONE, new ExcludeList());
-    Assertions.assertNotNull(block);
+    assertNotNull(block);
   }
 
   @Test
@@ -229,9 +234,9 @@ public class TestBlockManager {
     AllocatedBlock block = blockManager
         .allocateBlock(DEFAULT_BLOCK_SIZE, replicationConfig, OzoneConsts.OZONE,
             excludeList);
-    Assertions.assertNotNull(block);
+    assertNotNull(block);
     for (PipelineID id : excludeList.getPipelineIds()) {
-      Assertions.assertNotEquals(block.getPipeline().getId(), id);
+      assertNotEquals(block.getPipeline().getId(), id);
     }
 
     for (Pipeline pipeline : pipelineManager.getPipelines(replicationConfig)) {
@@ -240,7 +245,7 @@ public class TestBlockManager {
     block = blockManager
         .allocateBlock(DEFAULT_BLOCK_SIZE, replicationConfig, OzoneConsts.OZONE,
             excludeList);
-    Assertions.assertNotNull(block);
+    assertNotNull(block);
     assertThat(excludeList.getPipelineIds()).contains(block.getPipeline().getId());
   }
 
@@ -274,7 +279,7 @@ public class TestBlockManager {
           .allOf(futureList.toArray(new CompletableFuture[futureList.size()]))
           .get();
     } catch (Exception e) {
-      Assertions.fail("testAllocateBlockInParallel failed");
+      fail("testAllocateBlockInParallel failed");
     }
   }
 
@@ -323,17 +328,14 @@ public class TestBlockManager {
       CompletableFuture.allOf(futureList.toArray(
           new CompletableFuture[0])).get();
 
-      Assertions.assertEquals(1,
-          pipelineManager.getPipelines(replicationConfig).size());
-      Assertions.assertEquals(numContainerPerOwnerInPipeline,
-          allocatedBlockMap.size());
-      Assertions.assertEquals(numContainerPerOwnerInPipeline,
-          allocatedBlockMap.values().size());
+      assertEquals(1, pipelineManager.getPipelines(replicationConfig).size());
+      assertEquals(numContainerPerOwnerInPipeline, allocatedBlockMap.size());
+      assertEquals(numContainerPerOwnerInPipeline, allocatedBlockMap.values().size());
       allocatedBlockMap.values().forEach(v -> {
-        Assertions.assertEquals(numContainerPerOwnerInPipeline, v.size());
+        assertEquals(numContainerPerOwnerInPipeline, v.size());
       });
     } catch (Exception e) {
-      Assertions.fail("testAllocateBlockInParallel failed");
+      fail("testAllocateBlockInParallel failed");
     }
   }
 
@@ -384,24 +386,21 @@ public class TestBlockManager {
       CompletableFuture
               .allOf(futureList.toArray(
                       new CompletableFuture[futureList.size()])).get();
-      Assertions.assertEquals(1,
+      assertEquals(1,
           pipelineManager.getPipelines(replicationConfig).size());
       Pipeline pipeline =
           pipelineManager.getPipelines(replicationConfig).get(0);
       // total no of containers to be created will be number of healthy
       // volumes * number of numContainerPerOwnerInPipeline which is equal to
       // the thread count
-      Assertions.assertEquals(threadCount, pipelineManager.
-              getNumberOfContainers(pipeline.getId()));
-      Assertions.assertEquals(threadCount,
-              allocatedBlockMap.size());
-      Assertions.assertEquals(threadCount, allocatedBlockMap.
-              values().size());
+      assertEquals(threadCount, pipelineManager.getNumberOfContainers(pipeline.getId()));
+      assertEquals(threadCount, allocatedBlockMap.size());
+      assertEquals(threadCount, allocatedBlockMap.values().size());
       allocatedBlockMap.values().forEach(v -> {
-        Assertions.assertEquals(1, v.size());
+        assertEquals(1, v.size());
       });
     } catch (Exception e) {
-      Assertions.fail("testAllocateBlockInParallel failed");
+      fail("testAllocateBlockInParallel failed");
     }
   }
 
@@ -452,7 +451,7 @@ public class TestBlockManager {
       CompletableFuture
           .allOf(futureList.toArray(
               new CompletableFuture[futureList.size()])).get();
-      Assertions.assertEquals(1,
+      assertEquals(1,
           pipelineManager.getPipelines(replicationConfig).size());
       Pipeline pipeline =
           pipelineManager.getPipelines(replicationConfig).get(0);
@@ -460,22 +459,22 @@ public class TestBlockManager {
       int numContainers = (int)Math.ceil((double)
               (numContainerPerOwnerInPipeline *
                   numContainerPerOwnerInPipeline) / numMetaDataVolumes);
-      Assertions.assertEquals(numContainers, pipelineManager.
+      assertEquals(numContainers, pipelineManager.
           getNumberOfContainers(pipeline.getId()));
-      Assertions.assertEquals(numContainers, allocatedBlockMap.size());
-      Assertions.assertEquals(numContainers, allocatedBlockMap.values().size());
+      assertEquals(numContainers, allocatedBlockMap.size());
+      assertEquals(numContainers, allocatedBlockMap.values().size());
     } catch (Exception e) {
-      Assertions.fail("testAllocateBlockInParallel failed");
+      fail("testAllocateBlockInParallel failed");
     }
   }
 
   @Test
   public void testAllocateOversizedBlock() {
     long size = 6 * GB;
-    Throwable t = Assertions.assertThrows(IOException.class, () ->
+    Throwable t = assertThrows(IOException.class, () ->
         blockManager.allocateBlock(size,
             replicationConfig, OzoneConsts.OZONE, new ExcludeList()));
-    Assertions.assertEquals("Unsupported block size: " + size,
+    assertEquals("Unsupported block size: " + size,
         t.getMessage());
   }
 
@@ -485,17 +484,17 @@ public class TestBlockManager {
     scm.getScmContext().updateSafeModeStatus(
         new SCMSafeModeManager.SafeModeStatus(true, true));
     // Test1: In safe mode expect an SCMException.
-    Throwable t = Assertions.assertThrows(IOException.class, () ->
+    Throwable t = assertThrows(IOException.class, () ->
         blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,
             replicationConfig, OzoneConsts.OZONE, new ExcludeList()));
-    Assertions.assertEquals("SafeModePrecheck failed for allocateBlock",
+    assertEquals("SafeModePrecheck failed for allocateBlock",
         t.getMessage());
   }
 
   @Test
   public void testAllocateBlockSucInSafeMode() throws Exception {
     // Test2: Exit safe mode and then try allocateBock again.
-    Assertions.assertNotNull(blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,
+    assertNotNull(blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,
         replicationConfig, OzoneConsts.OZONE, new ExcludeList()));
   }
 
@@ -604,9 +603,8 @@ public class TestBlockManager {
     for (Pipeline pipeline : pipelineManager.getPipelines()) {
       pipelineManager.closePipeline(pipeline, false);
     }
-    Assertions.assertEquals(0,
-        pipelineManager.getPipelines(replicationConfig).size());
-    Assertions.assertNotNull(blockManager
+    assertEquals(0, pipelineManager.getPipelines(replicationConfig).size());
+    assertNotNull(blockManager
         .allocateBlock(DEFAULT_BLOCK_SIZE, replicationConfig, OzoneConsts.OZONE,
             new ExcludeList()));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -59,7 +59,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,12 +79,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys
-    .OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 /**
@@ -118,16 +118,16 @@ public class TestDeletedBlockLog {
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     conf.setInt(OZONE_SCM_BLOCK_DELETION_MAX_RETRY, 20);
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testDir.getAbsolutePath());
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     SCMConfigurator configurator = new SCMConfigurator();
     configurator.setSCMHAManager(SCMHAManagerStub.getInstance(true));
     configurator.setReplicationManager(replicationManager);
     scm = HddsTestUtils.getScm(conf, configurator);
-    containerManager = Mockito.mock(ContainerManager.class);
+    containerManager = mock(ContainerManager.class);
     containerTable = scm.getScmMetadataStore().getContainerTable();
     scmHADBTransactionBuffer =
         new SCMHADBTransactionBufferStub(scm.getScmMetadataStore().getStore());
-    metrics = Mockito.mock(ScmBlockDeletingServiceMetrics.class);
+    metrics = mock(ScmBlockDeletingServiceMetrics.class);
     deletedBlockLog = new DeletedBlockLogImpl(conf,
         containerManager,
         scm.getScmHAManager().getRatisServer(),
@@ -390,13 +390,13 @@ public class TestDeletedBlockLog {
   }
 
   private void mockContainerHealthResult(Boolean healthy) {
-    ContainerInfo containerInfo = Mockito.mock(ContainerInfo.class);
+    ContainerInfo containerInfo = mock(ContainerInfo.class);
     ContainerHealthResult healthResult =
         new ContainerHealthResult.HealthyResult(containerInfo);
     if (!healthy) {
       healthResult = new ContainerHealthResult.UnHealthyResult(containerInfo);
     }
-    Mockito.doReturn(healthResult).when(replicationManager)
+    doReturn(healthResult).when(replicationManager)
         .getContainerReplicationHealth(any(), any());
   }
 
@@ -857,7 +857,7 @@ public class TestDeletedBlockLog {
         .setReplicationConfig(pipeline.getReplicationConfig());
 
     ContainerInfo containerInfo = builder.build();
-    Mockito.doReturn(containerInfo).when(containerManager)
+    doReturn(containerInfo).when(containerManager)
         .getContainer(ContainerID.valueOf(containerID));
 
     final Set<ContainerReplica> replicaSet = dns.stream()
@@ -889,7 +889,7 @@ public class TestDeletedBlockLog {
         .setReplicationConfig(pipeline.getReplicationConfig());
 
     ContainerInfo containerInfo = builder.build();
-    Mockito.doReturn(containerInfo).when(containerManager)
+    doReturn(containerInfo).when(containerManager)
         .getContainer(ContainerID.valueOf(containerID));
 
     final Set<ContainerReplica> replicaSet = dns.stream()
@@ -905,7 +905,7 @@ public class TestDeletedBlockLog {
     } else {
       healthResult = new ContainerHealthResult.HealthyResult(containerInfo);
     }
-    Mockito.doReturn(healthResult).when(replicationManager)
+    doReturn(healthResult).when(replicationManager)
         .getContainerReplicationHealth(containerInfo, replicaSet);
     when(containerManager.getContainerReplicas(
         ContainerID.valueOf(containerID)))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -84,8 +84,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -56,7 +56,6 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -80,6 +79,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyObject;
@@ -328,23 +328,23 @@ public class TestDeletedBlockLog {
   public void testContainerManagerTransactionId() throws Exception {
     // Initially all containers should have deleteTransactionId as 0
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
-      Assertions.assertEquals(0, containerInfo.getDeleteTransactionId());
+      assertEquals(0, containerInfo.getDeleteTransactionId());
     }
 
     // Create 30 TXs
     addTransactions(generateData(30), false);
     // Since transactions are not yet flushed deleteTransactionId should be
     // 0 for all containers
-    Assertions.assertEquals(0, getAllTransactions().size());
+    assertEquals(0, getAllTransactions().size());
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
-      Assertions.assertEquals(0, containerInfo.getDeleteTransactionId());
+      assertEquals(0, containerInfo.getDeleteTransactionId());
     }
 
     scmHADBTransactionBuffer.flush();
     // After flush there should be 30 transactions in deleteTable
     // All containers should have positive deleteTransactionId
     mockContainerHealthResult(true);
-    Assertions.assertEquals(30 * THREE, getAllTransactions().size());
+    assertEquals(30 * THREE, getAllTransactions().size());
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
       assertThat(containerInfo.getDeleteTransactionId()).isGreaterThan(0);
     }
@@ -362,10 +362,10 @@ public class TestDeletedBlockLog {
     List<DeletedBlocksTransaction> blocks = getAllTransactions();
     List<Long> txIDs = blocks.stream().map(DeletedBlocksTransaction::getTxID)
         .distinct().collect(Collectors.toList());
-    Assertions.assertEquals(30, txIDs.size());
+    assertEquals(30, txIDs.size());
 
     for (DeletedBlocksTransaction block : blocks) {
-      Assertions.assertEquals(0, block.getCount());
+      assertEquals(0, block.getCount());
     }
 
     for (int i = 0; i < maxRetry; i++) {
@@ -373,7 +373,7 @@ public class TestDeletedBlockLog {
     }
     blocks = getAllTransactions();
     for (DeletedBlocksTransaction block : blocks) {
-      Assertions.assertEquals(maxRetry, block.getCount());
+      assertEquals(maxRetry, block.getCount());
     }
 
     // Increment another time so it exceed the maxRetry.
@@ -381,12 +381,12 @@ public class TestDeletedBlockLog {
     incrementCount(txIDs);
     blocks = getAllTransactions();
     for (DeletedBlocksTransaction block : blocks) {
-      Assertions.assertEquals(-1, block.getCount());
+      assertEquals(-1, block.getCount());
     }
 
     // If all TXs are failed, getTransactions call will always return nothing.
     blocks = getAllTransactions();
-    Assertions.assertEquals(0, blocks.size());
+    assertEquals(0, blocks.size());
   }
 
   private void mockContainerHealthResult(Boolean healthy) {
@@ -422,18 +422,18 @@ public class TestDeletedBlockLog {
     incrementCount(txIDs);
     blocks = getAllTransactions();
     for (DeletedBlocksTransaction block : blocks) {
-      Assertions.assertEquals(-1, block.getCount());
+      assertEquals(-1, block.getCount());
     }
 
     // If all TXs are failed, getTransactions call will always return nothing.
     blocks = getAllTransactions();
-    Assertions.assertEquals(0, blocks.size());
+    assertEquals(0, blocks.size());
 
     // Reset the retry count, these transactions should be accessible.
     resetCount(txIDs);
     blocks = getAllTransactions();
     for (DeletedBlocksTransaction block : blocks) {
-      Assertions.assertEquals(0, block.getCount());
+      assertEquals(0, block.getCount());
     }
 
     // Increment for the reset transactions.
@@ -443,10 +443,10 @@ public class TestDeletedBlockLog {
     incrementCount(txIDs);
     blocks = getAllTransactions();
     for (DeletedBlocksTransaction block : blocks) {
-      Assertions.assertEquals(1, block.getCount());
+      assertEquals(1, block.getCount());
     }
 
-    Assertions.assertEquals(30 * THREE, blocks.size());
+    assertEquals(30 * THREE, blocks.size());
   }
 
   @Test
@@ -463,24 +463,24 @@ public class TestDeletedBlockLog {
     commitTransactions(blocks);
 
     blocks = getTransactions(50 * BLOCKS_PER_TXN * THREE);
-    Assertions.assertEquals(30 * THREE, blocks.size());
+    assertEquals(30 * THREE, blocks.size());
     commitTransactions(blocks, dnList.get(1), dnList.get(2),
         DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
             .build());
 
     blocks = getTransactions(50 * BLOCKS_PER_TXN * THREE);
     // SCM will not repeat a transaction until it has timed out.
-    Assertions.assertEquals(0, blocks.size());
+    assertEquals(0, blocks.size());
     // Lets the SCM delete the transaction and wait for the DN reply
     // to timeout, thus allowing the transaction to resend the
     deletedBlockLog.setScmCommandTimeoutMs(-1L);
     blocks = getTransactions(50 * BLOCKS_PER_TXN * THREE);
     // only uncommitted dn have transactions
-    Assertions.assertEquals(30, blocks.size());
+    assertEquals(30, blocks.size());
     commitTransactions(blocks, dnList.get(0));
 
     blocks = getTransactions(50 * BLOCKS_PER_TXN * THREE);
-    Assertions.assertEquals(0, blocks.size());
+    assertEquals(0, blocks.size());
   }
 
   private void recordScmCommandToStatusManager(
@@ -511,7 +511,7 @@ public class TestDeletedBlockLog {
       Set<DeletedBlocksTransaction> txSet2 = new HashSet<>(map2.get(dnId));
 
       txSet1.retainAll(txSet2);
-      Assertions.assertEquals(0, txSet1.size(),
+      assertEquals(0, txSet1.size(),
           String.format("Duplicate Transactions found first transactions %s " +
               "second transactions %s for Dn %s", txSet1, txSet2, dnId));
     }
@@ -659,7 +659,7 @@ public class TestDeletedBlockLog {
         = deletedBlockLog.getTransactions(
         30 * BLOCKS_PER_TXN * THREE,
         dnList.subList(0, 1).stream().collect(Collectors.toSet()));
-    Assertions.assertEquals(0, transactions.getDatanodeTransactionMap().size());
+    assertEquals(0, transactions.getDatanodeTransactionMap().size());
   }
 
   @Test
@@ -687,7 +687,7 @@ public class TestDeletedBlockLog {
     // container replica's so getAllTransactions() won't be able to fetch them
     // and rest 20 txns are already committed and removed so in total
     // getAllTransactions() will fetch 0 txns.
-    Assertions.assertEquals(0, blocks.size());
+    assertEquals(0, blocks.size());
   }
 
   @Test
@@ -721,7 +721,7 @@ public class TestDeletedBlockLog {
             scm.getScmMetadataStore().getDeletedBlocksTXTable().iterator()) {
           AtomicInteger count = new AtomicInteger();
           iter.forEachRemaining((keyValue) -> count.incrementAndGet());
-          Assertions.assertEquals(added, count.get() + committed);
+          assertEquals(added, count.get() + committed);
         }
       }
     }
@@ -746,10 +746,10 @@ public class TestDeletedBlockLog {
         metrics);
     List<DeletedBlocksTransaction> blocks =
         getTransactions(10 * BLOCKS_PER_TXN * THREE);
-    Assertions.assertEquals(10 * THREE, blocks.size());
+    assertEquals(10 * THREE, blocks.size());
     commitTransactions(blocks);
     blocks = getTransactions(40 * BLOCKS_PER_TXN * THREE);
-    Assertions.assertEquals(40 * THREE, blocks.size());
+    assertEquals(40 * THREE, blocks.size());
     commitTransactions(blocks);
 
     // close db and reopen it again to make sure
@@ -764,8 +764,8 @@ public class TestDeletedBlockLog {
         scm.getSequenceIdGen(),
         metrics);
     blocks = getTransactions(40 * BLOCKS_PER_TXN * THREE);
-    Assertions.assertEquals(0, blocks.size());
-    //Assertions.assertEquals((long)deletedBlockLog.getCurrentTXID(), 50L);
+    assertEquals(0, blocks.size());
+    //assertEquals((long)deletedBlockLog.getCurrentTXID(), 50L);
   }
 
   @Test
@@ -799,7 +799,7 @@ public class TestDeletedBlockLog {
 
     blocks = getTransactions(txNum * BLOCKS_PER_TXN * ONE);
     // There should be one txn remaining
-    Assertions.assertEquals(1, blocks.size());
+    assertEquals(1, blocks.size());
 
     // add two transactions for same container
     containerID = blocks.get(0).getContainerID();
@@ -812,16 +812,16 @@ public class TestDeletedBlockLog {
     blocks = getTransactions(txNum * BLOCKS_PER_TXN * ONE);
     // Only newly added Blocks will be sent, as previously sent transactions
     // that have not yet timed out will not be sent.
-    Assertions.assertEquals(1, blocks.size());
-    Assertions.assertEquals(1, blocks.get(0).getLocalIDCount());
-    Assertions.assertEquals(blocks.get(0).getLocalID(0), localId);
+    assertEquals(1, blocks.size());
+    assertEquals(1, blocks.get(0).getLocalIDCount());
+    assertEquals(blocks.get(0).getLocalID(0), localId);
 
     // Lets the SCM delete the transaction and wait for the DN reply
     // to timeout, thus allowing the transaction to resend the
     deletedBlockLog.setScmCommandTimeoutMs(-1L);
     // get should return two transactions for the same container
     blocks = getTransactions(txNum * BLOCKS_PER_TXN * ONE);
-    Assertions.assertEquals(2, blocks.size());
+    assertEquals(2, blocks.size());
   }
 
   @Test
@@ -837,7 +837,7 @@ public class TestDeletedBlockLog {
 
     blocks = getTransactions(txNum * BLOCKS_PER_TXN);
     // There should be no txn remaining
-    Assertions.assertEquals(0, blocks.size());
+    assertEquals(0, blocks.size());
   }
 
   private void mockStandAloneContainerInfo(long containerID, DatanodeDetails dd)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -48,6 +48,11 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.DATANODE_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -60,7 +65,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -84,13 +88,13 @@ public class TestCloseContainerEventHandler {
   @BeforeEach
   public void setup() throws Exception {
     MockitoAnnotations.initMocks(this);
-    containerManager = Mockito.mock(ContainerManager.class);
-    pipelineManager = Mockito.mock(PipelineManager.class);
-    SCMContext scmContext = Mockito.mock(SCMContext.class);
-    Mockito.when(scmContext.isLeader()).thenReturn(true);
-    eventPublisher = Mockito.mock(EventPublisher.class);
-    LeaseManager leaseManager = Mockito.mock(LeaseManager.class);
-    Mockito.when(leaseManager.acquire(any(), anyLong(), any())).thenAnswer(
+    containerManager = mock(ContainerManager.class);
+    pipelineManager = mock(PipelineManager.class);
+    SCMContext scmContext = mock(SCMContext.class);
+    when(scmContext.isLeader()).thenReturn(true);
+    eventPublisher = mock(EventPublisher.class);
+    LeaseManager leaseManager = mock(LeaseManager.class);
+    when(leaseManager.acquire(any(), anyLong(), any())).thenAnswer(
         invocation -> invocation.getArgument(2, Callable.class).call());
     eventHandler = new CloseContainerEventHandler(
         pipelineManager, containerManager, scmContext, leaseManager, 0);
@@ -99,13 +103,11 @@ public class TestCloseContainerEventHandler {
   @Test
   public void testCloseContainerEventWithInvalidContainer()
       throws ContainerNotFoundException, PipelineNotFoundException {
-    Mockito.when(containerManager.getContainer(any()))
-        .thenThrow(ContainerNotFoundException.class);
-    Mockito.when(pipelineManager.getPipeline(any())).thenReturn(
-        createPipeline(RATIS_REP_CONFIG, 3));
+    when(containerManager.getContainer(any())).thenThrow(ContainerNotFoundException.class);
+    when(pipelineManager.getPipeline(any())).thenReturn(createPipeline(RATIS_REP_CONFIG, 3));
 
     eventHandler.onMessage(ContainerID.valueOf(1234), eventPublisher);
-    Mockito.verify(eventPublisher, never()).fireEvent(any(), any());
+    verify(eventPublisher, never()).fireEvent(any(), any());
   }
 
   @Test
@@ -115,12 +117,10 @@ public class TestCloseContainerEventHandler {
     final ContainerInfo container =
         createContainer(RATIS_REP_CONFIG, pipeline.getId());
     container.setState(HddsProtos.LifeCycleState.CLOSED);
-    Mockito.when(containerManager.getContainer(container.containerID()))
-        .thenReturn(container);
+    when(containerManager.getContainer(container.containerID())).thenReturn(container);
 
     eventHandler.onMessage(container.containerID(), eventPublisher);
-    Mockito.verify(eventPublisher, never())
-        .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
+    verify(eventPublisher, never()).fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
   }
 
   @Test
@@ -130,19 +130,17 @@ public class TestCloseContainerEventHandler {
     final ContainerInfo container =
         createContainer(RATIS_REP_CONFIG, pipeline.getId());
     container.setState(HddsProtos.LifeCycleState.CLOSING);
-    Mockito.when(containerManager.getContainer(container.containerID()))
-        .thenReturn(container);
+    when(containerManager.getContainer(container.containerID())).thenReturn(container);
 
-    SCMContext scmContext = Mockito.mock(SCMContext.class);
-    Mockito.when(scmContext.isLeader()).thenReturn(true);
+    SCMContext scmContext = mock(SCMContext.class);
+    when(scmContext.isLeader()).thenReturn(true);
     long timeoutInMs = 2000;
-    Mockito.when(pipelineManager.getPipeline(pipeline.getId()))
-        .thenReturn(pipeline);
+    when(pipelineManager.getPipeline(pipeline.getId())).thenReturn(pipeline);
     LeaseManager<Object> leaseManager = new LeaseManager<>("test", timeoutInMs);
     leaseManager.start();
-    LeaseManager mockLeaseManager = Mockito.mock(LeaseManager.class);
+    LeaseManager mockLeaseManager = mock(LeaseManager.class);
     List<Lease<Object>> leaseList = new ArrayList<>(1);
-    Mockito.when(mockLeaseManager.acquire(any(), anyLong(), any())).thenAnswer(
+    when(mockLeaseManager.acquire(any(), anyLong(), any())).thenAnswer(
         invocation -> {
           leaseList.add(leaseManager.acquire(
               invocation.getArgument(0, Object.class),
@@ -154,16 +152,15 @@ public class TestCloseContainerEventHandler {
         pipelineManager, containerManager, scmContext,
         mockLeaseManager, timeoutInMs);
     closeHandler.onMessage(container.containerID(), eventPublisher);
-    Mockito.verify(mockLeaseManager, atLeastOnce())
-        .acquire(any(), anyLong(), any());
+    verify(mockLeaseManager, atLeastOnce()).acquire(any(), anyLong(), any());
     assertThat(leaseList.size()).isGreaterThan(0);
+    assertTrue(leaseList.size() > 0);
     // immediate check if event is published
-    Mockito.verify(eventPublisher, never())
-        .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
+    verify(eventPublisher, never()).fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
     // wait for event to happen
     GenericTestUtils.waitFor(() -> {
       try {
-        Mockito.verify(eventPublisher, atLeastOnce())
+        verify(eventPublisher, atLeastOnce())
             .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
       } catch (Throwable ex) {
         return false;
@@ -191,21 +188,20 @@ public class TestCloseContainerEventHandler {
     final Pipeline pipeline = createPipeline(repConfig, nodeCount);
     final ContainerInfo container =
         createContainer(repConfig, pipeline.getId());
-    Mockito.when(containerManager.getContainer(container.containerID()))
+    when(containerManager.getContainer(container.containerID()))
         .thenReturn(container);
-    Mockito.doAnswer(
+    doAnswer(
         i -> {
           container.setState(HddsProtos.LifeCycleState.CLOSING);
           return null;
         }).when(containerManager).updateContainerState(container.containerID(),
         HddsProtos.LifeCycleEvent.FINALIZE);
-    Mockito.when(pipelineManager.getPipeline(pipeline.getId()))
-        .thenReturn(pipeline);
+    when(pipelineManager.getPipeline(pipeline.getId())).thenReturn(pipeline);
 
     eventHandler.onMessage(container.containerID(), eventPublisher);
 
-    Mockito.verify(containerManager).updateContainerState(any(), any());
-    Mockito.verify(eventPublisher, times(nodeCount))
+    verify(containerManager).updateContainerState(any(), any());
+    verify(eventPublisher, times(nodeCount))
         .fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
 
     List<CommandForDatanode> cmds = commandCaptor.getAllValues();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -48,7 +48,6 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.DATANODE_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
@@ -154,7 +153,6 @@ public class TestCloseContainerEventHandler {
     closeHandler.onMessage(container.containerID(), eventPublisher);
     verify(mockLeaseManager, atLeastOnce()).acquire(any(), anyLong(), any());
     assertThat(leaseList.size()).isGreaterThan(0);
-    assertTrue(leaseList.size() > 0);
     // immediate check if event is published
     verify(eventPublisher, never()).fireEvent(eq(DATANODE_COMMAND), commandCaptor.capture());
     // wait for event to happen

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerActionsHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerActionsHandler.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerActionsFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -39,7 +39,7 @@ public class TestContainerActionsHandler {
   public void testCloseContainerAction() {
     EventQueue queue = new EventQueue();
     ContainerActionsHandler actionsHandler = new ContainerActionsHandler();
-    CloseContainerEventHandler closeContainerEventHandler = Mockito.mock(
+    CloseContainerEventHandler closeContainerEventHandler = mock(
         CloseContainerEventHandler.class);
     queue.addHandler(SCMEvents.CLOSE_CONTAINER, closeContainerEventHandler);
     queue.addHandler(SCMEvents.CONTAINER_ACTIONS, actionsHandler);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -47,13 +47,15 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.OPEN;
@@ -109,13 +111,13 @@ public class TestContainerManagerImpl {
 
   @Test
   void testAllocateContainer() throws Exception {
-    Assertions.assertTrue(
+    assertTrue(
         containerManager.getContainers().isEmpty());
     final ContainerInfo container = containerManager.allocateContainer(
         RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "admin");
-    Assertions.assertEquals(1, containerManager.getContainers().size());
-    Assertions.assertNotNull(containerManager.getContainer(
+    assertEquals(1, containerManager.getContainers().size());
+    assertNotNull(containerManager.getContainer(
         container.containerID()));
   }
 
@@ -125,25 +127,21 @@ public class TestContainerManagerImpl {
         RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "admin");
     final ContainerID cid = container.containerID();
-    Assertions.assertEquals(LifeCycleState.OPEN,
-        containerManager.getContainer(cid).getState());
+    assertEquals(LifeCycleState.OPEN, containerManager.getContainer(cid).getState());
     containerManager.updateContainerState(cid,
         HddsProtos.LifeCycleEvent.FINALIZE);
-    Assertions.assertEquals(LifeCycleState.CLOSING,
-        containerManager.getContainer(cid).getState());
+    assertEquals(LifeCycleState.CLOSING, containerManager.getContainer(cid).getState());
     containerManager.updateContainerState(cid,
         HddsProtos.LifeCycleEvent.QUASI_CLOSE);
-    Assertions.assertEquals(LifeCycleState.QUASI_CLOSED,
-        containerManager.getContainer(cid).getState());
+    assertEquals(LifeCycleState.QUASI_CLOSED, containerManager.getContainer(cid).getState());
     containerManager.updateContainerState(cid,
         HddsProtos.LifeCycleEvent.FORCE_CLOSE);
-    Assertions.assertEquals(LifeCycleState.CLOSED,
-        containerManager.getContainer(cid).getState());
+    assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(cid).getState());
   }
 
   @Test
   void testGetContainers() throws Exception {
-    Assertions.assertEquals(emptyList(), containerManager.getContainers());
+    assertEquals(emptyList(), containerManager.getContainers());
 
     List<ContainerID> ids = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
@@ -184,13 +182,13 @@ public class TestContainerManagerImpl {
         HddsProtos.LifeCycleEvent.FINALIZE);
     containerManager.updateContainerState(ids.get(2),
         HddsProtos.LifeCycleEvent.CLOSE);
-    Assertions.assertEquals(7, containerManager.
+    assertEquals(7, containerManager.
         getContainerStateCount(LifeCycleState.OPEN));
-    Assertions.assertEquals(1, containerManager
+    assertEquals(1, containerManager
         .getContainerStateCount(LifeCycleState.CLOSING));
-    Assertions.assertEquals(1, containerManager
+    assertEquals(1, containerManager
         .getContainerStateCount(LifeCycleState.QUASI_CLOSED));
-    Assertions.assertEquals(1, containerManager
+    assertEquals(1, containerManager
         .getContainerStateCount(LifeCycleState.CLOSED));
   }
 
@@ -198,7 +196,7 @@ public class TestContainerManagerImpl {
       List<ContainerID> expected,
       List<ContainerInfo> containers
   ) {
-    Assertions.assertEquals(expected, containers.stream()
+    assertEquals(expected, containers.stream()
         .map(ContainerInfo::containerID)
         .collect(toList()));
   }
@@ -207,8 +205,8 @@ public class TestContainerManagerImpl {
   void testAllocateContainersWithECReplicationConfig() throws Exception {
     final ContainerInfo admin = containerManager
         .allocateContainer(new ECReplicationConfig(3, 2), "admin");
-    Assertions.assertEquals(1, containerManager.getContainers().size());
-    Assertions.assertNotNull(
+    assertEquals(1, containerManager.getContainers().size());
+    assertNotNull(
         containerManager.getContainer(admin.containerID()));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -50,8 +50,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.OPEN;
@@ -86,7 +88,7 @@ public class TestContainerManagerImpl {
         new MockPipelineManager(dbStore, scmhaManager, nodeManager);
     pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
         ReplicationFactor.THREE));
-    pendingOpsMock = Mockito.mock(ContainerReplicaPendingOps.class);
+    pendingOpsMock = mock(ContainerReplicaPendingOps.class);
     containerManager = new ContainerManagerImpl(conf,
         scmhaManager, sequenceIdGen, pipelineManager,
         SCMDBDefinition.CONTAINERS.getTable(dbStore), pendingOpsMock);
@@ -227,8 +229,7 @@ public class TestContainerManagerImpl {
             .setBytesUsed(1234)
             .setKeyCount(123)
             .build());
-    Mockito.verify(pendingOpsMock, Mockito.times(1))
-        .completeAddReplica(container.containerID(), dn, 0);
+    verify(pendingOpsMock, times(1)).completeAddReplica(container.containerID(), dn, 0);
   }
 
   @Test
@@ -248,8 +249,7 @@ public class TestContainerManagerImpl {
             .setBytesUsed(1234)
             .setKeyCount(123)
             .build());
-    Mockito.verify(pendingOpsMock, Mockito.times(1))
-        .completeDeleteReplica(container.containerID(), dn, 0);
+    verify(pendingOpsMock, times(1)).completeDeleteReplica(container.containerID(), dn, 0);
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -50,7 +50,6 @@ import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -276,7 +275,7 @@ public class TestContainerReportHandler {
     final ContainerReportFromDatanode containerReportFromDatanode =
         new ContainerReportFromDatanode(datanodeOne, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
-    Assertions.assertEquals(2, containerManager.getContainerReplicas(
+    assertEquals(2, containerManager.getContainerReplicas(
         containerOne.containerID()).size());
 
   }
@@ -336,7 +335,7 @@ public class TestContainerReportHandler {
         new ContainerReportFromDatanode(datanodeFour, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
 
-    Assertions.assertEquals(4, containerManager.getContainerReplicas(
+    assertEquals(4, containerManager.getContainerReplicas(
         containerOne.containerID()).size());
   }
 
@@ -407,7 +406,7 @@ public class TestContainerReportHandler {
         new ContainerReportFromDatanode(datanodeOne, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
 
-    Assertions.assertEquals(LifeCycleState.CLOSED,
+    assertEquals(LifeCycleState.CLOSED,
         containerManager.getContainer(containerOne.containerID()).getState());
   }
 
@@ -422,20 +421,17 @@ public class TestContainerReportHandler {
     createAndHandleContainerReport(container.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(1), 2);
     // index is 2; container shouldn't transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSING,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSING, containerManager.getContainer(container.containerID()).getState());
 
     createAndHandleContainerReport(container.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(2), 3);
     // index is 3; container shouldn't transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSING,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSING, containerManager.getContainer(container.containerID()).getState());
 
     createAndHandleContainerReport(container.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(0), 1);
     // index is 1; container should transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSED,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(container.containerID()).getState());
 
     // Test with an EC 6-3 container
     replicationConfig = new ECReplicationConfig(6, 3);
@@ -446,14 +442,12 @@ public class TestContainerReportHandler {
     createAndHandleContainerReport(container2.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(5), 6);
     // index is 6, container shouldn't transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSING,
-        containerManager.getContainer(container2.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSING, containerManager.getContainer(container2.containerID()).getState());
 
     createAndHandleContainerReport(container2.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(8), 9);
     // index is 9, container should transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSED,
-        containerManager.getContainer(container2.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(container2.containerID()).getState());
   }
 
   /**
@@ -467,7 +461,7 @@ public class TestContainerReportHandler {
   private List<DatanodeDetails> setupECContainerForTesting(
       ContainerInfo container)
       throws IOException, TimeoutException, NodeNotFoundException {
-    Assertions.assertEquals(HddsProtos.ReplicationType.EC,
+    assertEquals(HddsProtos.ReplicationType.EC,
         container.getReplicationType());
     final int numDatanodes =
         container.getReplicationConfig().getRequiredNodes();
@@ -576,8 +570,7 @@ public class TestContainerReportHandler {
         new ContainerReportFromDatanode(datanodeOne, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
 
-    Assertions.assertEquals(LifeCycleState.QUASI_CLOSED,
-        containerManager.getContainer(containerOne.containerID()).getState());
+    assertEquals(LifeCycleState.QUASI_CLOSED, containerManager.getContainer(containerOne.containerID()).getState());
   }
 
   @Test
@@ -648,8 +641,7 @@ public class TestContainerReportHandler {
         new ContainerReportFromDatanode(datanodeOne, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
 
-    Assertions.assertEquals(LifeCycleState.CLOSED,
-        containerManager.getContainer(containerOne.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(containerOne.containerID()).getState());
   }
 
   @Test
@@ -991,7 +983,7 @@ public class TestContainerReportHandler {
 
     verify(publisher, times(1)).fireEvent(any(), any(CommandForDatanode.class));
 
-    Assertions.assertEquals(0, containerManager.getContainerReplicas(
+    assertEquals(0, containerManager.getContainerReplicas(
         containerOne.containerID()).size());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -48,11 +48,10 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
@@ -130,7 +129,7 @@ public class TestContainerStateManager {
         .getContainerReplicas(c1.containerID());
 
     //THEN
-    Assertions.assertEquals(3, replicas.size());
+    assertEquals(3, replicas.size());
   }
 
   @Test
@@ -150,8 +149,8 @@ public class TestContainerStateManager {
     Set<ContainerReplica> replicas = containerStateManager
         .getContainerReplicas(c1.containerID());
 
-    Assertions.assertEquals(2, replicas.size());
-    Assertions.assertEquals(3, c1.getReplicationConfig().getRequiredNodes());
+    assertEquals(2, replicas.size());
+    assertEquals(3, c1.getReplicationConfig().getRequiredNodes());
   }
 
   private void addReplica(ContainerInfo cont, DatanodeDetails node) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -51,8 +51,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -76,7 +78,7 @@ public class TestContainerStateManager {
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testDir.getAbsolutePath());
     dbStore = DBStoreBuilder.createDBStore(
         conf, new SCMDBDefinition());
-    pipelineManager = Mockito.mock(PipelineManager.class);
+    pipelineManager = mock(PipelineManager.class);
     pipeline = Pipeline.newBuilder().setState(Pipeline.PipelineState.CLOSED)
             .setId(PipelineID.randomId())
             .setReplicationConfig(StandaloneReplicationConfig.getInstance(
@@ -84,8 +86,7 @@ public class TestContainerStateManager {
             .setNodes(new ArrayList<>()).build();
     when(pipelineManager.createPipeline(StandaloneReplicationConfig.getInstance(
         ReplicationFactor.THREE))).thenReturn(pipeline);
-    when(pipelineManager.containsPipeline(Mockito.any(PipelineID.class)))
-        .thenReturn(true);
+    when(pipelineManager.containsPipeline(any(PipelineID.class))).thenReturn(true);
 
 
     containerStateManager = ContainerStateManagerImpl.newBuilder()

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -90,6 +89,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.apache.hadoop.hdds.scm.container.TestContainerReportHandler.getContainerReportsProto;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 
@@ -233,8 +234,7 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeOne, containerReport);
     reportHandler.onMessage(icrFromDatanode, publisher);
-    Assertions.assertEquals(LifeCycleState.CLOSED,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(container.containerID()).getState());
   }
 
   /**
@@ -253,20 +253,17 @@ public class TestIncrementalContainerReportHandler {
     createAndHandleICR(container.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(1), 2);
     // index is 2; container shouldn't transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSING,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSING, containerManager.getContainer(container.containerID()).getState());
 
     createAndHandleICR(container.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(2), 3);
     // index is 3; container shouldn't transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSING,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSING, containerManager.getContainer(container.containerID()).getState());
 
     createAndHandleICR(container.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(0), 1);
     // index is 1; container should transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSED,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(container.containerID()).getState());
 
     // Test with an EC 6-3 container
     replicationConfig = new ECReplicationConfig(6, 3);
@@ -277,14 +274,12 @@ public class TestIncrementalContainerReportHandler {
     createAndHandleICR(container2.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(5), 6);
     // index is 6, container shouldn't transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSING,
-        containerManager.getContainer(container2.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSING, containerManager.getContainer(container2.containerID()).getState());
 
     createAndHandleICR(container2.containerID(),
         ContainerReplicaProto.State.CLOSED, dns.get(8), 9);
     // index is 9, container should transition to CLOSED
-    Assertions.assertEquals(LifeCycleState.CLOSED,
-        containerManager.getContainer(container2.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(container2.containerID()).getState());
   }
 
   /**
@@ -324,8 +319,7 @@ public class TestIncrementalContainerReportHandler {
   private List<DatanodeDetails> setupECContainerForTesting(
       ContainerInfo container)
       throws IOException, TimeoutException, NodeNotFoundException {
-    Assertions.assertEquals(HddsProtos.ReplicationType.EC,
-        container.getReplicationType());
+    assertEquals(HddsProtos.ReplicationType.EC, container.getReplicationType());
     final int numDatanodes =
         container.getReplicationConfig().getRequiredNodes();
     // Register required number of datanodes with NodeManager
@@ -387,8 +381,7 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeOne, containerReport);
     reportHandler.onMessage(icrFromDatanode, publisher);
-    Assertions.assertEquals(LifeCycleState.QUASI_CLOSED,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.QUASI_CLOSED, containerManager.getContainer(container.containerID()).getState());
   }
 
   @Test
@@ -424,8 +417,7 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeOne, containerReport);
     reportHandler.onMessage(icr, publisher);
-    Assertions.assertEquals(LifeCycleState.CLOSED,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSED, containerManager.getContainer(container.containerID()).getState());
   }
 
   @Test
@@ -465,8 +457,7 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeThree, containerReport);
     reportHandler.onMessage(icr, publisher);
-    Assertions.assertEquals(LifeCycleState.CLOSING,
-        containerManager.getContainer(container.containerID()).getState());
+    assertEquals(LifeCycleState.CLOSING, containerManager.getContainer(container.containerID()).getState());
   }
 
   @Test
@@ -490,18 +481,15 @@ public class TestIncrementalContainerReportHandler {
     containerStateManager.addContainer(container.getProtobuf());
     containerReplicas.forEach(r -> {
       containerStateManager.updateContainerReplica(container.containerID(), r);
-      try {
-        nodeManager.addContainer(
-            r.getDatanodeDetails(), container.containerID());
-      } catch (NodeNotFoundException e) {
-        Assertions.fail("Node should be found");
-      }
+
+      assertDoesNotThrow(() -> nodeManager.addContainer(r.getDatanodeDetails(), container.containerID()),
+          "Node should be found");
     });
-    Assertions.assertEquals(3, containerStateManager
+    assertEquals(3, containerStateManager
         .getContainerReplicas(container.containerID()).size());
-    Assertions.assertEquals(1, nodeManager.getContainers(datanodeOne).size());
-    Assertions.assertEquals(1, nodeManager.getContainers(datanodeTwo).size());
-    Assertions.assertEquals(1, nodeManager.getContainers(datanodeThree)
+    assertEquals(1, nodeManager.getContainers(datanodeOne).size());
+    assertEquals(1, nodeManager.getContainers(datanodeTwo).size());
+    assertEquals(1, nodeManager.getContainers(datanodeThree)
         .size());
     final IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(container.containerID(),
@@ -511,11 +499,11 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeOne, containerReport);
     reportHandler.onMessage(icr, publisher);
-    Assertions.assertEquals(2, containerStateManager
+    assertEquals(2, containerStateManager
         .getContainerReplicas(container.containerID()).size());
-    Assertions.assertEquals(0, nodeManager.getContainers(datanodeOne).size());
-    Assertions.assertEquals(1, nodeManager.getContainers(datanodeTwo).size());
-    Assertions.assertEquals(1, nodeManager.getContainers(datanodeThree)
+    assertEquals(0, nodeManager.getContainers(datanodeOne).size());
+    assertEquals(1, nodeManager.getContainers(datanodeTwo).size());
+    assertEquals(1, nodeManager.getContainers(datanodeThree)
         .size());
   }
 
@@ -538,7 +526,7 @@ public class TestIncrementalContainerReportHandler {
     containerStateManager.addContainer(container.getProtobuf());
     containerStateManager.addContainer(containerTwo.getProtobuf());
 
-    Assertions.assertEquals(0, nodeManager.getContainers(datanode).size());
+    assertEquals(0, nodeManager.getContainers(datanode).size());
 
     final IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(container.containerID(),
@@ -573,21 +561,21 @@ public class TestIncrementalContainerReportHandler {
         if (nmContainers.contains(container.containerID())) {
           // If we find "container" in the NM, then we must also have it in
           // Container Manager.
-          Assertions.assertEquals(1, containerStateManager
+          assertEquals(1, containerStateManager
               .getContainerReplicas(container.containerID())
               .size());
-          Assertions.assertEquals(2, nmContainers.size());
+          assertEquals(2, nmContainers.size());
         } else {
           // If the race condition occurs as mentioned in HDDS-5249, then this
           // assert should fail. We will have found nothing for "container" in
           // NM, but have found something for it in ContainerManager, and that
           // should not happen. It should be in both, or neither.
-          Assertions.assertEquals(0, containerStateManager
+          assertEquals(0, containerStateManager
               .getContainerReplicas(container.containerID())
               .size());
-          Assertions.assertEquals(1, nmContainers.size());
+          assertEquals(1, nmContainers.size());
         }
-        Assertions.assertEquals(1, containerStateManager
+        assertEquals(1, containerStateManager
             .getContainerReplicas(containerTwo.containerID())
             .size());
       }
@@ -653,10 +641,9 @@ public class TestIncrementalContainerReportHandler {
             new IncrementalContainerReportHandler(nodeManager,
                     containerManager, scmContext);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
-    Assertions.assertEquals(containerStateManager
-            .getContainerReplicas(container.containerID()).stream()
-            .collect(Collectors.toMap(ContainerReplica::getDatanodeDetails,
-                    ContainerReplica::getReplicaIndex)), expectedReplicaMap);
+    assertEquals(containerStateManager.getContainerReplicas(container.containerID()).stream()
+        .collect(Collectors.toMap(ContainerReplica::getDatanodeDetails,
+            ContainerReplica::getReplicaIndex)), expectedReplicaMap);
 
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -60,7 +60,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -87,6 +86,10 @@ import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProt
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getContainer;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getECContainer;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getReplicas;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.any;
 import static org.apache.hadoop.hdds.scm.container.TestContainerReportHandler.getContainerReportsProto;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 
@@ -114,16 +117,13 @@ public class TestIncrementalContainerReportHandler {
         GenericTestUtils.getTempPath(UUID.randomUUID().toString());
     Path scmPath = Paths.get(path, "scm-meta");
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, scmPath.toString());
-    this.containerManager = Mockito.mock(ContainerManager.class);
+    this.containerManager = mock(ContainerManager.class);
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
     EventQueue eventQueue = new EventQueue();
     SCMStorageConfig storageConfig = new SCMStorageConfig(conf);
-    this.versionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
-    Mockito.when(versionManager.getMetadataLayoutVersion())
-        .thenReturn(maxLayoutVersion());
-    Mockito.when(versionManager.getSoftwareLayoutVersion())
-        .thenReturn(maxLayoutVersion());
+    this.versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(versionManager.getSoftwareLayoutVersion()).thenReturn(maxLayoutVersion());
     this.nodeManager =
         new SCMNodeManager(conf, storageConfig, eventQueue, clusterMap,
             scmContext, versionManager);
@@ -147,48 +147,48 @@ public class TestIncrementalContainerReportHandler {
             Clock.system(ZoneId.systemDefault())))
         .build();
 
-    this.publisher = Mockito.mock(EventPublisher.class);
+    this.publisher = mock(EventPublisher.class);
 
-    Mockito.when(containerManager.getContainer(Mockito.any(ContainerID.class)))
+    when(containerManager.getContainer(any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainer(((ContainerID)invocation
                 .getArguments()[0])));
 
-    Mockito.when(containerManager.getContainerReplicas(
-        Mockito.any(ContainerID.class)))
+    when(containerManager.getContainerReplicas(
+        any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainerReplicas(((ContainerID)invocation
                 .getArguments()[0])));
 
-    Mockito.doAnswer(invocation -> {
+    doAnswer(invocation -> {
       containerStateManager
           .removeContainerReplica(((ContainerID)invocation
                   .getArguments()[0]),
               (ContainerReplica)invocation.getArguments()[1]);
       return null;
     }).when(containerManager).removeContainerReplica(
-        Mockito.any(ContainerID.class),
-        Mockito.any(ContainerReplica.class));
+        any(ContainerID.class),
+        any(ContainerReplica.class));
 
-    Mockito.doAnswer(invocation -> {
+    doAnswer(invocation -> {
       containerStateManager
           .updateContainerState(((ContainerID)invocation
                   .getArguments()[0]).getProtobuf(),
               (HddsProtos.LifeCycleEvent)invocation.getArguments()[1]);
       return null;
     }).when(containerManager).updateContainerState(
-        Mockito.any(ContainerID.class),
-        Mockito.any(HddsProtos.LifeCycleEvent.class));
+        any(ContainerID.class),
+        any(HddsProtos.LifeCycleEvent.class));
 
-    Mockito.doAnswer(invocation -> {
+    doAnswer(invocation -> {
       containerStateManager
           .updateContainerReplica(((ContainerID)invocation
                   .getArguments()[0]),
               (ContainerReplica) invocation.getArguments()[1]);
       return null;
     }).when(containerManager).updateContainerReplica(
-        Mockito.any(ContainerID.class),
-        Mockito.any(ContainerReplica.class));
+        any(ContainerID.class),
+        any(ContainerReplica.class));
 
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestUnknownContainerReport.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestUnknownContainerReport.java
@@ -19,6 +19,10 @@ package org.apache.hadoop.hdds.scm.container;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getContainer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.any;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,7 +59,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 /**
  * Test container deletion behaviour of unknown containers
@@ -76,7 +79,7 @@ public class TestUnknownContainerReport {
   public void setup() throws IOException {
     final OzoneConfiguration conf = SCMTestUtils.getConf();
     this.nodeManager = new MockNodeManager(true, 10);
-    this.containerManager = Mockito.mock(ContainerManager.class);
+    this.containerManager = mock(ContainerManager.class);
     testDir = GenericTestUtils.getTestDir(
         TestUnknownContainerReport.class.getSimpleName() + UUID.randomUUID());
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testDir.getAbsolutePath());
@@ -92,9 +95,9 @@ public class TestUnknownContainerReport {
         .setContainerStore(SCMDBDefinition.CONTAINERS.getTable(dbStore))
         .setSCMDBTransactionBuffer(scmhaManager.getDBTransactionBuffer())
         .build();
-    this.publisher = Mockito.mock(EventPublisher.class);
+    this.publisher = mock(EventPublisher.class);
 
-    Mockito.when(containerManager.getContainer(Mockito.any(ContainerID.class)))
+    when(containerManager.getContainer(any(ContainerID.class)))
         .thenThrow(new ContainerNotFoundException());
   }
 
@@ -115,8 +118,7 @@ public class TestUnknownContainerReport {
 
     // By default, unknown containers won't be taken delete action by SCM
     verify(publisher, times(0)).fireEvent(
-        Mockito.eq(SCMEvents.DATANODE_COMMAND),
-        Mockito.any(CommandForDatanode.class));
+        eq(SCMEvents.DATANODE_COMMAND), any(CommandForDatanode.class));
   }
 
   @Test
@@ -128,8 +130,7 @@ public class TestUnknownContainerReport {
 
     sendContainerReport(conf);
     verify(publisher, times(1)).fireEvent(
-        Mockito.eq(SCMEvents.DATANODE_COMMAND),
-        Mockito.any(CommandForDatanode.class));
+        eq(SCMEvents.DATANODE_COMMAND), any(CommandForDatanode.class));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -47,6 +46,9 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_NODE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -75,8 +77,8 @@ public class TestContainerBalancer {
     conf.setTimeDuration(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
         5, TimeUnit.SECONDS);
     conf.setTimeDuration(HDDS_NODE_REPORT_INTERVAL, 2, TimeUnit.SECONDS);
-    scm = Mockito.mock(StorageContainerManager.class);
-    serviceStateManager = Mockito.mock(StatefulServiceStateManagerImpl.class);
+    scm = mock(StorageContainerManager.class);
+    serviceStateManager = mock(StatefulServiceStateManagerImpl.class);
     balancerConfiguration =
         conf.getObject(ContainerBalancerConfiguration.class);
     balancerConfiguration.setThreshold(10);
@@ -93,20 +95,20 @@ public class TestContainerBalancer {
     when(scm.getConfiguration()).thenReturn(conf);
     when(scm.getStatefulServiceStateManager()).thenReturn(serviceStateManager);
     when(scm.getSCMServiceManager()).thenReturn(mock(SCMServiceManager.class));
-    when(scm.getMoveManager()).thenReturn(Mockito.mock(MoveManager.class));
+    when(scm.getMoveManager()).thenReturn(mock(MoveManager.class));
 
     /*
     When StatefulServiceStateManager#saveConfiguration is called, save to
     in-memory serviceToConfigMap and read from same.
      */
-    Mockito.doAnswer(i -> {
+    doAnswer(i -> {
       serviceToConfigMap.put(i.getArgument(0, String.class), i.getArgument(1,
           ByteString.class));
       return null;
     }).when(serviceStateManager).saveConfiguration(
-        Mockito.any(String.class),
-        Mockito.any(ByteString.class));
-    when(serviceStateManager.readConfiguration(Mockito.anyString())).thenAnswer(
+        any(String.class),
+        any(ByteString.class));
+    when(serviceStateManager.readConfiguration(anyString())).thenAnswer(
         i -> serviceToConfigMap.get(i.getArgument(0, String.class)));
 
     containerBalancer = new ContainerBalancer(scm);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Unhealthy;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -77,6 +76,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
@@ -244,15 +249,14 @@ public class TestContainerBalancerTask {
 
   @Test
   public void testCalculationOfUtilization() {
-    Assertions.assertEquals(nodesInCluster.size(), nodeUtilizations.size());
+    assertEquals(nodesInCluster.size(), nodeUtilizations.size());
     for (int i = 0; i < nodesInCluster.size(); i++) {
-      Assertions.assertEquals(nodeUtilizations.get(i),
+      assertEquals(nodeUtilizations.get(i),
           nodesInCluster.get(i).calculateUtilization(), 0.0001);
     }
 
     // should be equal to average utilization of the cluster
-    Assertions.assertEquals(averageUtilization,
-        containerBalancerTask.calculateAvgUtilization(nodesInCluster), 0.0001);
+    assertEquals(averageUtilization, containerBalancerTask.calculateAvgUtilization(nodesInCluster), 0.0001);
   }
 
   /**
@@ -281,13 +285,10 @@ public class TestContainerBalancerTask {
       unBalancedNodesAccordingToBalancer =
           containerBalancerTask.getUnBalancedNodes();
 
-      Assertions.assertEquals(
-          expectedUnBalancedNodes.size(),
-          unBalancedNodesAccordingToBalancer.size());
+      assertEquals(expectedUnBalancedNodes.size(), unBalancedNodesAccordingToBalancer.size());
 
       for (int j = 0; j < expectedUnBalancedNodes.size(); j++) {
-        Assertions.assertEquals(
-            expectedUnBalancedNodes.get(j).getDatanodeDetails(),
+        assertEquals(expectedUnBalancedNodes.get(j).getDatanodeDetails(),
             unBalancedNodesAccordingToBalancer.get(j).getDatanodeDetails());
       }
     }
@@ -324,9 +325,8 @@ public class TestContainerBalancerTask {
 
     stopBalancer();
     ContainerBalancerMetrics metrics = containerBalancerTask.getMetrics();
-    Assertions.assertEquals(0, containerBalancerTask.getUnBalancedNodes()
-        .size());
-    Assertions.assertEquals(0, metrics.getNumDatanodesUnbalanced());
+    assertEquals(0, containerBalancerTask.getUnBalancedNodes().size());
+    assertEquals(0, metrics.getNumDatanodesUnbalanced());
   }
 
   /**
@@ -368,16 +368,16 @@ public class TestContainerBalancerTask {
     stopBalancer();
 
     // balancer should have identified unbalanced nodes
-    Assertions.assertFalse(containerBalancerTask.getUnBalancedNodes()
+    assertFalse(containerBalancerTask.getUnBalancedNodes()
         .isEmpty());
     // no container should have been selected
-    Assertions.assertTrue(containerBalancerTask.getContainerToSourceMap()
+    assertTrue(containerBalancerTask.getContainerToSourceMap()
         .isEmpty());
     /*
     Iteration result should be CAN_NOT_BALANCE_ANY_MORE because no container
     move is generated
      */
-    Assertions.assertEquals(
+    assertEquals(
         ContainerBalancerTask.IterationResult.CAN_NOT_BALANCE_ANY_MORE,
         containerBalancerTask.getIterationResult());
 
@@ -391,7 +391,7 @@ public class TestContainerBalancerTask {
     // check whether all selected containers are closed
     for (ContainerID cid:
          containerBalancerTask.getContainerToSourceMap().keySet()) {
-      Assertions.assertSame(
+      assertSame(
           cidToInfoMap.get(cid).getState(), HddsProtos.LifeCycleState.CLOSED);
     }
   }
@@ -430,10 +430,10 @@ public class TestContainerBalancerTask {
     stopBalancer();
 
     // balancer should have identified unbalanced nodes
-    Assertions.assertFalse(containerBalancerTask.getUnBalancedNodes()
+    assertFalse(containerBalancerTask.getUnBalancedNodes()
         .isEmpty());
     // no container should have moved because all replicas are CLOSING
-    Assertions.assertTrue(
+    assertTrue(
         containerBalancerTask.getContainerToSourceMap().isEmpty());
   }
 
@@ -472,7 +472,7 @@ public class TestContainerBalancerTask {
     for (Map.Entry<ContainerID, DatanodeDetails> entry : map.entrySet()) {
       ContainerID container = entry.getKey();
       DatanodeDetails target = entry.getValue();
-      Assertions.assertTrue(cidToReplicasMap.get(container)
+      assertTrue(cidToReplicasMap.get(container)
           .stream()
           .map(ContainerReplica::getDatanodeDetails)
           .noneMatch(target::equals));
@@ -521,7 +521,7 @@ public class TestContainerBalancerTask {
             ecPlacementPolicy.validateContainerPlacement(replicas,
                 containerInfo.getReplicationConfig().getRequiredNodes());
       }
-      Assertions.assertTrue(placementStatus.isPolicySatisfied());
+      assertTrue(placementStatus.isPolicySatisfied());
     }
   }
 
@@ -540,9 +540,9 @@ public class TestContainerBalancerTask {
     stopBalancer();
     for (DatanodeDetails target : containerBalancerTask.getSelectedTargets()) {
       NodeStatus status = mockNodeManager.getNodeStatus(target);
-      Assertions.assertSame(HddsProtos.NodeOperationalState.IN_SERVICE,
+      assertSame(HddsProtos.NodeOperationalState.IN_SERVICE,
           status.getOperationalState());
-      Assertions.assertTrue(status.isHealthy());
+      assertTrue(status.isHealthy());
     }
   }
 
@@ -625,9 +625,9 @@ public class TestContainerBalancerTask {
     balancerConfiguration.setMaxSizeEnteringTarget(2 * OzoneConsts.MB);
     startBalancer(balancerConfiguration);
 
-    Assertions.assertFalse(containerBalancerTask.getUnBalancedNodes()
+    assertFalse(containerBalancerTask.getUnBalancedNodes()
         .isEmpty());
-    Assertions.assertTrue(containerBalancerTask.getContainerToSourceMap()
+    assertTrue(containerBalancerTask.getContainerToSourceMap()
         .isEmpty());
     stopBalancer();
 
@@ -643,9 +643,9 @@ public class TestContainerBalancerTask {
 
     stopBalancer();
     // balancer should have identified unbalanced nodes
-    Assertions.assertFalse(containerBalancerTask.getUnBalancedNodes()
+    assertFalse(containerBalancerTask.getUnBalancedNodes()
         .isEmpty());
-    Assertions.assertFalse(containerBalancerTask.getContainerToSourceMap()
+    assertFalse(containerBalancerTask.getContainerToSourceMap()
         .isEmpty());
   }
 
@@ -664,9 +664,9 @@ public class TestContainerBalancerTask {
     balancerConfiguration.setMaxSizeLeavingSource(2 * OzoneConsts.MB);
     startBalancer(balancerConfiguration);
 
-    Assertions.assertFalse(containerBalancerTask.getUnBalancedNodes()
+    assertFalse(containerBalancerTask.getUnBalancedNodes()
         .isEmpty());
-    Assertions.assertTrue(containerBalancerTask.getContainerToSourceMap()
+    assertTrue(containerBalancerTask.getContainerToSourceMap()
         .isEmpty());
     stopBalancer();
 
@@ -682,11 +682,11 @@ public class TestContainerBalancerTask {
 
     stopBalancer();
     // balancer should have identified unbalanced nodes
-    Assertions.assertFalse(containerBalancerTask.getUnBalancedNodes()
+    assertFalse(containerBalancerTask.getUnBalancedNodes()
         .isEmpty());
-    Assertions.assertFalse(containerBalancerTask.getContainerToSourceMap()
+    assertFalse(containerBalancerTask.getContainerToSourceMap()
         .isEmpty());
-    Assertions.assertNotEquals(0,
+    assertNotEquals(0,
         containerBalancerTask.getSizeScheduledForMoveInLatestIteration());
   }
 
@@ -713,21 +713,21 @@ public class TestContainerBalancerTask {
     stopBalancer();
 
     ContainerBalancerMetrics metrics = containerBalancerTask.getMetrics();
-    Assertions.assertEquals(determineExpectedUnBalancedNodes(
+    assertEquals(determineExpectedUnBalancedNodes(
             balancerConfiguration.getThreshold()).size(),
         metrics.getNumDatanodesUnbalanced());
     assertThat(metrics.getDataSizeMovedGBInLatestIteration()).isLessThanOrEqualTo(6);
     assertThat(metrics.getDataSizeMovedGB()).isGreaterThan(0);
-    Assertions.assertEquals(1, metrics.getNumIterations());
+    assertEquals(1, metrics.getNumIterations());
     assertThat(metrics.getNumContainerMovesScheduledInLatestIteration()).isGreaterThan(0);
-    Assertions.assertEquals(metrics.getNumContainerMovesScheduled(),
+    assertEquals(metrics.getNumContainerMovesScheduled(),
         metrics.getNumContainerMovesScheduledInLatestIteration());
-    Assertions.assertEquals(metrics.getNumContainerMovesScheduled(),
+    assertEquals(metrics.getNumContainerMovesScheduled(),
         metrics.getNumContainerMovesCompleted() +
             metrics.getNumContainerMovesFailed() +
             metrics.getNumContainerMovesTimeout());
-    Assertions.assertEquals(0, metrics.getNumContainerMovesTimeout());
-    Assertions.assertEquals(1, metrics.getNumContainerMovesFailed());
+    assertEquals(0, metrics.getNumContainerMovesTimeout());
+    assertEquals(1, metrics.getNumContainerMovesFailed());
   }
 
   /**
@@ -790,8 +790,8 @@ public class TestContainerBalancerTask {
         containerFromSourceMap.entrySet()) {
       DatanodeDetails source = entry.getValue();
       DatanodeDetails target = containerToTargetMap.get(entry.getKey());
-      Assertions.assertTrue(source.equals(dn1) || source.equals(dn2));
-      Assertions.assertTrue(target.equals(dn1) || target.equals(dn2));
+      assertTrue(source.equals(dn1) || source.equals(dn2));
+      assertTrue(target.equals(dn1) || target.equals(dn2));
     }
   }
 
@@ -815,13 +815,13 @@ public class TestContainerBalancerTask {
 
     ContainerBalancerConfiguration cbConf =
         ozoneConfiguration.getObject(ContainerBalancerConfiguration.class);
-    Assertions.assertEquals(1, cbConf.getThreshold(), 0.001);
+    assertEquals(1, cbConf.getThreshold(), 0.001);
 
     // Expected is 26 GB
-    Assertions.assertEquals(maxSizeLeavingSource * 1024 * 1024 * 1024,
+    assertEquals(maxSizeLeavingSource * 1024 * 1024 * 1024,
         cbConf.getMaxSizeLeavingSource());
-    Assertions.assertEquals(moveTimeout, cbConf.getMoveTimeout().toMinutes());
-    Assertions.assertEquals(replicationTimeout,
+    assertEquals(moveTimeout, cbConf.getMoveTimeout().toMinutes());
+    assertEquals(replicationTimeout,
         cbConf.getMoveReplicationTimeout().toMinutes());
   }
 
@@ -844,7 +844,7 @@ public class TestContainerBalancerTask {
     According to the setup and configurations, this iteration's result should
     be ITERATION_COMPLETED.
      */
-    Assertions.assertEquals(
+    assertEquals(
         ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
     stopBalancer();
@@ -862,7 +862,7 @@ public class TestContainerBalancerTask {
 
     startBalancer(balancerConfiguration);
 
-    Assertions.assertEquals(
+    assertEquals(
         ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
     stopBalancer();
@@ -872,7 +872,7 @@ public class TestContainerBalancerTask {
      */
     rmConf.setEnableLegacy(false);
     startBalancer(balancerConfiguration);
-    Assertions.assertEquals(
+    assertEquals(
         ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
     stopBalancer();
@@ -910,12 +910,9 @@ public class TestContainerBalancerTask {
     According to the setup and configurations, this iteration's result should
     be ITERATION_COMPLETED.
      */
-    Assertions.assertEquals(
-        ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
+    assertEquals(ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
-    Assertions.assertEquals(1,
-        containerBalancerTask.getMetrics()
-            .getNumContainerMovesCompletedInLatestIteration());
+    assertEquals(1, containerBalancerTask.getMetrics().getNumContainerMovesCompletedInLatestIteration());
     assertThat(containerBalancerTask.getMetrics()
             .getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(1);
     stopBalancer();
@@ -933,12 +930,9 @@ public class TestContainerBalancerTask {
         .thenAnswer(invocation -> genCompletableFuture(2000));
 
     startBalancer(balancerConfiguration);
-    Assertions.assertEquals(
-        ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
+    assertEquals(ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
-    Assertions.assertEquals(1,
-        containerBalancerTask.getMetrics()
-            .getNumContainerMovesCompletedInLatestIteration());
+    assertEquals(1, containerBalancerTask.getMetrics().getNumContainerMovesCompletedInLatestIteration());
     assertThat(containerBalancerTask.getMetrics()
         .getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(1);
     stopBalancer();
@@ -971,8 +965,7 @@ public class TestContainerBalancerTask {
 
     assertThat(containerBalancerTask.getMetrics()
         .getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(0);
-    Assertions.assertEquals(0, containerBalancerTask.getMetrics()
-        .getNumContainerMovesCompletedInLatestIteration());
+    assertEquals(0, containerBalancerTask.getMetrics().getNumContainerMovesCompletedInLatestIteration());
     stopBalancer();
 
     /*
@@ -987,8 +980,7 @@ public class TestContainerBalancerTask {
     startBalancer(balancerConfiguration);
     assertThat(containerBalancerTask.getMetrics()
         .getNumContainerMovesTimeoutInLatestIteration()).isGreaterThan(0);
-    Assertions.assertEquals(0, containerBalancerTask.getMetrics()
-        .getNumContainerMovesCompletedInLatestIteration());
+    assertEquals(0, containerBalancerTask.getMetrics().getNumContainerMovesCompletedInLatestIteration());
     stopBalancer();
   }
 
@@ -1025,8 +1017,7 @@ public class TestContainerBalancerTask {
 
     startBalancer(balancerConfiguration);
 
-    Assertions.assertEquals(
-        ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
+    assertEquals(ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
     assertThat(containerBalancerTask.getMetrics().getNumContainerMovesFailed())
         .isGreaterThanOrEqualTo(3);
@@ -1050,8 +1041,7 @@ public class TestContainerBalancerTask {
 
     rmConf.setEnableLegacy(false);
     startBalancer(balancerConfiguration);
-    Assertions.assertEquals(
-        ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
+    assertEquals(ContainerBalancerTask.IterationResult.ITERATION_COMPLETED,
         containerBalancerTask.getIterationResult());
     assertThat(containerBalancerTask.getMetrics().getNumContainerMovesFailed())
         .isGreaterThanOrEqualTo(3);
@@ -1069,8 +1059,7 @@ public class TestContainerBalancerTask {
     Thread balancingThread = new Thread(containerBalancerTask);
     // start the thread and assert that balancer is RUNNING
     balancingThread.start();
-    Assertions.assertEquals(ContainerBalancerTask.Status.RUNNING,
-        containerBalancerTask.getBalancerStatus());
+    assertEquals(ContainerBalancerTask.Status.RUNNING, containerBalancerTask.getBalancerStatus());
 
     /*
      Wait for the thread to start sleeping and assert that it's sleeping.
@@ -1078,7 +1067,7 @@ public class TestContainerBalancerTask {
      */
     GenericTestUtils.waitFor(
         () -> balancingThread.getState() == Thread.State.TIMED_WAITING, 1, 20);
-    Assertions.assertEquals(Thread.State.TIMED_WAITING,
+    assertEquals(Thread.State.TIMED_WAITING,
         balancingThread.getState());
 
     // interrupt the thread from its sleep, wait and assert that balancer has
@@ -1086,12 +1075,11 @@ public class TestContainerBalancerTask {
     balancingThread.interrupt();
     GenericTestUtils.waitFor(() -> containerBalancerTask.getBalancerStatus() ==
         ContainerBalancerTask.Status.STOPPED, 1, 20);
-    Assertions.assertEquals(ContainerBalancerTask.Status.STOPPED,
-        containerBalancerTask.getBalancerStatus());
+    assertEquals(ContainerBalancerTask.Status.STOPPED, containerBalancerTask.getBalancerStatus());
 
     // ensure the thread dies
     GenericTestUtils.waitFor(() -> !balancingThread.isAlive(), 1, 20);
-    Assertions.assertFalse(balancingThread.isAlive());
+    assertFalse(balancingThread.isAlive());
   }
 
   /**
@@ -1119,11 +1107,11 @@ public class TestContainerBalancerTask {
      */
     Map<ContainerID, DatanodeDetails> containerToSource =
         containerBalancerTask.getContainerToSourceMap();
-    Assertions.assertFalse(containerToSource.isEmpty());
+    assertFalse(containerToSource.isEmpty());
     for (Map.Entry<ContainerID, DatanodeDetails> entry :
         containerToSource.entrySet()) {
       ContainerInfo containerInfo = cidToInfoMap.get(entry.getKey());
-      Assertions.assertNotSame(HddsProtos.ReplicationType.EC,
+      assertNotSame(HddsProtos.ReplicationType.EC,
           containerInfo.getReplicationType());
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -57,7 +57,6 @@ import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -80,7 +79,11 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -129,13 +132,13 @@ public class TestContainerBalancerTask {
       TimeoutException {
     conf = new OzoneConfiguration();
     rmConf = new ReplicationManagerConfiguration();
-    scm = Mockito.mock(StorageContainerManager.class);
-    containerManager = Mockito.mock(ContainerManager.class);
-    replicationManager = Mockito.mock(ReplicationManager.class);
-    serviceStateManager = Mockito.mock(StatefulServiceStateManagerImpl.class);
-    SCMServiceManager scmServiceManager = Mockito.mock(SCMServiceManager.class);
-    moveManager = Mockito.mock(MoveManager.class);
-    Mockito.when(moveManager.move(any(ContainerID.class),
+    scm = mock(StorageContainerManager.class);
+    containerManager = mock(ContainerManager.class);
+    replicationManager = mock(ReplicationManager.class);
+    serviceStateManager = mock(StatefulServiceStateManagerImpl.class);
+    SCMServiceManager scmServiceManager = mock(SCMServiceManager.class);
+    moveManager = mock(MoveManager.class);
+    when(moveManager.move(any(ContainerID.class),
             any(DatanodeDetails.class), any(DatanodeDetails.class)))
         .thenReturn(CompletableFuture.completedFuture(
             MoveManager.MoveResult.COMPLETED));
@@ -144,7 +147,7 @@ public class TestContainerBalancerTask {
     Disable LegacyReplicationManager. This means balancer should select RATIS
      as well as EC containers for balancing. Also, MoveManager will be used.
      */
-    Mockito.when(replicationManager.getConfig()).thenReturn(rmConf);
+    when(replicationManager.getConfig()).thenReturn(rmConf);
     rmConf.setEnableLegacy(false);
     // these configs will usually be specified in each test
     balancerConfiguration =
@@ -171,26 +174,26 @@ public class TestContainerBalancerTask {
     placementPolicyValidateProxy = new PlacementPolicyValidateProxy(
         placementPolicy, ecPlacementPolicy);
 
-    Mockito.when(replicationManager
-        .isContainerReplicatingOrDeleting(Mockito.any(ContainerID.class)))
+    when(replicationManager
+        .isContainerReplicatingOrDeleting(any(ContainerID.class)))
         .thenReturn(false);
 
-    Mockito.when(replicationManager.move(Mockito.any(ContainerID.class),
-        Mockito.any(DatanodeDetails.class),
-        Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.move(any(ContainerID.class),
+        any(DatanodeDetails.class),
+        any(DatanodeDetails.class)))
         .thenReturn(CompletableFuture.
             completedFuture(MoveManager.MoveResult.COMPLETED));
 
-    Mockito.when(replicationManager.getClock())
+    when(replicationManager.getClock())
         .thenReturn(Clock.system(ZoneId.systemDefault()));
 
-    when(containerManager.getContainerReplicas(Mockito.any(ContainerID.class)))
+    when(containerManager.getContainerReplicas(any(ContainerID.class)))
         .thenAnswer(invocationOnMock -> {
           ContainerID cid = (ContainerID) invocationOnMock.getArguments()[0];
           return cidToReplicasMap.get(cid);
         });
 
-    when(containerManager.getContainer(Mockito.any(ContainerID.class)))
+    when(containerManager.getContainer(any(ContainerID.class)))
         .thenAnswer(invocationOnMock -> {
           ContainerID cid = (ContainerID) invocationOnMock.getArguments()[0];
           return cidToInfoMap.get(cid);
@@ -217,23 +220,23 @@ public class TestContainerBalancerTask {
     When StatefulServiceStateManager#saveConfiguration is called, save to
     in-memory serviceToConfigMap instead.
      */
-    Mockito.doAnswer(i -> {
+    doAnswer(i -> {
       serviceToConfigMap.put(i.getArgument(0, String.class), i.getArgument(1,
           ByteString.class));
       return null;
     }).when(serviceStateManager).saveConfiguration(
-        Mockito.any(String.class),
-        Mockito.any(ByteString.class));
+        any(String.class),
+        any(ByteString.class));
 
     /*
     When StatefulServiceStateManager#readConfiguration is called, read from
     serviceToConfigMap instead.
      */
-    when(serviceStateManager.readConfiguration(Mockito.anyString())).thenAnswer(
+    when(serviceStateManager.readConfiguration(anyString())).thenAnswer(
         i -> serviceToConfigMap.get(i.getArgument(0, String.class)));
 
-    Mockito.doNothing().when(scmServiceManager)
-        .register(Mockito.any(SCMService.class));
+    doNothing().when(scmServiceManager)
+        .register(any(SCMService.class));
     ContainerBalancer sb = new ContainerBalancer(scm);
     containerBalancerTask = new ContainerBalancerTask(scm, 0, sb,
         sb.getMetrics(), balancerConfiguration, false);
@@ -297,14 +300,14 @@ public class TestContainerBalancerTask {
       NodeNotFoundException {
     rmConf.setEnableLegacy(false);
     startBalancer(balancerConfiguration);
-    Mockito.verify(moveManager, atLeastOnce())
-        .move(Mockito.any(ContainerID.class),
-            Mockito.any(DatanodeDetails.class),
-            Mockito.any(DatanodeDetails.class));
+    verify(moveManager, atLeastOnce())
+        .move(any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class));
 
-    Mockito.verify(replicationManager, times(0))
-        .move(Mockito.any(ContainerID.class), Mockito.any(
-            DatanodeDetails.class), Mockito.any(DatanodeDetails.class));
+    verify(replicationManager, times(0))
+        .move(any(ContainerID.class), any(
+            DatanodeDetails.class), any(DatanodeDetails.class));
   }
 
   /**
@@ -402,7 +405,7 @@ public class TestContainerBalancerTask {
       InvalidContainerBalancerConfigurationException, TimeoutException {
 
     // let's mock such that all replicas have CLOSING state
-    when(containerManager.getContainerReplicas(Mockito.any(ContainerID.class)))
+    when(containerManager.getContainerReplicas(any(ContainerID.class)))
         .thenAnswer(invocationOnMock -> {
           ContainerID cid = (ContainerID) invocationOnMock.getArguments()[0];
           Set<ContainerReplica> replicas = cidToReplicasMap.get(cid);
@@ -569,7 +572,7 @@ public class TestContainerBalancerTask {
      move should equal number of unique, selected containers (from
      containerToTargetMap).
      */
-    Mockito.verify(replicationManager, times(numContainers))
+    verify(replicationManager, times(numContainers))
         .move(any(ContainerID.class), any(DatanodeDetails.class),
             any(DatanodeDetails.class));
 
@@ -581,7 +584,7 @@ public class TestContainerBalancerTask {
     startBalancer(balancerConfiguration);
     stopBalancer();
     numContainers = containerBalancerTask.getContainerToTargetMap().size();
-    Mockito.verify(moveManager, times(numContainers))
+    verify(moveManager, times(numContainers))
         .move(any(ContainerID.class), any(DatanodeDetails.class),
             any(DatanodeDetails.class));
   }
@@ -700,7 +703,7 @@ public class TestContainerBalancerTask {
     // deliberately set max size per iteration to a low value, 6 GB
     balancerConfiguration.setMaxSizeToMovePerIteration(6 * STORAGE_UNIT);
     balancerConfiguration.setMaxDatanodesPercentageToInvolvePerIteration(100);
-    Mockito.when(moveManager.move(any(), any(), any()))
+    when(moveManager.move(any(), any(), any()))
            .thenReturn(CompletableFuture.completedFuture(
                MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY))
            .thenReturn(CompletableFuture.completedFuture(
@@ -850,9 +853,9 @@ public class TestContainerBalancerTask {
     Now, limit maxSizeToMovePerIteration but fail all container moves. The
     result should still be ITERATION_COMPLETED.
      */
-    Mockito.when(replicationManager.move(Mockito.any(ContainerID.class),
-            Mockito.any(DatanodeDetails.class),
-            Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class)))
         .thenReturn(CompletableFuture.completedFuture(
             MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY));
     balancerConfiguration.setMaxSizeToMovePerIteration(10 * STORAGE_UNIT);
@@ -888,9 +891,9 @@ public class TestContainerBalancerTask {
 
     CompletableFuture<MoveManager.MoveResult> completedFuture =
         CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED);
-    Mockito.when(replicationManager.move(Mockito.any(ContainerID.class),
-            Mockito.any(DatanodeDetails.class),
-            Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class)))
         .thenReturn(completedFuture)
         .thenAnswer(invocation -> genCompletableFuture(2000));
 
@@ -923,9 +926,9 @@ public class TestContainerBalancerTask {
     should be successful. The rest should fail.
      */
     rmConf.setEnableLegacy(false);
-    Mockito.when(moveManager.move(Mockito.any(ContainerID.class),
-            Mockito.any(DatanodeDetails.class),
-            Mockito.any(DatanodeDetails.class)))
+    when(moveManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class)))
         .thenReturn(completedFuture)
         .thenAnswer(invocation -> genCompletableFuture(2000));
 
@@ -952,9 +955,9 @@ public class TestContainerBalancerTask {
     CompletableFuture<MoveManager.MoveResult> future2
         = CompletableFuture.supplyAsync(() ->
         MoveManager.MoveResult.DELETION_FAIL_TIME_OUT);
-    Mockito.when(replicationManager.move(Mockito.any(ContainerID.class),
-            Mockito.any(DatanodeDetails.class),
-            Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class)))
         .thenReturn(future, future2);
 
     balancerConfiguration.setThreshold(10);
@@ -975,9 +978,9 @@ public class TestContainerBalancerTask {
     /*
     Try the same test with MoveManager instead of LegacyReplicationManager.
      */
-    Mockito.when(moveManager.move(Mockito.any(ContainerID.class),
-            Mockito.any(DatanodeDetails.class),
-            Mockito.any(DatanodeDetails.class)))
+    when(moveManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class)))
         .thenReturn(future).thenAnswer(invocation -> future2);
 
     rmConf.setEnableLegacy(false);
@@ -999,9 +1002,9 @@ public class TestContainerBalancerTask {
     CompletableFuture<MoveManager.MoveResult> future =
         new CompletableFuture<>();
     future.completeExceptionally(new RuntimeException("Runtime Exception"));
-    Mockito.when(replicationManager.move(Mockito.any(ContainerID.class),
-            Mockito.any(DatanodeDetails.class),
-            Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class)))
         .thenReturn(CompletableFuture.supplyAsync(() -> {
           try {
             Thread.sleep(1);
@@ -1032,9 +1035,9 @@ public class TestContainerBalancerTask {
     /*
     Try the same test but with MoveManager instead of ReplicationManager.
      */
-    Mockito.when(moveManager.move(Mockito.any(ContainerID.class),
-            Mockito.any(DatanodeDetails.class),
-            Mockito.any(DatanodeDetails.class)))
+    when(moveManager.move(any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class)))
         .thenReturn(CompletableFuture.supplyAsync(() -> {
           try {
             Thread.sleep(1);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestFindTargetStrategy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestFindTargetStrategy.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -78,16 +77,13 @@ public class TestFindTargetStrategy {
 
     Object[] sortedPotentialTargetArray = potentialTargets.toArray();
 
-    Assertions.assertEquals(sortedPotentialTargetArray.length, 3);
+    assertEquals(3, sortedPotentialTargetArray.length);
 
     //make sure after sorting target for source, the potentialTargets is
     //sorted in descending order of usage
-    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[0])
-        .getDatanodeDetails(), dui3.getDatanodeDetails());
-    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[1])
-        .getDatanodeDetails(), dui2.getDatanodeDetails());
-    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2])
-        .getDatanodeDetails(), dui1.getDatanodeDetails());
+    assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[0]).getDatanodeDetails(), dui3.getDatanodeDetails());
+    assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[1]).getDatanodeDetails(), dui2.getDatanodeDetails());
+    assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2]).getDatanodeDetails(), dui1.getDatanodeDetails());
 
   }
 
@@ -118,10 +114,8 @@ public class TestFindTargetStrategy {
     List<DatanodeDetails> newPotentialTargets = new ArrayList<>(1);
     newPotentialTargets.add(dui1.getDatanodeDetails());
     findTargetGreedyByUsageInfo.resetPotentialTargets(newPotentialTargets);
-    Assertions.assertEquals(1,
-        findTargetGreedyByUsageInfo.getPotentialTargets().size());
-    Assertions.assertEquals(dui1,
-        findTargetGreedyByUsageInfo.getPotentialTargets().iterator().next());
+    assertEquals(1, findTargetGreedyByUsageInfo.getPotentialTargets().size());
+    assertEquals(dui1, findTargetGreedyByUsageInfo.getPotentialTargets().iterator().next());
   }
 
   /**
@@ -206,26 +200,21 @@ public class TestFindTargetStrategy {
         findTargetGreedyByNetworkTopology.getPotentialTargets();
 
     Object[] sortedPotentialTargetArray = potentialTargets.toArray();
-    Assertions.assertEquals(sortedPotentialTargetArray.length, 5);
+    assertEquals(5, sortedPotentialTargetArray.length);
 
     // although target1 has the highest usage, it has the nearest network
     // topology distance to source, so it should be at the head of the
     // sorted PotentialTargetArray
-    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[0])
-        .getDatanodeDetails(), target1);
+    assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[0]).getDatanodeDetails(), target1);
 
     // these targets have same network topology distance to source,
     // so they should be sorted by usage
-    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[1])
-        .getDatanodeDetails(), target4);
-    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2])
-        .getDatanodeDetails(), target3);
-    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[3])
-        .getDatanodeDetails(), target2);
+    assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[1]).getDatanodeDetails(), target4);
+    assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2]).getDatanodeDetails(), target3);
+    assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[3]).getDatanodeDetails(), target2);
 
     //target5 has the lowest usage , but it has the farthest distance to source
     //so it should be at the tail of the sorted PotentialTargetArray
-    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[4])
-        .getDatanodeDetails(), target5);
+    assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[4]).getDatanodeDetails(), target5);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +51,11 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLU
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -153,12 +156,12 @@ public class TestContainerPlacementFactory {
     int nodeNum = 3;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(null, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(1),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
   }
 
@@ -168,7 +171,7 @@ public class TestContainerPlacementFactory {
             SCMContainerPlacementRackAware.class.getName());
     PlacementPolicy policy = ContainerPlacementPolicyFactory
         .getPolicy(conf, null, null, true, null);
-    Assertions.assertSame(SCMContainerPlacementRackAware.class,
+    assertSame(SCMContainerPlacementRackAware.class,
             policy.getClass());
   }
 
@@ -176,7 +179,7 @@ public class TestContainerPlacementFactory {
   public void testECPolicy() throws IOException {
     PlacementPolicy policy = ContainerPlacementPolicyFactory
         .getECPolicy(conf, null, null, true, null);
-    Assertions.assertSame(SCMContainerPlacementRackScatter.class,
+    assertSame(SCMContainerPlacementRackScatter.class,
         policy.getClass());
   }
 
@@ -220,7 +223,7 @@ public class TestContainerPlacementFactory {
     conf.set(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
         DummyImpl.class.getName());
 
-    Assertions.assertThrows(SCMException.class, () ->
+    assertThrows(SCMException.class, () ->
         ContainerPlacementPolicyFactory.getPolicy(conf, null, null, true, null)
     );
   }
@@ -230,7 +233,7 @@ public class TestContainerPlacementFactory {
     // set a placement class not implemented
     conf.set(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
         "org.apache.hadoop.hdds.scm.container.placement.algorithm.HelloWorld");
-    Assertions.assertThrows(RuntimeException.class, () ->
+    assertThrows(RuntimeException.class, () ->
         ContainerPlacementPolicyFactory.getPolicy(conf, null, null, true, null)
     );
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -47,13 +47,13 @@ import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -138,7 +138,7 @@ public class TestContainerPlacementFactory {
         new ArrayList<>(Arrays.asList(storage4)));
 
     // create mock node manager
-    nodeManager = Mockito.mock(NodeManager.class);
+    nodeManager = mock(NodeManager.class);
     when(nodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
     for (DatanodeInfo dn: dnInfos) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -99,7 +99,7 @@ public class TestSCMContainerPlacementCapacity {
     datanodes.get(4).updateStorageReports(
         new ArrayList<>(Arrays.asList(storage4)));
 
-    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
+    NodeManager mockNodeManager = mock(NodeManager.class);
     when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -37,9 +37,11 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -137,16 +139,16 @@ public class TestSCMContainerPlacementCapacity {
           .chooseDatanodes(existingNodes, null, 1, 15, 15);
 
       //then
-      Assertions.assertEquals(1, datanodeDetails.size());
+      assertEquals(1, datanodeDetails.size());
       DatanodeDetails datanode0Details = datanodeDetails.get(0);
 
-      Assertions.assertNotEquals(
+      assertNotEquals(
           datanodes.get(0), datanode0Details,
           "Datanode 0 should not been selected: excluded by parameter");
-      Assertions.assertNotEquals(
+      assertNotEquals(
           datanodes.get(1), datanode0Details,
           "Datanode 1 should not been selected: excluded by parameter");
-      Assertions.assertNotEquals(
+      assertNotEquals(
           datanodes.get(2), datanode0Details,
           "Datanode 2 should not been selected: not enough space there");
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -65,7 +65,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -67,6 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -173,7 +173,7 @@ public class TestSCMContainerPlacementRackAware {
     }
 
     // create mock node manager
-    nodeManager = Mockito.mock(NodeManager.class);
+    nodeManager = mock(NodeManager.class);
     when(nodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
     for (DatanodeInfo dn: dnInfos) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,9 +60,12 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
@@ -210,40 +212,40 @@ public class TestSCMContainerPlacementRackAware {
     int nodeNum = 1;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // 2 replicas
     nodeNum = 2;
     datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)) || (datanodeCount % NODE_PER_RACK == 1));
 
     //  3 replicas
     nodeNum = 3;
     datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
     // requires at least 2 racks for following statement
     assumeTrue(datanodeCount > NODE_PER_RACK &&
         datanodeCount % NODE_PER_RACK > 1);
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(1),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
 
     //  4 replicas
     nodeNum = 4;
     datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
     // requires at least 2 racks and enough datanodes for following statement
     assumeTrue(datanodeCount > NODE_PER_RACK + 1);
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(1),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
   }
 
@@ -262,10 +264,10 @@ public class TestSCMContainerPlacementRackAware {
     excludedNodes.add(datanodes.get(1));
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(
         excludedNodes, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         excludedNodes.get(0)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         excludedNodes.get(1)));
 
     // 3 replicas, one existing datanode
@@ -274,8 +276,8 @@ public class TestSCMContainerPlacementRackAware {
     excludedNodes.add(datanodes.get(0));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertTrue(cluster.isSameParent(
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertTrue(cluster.isSameParent(
         datanodeDetails.get(0), excludedNodes.get(0)) ||
         cluster.isSameParent(datanodeDetails.get(0), excludedNodes.get(1)));
 
@@ -286,8 +288,8 @@ public class TestSCMContainerPlacementRackAware {
     excludedNodes.add(datanodes.get(5));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertTrue(cluster.isSameParent(
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertTrue(cluster.isSameParent(
         datanodeDetails.get(0), excludedNodes.get(0)) ||
         cluster.isSameParent(datanodeDetails.get(0), excludedNodes.get(1)));
   }
@@ -305,7 +307,7 @@ public class TestSCMContainerPlacementRackAware {
         policy.chooseDatanodes(excludeNodes, null, 1, 0, 0);
     assertEquals(1, chooseDatanodes.size());
     // the selected node should be on the same rack as the second exclude node
-    Assertions.assertTrue(
+    assertTrue(
         cluster.isSameParent(chooseDatanodes.get(0), excludeNodes.get(1)),
         chooseDatanodes.get(0).toString());
   }
@@ -322,16 +324,16 @@ public class TestSCMContainerPlacementRackAware {
     int nodeNum = 5;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(1),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(3)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(2),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(2),
         datanodeDetails.get(3)));
 
     // get metrics
@@ -341,8 +343,8 @@ public class TestSCMContainerPlacementRackAware {
     long compromiseCount = metrics.getDatanodeChooseFallbackCount();
 
     // verify metrics
-    Assertions.assertEquals(totalRequest, nodeNum);
-    Assertions.assertEquals(successCount, nodeNum);
+    assertEquals(totalRequest, nodeNum);
+    assertEquals(successCount, nodeNum);
     assertThat(tryCount).isGreaterThan(nodeNum);
     assertThat(compromiseCount).isGreaterThanOrEqualTo(1);
   }
@@ -368,12 +370,12 @@ public class TestSCMContainerPlacementRackAware {
     long tryCount = metrics.getDatanodeChooseAttemptCount();
     long compromiseCount = metrics.getDatanodeChooseFallbackCount();
 
-    Assertions.assertEquals(nodeNum, totalRequest);
+    assertEquals(nodeNum, totalRequest);
     assertThat(successCount).withFailMessage("Not enough success count")
         .isGreaterThanOrEqualTo(1);
     assertThat(tryCount).withFailMessage("Not enough try count")
         .isGreaterThanOrEqualTo(1);
-    Assertions.assertEquals(0, compromiseCount);
+    assertEquals(0, compromiseCount);
   }
 
   @ParameterizedTest
@@ -389,8 +391,8 @@ public class TestSCMContainerPlacementRackAware {
     favoredNodes.add(datanodes.get(0));
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(
         excludedNodes, favoredNodes, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertEquals(datanodeDetails.get(0).getNetworkFullPath(),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(datanodeDetails.get(0).getNetworkFullPath(),
         favoredNodes.get(0).getNetworkFullPath());
 
     // no overlap between excludedNodes and favoredNodes, favoredNodes can been
@@ -401,8 +403,8 @@ public class TestSCMContainerPlacementRackAware {
     favoredNodes.add(datanodes.get(2));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, favoredNodes, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertEquals(datanodeDetails.get(0).getNetworkFullPath(),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(datanodeDetails.get(0).getNetworkFullPath(),
         favoredNodes.get(0).getNetworkFullPath());
 
     // there is overlap between excludedNodes and favoredNodes, favoredNodes
@@ -413,8 +415,8 @@ public class TestSCMContainerPlacementRackAware {
     favoredNodes.add(datanodes.get(0));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, favoredNodes, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertNotEquals(datanodeDetails.get(0).getNetworkFullPath(),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertNotEquals(datanodeDetails.get(0).getNetworkFullPath(),
         favoredNodes.get(0).getNetworkFullPath());
   }
 
@@ -438,10 +440,10 @@ public class TestSCMContainerPlacementRackAware {
     long tryCount = metrics.getDatanodeChooseAttemptCount();
     long compromiseCount = metrics.getDatanodeChooseFallbackCount();
 
-    Assertions.assertEquals(totalRequest, nodeNum);
-    Assertions.assertEquals(successCount, 0);
+    assertEquals(totalRequest, nodeNum);
+    assertEquals(successCount, 0);
     assertThat(tryCount).withFailMessage("Not enough try").isGreaterThanOrEqualTo(nodeNum);
-    Assertions.assertEquals(compromiseCount, 0);
+    assertEquals(compromiseCount, 0);
   }
 
   @ParameterizedTest
@@ -478,7 +480,7 @@ public class TestSCMContainerPlacementRackAware {
       clusterMap.add(dn);
       dnInfoList.add(dnInfo);
     }
-    Assertions.assertEquals(dataList.size(), StringUtils.countMatches(
+    assertEquals(dataList.size(), StringUtils.countMatches(
         clusterMap.toString(), NetConstants.DEFAULT_RACK));
     for (DatanodeInfo dn: dnInfoList) {
       when(nodeManager.getNodeByUuid(dn.getUuid()))
@@ -492,12 +494,12 @@ public class TestSCMContainerPlacementRackAware {
             metrics);
     List<DatanodeDetails> datanodeDetails =
         newPolicy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(1),
+    assertTrue(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
   }
 
@@ -629,7 +631,7 @@ public class TestSCMContainerPlacementRackAware {
       try {
         List<DatanodeDetails> datanodeDetails =
             policy.chooseDatanodes(null, null, 1, 0, 0);
-        Assertions.assertEquals(dnInfos.get(index), datanodeDetails.get(0));
+        assertEquals(dnInfos.get(index), datanodeDetails.get(0));
       } catch (SCMException e) {
         // If we get SCMException: No satisfied datanode to meet the ... this is
         // ok, as there is only 1 IN_SERVICE node and with the retry logic we
@@ -655,10 +657,10 @@ public class TestSCMContainerPlacementRackAware {
 
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(usedNodes,
         excludedNodes, null, nodeNum, 0, 5);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // New DN should be on different rack than DN0 & DN1
-    Assertions.assertTrue(!cluster.isSameParent(
+    assertTrue(!cluster.isSameParent(
         datanodes.get(0), datanodeDetails.get(0)) &&
         !cluster.isSameParent(datanodes.get(1), datanodeDetails.get(0)));
 
@@ -671,10 +673,10 @@ public class TestSCMContainerPlacementRackAware {
 
     datanodeDetails = policy.chooseDatanodes(usedNodes,
         excludedNodes, null, nodeNum, 0, 5);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // New replica should be either on rack0 or rack1
-    Assertions.assertTrue(cluster.isSameParent(
+    assertTrue(cluster.isSameParent(
         datanodes.get(0), datanodeDetails.get(0)) ||
         cluster.isSameParent(datanodes.get(5), datanodeDetails.get(0)));
   }
@@ -695,9 +697,9 @@ public class TestSCMContainerPlacementRackAware {
 
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(usedNodes,
         excludedNodes, null, nodeNum, 0, 5);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
-    Assertions.assertTrue(cluster.isSameParent(
+    assertTrue(cluster.isSameParent(
         datanodes.get(0), datanodeDetails.get(0)) &&
         cluster.isSameParent(datanodes.get(1), datanodeDetails.get(0)) &&
         excludedNodes.get(0).getUuid() != datanodeDetails.get(0).getUuid());
@@ -711,9 +713,9 @@ public class TestSCMContainerPlacementRackAware {
 
     datanodeDetails = policy.chooseDatanodes(usedNodes,
         excludedNodes, null, nodeNum, 0, 5);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
-    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+    assertTrue(excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(0).getUuid() &&
         excludedNodes.get(0).getUuid() != datanodeDetails.get(1).getUuid());
 
@@ -723,9 +725,9 @@ public class TestSCMContainerPlacementRackAware {
 
     datanodeDetails = policy.chooseDatanodes(usedNodes,
         excludedNodes, null, nodeNum, 0, 5);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
-    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+    assertTrue(excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(0).getUuid() &&
         excludedNodes.get(0).getUuid() != datanodeDetails.get(1).getUuid());
   }
@@ -748,10 +750,10 @@ public class TestSCMContainerPlacementRackAware {
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(usedNodes,
         excludedNodes, null, nodeNum, 0, 5);
 
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // Exclude node should not be returned
-    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+    assertTrue(excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(0).getUuid() && excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(1).getUuid());
 
@@ -766,13 +768,13 @@ public class TestSCMContainerPlacementRackAware {
     datanodeDetails = policy.chooseDatanodes(usedNodes,
         excludedNodes, null, nodeNum, 0, 5);
 
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
-    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+    assertTrue(excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(0).getUuid() && excludedNodes.get(1).getUuid() !=
         datanodeDetails.get(0).getUuid());
 
-    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+    assertTrue(excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(1).getUuid() && excludedNodes.get(1).getUuid() !=
         datanodeDetails.get(1).getUuid());
   }
@@ -791,10 +793,10 @@ public class TestSCMContainerPlacementRackAware {
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(null,
         excludedNodes, null, nodeNum, 0, 5);
 
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // Exclude node should not be returned
-    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+    assertTrue(excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(0).getUuid() && excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(1).getUuid());
 
@@ -806,14 +808,14 @@ public class TestSCMContainerPlacementRackAware {
     datanodeDetails = policy.chooseDatanodes(null,
         excludedNodes, null, nodeNum, 0, 5);
 
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // Exclude node should not be returned
-    Assertions.assertTrue(excludedNodes.get(0).getUuid() !=
+    assertTrue(excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(0).getUuid() && excludedNodes.get(0).getUuid() !=
         datanodeDetails.get(1).getUuid());
 
-    Assertions.assertTrue(excludedNodes.get(1).getUuid() !=
+    assertTrue(excludedNodes.get(1).getUuid() !=
         datanodeDetails.get(0).getUuid() && excludedNodes.get(1).getUuid() !=
         datanodeDetails.get(1).getUuid());
   }
@@ -842,12 +844,12 @@ public class TestSCMContainerPlacementRackAware {
     long tryCount = metrics.getDatanodeChooseAttemptCount();
     long compromiseCount = metrics.getDatanodeChooseFallbackCount();
 
-    Assertions.assertEquals(nodeNum, totalRequest);
+    assertEquals(nodeNum, totalRequest);
     assertThat(successCount).withFailMessage("Not enough success count")
         .isGreaterThanOrEqualTo(1);
     assertThat(tryCount).withFailMessage("Not enough try count")
         .isGreaterThanOrEqualTo(1);
-    Assertions.assertEquals(0, compromiseCount);
+    assertEquals(0, compromiseCount);
   }
 
   @Test
@@ -868,10 +870,10 @@ public class TestSCMContainerPlacementRackAware {
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(usedNodes,
         null, favouredNodes, nodeNum, 0, 5);
 
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
     // Favoured node should not be returned,
     // Returned node should be on the different rack than the favoured node.
-    Assertions.assertFalse(cluster.isSameParent(
+    assertFalse(cluster.isSameParent(
         favouredNodes.get(0), datanodeDetails.get(0)));
 
     favouredNodes.clear();
@@ -881,11 +883,11 @@ public class TestSCMContainerPlacementRackAware {
     datanodeDetails = policy.chooseDatanodes(usedNodes,
         null, favouredNodes, nodeNum, 0, 5);
 
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // Favoured node should be returned,
     // as favoured node is in the different rack as used nodes.
-    Assertions.assertSame(favouredNodes.get(0).getUuid(), datanodeDetails.get(0).getUuid());
+    assertSame(favouredNodes.get(0).getUuid(), datanodeDetails.get(0).getUuid());
 
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -242,7 +242,7 @@ public class TestSCMContainerPlacementRackScatter {
     }
 
     // create mock node manager
-    nodeManager = Mockito.mock(NodeManager.class);
+    nodeManager = mock(NodeManager.class);
     when(nodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
     for (DatanodeInfo dn: dnInfos) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,8 +69,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
@@ -280,21 +281,21 @@ public class TestSCMContainerPlacementRackScatter {
     int nodeNum = 1;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // 2 replicas
     nodeNum = 2;
     datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertTrue(!cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertTrue(!cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)) || (datanodeCount <= NODE_PER_RACK));
 
     //  3 replicas
     nodeNum = 3;
     if (datanodeCount > nodeNum) {
       datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-      Assertions.assertEquals(nodeNum, datanodeDetails.size());
-      Assertions.assertEquals(getRackSize(datanodeDetails),
+      assertEquals(nodeNum, datanodeDetails.size());
+      assertEquals(getRackSize(datanodeDetails),
           Math.min(nodeNum, rackNum));
     }
 
@@ -309,9 +310,8 @@ public class TestSCMContainerPlacementRackScatter {
         assertEquals(FAILED_TO_FIND_HEALTHY_NODES, e.getResult());
       } else {
         datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-        Assertions.assertEquals(nodeNum, datanodeDetails.size());
-        Assertions.assertEquals(getRackSize(datanodeDetails),
-                Math.min(nodeNum, rackNum));
+        assertEquals(nodeNum, datanodeDetails.size());
+        assertEquals(getRackSize(datanodeDetails), Math.min(nodeNum, rackNum));
       }
     }
 
@@ -326,9 +326,8 @@ public class TestSCMContainerPlacementRackScatter {
         assertEquals(FAILED_TO_FIND_HEALTHY_NODES, e.getResult());
       } else {
         datanodeDetails = policy.chooseDatanodes(null, null, nodeNum, 0, 15);
-        Assertions.assertEquals(nodeNum, datanodeDetails.size());
-        Assertions.assertEquals(getRackSize(datanodeDetails),
-                Math.min(nodeNum, rackNum));
+        assertEquals(nodeNum, datanodeDetails.size());
+        assertEquals(getRackSize(datanodeDetails), Math.min(nodeNum, rackNum));
       }
     }
   }
@@ -351,10 +350,10 @@ public class TestSCMContainerPlacementRackScatter {
     excludedNodes.add(datanodes.get(1));
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(
         excludedNodes, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         excludedNodes.get(0)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         excludedNodes.get(1)));
 
     // 3 replicas, one existing datanode
@@ -364,8 +363,8 @@ public class TestSCMContainerPlacementRackScatter {
     excludedNodes.add(datanodes.get(0));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertEquals(getRackSize(datanodeDetails, excludedNodes),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(getRackSize(datanodeDetails, excludedNodes),
         Math.min(totalNum, rackNum));
 
     // 3 replicas, two existing datanodes on different rack
@@ -376,8 +375,8 @@ public class TestSCMContainerPlacementRackScatter {
     excludedNodes.add(datanodes.get(5));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertEquals(getRackSize(datanodeDetails, excludedNodes),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(getRackSize(datanodeDetails, excludedNodes),
         Math.min(totalNum, rackNum));
 
     // 5 replicas, one existing datanode
@@ -394,8 +393,8 @@ public class TestSCMContainerPlacementRackScatter {
     } else {
       datanodeDetails = policy.chooseDatanodes(
               excludedNodes, null, nodeNum, 0, 15);
-      Assertions.assertEquals(nodeNum, datanodeDetails.size());
-      Assertions.assertEquals(getRackSize(datanodeDetails, excludedNodes),
+      assertEquals(nodeNum, datanodeDetails.size());
+      assertEquals(getRackSize(datanodeDetails, excludedNodes),
               Math.min(totalNum, rackNum));
     }
 
@@ -408,8 +407,8 @@ public class TestSCMContainerPlacementRackScatter {
     excludedNodes.add(datanodes.get(5));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertEquals(getRackSize(datanodeDetails, excludedNodes),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(getRackSize(datanodeDetails, excludedNodes),
         Math.min(totalNum, rackNum));
   }
 
@@ -426,8 +425,8 @@ public class TestSCMContainerPlacementRackScatter {
     favoredNodes.add(datanodes.get(0));
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(
         excludedNodes, favoredNodes, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertEquals(datanodeDetails.get(0).getNetworkFullPath(),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(datanodeDetails.get(0).getNetworkFullPath(),
         favoredNodes.get(0).getNetworkFullPath());
 
     // no overlap between excludedNodes and favoredNodes, favoredNodes can be
@@ -438,8 +437,8 @@ public class TestSCMContainerPlacementRackScatter {
     favoredNodes.add(datanodes.get(1));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, favoredNodes, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertEquals(datanodeDetails.get(0).getNetworkFullPath(),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(datanodeDetails.get(0).getNetworkFullPath(),
         favoredNodes.get(0).getNetworkFullPath());
 
     // there is overlap between excludedNodes and favoredNodes, favoredNodes
@@ -450,8 +449,8 @@ public class TestSCMContainerPlacementRackScatter {
     favoredNodes.add(datanodes.get(0));
     datanodeDetails = policy.chooseDatanodes(
         excludedNodes, favoredNodes, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertNotEquals(datanodeDetails.get(0).getNetworkFullPath(),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertNotEquals(datanodeDetails.get(0).getNetworkFullPath(),
         favoredNodes.get(0).getNetworkFullPath());
   }
 
@@ -475,10 +474,10 @@ public class TestSCMContainerPlacementRackScatter {
     long tryCount = metrics.getDatanodeChooseAttemptCount();
     long compromiseCount = metrics.getDatanodeChooseFallbackCount();
 
-    Assertions.assertEquals(totalRequest, nodeNum);
-    Assertions.assertEquals(successCount, 0);
+    assertEquals(totalRequest, nodeNum);
+    assertEquals(successCount, 0);
     assertThat(tryCount).withFailMessage("Not enough try").isGreaterThanOrEqualTo(nodeNum);
-    Assertions.assertEquals(compromiseCount, 0);
+    assertEquals(compromiseCount, 0);
   }
 
   @ParameterizedTest
@@ -515,7 +514,7 @@ public class TestSCMContainerPlacementRackScatter {
       clusterMap.add(dn);
       dnInfoList.add(dnInfo);
     }
-    Assertions.assertEquals(dataList.size(), StringUtils.countMatches(
+    assertEquals(dataList.size(), StringUtils.countMatches(
         clusterMap.toString(), NetConstants.DEFAULT_RACK));
     for (DatanodeInfo dn: dnInfoList) {
       when(nodeManager.getNodeByUuid(dn.getUuid()))
@@ -529,8 +528,8 @@ public class TestSCMContainerPlacementRackScatter {
             true, metrics);
     List<DatanodeDetails> datanodeDetails =
         newPolicy.chooseDatanodes(null, null, nodeNum, 0, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertEquals(1, getRackSize(datanodeDetails));
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(1, getRackSize(datanodeDetails));
   }
 
   @ParameterizedTest
@@ -720,12 +719,12 @@ public class TestSCMContainerPlacementRackScatter {
     List<DatanodeDetails> chosenNodes =
         policy.chooseDatanodes(usedDns, excludedDns,
             null, 1, 0, 5);
-    Assertions.assertEquals(1, chosenNodes.size());
+    assertEquals(1, chosenNodes.size());
     /*
     The chosen node should be node4 from the third rack because we prefer to
     choose from racks that don't have used or excluded nodes.
      */
-    Assertions.assertEquals(datanodes.get(4), chosenNodes.get(0));
+    assertEquals(datanodes.get(4), chosenNodes.get(0));
   }
 
   /**
@@ -754,8 +753,8 @@ public class TestSCMContainerPlacementRackScatter {
     List<DatanodeDetails> chosenNode =
         policy.chooseDatanodes(usedDns, excludedDns,
             null, 1, 0, 5);
-    Assertions.assertEquals(1, chosenNode.size());
-    Assertions.assertTrue(chosenNode.get(0).equals(datanodes.get(3)) ||
+    assertEquals(1, chosenNode.size());
+    assertTrue(chosenNode.get(0).equals(datanodes.get(3)) ||
         chosenNode.get(0).equals(datanodes.get(4)));
   }
 
@@ -764,7 +763,7 @@ public class TestSCMContainerPlacementRackScatter {
     setup(5, 2);
     List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1));
     List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(2));
-    SCMException exception = Assertions.assertThrows(SCMException.class, () ->
+    SCMException exception = assertThrows(SCMException.class, () ->
         policy.chooseDatanodes(usedDns, excludedDns,
             null, 3, 0, 5));
     assertThat(exception.getMessage(),
@@ -790,9 +789,9 @@ public class TestSCMContainerPlacementRackScatter {
     List<DatanodeDetails> chosenDatanodes =
         policy.chooseDatanodes(usedDns, excludedDns, null, 2, 0, 5);
 
-    Assertions.assertEquals(2, chosenDatanodes.size());
+    assertEquals(2, chosenDatanodes.size());
     for (DatanodeDetails dn : chosenDatanodes) {
-      Assertions.assertTrue(
+      assertTrue(
           dn.equals(datanodes.get(2)) || dn.equals(datanodes.get(3)));
     }
   }
@@ -848,7 +847,7 @@ public class TestSCMContainerPlacementRackScatter {
 
     List<DatanodeDetails> datanodeDetails = policy.chooseDatanodes(
         excludedNodes, null, nodeNum, 0, 5);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
   }
 
   @Test
@@ -876,7 +875,7 @@ public class TestSCMContainerPlacementRackScatter {
     List<DatanodeDetails> chosenNodes =
         policy.chooseDatanodes(usedDns, excludedDns,
             null, 1, 0, 5);
-    Assertions.assertEquals(1, chosenNodes.size());
+    assertEquals(1, chosenNodes.size());
   }
 
   @Test
@@ -897,7 +896,7 @@ public class TestSCMContainerPlacementRackScatter {
     List<DatanodeDetails> chosenNodes =
         policy.chooseDatanodes(usedDns, excludedDns,
             null, 1, 0, 5);
-    Assertions.assertEquals(1, chosenNodes.size());
+    assertEquals(1, chosenNodes.size());
   }
 
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -72,7 +72,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -34,12 +34,12 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -103,17 +103,14 @@ public class TestSCMContainerPlacementRandom {
           .chooseDatanodes(existingNodes, null, 1, 15, 15);
 
       //then
-      Assertions.assertEquals(1, datanodeDetails.size());
+      assertEquals(1, datanodeDetails.size());
       DatanodeDetails datanode0Details = datanodeDetails.get(0);
 
-      Assertions.assertNotEquals(
-          datanodes.get(0), datanode0Details,
+      assertNotEquals(datanodes.get(0), datanode0Details,
           "Datanode 0 should not been selected: excluded by parameter");
-      Assertions.assertNotEquals(
-          datanodes.get(1), datanode0Details,
+      assertNotEquals(datanodes.get(1), datanode0Details,
           "Datanode 1 should not been selected: excluded by parameter");
-      Assertions.assertNotEquals(
-          datanodes.get(2), datanode0Details,
+      assertNotEquals(datanodes.get(2), datanode0Details,
           "Datanode 2 should not been selected: not enough space there");
 
     }
@@ -215,11 +212,11 @@ public class TestSCMContainerPlacementRandom {
         new SCMContainerPlacementRandom(mockNodeManager, conf, null, true,
             null);
 
-    Assertions.assertTrue(
+    assertTrue(
         scmContainerPlacementRandom.isValidNode(datanodes.get(0), 15L, 15L));
-    Assertions.assertFalse(
+    assertFalse(
         scmContainerPlacementRandom.isValidNode(datanodes.get(1), 15L, 15L));
-    Assertions.assertFalse(
+    assertFalse(
         scmContainerPlacementRandom.isValidNode(datanodes.get(2), 15L, 15L));
 
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -85,7 +85,7 @@ public class TestSCMContainerPlacementRandom {
     datanodes.get(2).updateStorageReports(
         new ArrayList<>(Arrays.asList(storage2)));
 
-    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
+    NodeManager mockNodeManager = mock(NodeManager.class);
     when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
 
@@ -131,7 +131,7 @@ public class TestSCMContainerPlacementRandom {
       datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
     }
 
-    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
+    NodeManager mockNodeManager = mock(NodeManager.class);
     SCMContainerPlacementRandom scmContainerPlacementRandom =
         new SCMContainerPlacementRandom(mockNodeManager, conf, null, true,
             null);
@@ -201,7 +201,7 @@ public class TestSCMContainerPlacementRandom {
     datanodes.get(2).updateMetaDataStorageReports(
         new ArrayList<>(Arrays.asList(metaStorage2)));
 
-    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
+    NodeManager mockNodeManager = mock(NodeManager.class);
     when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
     when(mockNodeManager.getNodeByUuid(datanodes.get(0).getUuid()))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
@@ -54,9 +53,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 
 /**
@@ -396,8 +396,7 @@ public final class ReplicationTestUtil {
       commandsSent.add(Pair.of(sources.get(0), command));
       return null;
     }).when(mock).sendThrottledReplicationCommand(
-        Mockito.any(ContainerInfo.class), Mockito.anyList(),
-        Mockito.any(DatanodeDetails.class), anyInt());
+        any(ContainerInfo.class), anyList(), any(DatanodeDetails.class), anyInt());
   }
 
   /**
@@ -423,8 +422,7 @@ public final class ReplicationTestUtil {
       ReconstructECContainersCommand cmd = invocationOnMock.getArgument(1);
       commandsSent.add(Pair.of(cmd.getTargetDatanodes().get(0), cmd));
       return null;
-    }).when(mock).sendThrottledReconstructionCommand(
-        Mockito.any(ContainerInfo.class), Mockito.any());
+    }).when(mock).sendThrottledReconstructionCommand(any(ContainerInfo.class), any());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
@@ -27,13 +27,17 @@ import org.apache.ozone.test.TestClock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.ADD;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.DELETE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,8 +64,8 @@ public class TestContainerReplicaPendingOps {
     ConfigurationSource conf = new OzoneConfiguration();
     ReplicationManager.ReplicationManagerConfiguration rmConf = conf
         .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
-    ReplicationManager rm = Mockito.mock(ReplicationManager.class);
-    Mockito.when(rm.getConfig()).thenReturn(rmConf);
+    ReplicationManager rm = mock(ReplicationManager.class);
+    when(rm.getConfig()).thenReturn(rmConf);
     metrics = ReplicationManagerMetrics.create(rm);
     pendingOps.setReplicationMetrics(metrics);
     dn1 = MockDatanodeDetails.randomDatanodeDetails();
@@ -332,9 +336,9 @@ public class TestContainerReplicaPendingOps {
   @Test
   public void testNotifySubscribers() {
     // register subscribers
-    ContainerReplicaPendingOpsSubscriber subscriber1 = Mockito.mock(
+    ContainerReplicaPendingOpsSubscriber subscriber1 = mock(
         ContainerReplicaPendingOpsSubscriber.class);
-    ContainerReplicaPendingOpsSubscriber subscriber2 = Mockito.mock(
+    ContainerReplicaPendingOpsSubscriber subscriber2 = mock(
         ContainerReplicaPendingOpsSubscriber.class);
     pendingOps.registerSubscriber(subscriber1);
     pendingOps.registerSubscriber(subscriber2);
@@ -347,18 +351,14 @@ public class TestContainerReplicaPendingOps {
 
     // complete the ADD and verify that subscribers were notified
     pendingOps.completeAddReplica(containerID, dn1, 0);
-    Mockito.verify(subscriber1, Mockito.times(1)).opCompleted(addOp,
-        containerID, false);
-    Mockito.verify(subscriber2, Mockito.times(1)).opCompleted(addOp,
-        containerID, false);
+    verify(subscriber1, times(1)).opCompleted(addOp, containerID, false);
+    verify(subscriber2, times(1)).opCompleted(addOp, containerID, false);
 
     // complete the DELETE and verify subscribers were notified
     ContainerReplicaOp deleteOp = pendingOps.getPendingOps(containerID).get(0);
     pendingOps.completeDeleteReplica(containerID, dn1, 0);
-    Mockito.verify(subscriber1, Mockito.times(1)).opCompleted(deleteOp,
-        containerID, false);
-    Mockito.verify(subscriber2, Mockito.times(1)).opCompleted(deleteOp,
-        containerID, false);
+    verify(subscriber1, times(1)).opCompleted(deleteOp, containerID, false);
+    verify(subscriber2, times(1)).opCompleted(deleteOp, containerID, false);
 
     // now, test notification on expiration
     pendingOps.scheduleDeleteReplica(containerID, dn1, 0, deadline);
@@ -373,14 +373,10 @@ public class TestContainerReplicaPendingOps {
     clock.fastForward(20000);
     pendingOps.removeExpiredEntries();
     // the clock is at 1000 and commands expired at 500
-    Mockito.verify(subscriber1, Mockito.times(1)).opCompleted(addOp,
-        containerID, true);
-    Mockito.verify(subscriber1, Mockito.times(1)).opCompleted(deleteOp,
-        containerID, true);
-    Mockito.verify(subscriber2, Mockito.times(1)).opCompleted(addOp,
-        containerID, true);
-    Mockito.verify(subscriber2, Mockito.times(1)).opCompleted(deleteOp,
-        containerID, true);
+    verify(subscriber1, times(1)).opCompleted(addOp, containerID, true);
+    verify(subscriber1, times(1)).opCompleted(deleteOp, containerID, true);
+    verify(subscriber2, times(1)).opCompleted(addOp, containerID, true);
+    verify(subscriber2, times(1)).opCompleted(deleteOp, containerID, true);
   }
 
   @Test
@@ -392,7 +388,7 @@ public class TestContainerReplicaPendingOps {
     pendingOps.scheduleAddReplica(containerID, dn2, 0, deadline);
 
     // register subscriber
-    ContainerReplicaPendingOpsSubscriber subscriber1 = Mockito.mock(
+    ContainerReplicaPendingOpsSubscriber subscriber1 = mock(
         ContainerReplicaPendingOpsSubscriber.class);
     pendingOps.registerSubscriber(subscriber1);
 
@@ -400,6 +396,6 @@ public class TestContainerReplicaPendingOps {
     pendingOps.removeExpiredEntries();
     // no entries have expired, so there should be zero interactions with the
     // subscriber
-    Mockito.verifyZeroInteractions(subscriber1);
+    verifyZeroInteractions(subscriber1);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestContainerReplicaPendingOps.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.ozone.test.TestClock;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,9 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -77,7 +78,7 @@ public class TestContainerReplicaPendingOps {
   public void testGetPendingOpsReturnsEmptyList() {
     List<ContainerReplicaOp> ops =
         pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(0, ops.size());
+    assertEquals(0, ops.size());
   }
 
   @Test
@@ -85,21 +86,15 @@ public class TestContainerReplicaPendingOps {
     pendingOps.scheduleAddReplica(new ContainerID(1), dn1, 0, deadline);
     pendingOps.scheduleDeleteReplica(new ContainerID(2), dn1, 0, deadline);
 
-    Assertions.assertEquals(1,
-        pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
-    Assertions.assertEquals(1,
-        pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE));
+    assertEquals(1, pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
+    assertEquals(1, pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE));
 
     pendingOps.clear();
 
-    Assertions.assertEquals(0,
-        pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
-    Assertions.assertEquals(0,
-        pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE));
-    Assertions.assertEquals(0,
-        pendingOps.getPendingOps(new ContainerID(1)).size());
-    Assertions.assertEquals(0,
-        pendingOps.getPendingOps(new ContainerID(2)).size());
+    assertEquals(0, pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.ADD));
+    assertEquals(0, pendingOps.getPendingOpCount(ContainerReplicaOp.PendingOpType.DELETE));
+    assertEquals(0, pendingOps.getPendingOps(new ContainerID(1)).size());
+    assertEquals(0, pendingOps.getPendingOps(new ContainerID(2)).size());
 
   }
 
@@ -112,10 +107,10 @@ public class TestContainerReplicaPendingOps {
 
     List<ContainerReplicaOp> ops =
         pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(3, ops.size());
+    assertEquals(3, ops.size());
     for (ContainerReplicaOp op : ops) {
-      Assertions.assertEquals(0, op.getReplicaIndex());
-      Assertions.assertEquals(ADD, op.getOpType());
+      assertEquals(0, op.getReplicaIndex());
+      assertEquals(ADD, op.getOpType());
     }
     List<DatanodeDetails> allDns = ops.stream()
         .map(ContainerReplicaOp::getTarget).collect(Collectors.toList());
@@ -124,10 +119,10 @@ public class TestContainerReplicaPendingOps {
     assertThat(allDns).contains(dn3);
 
     ops = pendingOps.getPendingOps(new ContainerID(2));
-    Assertions.assertEquals(1, ops.size());
-    Assertions.assertEquals(1, ops.get(0).getReplicaIndex());
-    Assertions.assertEquals(ADD, ops.get(0).getOpType());
-    Assertions.assertEquals(dn1, ops.get(0).getTarget());
+    assertEquals(1, ops.size());
+    assertEquals(1, ops.get(0).getReplicaIndex());
+    assertEquals(ADD, ops.get(0).getOpType());
+    assertEquals(dn1, ops.get(0).getTarget());
   }
 
   @Test
@@ -139,10 +134,10 @@ public class TestContainerReplicaPendingOps {
 
     List<ContainerReplicaOp> ops =
         pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(3, ops.size());
+    assertEquals(3, ops.size());
     for (ContainerReplicaOp op : ops) {
-      Assertions.assertEquals(0, op.getReplicaIndex());
-      Assertions.assertEquals(DELETE, op.getOpType());
+      assertEquals(0, op.getReplicaIndex());
+      assertEquals(DELETE, op.getOpType());
     }
     List<DatanodeDetails> allDns = ops.stream()
         .map(ContainerReplicaOp::getTarget).collect(Collectors.toList());
@@ -151,10 +146,10 @@ public class TestContainerReplicaPendingOps {
     assertThat(allDns).contains(dn3);
 
     ops = pendingOps.getPendingOps(new ContainerID(2));
-    Assertions.assertEquals(1, ops.size());
-    Assertions.assertEquals(1, ops.get(0).getReplicaIndex());
-    Assertions.assertEquals(DELETE, ops.get(0).getOpType());
-    Assertions.assertEquals(dn1, ops.get(0).getTarget());
+    assertEquals(1, ops.size());
+    assertEquals(1, ops.get(0).getReplicaIndex());
+    assertEquals(DELETE, ops.get(0).getOpType());
+    assertEquals(dn1, ops.get(0).getTarget());
   }
 
   @Test
@@ -169,25 +164,25 @@ public class TestContainerReplicaPendingOps {
         pendingOps.getPendingOps(new ContainerID(1));
 
     // We expect 4 entries - 2 add and 2 delete.
-    Assertions.assertEquals(4, ops.size());
+    assertEquals(4, ops.size());
 
-    Assertions.assertTrue(pendingOps
+    assertTrue(pendingOps
         .completeAddReplica(new ContainerID(1), dn1, 0));
     ops = pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(3, ops.size());
+    assertEquals(3, ops.size());
 
     // Complete one that does not exist:
-    Assertions.assertFalse(pendingOps
+    assertFalse(pendingOps
         .completeAddReplica(new ContainerID(1), dn1, 0));
     ops = pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(3, ops.size());
+    assertEquals(3, ops.size());
 
     // Complete the remaining ones
     pendingOps.completeDeleteReplica(new ContainerID(1), dn1, 0);
     pendingOps.completeDeleteReplica(new ContainerID(1), dn2, 0);
     pendingOps.completeAddReplica(new ContainerID(1), dn3, 0);
     ops = pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(0, ops.size());
+    assertEquals(0, ops.size());
   }
 
   @Test
@@ -200,14 +195,14 @@ public class TestContainerReplicaPendingOps {
 
     ContainerID cid = new ContainerID(1);
     List<ContainerReplicaOp> ops = pendingOps.getPendingOps(cid);
-    Assertions.assertEquals(4, ops.size());
+    assertEquals(4, ops.size());
     for (ContainerReplicaOp op : ops) {
-      Assertions.assertTrue(pendingOps.removeOp(cid, op));
+      assertTrue(pendingOps.removeOp(cid, op));
     }
     // Attempt to remove one that no longer exists
-    Assertions.assertFalse(pendingOps.removeOp(cid, ops.get(0)));
+    assertFalse(pendingOps.removeOp(cid, ops.get(0)));
     ops = pendingOps.getPendingOps(cid);
-    Assertions.assertEquals(0, ops.size());
+    assertEquals(0, ops.size());
   }
 
   @Test
@@ -223,9 +218,9 @@ public class TestContainerReplicaPendingOps {
 
     List<ContainerReplicaOp> ops =
         pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(4, ops.size());
+    assertEquals(4, ops.size());
     ops = pendingOps.getPendingOps(new ContainerID(2));
-    Assertions.assertEquals(1, ops.size());
+    assertEquals(1, ops.size());
 
     // Some entries expire at "start + 1000" some at start + 2000 and
     // start + 3000. Clock is currently at "start"
@@ -233,13 +228,13 @@ public class TestContainerReplicaPendingOps {
     pendingOps.removeExpiredEntries();
     // Nothing is remove as no deadline is older than the current clock time.
     ops = pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(4, ops.size());
+    assertEquals(4, ops.size());
 
     clock.fastForward(1000);
     pendingOps.removeExpiredEntries();
     // Those with deadline + 1000 should be removed.
     ops = pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(2, ops.size());
+    assertEquals(2, ops.size());
     // We should lose the entries for DN1
     List<DatanodeDetails> dns = ops.stream()
         .map(ContainerReplicaOp::getTarget)
@@ -253,15 +248,15 @@ public class TestContainerReplicaPendingOps {
 
     // Now should only have entries for container 2
     ops = pendingOps.getPendingOps(new ContainerID(1));
-    Assertions.assertEquals(0, ops.size());
+    assertEquals(0, ops.size());
     ops = pendingOps.getPendingOps(new ContainerID(2));
-    Assertions.assertEquals(1, ops.size());
+    assertEquals(1, ops.size());
 
     // Advance the clock again and all should be removed
     clock.fastForward(1000);
     pendingOps.removeExpiredEntries();
     ops = pendingOps.getPendingOps(new ContainerID(2));
-    Assertions.assertEquals(0, ops.size());
+    assertEquals(0, ops.size());
   }
 
   @Test
@@ -275,26 +270,22 @@ public class TestContainerReplicaPendingOps {
     pendingOps.scheduleDeleteReplica(new ContainerID(4), dn3, 0, expiry);
 
     // InFlight Replication and Deletion
-    Assertions.assertEquals(3, pendingOps.getPendingOpCount(ADD));
-    Assertions.assertEquals(3, pendingOps.getPendingOpCount(DELETE));
-    Assertions.assertEquals(1,
-        pendingOps.getPendingOpCount(ADD, ReplicationType.RATIS));
-    Assertions.assertEquals(1,
-        pendingOps.getPendingOpCount(DELETE, ReplicationType.RATIS));
-    Assertions.assertEquals(2,
-        pendingOps.getPendingOpCount(ADD, ReplicationType.EC));
-    Assertions.assertEquals(2,
-        pendingOps.getPendingOpCount(DELETE, ReplicationType.EC));
+    assertEquals(3, pendingOps.getPendingOpCount(ADD));
+    assertEquals(3, pendingOps.getPendingOpCount(DELETE));
+    assertEquals(1, pendingOps.getPendingOpCount(ADD, ReplicationType.RATIS));
+    assertEquals(1, pendingOps.getPendingOpCount(DELETE, ReplicationType.RATIS));
+    assertEquals(2, pendingOps.getPendingOpCount(ADD, ReplicationType.EC));
+    assertEquals(2, pendingOps.getPendingOpCount(DELETE, ReplicationType.EC));
 
     clock.fastForward(1500);
 
     pendingOps.removeExpiredEntries();
 
     // Two Delete and Replication command should be timeout
-    Assertions.assertEquals(metrics.getEcReplicaCreateTimeoutTotal(), 2);
-    Assertions.assertEquals(metrics.getEcReplicaDeleteTimeoutTotal(), 2);
-    Assertions.assertEquals(metrics.getReplicaCreateTimeoutTotal(), 1);
-    Assertions.assertEquals(metrics.getReplicaDeleteTimeoutTotal(), 1);
+    assertEquals(metrics.getEcReplicaCreateTimeoutTotal(), 2);
+    assertEquals(metrics.getEcReplicaDeleteTimeoutTotal(), 2);
+    assertEquals(metrics.getReplicaCreateTimeoutTotal(), 1);
+    assertEquals(metrics.getReplicaDeleteTimeoutTotal(), 1);
 
     expiry = clock.millis() + 1000;
     pendingOps.scheduleDeleteReplica(new ContainerID(3), dn1, 2, expiry);
@@ -306,8 +297,8 @@ public class TestContainerReplicaPendingOps {
 
     // InFlight Replication and Deletion. Previous Inflight should be
     // removed as they were timed out.
-    Assertions.assertEquals(3, pendingOps.getPendingOpCount(ADD));
-    Assertions.assertEquals(3, pendingOps.getPendingOpCount(DELETE));
+    assertEquals(3, pendingOps.getPendingOpCount(ADD));
+    assertEquals(3, pendingOps.getPendingOpCount(DELETE));
 
     pendingOps.completeDeleteReplica(new ContainerID(3), dn1, 2);
     pendingOps.completeAddReplica(new ContainerID(3), dn1, 3);
@@ -316,17 +307,17 @@ public class TestContainerReplicaPendingOps {
     pendingOps.completeDeleteReplica(new ContainerID(6), dn3, 0);
     pendingOps.completeAddReplica(new ContainerID(5), dn3, 0);
 
-    Assertions.assertEquals(metrics.getEcReplicasCreatedTotal(), 2);
-    Assertions.assertEquals(metrics.getEcReplicasDeletedTotal(), 2);
-    Assertions.assertEquals(metrics.getReplicasCreatedTotal(), 1);
-    Assertions.assertEquals(metrics.getReplicasDeletedTotal(), 1);
+    assertEquals(metrics.getEcReplicasCreatedTotal(), 2);
+    assertEquals(metrics.getEcReplicasDeletedTotal(), 2);
+    assertEquals(metrics.getReplicasCreatedTotal(), 1);
+    assertEquals(metrics.getReplicasDeletedTotal(), 1);
 
     pendingOps.completeDeleteReplica(new ContainerID(3), dn1, 2);
     pendingOps.completeAddReplica(new ContainerID(2), dn1, 3);
 
     // Checking pendingOpCount doesn't go below zero
-    Assertions.assertEquals(0, pendingOps.getPendingOpCount(ADD));
-    Assertions.assertEquals(0, pendingOps.getPendingOpCount(DELETE));
+    assertEquals(0, pendingOps.getPendingOpCount(ADD));
+    assertEquals(0, pendingOps.getPendingOpCount(DELETE));
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestDatanodeCommandCountUpdatedHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestDatanodeCommandCountUpdatedHandler.java
@@ -21,8 +21,9 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.eq;
 
 /**
@@ -35,7 +36,7 @@ public class TestDatanodeCommandCountUpdatedHandler {
 
   @BeforeEach
   public void setup() {
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     handler = new DatanodeCommandCountUpdatedHandler(replicationManager);
   }
 
@@ -43,7 +44,6 @@ public class TestDatanodeCommandCountUpdatedHandler {
   public void testReplicationManagerNotified() {
     DatanodeDetails datanode = MockDatanodeDetails.randomDatanodeDetails();
     handler.onMessage(datanode, null);
-    Mockito.verify(replicationManager)
-        .datanodeCommandCountUpdated(eq(datanode));
+    verify(replicationManager).datanodeCommandCountUpdated(eq(datanode));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerReplicaCount.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
@@ -71,8 +72,8 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica,
             Collections.emptyList(), 1);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isUnrecoverable());
+    assertTrue(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isUnrecoverable());
   }
 
   @Test
@@ -83,10 +84,9 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica,
             Collections.emptyList(), 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertEquals(1, rcnt.unavailableIndexes(true).size());
-    Assertions.assertEquals(5,
-        rcnt.unavailableIndexes(true).get(0).intValue());
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertEquals(1, rcnt.unavailableIndexes(true).size());
+    assertEquals(5, rcnt.unavailableIndexes(true).get(0).intValue());
 
     // Add a pending add op for the missing replica and ensure it no longer
     // appears missing
@@ -94,8 +94,8 @@ public class TestECContainerReplicaCount {
         ContainerReplicaOp.PendingOpType.ADD,
         MockDatanodeDetails.randomDatanodeDetails(), 5, Long.MAX_VALUE);
     rcnt.addPendingOp(op);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(true));
-    Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
+    assertTrue(rcnt.isSufficientlyReplicated(true));
+    assertEquals(0, rcnt.unavailableIndexes(true).size());
   }
 
   @Test
@@ -109,10 +109,9 @@ public class TestECContainerReplicaCount {
         getContainerReplicaOps(ImmutableList.of(), ImmutableList.of(1));
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertEquals(1, rcnt.unavailableIndexes(true).size());
-    Assertions.assertEquals(1,
-        rcnt.unavailableIndexes(true).get(0).intValue());
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertEquals(1, rcnt.unavailableIndexes(true).size());
+    assertEquals(1, rcnt.unavailableIndexes(true).get(0).intValue());
   }
 
   @Test
@@ -130,12 +129,11 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replicas, pending, 1);
 
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(true));
-    Assertions.assertEquals(1, rcnt.unavailableIndexes(false).size());
-    Assertions.assertEquals(5,
-        rcnt.unavailableIndexes(false).get(0).intValue());
-    Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertTrue(rcnt.isSufficientlyReplicated(true));
+    assertEquals(1, rcnt.unavailableIndexes(false).size());
+    assertEquals(5, rcnt.unavailableIndexes(false).get(0).intValue());
+    assertEquals(0, rcnt.unavailableIndexes(true).size());
   }
 
   @Test
@@ -150,8 +148,8 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
+    assertTrue(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
   }
 
   @Test
@@ -166,9 +164,9 @@ public class TestECContainerReplicaCount {
         getContainerReplicaOps(ImmutableList.of(), ImmutableList.of(1, 2, 2));
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertEquals(1, rcnt.unavailableIndexes(true).size());
-    Assertions.assertEquals(2,
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertEquals(1, rcnt.unavailableIndexes(true).size());
+    assertEquals(2,
         rcnt.unavailableIndexes(true).get(0).intValue());
   }
 
@@ -181,14 +179,14 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica,
             Collections.emptyList(), 0);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(false));
+    assertTrue(rcnt.isSufficientlyReplicated(false));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
     List<ContainerReplicaOp> pendingOps =
         getContainerReplicaOps(ImmutableList.of(), ImmutableList.of(1));
     rcnt = new ECContainerReplicaCount(container, replica, pendingOps, 0);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
   }
 
   @Test
@@ -204,20 +202,19 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertTrue(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(2,
-        rcnt.overReplicatedIndexes(true).get(0).intValue());
-    Assertions.assertEquals(1, rcnt.overReplicatedIndexes(true).size());
-    Assertions.assertTrue(rcnt.isOverReplicated(false));
-    Assertions.assertEquals(2, rcnt.overReplicatedIndexes(false).size());
+    assertTrue(rcnt.isSufficientlyReplicated(false));
+    assertTrue(rcnt.isOverReplicated(true));
+    assertEquals(2, rcnt.overReplicatedIndexes(true).get(0).intValue());
+    assertEquals(1, rcnt.overReplicatedIndexes(true).size());
+    assertTrue(rcnt.isOverReplicated(false));
+    assertEquals(2, rcnt.overReplicatedIndexes(false).size());
 
     // Add a pending delete op for the excess replica and ensure it now reports
     // as not over replicated.
     rcnt.addPendingOp(new ContainerReplicaOp(
         ContainerReplicaOp.PendingOpType.DELETE,
         MockDatanodeDetails.randomDatanodeDetails(), 2, Long.MAX_VALUE));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
+    assertFalse(rcnt.isOverReplicated(true));
   }
 
   @Test
@@ -236,11 +233,11 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(0, rcnt.overReplicatedIndexes(true).size());
-    Assertions.assertTrue(rcnt.isOverReplicated(false));
-    Assertions.assertEquals(2, rcnt.overReplicatedIndexes(false).size());
+    assertTrue(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(0, rcnt.overReplicatedIndexes(true).size());
+    assertTrue(rcnt.isOverReplicated(false));
+    assertEquals(2, rcnt.overReplicatedIndexes(false).size());
   }
 
   @Test
@@ -262,10 +259,9 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertTrue(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(2,
-        rcnt.overReplicatedIndexes(true).get(0).intValue());
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertTrue(rcnt.isOverReplicated(true));
+    assertEquals(2, rcnt.overReplicatedIndexes(true).get(0).intValue());
   }
 
   @Test
@@ -278,9 +274,9 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica,
             Collections.emptyList(), 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(4, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(4, rcnt.additionalMaintenanceCopiesNeeded(false));
     Set<Integer> maintenanceOnly = rcnt.maintenanceOnlyIndexes(false);
     for (int i = 1; i <= repConfig.getRequiredNodes(); i++) {
       assertThat(maintenanceOnly).contains(i);
@@ -290,9 +286,9 @@ public class TestECContainerReplicaCount {
     List<ContainerReplicaOp> pending =
         getContainerReplicaOps(ImmutableList.of(1, 2, 3), ImmutableList.of(1));
     rcnt = new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(true));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded(true));
+    assertFalse(rcnt.isSufficientlyReplicated(true));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded(true));
   }
 
   @Test
@@ -304,23 +300,23 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica,
             Collections.emptyList(), 1);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertTrue(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
+    assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
 
     // Repeat the test with redundancy of 2. Once the maintenance copies go
     // offline, we should be able to lost 2 more containers.
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 2);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded(false));
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
+    assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
     assertThat(rcnt.maintenanceOnlyIndexes(false)).contains(5);
   }
 
@@ -336,12 +332,12 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica,
             pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded(false));
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assertions.assertEquals(2, rcnt.maintenanceOnlyIndexes(false).size());
+    assertEquals(2, rcnt.maintenanceOnlyIndexes(false).size());
     assertThat(rcnt.maintenanceOnlyIndexes(false)).contains(1);
     assertThat(rcnt.maintenanceOnlyIndexes(false)).contains(5);
   }
@@ -356,23 +352,23 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica,
             Collections.emptyList(), 1);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertTrue(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
+    assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
 
     // Repeat the test with redundancy of 2. Once the maintenance copies go
     // offline, we should be able to lost 2 more containers.
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 2);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded(false));
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
+    assertEquals(1, rcnt.maintenanceOnlyIndexes(false).size());
     assertThat(rcnt.maintenanceOnlyIndexes(false)).contains(5);
   }
 
@@ -388,7 +384,7 @@ public class TestECContainerReplicaCount {
     // EC Parity is 2, which is max redundancy, but we have a
     // maintenanceRedundancy of 5, which is not possible. Only 2 more copies
     // should be needed.
-    Assertions.assertEquals(2, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertEquals(2, rcnt.additionalMaintenanceCopiesNeeded(false));
     // After replication, zero should be needed
     replica = ReplicationTestUtil
         .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
@@ -397,7 +393,7 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_SERVICE, 5));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 5);
-    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
 
   }
 
@@ -410,14 +406,14 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica,
             Collections.emptyList(), 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assertions.assertEquals(0, rcnt.maintenanceOnlyIndexes(false).size());
+    assertEquals(0, rcnt.maintenanceOnlyIndexes(false).size());
 
-    Assertions.assertEquals(2, rcnt.unavailableIndexes(true).size());
+    assertEquals(2, rcnt.unavailableIndexes(true).size());
     assertThat(rcnt.unavailableIndexes(true)).contains(4);
     assertThat(rcnt.unavailableIndexes(true)).contains(5);
   }
@@ -434,14 +430,14 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(true));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(4, rcnt.additionalMaintenanceCopiesNeeded(false));
-    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(true));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertTrue(rcnt.isSufficientlyReplicated(true));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(4, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(true));
 
     Set<Integer> maintenanceOnly = rcnt.maintenanceOnlyIndexes(true);
-    Assertions.assertEquals(1, maintenanceOnly.size());
+    assertEquals(1, maintenanceOnly.size());
     assertThat(maintenanceOnly).contains(5);
   }
 
@@ -456,17 +452,17 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(true));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertTrue(rcnt.isSufficientlyReplicated(true));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assertions.assertEquals(0, rcnt.maintenanceOnlyIndexes(false).size());
+    assertEquals(0, rcnt.maintenanceOnlyIndexes(false).size());
 
     // Zero unavailable, as the pending adds are scheduled as we assume they
     // will complete.
-    Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
+    assertEquals(0, rcnt.unavailableIndexes(true).size());
   }
 
   @Test
@@ -480,10 +476,10 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
 
-    Assertions.assertEquals(2, rcnt.unavailableIndexes(true).size());
+    assertEquals(2, rcnt.unavailableIndexes(true).size());
     assertThat(rcnt.unavailableIndexes(true)).contains(1);
     assertThat(rcnt.unavailableIndexes(true)).contains(5);
   }
@@ -500,14 +496,14 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
-    Assertions.assertEquals(3, rcnt.additionalMaintenanceCopiesNeeded(true));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
+    assertEquals(3, rcnt.additionalMaintenanceCopiesNeeded(true));
     Set<Integer> maintenanceOnly = rcnt.maintenanceOnlyIndexes(true);
-    Assertions.assertEquals(4, maintenanceOnly.size());
+    assertEquals(4, maintenanceOnly.size());
     assertThat(maintenanceOnly).contains(2, 3, 4, 5);
 
-    Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
+    assertEquals(0, rcnt.unavailableIndexes(true).size());
   }
 
   @Test
@@ -522,10 +518,10 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertFalse(rcnt.isOverReplicated(true));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertFalse(rcnt.isOverReplicated(true));
 
-    Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
+    assertEquals(0, rcnt.unavailableIndexes(true).size());
   }
 
   @NotNull
@@ -551,8 +547,8 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, new HashSet<>(),
             Collections.emptyList(), 1);
-    Assertions.assertTrue(rcnt.isUnrecoverable());
-    Assertions.assertEquals(5, rcnt.unavailableIndexes(true).size());
+    assertTrue(rcnt.isUnrecoverable());
+    assertEquals(5, rcnt.unavailableIndexes(true).size());
 
     Set<ContainerReplica> replica = ReplicationTestUtil
         .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_MAINTENANCE, 2));
@@ -562,9 +558,9 @@ public class TestECContainerReplicaCount {
         UNHEALTHY, Pair.of(IN_SERVICE, 3)));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
-    Assertions.assertTrue(rcnt.isUnrecoverable());
-    Assertions.assertEquals(3, rcnt.unavailableIndexes(true).size());
-    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
+    assertTrue(rcnt.isUnrecoverable());
+    assertEquals(3, rcnt.unavailableIndexes(true).size());
+    assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded(false));
 
     replica = ReplicationTestUtil
         .createReplicas(Pair.of(DECOMMISSIONED, 1), Pair.of(DECOMMISSIONED, 2),
@@ -573,8 +569,8 @@ public class TestECContainerReplicaCount {
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
     // Not missing as the decommission replicas are still online
-    Assertions.assertFalse(rcnt.isUnrecoverable());
-    Assertions.assertEquals(0, rcnt.unavailableIndexes(true).size());
+    assertFalse(rcnt.isUnrecoverable());
+    assertEquals(0, rcnt.unavailableIndexes(true).size());
 
     // All unhealthy replicas is still un-recoverable.
     replica = ReplicationTestUtil.createReplicas(
@@ -584,7 +580,7 @@ public class TestECContainerReplicaCount {
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
     // Not missing as the decommission replicas are still online
-    Assertions.assertTrue(rcnt.isUnrecoverable());
+    assertTrue(rcnt.isUnrecoverable());
   }
 
   @Test
@@ -593,16 +589,16 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, new HashSet<>(),
             Collections.emptyList(), 1);
-    Assertions.assertTrue(rcnt.isMissing());
-    Assertions.assertTrue(rcnt.isUnrecoverable());
+    assertTrue(rcnt.isMissing());
+    assertTrue(rcnt.isUnrecoverable());
 
     // 1 unhealthy
     Set<ContainerReplica> replica = ReplicationTestUtil
         .createReplicas(UNHEALTHY, Pair.of(IN_SERVICE, 1));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
-    Assertions.assertTrue(rcnt.isMissing());
-    Assertions.assertTrue(rcnt.isUnrecoverable());
+    assertTrue(rcnt.isMissing());
+    assertTrue(rcnt.isUnrecoverable());
 
     // 2 unhealthy
     replica = ReplicationTestUtil
@@ -610,8 +606,8 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_SERVICE, 2));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
-    Assertions.assertTrue(rcnt.isMissing());
-    Assertions.assertTrue(rcnt.isUnrecoverable());
+    assertTrue(rcnt.isMissing());
+    assertTrue(rcnt.isUnrecoverable());
 
     // 3 unhealthy
     replica = ReplicationTestUtil
@@ -619,8 +615,8 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_SERVICE, 2), Pair.of(IN_SERVICE, 3));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
-    Assertions.assertFalse(rcnt.isMissing());
-    Assertions.assertTrue(rcnt.isUnrecoverable());
+    assertFalse(rcnt.isMissing());
+    assertTrue(rcnt.isUnrecoverable());
 
 
     // 3 replicas, with 1 unhealthy
@@ -630,8 +626,8 @@ public class TestECContainerReplicaCount {
         UNHEALTHY, Pair.of(IN_SERVICE, 3)));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
-    Assertions.assertFalse(rcnt.isMissing());
-    Assertions.assertTrue(rcnt.isUnrecoverable());
+    assertFalse(rcnt.isMissing());
+    assertTrue(rcnt.isUnrecoverable());
 
     // 4 replicas, with 1 unhealthy
     replica = ReplicationTestUtil
@@ -641,8 +637,8 @@ public class TestECContainerReplicaCount {
         UNHEALTHY, Pair.of(IN_SERVICE, 4)));
     rcnt = new ECContainerReplicaCount(container, replica,
         Collections.emptyList(), 1);
-    Assertions.assertFalse(rcnt.isMissing());
-    Assertions.assertFalse(rcnt.isUnrecoverable());
+    assertFalse(rcnt.isMissing());
+    assertFalse(rcnt.isUnrecoverable());
   }
 
   @Test
@@ -656,10 +652,9 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pending, 1);
-    Assertions.assertEquals(ImmutableSet.of(1),
+    assertEquals(ImmutableSet.of(1),
         rcnt.decommissioningOnlyIndexes(false));
-    Assertions
-        .assertEquals(ImmutableSet.of(), rcnt.decommissioningOnlyIndexes(true));
+    assertEquals(ImmutableSet.of(), rcnt.decommissioningOnlyIndexes(true));
   }
 
   @Test
@@ -685,19 +680,19 @@ public class TestECContainerReplicaCount {
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, Collections.emptyList(),
             1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertTrue(rcnt.isSufficientlyReplicatedForOffline(
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertTrue(rcnt.isSufficientlyReplicatedForOffline(
         offlineReplica.getDatanodeDetails(), null));
-    Assertions.assertFalse(rcnt.isSufficientlyReplicatedForOffline(
+    assertFalse(rcnt.isSufficientlyReplicatedForOffline(
         offlineNotReplicated.getDatanodeDetails(), null));
 
     // A random DN not hosting a replica for this container should return false.
-    Assertions.assertFalse(rcnt.isSufficientlyReplicatedForOffline(
+    assertFalse(rcnt.isSufficientlyReplicatedForOffline(
         MockDatanodeDetails.randomDatanodeDetails(), null));
 
     // Passing the IN_SERVICE node should return false even though the
     // replica is on a healthy node
-    Assertions.assertFalse(rcnt.isSufficientlyReplicatedForOffline(
+    assertFalse(rcnt.isSufficientlyReplicatedForOffline(
         inServiceReplica.getDatanodeDetails(), null));
   }
 
@@ -723,7 +718,7 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt =
         new ECContainerReplicaCount(container, replica, pendingOps, 1);
-    Assertions.assertTrue(rcnt.isSufficientlyReplicated(false));
+    assertTrue(rcnt.isSufficientlyReplicated(false));
 
     // Add another pending delete to an index that is not an unhealthy index
     pendingOps.add(ContainerReplicaOp.create(
@@ -731,7 +726,7 @@ public class TestECContainerReplicaCount {
         MockDatanodeDetails.randomDatanodeDetails(), 2));
 
     rcnt = new ECContainerReplicaCount(container, replica, pendingOps, 1);
-    Assertions.assertFalse(rcnt.isSufficientlyReplicated(false));
-    Assertions.assertEquals(2, rcnt.unavailableIndexes(false).get(0));
+    assertFalse(rcnt.isSufficientlyReplicated(false));
+    assertEquals(2, rcnt.unavailableIndexes(false).get(0));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECMisReplicationHandler.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -46,9 +45,13 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests the ECMisReplicationHandling functionality.
@@ -83,16 +86,14 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
             .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
                     Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
                     Pair.of(IN_SERVICE, 5));
-    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
+    PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
     ContainerPlacementStatus mockedContainerPlacementStatus =
-            Mockito.mock(ContainerPlacementStatus.class);
-    Mockito.when(mockedContainerPlacementStatus.isPolicySatisfied())
-            .thenReturn(false);
-    Mockito.when(placementPolicy.validateContainerPlacement(anyList(),
-                    anyInt())).thenReturn(mockedContainerPlacementStatus);
-    Mockito.when(placementPolicy.chooseDatanodes(
-                    any(), any(), any(),
-                    Mockito.anyInt(), Mockito.anyLong(), Mockito.anyLong()))
+            mock(ContainerPlacementStatus.class);
+    when(mockedContainerPlacementStatus.isPolicySatisfied()).thenReturn(false);
+    when(placementPolicy.validateContainerPlacement(anyList(),
+        anyInt())).thenReturn(mockedContainerPlacementStatus);
+    when(placementPolicy.chooseDatanodes(
+        any(), any(), any(), anyInt(), anyLong(), anyLong()))
             .thenThrow(new IOException("No nodes found"));
     assertThrows(SCMException.class, () -> testMisReplication(
             availableReplicas, placementPolicy, Collections.emptyList(),
@@ -136,12 +137,11 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
             .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
                     Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
                     Pair.of(IN_SERVICE, 5));
-    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
+    PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
     ContainerPlacementStatus mockedContainerPlacementStatus =
-            Mockito.mock(ContainerPlacementStatus.class);
-    Mockito.when(mockedContainerPlacementStatus.isPolicySatisfied())
-            .thenReturn(true);
-    Mockito.when(placementPolicy.validateContainerPlacement(anyList(),
+            mock(ContainerPlacementStatus.class);
+    when(mockedContainerPlacementStatus.isPolicySatisfied()).thenReturn(true);
+    when(placementPolicy.validateContainerPlacement(anyList(),
                     anyInt())).thenReturn(mockedContainerPlacementStatus);
     testMisReplication(availableReplicas, placementPolicy,
             Collections.emptyList(), 0, 1, 0);
@@ -154,12 +154,11 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
             .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
                     Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
                     Pair.of(IN_SERVICE, 5));
-    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
+    PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
     ContainerPlacementStatus mockedContainerPlacementStatus =
-            Mockito.mock(ContainerPlacementStatus.class);
-    Mockito.when(mockedContainerPlacementStatus.isPolicySatisfied())
-            .thenReturn(true);
-    Mockito.when(placementPolicy.validateContainerPlacement(anyList(),
+            mock(ContainerPlacementStatus.class);
+    when(mockedContainerPlacementStatus.isPolicySatisfied()).thenReturn(true);
+    when(placementPolicy.validateContainerPlacement(anyList(),
             anyInt())).thenReturn(mockedContainerPlacementStatus);
     List<ContainerReplicaOp> pendingOp = singletonList(
             ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.ADD,
@@ -176,7 +175,7 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
   @Test
   public void testAllSourcesOverloaded() throws IOException {
     ReplicationManager replicationManager = getReplicationManager();
-    Mockito.doThrow(new CommandTargetOverloadedException("Overloaded"))
+    doThrow(new CommandTargetOverloadedException("Overloaded"))
         .when(replicationManager).sendThrottledReplicationCommand(any(),
             anyList(), any(), anyInt());
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
@@ -206,12 +205,10 @@ public class TestECMisReplicationHandler extends TestMisReplicationHandler {
         .createReplicas(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
             Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
             Pair.of(IN_SERVICE, 5));
-    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
+    PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
     List<DatanodeDetails> targetDatanodes = singletonList(
         availableReplicas.iterator().next().getDatanodeDetails());
-    Mockito.when(placementPolicy.chooseDatanodes(
-            any(), any(), any(),
-            Mockito.anyInt(), Mockito.anyLong(), Mockito.anyLong()))
+    when(placementPolicy.chooseDatanodes(any(), any(), any(), anyInt(), anyLong(), anyLong()))
         .thenReturn(targetDatanodes);
     assertThrows(InsufficientDatanodesException.class,
         () -> testMisReplication(availableReplicas, Collections.emptyList(),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -42,7 +42,6 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
@@ -68,6 +67,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
 
 /**
@@ -85,8 +86,8 @@ public class TestECOverReplicationHandler {
       CommandTargetOverloadedException {
     staleNode = null;
 
-    replicationManager = Mockito.mock(ReplicationManager.class);
-    Mockito.when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+    replicationManager = mock(ReplicationManager.class);
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
           if (staleNode != null && staleNode.equals(dd)) {
@@ -202,9 +203,8 @@ public class TestECOverReplicationHandler {
     ContainerReplica toReturn = ReplicationTestUtil.createContainerReplica(
         container.containerID(), 1, IN_SERVICE,
         ContainerReplicaProto.State.CLOSED);
-    policy = Mockito.mock(PlacementPolicy.class);
-    Mockito.when(policy.replicasToRemoveToFixOverreplication(
-        Mockito.any(), Mockito.anyInt()))
+    policy = mock(PlacementPolicy.class);
+    when(policy.replicasToRemoveToFixOverreplication(any(), anyInt()))
         .thenReturn(ImmutableSet.of(toReturn));
     testOverReplicationWithIndexes(availableReplicas, Collections.emptyMap(),
         ImmutableList.of());
@@ -329,8 +329,8 @@ public class TestECOverReplicationHandler {
     ECOverReplicationHandler ecORH =
         new ECOverReplicationHandler(policy, replicationManager);
     ContainerHealthResult.OverReplicatedHealthResult result =
-        Mockito.mock(ContainerHealthResult.OverReplicatedHealthResult.class);
-    Mockito.when(result.getContainerInfo()).thenReturn(container);
+        mock(ContainerHealthResult.OverReplicatedHealthResult.class);
+    when(result.getContainerInfo()).thenReturn(container);
 
     ecORH.processAndSendCommands(availableReplicas, pendingOps,
             result, 1);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -64,6 +63,7 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -314,7 +314,7 @@ public class TestECOverReplicationHandler {
     try {
       ecORH.processAndSendCommands(availableReplicas, ImmutableList.of(),
           health, 1);
-      Assertions.fail("Expected CommandTargetOverloadedException");
+      fail("Expected CommandTargetOverloadedException");
     } catch (CommandTargetOverloadedException e) {
       // This is expected.
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -81,7 +81,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.Clock;
@@ -124,6 +123,13 @@ import static org.apache.hadoop.hdds.scm.HddsTestUtils.getReplicas;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
@@ -161,14 +167,14 @@ public class TestLegacyReplicationManager {
 
     scmLogs = GenericTestUtils.LogCapturer.
         captureLogs(LegacyReplicationManager.LOG);
-    containerManager = Mockito.mock(ContainerManager.class);
+    containerManager = mock(ContainerManager.class);
     nodeManager = new SimpleMockNodeManager();
     eventQueue = new EventQueue();
     SCMHAManager scmhaManager = SCMHAManagerStub.getInstance(true);
     dbStore = DBStoreBuilder.createDBStore(
         conf, new SCMDBDefinition());
-    PipelineManager pipelineManager = Mockito.mock(PipelineManager.class);
-    when(pipelineManager.containsPipeline(Mockito.any(PipelineID.class)))
+    PipelineManager pipelineManager = mock(PipelineManager.class);
+    when(pipelineManager.containsPipeline(any(PipelineID.class)))
         .thenReturn(true);
     containerStateManager = ContainerStateManagerImpl.newBuilder()
         .setConfiguration(conf)
@@ -184,7 +190,7 @@ public class TestLegacyReplicationManager {
     datanodeCommandHandler = new DatanodeCommandHandler();
     eventQueue.addHandler(SCMEvents.DATANODE_COMMAND, datanodeCommandHandler);
 
-    Mockito.when(containerManager.getContainers())
+    when(containerManager.getContainers())
         .thenAnswer(invocation -> {
           Set<ContainerID> ids = containerStateManager.getContainerIDs();
           List<ContainerInfo> containers = new ArrayList<>();
@@ -195,23 +201,23 @@ public class TestLegacyReplicationManager {
           return containers;
         });
 
-    Mockito.when(containerManager.getContainer(Mockito.any(ContainerID.class)))
+    when(containerManager.getContainer(any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainer(((ContainerID)invocation
                 .getArguments()[0])));
 
-    Mockito.when(containerManager.getContainerReplicas(
-        Mockito.any(ContainerID.class)))
+    when(containerManager.getContainerReplicas(
+        any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainerReplicas(((ContainerID)invocation
                 .getArguments()[0])));
 
-    ratisContainerPlacementPolicy = Mockito.mock(PlacementPolicy.class);
-    ecContainerPlacementPolicy = Mockito.mock(PlacementPolicy.class);
+    ratisContainerPlacementPolicy = mock(PlacementPolicy.class);
+    ecContainerPlacementPolicy = mock(PlacementPolicy.class);
 
-    Mockito.when(ratisContainerPlacementPolicy.chooseDatanodes(
-        Mockito.any(), Mockito.any(), Mockito.anyInt(),
-            Mockito.anyLong(), Mockito.anyLong()))
+    when(ratisContainerPlacementPolicy.chooseDatanodes(
+        any(), any(), anyInt(),
+            anyLong(), anyLong()))
         .thenAnswer(invocation -> {
           int count = (int) invocation.getArguments()[2];
           return IntStream.range(0, count)
@@ -219,9 +225,9 @@ public class TestLegacyReplicationManager {
               .collect(Collectors.toList());
         });
 
-    Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(ratisContainerPlacementPolicy.validateContainerPlacement(
+        any(),
+        anyInt()
         )).thenAnswer(invocation ->
         new ContainerPlacementStatusDefault(2, 2, 3));
     clock = new TestClock(Instant.now(), ZoneId.of("UTC"));
@@ -469,9 +475,8 @@ public class TestLegacyReplicationManager {
       Assertions.assertEquals(1, report.getStat(
               ReplicationManagerReport.HealthState.MIS_REPLICATED));
 
-      Mockito.verify(containerManager, times(0))
-          .updateContainerState(container.containerID(),
-              LifeCycleEvent.QUASI_CLOSE);
+      verify(containerManager, times(0)).updateContainerState(container.containerID(),
+          LifeCycleEvent.QUASI_CLOSE);
     }
 
     @Test
@@ -654,7 +659,7 @@ public class TestLegacyReplicationManager {
       }
 
       replicationManager.processAll();
-      Mockito.verify(containerManager, times(1))
+      verify(containerManager, times(1))
           .updateContainerState(container.containerID(),
               LifeCycleEvent.QUASI_CLOSE);
 
@@ -692,7 +697,7 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Mockito.verify(containerManager, times(0))
+      verify(containerManager, times(0))
           .updateContainerState(container.containerID(),
               LifeCycleEvent.QUASI_CLOSE);
       Assertions.assertEquals(currentCloseCommandCount + 1,
@@ -1421,9 +1426,7 @@ public class TestLegacyReplicationManager {
       policy could not find any targets. In the second iteration, return a list
       of required targets.
        */
-      Mockito.when(ratisContainerPlacementPolicy.chooseDatanodes(
-          Mockito.any(), Mockito.any(), Mockito.anyInt(),
-              Mockito.anyLong(), Mockito.anyLong()))
+      when(ratisContainerPlacementPolicy.chooseDatanodes(any(), any(), anyInt(), anyLong(), anyLong()))
           .thenAnswer(invocation -> {
             throw new SCMException(
                 SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
@@ -1506,9 +1509,7 @@ public class TestLegacyReplicationManager {
     @Test
     public void testUnderRepQuasiClosedContainerBlockedByUnhealthyReplicas()
         throws IOException, TimeoutException {
-      Mockito.when(ratisContainerPlacementPolicy.chooseDatanodes(
-              Mockito.anyList(), Mockito.any(), Mockito.anyInt(),
-              Mockito.anyLong(), Mockito.anyLong()))
+      when(ratisContainerPlacementPolicy.chooseDatanodes(anyList(), any(), anyInt(), anyLong(), anyLong()))
           .thenAnswer(invocation -> {
             List<DatanodeDetails> excluded = invocation.getArgument(0);
             if (excluded.size() == 3) {
@@ -1858,14 +1859,12 @@ public class TestLegacyReplicationManager {
         containerStateManager.updateContainerReplica(id, replica);
       }
 
-      final CloseContainerEventHandler closeContainerHandler =
-          Mockito.mock(CloseContainerEventHandler.class);
+      final CloseContainerEventHandler closeContainerHandler = mock(CloseContainerEventHandler.class);
       eventQueue.addHandler(SCMEvents.CLOSE_CONTAINER, closeContainerHandler);
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Mockito.verify(closeContainerHandler, Mockito.times(1))
-          .onMessage(id, eventQueue);
+      verify(closeContainerHandler, times(1)).onMessage(id, eventQueue);
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
       Assertions.assertEquals(1, report.getStat(LifeCycleState.OPEN));
@@ -2980,9 +2979,9 @@ public class TestLegacyReplicationManager {
       // Ensure a mis-replicated status is returned for any containers in this
       // test where there are 3 replicas. When there are 2 or 4 replicas
       // the status returned will be healthy.
-      Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
-              Mockito.argThat(list -> list.size() == 3),
-              Mockito.anyInt()
+      when(ratisContainerPlacementPolicy.validateContainerPlacement(
+              argThat(list -> list.size() == 3),
+              anyInt()
       )).thenAnswer(invocation -> {
         return new ContainerPlacementStatusDefault(1, 2, 3);
       });
@@ -3016,9 +3015,9 @@ public class TestLegacyReplicationManager {
       // Now make it so that all containers seem mis-replicated no matter how
       // many replicas. This will test replicas are not scheduled if the new
       // replica does not fix the mis-replication.
-      Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
-              Mockito.anyList(),
-              Mockito.anyInt()
+      when(ratisContainerPlacementPolicy.validateContainerPlacement(
+              anyList(),
+              anyInt()
       )).thenAnswer(invocation -> {
         return new ContainerPlacementStatusDefault(1, 2, 3);
       });
@@ -3066,9 +3065,9 @@ public class TestLegacyReplicationManager {
 
       // Ensure a mis-replicated status is returned for any containers in this
       // test where there are exactly 3 replicas checked.
-      Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
-              Mockito.argThat(list -> list.size() == 3),
-              Mockito.anyInt()
+      when(ratisContainerPlacementPolicy.validateContainerPlacement(
+              argThat(list -> list.size() == 3),
+              anyInt()
       )).thenAnswer(
               invocation -> new ContainerPlacementStatusDefault(1, 2, 3));
 
@@ -3119,9 +3118,9 @@ public class TestLegacyReplicationManager {
               id, replicaThree);
       containerStateManager.updateContainerReplica(id, replicaFour);
 
-      Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
-              Mockito.argThat(list -> list.size() == 3),
-              Mockito.anyInt()
+      when(ratisContainerPlacementPolicy.validateContainerPlacement(
+              argThat(list -> list.size() == 3),
+              anyInt()
       )).thenAnswer(
               invocation -> new ContainerPlacementStatusDefault(2, 2, 3));
 
@@ -3170,9 +3169,9 @@ public class TestLegacyReplicationManager {
       containerStateManager.updateContainerReplica(id, replicaFour);
       containerStateManager.updateContainerReplica(id, replicaFive);
 
-      Mockito.when(ratisContainerPlacementPolicy.validateContainerPlacement(
-              Mockito.argThat(list -> list != null && list.size() <= 4),
-              Mockito.anyInt()
+      when(ratisContainerPlacementPolicy.validateContainerPlacement(
+              argThat(list -> list != null && list.size() <= 4),
+              anyInt()
       )).thenAnswer(
               invocation -> new ContainerPlacementStatusDefault(1, 2, 3));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -74,7 +74,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -123,6 +122,10 @@ import static org.apache.hadoop.hdds.scm.HddsTestUtils.getReplicas;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyInt;
@@ -311,14 +314,14 @@ public class TestLegacyReplicationManager {
      */
     @Test
     public void testReplicationManagerRestart() throws InterruptedException {
-      Assertions.assertTrue(replicationManager.isRunning());
+      assertTrue(replicationManager.isRunning());
       replicationManager.stop();
       // Stop is a non-blocking call, it might take sometime for the
       // ReplicationManager to shutdown
       Thread.sleep(500);
-      Assertions.assertFalse(replicationManager.isRunning());
+      assertFalse(replicationManager.isRunning());
       replicationManager.start();
-      Assertions.assertTrue(replicationManager.isRunning());
+      assertTrue(replicationManager.isRunning());
     }
 
     @Test
@@ -336,17 +339,17 @@ public class TestLegacyReplicationManager {
               .getContainerReplicaCount(container);
 
       assertInstanceOf(LegacyRatisContainerReplicaCount.class, replicaCount);
-      Assertions.assertFalse(replicaCount.isSufficientlyReplicated());
-      Assertions.assertFalse(replicaCount.isSufficientlyReplicatedForOffline(
+      assertFalse(replicaCount.isSufficientlyReplicated());
+      assertFalse(replicaCount.isSufficientlyReplicatedForOffline(
           decommissioningReplica.getDatanodeDetails(), nodeManager));
 
       addReplica(container, NodeStatus.inServiceHealthy(), UNHEALTHY);
       replicaCount = replicationManager.getLegacyReplicationManager()
           .getContainerReplicaCount(container);
-      Assertions.assertTrue(replicaCount.isSufficientlyReplicated());
-      Assertions.assertTrue(replicaCount.isSufficientlyReplicatedForOffline(
+      assertTrue(replicaCount.isSufficientlyReplicated());
+      assertTrue(replicaCount.isSufficientlyReplicatedForOffline(
           decommissioningReplica.getDatanodeDetails(), nodeManager));
-      Assertions.assertTrue(replicaCount.isHealthyEnoughForOffline());
+      assertTrue(replicaCount.isHealthyEnoughForOffline());
     }
   }
 
@@ -368,8 +371,8 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.OPEN));
-      Assertions.assertEquals(0, datanodeCommandHandler.getInvocation());
+      assertEquals(1, report.getStat(LifeCycleState.OPEN));
+      assertEquals(0, datanodeCommandHandler.getInvocation());
     }
 
     /**
@@ -402,7 +405,7 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentCloseCommandCount + 3,
+      assertEquals(currentCloseCommandCount + 3,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
 
@@ -413,11 +416,11 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentCloseCommandCount + 6,
+      assertEquals(currentCloseCommandCount + 6,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.CLOSING));
+      assertEquals(1, report.getStat(LifeCycleState.CLOSING));
     }
 
     /**
@@ -447,13 +450,13 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentCloseCommandCount + 1,
+      assertEquals(currentCloseCommandCount + 1,
               datanodeCommandHandler.getInvocationCount(
                       SCMCommandProto.Type.closeContainerCommand));
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.CLOSING));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.CLOSING));
+      assertEquals(0, report.getStat(
               ReplicationManagerReport.HealthState.MISSING));
 
       for (ContainerReplica replica : replicas) {
@@ -462,17 +465,17 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentCloseCommandCount + 1,
+      assertEquals(currentCloseCommandCount + 1,
               datanodeCommandHandler.getInvocationCount(
                       SCMCommandProto.Type.closeContainerCommand));
 
       report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.CLOSING));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.CLOSING));
+      assertEquals(1, report.getStat(
               ReplicationManagerReport.HealthState.MISSING));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
               ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
               ReplicationManagerReport.HealthState.MIS_REPLICATED));
 
       verify(containerManager, times(0)).updateContainerState(container.containerID(),
@@ -496,7 +499,7 @@ public class TestLegacyReplicationManager {
       // scheduled
       clock.fastForward(timeout + 1000);
       assertReplicaScheduled(1);
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, replicationManager.getMetrics()
               .getReplicaCreateTimeoutTotal());
     }
 
@@ -519,7 +522,7 @@ public class TestLegacyReplicationManager {
       // scheduled
       clock.fastForward(timeout + 1000);
       assertDeleteScheduled(1);
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, replicationManager.getMetrics()
               .getReplicaDeleteTimeoutTotal());
     }
 
@@ -557,9 +560,9 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1,
+      assertEquals(1,
           report.getStat(ReplicationManagerReport.HealthState.EMPTY));
-      Assertions.assertEquals(LifeCycleState.CLOSED, container.getState());
+      assertEquals(LifeCycleState.CLOSED, container.getState());
     }
 
     @Test
@@ -620,13 +623,13 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(0, datanodeCommandHandler.getInvocation());
+      assertEquals(0, datanodeCommandHandler.getInvocation());
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.CLOSED));
+      assertEquals(1, report.getStat(LifeCycleState.CLOSED));
       for (ReplicationManagerReport.HealthState s :
               ReplicationManagerReport.HealthState.values()) {
-        Assertions.assertEquals(0, report.getStat(s));
+        assertEquals(0, report.getStat(s));
       }
     }
   }
@@ -667,7 +670,7 @@ public class TestLegacyReplicationManager {
           container.containerID().getProtobuf(), LifeCycleEvent.QUASI_CLOSE);
 
       replicationManager.processAll();
-      Assertions.assertEquals(1,
+      assertEquals(1,
           replicationManager.getContainerReport().getStat(
               ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
     }
@@ -700,18 +703,17 @@ public class TestLegacyReplicationManager {
       verify(containerManager, times(0))
           .updateContainerState(container.containerID(),
               LifeCycleEvent.QUASI_CLOSE);
-      Assertions.assertEquals(currentCloseCommandCount + 1,
+      assertEquals(currentCloseCommandCount + 1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
-      Assertions.assertEquals(1,
-          datanodeCommandHandler.getReceivedCommands().size());
+      assertEquals(1, datanodeCommandHandler.getReceivedCommands().size());
       SCMCommand command =
           datanodeCommandHandler.getReceivedCommands().iterator().next()
               .getCommand();
-      Assertions.assertSame(SCMCommandProto.Type.closeContainerCommand,
+      assertSame(SCMCommandProto.Type.closeContainerCommand,
           command.getType());
       CloseContainerCommand closeCommand = (CloseContainerCommand) command;
-      Assertions.assertFalse(closeCommand.isForce());
+      assertFalse(closeCommand.isForce());
     }
 
     /**
@@ -746,17 +748,17 @@ public class TestLegacyReplicationManager {
       // Two of the replicas are in OPEN state
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentCloseCommandCount + 2,
+      assertEquals(currentCloseCommandCount + 2,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
           SCMCommandProto.Type.closeContainerCommand,
           replicaTwo.getDatanodeDetails()));
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
           SCMCommandProto.Type.closeContainerCommand,
           replicaThree.getDatanodeDetails()));
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
     }
 
     /**
@@ -790,10 +792,10 @@ public class TestLegacyReplicationManager {
       // container will not be closed. ReplicationManager should take no action.
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(0, datanodeCommandHandler.getInvocation());
+      assertEquals(0, datanodeCommandHandler.getInvocation());
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
     }
 
@@ -839,7 +841,7 @@ public class TestLegacyReplicationManager {
       // container will not be closed. ReplicationManager should take no action.
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(0, datanodeCommandHandler.getInvocation());
+      assertEquals(0, datanodeCommandHandler.getInvocation());
 
       // Make the first replica unhealthy
       final ContainerReplica unhealthyReplica = getReplicas(
@@ -858,27 +860,27 @@ public class TestLegacyReplicationManager {
       assertDeleteScheduled(0);
       currentReplicateCommandCount += 1;
       currentBytesToReplicate += 100L;
-      Assertions.assertEquals(currentReplicateCommandCount,
+      assertEquals(currentReplicateCommandCount,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(currentReplicateCommandCount,
+      assertEquals(currentReplicateCommandCount,
           replicationManager.getMetrics().getReplicationCmdsSentTotal());
-      Assertions.assertEquals(currentBytesToReplicate,
+      assertEquals(currentBytesToReplicate,
           replicationManager.getMetrics().getReplicationBytesTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.REPLICATION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.REPLICATION));
+      assertEquals(1, replicationManager.getMetrics()
           .getInflightReplication());
 
       // The quasi closed container cannot be closed, but it should have been
       // restored to full replication on the previous run.
       // The unhealthy replica should remain until the next iteration.
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.UNHEALTHY));
 
       // Create the replica so replication manager sees it on the next run.
@@ -903,16 +905,15 @@ public class TestLegacyReplicationManager {
       assertExactDeleteTargets(unhealthyReplica.getDatanodeDetails());
       // Replication should have finished on the previous iteration, leaving
       // these numbers unchanged.
-      Assertions.assertEquals(currentReplicateCommandCount,
+      assertEquals(currentReplicateCommandCount,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(currentReplicateCommandCount,
+      assertEquals(currentReplicateCommandCount,
           replicationManager.getMetrics().getReplicationCmdsSentTotal());
-      Assertions.assertEquals(currentBytesToReplicate,
+      assertEquals(currentBytesToReplicate,
           replicationManager.getMetrics().getReplicationBytesTotal());
-      Assertions.assertEquals(0, getInflightCount(InflightType.REPLICATION));
-      Assertions.assertEquals(0, replicationManager.getMetrics()
-          .getInflightReplication());
+      assertEquals(0, getInflightCount(InflightType.REPLICATION));
+      assertEquals(0, replicationManager.getMetrics().getInflightReplication());
 
       // Now we will delete the unhealthy replica.
       containerStateManager.removeContainerReplica(id, unhealthyReplica);
@@ -921,7 +922,7 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
       // The two commands shown are the previous delete and replicate commands.
-      Assertions.assertEquals(2, datanodeCommandHandler.getInvocation());
+      assertEquals(2, datanodeCommandHandler.getInvocation());
     }
 
 
@@ -962,11 +963,11 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
 
@@ -991,25 +992,25 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.UNDER_REPLICATED));
       // Even though we have extra replicas, we are deliberately keeping them
       // since they are unique. This does not count as over-replication.
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.OVER_REPLICATED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.UNHEALTHY));
     }
 
@@ -1062,10 +1063,10 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(1000);
 
       // 1 replicate command should have been sent
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(1,
+      assertEquals(1,
           replicationManager.getContainerReport().getStat(
               ReplicationManagerReport.HealthState.UNDER_REPLICATED));
 
@@ -1073,15 +1074,15 @@ public class TestLegacyReplicationManager {
       // replica on the decommissioning node
       CommandForDatanode command =
           datanodeCommandHandler.getReceivedCommands().iterator().next();
-      Assertions.assertEquals(SCMCommandProto.Type.replicateContainerCommand,
+      assertEquals(SCMCommandProto.Type.replicateContainerCommand,
           command.getCommand().getType());
       ReplicateContainerCommand replicateCommand =
           (ReplicateContainerCommand) command.getCommand();
-      Assertions.assertEquals(1, replicateCommand.getSourceDatanodes().size());
-      Assertions.assertEquals(replica4.getDatanodeDetails(),
+      assertEquals(1, replicateCommand.getSourceDatanodes().size());
+      assertEquals(replica4.getDatanodeDetails(),
           replicateCommand.getSourceDatanodes().iterator().next());
 
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
 
@@ -1091,10 +1092,10 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(100);
 
       // that 1 command is the one RM sent in the last iteration
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
 
@@ -1112,10 +1113,10 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(100);
 
       // that 1 command is the one RM sent in the last iteration
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
     }
@@ -1160,10 +1161,10 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(1,
+      assertEquals(1,
           replicationManager.getContainerReport().getStat(
               ReplicationManagerReport.HealthState.UNDER_REPLICATED));
 
@@ -1171,15 +1172,15 @@ public class TestLegacyReplicationManager {
       // either of the QUASI_CLOSED replicas
       CommandForDatanode command =
           datanodeCommandHandler.getReceivedCommands().iterator().next();
-      Assertions.assertEquals(SCMCommandProto.Type.replicateContainerCommand,
+      assertEquals(SCMCommandProto.Type.replicateContainerCommand,
           command.getCommand().getType());
       ReplicateContainerCommand replicateCommand =
           (ReplicateContainerCommand) command.getCommand();
       List<DatanodeDetails> sourceDatanodes =
           replicateCommand.getSourceDatanodes();
-      Assertions.assertEquals(2, sourceDatanodes.size());
+      assertEquals(2, sourceDatanodes.size());
       assertThat(sourceDatanodes).doesNotContain(unhealthyReplica.getDatanodeDetails());
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
 
@@ -1195,22 +1196,22 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(1,
+      assertEquals(1,
           replicationManager.getContainerReport().getStat(
               ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getReceivedCommands().size());
       command = datanodeCommandHandler.getReceivedCommands().iterator().next();
-      Assertions.assertEquals(SCMCommandProto.Type.replicateContainerCommand,
+      assertEquals(SCMCommandProto.Type.replicateContainerCommand,
           command.getCommand().getType());
       replicateCommand = (ReplicateContainerCommand) command.getCommand();
-      Assertions.assertEquals(1, replicateCommand.getSourceDatanodes().size());
-      Assertions.assertEquals(unhealthyReplica.getDatanodeDetails(),
+      assertEquals(1, replicateCommand.getSourceDatanodes().size());
+      assertEquals(unhealthyReplica.getDatanodeDetails(),
           replicateCommand.getSourceDatanodes().iterator().next());
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
     }
@@ -1243,20 +1244,20 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
       Optional<CommandForDatanode> cmdOptional =
           datanodeCommandHandler.getReceivedCommands().stream().findFirst();
-      Assertions.assertTrue(cmdOptional.isPresent());
+      assertTrue(cmdOptional.isPresent());
       SCMCommand<?> scmCmd = cmdOptional.get().getCommand();
       assertInstanceOf(ReplicateContainerCommand.class, scmCmd);
       ReplicateContainerCommand repCmd = (ReplicateContainerCommand) scmCmd;
 
       // Only the closed replicas should have been used as sources.
       List<DatanodeDetails> repSources = repCmd.getSourceDatanodes();
-      Assertions.assertEquals(2, repSources.size());
+      assertEquals(2, repSources.size());
       assertThat(repSources).containsAll(
           Arrays.asList(closedReplica1.getDatanodeDetails(),
               closedReplica2.getDatanodeDetails()));
@@ -1291,20 +1292,20 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
       Optional<CommandForDatanode> cmdOptional =
           datanodeCommandHandler.getReceivedCommands().stream().findFirst();
-      Assertions.assertTrue(cmdOptional.isPresent());
+      assertTrue(cmdOptional.isPresent());
       SCMCommand<?> scmCmd = cmdOptional.get().getCommand();
       assertInstanceOf(ReplicateContainerCommand.class, scmCmd);
       ReplicateContainerCommand repCmd = (ReplicateContainerCommand) scmCmd;
 
       // Only the quasi closed replicas should have been used as a sources.
       List<DatanodeDetails> repSources = repCmd.getSourceDatanodes();
-      Assertions.assertEquals(2, repSources.size());
+      assertEquals(2, repSources.size());
       assertThat(repSources).containsAll(
           Arrays.asList(quasiReplica1.getDatanodeDetails(),
               quasiReplica2.getDatanodeDetails()));
@@ -1344,7 +1345,7 @@ public class TestLegacyReplicationManager {
       // All the containers are unhealthy, so it will not be counted as under
       // replicated.
       assertUnderReplicatedCount(0);
-      Assertions.assertEquals(2,
+      assertEquals(2,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
 
@@ -1367,7 +1368,7 @@ public class TestLegacyReplicationManager {
       // Now that we have healthy replicas, they should be replicated.
       assertDeleteScheduled(0);
       assertUnderReplicatedCount(1);
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
@@ -1395,7 +1396,7 @@ public class TestLegacyReplicationManager {
       // of a closed container.
       assertDeleteScheduled(1);
       assertUnderReplicatedCount(0);
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
       assertExactDeleteTargets(unhealthyReplica.getDatanodeDetails());
@@ -1455,10 +1456,10 @@ public class TestLegacyReplicationManager {
       // delete command should be sent for quasiToDelete to unblock under rep
       // handling.
       assertDeleteScheduled(1);
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
           SCMCommandProto.Type.closeContainerCommand,
           quasi2.getDatanodeDetails()));
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
           SCMCommandProto.Type.deleteContainerCommand,
           quasiToDelete.getDatanodeDetails()));
       assertUnderReplicatedCount(1);
@@ -1484,7 +1485,7 @@ public class TestLegacyReplicationManager {
           .filter(c -> c.getCommand().getType()
               .equals(SCMCommandProto.Type.replicateContainerCommand))
           .collect(Collectors.toList());
-      Assertions.assertEquals(1, replicateCommands.size());
+      assertEquals(1, replicateCommands.size());
       // Report the new replica to SCM.
       for (CommandForDatanode replicateCommand: replicateCommands) {
         DatanodeDetails newNode = createDatanodeDetails(
@@ -1550,16 +1551,16 @@ public class TestLegacyReplicationManager {
       // delete command should be sent for unhealthy to unblock under rep
       // handling.
       assertDeleteScheduled(1);
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
           SCMCommandProto.Type.deleteContainerCommand,
           unhealthy.getDatanodeDetails()));
 
       List<CommandForDatanode> commands = datanodeCommandHandler
           .getReceivedCommands();
-      Assertions.assertEquals(1, commands.size());
+      assertEquals(1, commands.size());
       DeleteContainerCommand deleteContainerCommand =
           (DeleteContainerCommand) commands.get(0).getCommand();
-      Assertions.assertTrue(deleteContainerCommand.isForce());
+      assertTrue(deleteContainerCommand.isForce());
 
       assertUnderReplicatedCount(1);
       // Update RM with the result of delete command
@@ -1577,7 +1578,7 @@ public class TestLegacyReplicationManager {
               .filter(command -> command.getCommand().getType()
                   .equals(SCMCommandProto.Type.replicateContainerCommand))
               .collect(Collectors.toList());
-      Assertions.assertEquals(1, replicateCommands.size());
+      assertEquals(1, replicateCommands.size());
       ReplicateContainerCommand command = (ReplicateContainerCommand)
           replicateCommands.iterator().next().getCommand();
       List<DatanodeDetails> sources = command.getSourceDatanodes();
@@ -1686,8 +1687,8 @@ public class TestLegacyReplicationManager {
         }
       }
 
-      Assertions.assertTrue(unhealthyDeleted);
-      Assertions.assertFalse(closedDeleted);
+      assertTrue(unhealthyDeleted);
+      assertFalse(closedDeleted);
 
       containerStateManager.removeContainerReplica(
           container.containerID(), unhealthy);
@@ -1708,8 +1709,8 @@ public class TestLegacyReplicationManager {
         }
       }
 
-      Assertions.assertTrue(unhealthyDeleted);
-      Assertions.assertTrue(closedDeleted);
+      assertTrue(unhealthyDeleted);
+      assertTrue(closedDeleted);
     }
 
     /**
@@ -1731,16 +1732,16 @@ public class TestLegacyReplicationManager {
       // No replications should be scheduled.
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(0,
+      assertEquals(0,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
       assertUnderReplicatedCount(0);
 
       // One replica should be deleted.
-      Assertions.assertEquals(1,
+      assertEquals(1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
-      Assertions.assertTrue(
+      assertTrue(
           datanodeCommandHandler.getReceivedCommands().stream()
               .anyMatch(c -> c.getCommand().getType() ==
                   SCMCommandProto.Type.deleteContainerCommand &&
@@ -1780,20 +1781,20 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
           datanodeCommandHandler
               .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
           replicationManager.getMetrics().getDeletionCmdsSentTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.DELETION));
+      assertEquals(1, replicationManager.getMetrics()
           .getInflightDeletion());
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.OVER_REPLICATED));
 
       // Now we remove the replica according to inflight
@@ -1821,19 +1822,19 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(0, getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(0, replicationManager.getMetrics()
+      assertEquals(0, getInflightCount(InflightType.DELETION));
+      assertEquals(0, replicationManager.getMetrics()
           .getInflightDeletion());
-      Assertions.assertEquals(currentDeleteCommandCompleted + 1,
+      assertEquals(currentDeleteCommandCompleted + 1,
           replicationManager.getMetrics().getReplicasDeletedTotal());
-      Assertions.assertEquals(deleteBytesCompleted + 101,
+      assertEquals(deleteBytesCompleted + 101,
           replicationManager.getMetrics().getDeletionBytesCompletedTotal());
 
       report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.OVER_REPLICATED));
     }
 
@@ -1867,8 +1868,8 @@ public class TestLegacyReplicationManager {
       verify(closeContainerHandler, times(1)).onMessage(id, eventQueue);
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.OPEN));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.OPEN));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.OPEN_UNHEALTHY));
     }
 
@@ -1897,7 +1898,7 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       // Wait for EventQueue to call the event handler
       eventQueue.processAll(1000);
-      Assertions.assertEquals(2,
+      assertEquals(2,
           datanodeCommandHandler.getInvocation());
     }
 
@@ -1935,7 +1936,7 @@ public class TestLegacyReplicationManager {
       containerStateManager.updateContainerReplica(id, replicaFour);
 
       assertDeleteScheduled(1);
-      Assertions.assertTrue(
+      assertTrue(
           datanodeCommandHandler.getReceivedCommands().stream()
               .anyMatch(c -> c.getCommand().getType() ==
                   SCMCommandProto.Type.deleteContainerCommand &&
@@ -1943,12 +1944,12 @@ public class TestLegacyReplicationManager {
                       unhealthyReplica.getDatanodeDetails().getUuid())));
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
       // Container should have been considered over replicated including the
       // unhealthy replica.
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.OVER_REPLICATED));
 
       final long currentDeleteCommandCompleted = replicationManager.getMetrics()
@@ -1961,17 +1962,17 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertEquals(currentDeleteCommandCompleted + 1,
+      assertEquals(currentDeleteCommandCompleted + 1,
           replicationManager.getMetrics().getReplicasDeletedTotal());
-      Assertions.assertEquals(0, getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(0, replicationManager.getMetrics()
+      assertEquals(0, getInflightCount(InflightType.DELETION));
+      assertEquals(0, replicationManager.getMetrics()
           .getInflightDeletion());
 
       report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.OVER_REPLICATED));
     }
 
@@ -2004,22 +2005,22 @@ public class TestLegacyReplicationManager {
       // replicated.
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentReplicateCommandCount + 1,
+      assertEquals(currentReplicateCommandCount + 1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(currentReplicateCommandCount + 1,
+      assertEquals(currentReplicateCommandCount + 1,
           replicationManager.getMetrics().getReplicationCmdsSentTotal());
-      Assertions.assertEquals(currentBytesToReplicate + 100,
+      assertEquals(currentBytesToReplicate + 100,
           replicationManager.getMetrics().getReplicationBytesTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.REPLICATION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.REPLICATION));
+      assertEquals(1, replicationManager.getMetrics()
           .getInflightReplication());
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.UNDER_REPLICATED));
 
       final long currentReplicateCommandCompleted = replicationManager
@@ -2040,19 +2041,19 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertEquals(currentReplicateCommandCompleted + 1,
+      assertEquals(currentReplicateCommandCompleted + 1,
           replicationManager.getMetrics().getReplicasCreatedTotal());
-      Assertions.assertEquals(currentReplicateBytesCompleted + 100,
+      assertEquals(currentReplicateBytesCompleted + 100,
           replicationManager.getMetrics().getReplicationBytesCompletedTotal());
-      Assertions.assertEquals(0, getInflightCount(InflightType.REPLICATION));
-      Assertions.assertEquals(0, replicationManager.getMetrics()
+      assertEquals(0, getInflightCount(InflightType.REPLICATION));
+      assertEquals(0, replicationManager.getMetrics()
           .getInflightReplication());
 
       report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     }
 
@@ -2104,13 +2105,13 @@ public class TestLegacyReplicationManager {
           50, 5000);
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1,
+      assertEquals(1,
           report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.UNHEALTHY));
 
       List<CommandForDatanode> replicateCommands = datanodeCommandHandler
@@ -2119,7 +2120,7 @@ public class TestLegacyReplicationManager {
               .equals(SCMCommandProto.Type.replicateContainerCommand))
           .collect(Collectors.toList());
 
-      Assertions.assertEquals(2, replicateCommands.size());
+      assertEquals(2, replicateCommands.size());
 
       // Report the two new replicas to SCM.
       for (CommandForDatanode replicateCommand: replicateCommands) {
@@ -2136,31 +2137,31 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
           datanodeCommandHandler
               .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
           SCMCommandProto.Type.deleteContainerCommand,
           unhealthyReplica.getDatanodeDetails()));
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
           replicationManager.getMetrics().getDeletionCmdsSentTotal());
-      Assertions.assertEquals(currentBytesToDelete + 99,
+      assertEquals(currentBytesToDelete + 99,
           replicationManager.getMetrics().getDeletionBytesTotal());
-      Assertions.assertEquals(1,
+      assertEquals(1,
           getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, replicationManager.getMetrics()
           .getInflightDeletion());
 
       containerStateManager.removeContainerReplica(id, unhealthyReplica);
 
       report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1,
+      assertEquals(1,
           report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.UNHEALTHY));
     }
 
@@ -2204,28 +2205,28 @@ public class TestLegacyReplicationManager {
        */
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentCloseCommandCount,
+      assertEquals(currentCloseCommandCount,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
 
       // One replication command should be sent
-      Assertions.assertEquals(currentReplicateCommandCount + 1,
+      assertEquals(currentReplicateCommandCount + 1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(currentReplicateCommandCount + 1,
+      assertEquals(currentReplicateCommandCount + 1,
           replicationManager.getMetrics().getReplicationCmdsSentTotal());
-      Assertions.assertEquals(
+      assertEquals(
           currentBytesToReplicate + container.getUsedBytes(),
           replicationManager.getMetrics().getReplicationBytesTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.REPLICATION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.REPLICATION));
+      assertEquals(1, replicationManager.getMetrics()
           .getInflightReplication());
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(
           ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     }
 
@@ -2259,14 +2260,14 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(1000);
 
       // All the replicas have same BCSID, so all of them will be closed.
-      Assertions.assertEquals(currentCloseCommandCount + 3,
+      assertEquals(currentCloseCommandCount + 3,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1,
+      assertEquals(1,
           report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
     }
 
@@ -2295,29 +2296,29 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertEquals(currentCloseCommandCount + 1,
+      assertEquals(currentCloseCommandCount + 1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
 
       // The highest BCSID replica should have been closed.
       Optional<CommandForDatanode> cmd =
           datanodeCommandHandler.getReceivedCommands().stream().findFirst();
-      Assertions.assertTrue(cmd.isPresent());
-      Assertions.assertEquals(replicaOne.getDatanodeDetails().getUuid(),
+      assertTrue(cmd.isPresent());
+      assertEquals(replicaOne.getDatanodeDetails().getUuid(),
           cmd.get().getDatanodeId());
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
       // Container will register as closed after the closed replica is
       // reported in the next iteration.
-      Assertions.assertEquals(0,
+      assertEquals(0,
           report.getStat(LifeCycleState.CLOSED));
       // Legacy replication manager does not count over/under replicated
       // status until the container is eligible to be replicated.
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-      Assertions.assertEquals(1,
+      assertEquals(1,
           report.getStat(LifeCycleState.QUASI_CLOSED));
-      Assertions.assertEquals(0, report.getStat(
+      assertEquals(0, report.getStat(
           ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
 
       // Move the higher BCSID replica to closed state.
@@ -2335,18 +2336,18 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
       // No more close commands should be sent.
-      Assertions.assertEquals(currentCloseCommandCount,
+      assertEquals(currentCloseCommandCount,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.closeContainerCommand));
       // Two replicate commands should be triggered for the now closed
       // container.
-      Assertions.assertEquals(currentReplicateCommandCount + 2,
+      assertEquals(currentReplicateCommandCount + 2,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(currentReplicateCommandCount + 2,
+      assertEquals(currentReplicateCommandCount + 2,
           replicationManager.getMetrics().getReplicationCmdsSentTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.REPLICATION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.REPLICATION));
+      assertEquals(1, replicationManager.getMetrics()
           .getInflightReplication());
 
       // Once the replicas are closed, moving the container to CLOSED state
@@ -2543,13 +2544,13 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentDeleteCommandCount + 2,
+      assertEquals(currentDeleteCommandCount + 2,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
-      Assertions.assertEquals(currentDeleteCommandCount + 2,
+      assertEquals(currentDeleteCommandCount + 2,
           replicationManager.getMetrics().getDeletionCmdsSentTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.DELETION));
+      assertEquals(1, replicationManager.getMetrics()
           .getInflightDeletion());
       // Get the DECOM and Maint replica and ensure none of them are scheduled
       // for removal
@@ -2561,7 +2562,7 @@ public class TestLegacyReplicationManager {
                   r.getDatanodeDetails().getPersistedOpState() != IN_SERVICE)
               .collect(Collectors.toSet());
       for (ContainerReplica r : decom) {
-        Assertions.assertFalse(datanodeCommandHandler.received(
+        assertFalse(datanodeCommandHandler.received(
             SCMCommandProto.Type.deleteContainerCommand,
             r.getDatanodeDetails()));
       }
@@ -2620,9 +2621,9 @@ public class TestLegacyReplicationManager {
       assertThat(scmLogs.getOutput()).contains(
               "receive a move request about container");
       Thread.sleep(100L);
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
               SCMCommandProto.Type.replicateContainerCommand, dn3));
-      Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+      assertEquals(1, datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
       //replicate container to dn3
@@ -2630,17 +2631,17 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
           SCMCommandProto.Type.deleteContainerCommand,
           dn1.getDatanodeDetails()));
-      Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+      assertEquals(1, datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
       containerStateManager.removeContainerReplica(id, dn1);
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertTrue(
+      assertTrue(
           cf.isDone() && cf.get() == MoveManager.MoveResult.COMPLETED);
     }
 
@@ -2663,9 +2664,9 @@ public class TestLegacyReplicationManager {
       assertThat(scmLogs.getOutput()).contains(
               "receive a move request about container");
       Thread.sleep(100L);
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
               SCMCommandProto.Type.replicateContainerCommand, dn3));
-      Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+      assertEquals(1, datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
       //crash happens, restart scm.
@@ -2673,24 +2674,24 @@ public class TestLegacyReplicationManager {
       resetReplicationManager();
       replicationManager.getMoveScheduler()
               .reinitialize(SCMDBDefinition.MOVE.getTable(dbStore));
-      Assertions.assertTrue(replicationManager.getMoveScheduler()
+      assertTrue(replicationManager.getMoveScheduler()
               .getInflightMove().containsKey(id));
       MoveDataNodePair kv = replicationManager.getMoveScheduler()
               .getInflightMove().get(id);
-      Assertions.assertEquals(kv.getSrc(), dn1.getDatanodeDetails());
-      Assertions.assertEquals(kv.getTgt(), dn3);
+      assertEquals(kv.getSrc(), dn1.getDatanodeDetails());
+      assertEquals(kv.getTgt(), dn3);
       serviceManager.notifyStatusChanged();
 
       Thread.sleep(100L);
       // now, the container is not over-replicated,
       // so no deleteContainerCommand will be sent
-      Assertions.assertFalse(datanodeCommandHandler.received(
+      assertFalse(datanodeCommandHandler.received(
           SCMCommandProto.Type.deleteContainerCommand,
           dn1.getDatanodeDetails()));
       //replica does not exist in target datanode, so a
       // replicateContainerCommand will be sent again at
       // notifyStatusChanged#onLeaderReadyAndOutOfSafeMode
-      Assertions.assertEquals(2, datanodeCommandHandler.getInvocationCount(
+      assertEquals(2, datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
 
@@ -2700,7 +2701,7 @@ public class TestLegacyReplicationManager {
       eventQueue.processAll(1000);
 
       //deleteContainerCommand is sent, but the src replica is not deleted now
-      Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+      assertEquals(1, datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
 
       //crash happens, restart scm.
@@ -2708,17 +2709,17 @@ public class TestLegacyReplicationManager {
       resetReplicationManager();
       replicationManager.getMoveScheduler()
               .reinitialize(SCMDBDefinition.MOVE.getTable(dbStore));
-      Assertions.assertTrue(replicationManager.getMoveScheduler()
+      assertTrue(replicationManager.getMoveScheduler()
               .getInflightMove().containsKey(id));
       kv = replicationManager.getMoveScheduler()
               .getInflightMove().get(id);
-      Assertions.assertEquals(kv.getSrc(), dn1.getDatanodeDetails());
-      Assertions.assertEquals(kv.getTgt(), dn3);
+      assertEquals(kv.getSrc(), dn1.getDatanodeDetails());
+      assertEquals(kv.getTgt(), dn3);
       serviceManager.notifyStatusChanged();
 
       //after restart and the container is over-replicated now,
       //deleteContainerCommand will be sent again
-      Assertions.assertEquals(2, datanodeCommandHandler.getInvocationCount(
+      assertEquals(2, datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
       containerStateManager.removeContainerReplica(id, dn1);
 
@@ -2761,9 +2762,9 @@ public class TestLegacyReplicationManager {
       assertThat(scmLogs.getOutput()).contains(
               "receive a move request about container");
       Thread.sleep(100L);
-      Assertions.assertTrue(datanodeCommandHandler.received(
+      assertTrue(datanodeCommandHandler.received(
               SCMCommandProto.Type.replicateContainerCommand, dn4));
-      Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+      assertEquals(1, datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 
       //replicate container to dn4
@@ -2775,12 +2776,12 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertFalse(
+      assertFalse(
           datanodeCommandHandler.received(
               SCMCommandProto.Type.deleteContainerCommand,
               dn1.getDatanodeDetails()));
 
-      Assertions.assertTrue(cf.isDone() &&
+      assertTrue(cf.isDone() &&
               cf.get() == MoveManager.MoveResult.DELETE_FAIL_POLICY);
     }
 
@@ -2810,7 +2811,7 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
 
       nodeManager.setNodeStatus(dn3, new NodeStatus(IN_SERVICE, HEALTHY));
@@ -2823,7 +2824,7 @@ public class TestLegacyReplicationManager {
       replicationManager.processAll();
       eventQueue.processAll(1000);
 
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.DELETION_FAIL_NODE_UNHEALTHY);
     }
 
@@ -2854,32 +2855,32 @@ public class TestLegacyReplicationManager {
       replicationManager.stop();
       Thread.sleep(100L);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.FAIL_UNEXPECTED_ERROR);
       replicationManager.start();
       Thread.sleep(100L);
 
       //container in not in OPEN state
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
       //open -> closing
       containerStateManager.updateContainerState(id.getProtobuf(),
               LifeCycleEvent.FINALIZE);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
       //closing -> quasi_closed
       containerStateManager.updateContainerState(id.getProtobuf(),
               LifeCycleEvent.QUASI_CLOSE);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
 
       //quasi_closed -> closed
       containerStateManager.updateContainerState(id.getProtobuf(),
               LifeCycleEvent.FORCE_CLOSE);
-      Assertions.assertSame(LifeCycleState.CLOSED,
+      assertSame(LifeCycleState.CLOSED,
               containerStateManager.getContainer(id).getState());
 
       //Node is not in healthy state
@@ -2888,10 +2889,10 @@ public class TestLegacyReplicationManager {
           nodeManager.setNodeStatus(dn3,
                   new NodeStatus(IN_SERVICE, state));
           cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-          Assertions.assertTrue(cf.isDone() && cf.get() ==
+          assertTrue(cf.isDone() && cf.get() ==
                   MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
           cf = replicationManager.move(id, dn3, dn1.getDatanodeDetails());
-          Assertions.assertTrue(cf.isDone() && cf.get() ==
+          assertTrue(cf.isDone() && cf.get() ==
                   MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
         }
       }
@@ -2904,10 +2905,10 @@ public class TestLegacyReplicationManager {
           nodeManager.setNodeStatus(dn3,
                   new NodeStatus(state, HEALTHY));
           cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-          Assertions.assertTrue(cf.isDone() && cf.get() ==
+          assertTrue(cf.isDone() && cf.get() ==
                   MoveManager.MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
           cf = replicationManager.move(id, dn3, dn1.getDatanodeDetails());
-          Assertions.assertTrue(cf.isDone() && cf.get() ==
+          assertTrue(cf.isDone() && cf.get() ==
                   MoveManager.MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
         }
       }
@@ -2916,12 +2917,12 @@ public class TestLegacyReplicationManager {
       //container exists in target datanode
       cf = replicationManager.move(id, dn1.getDatanodeDetails(),
               dn2.getDatanodeDetails());
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.REPLICATION_FAIL_EXIST_IN_TARGET);
 
       //container does not exist in source datanode
       cf = replicationManager.move(id, dn3, dn3);
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.REPLICATION_FAIL_NOT_EXIST_IN_SOURCE);
 
       //make container over relplicated to test the
@@ -2932,7 +2933,7 @@ public class TestLegacyReplicationManager {
       //waiting for inflightDeletion generation
       eventQueue.processAll(1000);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.REPLICATION_FAIL_INFLIGHT_DELETION);
       resetReplicationManager();
 
@@ -2945,7 +2946,7 @@ public class TestLegacyReplicationManager {
       //waiting for inflightReplication generation
       eventQueue.processAll(1000);
       cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-      Assertions.assertTrue(cf.isDone() && cf.get() ==
+      assertTrue(cf.isDone() && cf.get() ==
               MoveManager.MoveResult.REPLICATION_FAIL_INFLIGHT_REPLICATION);
     }
   }
@@ -2996,20 +2997,20 @@ public class TestLegacyReplicationManager {
       // At this stage, due to the mocked calls to validateContainerPlacement
       // the policy will not be satisfied, and replication will be triggered.
 
-      Assertions.assertEquals(currentReplicateCommandCount + 1,
+      assertEquals(currentReplicateCommandCount + 1,
               datanodeCommandHandler.getInvocationCount(
                       SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(currentReplicateCommandCount + 1,
+      assertEquals(currentReplicateCommandCount + 1,
               replicationManager.getMetrics().getReplicationCmdsSentTotal());
-      Assertions.assertEquals(currentBytesToReplicate + 100,
+      assertEquals(currentBytesToReplicate + 100,
               replicationManager.getMetrics().getReplicationBytesTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.REPLICATION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.REPLICATION));
+      assertEquals(1, replicationManager.getMetrics()
               .getInflightReplication());
 
       ReplicationManagerReport report = replicationManager.getContainerReport();
-      Assertions.assertEquals(1, report.getStat(LifeCycleState.CLOSED));
-      Assertions.assertEquals(1, report.getStat(
+      assertEquals(1, report.getStat(LifeCycleState.CLOSED));
+      assertEquals(1, report.getStat(
               ReplicationManagerReport.HealthState.MIS_REPLICATED));
 
       // Now make it so that all containers seem mis-replicated no matter how
@@ -3030,13 +3031,13 @@ public class TestLegacyReplicationManager {
       // At this stage, due to the mocked calls to validateContainerPlacement
       // the mis-replicated racks will not have improved, so expect to see
       // nothing scheduled.
-      Assertions.assertEquals(currentReplicateCommandCount,
+      assertEquals(currentReplicateCommandCount,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
-      Assertions.assertEquals(currentReplicateCommandCount,
+      assertEquals(currentReplicateCommandCount,
               replicationManager.getMetrics().getReplicationCmdsSentTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.REPLICATION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.REPLICATION));
+      assertEquals(1, replicationManager.getMetrics()
               .getInflightReplication());
     }
 
@@ -3084,14 +3085,14 @@ public class TestLegacyReplicationManager {
       //  3. Fixing topology issues left by the previous cleanup tasks.
       // Current legacy RM implementation will take no action in this case
       // because deletion would compromise topology.
-      Assertions.assertEquals(currentDeleteCommandCount,
+      assertEquals(currentDeleteCommandCount,
               datanodeCommandHandler.getInvocationCount(
                   SCMCommandProto.Type.deleteContainerCommand));
-      Assertions.assertEquals(currentDeleteCommandCount,
+      assertEquals(currentDeleteCommandCount,
               replicationManager.getMetrics().getDeletionCmdsSentTotal());
 
-      Assertions.assertEquals(0, getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(0, replicationManager.getMetrics()
+      assertEquals(0, getInflightCount(InflightType.DELETION));
+      assertEquals(0, replicationManager.getMetrics()
               .getInflightDeletion());
       assertOverReplicatedCount(1);
     }
@@ -3129,13 +3130,13 @@ public class TestLegacyReplicationManager {
 
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
               datanodeCommandHandler.getInvocationCount(
                   SCMCommandProto.Type.deleteContainerCommand));
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
               replicationManager.getMetrics().getDeletionCmdsSentTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.DELETION));
+      assertEquals(1, replicationManager.getMetrics()
               .getInflightDeletion());
 
       assertOverReplicatedCount(1);
@@ -3181,13 +3182,13 @@ public class TestLegacyReplicationManager {
       // On the first run, RM will delete one of the extra closed replicas.
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
               datanodeCommandHandler.getInvocationCount(
                   SCMCommandProto.Type.deleteContainerCommand));
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
               replicationManager.getMetrics().getDeletionCmdsSentTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.DELETION));
+      assertEquals(1, replicationManager.getMetrics()
               .getInflightDeletion());
 
       assertAnyDeleteTargets(
@@ -3205,13 +3206,13 @@ public class TestLegacyReplicationManager {
       // be deleted by the unhealthy container handler.
       replicationManager.processAll();
       eventQueue.processAll(1000);
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
           datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.deleteContainerCommand));
-      Assertions.assertEquals(currentDeleteCommandCount + 1,
+      assertEquals(currentDeleteCommandCount + 1,
           replicationManager.getMetrics().getDeletionCmdsSentTotal());
-      Assertions.assertEquals(1, getInflightCount(InflightType.DELETION));
-      Assertions.assertEquals(1, replicationManager.getMetrics()
+      assertEquals(1, getInflightCount(InflightType.DELETION));
+      assertEquals(1, replicationManager.getMetrics()
           .getInflightDeletion());
 
       assertDeleteTargetsContain(replicaFive.getDatanodeDetails());
@@ -3229,9 +3230,9 @@ public class TestLegacyReplicationManager {
 
     testcase.call();
 
-    Assertions.assertEquals(replicationSkipped + expectedReplicationSkipped,
+    assertEquals(replicationSkipped + expectedReplicationSkipped,
         metrics.getInflightReplicationSkipped());
-    Assertions.assertEquals(deletionSkipped + expectedDeletionSkipped,
+    assertEquals(deletionSkipped + expectedDeletionSkipped,
         metrics.getInflightDeletionSkipped());
 
     //reset limits for other tests.
@@ -3249,7 +3250,7 @@ public class TestLegacyReplicationManager {
             SCMCommandProto.Type.deleteContainerCommand)
         .collect(Collectors.toList());
 
-    Assertions.assertEquals(targetDNs.length, deleteCommands.size());
+    assertEquals(targetDNs.length, deleteCommands.size());
 
     Set<UUID> targetDNIDs = Arrays.stream(targetDNs)
         .map(DatanodeDetails::getUuid)
@@ -3258,7 +3259,7 @@ public class TestLegacyReplicationManager {
         .map(CommandForDatanode::getDatanodeId)
         .collect(Collectors.toSet());
 
-    Assertions.assertEquals(targetDNIDs, chosenDNIDs);
+    assertEquals(targetDNIDs, chosenDNIDs);
   }
 
   /**
@@ -3392,10 +3393,10 @@ public class TestLegacyReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentReplicateCommandCount + delta,
+    assertEquals(currentReplicateCommandCount + delta,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.replicateContainerCommand));
-    Assertions.assertEquals(currentReplicateCommandCount + delta,
+    assertEquals(currentReplicateCommandCount + delta,
         replicationManager.getMetrics().getReplicationCmdsSentTotal());
   }
 
@@ -3405,29 +3406,27 @@ public class TestLegacyReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentDeleteCommandCount + delta,
+    assertEquals(currentDeleteCommandCount + delta,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.deleteContainerCommand));
-    Assertions.assertEquals(currentDeleteCommandCount + delta,
+    assertEquals(currentDeleteCommandCount + delta,
         replicationManager.getMetrics().getDeletionCmdsSentTotal());
   }
 
   private void assertUnderReplicatedCount(int count) {
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assertions.assertEquals(count, report.getStat(
+    assertEquals(count, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
   private void assertMissingCount(int count) {
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assertions.assertEquals(count, report.getStat(
-        ReplicationManagerReport.HealthState.MISSING));
+    assertEquals(count, report.getStat(ReplicationManagerReport.HealthState.MISSING));
   }
 
   private void assertOverReplicatedCount(int count) {
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assertions.assertEquals(count, report.getStat(
-        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    assertEquals(count, report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
   
   private static class DatanodeCommandHandler implements

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
@@ -49,7 +49,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.replicateContainerCommand;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -49,6 +48,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.replicateContainerCommand;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
@@ -219,13 +221,13 @@ public abstract class TestMisReplicationHandler {
       misReplicationHandler.processAndSendCommands(availableReplicas,
           pendingOp, result, maintenanceCnt);
     } finally {
-      Assertions.assertEquals(expectedNumberOfCommands, commandsSent.size());
+      assertEquals(expectedNumberOfCommands, commandsSent.size());
       for (Pair<DatanodeDetails, SCMCommand<?>> pair : commandsSent) {
         SCMCommand<?> command = pair.getValue();
-        Assertions.assertSame(replicateContainerCommand, command.getType());
+        assertSame(replicateContainerCommand, command.getType());
         ReplicateContainerCommand replicateContainerCommand =
             (ReplicateContainerCommand) command;
-        Assertions.assertEquals(replicateContainerCommand.getContainerID(),
+        assertEquals(replicateContainerCommand.getContainerID(),
             container.getContainerID());
         DatanodeDetails replicateSrcDn = pair.getKey();
         DatanodeDetails target = replicateContainerCommand.getTargetDatanode();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestMisReplicationHandler.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.Assertions;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -57,6 +56,10 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -80,8 +83,8 @@ public abstract class TestMisReplicationHandler {
       NotLeaderException {
     conf = SCMTestUtils.getConf();
 
-    replicationManager = Mockito.mock(ReplicationManager.class);
-    Mockito.when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+    replicationManager = mock(ReplicationManager.class);
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
           return new NodeStatus(dd.getPersistedOpState(),
@@ -89,10 +92,9 @@ public abstract class TestMisReplicationHandler {
         });
     ReplicationManagerConfiguration rmConf =
         conf.getObject(ReplicationManagerConfiguration.class);
-    Mockito.when(replicationManager.getConfig())
-        .thenReturn(rmConf);
+    when(replicationManager.getConfig()).thenReturn(rmConf);
     metrics = ReplicationManagerMetrics.create(replicationManager);
-    Mockito.when(replicationManager.getMetrics()).thenReturn(metrics);
+    when(replicationManager.getMetrics()).thenReturn(metrics);
 
     commandsSent = new HashSet<>();
     ReplicationTestUtil.mockRMSendDatanodeCommand(
@@ -120,12 +122,10 @@ public abstract class TestMisReplicationHandler {
   }
 
   static PlacementPolicy mockPlacementPolicy() {
-    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
-    ContainerPlacementStatus mockedContainerPlacementStatus =
-        Mockito.mock(ContainerPlacementStatus.class);
-    Mockito.when(mockedContainerPlacementStatus.isPolicySatisfied())
-        .thenReturn(false);
-    Mockito.when(placementPolicy.validateContainerPlacement(anyList(),
+    PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
+    ContainerPlacementStatus mockedContainerPlacementStatus = mock(ContainerPlacementStatus.class);
+    when(mockedContainerPlacementStatus.isPolicySatisfied()).thenReturn(false);
+    when(placementPolicy.validateContainerPlacement(anyList(),
         anyInt())).thenReturn(mockedContainerPlacementStatus);
     return placementPolicy;
   }
@@ -164,9 +164,9 @@ public abstract class TestMisReplicationHandler {
         mockedPlacementPolicy, conf, replicationManager);
 
     ContainerHealthResult.MisReplicatedHealthResult result =
-            Mockito.mock(ContainerHealthResult.MisReplicatedHealthResult.class);
-    Mockito.when(result.isReplicatedOkAfterPending()).thenReturn(false);
-    Mockito.when(result.getContainerInfo()).thenReturn(container);
+        mock(ContainerHealthResult.MisReplicatedHealthResult.class);
+    when(result.isReplicatedOkAfterPending()).thenReturn(false);
+    when(result.getContainerInfo()).thenReturn(container);
     Map<ContainerReplica, Boolean> sources = availableReplicas.stream()
             .collect(Collectors.toMap(Function.identity(),
                     r -> {
@@ -190,7 +190,7 @@ public abstract class TestMisReplicationHandler {
     Set<ContainerReplica> copy = sources.entrySet().stream()
             .filter(Map.Entry::getValue).limit(misreplicationCount)
             .map(Map.Entry::getKey).collect(Collectors.toSet());
-    Mockito.when(mockedPlacementPolicy.replicasToCopyToFixMisreplication(
+    when(mockedPlacementPolicy.replicasToCopyToFixMisreplication(
             anyMap())).thenAnswer(invocation -> copy);
     Set<DatanodeDetails> remainingReplicasAfterCopy =
             availableReplicas.stream().filter(r -> !copy.contains(r))
@@ -201,9 +201,9 @@ public abstract class TestMisReplicationHandler {
                     .mapToObj(i -> MockDatanodeDetails.randomDatanodeDetails())
                     .collect(Collectors.toList());
     if (expectedNumberOfNodes > 0) {
-      Mockito.when(mockedPlacementPolicy.chooseDatanodes(
+      when(mockedPlacementPolicy.chooseDatanodes(
                       any(), any(), any(),
-                      eq(copy.size()), Mockito.anyLong(), Mockito.anyLong()))
+                      eq(copy.size()), anyLong(), anyLong()))
               .thenAnswer(invocation -> {
                 List<DatanodeDetails> datanodeDetails =
                         invocation.getArgument(0);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
@@ -26,13 +26,14 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.Ov
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.ArgumentMatchers.any;
 
 /**
  * Tests for the OverReplicatedProcessor class.
@@ -49,22 +50,20 @@ public class TestOverReplicatedProcessor {
     ConfigurationSource conf = new OzoneConfiguration();
     ReplicationManagerConfiguration rmConf =
         conf.getObject(ReplicationManagerConfiguration.class);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
 
     // use real queue
     queue = new ReplicationQueue();
     repConfig = new ECReplicationConfig(3, 2);
     overReplicatedProcessor = new OverReplicatedProcessor(
         replicationManager, rmConf::getOverReplicatedInterval);
-    Mockito.when(replicationManager.shouldRun()).thenReturn(true);
+    when(replicationManager.shouldRun()).thenReturn(true);
 
     // Even through the limit has been exceeded, it should not stop over-rep
     // processing, as the over-rep handler ignores the limit as it only does
     // delete.
-    Mockito.when(replicationManager.getReplicationInFlightLimit())
-        .thenReturn(1L);
-    Mockito.when(replicationManager.getInflightReplicationCount())
-        .thenReturn(2L);
+    when(replicationManager.getReplicationInFlightLimit()).thenReturn(1L);
+    when(replicationManager.getInflightReplicationCount()).thenReturn(2L);
   }
 
   @Test
@@ -74,8 +73,7 @@ public class TestOverReplicatedProcessor {
     queue.enqueue(new OverReplicatedHealthResult(
         container, 3, false));
 
-    Mockito.when(replicationManager.processOverReplicatedContainer(any()))
-        .thenReturn(1);
+    when(replicationManager.processOverReplicatedContainer(any())).thenReturn(1);
     overReplicatedProcessor.processAll(queue);
 
     assertEquals(0, queue.overReplicatedQueueSize());
@@ -89,7 +87,7 @@ public class TestOverReplicatedProcessor {
         container, 3, false);
     queue.enqueue(result);
 
-    Mockito.when(replicationManager
+    when(replicationManager
             .processOverReplicatedContainer(any()))
         .thenThrow(new IOException("Test Exception"))
         .thenThrow(new AssertionError("Should process only one item"));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -45,9 +44,13 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests the RatisReplicationHandling functionality.
@@ -89,16 +92,14 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
             .createReplicas(Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0),
                     Pair.of(IN_SERVICE, 0));
-    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
-    ContainerPlacementStatus mockedContainerPlacementStatus =
-            Mockito.mock(ContainerPlacementStatus.class);
-    Mockito.when(mockedContainerPlacementStatus.isPolicySatisfied())
-            .thenReturn(false);
-    Mockito.when(placementPolicy.validateContainerPlacement(anyList(),
+    PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
+    ContainerPlacementStatus mockedContainerPlacementStatus = mock(ContainerPlacementStatus.class);
+    when(mockedContainerPlacementStatus.isPolicySatisfied()).thenReturn(false);
+    when(placementPolicy.validateContainerPlacement(anyList(),
                     anyInt())).thenReturn(mockedContainerPlacementStatus);
-    Mockito.when(placementPolicy.chooseDatanodes(
-                    Mockito.any(), Mockito.any(), Mockito.any(),
-                    Mockito.anyInt(), Mockito.anyLong(), Mockito.anyLong()))
+    when(placementPolicy.chooseDatanodes(
+                    any(), any(), any(),
+                    anyInt(), anyLong(), anyLong()))
             .thenThrow(new IOException("No nodes found"));
     Assertions.assertThrows(SCMException.class, () -> testMisReplication(
             availableReplicas, placementPolicy, Collections.emptyList(),
@@ -138,12 +139,10 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
             .createReplicas(Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0),
                     Pair.of(IN_SERVICE, 0));
-    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
-    ContainerPlacementStatus mockedContainerPlacementStatus =
-            Mockito.mock(ContainerPlacementStatus.class);
-    Mockito.when(mockedContainerPlacementStatus.isPolicySatisfied())
-            .thenReturn(true);
-    Mockito.when(placementPolicy.validateContainerPlacement(anyList(),
+    PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
+    ContainerPlacementStatus mockedContainerPlacementStatus = mock(ContainerPlacementStatus.class);
+    when(mockedContainerPlacementStatus.isPolicySatisfied()).thenReturn(true);
+    when(placementPolicy.validateContainerPlacement(anyList(),
                     anyInt())).thenReturn(mockedContainerPlacementStatus);
     testMisReplication(availableReplicas, placementPolicy,
             Collections.emptyList(), 0, 1, 0);
@@ -155,12 +154,10 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
             .createReplicas(Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0),
                     Pair.of(IN_SERVICE, 0));
-    PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
-    ContainerPlacementStatus mockedContainerPlacementStatus =
-            Mockito.mock(ContainerPlacementStatus.class);
-    Mockito.when(mockedContainerPlacementStatus.isPolicySatisfied())
-            .thenReturn(true);
-    Mockito.when(placementPolicy.validateContainerPlacement(anyList(),
+    PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
+    ContainerPlacementStatus mockedContainerPlacementStatus = mock(ContainerPlacementStatus.class);
+    when(mockedContainerPlacementStatus.isPolicySatisfied()).thenReturn(true);
+    when(placementPolicy.validateContainerPlacement(anyList(),
             anyInt())).thenReturn(mockedContainerPlacementStatus);
     List<ContainerReplicaOp> pendingOp = Collections.singletonList(
             ContainerReplicaOp.create(ContainerReplicaOp.PendingOpType.ADD,
@@ -178,7 +175,7 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
   @Test
   public void testAllSourcesOverloaded() throws IOException {
     ReplicationManager replicationManager = getReplicationManager();
-    Mockito.doThrow(new CommandTargetOverloadedException("Overloaded"))
+    doThrow(new CommandTargetOverloadedException("Overloaded"))
         .when(replicationManager).sendThrottledReplicationCommand(any(),
             anyList(), any(), anyInt());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisMisReplicationHandler.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,6 +43,8 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doThrow;
@@ -101,7 +102,7 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
                     any(), any(), any(),
                     anyInt(), anyLong(), anyLong()))
             .thenThrow(new IOException("No nodes found"));
-    Assertions.assertThrows(SCMException.class, () -> testMisReplication(
+    assertThrows(SCMException.class, () -> testMisReplication(
             availableReplicas, placementPolicy, Collections.emptyList(),
             0, 2, 0));
   }
@@ -182,7 +183,7 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
         .createReplicas(Pair.of(IN_SERVICE, 0), Pair.of(IN_SERVICE, 0),
             Pair.of(IN_SERVICE, 0));
-    Assertions.assertThrows(CommandTargetOverloadedException.class,
+    assertThrows(CommandTargetOverloadedException.class,
         () -> testMisReplication(availableReplicas, mockPlacementPolicy(),
             Collections.emptyList(), 0, 1, 1, 0));
   }
@@ -199,6 +200,6 @@ public class TestRatisMisReplicationHandler extends TestMisReplicationHandler {
   protected void assertReplicaIndex(
       Map<DatanodeDetails, Integer> expectedReplicaIndexes,
       DatanodeDetails sourceDatanode, int actualReplicaIndex) {
-    Assertions.assertEquals(0, actualReplicaIndex);
+    assertEquals(0, actualReplicaIndex);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisOverReplicationHandler.java
@@ -38,7 +38,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.slf4j.event.Level;
 
@@ -61,10 +60,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 
@@ -85,13 +88,12 @@ public class TestRatisOverReplicationHandler {
     container = createContainer(HddsProtos.LifeCycleState.CLOSED,
         RATIS_REPLICATION_CONFIG);
 
-    policy = Mockito.mock(PlacementPolicy.class);
-    Mockito.when(policy.validateContainerPlacement(
-        Mockito.anyList(), Mockito.anyInt()))
+    policy = mock(PlacementPolicy.class);
+    when(policy.validateContainerPlacement(anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
 
-    replicationManager = Mockito.mock(ReplicationManager.class);
-    Mockito.when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+    replicationManager = mock(ReplicationManager.class);
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
           return new NodeStatus(dd.getPersistedOpState(),
@@ -133,7 +135,7 @@ public class TestRatisOverReplicationHandler {
         ContainerReplicaProto.State.CLOSED, 0, 0, 0, 0);
 
     ContainerReplica stale = replicas.stream().findFirst().get();
-    Mockito.when(replicationManager.getNodeStatus(stale.getDatanodeDetails()))
+    when(replicationManager.getNodeStatus(stale.getDatanodeDetails()))
         .thenAnswer(invocation ->
             NodeStatus.inServiceStale());
 
@@ -205,7 +207,7 @@ public class TestRatisOverReplicationHandler {
             State.UNHEALTHY, container.getNumberOfKeys(),
             container.getUsedBytes(), staleNode,
             unhealthyReplica.getOriginDatanodeId()));
-    Mockito.when(replicationManager.getNodeStatus(eq(staleNode)))
+    when(replicationManager.getNodeStatus(eq(staleNode)))
         .thenAnswer(invocation -> {
           DatanodeDetails dd = invocation.getArgument(0);
           return new NodeStatus(dd.getPersistedOpState(),
@@ -261,8 +263,7 @@ public class TestRatisOverReplicationHandler {
 
     // Ensure a mis-replicated status is returned when 4 or fewer replicas are
     // checked.
-    Mockito.when(policy.validateContainerPlacement(
-        Mockito.argThat(list -> list.size() <= 4), Mockito.anyInt()))
+    when(policy.validateContainerPlacement(argThat(list -> list.size() <= 4), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 2, 3));
 
     testProcessing(replicas, Collections.emptyList(),
@@ -331,8 +332,8 @@ public class TestRatisOverReplicationHandler {
 
     // Ensure a mis-replicated status is returned when 4 or fewer replicas are
     // checked.
-    Mockito.when(policy.validateContainerPlacement(
-            Mockito.argThat(list -> list.size() <= 4), Mockito.anyInt()))
+    when(policy.validateContainerPlacement(
+            argThat(list -> list.size() <= 4), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 2, 3));
 
     Set<Pair<DatanodeDetails, SCMCommand<?>>> commands = testProcessing(
@@ -428,7 +429,7 @@ public class TestRatisOverReplicationHandler {
     // one of the CLOSED replicas is removed.
     doThrow(CommandTargetOverloadedException.class)
         .when(replicationManager)
-        .sendThrottledDeleteCommand(Mockito.any(ContainerInfo.class),
+        .sendThrottledDeleteCommand(any(ContainerInfo.class),
             anyInt(),
             eq(quasiClosedReplica.getDatanodeDetails()),
             anyBoolean());
@@ -515,8 +516,8 @@ public class TestRatisOverReplicationHandler {
   private ContainerHealthResult.OverReplicatedHealthResult
       getOverReplicatedHealthResult() {
     ContainerHealthResult.OverReplicatedHealthResult healthResult =
-        Mockito.mock(ContainerHealthResult.OverReplicatedHealthResult.class);
-    Mockito.when(healthResult.getContainerInfo()).thenReturn(container);
+        mock(ContainerHealthResult.OverReplicatedHealthResult.class);
+    when(healthResult.getContainerInfo()).thenReturn(container);
     return healthResult;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -42,7 +42,6 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,6 +68,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
 /**
@@ -91,24 +94,24 @@ public class TestRatisUnderReplicationHandler {
     container = ReplicationTestUtil.createContainer(
         HddsProtos.LifeCycleState.CLOSED, RATIS_REPLICATION_CONFIG);
 
-    nodeManager = Mockito.mock(NodeManager.class);
+    nodeManager = mock(NodeManager.class);
     conf = SCMTestUtils.getConf();
     policy = ReplicationTestUtil
         .getSimpleTestPlacementPolicy(nodeManager, conf);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.setBoolean("hdds.scm.replication.push", true);
-    Mockito.when(replicationManager.getConfig())
+    when(replicationManager.getConfig())
         .thenReturn(ozoneConfiguration.getObject(
             ReplicationManagerConfiguration.class));
     metrics = ReplicationManagerMetrics.create(replicationManager);
-    Mockito.when(replicationManager.getMetrics()).thenReturn(metrics);
+    when(replicationManager.getMetrics()).thenReturn(metrics);
 
     /*
       Return NodeStatus with NodeOperationalState as specified in
       DatanodeDetails, and NodeState as HEALTHY.
     */
-    Mockito.when(
+    when(
         replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocationOnMock -> {
           DatanodeDetails dn = invocationOnMock.getArgument(0);
@@ -457,16 +460,14 @@ public class TestRatisUnderReplicationHandler {
         getUnderReplicatedHealthResult(), 2, 1);
 
     // Ensure that the replica with SEQ=2 is the only source sent
-    Mockito.verify(replicationManager).sendThrottledReplicationCommand(
-        any(ContainerInfo.class),
-        Mockito.eq(Collections.singletonList(valid.getDatanodeDetails())),
-        any(DatanodeDetails.class), anyInt());
+    verify(replicationManager).sendThrottledReplicationCommand(any(ContainerInfo.class),
+        eq(Collections.singletonList(valid.getDatanodeDetails())), any(DatanodeDetails.class), anyInt());
   }
 
   @Test
   public void testCorrectUsedAndExcludedNodesPassed() throws IOException {
-    PlacementPolicy mockPolicy = Mockito.mock(PlacementPolicy.class);
-    Mockito.when(mockPolicy.chooseDatanodes(any(), any(), any(),
+    PlacementPolicy mockPolicy = mock(PlacementPolicy.class);
+    when(mockPolicy.chooseDatanodes(any(), any(), any(),
         anyInt(), anyLong(), anyLong()))
         .thenReturn(Collections.singletonList(
             MockDatanodeDetails.randomDatanodeDetails()));
@@ -511,7 +512,7 @@ public class TestRatisUnderReplicationHandler {
         getUnderReplicatedHealthResult(), 2);
 
 
-    Mockito.verify(mockPolicy, times(1)).chooseDatanodes(
+    verify(mockPolicy, times(1)).chooseDatanodes(
         usedNodesCaptor.capture(), excludedNodesCaptor.capture(), any(),
         anyInt(), anyLong(), anyLong());
 
@@ -573,7 +574,7 @@ public class TestRatisUnderReplicationHandler {
             DECOMMISSIONING, State.UNHEALTHY, sequenceID);
     replicas.add(unhealthyReplica);
     UnderReplicatedHealthResult result = getUnderReplicatedHealthResult();
-    Mockito.when(result.hasVulnerableUnhealthy()).thenReturn(true);
+    when(result.hasVulnerableUnhealthy()).thenReturn(true);
 
     final Set<Pair<DatanodeDetails, SCMCommand<?>>> commands = testProcessing(replicas, Collections.emptyList(),
         result, 2, 1);
@@ -611,7 +612,7 @@ public class TestRatisUnderReplicationHandler {
     replicas.add(unhealthyReplica);
     replicas.add(unhealthyReplica2);
     UnderReplicatedHealthResult result = getUnderReplicatedHealthResult();
-    Mockito.when(result.hasVulnerableUnhealthy()).thenReturn(true);
+    when(result.hasVulnerableUnhealthy()).thenReturn(true);
     ReplicationTestUtil.mockRMSendThrottleReplicateCommand(replicationManager, commandsSent, new AtomicBoolean(true));
 
     RatisUnderReplicationHandler handler = new RatisUnderReplicationHandler(policy, conf, replicationManager);
@@ -718,9 +719,8 @@ public class TestRatisUnderReplicationHandler {
   }
 
   private UnderReplicatedHealthResult getUnderReplicatedHealthResult() {
-    UnderReplicatedHealthResult healthResult =
-        Mockito.mock(UnderReplicatedHealthResult.class);
-    Mockito.when(healthResult.getContainerInfo()).thenReturn(container);
+    UnderReplicatedHealthResult healthResult = mock(UnderReplicatedHealthResult.class);
+    when(healthResult.getContainerInfo()).thenReturn(container);
     return healthResult;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -56,7 +56,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -90,11 +89,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.clearInvocations;
 
 /**
  * Tests for the ReplicationManager.
@@ -124,39 +130,39 @@ public class TestReplicationManager {
   public void setup() throws IOException {
     configuration = new OzoneConfiguration();
     configuration.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
-    containerManager = Mockito.mock(ContainerManager.class);
-    ratisPlacementPolicy = Mockito.mock(PlacementPolicy.class);
-    Mockito.when(ratisPlacementPolicy.validateContainerPlacement(anyList(),
+    containerManager = mock(ContainerManager.class);
+    ratisPlacementPolicy = mock(PlacementPolicy.class);
+    when(ratisPlacementPolicy.validateContainerPlacement(anyList(),
         anyInt())).thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
-    ecPlacementPolicy = Mockito.mock(PlacementPolicy.class);
-    Mockito.when(ecPlacementPolicy.validateContainerPlacement(
+    ecPlacementPolicy = mock(PlacementPolicy.class);
+    when(ecPlacementPolicy.validateContainerPlacement(
         anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
 
-    scmContext = Mockito.mock(SCMContext.class);
+    scmContext = mock(SCMContext.class);
 
-    nodeManager = Mockito.mock(NodeManager.class);
+    nodeManager = mock(NodeManager.class);
     commandsSent = new HashSet<>();
-    eventPublisher = Mockito.mock(EventPublisher.class);
-    Mockito.doAnswer(invocation -> {
+    eventPublisher = mock(EventPublisher.class);
+    doAnswer(invocation -> {
       commandsSent.add(Pair.of(invocation.getArgument(0),
           invocation.getArgument(1)));
       return null;
     }).when(nodeManager).addDatanodeCommand(any(), any());
 
-    legacyReplicationManager = Mockito.mock(LegacyReplicationManager.class);
+    legacyReplicationManager = mock(LegacyReplicationManager.class);
     clock = new TestClock(Instant.now(), ZoneId.systemDefault());
     containerReplicaPendingOps =
         new ContainerReplicaPendingOps(clock);
 
-    Mockito.when(containerManager
-        .getContainerReplicas(Mockito.any(ContainerID.class))).thenAnswer(
+    when(containerManager
+        .getContainerReplicas(any(ContainerID.class))).thenAnswer(
           invocation -> {
             ContainerID cid = invocation.getArgument(0);
             return containerReplicaMap.get(cid);
           });
 
-    Mockito.when(containerManager.getContainers()).thenAnswer(
+    when(containerManager.getContainers()).thenAnswer(
         invocation -> new ArrayList<>(containerInfoSet));
     replicationManager = createReplicationManager();
     containerReplicaMap = new HashMap<>();
@@ -166,8 +172,8 @@ public class TestReplicationManager {
     repQueue = new ReplicationQueue();
 
     // Ensure that RM will run when asked.
-    Mockito.when(scmContext.isLeaderReady()).thenReturn(true);
-    Mockito.when(scmContext.isInSafeMode()).thenReturn(false);
+    when(scmContext.isLeaderReady()).thenReturn(true);
+    when(scmContext.isInSafeMode()).thenReturn(false);
   }
 
   private ReplicationManager createReplicationManager() throws IOException {
@@ -237,7 +243,7 @@ public class TestReplicationManager {
     addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
     replicationManager.processContainer(
         container, repQueue, repReport);
-    Mockito.verify(eventPublisher, Mockito.times(1))
+    verify(eventPublisher, times(1))
         .fireEvent(SCMEvents.CLOSE_CONTAINER, container.containerID());
     assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.OPEN_UNHEALTHY));
@@ -262,8 +268,7 @@ public class TestReplicationManager {
 
     replicationManager.processContainer(container, repQueue, repReport);
 
-    Mockito.verify(nodeManager, Mockito.times(3))
-        .addDatanodeCommand(any(), any());
+    verify(nodeManager, times(3)).addDatanodeCommand(any(), any());
     assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
     assertEquals(0, repQueue.underReplicatedQueueSize());
@@ -295,8 +300,7 @@ public class TestReplicationManager {
 
     replicationManager.processContainer(container, repQueue, repReport);
 
-    Mockito.verify(nodeManager, Mockito.times(1))
-        .addDatanodeCommand(any(), any());
+    verify(nodeManager, times(1)).addDatanodeCommand(any(), any());
     assertEquals(1, repReport.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
     assertEquals(1, repQueue.underReplicatedQueueSize());
@@ -338,7 +342,7 @@ public class TestReplicationManager {
   @Test
   public void testQuasiClosedContainerWithExcessUnhealthyReplica()
       throws IOException, NodeNotFoundException {
-    Mockito.when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
+    when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenReturn(NodeStatus.inServiceHealthy());
     RatisReplicationConfig ratisRepConfig =
         RatisReplicationConfig.getInstance(THREE);
@@ -467,7 +471,7 @@ public class TestReplicationManager {
             ContainerReplicaProto.State.UNHEALTHY, sequenceID);
     replicas.add(decommissioning);
     storeContainerAndReplicas(container, replicas);
-    Mockito.when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(decommissioning.getDatanodeDetails())) {
@@ -485,9 +489,9 @@ public class TestReplicationManager {
     assertEquals(1, repQueue.underReplicatedQueueSize());
     assertEquals(0, repQueue.overReplicatedQueueSize());
 
-    Mockito.when(ratisPlacementPolicy.chooseDatanodes(anyList(), anyList(), eq(null), eq(1), anyLong(),
+    when(ratisPlacementPolicy.chooseDatanodes(anyList(), anyList(), eq(null), eq(1), anyLong(),
         anyLong())).thenAnswer(invocation -> ImmutableList.of(MockDatanodeDetails.randomDatanodeDetails()));
-    Mockito.when(nodeManager.getTotalDatanodeCommandCounts(any(DatanodeDetails.class), any(), any()))
+    when(nodeManager.getTotalDatanodeCommandCounts(any(DatanodeDetails.class), any(), any()))
         .thenAnswer(invocation -> {
           Map<SCMCommandProto.Type, Integer> map = new HashMap<>();
           map.put(SCMCommandProto.Type.replicateContainerCommand, 0);
@@ -890,7 +894,7 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
 
     // now, pass this container to ec under replication handling
-    Mockito.when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
+    when(nodeManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenReturn(NodeStatus.inServiceHealthy());
     ECUnderReplicationHandler handler = new ECUnderReplicationHandler(
         getNoNodesTestPlacementPolicy(nodeManager, configuration),
@@ -953,8 +957,7 @@ public class TestReplicationManager {
 
   @Test
   public void testMisReplicatedECContainer() throws IOException {
-    Mockito.when(ecPlacementPolicy.validateContainerPlacement(
-            anyList(), anyInt()))
+    when(ecPlacementPolicy.validateContainerPlacement(anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(4, 5, 5));
 
     ContainerInfo container = createContainerInfo(repConfig, 1,
@@ -981,8 +984,7 @@ public class TestReplicationManager {
   @Test
   public void testMisReplicatedECContainerWithUnhealthyReplica()
       throws ContainerNotFoundException {
-    Mockito.when(ecPlacementPolicy.validateContainerPlacement(
-            anyList(), anyInt()))
+    when(ecPlacementPolicy.validateContainerPlacement(anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(5, 5, 5, 1,
             Lists.newArrayList(2, 1, 1, 1, 1)));
 
@@ -1012,7 +1014,7 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
     List<ContainerReplicaOp> ops =
         containerReplicaPendingOps.getPendingOps(container.containerID());
-    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
+    verify(nodeManager).addDatanodeCommand(any(), any());
     assertEquals(1, ops.size());
     assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
         ops.get(0).getOpType());
@@ -1032,8 +1034,7 @@ public class TestReplicationManager {
     replicas.remove(unhealthyReplica);
     containerReplicaPendingOps.completeDeleteReplica(container.containerID(),
         unhealthyReplica.getDatanodeDetails(), 1);
-    Mockito.when(ecPlacementPolicy.validateContainerPlacement(
-            anyList(), anyInt()))
+    when(ecPlacementPolicy.validateContainerPlacement(anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(4, 5, 5, 1,
             Lists.newArrayList(2, 1, 1, 1)));
 
@@ -1054,8 +1055,7 @@ public class TestReplicationManager {
     // Make it always return mis-replicated. Only a perfectly replicated
     // container should make it the mis-replicated state as under / over
     // replicated take precedence.
-    Mockito.when(ecPlacementPolicy.validateContainerPlacement(
-            anyList(), anyInt()))
+    when(ecPlacementPolicy.validateContainerPlacement(anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(1, 2, 3));
 
     ContainerInfo decomContainer = createContainerInfo(repConfig, 1,
@@ -1137,7 +1137,7 @@ public class TestReplicationManager {
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
-    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
+    verify(nodeManager).addDatanodeCommand(any(), any());
     assertEquals(1, ops.size());
     assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
         ops.get(0).getOpType());
@@ -1149,7 +1149,7 @@ public class TestReplicationManager {
         .getDeletionCmdsSentTotal());
 
     // Repeat with Ratis container, as different metrics should be incremented
-    Mockito.clearInvocations(nodeManager);
+    clearInvocations(nodeManager);
     RatisReplicationConfig ratisRepConfig =
         RatisReplicationConfig.getInstance(THREE);
     containerInfo = ReplicationTestUtil.createContainerInfo(ratisRepConfig, 2,
@@ -1161,7 +1161,7 @@ public class TestReplicationManager {
         containerInfo, target);
 
     ops = containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
-    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
+    verify(nodeManager).addDatanodeCommand(any(), any());
     assertEquals(1, ops.size());
     assertEquals(ContainerReplicaOp.PendingOpType.DELETE,
         ops.get(0).getOpType());
@@ -1204,7 +1204,7 @@ public class TestReplicationManager {
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
-    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
+    verify(nodeManager).addDatanodeCommand(any(), any());
     assertEquals(2, ops.size());
     Set<DatanodeDetails> cmdTargets = new HashSet<>();
     Set<Integer> cmdIndexes = new HashSet<>();
@@ -1255,7 +1255,7 @@ public class TestReplicationManager {
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
-    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
+    verify(nodeManager).addDatanodeCommand(any(), any());
     assertEquals(1, ops.size());
     assertEquals(ContainerReplicaOp.PendingOpType.ADD,
         ops.get(0).getOpType());
@@ -1267,7 +1267,7 @@ public class TestReplicationManager {
         .getReplicationCmdsSentTotal());
 
     // Repeat with Ratis container, as different metrics should be incremented
-    Mockito.clearInvocations(nodeManager);
+    clearInvocations(nodeManager);
     RatisReplicationConfig ratisRepConfig =
         RatisReplicationConfig.getInstance(THREE);
     containerInfo = ReplicationTestUtil.createContainerInfo(ratisRepConfig, 2,
@@ -1278,7 +1278,7 @@ public class TestReplicationManager {
     replicationManager.sendDatanodeCommand(command, containerInfo, target);
 
     ops = containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
-    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
+    verify(nodeManager).addDatanodeCommand(any(), any());
     assertEquals(1, ops.size());
     assertEquals(ContainerReplicaOp.PendingOpType.ADD,
         ops.get(0).getOpType());
@@ -1321,7 +1321,7 @@ public class TestReplicationManager {
 
     List<ContainerReplicaOp> ops = containerReplicaPendingOps.getPendingOps(
         containerInfo.containerID());
-    Mockito.verify(nodeManager).addDatanodeCommand(any(), any());
+    verify(nodeManager).addDatanodeCommand(any(), any());
     assertEquals(1, ops.size());
     assertEquals(ContainerReplicaOp.PendingOpType.ADD,
         ops.get(0).getOpType());
@@ -1354,8 +1354,7 @@ public class TestReplicationManager {
         ArgumentCaptor.forClass(SCMCommand.class);
     ArgumentCaptor<UUID> targetUUID =
         ArgumentCaptor.forClass(UUID.class);
-    Mockito.verify(nodeManager).addDatanodeCommand(targetUUID.capture(),
-        command.capture());
+    verify(nodeManager).addDatanodeCommand(targetUUID.capture(), command.capture());
 
     ReplicateContainerCommand sentCommand =
         (ReplicateContainerCommand)command.getValue();
@@ -1534,7 +1533,7 @@ public class TestReplicationManager {
   public void testCreateThrottledDeleteContainerCommand()
       throws CommandTargetOverloadedException, NodeNotFoundException,
       NotLeaderException {
-    Mockito.when(nodeManager.getTotalDatanodeCommandCount(any(),
+    when(nodeManager.getTotalDatanodeCommandCount(any(),
             eq(SCMCommandProto.Type.deleteContainerCommand)))
         .thenAnswer(invocation -> 0);
 
@@ -1552,7 +1551,7 @@ public class TestReplicationManager {
       throws NodeNotFoundException {
     int limit = replicationManager.getConfig().getDatanodeDeleteLimit();
 
-    Mockito.when(nodeManager.getTotalDatanodeCommandCount(any(),
+    when(nodeManager.getTotalDatanodeCommandCount(any(),
             eq(SCMCommandProto.Type.deleteContainerCommand)))
         .thenAnswer(invocation -> limit + 1);
 
@@ -1635,8 +1634,7 @@ public class TestReplicationManager {
     int healthyNodes = 10;
     ReplicationManager.ReplicationManagerConfiguration config =
         new ReplicationManager.ReplicationManagerConfiguration();
-    Mockito.when(nodeManager.getNodeCount(
-        Mockito.isNull(), eq(HddsProtos.NodeState.HEALTHY)))
+    when(nodeManager.getNodeCount(isNull(), eq(HddsProtos.NodeState.HEALTHY)))
         .thenReturn(healthyNodes);
 
     config.setInflightReplicationLimitFactor(0.0);
@@ -1688,7 +1686,7 @@ public class TestReplicationManager {
       Function<DatanodeDetails, Integer> replicateCount,
       Function<DatanodeDetails, Integer> reconstructCount
   ) throws NodeNotFoundException {
-    Mockito.when(nodeManager.getTotalDatanodeCommandCounts(any(),
+    when(nodeManager.getTotalDatanodeCommandCounts(any(),
             eq(SCMCommandProto.Type.replicateContainerCommand),
             eq(SCMCommandProto.Type.reconstructECContainersCommand)))
         .thenAnswer(invocation -> {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerMetrics.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 import static org.apache.hadoop.test.MetricsAsserts.getLongGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 
@@ -55,23 +57,20 @@ public class TestReplicationManagerMetrics {
         report.increment(s);
       }
     }
-    final LegacyReplicationManager lrm = Mockito.mock(
+    final LegacyReplicationManager lrm = mock(
         LegacyReplicationManager.class);
-    Mockito.when(lrm.getInflightCount(Mockito.any(InflightType.class)))
+    when(lrm.getInflightCount(any(InflightType.class)))
         .thenReturn(0);
     ConfigurationSource conf = new OzoneConfiguration();
     ReplicationManager.ReplicationManagerConfiguration rmConf = conf
         .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
-    ReplicationManager replicationManager =
-        Mockito.mock(ReplicationManager.class);
-    Mockito.when(replicationManager.getConfig()).thenReturn(rmConf);
-    Mockito.when(replicationManager.getLegacyReplicationManager())
-        .thenReturn(lrm);
-    Mockito.when(replicationManager.getContainerReport()).thenReturn(report);
-    Mockito.when(replicationManager.getContainerReplicaPendingOps())
-        .thenReturn(Mockito.mock(ContainerReplicaPendingOps.class));
-    Mockito.when(replicationManager.getQueue())
-        .thenReturn(new ReplicationQueue());
+    ReplicationManager replicationManager = mock(ReplicationManager.class);
+    when(replicationManager.getConfig()).thenReturn(rmConf);
+    when(replicationManager.getLegacyReplicationManager()).thenReturn(lrm);
+    when(replicationManager.getContainerReport()).thenReturn(report);
+    when(replicationManager.getContainerReplicaPendingOps())
+        .thenReturn(mock(ContainerReplicaPendingOps.class));
+    when(replicationManager.getQueue()).thenReturn(new ReplicationQueue());
     metrics = ReplicationManagerMetrics.create(replicationManager);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerMetrics.java
@@ -22,13 +22,13 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.test.MetricsAsserts.getLongGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 
@@ -81,25 +81,19 @@ public class TestReplicationManagerMetrics {
 
   @Test
   public void testLifeCycleStateMetricsPresent() {
-    Assertions.assertEquals(HddsProtos.LifeCycleState.OPEN.getNumber(),
-        getGauge("OpenContainers"));
-    Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSING.getNumber(),
-        getGauge("ClosingContainers"));
-    Assertions.assertEquals(HddsProtos.LifeCycleState.QUASI_CLOSED.getNumber(),
-        getGauge("QuasiClosedContainers"));
-    Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSED.getNumber(),
-        getGauge("ClosedContainers"));
-    Assertions.assertEquals(HddsProtos.LifeCycleState.DELETING.getNumber(),
-        getGauge("DeletingContainers"));
-    Assertions.assertEquals(HddsProtos.LifeCycleState.DELETED.getNumber(),
-        getGauge("DeletedContainers"));
+    assertEquals(HddsProtos.LifeCycleState.OPEN.getNumber(), getGauge("OpenContainers"));
+    assertEquals(HddsProtos.LifeCycleState.CLOSING.getNumber(), getGauge("ClosingContainers"));
+    assertEquals(HddsProtos.LifeCycleState.QUASI_CLOSED.getNumber(), getGauge("QuasiClosedContainers"));
+    assertEquals(HddsProtos.LifeCycleState.CLOSED.getNumber(), getGauge("ClosedContainers"));
+    assertEquals(HddsProtos.LifeCycleState.DELETING.getNumber(), getGauge("DeletingContainers"));
+    assertEquals(HddsProtos.LifeCycleState.DELETED.getNumber(), getGauge("DeletedContainers"));
   }
 
   @Test
   public void testHealthStateMetricsPresent() {
     for (ReplicationManagerReport.HealthState s :
         ReplicationManagerReport.HealthState.values()) {
-      Assertions.assertEquals(s.ordinal(), getGauge(s.getMetricName()));
+      assertEquals(s.ordinal(), getGauge(s.getMetricName()));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerScenarios.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.TestClock;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,6 +69,9 @@ import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
 import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class tests the replication manager using a set of scenarios defined in
@@ -115,7 +117,7 @@ public class TestReplicationManagerScenarios {
         .getResource(TEST_RESOURCE_PATH)
         .toURI())).listFiles();
     if (fileList == null) {
-      Assertions.fail("No test file resources found");
+      fail("No test file resources found");
       // Make findbugs happy.
       return Collections.emptyList();
     }
@@ -152,7 +154,7 @@ public class TestReplicationManagerScenarios {
       Set<String> names = new HashSet<>();
       for (Scenario scenario : scenarios) {
         if (!names.add(scenario.getDescription())) {
-          Assertions.fail("Duplicate test name: " + scenario.getDescription() + " in file: " + file);
+          fail("Duplicate test name: " + scenario.getDescription() + " in file: " + file);
         }
         scenario.setResourceName(file.toString());
       }
@@ -287,9 +289,9 @@ public class TestReplicationManagerScenarios {
     // Check the results in the report and queue against the expected results.
     assertExpectations(scenario, repReport);
     Expectation expectation = scenario.getExpectation();
-    Assertions.assertEquals(expectation.getUnderReplicatedQueue(), repQueue.underReplicatedQueueSize(),
+    assertEquals(expectation.getUnderReplicatedQueue(), repQueue.underReplicatedQueueSize(),
         "Test: " + scenario + ": Unexpected count for underReplicatedQueue");
-    Assertions.assertEquals(expectation.getOverReplicatedQueue(), repQueue.overReplicatedQueueSize(),
+    assertEquals(expectation.getOverReplicatedQueue(), repQueue.overReplicatedQueueSize(),
         "Test: " + scenario + ": Unexpected count for overReplicatedQueue");
 
     assertExpectedCommands(scenario, scenario.getCheckCommands());
@@ -297,7 +299,7 @@ public class TestReplicationManagerScenarios {
 
     ReplicationManagerReport roReport = new ReplicationManagerReport();
     replicationManager.checkContainerStatus(containerInfo, roReport);
-    Assertions.assertEquals(0, commandsSent.size());
+    assertEquals(0, commandsSent.size());
     assertExpectations(scenario, roReport);
 
     // Now run the replication manager execute phase, where we expect commands
@@ -315,14 +317,14 @@ public class TestReplicationManagerScenarios {
     Expectation expectation = scenario.getExpectation();
     for (ReplicationManagerReport.HealthState state :
         ReplicationManagerReport.HealthState.values()) {
-      Assertions.assertEquals(expectation.getExpected(state), report.getStat(state),
+      assertEquals(expectation.getExpected(state), report.getStat(state),
           "Test: " + scenario + ": Unexpected count for " + state);
     }
   }
 
   private void assertExpectedCommands(Scenario scenario,
       List<ExpectedCommands> expectedCommands) {
-    Assertions.assertEquals(expectedCommands.size(), commandsSent.size(),
+    assertEquals(expectedCommands.size(), commandsSent.size(),
         "Test: " + scenario + ": Unexpected count for commands sent");
     // Iterate the expected commands and check that they were all sent. If we
     // have a target datanode, then we need to check that the command was sent
@@ -349,7 +351,7 @@ public class TestReplicationManagerScenarios {
           }
         }
       }
-      Assertions.assertTrue(found, "Test: " + scenario + ": Expected command not sent: " + expectedCommand.getType());
+      assertTrue(found, "Test: " + scenario + ": Expected command not sent: " + expectedCommand.getType());
     }
   }
 
@@ -570,7 +572,7 @@ public class TestReplicationManagerScenarios {
       }
       DatanodeDetails datanodeDetails = DATANODE_ALIASES.get(this.datanode);
       if (datanodeDetails == null) {
-        Assertions.fail("Unable to find a datanode for the alias: " + datanode + " in the expected commands.");
+        fail("Unable to find a datanode for the alias: " + datanode + " in the expected commands.");
       }
       return datanodeDetails;
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerUtil.java
@@ -29,8 +29,6 @@ import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -43,6 +41,9 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests for ReplicationManagerUtil.
@@ -53,7 +54,7 @@ public class TestReplicationManagerUtil {
 
   @BeforeEach
   public void setup() {
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
   }
 
   @Test
@@ -99,7 +100,7 @@ public class TestReplicationManagerUtil {
     pending.add(ContainerReplicaOp.create(
         ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0));
 
-    Mockito.when(replicationManager.getNodeStatus(Mockito.any())).thenAnswer(
+    when(replicationManager.getNodeStatus(any())).thenAnswer(
         invocation -> {
           final DatanodeDetails dn = invocation.getArgument(0);
           for (ContainerReplica r : replicas) {
@@ -183,7 +184,7 @@ public class TestReplicationManagerUtil {
     pending.add(ContainerReplicaOp.create(
         ContainerReplicaOp.PendingOpType.DELETE, pendingDelete, 0));
 
-    Mockito.when(replicationManager.getNodeStatus(Mockito.any())).thenAnswer(
+    when(replicationManager.getNodeStatus(any())).thenAnswer(
         invocation -> {
           final DatanodeDetails dn = invocation.getArgument(0);
           for (ContainerReplica r : replicas) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -26,14 +26,18 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.Un
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests for the UnderReplicatedProcessor class.
@@ -51,18 +55,16 @@ public class TestUnderReplicatedProcessor {
     ConfigurationSource conf = new OzoneConfiguration();
     ReplicationManagerConfiguration rmConf =
         conf.getObject(ReplicationManagerConfiguration.class);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
 
     // use real queue
     queue = new ReplicationQueue();
     repConfig = new ECReplicationConfig(3, 2);
-    Mockito.when(replicationManager.shouldRun()).thenReturn(true);
-    Mockito.when(replicationManager.getConfig()).thenReturn(rmConf);
+    when(replicationManager.shouldRun()).thenReturn(true);
+    when(replicationManager.getConfig()).thenReturn(rmConf);
     rmMetrics = ReplicationManagerMetrics.create(replicationManager);
-    Mockito.when(replicationManager.getMetrics())
-        .thenReturn(rmMetrics);
-    Mockito.when(replicationManager.getReplicationInFlightLimit())
-        .thenReturn(0L);
+    when(replicationManager.getMetrics()).thenReturn(rmMetrics);
+    when(replicationManager.getReplicationInFlightLimit()).thenReturn(0L);
     underReplicatedProcessor = new UnderReplicatedProcessor(
         replicationManager, rmConf::getUnderReplicatedInterval);
   }
@@ -73,7 +75,7 @@ public class TestUnderReplicatedProcessor {
         .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
     queue.enqueue(new UnderReplicatedHealthResult(
         container, 3, true, false, false));
-    Mockito.when(replicationManager
+    when(replicationManager
             .processUnderReplicatedContainer(any()))
         .thenReturn(1);
     underReplicatedProcessor.processAll(queue);
@@ -89,7 +91,7 @@ public class TestUnderReplicatedProcessor {
         container, 3, false, false, false);
     queue.enqueue(result);
 
-    Mockito.when(replicationManager
+    when(replicationManager
             .processUnderReplicatedContainer(any()))
         .thenThrow(new IOException("Test Exception"))
         .thenThrow(new AssertionError("Should process only one item"));
@@ -102,13 +104,10 @@ public class TestUnderReplicatedProcessor {
   @Test
   public void testMessageNotProcessedIfGlobalLimitReached() throws IOException {
     AtomicLong inFlightReplications = new AtomicLong(11);
-    Mockito.when(replicationManager.getReplicationInFlightLimit())
-        .thenReturn(10L);
-    Mockito.doAnswer(invocation -> inFlightReplications.get())
+    when(replicationManager.getReplicationInFlightLimit()).thenReturn(10L);
+    doAnswer(invocation -> inFlightReplications.get())
         .when(replicationManager).getInflightReplicationCount();
-    Mockito.when(replicationManager
-            .processUnderReplicatedContainer(any()))
-        .thenReturn(1);
+    when(replicationManager.processUnderReplicatedContainer(any())).thenReturn(1);
 
     ContainerInfo container = ReplicationTestUtil
         .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
@@ -121,8 +120,7 @@ public class TestUnderReplicatedProcessor {
     // The message should not be processed and still be on the queue (re-queued)
     assertEquals(1, queue.underReplicatedQueueSize());
     // We should not have processed anything in RM
-    Mockito.verify(replicationManager, Mockito.times(0))
-        .processUnderReplicatedContainer(any());
+    verify(replicationManager, times(0)).processUnderReplicatedContainer(any());
 
     // Change the inflight replications to a value below the limit
     inFlightReplications.set(8);
@@ -130,8 +128,7 @@ public class TestUnderReplicatedProcessor {
 
     assertEquals(0, queue.underReplicatedQueueSize());
     // We should have processed the message now
-    Mockito.verify(replicationManager, Mockito.times(1))
-        .processUnderReplicatedContainer(any());
+    verify(replicationManager, times(1)).processUnderReplicatedContainer(any());
     assertEquals(1, rmMetrics.getPendingReplicationLimitReachedTotal());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosedWithUnhealthyReplicasHandler.java
@@ -34,8 +34,6 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-
 import java.util.Collections;
 import java.util.Set;
 
@@ -44,6 +42,12 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CL
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerReplica;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,7 +64,7 @@ public class TestClosedWithUnhealthyReplicasHandler {
   @BeforeEach
   public void setup() {
     ecReplicationConfig = new ECReplicationConfig(3, 2);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     handler = new ClosedWithUnhealthyReplicasHandler(replicationManager);
     requestBuilder = new ContainerCheckRequest.Builder()
         .setPendingOps(Collections.emptyList())
@@ -156,9 +160,8 @@ public class TestClosedWithUnhealthyReplicasHandler {
     // triggered one.
     ArgumentCaptor<Integer> replicaIndexCaptor =
         ArgumentCaptor.forClass(Integer.class);
-    Mockito.verify(replicationManager, Mockito.times(2))
-        .sendDeleteCommand(Mockito.eq(container), Mockito.anyInt(), Mockito.any(
-            DatanodeDetails.class), Mockito.eq(true));
+    verify(replicationManager, times(2)).sendDeleteCommand(eq(container), anyInt(), any(
+            DatanodeDetails.class), eq(true));
     // replica index that delete was sent for should either be 2 or 5
     replicaIndexCaptor.getAllValues()
         .forEach(index -> assertTrue(index == 2 || index == 5));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.ozone.test.TestClock;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,6 +51,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CL
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
@@ -208,7 +209,7 @@ public class TestClosingContainerHandler {
 
     assertAndVerify(readRequest, true, 0);
     assertAndVerify(request, true, 3);
-    report.getStats().forEach((k, v) -> Assertions.assertEquals(0L, v));
+    report.getStats().forEach((k, v) -> assertEquals(0L, v));
   }
 
   @Test
@@ -227,9 +228,9 @@ public class TestClosingContainerHandler {
     assertAndVerify(request, true, 0);
     report.getStats().forEach((k, v) -> {
       if (k.equals("MISSING")) {
-        Assertions.assertEquals(1L, v);
+        assertEquals(1L, v);
       } else {
-        Assertions.assertEquals(0L, v);
+        assertEquals(0L, v);
       }
     });
   }
@@ -384,17 +385,17 @@ public class TestClosingContainerHandler {
 
     ArgumentCaptor<Boolean> forceCaptor =
         ArgumentCaptor.forClass(Boolean.class);
-    Assertions.assertTrue(subject.handle(request));
+    assertTrue(subject.handle(request));
     verify(replicationManager, times(replicas))
         .sendCloseContainerReplicaCommand(any(ContainerInfo.class),
             any(DatanodeDetails.class), forceCaptor.capture());
     forceCaptor.getAllValues()
-        .forEach(f -> Assertions.assertEquals(force, f));
+        .forEach(f -> assertEquals(force, f));
   }
 
   private void assertAndVerify(ContainerCheckRequest request,
       boolean assertion, int times) {
-    Assertions.assertEquals(assertion, subject.handle(request));
+    assertEquals(assertion, subject.handle(request));
     verify(replicationManager, times(times))
         .sendCloseContainerReplicaCommand(any(ContainerInfo.class),
             any(DatanodeDetails.class), anyBoolean());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestClosingContainerHandler.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -53,7 +52,14 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CL
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests for {@link ClosingContainerHandler}.
@@ -74,9 +80,8 @@ public class TestClosingContainerHandler {
 
   @BeforeEach
   public void setup() {
-    replicationManager = Mockito.mock(ReplicationManager.class);
-    Mockito.when(replicationManager.getConfig())
-        .thenReturn(rmConf);
+    replicationManager = mock(ReplicationManager.class);
+    when(replicationManager.getConfig()).thenReturn(rmConf);
     subject = new ClosingContainerHandler(replicationManager, clock);
   }
 
@@ -256,14 +261,14 @@ public class TestClosingContainerHandler {
     Duration notEnoughTime = replicationInterval.multipliedBy(3).plusMillis(1);
     clock.fastForward(notEnoughTime);
     assertAndVerify(request, true, 0);
-    Mockito.verify(replicationManager, never())
+    verify(replicationManager, never())
         .updateContainerState(containerInfo.containerID(), CLOSE);
 
     // wait time has elapsed (3x + 2x + a bit)
     Duration moreTime = replicationInterval.multipliedBy(2);
     clock.fastForward(moreTime);
     assertAndVerify(request, true, 0);
-    Mockito.verify(replicationManager, Mockito.times(1))
+    verify(replicationManager, times(1))
         .updateContainerState(containerInfo.containerID(), CLOSE);
   }
 
@@ -285,10 +290,10 @@ public class TestClosingContainerHandler {
         .build();
     subject.handle(request);
 
-    Mockito.verify(replicationManager, Mockito.times(1))
+    verify(replicationManager, times(1))
         .updateContainerState(containerInfo.containerID(), QUASI_CLOSE);
 
-    Mockito.clearInvocations(replicationManager);
+    clearInvocations(replicationManager);
 
     // Now add an open container. This time, the container should not move to
     // quasi-closed, and a close should be sent for the open replica.
@@ -297,7 +302,7 @@ public class TestClosingContainerHandler {
             ContainerReplicaProto.State.OPEN, 0));
 
     assertAndVerify(request, true, 1);
-    Mockito.verify(replicationManager, Mockito.times(0))
+    verify(replicationManager, times(0))
         .updateContainerState(containerInfo.containerID(), QUASI_CLOSE);
   }
 
@@ -319,10 +324,10 @@ public class TestClosingContainerHandler {
         .build();
     subject.handle(request);
 
-    Mockito.verify(replicationManager, Mockito.times(1))
+    verify(replicationManager, times(1))
         .updateContainerState(containerInfo.containerID(), CLOSE);
 
-    Mockito.clearInvocations(replicationManager);
+    clearInvocations(replicationManager);
 
     // Now add an open container. This time, the container should not move to
     // quasi-closed, and a close should be sent for the open replica.
@@ -331,7 +336,7 @@ public class TestClosingContainerHandler {
             ContainerReplicaProto.State.OPEN, 1));
 
     assertAndVerify(request, true, 1);
-    Mockito.verify(replicationManager, Mockito.times(0))
+    verify(replicationManager, times(0))
         .updateContainerState(containerInfo.containerID(), CLOSE);
   }
 
@@ -380,9 +385,9 @@ public class TestClosingContainerHandler {
     ArgumentCaptor<Boolean> forceCaptor =
         ArgumentCaptor.forClass(Boolean.class);
     Assertions.assertTrue(subject.handle(request));
-    Mockito.verify(replicationManager, Mockito.times(replicas))
-        .sendCloseContainerReplicaCommand(Mockito.any(ContainerInfo.class),
-            Mockito.any(DatanodeDetails.class), forceCaptor.capture());
+    verify(replicationManager, times(replicas))
+        .sendCloseContainerReplicaCommand(any(ContainerInfo.class),
+            any(DatanodeDetails.class), forceCaptor.capture());
     forceCaptor.getAllValues()
         .forEach(f -> Assertions.assertEquals(force, f));
   }
@@ -390,8 +395,8 @@ public class TestClosingContainerHandler {
   private void assertAndVerify(ContainerCheckRequest request,
       boolean assertion, int times) {
     Assertions.assertEquals(assertion, subject.handle(request));
-    Mockito.verify(replicationManager, Mockito.times(times))
-        .sendCloseContainerReplicaCommand(Mockito.any(ContainerInfo.class),
-            Mockito.any(DatanodeDetails.class), Mockito.anyBoolean());
+    verify(replicationManager, times(times))
+        .sendCloseContainerReplicaCommand(any(ContainerInfo.class),
+            any(DatanodeDetails.class), anyBoolean());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestDeletingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestDeletingContainerHandler.java
@@ -36,7 +36,6 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,6 +44,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.DELETING;
 
@@ -64,11 +71,10 @@ public class TestDeletingContainerHandler {
     ecReplicationConfig = new ECReplicationConfig(3, 2);
     ratisReplicationConfig = RatisReplicationConfig.getInstance(
         HddsProtos.ReplicationFactor.THREE);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
 
-    Mockito.doNothing().when(replicationManager)
-        .updateContainerState(Mockito.any(ContainerID.class),
-            Mockito.any(HddsProtos.LifeCycleEvent.class));
+    doNothing().when(replicationManager).updateContainerState(any(ContainerID.class),
+        any(HddsProtos.LifeCycleEvent.class));
 
     deletingContainerHandler =
         new DeletingContainerHandler(replicationManager);
@@ -132,7 +138,7 @@ public class TestDeletingContainerHandler {
 
   private void cleanupIfNoReplicaExist(
       ReplicationConfig replicationConfig, int times) {
-    Mockito.clearInvocations(replicationManager);
+    clearInvocations(replicationManager);
     ContainerInfo containerInfo = ReplicationTestUtil.createContainerInfo(
         replicationConfig, 1, DELETING);
 
@@ -149,14 +155,12 @@ public class TestDeletingContainerHandler {
     ContainerCheckRequest readRequest = builder.build();
 
     Assertions.assertTrue(deletingContainerHandler.handle(readRequest));
-    Mockito.verify(replicationManager, Mockito.times(0))
-        .updateContainerState(Mockito.any(ContainerID.class),
-            Mockito.any(HddsProtos.LifeCycleEvent.class));
+    verify(replicationManager, times(0)).updateContainerState(any(ContainerID.class),
+        any(HddsProtos.LifeCycleEvent.class));
 
     Assertions.assertTrue(deletingContainerHandler.handle(request));
-    Mockito.verify(replicationManager, Mockito.times(times))
-        .updateContainerState(Mockito.any(ContainerID.class),
-            Mockito.any(HddsProtos.LifeCycleEvent.class));
+    verify(replicationManager, times(times)).updateContainerState(any(ContainerID.class),
+        any(HddsProtos.LifeCycleEvent.class));
   }
 
   /**
@@ -239,8 +243,7 @@ public class TestDeletingContainerHandler {
 
     Assertions.assertTrue(deletingContainerHandler.handle(request));
 
-    Mockito.verify(replicationManager, Mockito.times(times))
-        .sendDeleteCommand(Mockito.any(ContainerInfo.class), Mockito.anyInt(),
-            Mockito.any(DatanodeDetails.class), Mockito.eq(false));
+    verify(replicationManager, times(times)).sendDeleteCommand(any(ContainerInfo.class), anyInt(),
+        any(DatanodeDetails.class), eq(false));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestDeletingContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestDeletingContainerHandler.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +51,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.DELETING;
 
@@ -100,7 +101,7 @@ public class TestDeletingContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assertions.assertFalse(deletingContainerHandler.handle(request));
+    assertFalse(deletingContainerHandler.handle(request));
   }
 
   @Test
@@ -118,7 +119,7 @@ public class TestDeletingContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assertions.assertFalse(deletingContainerHandler.handle(request));
+    assertFalse(deletingContainerHandler.handle(request));
   }
 
   /**
@@ -154,11 +155,11 @@ public class TestDeletingContainerHandler {
     builder.setReadOnly(true);
     ContainerCheckRequest readRequest = builder.build();
 
-    Assertions.assertTrue(deletingContainerHandler.handle(readRequest));
+    assertTrue(deletingContainerHandler.handle(readRequest));
     verify(replicationManager, times(0)).updateContainerState(any(ContainerID.class),
         any(HddsProtos.LifeCycleEvent.class));
 
-    Assertions.assertTrue(deletingContainerHandler.handle(request));
+    assertTrue(deletingContainerHandler.handle(request));
     verify(replicationManager, times(times)).updateContainerState(any(ContainerID.class),
         any(HddsProtos.LifeCycleEvent.class));
   }
@@ -241,7 +242,7 @@ public class TestDeletingContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assertions.assertTrue(deletingContainerHandler.handle(request));
+    assertTrue(deletingContainerHandler.handle(request));
 
     verify(replicationManager, times(times)).sendDeleteCommand(any(ContainerInfo.class), anyInt(),
         any(DatanodeDetails.class), eq(false));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECMisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECMisReplicationCheckHandler.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,8 +52,11 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
 
 /**
  * Unit tests for {@link ECMisReplicationCheckHandler}.
@@ -69,9 +71,8 @@ public class TestECMisReplicationCheckHandler {
 
   @BeforeEach
   public void setup() {
-    placementPolicy = Mockito.mock(PlacementPolicy.class);
-    Mockito.when(placementPolicy.validateContainerPlacement(
-            anyList(), anyInt()))
+    placementPolicy = mock(PlacementPolicy.class);
+    when(placementPolicy.validateContainerPlacement(anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(5, 5, 5));
     handler = new ECMisReplicationCheckHandler(placementPolicy);
     repConfig = new ECReplicationConfig(3, 2);
@@ -126,9 +127,7 @@ public class TestECMisReplicationCheckHandler {
     ContainerInfo container = createContainerInfo(repConfig);
 
     // Placement policy is always violated
-    Mockito.when(placementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(placementPolicy.validateContainerPlacement(any(), anyInt()
     )).thenAnswer(invocation ->
         new ContainerPlacementStatusDefault(4, 5, 9));
 
@@ -163,9 +162,7 @@ public class TestECMisReplicationCheckHandler {
   public void shouldReturnFalseForMisReplicatedContainerFixedByPending() {
     ContainerInfo container = createContainerInfo(repConfig);
 
-    Mockito.when(placementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(placementPolicy.validateContainerPlacement(any(), anyInt()
     )).thenAnswer(invocation -> {
       List<DatanodeDetails> dns = invocation.getArgument(0);
       // If the number of DNs is 5 or less make it be mis-replicated
@@ -214,9 +211,7 @@ public class TestECMisReplicationCheckHandler {
   public void testMisReplicationWithUnhealthyReplica() {
     ContainerInfo container = createContainerInfo(repConfig);
 
-    Mockito.when(placementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(placementPolicy.validateContainerPlacement(any(), anyInt()
     )).thenAnswer(invocation -> {
       List<DatanodeDetails> dns = invocation.getArgument(0);
       // If the number of DNs is 6 or more make it mis-replicated

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestECReplicationCheckHandler.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationQueue;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,8 +58,11 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
 
 /**
  * Tests for the ECContainerHealthCheck class.
@@ -77,9 +79,8 @@ public class TestECReplicationCheckHandler {
 
   @BeforeEach
   public void setup() {
-    placementPolicy = Mockito.mock(PlacementPolicy.class);
-    Mockito.when(placementPolicy.validateContainerPlacement(
-        anyList(), anyInt()))
+    placementPolicy = mock(PlacementPolicy.class);
+    when(placementPolicy.validateContainerPlacement(anyList(), anyInt()))
         .thenReturn(new ContainerPlacementStatusDefault(2, 2, 3));
     healthCheck = new ECReplicationCheckHandler();
     repConfig = new ECReplicationConfig(3, 2);
@@ -587,9 +588,7 @@ public class TestECReplicationCheckHandler {
     ContainerInfo container = createContainerInfo(repConfig);
 
     // Placement policy is always violated
-    Mockito.when(placementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(placementPolicy.validateContainerPlacement(any(), anyInt()
     )).thenAnswer(invocation ->
         new ContainerPlacementStatusDefault(4, 5, 9));
 
@@ -622,9 +621,9 @@ public class TestECReplicationCheckHandler {
     ContainerInfo container = createContainerInfo(repConfig);
 
     // Placement policy is always violated
-    Mockito.when(placementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(placementPolicy.validateContainerPlacement(
+        any(),
+        anyInt()
     )).thenAnswer(invocation ->
         new ContainerPlacementStatusDefault(4, 5, 9));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
@@ -34,13 +34,18 @@ import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionExcepti
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
 
@@ -59,7 +64,7 @@ public class TestEmptyContainerHandler {
     ecReplicationConfig = new ECReplicationConfig(3, 2);
     ratisReplicationConfig = RatisReplicationConfig.getInstance(
         HddsProtos.ReplicationFactor.THREE);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     emptyContainerHandler =
         new EmptyContainerHandler(replicationManager);
   }
@@ -253,16 +258,14 @@ public class TestEmptyContainerHandler {
       boolean assertion, int times, long numEmptyExpected)
       throws IOException {
     Assertions.assertEquals(assertion, emptyContainerHandler.handle(request));
-    Mockito.verify(replicationManager, Mockito.times(times))
-        .sendDeleteCommand(Mockito.any(ContainerInfo.class), Mockito.anyInt(),
-            Mockito.any(DatanodeDetails.class), Mockito.eq(false));
+    verify(replicationManager, times(times)).sendDeleteCommand(any(ContainerInfo.class), anyInt(),
+        any(DatanodeDetails.class), eq(false));
     Assertions.assertEquals(numEmptyExpected, request.getReport().getStat(
         ReplicationManagerReport.HealthState.EMPTY));
 
     if (times > 0) {
-      Mockito.verify(replicationManager, Mockito.times(1))
-          .updateContainerState(Mockito.any(ContainerID.class),
-              Mockito.any(HddsProtos.LifeCycleEvent.class));
+      verify(replicationManager, times(1)).updateContainerState(any(ContainerID.class),
+          any(HddsProtos.LifeCycleEvent.class));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestEmptyContainerHandler.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +45,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
 
@@ -257,11 +257,10 @@ public class TestEmptyContainerHandler {
   private void assertAndVerify(ContainerCheckRequest request,
       boolean assertion, int times, long numEmptyExpected)
       throws IOException {
-    Assertions.assertEquals(assertion, emptyContainerHandler.handle(request));
+    assertEquals(assertion, emptyContainerHandler.handle(request));
     verify(replicationManager, times(times)).sendDeleteCommand(any(ContainerInfo.class), anyInt(),
         any(DatanodeDetails.class), eq(false));
-    Assertions.assertEquals(numEmptyExpected, request.getReport().getStat(
-        ReplicationManagerReport.HealthState.EMPTY));
+    assertEquals(numEmptyExpected, request.getReport().getStat(ReplicationManagerReport.HealthState.EMPTY));
 
     if (times > 0) {
       verify(replicationManager, times(1)).updateContainerState(any(ContainerID.class),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -39,9 +38,11 @@ import java.util.Set;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QUASI_CLOSED;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests for the MismatchedReplicasHandler.
@@ -58,7 +59,7 @@ public class TestMismatchedReplicasHandler {
     ecReplicationConfig = new ECReplicationConfig(3, 2);
     ratisReplicationConfig = RatisReplicationConfig.getInstance(
         HddsProtos.ReplicationFactor.THREE);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     handler = new MismatchedReplicasHandler(replicationManager);
   }
 
@@ -74,9 +75,8 @@ public class TestMismatchedReplicasHandler {
         .build();
 
     Assertions.assertFalse(handler.handle(request));
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerReplicaCommand(
-            any(), any(), anyBoolean());
+    verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
+        any(), any(), anyBoolean());
   }
 
   @Test
@@ -94,9 +94,8 @@ public class TestMismatchedReplicasHandler {
         .build();
     Assertions.assertFalse(handler.handle(request));
 
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerReplicaCommand(
-          any(), any(), anyBoolean());
+    verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
+        any(), any(), anyBoolean());
   }
 
   @Test
@@ -141,16 +140,13 @@ public class TestMismatchedReplicasHandler {
     Assertions.assertFalse(handler.handle(request));
     Assertions.assertFalse(handler.handle(readRequest));
 
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch1.getDatanodeDetails(), true);
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch2.getDatanodeDetails(), true);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch1.getDatanodeDetails(), true);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch2.getDatanodeDetails(), true);
     // close command should not be sent for unhealthy replica
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch3.getDatanodeDetails(), true);
+    verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch3.getDatanodeDetails(), true);
   }
 
   @Test
@@ -165,9 +161,8 @@ public class TestMismatchedReplicasHandler {
         .build();
 
     Assertions.assertFalse(handler.handle(request));
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerReplicaCommand(
-            any(), any(), anyBoolean());
+    verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
+        any(), any(), anyBoolean());
   }
 
   @Test
@@ -185,9 +180,8 @@ public class TestMismatchedReplicasHandler {
         .build();
     Assertions.assertFalse(handler.handle(request));
 
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerReplicaCommand(
-            any(), any(), anyBoolean());
+    verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
+        any(), any(), anyBoolean());
   }
 
   @Test
@@ -229,16 +223,13 @@ public class TestMismatchedReplicasHandler {
     Assertions.assertFalse(handler.handle(request));
     Assertions.assertFalse(handler.handle(readRequest));
 
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch1.getDatanodeDetails(), true);
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch2.getDatanodeDetails(), true);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch1.getDatanodeDetails(), true);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch2.getDatanodeDetails(), true);
     // close command should not be sent for unhealthy replica
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch3.getDatanodeDetails(), true);
+    verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch3.getDatanodeDetails(), true);
   }
 
   /**
@@ -284,16 +275,13 @@ public class TestMismatchedReplicasHandler {
     Assertions.assertFalse(handler.handle(request));
     Assertions.assertFalse(handler.handle(readRequest));
 
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch1.getDatanodeDetails(), false);
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch2.getDatanodeDetails(), false);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch1.getDatanodeDetails(), false);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch2.getDatanodeDetails(), false);
     // close command should not be sent for unhealthy replica
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, mismatch3.getDatanodeDetails(), false);
+    verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
+        containerInfo, mismatch3.getDatanodeDetails(), false);
   }
 
   @Test
@@ -334,11 +322,9 @@ public class TestMismatchedReplicasHandler {
     Assertions.assertFalse(handler.handle(request));
     Assertions.assertFalse(handler.handle(readRequest));
 
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(
-            containerInfo, sameSeqID.getDatanodeDetails(), true);
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerReplicaCommand(containerInfo,
-            differentSeqID.getDatanodeDetails(), true);
+    verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
+        containerInfo, sameSeqID.getDatanodeDetails(), true);
+    verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(containerInfo,
+        differentSeqID.getDatanodeDetails(), true);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestMismatchedReplicasHandler.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +37,7 @@ import java.util.Set;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QUASI_CLOSED;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -74,7 +74,7 @@ public class TestMismatchedReplicasHandler {
         .setContainerReplicas(Collections.emptySet())
         .build();
 
-    Assertions.assertFalse(handler.handle(request));
+    assertFalse(handler.handle(request));
     verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
         any(), any(), anyBoolean());
   }
@@ -92,7 +92,7 @@ public class TestMismatchedReplicasHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
-    Assertions.assertFalse(handler.handle(request));
+    assertFalse(handler.handle(request));
 
     verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
         any(), any(), anyBoolean());
@@ -137,8 +137,8 @@ public class TestMismatchedReplicasHandler {
 
     // this handler always returns false so other handlers can fix issues
     // such as under replication
-    Assertions.assertFalse(handler.handle(request));
-    Assertions.assertFalse(handler.handle(readRequest));
+    assertFalse(handler.handle(request));
+    assertFalse(handler.handle(readRequest));
 
     verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
         containerInfo, mismatch1.getDatanodeDetails(), true);
@@ -160,7 +160,7 @@ public class TestMismatchedReplicasHandler {
         .setContainerReplicas(Collections.emptySet())
         .build();
 
-    Assertions.assertFalse(handler.handle(request));
+    assertFalse(handler.handle(request));
     verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
         any(), any(), anyBoolean());
   }
@@ -178,7 +178,7 @@ public class TestMismatchedReplicasHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
-    Assertions.assertFalse(handler.handle(request));
+    assertFalse(handler.handle(request));
 
     verify(replicationManager, times(0)).sendCloseContainerReplicaCommand(
         any(), any(), anyBoolean());
@@ -220,8 +220,8 @@ public class TestMismatchedReplicasHandler {
 
     // this handler always returns false so other handlers can fix issues
     // such as under replication
-    Assertions.assertFalse(handler.handle(request));
-    Assertions.assertFalse(handler.handle(readRequest));
+    assertFalse(handler.handle(request));
+    assertFalse(handler.handle(readRequest));
 
     verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
         containerInfo, mismatch1.getDatanodeDetails(), true);
@@ -272,8 +272,8 @@ public class TestMismatchedReplicasHandler {
 
     // this handler always returns false so other handlers can fix issues
     // such as under replication
-    Assertions.assertFalse(handler.handle(request));
-    Assertions.assertFalse(handler.handle(readRequest));
+    assertFalse(handler.handle(request));
+    assertFalse(handler.handle(readRequest));
 
     verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
         containerInfo, mismatch1.getDatanodeDetails(), false);
@@ -319,8 +319,8 @@ public class TestMismatchedReplicasHandler {
 
     // this handler always returns false so other handlers can fix issues
     // such as under replication
-    Assertions.assertFalse(handler.handle(request));
-    Assertions.assertFalse(handler.handle(readRequest));
+    assertFalse(handler.handle(request));
+    assertFalse(handler.handle(readRequest));
 
     verify(replicationManager, times(1)).sendCloseContainerReplicaCommand(
         containerInfo, sameSeqID.getDatanodeDetails(), true);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,8 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -73,7 +74,7 @@ public class TestOpenContainerHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
-    Assertions.assertFalse(openContainerHandler.handle(request));
+    assertFalse(openContainerHandler.handle(request));
     verify(replicationManager, times(0)).sendCloseContainerEvent(any());
   }
 
@@ -90,7 +91,7 @@ public class TestOpenContainerHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
-    Assertions.assertTrue(openContainerHandler.handle(request));
+    assertTrue(openContainerHandler.handle(request));
     verify(replicationManager, times(0)).sendCloseContainerEvent(any());
   }
 
@@ -114,8 +115,8 @@ public class TestOpenContainerHandler {
         .setContainerReplicas(containerReplicas)
         .setReadOnly(true)
         .build();
-    Assertions.assertTrue(openContainerHandler.handle(request));
-    Assertions.assertTrue(openContainerHandler.handle(readRequest));
+    assertTrue(openContainerHandler.handle(request));
+    assertTrue(openContainerHandler.handle(readRequest));
     verify(replicationManager, times(1))
         .sendCloseContainerEvent(containerInfo.containerID());
   }
@@ -133,7 +134,7 @@ public class TestOpenContainerHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
-    Assertions.assertFalse(openContainerHandler.handle(request));
+    assertFalse(openContainerHandler.handle(request));
     verify(replicationManager, times(0)).sendCloseContainerEvent(any());
   }
 
@@ -150,7 +151,7 @@ public class TestOpenContainerHandler {
         .setContainerInfo(containerInfo)
         .setContainerReplicas(containerReplicas)
         .build();
-    Assertions.assertTrue(openContainerHandler.handle(request));
+    assertTrue(openContainerHandler.handle(request));
     verify(replicationManager, times(0)).sendCloseContainerEvent(any());
   }
 
@@ -174,8 +175,8 @@ public class TestOpenContainerHandler {
         .setContainerReplicas(containerReplicas)
         .setReadOnly(true)
         .build();
-    Assertions.assertTrue(openContainerHandler.handle(request));
-    Assertions.assertTrue(openContainerHandler.handle(readRequest));
+    assertTrue(openContainerHandler.handle(request));
+    assertTrue(openContainerHandler.handle(readRequest));
     verify(replicationManager, times(1)).sendCloseContainerEvent(any());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
@@ -30,14 +30,16 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests for the OpenContainerHandler class.
@@ -54,7 +56,7 @@ public class TestOpenContainerHandler {
     ecReplicationConfig = new ECReplicationConfig(3, 2);
     ratisReplicationConfig = RatisReplicationConfig.getInstance(
         HddsProtos.ReplicationFactor.THREE);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     openContainerHandler = new OpenContainerHandler(replicationManager);
   }
 
@@ -72,8 +74,7 @@ public class TestOpenContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
     Assertions.assertFalse(openContainerHandler.handle(request));
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerEvent(Mockito.any());
+    verify(replicationManager, times(0)).sendCloseContainerEvent(any());
   }
 
   @Test
@@ -90,8 +91,7 @@ public class TestOpenContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
     Assertions.assertTrue(openContainerHandler.handle(request));
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerEvent(Mockito.any());
+    verify(replicationManager, times(0)).sendCloseContainerEvent(any());
   }
 
   @Test
@@ -116,7 +116,7 @@ public class TestOpenContainerHandler {
         .build();
     Assertions.assertTrue(openContainerHandler.handle(request));
     Assertions.assertTrue(openContainerHandler.handle(readRequest));
-    Mockito.verify(replicationManager, times(1))
+    verify(replicationManager, times(1))
         .sendCloseContainerEvent(containerInfo.containerID());
   }
 
@@ -134,8 +134,7 @@ public class TestOpenContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
     Assertions.assertFalse(openContainerHandler.handle(request));
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerEvent(Mockito.any());
+    verify(replicationManager, times(0)).sendCloseContainerEvent(any());
   }
 
   @Test
@@ -152,8 +151,7 @@ public class TestOpenContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
     Assertions.assertTrue(openContainerHandler.handle(request));
-    Mockito.verify(replicationManager, times(0))
-        .sendCloseContainerEvent(Mockito.any());
+    verify(replicationManager, times(0)).sendCloseContainerEvent(any());
   }
 
   @Test
@@ -178,7 +176,6 @@ public class TestOpenContainerHandler {
         .build();
     Assertions.assertTrue(openContainerHandler.handle(request));
     Assertions.assertTrue(openContainerHandler.handle(readRequest));
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerEvent(Mockito.any());
+    verify(replicationManager, times(1)).sendCloseContainerEvent(any());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedContainerHandler.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +42,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OP
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QUASI_CLOSED;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getContainer;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getReplicas;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.eq;
@@ -82,7 +83,7 @@ public class TestQuasiClosedContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
+    assertFalse(quasiClosedContainerHandler.handle(request));
     verify(replicationManager, times(0))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
   }
@@ -101,7 +102,7 @@ public class TestQuasiClosedContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
+    assertFalse(quasiClosedContainerHandler.handle(request));
     verify(replicationManager, times(0))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
   }
@@ -137,8 +138,8 @@ public class TestQuasiClosedContainerHandler {
         .setReadOnly(true)
         .build();
 
-    Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
-    Assertions.assertFalse(quasiClosedContainerHandler.handle(readRequest));
+    assertFalse(quasiClosedContainerHandler.handle(request));
+    assertFalse(quasiClosedContainerHandler.handle(readRequest));
     verify(replicationManager, times(2))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
   }
@@ -162,10 +163,10 @@ public class TestQuasiClosedContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
+    assertFalse(quasiClosedContainerHandler.handle(request));
     verify(replicationManager, times(0))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
-    Assertions.assertEquals(1, request.getReport().getStat(
+    assertEquals(1, request.getReport().getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
   }
 
@@ -192,10 +193,10 @@ public class TestQuasiClosedContainerHandler {
         .setContainerReplicas(containerReplicas)
         .build();
 
-    Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
+    assertFalse(quasiClosedContainerHandler.handle(request));
     verify(replicationManager, times(0))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
-    Assertions.assertEquals(1, request.getReport().getStat(
+    assertEquals(1, request.getReport().getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
   }
 
@@ -241,8 +242,8 @@ public class TestQuasiClosedContainerHandler {
         .setReadOnly(true)
         .build();
 
-    Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
-    Assertions.assertFalse(quasiClosedContainerHandler.handle(readRequest));
+    assertFalse(quasiClosedContainerHandler.handle(request));
+    assertFalse(quasiClosedContainerHandler.handle(readRequest));
     // verify close command was sent for replicas with sequence ID 1001, that
     // is dnTwo and dnThree
     verify(replicationManager, times(1))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestQuasiClosedContainerHandler.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -44,9 +43,11 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OP
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QUASI_CLOSED;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getContainer;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getReplicas;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.times;
 
 /**
@@ -62,7 +63,7 @@ public class TestQuasiClosedContainerHandler {
   public void setup() {
     ratisReplicationConfig = RatisReplicationConfig.getInstance(
         HddsProtos.ReplicationFactor.THREE);
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     quasiClosedContainerHandler =
         new QuasiClosedContainerHandler(replicationManager);
   }
@@ -82,7 +83,7 @@ public class TestQuasiClosedContainerHandler {
         .build();
 
     Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
-    Mockito.verify(replicationManager, times(0))
+    verify(replicationManager, times(0))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
   }
 
@@ -101,7 +102,7 @@ public class TestQuasiClosedContainerHandler {
         .build();
 
     Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
-    Mockito.verify(replicationManager, times(0))
+    verify(replicationManager, times(0))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
   }
 
@@ -138,7 +139,7 @@ public class TestQuasiClosedContainerHandler {
 
     Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
     Assertions.assertFalse(quasiClosedContainerHandler.handle(readRequest));
-    Mockito.verify(replicationManager, times(2))
+    verify(replicationManager, times(2))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
   }
 
@@ -162,7 +163,7 @@ public class TestQuasiClosedContainerHandler {
         .build();
 
     Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
-    Mockito.verify(replicationManager, times(0))
+    verify(replicationManager, times(0))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
     Assertions.assertEquals(1, request.getReport().getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
@@ -192,7 +193,7 @@ public class TestQuasiClosedContainerHandler {
         .build();
 
     Assertions.assertFalse(quasiClosedContainerHandler.handle(request));
-    Mockito.verify(replicationManager, times(0))
+    verify(replicationManager, times(0))
         .sendCloseContainerReplicaCommand(any(), any(), anyBoolean());
     Assertions.assertEquals(1, request.getReport().getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
@@ -244,11 +245,9 @@ public class TestQuasiClosedContainerHandler {
     Assertions.assertFalse(quasiClosedContainerHandler.handle(readRequest));
     // verify close command was sent for replicas with sequence ID 1001, that
     // is dnTwo and dnThree
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(eq(containerInfo), eq(dnTwo),
-            anyBoolean());
-    Mockito.verify(replicationManager, times(1))
-        .sendCloseContainerReplicaCommand(eq(containerInfo), eq(dnThree),
-            anyBoolean());
+    verify(replicationManager, times(1))
+        .sendCloseContainerReplicaCommand(eq(containerInfo), eq(dnTwo), anyBoolean());
+    verify(replicationManager, times(1))
+        .sendCloseContainerReplicaCommand(eq(containerInfo), eq(dnThree), anyBoolean());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestRatisReplicationCheckHandler.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,6 +68,10 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests for the RatisReplicationCheckHandler class.
@@ -86,15 +89,15 @@ public class TestRatisReplicationCheckHandler {
 
   @BeforeEach
   public void setup() throws IOException, NodeNotFoundException {
-    containerPlacementPolicy = Mockito.mock(PlacementPolicy.class);
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    containerPlacementPolicy = mock(PlacementPolicy.class);
+    when(containerPlacementPolicy.validateContainerPlacement(
+        any(),
+        anyInt()
     )).thenAnswer(invocation ->
         new ContainerPlacementStatusDefault(2, 2, 3));
 
-    replicationManager = Mockito.mock(ReplicationManager.class);
-    Mockito.when(replicationManager.getNodeStatus(Mockito.any()))
+    replicationManager = mock(ReplicationManager.class);
+    when(replicationManager.getNodeStatus(any()))
         .thenReturn(NodeStatus.inServiceHealthy());
     healthCheck = new RatisReplicationCheckHandler(containerPlacementPolicy,
         replicationManager);
@@ -738,9 +741,9 @@ public class TestRatisReplicationCheckHandler {
    */
   @Test
   public void testOverReplicatedWithMisReplication() {
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(containerPlacementPolicy.validateContainerPlacement(
+        any(),
+        anyInt()
     )).thenAnswer(invocation ->
         new ContainerPlacementStatusDefault(1, 2, 3));
 
@@ -776,9 +779,9 @@ public class TestRatisReplicationCheckHandler {
 
   @Test
   public void testUnderReplicatedWithMisReplication() {
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(containerPlacementPolicy.validateContainerPlacement(
+        any(),
+        anyInt()
     )).thenAnswer(invocation ->
         new ContainerPlacementStatusDefault(1, 2, 3));
 
@@ -805,9 +808,9 @@ public class TestRatisReplicationCheckHandler {
 
   @Test
   public void testUnderReplicatedWithMisReplicationFixedByPending() {
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(containerPlacementPolicy.validateContainerPlacement(
+        any(),
+        anyInt()
     )).thenAnswer(invocation -> {
       List<DatanodeDetails> dns = invocation.getArgument(0);
       // If the number of DNs is 3 or less make it be mis-replicated
@@ -849,9 +852,9 @@ public class TestRatisReplicationCheckHandler {
 
   @Test
   public void testMisReplicated() {
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(containerPlacementPolicy.validateContainerPlacement(
+        any(),
+        anyInt()
     )).thenAnswer(invocation ->
         new ContainerPlacementStatusDefault(1, 2, 3));
 
@@ -876,9 +879,9 @@ public class TestRatisReplicationCheckHandler {
 
   @Test
   public void testMisReplicatedFixedByPending() {
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
-        Mockito.any(),
-        Mockito.anyInt()
+    when(containerPlacementPolicy.validateContainerPlacement(
+        any(),
+        anyInt()
     )).thenAnswer(invocation -> {
       List<DatanodeDetails> dns = invocation.getArgument(0);
       // If the number of DNs is 3 or less make it be mis-replicated

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestVulnerableUnhealthyReplicasHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestVulnerableUnhealthyReplicasHandler.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -51,6 +50,9 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 
 /**
  * Tests for {@link VulnerableUnhealthyReplicasHandler}.
@@ -65,7 +67,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
 
   @BeforeEach
   public void setup() throws NodeNotFoundException {
-    replicationManager = Mockito.mock(ReplicationManager.class);
+    replicationManager = mock(ReplicationManager.class);
     handler = new VulnerableUnhealthyReplicasHandler(replicationManager);
     repConfig = RatisReplicationConfig.getInstance(THREE);
     repQueue = new ReplicationQueue();
@@ -76,7 +78,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
         .setPendingOps(Collections.emptyList())
         .setReport(report);
 
-    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenReturn(NodeStatus.inServiceHealthy());
   }
 
@@ -139,7 +141,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
     ContainerReplica unhealthy =
         createContainerReplica(container.containerID(), 0, DECOMMISSIONING, State.UNHEALTHY, sequenceId);
     replicas.add(unhealthy);
-    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(unhealthy.getDatanodeDetails())) {
@@ -167,7 +169,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
     ContainerReplica unhealthy =
         createContainerReplica(container.containerID(), 0, DECOMMISSIONING, State.UNHEALTHY, sequenceId);
     replicas.add(unhealthy);
-    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(unhealthy.getDatanodeDetails())) {
@@ -198,7 +200,7 @@ public class TestVulnerableUnhealthyReplicasHandler {
     ContainerReplica unhealthy =
         createContainerReplica(container.containerID(), 0, DECOMMISSIONING, State.UNHEALTHY, sequenceId);
     replicas.add(unhealthy);
-    Mockito.when(replicationManager.getNodeStatus(Mockito.any(DatanodeDetails.class)))
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(unhealthy.getDatanodeDetails())) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/report/TestContainerReportValidator.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/report/TestContainerReportValidator.java
@@ -29,10 +29,12 @@ import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  *
@@ -56,7 +58,7 @@ public class TestContainerReportValidator {
     DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
     ContainerReplicaProto replica = getContainerReplica(
             containerInfo.containerID(), 1, dn);
-    Assertions.assertTrue(ContainerReportValidator.validate(containerInfo, dn,
+    assertTrue(ContainerReportValidator.validate(containerInfo, dn,
             replica));
   }
 
@@ -70,7 +72,7 @@ public class TestContainerReportValidator {
     DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
     ContainerReplicaProto replica = getContainerReplica(
             containerInfo.containerID(), replicaIndex, dn);
-    Assertions.assertFalse(ContainerReportValidator.validate(containerInfo, dn,
+    assertFalse(ContainerReportValidator.validate(containerInfo, dn,
             replica));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerAttribute.java
@@ -20,13 +20,16 @@ package org.apache.hadoop.hdds.scm.container.states;
 
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test ContainerAttribute management.
@@ -38,16 +41,14 @@ public class TestContainerAttribute {
     ContainerAttribute<Integer> containerAttribute = new ContainerAttribute<>();
     ContainerID id = ContainerID.valueOf(42);
     containerAttribute.insert(1, id);
-    Assertions.assertEquals(1,
-        containerAttribute.getCollection(1).size());
+    assertEquals(1, containerAttribute.getCollection(1).size());
     assertThat(containerAttribute.getCollection(1)).contains(id);
 
     // Insert again and verify that the new ContainerId is inserted.
     ContainerID newId =
         ContainerID.valueOf(42);
     containerAttribute.insert(1, newId);
-    Assertions.assertEquals(1,
-        containerAttribute.getCollection(1).size());
+    assertEquals(1, containerAttribute.getCollection(1).size());
     assertThat(containerAttribute.getCollection(1)).contains(newId);
   }
 
@@ -58,12 +59,12 @@ public class TestContainerAttribute {
     for (int x = 1; x < 42; x++) {
       containerAttribute.insert(1, ContainerID.valueOf(x));
     }
-    Assertions.assertTrue(containerAttribute.hasKey(1));
+    assertTrue(containerAttribute.hasKey(1));
     for (int x = 1; x < 42; x++) {
-      Assertions.assertTrue(containerAttribute.hasContainerID(1, x));
+      assertTrue(containerAttribute.hasContainerID(1, x));
     }
 
-    Assertions.assertFalse(containerAttribute.hasContainerID(1,
+    assertFalse(containerAttribute.hasContainerID(1,
         ContainerID.valueOf(42)));
   }
 
@@ -77,12 +78,10 @@ public class TestContainerAttribute {
       }
     }
     for (String k : keyslist) {
-      Assertions.assertEquals(100,
-          containerAttribute.getCollection(k).size());
+      assertEquals(100, containerAttribute.getCollection(k).size());
     }
     containerAttribute.clearSet("Key1");
-    Assertions.assertEquals(0,
-        containerAttribute.getCollection("Key1").size());
+    assertEquals(0, containerAttribute.getCollection("Key1").size());
   }
 
   @Test
@@ -101,18 +100,15 @@ public class TestContainerAttribute {
     }
 
     for (int x = 1; x < 101; x += 2) {
-      Assertions.assertFalse(containerAttribute.hasContainerID("Key1",
+      assertFalse(containerAttribute.hasContainerID("Key1",
           ContainerID.valueOf(x)));
     }
 
-    Assertions.assertEquals(100,
-        containerAttribute.getCollection("Key2").size());
+    assertEquals(100, containerAttribute.getCollection("Key2").size());
 
-    Assertions.assertEquals(100,
-        containerAttribute.getCollection("Key3").size());
+    assertEquals(100, containerAttribute.getCollection("Key3").size());
 
-    Assertions.assertEquals(50,
-        containerAttribute.getCollection("Key1").size());
+    assertEquals(50, containerAttribute.getCollection("Key1").size());
   }
 
   @Test
@@ -125,16 +121,16 @@ public class TestContainerAttribute {
     ContainerID id = ContainerID.valueOf(42);
 
     containerAttribute.insert(key1, id);
-    Assertions.assertTrue(containerAttribute.hasContainerID(key1, id));
-    Assertions.assertFalse(containerAttribute.hasContainerID(key2, id));
+    assertTrue(containerAttribute.hasContainerID(key1, id));
+    assertFalse(containerAttribute.hasContainerID(key2, id));
 
     // This should move the id from key1 bucket to key2 bucket.
     containerAttribute.update(key1, key2, id);
-    Assertions.assertFalse(containerAttribute.hasContainerID(key1, id));
-    Assertions.assertTrue(containerAttribute.hasContainerID(key2, id));
+    assertFalse(containerAttribute.hasContainerID(key1, id));
+    assertTrue(containerAttribute.hasContainerID(key2, id));
 
     // This should fail since we cannot find this id in the key3 bucket.
-    Assertions.assertThrows(SCMException.class,
+    assertThrows(SCMException.class,
         () -> containerAttribute.update(key3, key1, id));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
@@ -35,6 +35,9 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests on {@link org.apache.hadoop.hdds.scm.metadata.Replicate}.
@@ -129,7 +132,7 @@ public class TestReplicationAnnotation {
       proxy.addContainer(HddsProtos.ContainerInfoProto.getDefaultInstance());
       Assertions.fail("Cannot reach here: should have seen a IOException");
     } catch (IOException e) {
-      Assertions.assertNotNull(e.getMessage());
+      assertNotNull(e.getMessage());
       assertThat(e.getMessage()).contains("submitRequest is called");
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerStateManager;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.server.RaftServer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -130,7 +128,7 @@ public class TestReplicationAnnotation {
 
     try {
       proxy.addContainer(HddsProtos.ContainerInfoProto.getDefaultInstance());
-      Assertions.fail("Cannot reach here: should have seen a IOException");
+      fail("Cannot reach here: should have seen a IOException");
     } catch (IOException e) {
       assertNotNull(e.getMessage());
       assertThat(e.getMessage()).contains("submitRequest is called");

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,6 +67,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test for SCM HA-related configuration.
@@ -139,9 +140,8 @@ class TestSCMHAConfiguration {
           scmServiceId, nodeId), port++);
     }
 
-    SCMStorageConfig scmStorageConfig = Mockito.mock(SCMStorageConfig.class);
-    Mockito.when(scmStorageConfig.getState())
-        .thenReturn(Storage.StorageState.NOT_INITIALIZED);
+    SCMStorageConfig scmStorageConfig = mock(SCMStorageConfig.class);
+    when(scmStorageConfig.getState()).thenReturn(Storage.StorageState.NOT_INITIALIZED);
     SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
 
     port = 9880;
@@ -247,9 +247,8 @@ class TestSCMHAConfiguration {
     conf.set(OZONE_SCM_DATANODE_PORT_KEY, "9898");
     conf.set(OZONE_SCM_SECURITY_SERVICE_PORT_KEY, "9899");
 
-    SCMStorageConfig scmStorageConfig = Mockito.mock(SCMStorageConfig.class);
-    Mockito.when(scmStorageConfig.getState())
-        .thenReturn(Storage.StorageState.NOT_INITIALIZED);
+    SCMStorageConfig scmStorageConfig = mock(SCMStorageConfig.class);
+    when(scmStorageConfig.getState()).thenReturn(Storage.StorageState.NOT_INITIALIZED);
     SCMHANodeDetails scmhaNodeDetails =
         SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
 
@@ -304,9 +303,8 @@ class TestSCMHAConfiguration {
   @Test
   public void testRatisEnabledDefaultConfigWithoutInitializedSCM()
       throws IOException {
-    SCMStorageConfig scmStorageConfig = Mockito.mock(SCMStorageConfig.class);
-    Mockito.when(scmStorageConfig.getState())
-        .thenReturn(Storage.StorageState.NOT_INITIALIZED);
+    SCMStorageConfig scmStorageConfig = mock(SCMStorageConfig.class);
+    when(scmStorageConfig.getState()).thenReturn(Storage.StorageState.NOT_INITIALIZED);
     SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
     assertEquals(SCMHAUtils.isSCMHAEnabled(conf),
         ScmConfigKeys.OZONE_SCM_HA_ENABLE_DEFAULT);
@@ -323,25 +321,25 @@ class TestSCMHAConfiguration {
   @Test
   public void testRatisEnabledDefaultConfigWithInitializedSCM()
       throws IOException {
-    SCMStorageConfig scmStorageConfig = Mockito.mock(SCMStorageConfig.class);
-    Mockito.when(scmStorageConfig.getState())
+    SCMStorageConfig scmStorageConfig = mock(SCMStorageConfig.class);
+    when(scmStorageConfig.getState())
         .thenReturn(Storage.StorageState.INITIALIZED);
-    Mockito.when(scmStorageConfig.isSCMHAEnabled()).thenReturn(false);
+    when(scmStorageConfig.isSCMHAEnabled()).thenReturn(false);
     DefaultConfigManager.clearDefaultConfigs();
     SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
     assertEquals(SCMHAUtils.isSCMHAEnabled(conf),
         scmStorageConfig.isSCMHAEnabled());
-    Mockito.when(scmStorageConfig.isSCMHAEnabled()).thenReturn(false);
+    when(scmStorageConfig.isSCMHAEnabled()).thenReturn(false);
     DefaultConfigManager.clearDefaultConfigs();
     assertTrue(SCMHAUtils.isSCMHAEnabled(conf));
   }
 
   @Test
   public void testRatisEnabledDefaultConflictConfigWithInitializedSCM() {
-    SCMStorageConfig scmStorageConfig = Mockito.mock(SCMStorageConfig.class);
-    Mockito.when(scmStorageConfig.getState())
+    SCMStorageConfig scmStorageConfig = mock(SCMStorageConfig.class);
+    when(scmStorageConfig.getState())
         .thenReturn(Storage.StorageState.INITIALIZED);
-    Mockito.when(scmStorageConfig.isSCMHAEnabled()).thenReturn(true);
+    when(scmStorageConfig.isSCMHAEnabled()).thenReturn(true);
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, false);
     assertThrows(ConfigurationException.class,
             () -> SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.DivisionInfo;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -56,6 +55,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -111,7 +111,7 @@ class TestSCMHAManagerImpl {
 
   @Test
   public void testAddSCM() throws IOException, InterruptedException {
-    Assertions.assertEquals(1, primarySCMHAManager.getRatisServer()
+    assertEquals(1, primarySCMHAManager.getRatisServer()
         .getDivision().getGroup().getPeers().size());
 
     final StorageContainerManager scm2 = getMockStorageContainerManager(
@@ -124,7 +124,7 @@ class TestSCMHAManagerImpl {
               .getDivision().getRaftServer().getServerRpc()
               .getInetSocketAddress().getPort());
       primarySCMHAManager.addSCM(request);
-      Assertions.assertEquals(2, primarySCMHAManager.getRatisServer()
+      assertEquals(2, primarySCMHAManager.getRatisServer()
           .getDivision().getGroup().getPeers().size());
     } finally {
       scm2.getScmHAManager().getRatisServer().stop();
@@ -162,7 +162,7 @@ class TestSCMHAManagerImpl {
   }
   @Test
   public void testRemoveSCM() throws IOException, InterruptedException {
-    Assertions.assertEquals(1, primarySCMHAManager.getRatisServer()
+    assertEquals(1, primarySCMHAManager.getRatisServer()
         .getDivision().getGroup().getPeers().size());
 
     final StorageContainerManager scm2 = getMockStorageContainerManager(
@@ -175,7 +175,7 @@ class TestSCMHAManagerImpl {
               .getDivision().getRaftServer().getServerRpc()
               .getInetSocketAddress().getPort());
       primarySCMHAManager.addSCM(addSCMRequest);
-      Assertions.assertEquals(2, primarySCMHAManager.getRatisServer()
+      assertEquals(2, primarySCMHAManager.getRatisServer()
           .getDivision().getGroup().getPeers().size());
 
       final RemoveSCMRequest removeSCMRequest = new RemoveSCMRequest(
@@ -183,7 +183,7 @@ class TestSCMHAManagerImpl {
           scm2.getScmHAManager().getRatisServer().getDivision()
               .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
       primarySCMHAManager.removeSCM(removeSCMRequest);
-      Assertions.assertEquals(1, primarySCMHAManager.getRatisServer()
+      assertEquals(1, primarySCMHAManager.getRatisServer()
           .getDivision().getGroup().getPeers().size());
     } finally {
       scm2.getScmHAManager().getRatisServer().stop();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAMetrics.java
@@ -20,8 +20,9 @@ package org.apache.hadoop.hdds.scm.ha;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link SCMHAMetrics}.
@@ -50,7 +51,7 @@ class TestSCMHAMetrics {
     scmhaMetrics.getMetrics(METRICS_COLLECTOR, true);
 
     // THEN
-    Assertions.assertEquals(1, scmhaMetrics.getSCMHAMetricsInfoLeaderState());
+    assertEquals(1, scmhaMetrics.getSCMHAMetricsInfoLeaderState());
   }
 
   @Test
@@ -63,7 +64,7 @@ class TestSCMHAMetrics {
     scmhaMetrics.getMetrics(METRICS_COLLECTOR, true);
 
     // THEN
-    Assertions.assertEquals(0, scmhaMetrics.getSCMHAMetricsInfoLeaderState());
+    assertEquals(0, scmhaMetrics.getSCMHAMetricsInfoLeaderState());
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisRequest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisRequest.java
@@ -22,13 +22,14 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.ratis.protocol.Message;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType.PIPELINE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test for SCMRatisRequest.
@@ -42,10 +43,8 @@ public class TestSCMRatisRequest {
     String operation = "test";
     SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
         new Class[]{pipelineID.getProtobuf().getClass()}, args);
-    Assertions.assertEquals(operation,
-        SCMRatisRequest.decode(request.encode()).getOperation());
-    Assertions.assertEquals(args[0],
-        SCMRatisRequest.decode(request.encode()).getArguments()[0]);
+    assertEquals(operation, SCMRatisRequest.decode(request.encode()).getOperation());
+    assertEquals(args[0], SCMRatisRequest.decode(request.encode()).getArguments()[0]);
   }
 
   @Test
@@ -56,7 +55,7 @@ public class TestSCMRatisRequest {
     SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, "test",
         new Class[]{pipelineID.getClass()}, args);
     // Should throw exception there.
-    Assertions.assertThrows(InvalidProtocolBufferException.class,
+    assertThrows(InvalidProtocolBufferException.class,
         request::encode);
   }
 
@@ -65,7 +64,7 @@ public class TestSCMRatisRequest {
     // Non proto message
     Message message = Message.valueOf("randomMessage");
     // Should throw exception there.
-    Assertions.assertThrows(InvalidProtocolBufferException.class,
+    assertThrows(InvalidProtocolBufferException.class,
         () -> SCMRatisRequest.decode(message));
   }
 
@@ -79,10 +78,8 @@ public class TestSCMRatisRequest {
     String operation = "test";
     SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
         new Class[]{pids.getClass()}, args);
-    Assertions.assertEquals(operation,
-        SCMRatisRequest.decode(request.encode()).getOperation());
-    Assertions.assertEquals(args[0],
-        SCMRatisRequest.decode(request.encode()).getArguments()[0]);
+    assertEquals(operation, SCMRatisRequest.decode(request.encode()).getOperation());
+    assertEquals(args[0], SCMRatisRequest.decode(request.encode()).getArguments()[0]);
   }
 
   @Test
@@ -91,9 +88,7 @@ public class TestSCMRatisRequest {
     String operation = "test";
     SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
         new Class[]{value.getClass()}, value);
-    Assertions.assertEquals(operation,
-        SCMRatisRequest.decode(request.encode()).getOperation());
-    Assertions.assertEquals(value,
-        SCMRatisRequest.decode(request.encode()).getArguments()[0]);
+    assertEquals(operation, SCMRatisRequest.decode(request.encode()).getOperation());
+    assertEquals(value, SCMRatisRequest.decode(request.encode()).getArguments()[0]);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisResponse.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisResponse.java
@@ -28,9 +28,14 @@ import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
 import org.apache.ratis.protocol.exceptions.RaftException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test for SCMRatisResponse.
@@ -57,9 +62,8 @@ public class TestSCMRatisResponse {
         .setLogIndex(1L)
         .build();
     SCMRatisResponse response = SCMRatisResponse.decode(reply);
-    Assertions.assertTrue(response.isSuccess());
-    Assertions.assertEquals(Message.EMPTY,
-        SCMRatisResponse.encode(response.getResult()));
+    assertTrue(response.isSuccess());
+    assertEquals(Message.EMPTY, SCMRatisResponse.encode(response.getResult()));
   }
 
   @Test
@@ -75,9 +79,9 @@ public class TestSCMRatisResponse {
         .setLogIndex(1L)
         .build();
     SCMRatisResponse response = SCMRatisResponse.decode(reply);
-    Assertions.assertFalse(response.isSuccess());
+    assertFalse(response.isSuccess());
     assertInstanceOf(RaftException.class, response.getException());
-    Assertions.assertNull(response.getResult());
+    assertNull(response.getResult());
   }
 
   @Test
@@ -85,7 +89,7 @@ public class TestSCMRatisResponse {
     // Non proto input
     Message message = Message.valueOf("test");
     // Should fail with exception.
-    Assertions.assertThrows(InvalidProtocolBufferException.class,
+    assertThrows(InvalidProtocolBufferException.class,
         () -> SCMRatisResponse.encode(message));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSequenceIDGenerator.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSequenceIDGenerator.java
@@ -24,12 +24,13 @@ import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStoreImpl;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBTransactionBufferImpl;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SEQUENCE_ID_BATCH_SIZE;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -50,33 +51,33 @@ public class TestSequenceIDGenerator {
         conf, scmHAManager, scmMetadataStore.getSequenceIdTable());
 
     // the first batch is [1, 1000]
-    Assertions.assertEquals(1L, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(2L, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(3L, sequenceIdGen.getNextId("someKey"));
+    assertEquals(1L, sequenceIdGen.getNextId("someKey"));
+    assertEquals(2L, sequenceIdGen.getNextId("someKey"));
+    assertEquals(3L, sequenceIdGen.getNextId("someKey"));
 
-    Assertions.assertEquals(1L, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(2L, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(3L, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(1L, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(2L, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(3L, sequenceIdGen.getNextId("otherKey"));
 
     // default batchSize is 1000, the next batch is [1001, 2000]
     sequenceIdGen.invalidateBatch();
-    Assertions.assertEquals(1001, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(1002, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(1003, sequenceIdGen.getNextId("someKey"));
+    assertEquals(1001, sequenceIdGen.getNextId("someKey"));
+    assertEquals(1002, sequenceIdGen.getNextId("someKey"));
+    assertEquals(1003, sequenceIdGen.getNextId("someKey"));
 
-    Assertions.assertEquals(1001, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(1002, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(1003, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(1001, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(1002, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(1003, sequenceIdGen.getNextId("otherKey"));
 
     // default batchSize is 1000, the next batch is [2001, 3000]
     sequenceIdGen.invalidateBatch();
-    Assertions.assertEquals(2001, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(2002, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(2003, sequenceIdGen.getNextId("someKey"));
+    assertEquals(2001, sequenceIdGen.getNextId("someKey"));
+    assertEquals(2002, sequenceIdGen.getNextId("someKey"));
+    assertEquals(2003, sequenceIdGen.getNextId("someKey"));
 
-    Assertions.assertEquals(2001, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(2002, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(2003, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(2001, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(2002, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(2003, sequenceIdGen.getNextId("otherKey"));
   }
 
   @Test
@@ -95,33 +96,33 @@ public class TestSequenceIDGenerator {
         conf, scmHAManager, scmMetadataStore.getSequenceIdTable());
 
     // the first batch is [1, 100]
-    Assertions.assertEquals(1L, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(2L, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(3L, sequenceIdGen.getNextId("someKey"));
+    assertEquals(1L, sequenceIdGen.getNextId("someKey"));
+    assertEquals(2L, sequenceIdGen.getNextId("someKey"));
+    assertEquals(3L, sequenceIdGen.getNextId("someKey"));
 
-    Assertions.assertEquals(1L, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(2L, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(3L, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(1L, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(2L, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(3L, sequenceIdGen.getNextId("otherKey"));
 
     // the next batch is [101, 200]
     sequenceIdGen.invalidateBatch();
-    Assertions.assertEquals(101, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(102, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(103, sequenceIdGen.getNextId("someKey"));
+    assertEquals(101, sequenceIdGen.getNextId("someKey"));
+    assertEquals(102, sequenceIdGen.getNextId("someKey"));
+    assertEquals(103, sequenceIdGen.getNextId("someKey"));
 
-    Assertions.assertEquals(101, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(102, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(103, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(101, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(102, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(103, sequenceIdGen.getNextId("otherKey"));
 
     // the next batch is [201, 300]
     sequenceIdGen.invalidateBatch();
-    Assertions.assertEquals(201, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(202, sequenceIdGen.getNextId("someKey"));
-    Assertions.assertEquals(203, sequenceIdGen.getNextId("someKey"));
+    assertEquals(201, sequenceIdGen.getNextId("someKey"));
+    assertEquals(202, sequenceIdGen.getNextId("someKey"));
+    assertEquals(203, sequenceIdGen.getNextId("someKey"));
 
-    Assertions.assertEquals(201, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(202, sequenceIdGen.getNextId("otherKey"));
-    Assertions.assertEquals(203, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(201, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(202, sequenceIdGen.getNextId("otherKey"));
+    assertEquals(203, sequenceIdGen.getNextId("otherKey"));
   }
 
   @Test
@@ -151,7 +152,7 @@ public class TestSequenceIDGenerator {
       }
     };
 
-    Assertions.assertEquals(1L, sequenceIdGen.getNextId("someKey"));
+    assertEquals(1L, sequenceIdGen.getNextId("someKey"));
 
     // Simulation currently this SCM is not a leader node,
     // So this SCM can only allocate IDs within the current batch
@@ -164,7 +165,7 @@ public class TestSequenceIDGenerator {
       try {
         long nextID = sequenceIdGen.getNextId("someKey");
         if (nextID > batchSize) {
-          Assertions.fail("Should not allocate a blockID: " + nextID +
+          fail("Should not allocate a blockID: " + nextID +
               " that exceeds the current Batch: " + batchSize);
         }
       } catch (Exception e) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestStatefulServiceStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestStatefulServiceStateManagerImpl.java
@@ -27,13 +27,13 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
 import java.io.File;
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests StatefulServiceStateManagerImpl.
@@ -81,7 +81,6 @@ public class TestStatefulServiceStateManagerImpl {
     stateManager.saveConfiguration(serviceName,
         ByteString.copyFromUtf8(message));
     scmhaManager.asSCMHADBTransactionBuffer().flush();
-    Assertions.assertEquals(ByteString.copyFromUtf8(message),
-        stateManager.readConfiguration(serviceName));
+    assertEquals(ByteString.copyFromUtf8(message), stateManager.readConfiguration(serviceName));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestBigIntegerCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestBigIntegerCodec.java
@@ -18,10 +18,11 @@
 package org.apache.hadoop.hdds.scm.ha.io;
 
 import com.google.protobuf.ByteString;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Class to test BigIntegerCodec serialize and deserialize.
@@ -37,6 +38,6 @@ public class TestBigIntegerCodec {
 
     BigInteger actual =
         (BigInteger) bigIntegerCodec.deserialize(BigInteger.class, byteString);
-    Assertions.assertEquals(bigInteger, actual);
+    assertEquals(bigInteger, actual);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestX509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestX509CertificateCodec.java
@@ -20,13 +20,14 @@ package org.apache.hadoop.hdds.scm.ha.io;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Class to test X509CertificateCodec serialize and deserialize.
@@ -46,7 +47,7 @@ public class TestX509CertificateCodec {
     X509Certificate actual = (X509Certificate)
         x509CertificateCodec.deserialize(X509Certificate.class, byteString);
 
-    Assertions.assertEquals(x509Certificate, actual);
+    assertEquals(x509Certificate, actual);
 
   }
 
@@ -56,7 +57,7 @@ public class TestX509CertificateCodec {
     X509CertificateCodec x509CertificateCodec = new X509CertificateCodec();
     ByteString byteString = ByteString.copyFrom("dummy".getBytes(UTF_8));
 
-    Assertions.assertThrows(InvalidProtocolBufferException.class, () ->
+    assertThrows(InvalidProtocolBufferException.class, () ->
         x509CertificateCodec.deserialize(X509Certificate.class, byteString));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorTestUtil.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hdds.scm.container.replication.RatisContainerReplicaCou
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -43,6 +42,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 
 /**
  * Helper class to provide common methods used to test DatanodeAdminMonitor
@@ -157,8 +158,8 @@ public final class DatanodeAdminMonitorTestUtil {
       HddsProtos.NodeOperationalState...replicaStates)
       throws ContainerNotFoundException {
     reset(repManager);
-    Mockito.when(repManager.getContainerReplicaCount(
-        Mockito.any(ContainerID.class)))
+    when(repManager.getContainerReplicaCount(
+        any(ContainerID.class)))
         .thenAnswer(invocation ->
             generateReplicaCount((ContainerID)invocation.getArguments()[0],
                 containerState, replicaStates));
@@ -185,8 +186,8 @@ public final class DatanodeAdminMonitorTestUtil {
           Integer>...replicaStates)
       throws ContainerNotFoundException {
     reset(repManager);
-    Mockito.when(repManager.getContainerReplicaCount(
-            Mockito.any(ContainerID.class)))
+    when(repManager.getContainerReplicaCount(
+            any(ContainerID.class)))
         .thenAnswer(invocation ->
             generateECReplicaCount((ContainerID)invocation.getArguments()[0],
                 repConfig, containerState, replicaStates));
@@ -195,8 +196,8 @@ public final class DatanodeAdminMonitorTestUtil {
 
   static void mockCheckContainerState(ReplicationManager repManager, boolean underReplicated)
       throws ContainerNotFoundException {
-    Mockito.when(repManager.checkContainerStatus(Mockito.any(ContainerInfo.class),
-            Mockito.any(ReplicationManagerReport.class)))
+    when(repManager.checkContainerStatus(any(ContainerInfo.class),
+            any(ReplicationManagerReport.class)))
         .then(invocation -> {
           ReplicationManagerReport report = invocation.getArgument(1);
           if (underReplicated) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -62,20 +62,20 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.test.PathUtils;
-
 import org.apache.commons.io.IOUtils;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
-
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVersionProto;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
+
 
 /**
  * Test for different container placement policy.
@@ -135,22 +135,16 @@ public class TestContainerPlacement {
 
   SCMNodeManager createNodeManager(OzoneConfiguration config) {
     EventQueue eventQueue = new EventQueue();
-    eventQueue.addHandler(SCMEvents.NEW_NODE,
-        Mockito.mock(NewNodeHandler.class));
-    eventQueue.addHandler(SCMEvents.STALE_NODE,
-        Mockito.mock(StaleNodeHandler.class));
-    eventQueue.addHandler(SCMEvents.DEAD_NODE,
-        Mockito.mock(DeadNodeHandler.class));
+    eventQueue.addHandler(SCMEvents.NEW_NODE, mock(NewNodeHandler.class));
+    eventQueue.addHandler(SCMEvents.STALE_NODE, mock(StaleNodeHandler.class));
+    eventQueue.addHandler(SCMEvents.DEAD_NODE, mock(DeadNodeHandler.class));
 
-    SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
-    Mockito.when(storageConfig.getClusterID()).thenReturn("cluster1");
+    SCMStorageConfig storageConfig = mock(SCMStorageConfig.class);
+    when(storageConfig.getClusterID()).thenReturn("cluster1");
 
-    HDDSLayoutVersionManager versionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
-    Mockito.when(versionManager.getMetadataLayoutVersion())
-        .thenReturn(maxLayoutVersion());
-    Mockito.when(versionManager.getSoftwareLayoutVersion())
-        .thenReturn(maxLayoutVersion());
+    HDDSLayoutVersionManager versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(versionManager.getSoftwareLayoutVersion()).thenReturn(maxLayoutVersion());
     SCMNodeManager scmNodeManager = new SCMNodeManager(config, storageConfig,
         eventQueue, null, SCMContext.emptyContext(), versionManager);
     return scmNodeManager;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -50,6 +49,9 @@ import java.util.Set;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
@@ -81,7 +83,7 @@ public class TestDatanodeAdminMonitor {
 
     nodeManager = new SimpleMockNodeManager();
 
-    repManager = Mockito.mock(ReplicationManager.class);
+    repManager = mock(ReplicationManager.class);
 
     monitor =
         new DatanodeAdminMonitorImpl(conf, eventQueue, nodeManager, repManager);
@@ -266,7 +268,7 @@ public class TestDatanodeAdminMonitor {
     replicas.add(unhealthy);
     nodeManager.setContainers(dn1, ImmutableSet.of(containerID));
 
-    Mockito.when(repManager.getContainerReplicaCount(Mockito.eq(containerID)))
+    when(repManager.getContainerReplicaCount(eq(containerID)))
         .thenReturn(new LegacyRatisContainerReplicaCount(container, replicas,
             0, 0, 3, 2));
 
@@ -289,7 +291,7 @@ public class TestDatanodeAdminMonitor {
         .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
         .build();
     replicas.add(copyOfUnhealthyOnNewNode);
-    Mockito.when(repManager.getContainerReplicaCount(Mockito.eq(containerID)))
+    when(repManager.getContainerReplicaCount(eq(containerID)))
         .thenReturn(new LegacyRatisContainerReplicaCount(container, replicas,
             0, 0, 3, 2));
     monitor.run();
@@ -338,7 +340,7 @@ public class TestDatanodeAdminMonitor {
     replicas.add(unhealthy);
     nodeManager.setContainers(dn1, ImmutableSet.of(containerID));
 
-    Mockito.when(repManager.getContainerReplicaCount(Mockito.eq(containerID)))
+    when(repManager.getContainerReplicaCount(eq(containerID)))
         .thenReturn(new RatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2, false));
     DatanodeAdminMonitorTestUtil.mockCheckContainerState(repManager, true);
@@ -362,7 +364,7 @@ public class TestDatanodeAdminMonitor {
         .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
         .build();
     replicas.add(copyOfUnhealthyOnNewNode);
-    Mockito.when(repManager.getContainerReplicaCount(Mockito.eq(containerID)))
+    when(repManager.getContainerReplicaCount(eq(containerID)))
         .thenReturn(new RatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2, false));
     DatanodeAdminMonitorTestUtil.mockCheckContainerState(repManager, false);
@@ -403,8 +405,8 @@ public class TestDatanodeAdminMonitor {
     nodeManager.setContainers(decommissioningNode,
         ImmutableSet.of(container.containerID()));
 
-    Mockito.when(repManager.getContainerReplicaCount(
-            Mockito.eq(container.containerID())))
+    when(repManager.getContainerReplicaCount(
+            eq(container.containerID())))
         .thenReturn(new LegacyRatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 2, true));
 
@@ -428,8 +430,8 @@ public class TestDatanodeAdminMonitor {
             .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails())
             .build();
     replicas.add(copyOfUnhealthyOnNewNode);
-    Mockito.when(repManager.getContainerReplicaCount(
-            Mockito.eq(container.containerID())))
+    when(repManager.getContainerReplicaCount(
+            eq(container.containerID())))
         .thenReturn(new LegacyRatisContainerReplicaCount(container, replicas,
             Collections.emptyList(), 3, true));
     monitor.run();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.hdds.scm.node;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -73,7 +76,6 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -228,14 +230,14 @@ public class TestDeadNodeHandler {
     // First set the node to IN_MAINTENANCE and ensure the container replicas
     // are not removed on the dead event
     datanode1 = nodeManager.getNodeByUuid(datanode1.getUuidString());
-    Assertions.assertTrue(
+    assertTrue(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
     nodeManager.setNodeOperationalState(datanode1,
         HddsProtos.NodeOperationalState.IN_MAINTENANCE);
     deadNodeHandler.onMessage(datanode1, publisher);
     // make sure the node is removed from
     // ClusterNetworkTopology when it is considered as dead
-    Assertions.assertFalse(
+    assertFalse(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
 
     verify(deletedBlockLog, times(0))
@@ -243,16 +245,16 @@ public class TestDeadNodeHandler {
 
     Set<ContainerReplica> container1Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container1.getContainerID()));
-    Assertions.assertEquals(2, container1Replicas.size());
+    assertEquals(2, container1Replicas.size());
 
     Set<ContainerReplica> container2Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container2.getContainerID()));
-    Assertions.assertEquals(2, container2Replicas.size());
+    assertEquals(2, container2Replicas.size());
 
     Set<ContainerReplica> container3Replicas = containerManager
             .getContainerReplicas(
                 ContainerID.valueOf(container3.getContainerID()));
-    Assertions.assertEquals(1, container3Replicas.size());
+    assertEquals(1, container3Replicas.size());
 
     // Now set the node to anything other than IN_MAINTENANCE and the relevant
     // replicas should be removed
@@ -263,35 +265,31 @@ public class TestDeadNodeHandler {
     deadNodeHandler.onMessage(datanode1, publisher);
     //datanode1 has been removed from ClusterNetworkTopology, another
     //deadNodeHandler.onMessage call will not change this
-    Assertions.assertFalse(
+    assertFalse(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
-    Assertions.assertEquals(0, 
-        nodeManager.getCommandQueueCount(datanode1.getUuid(), cmd.getType()));
+    assertEquals(0, nodeManager.getCommandQueueCount(datanode1.getUuid(), cmd.getType()));
 
     verify(deletedBlockLog, times(1))
         .onDatanodeDead(datanode1.getUuid());
 
     container1Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container1.getContainerID()));
-    Assertions.assertEquals(1, container1Replicas.size());
-    Assertions.assertEquals(datanode2,
-        container1Replicas.iterator().next().getDatanodeDetails());
+    assertEquals(1, container1Replicas.size());
+    assertEquals(datanode2, container1Replicas.iterator().next().getDatanodeDetails());
 
     container2Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container2.getContainerID()));
-    Assertions.assertEquals(1, container2Replicas.size());
-    Assertions.assertEquals(datanode2,
-        container2Replicas.iterator().next().getDatanodeDetails());
+    assertEquals(1, container2Replicas.size());
+    assertEquals(datanode2, container2Replicas.iterator().next().getDatanodeDetails());
 
     container3Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container3.getContainerID()));
-    Assertions.assertEquals(1, container3Replicas.size());
-    Assertions.assertEquals(datanode3,
-        container3Replicas.iterator().next().getDatanodeDetails());
+    assertEquals(1, container3Replicas.size());
+    assertEquals(datanode3, container3Replicas.iterator().next().getDatanodeDetails());
 
     //datanode will be added back to ClusterNetworkTopology if it resurrects
     healthyReadOnlyNodeHandler.onMessage(datanode1, publisher);
-    Assertions.assertTrue(
+    assertTrue(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
 
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.hdds.scm.node;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
@@ -66,15 +69,13 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.protocol.commands.DeleteBlocksCommand;
-import org.apache.hadoop.security.authentication.client
-    .AuthenticationException;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 /**
  * Test DeadNodeHandler.
@@ -119,14 +120,14 @@ public class TestDeadNodeHandler {
     pipelineManager.setPipelineProvider(RATIS,
         mockRatisProvider);
     containerManager = scm.getContainerManager();
-    deletedBlockLog = Mockito.mock(DeletedBlockLog.class);
+    deletedBlockLog = mock(DeletedBlockLog.class);
     deadNodeHandler = new DeadNodeHandler(nodeManager,
-        Mockito.mock(PipelineManager.class), containerManager, deletedBlockLog);
+        mock(PipelineManager.class), containerManager, deletedBlockLog);
     healthyReadOnlyNodeHandler =
         new HealthyReadOnlyNodeHandler(nodeManager,
             pipelineManager);
     eventQueue.addHandler(SCMEvents.DEAD_NODE, deadNodeHandler);
-    publisher = Mockito.mock(EventPublisher.class);
+    publisher = mock(EventPublisher.class);
   }
 
   @AfterEach
@@ -237,7 +238,7 @@ public class TestDeadNodeHandler {
     Assertions.assertFalse(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
 
-    Mockito.verify(deletedBlockLog, Mockito.times(0))
+    verify(deletedBlockLog, times(0))
         .onDatanodeDead(datanode1.getUuid());
 
     Set<ContainerReplica> container1Replicas = containerManager
@@ -267,7 +268,7 @@ public class TestDeadNodeHandler {
     Assertions.assertEquals(0, 
         nodeManager.getCommandQueueCount(datanode1.getUuid(), cmd.getType()));
 
-    Mockito.verify(deletedBlockLog, Mockito.times(1))
+    verify(deletedBlockLog, times(1))
         .onDatanodeDead(datanode1.getUuid());
 
     container1Replicas = containerManager

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
@@ -29,13 +29,13 @@ import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.util.HashSet;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
@@ -88,8 +88,7 @@ public class TestNodeDecommissionMetrics {
             HddsProtos.NodeState.HEALTHY));
     monitor.startMonitoring(dn1);
     monitor.run();
-    Assertions.assertEquals(1,
-        metrics.getDecommissioningMaintenanceNodesTotal());
+    assertEquals(1, metrics.getDecommissioningMaintenanceNodesTotal());
   }
 
   /**
@@ -108,10 +107,8 @@ public class TestNodeDecommissionMetrics {
     // Stop monitor and run.
     monitor.stopMonitoring(dn1);
     monitor.run();
-    Assertions.assertEquals(0,
-        metrics.getDecommissioningMaintenanceNodesTotal());
-    Assertions.assertEquals(1,
-        metrics.getRecommissionNodesTotal());
+    assertEquals(0, metrics.getDecommissioningMaintenanceNodesTotal());
+    assertEquals(1, metrics.getRecommissionNodesTotal());
   }
 
   /**
@@ -133,22 +130,17 @@ public class TestNodeDecommissionMetrics {
     monitor.run();
     // Ensure a StartAdmin event was fired
     eventQueue.processAll(20000);
-    Assertions.assertEquals(2,
-        metrics.getPipelinesWaitingToCloseTotal());
+    assertEquals(2, metrics.getPipelinesWaitingToCloseTotal());
 
     // should have host specific metric collected
     // for datanode_host1
-    Assertions.assertEquals(2,
-        metrics.getPipelinesWaitingToCloseByHost(
-            "datanode_host1"));
+    assertEquals(2, metrics.getPipelinesWaitingToCloseByHost("datanode_host1"));
     // Clear the pipelines and the metric collected for
     // datanode_host1 should clear
     nodeManager.setPipelines(dn1, 0);
     monitor.run();
     eventQueue.processAll(20000);
-    Assertions.assertEquals(0,
-        metrics.getPipelinesWaitingToCloseByHost(
-            "datanode_host1"));
+    assertEquals(0, metrics.getPipelinesWaitingToCloseByHost("datanode_host1"));
   }
 
   /**
@@ -184,13 +176,11 @@ public class TestNodeDecommissionMetrics {
     // container after the first run
     monitor.startMonitoring(dn1);
     monitor.run();
-    Assertions.assertEquals(1,
-        metrics.getContainersUnderReplicatedTotal());
+    assertEquals(1, metrics.getContainersUnderReplicatedTotal());
 
     // should have host specific metric collected
     // for datanode_host1
-    Assertions.assertEquals(1,
-        metrics.getUnderReplicatedByHost("datanode_host1"));
+    assertEquals(1, metrics.getUnderReplicatedByHost("datanode_host1"));
   }
 
   /**
@@ -224,13 +214,11 @@ public class TestNodeDecommissionMetrics {
     monitor.run();
     // expect dn in decommissioning workflow with container
     // sufficiently replicated
-    Assertions.assertEquals(1,
-        metrics.getContainersSufficientlyReplicatedTotal());
+    assertEquals(1, metrics.getContainersSufficientlyReplicatedTotal());
 
     // should have host specific metric collected
     // for datanode_host1
-    Assertions.assertEquals(1,
-        metrics.getSufficientlyReplicatedByHost("datanode_host1"));
+    assertEquals(1, metrics.getSufficientlyReplicatedByHost("datanode_host1"));
   }
 
   /**
@@ -260,14 +248,11 @@ public class TestNodeDecommissionMetrics {
     monitor.startMonitoring(dn1);
 
     monitor.run();
-    Assertions.assertEquals(1,
-        metrics.getContainersUnClosedTotal());
+    assertEquals(1, metrics.getContainersUnClosedTotal());
 
     // should have host specific metric collected
     // for datanode_host1
-    Assertions.assertEquals(1,
-        metrics.getUnClosedContainersByHost(
-            "datanode_host1"));
+    assertEquals(1, metrics.getUnClosedContainersByHost("datanode_host1"));
   }
 
   /**
@@ -311,8 +296,7 @@ public class TestNodeDecommissionMetrics {
     monitor.startMonitoring(dn2);
 
     monitor.run();
-    Assertions.assertEquals(3,
-        metrics.getContainersUnderReplicatedTotal());
+    assertEquals(3, metrics.getContainersUnderReplicatedTotal());
   }
 
   /**
@@ -340,8 +324,7 @@ public class TestNodeDecommissionMetrics {
     monitor.startMonitoring(dn2);
 
     monitor.run();
-    Assertions.assertEquals(3,
-        metrics.getPipelinesWaitingToCloseTotal());
+    assertEquals(3, metrics.getPipelinesWaitingToCloseTotal());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
@@ -32,11 +32,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
@@ -64,7 +63,7 @@ public class TestNodeDecommissionMetrics {
         .DatanodeAdminHandler();
     eventQueue.addHandler(SCMEvents.START_ADMIN_ON_NODE, startAdminHandler);
     nodeManager = new SimpleMockNodeManager();
-    repManager = Mockito.mock(ReplicationManager.class);
+    repManager = mock(ReplicationManager.class);
     monitor =
         new DatanodeAdminMonitorImpl(
             conf, eventQueue, nodeManager, repManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionMetrics.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
@@ -345,7 +346,7 @@ public class TestNodeDecommissionMetrics {
     monitor.run();
     long startTime = monitor.getSingleTrackedNode(dn1.getIpAddress())
         .getStartTime();
-    Assertions.assertTrue(before <= startTime);
-    Assertions.assertTrue(after >= startTime);
+    assertTrue(before <= startTime);
+    assertTrue(after >= startTime);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
@@ -17,6 +17,8 @@
 package org.apache.hadoop.hdds.scm.node;
 
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +44,6 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -88,15 +89,15 @@ public class TestNodeReportHandler implements EventPublisher {
         .createMetadataStorageReport(metaStoragePath, 100, 10, 90, null);
 
     SCMNodeMetric nodeMetric = nodeManager.getNodeStat(dn);
-    Assertions.assertNull(nodeMetric);
+    assertNull(nodeMetric);
 
     nodeManager.register(dn, getNodeReport(dn, Arrays.asList(storageOne),
         Arrays.asList(metaStorageOne)).getReport(), null);
     nodeMetric = nodeManager.getNodeStat(dn);
 
-    Assertions.assertEquals(100, (long) nodeMetric.get().getCapacity().get());
-    Assertions.assertEquals(90, (long) nodeMetric.get().getRemaining().get());
-    Assertions.assertEquals(10, (long) nodeMetric.get().getScmUsed().get());
+    assertEquals(100, (long) nodeMetric.get().getCapacity().get());
+    assertEquals(90, (long) nodeMetric.get().getRemaining().get());
+    assertEquals(10, (long) nodeMetric.get().getScmUsed().get());
 
     StorageReportProto storageTwo = HddsTestUtils
         .createStorageReport(dn.getUuid(), storagePath, 100, 10, 90, null);
@@ -105,9 +106,9 @@ public class TestNodeReportHandler implements EventPublisher {
             Arrays.asList(metaStorageOne)), this);
     nodeMetric = nodeManager.getNodeStat(dn);
 
-    Assertions.assertEquals(200, (long) nodeMetric.get().getCapacity().get());
-    Assertions.assertEquals(180, (long) nodeMetric.get().getRemaining().get());
-    Assertions.assertEquals(20, (long) nodeMetric.get().getScmUsed().get());
+    assertEquals(200, (long) nodeMetric.get().getCapacity().get());
+    assertEquals(180, (long) nodeMetric.get().getRemaining().get());
+    assertEquals(20, (long) nodeMetric.get().getScmUsed().get());
 
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
@@ -17,6 +17,8 @@
 package org.apache.hadoop.hdds.scm.node;
 
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,7 +45,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,16 +66,13 @@ public class TestNodeReportHandler implements EventPublisher {
   @BeforeEach
   public void resetEventCollector() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
-    SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
-    Mockito.when(storageConfig.getClusterID()).thenReturn("cluster1");
+    SCMStorageConfig storageConfig = mock(SCMStorageConfig.class);
+    when(storageConfig.getClusterID()).thenReturn("cluster1");
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
 
-    this.versionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
-    Mockito.when(versionManager.getMetadataLayoutVersion())
-        .thenReturn(maxLayoutVersion());
-    Mockito.when(versionManager.getSoftwareLayoutVersion())
-        .thenReturn(maxLayoutVersion());
+    this.versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(versionManager.getSoftwareLayoutVersion()).thenReturn(maxLayoutVersion());
     nodeManager =
         new SCMNodeManager(conf, storageConfig, new EventQueue(), clusterMap,
             SCMContext.emptyContext(), versionManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,6 +51,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 
@@ -98,12 +99,9 @@ public class TestNodeStateManager {
     eventPublisher = new MockEventPublisher();
     scmSlv = maxLayoutVersion();
     scmMlv = maxLayoutVersion();
-    LayoutVersionManager mockVersionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
-    Mockito.when(mockVersionManager.getMetadataLayoutVersion())
-        .thenReturn(scmMlv);
-    Mockito.when(mockVersionManager.getSoftwareLayoutVersion())
-        .thenReturn(scmSlv);
+    LayoutVersionManager mockVersionManager = mock(HDDSLayoutVersionManager.class);
+    when(mockVersionManager.getMetadataLayoutVersion()).thenReturn(scmMlv);
+    when(mockVersionManager.getSoftwareLayoutVersion()).thenReturn(scmSlv);
     nsm = new NodeStateManager(conf, eventPublisher, mockVersionManager,
         scmContext);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -51,8 +51,6 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -51,6 +51,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
@@ -143,8 +145,7 @@ public class TestNodeStateManager {
   public void testGetNodeCount() throws NodeAlreadyExistsException {
     DatanodeDetails dn = generateDatanode();
     nsm.addNode(dn, UpgradeUtils.defaultLayoutVersionProto());
-    assertEquals(1, nsm.getNodeCount(
-        NodeStatus.inServiceHealthy()));
+    assertEquals(1, nsm.getNodeCount(NodeStatus.inServiceHealthy()));
     assertEquals(0, nsm.getNodeCount(NodeStatus.inServiceStale()));
   }
 
@@ -217,8 +218,7 @@ public class TestNodeStateManager {
     dni.updateLastHeartbeatTime();
     nsm.checkNodesHealth();
     assertEquals(NodeState.HEALTHY_READONLY, nsm.getNodeStatus(dn).getHealth());
-    assertEquals(SCMEvents.HEALTHY_READONLY_NODE,
-        eventPublisher.getLastEvent());
+    assertEquals(SCMEvents.HEALTHY_READONLY_NODE, eventPublisher.getLastEvent());
 
     // Make the node stale again, and transition to healthy.
     dni.updateLastHeartbeatTime(now - staleLimit);
@@ -228,15 +228,13 @@ public class TestNodeStateManager {
     dni.updateLastHeartbeatTime();
     nsm.checkNodesHealth();
     assertEquals(NodeState.HEALTHY_READONLY, nsm.getNodeStatus(dn).getHealth());
-    assertEquals(SCMEvents.HEALTHY_READONLY_NODE,
-        eventPublisher.getLastEvent());
+    assertEquals(SCMEvents.HEALTHY_READONLY_NODE, eventPublisher.getLastEvent());
 
     // Another health check run should move the node to healthy since its
     // metadata layout version matches SCM's.
     nsm.checkNodesHealth();
     assertEquals(NodeState.HEALTHY, nsm.getNodeStatus(dn).getHealth());
-    assertEquals(SCMEvents.HEALTHY_READONLY_TO_HEALTHY_NODE,
-        eventPublisher.getLastEvent());
+    assertEquals(SCMEvents.HEALTHY_READONLY_TO_HEALTHY_NODE, eventPublisher.getLastEvent());
     eventPublisher.clearEvents();
 
     // Test how node state manager handles datanodes with lower metadata
@@ -252,10 +250,8 @@ public class TestNodeStateManager {
       // Datanodes should not be moved to healthy readonly until the SCM has
       // finished updating its metadata layout version as part of finalization.
       if (checkpoint.hasCrossed(FinalizationCheckpoint.MLV_EQUALS_SLV)) {
-        assertEquals(NodeState.HEALTHY_READONLY,
-            nsm.getNodeStatus(dn).getHealth());
-        assertEquals(SCMEvents.HEALTHY_READONLY_NODE,
-            eventPublisher.getLastEvent());
+        assertEquals(NodeState.HEALTHY_READONLY, nsm.getNodeStatus(dn).getHealth());
+        assertEquals(SCMEvents.HEALTHY_READONLY_NODE, eventPublisher.getLastEvent());
       } else {
         assertEquals(NodeState.HEALTHY, nsm.getNodeStatus(dn).getHealth());
         assertNull(eventPublisher.getLastEvent());
@@ -273,8 +269,7 @@ public class TestNodeStateManager {
         HddsProtos.NodeOperationalState.DECOMMISSIONED);
 
     NodeStatus newStatus = nsm.getNodeStatus(dn);
-    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONED,
-        newStatus.getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONED, newStatus.getOperationalState());
     assertEquals(NodeState.HEALTHY, newStatus.getHealth());
   }
 
@@ -313,8 +308,7 @@ public class TestNodeStateManager {
         HddsProtos.NodeOperationalState.values()) {
       eventPublisher.clearEvents();
       nsm.setNodeOperationalState(dn, s);
-      assertEquals(SCMEvents.HEALTHY_READONLY_TO_HEALTHY_NODE,
-          eventPublisher.getLastEvent());
+      assertEquals(SCMEvents.HEALTHY_READONLY_TO_HEALTHY_NODE, eventPublisher.getLastEvent());
     }
 
     // Now make the node stale and run through all states again ensuring the
@@ -381,8 +375,7 @@ public class TestNodeStateManager {
     DatanodeInfo updatedDn = nsm.getNode(dn);
     assertEquals(newIpAddress, updatedDn.getIpAddress());
     assertEquals(newHostName, updatedDn.getHostName());
-    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
-            updatedDn.getPersistedOpState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE, updatedDn.getPersistedOpState());
     assertEquals(NodeStatus.inServiceHealthy(), updatedDn.getNodeStatus());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -80,7 +80,6 @@ import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.test.PathUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -602,8 +601,7 @@ public class TestSCMNodeManager {
       }
       //TODO: wait for heartbeat to be processed
       Thread.sleep(4 * 1000);
-      assertEquals(count, nodeManager.getNodeCount(
-          NodeStatus.inServiceHealthy()));
+      assertEquals(count, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
 
       Map<String, Map<String, Integer>> nodeCounts = nodeManager.getNodeCount();
       assertEquals(count,
@@ -1016,9 +1014,9 @@ public class TestSCMNodeManager {
           new DeleteBlocksCommand(emptyList()));
     }
 
-    Assertions.assertEquals(3, nodeManager.getTotalDatanodeCommandCount(
+    assertEquals(3, nodeManager.getTotalDatanodeCommandCount(
         node1, SCMCommandProto.Type.replicateContainerCommand));
-    Assertions.assertEquals(5, nodeManager.getTotalDatanodeCommandCount(
+    assertEquals(5, nodeManager.getTotalDatanodeCommandCount(
         node1, SCMCommandProto.Type.deleteBlocksCommand));
 
     nodeManager.processHeartbeat(node1, layoutInfo,
@@ -1037,9 +1035,9 @@ public class TestSCMNodeManager {
     assertEquals(5, nodeManager.getNodeQueuedCommandCount(
         node1, SCMCommandProto.Type.deleteBlocksCommand));
 
-    Assertions.assertEquals(126, nodeManager.getTotalDatanodeCommandCount(
+    assertEquals(126, nodeManager.getTotalDatanodeCommandCount(
         node1, SCMCommandProto.Type.replicateContainerCommand));
-    Assertions.assertEquals(5, nodeManager.getTotalDatanodeCommandCount(
+    assertEquals(5, nodeManager.getTotalDatanodeCommandCount(
         node1, SCMCommandProto.Type.deleteBlocksCommand));
 
     ArgumentCaptor<DatanodeDetails> captor =
@@ -1071,17 +1069,17 @@ public class TestSCMNodeManager {
       nodeManager.addDatanodeCommand(node1.getUuid(),
           new CloseContainerCommand(1, PipelineID.randomId()));
     }
-    Assertions.assertEquals(0, nodeManager.getTotalDatanodeCommandCount(
+    assertEquals(0, nodeManager.getTotalDatanodeCommandCount(
         node1, SCMCommandProto.Type.replicateContainerCommand));
-    Assertions.assertEquals(16, nodeManager.getTotalDatanodeCommandCount(
+    assertEquals(16, nodeManager.getTotalDatanodeCommandCount(
         node1, SCMCommandProto.Type.closeContainerCommand));
     Map<SCMCommandProto.Type, Integer> counts =
         nodeManager.getTotalDatanodeCommandCounts(node1,
             SCMCommandProto.Type.replicateContainerCommand,
             SCMCommandProto.Type.closeContainerCommand);
-    Assertions.assertEquals(0,
+    assertEquals(0,
         counts.get(SCMCommandProto.Type.replicateContainerCommand));
-    Assertions.assertEquals(16,
+    assertEquals(16,
         counts.get(SCMCommandProto.Type.closeContainerCommand));
   }
 
@@ -1565,14 +1563,10 @@ public class TestSCMNodeManager {
       //TODO: wait for EventQueue to be processed
       eventQueue.processAll(8000L);
 
-      assertEquals(nodeCount, nodeManager.getNodeCount(
-          NodeStatus.inServiceHealthy()));
-      assertEquals(capacity * nodeCount, (long) nodeManager.getStats()
-          .getCapacity().get());
-      assertEquals(used * nodeCount, (long) nodeManager.getStats()
-          .getScmUsed().get());
-      assertEquals(remaining * nodeCount, (long) nodeManager.getStats()
-          .getRemaining().get());
+      assertEquals(nodeCount, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+      assertEquals(capacity * nodeCount, (long) nodeManager.getStats().getCapacity().get());
+      assertEquals(used * nodeCount, (long) nodeManager.getStats().getScmUsed().get());
+      assertEquals(remaining * nodeCount, (long) nodeManager.getStats().getRemaining().get());
       assertEquals(1, nodeManager.minHealthyVolumeNum(dnList));
       dnList.clear();
     }
@@ -1622,10 +1616,8 @@ public class TestSCMNodeManager {
       //TODO: wait for EventQueue to be processed
       eventQueue.processAll(8000L);
 
-      assertEquals(1, nodeManager
-          .getNodeCount(NodeStatus.inServiceHealthy()));
-      assertEquals(volumeCount / 2,
-          nodeManager.minHealthyVolumeNum(dnList));
+      assertEquals(1, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+      assertEquals(volumeCount / 2, nodeManager.minHealthyVolumeNum(dnList));
       dnList.clear();
     }
   }
@@ -1861,8 +1853,7 @@ public class TestSCMNodeManager {
       // verify network topology cluster has all the registered nodes
       Thread.sleep(4 * 1000);
       NetworkTopology clusterMap = scm.getClusterMap();
-      assertEquals(nodeCount,
-          nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+      assertEquals(nodeCount, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
       assertEquals(nodeCount, clusterMap.getNumOfLeafNode(""));
       assertEquals(4, clusterMap.getMaxLevel());
       List<DatanodeDetails> nodeList = nodeManager.getAllNodes();
@@ -2078,8 +2069,7 @@ public class TestSCMNodeManager {
               nodeUuid, updatedHostName, updatedIpAddress, null);
       nodeManager.register(updatedNode, null, null);
 
-      assertEquals(1,
-              nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+      assertEquals(1, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
       assertEquals(1, clusterMap.getNumOfLeafNode(""));
       assertEquals(4, clusterMap.getMaxLevel());
       List<DatanodeDetails> updatedNodeList = nodeManager.getAllNodes();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -118,14 +118,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -975,7 +975,7 @@ public class TestSCMNodeManager {
       // If the mlv equals slv checkpoint passed, datanodes with older mlvs
       // should be instructed to finalize.
       verify(eventPublisher, times(1))
-          .fireEvent(Mockito.eq(DATANODE_COMMAND), captor.capture());
+          .fireEvent(eq(DATANODE_COMMAND), captor.capture());
       assertEquals(captor.getValue().getDatanodeId(), node1.getUuid());
       assertEquals(captor.getValue().getCommand().getType(),
           finalizeNewLayoutVersionCommand);
@@ -983,7 +983,7 @@ public class TestSCMNodeManager {
       // SCM has not finished finalizing its mlv, so datanodes with older
       // mlvs should not be instructed to finalize yet.
       verify(eventPublisher, times(0))
-          .fireEvent(Mockito.eq(DATANODE_COMMAND), captor.capture());
+          .fireEvent(eq(DATANODE_COMMAND), captor.capture());
     }
   }
 
@@ -1045,7 +1045,7 @@ public class TestSCMNodeManager {
     ArgumentCaptor<DatanodeDetails> captor =
         ArgumentCaptor.forClass(DatanodeDetails.class);
     verify(eventPublisher, times(1))
-        .fireEvent(Mockito.eq(DATANODE_COMMAND_COUNT_UPDATED),
+        .fireEvent(eq(DATANODE_COMMAND_COUNT_UPDATED),
             captor.capture());
     assertEquals(node1, captor.getValue());
 
@@ -1062,7 +1062,7 @@ public class TestSCMNodeManager {
         node1, SCMCommandProto.Type.closeContainerCommand));
 
     verify(eventPublisher, times(2))
-        .fireEvent(Mockito.eq(DATANODE_COMMAND_COUNT_UPDATED),
+        .fireEvent(eq(DATANODE_COMMAND_COUNT_UPDATED),
             captor.capture());
     assertEquals(node1, captor.getValue());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeStorageStatMap.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeStorageStatMap.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +42,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test Node Storage Map.
@@ -88,9 +92,9 @@ public class TestSCMNodeStorageStatMap {
     UUID unknownNode = UUID.randomUUID();
     Set<StorageLocationReport> report = testData.get(knownNode);
     map.insertNewDatanode(knownNode, report);
-    Assertions.assertTrue(map.isKnownDatanode(knownNode),
+    assertTrue(map.isKnownDatanode(knownNode),
         "Not able to detect a known node");
-    Assertions.assertFalse(map.isKnownDatanode(unknownNode),
+    assertFalse(map.isKnownDatanode(unknownNode),
         "Unknown node detected");
   }
 
@@ -100,11 +104,10 @@ public class TestSCMNodeStorageStatMap {
     UUID knownNode = getFirstKey();
     Set<StorageLocationReport> report = testData.get(knownNode);
     map.insertNewDatanode(knownNode, report);
-    Assertions.assertEquals(map.getStorageVolumes(knownNode),
-        testData.get(knownNode));
-    Throwable t = Assertions.assertThrows(SCMException.class,
+    assertEquals(map.getStorageVolumes(knownNode), testData.get(knownNode));
+    Throwable t = assertThrows(SCMException.class,
         () -> map.insertNewDatanode(knownNode, report));
-    Assertions.assertEquals("Node already exists in the map", t.getMessage());
+    assertEquals("Node already exists in the map", t.getMessage());
   }
 
   @Test
@@ -119,9 +122,9 @@ public class TestSCMNodeStorageStatMap {
         .setStorageLocation(path).setScmUsed(used).setRemaining(remaining)
         .setCapacity(capacity).setFailed(false);
     reportSet.add(builder.build());
-    Throwable t = Assertions.assertThrows(SCMException.class,
+    Throwable t = assertThrows(SCMException.class,
         () -> map.updateDatanodeMap(unknownNode, reportSet));
-    Assertions.assertEquals("No such datanode", t.getMessage());
+    assertEquals("No such datanode", t.getMessage());
   }
 
   @Test
@@ -131,7 +134,7 @@ public class TestSCMNodeStorageStatMap {
     Set<StorageLocationReport> reportSet = testData.get(key);
     SCMNodeStorageStatMap map = new SCMNodeStorageStatMap(conf);
     map.insertNewDatanode(key, reportSet);
-    Assertions.assertTrue(map.isKnownDatanode(key));
+    assertTrue(map.isKnownDatanode(key));
     UUID storageId = UUID.randomUUID();
     String path =
         GenericTestUtils.getRandomizedTempPath().concat("/" + storageId);
@@ -145,25 +148,21 @@ public class TestSCMNodeStorageStatMap {
     StorageReportResult result =
         map.processNodeReport(key, HddsTestUtils.createNodeReport(
             Arrays.asList(storageReport), Collections.emptyList()));
-    Assertions.assertEquals(SCMNodeStorageStatMap.ReportStatus.ALL_IS_WELL,
-        result.getStatus());
+    assertEquals(SCMNodeStorageStatMap.ReportStatus.ALL_IS_WELL, result.getStatus());
     StorageContainerDatanodeProtocolProtos.NodeReportProto.Builder nrb =
         NodeReportProto.newBuilder();
     StorageReportProto srb = reportSet.iterator().next().getProtoBufMessage();
     reportList.add(srb);
     result = map.processNodeReport(key, HddsTestUtils.createNodeReport(
         reportList, Collections.emptyList()));
-    Assertions.assertEquals(SCMNodeStorageStatMap.ReportStatus.ALL_IS_WELL,
-        result.getStatus());
+    assertEquals(SCMNodeStorageStatMap.ReportStatus.ALL_IS_WELL, result.getStatus());
 
     reportList.add(HddsTestUtils
         .createStorageReport(UUID.randomUUID(), path, reportCapacity,
             reportCapacity, 0, null));
     result = map.processNodeReport(key, HddsTestUtils.createNodeReport(
         reportList, Collections.emptyList()));
-    Assertions.assertEquals(
-        SCMNodeStorageStatMap.ReportStatus.STORAGE_OUT_OF_SPACE,
-        result.getStatus());
+    assertEquals(SCMNodeStorageStatMap.ReportStatus.STORAGE_OUT_OF_SPACE, result.getStatus());
     // Mark a disk failed 
     StorageReportProto srb2 = StorageReportProto.newBuilder()
         .setStorageUuid(UUID.randomUUID().toString())
@@ -172,8 +171,7 @@ public class TestSCMNodeStorageStatMap {
     reportList.add(srb2);
     nrb.addAllStorageReport(reportList);
     result = map.processNodeReport(key, nrb.addStorageReport(srb).build());
-    Assertions.assertEquals(SCMNodeStorageStatMap.ReportStatus
-        .FAILED_AND_OUT_OF_SPACE_STORAGE, result.getStatus());
+    assertEquals(SCMNodeStorageStatMap.ReportStatus.FAILED_AND_OUT_OF_SPACE_STORAGE, result.getStatus());
 
   }
 
@@ -186,10 +184,9 @@ public class TestSCMNodeStorageStatMap {
         .entrySet()) {
       map.insertNewDatanode(keyEntry.getKey(), keyEntry.getValue());
     }
-    Assertions.assertEquals(DATANODE_COUNT * capacity, map.getTotalCapacity());
-    Assertions.assertEquals(DATANODE_COUNT * remaining,
-        map.getTotalFreeSpace());
-    Assertions.assertEquals(DATANODE_COUNT * used, map.getTotalSpaceUsed());
+    assertEquals(DATANODE_COUNT * capacity, map.getTotalCapacity());
+    assertEquals(DATANODE_COUNT * remaining, map.getTotalFreeSpace());
+    assertEquals(DATANODE_COUNT * used, map.getTotalSpaceUsed());
 
     // update 1/4th of the datanode to be full
     for (Map.Entry<UUID, Set<StorageLocationReport>> keyEntry : testData
@@ -212,22 +209,16 @@ public class TestSCMNodeStorageStatMap {
         break;
       }
     }
-    Assertions.assertEquals(DATANODE_COUNT / 4,
-        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.CRITICAL)
-            .size());
-    Assertions.assertEquals(0,
-        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.WARN)
-            .size());
-    Assertions.assertEquals(0.75 * DATANODE_COUNT,
-        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.NORMAL)
-            .size(), 0);
+    assertEquals(DATANODE_COUNT / 4,
+        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.CRITICAL).size());
+    assertEquals(0,
+        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.WARN).size());
+    assertEquals(0.75 * DATANODE_COUNT,
+        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.NORMAL).size(), 0);
 
-    Assertions.assertEquals(DATANODE_COUNT * capacity,
-        map.getTotalCapacity(), 0);
-    Assertions.assertEquals(0.75 * DATANODE_COUNT * remaining,
-        map.getTotalFreeSpace(), 0);
-    Assertions.assertEquals(
-        0.75 * DATANODE_COUNT * used + (0.25 * DATANODE_COUNT * capacity),
+    assertEquals(DATANODE_COUNT * capacity, map.getTotalCapacity(), 0);
+    assertEquals(0.75 * DATANODE_COUNT * remaining, map.getTotalFreeSpace(), 0);
+    assertEquals(0.75 * DATANODE_COUNT * used + (0.25 * DATANODE_COUNT * capacity),
         map.getTotalSpaceUsed(), 0);
     counter = 1;
     // Remove 1/4 of the DataNodes from the Map
@@ -240,22 +231,14 @@ public class TestSCMNodeStorageStatMap {
       }
     }
 
-    Assertions.assertEquals(0,
-        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.CRITICAL)
-            .size());
-    Assertions.assertEquals(0,
-        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.WARN)
-            .size());
-    Assertions.assertEquals(0.75 * DATANODE_COUNT,
-        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.NORMAL)
-            .size(), 0);
+    assertEquals(0, map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.CRITICAL).size());
+    assertEquals(0, map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.WARN).size());
+    assertEquals(0.75 * DATANODE_COUNT,
+        map.getDatanodeList(SCMNodeStorageStatMap.UtilizationThreshold.NORMAL).size(), 0);
 
-    Assertions.assertEquals(0.75 * DATANODE_COUNT * capacity,
-        map.getTotalCapacity(), 0);
-    Assertions.assertEquals(0.75 * DATANODE_COUNT * remaining,
-        map.getTotalFreeSpace(), 0);
-    Assertions.assertEquals(0.75 * DATANODE_COUNT * used,
-        map.getTotalSpaceUsed(), 0);
+    assertEquals(0.75 * DATANODE_COUNT * capacity, map.getTotalCapacity(), 0);
+    assertEquals(0.75 * DATANODE_COUNT * remaining, map.getTotalFreeSpace(), 0);
+    assertEquals(0.75 * DATANODE_COUNT * used, map.getTotalSpaceUsed(), 0);
 
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -53,6 +52,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Verifies the statics in NodeManager.
@@ -111,14 +111,14 @@ public class TestStatisticsUpdate {
         mock(EventPublisher.class));
 
     SCMNodeStat stat = nodeManager.getStats();
-    Assertions.assertEquals(300L, stat.getCapacity().get());
-    Assertions.assertEquals(270L, stat.getRemaining().get());
-    Assertions.assertEquals(30L, stat.getScmUsed().get());
+    assertEquals(300L, stat.getCapacity().get());
+    assertEquals(270L, stat.getRemaining().get());
+    assertEquals(30L, stat.getScmUsed().get());
 
     SCMNodeMetric nodeStat = nodeManager.getNodeStat(datanode1);
-    Assertions.assertEquals(100L, nodeStat.get().getCapacity().get());
-    Assertions.assertEquals(90L, nodeStat.get().getRemaining().get());
-    Assertions.assertEquals(10L, nodeStat.get().getScmUsed().get());
+    assertEquals(100L, nodeStat.get().getCapacity().get());
+    assertEquals(90L, nodeStat.get().getRemaining().get());
+    assertEquals(10L, nodeStat.get().getScmUsed().get());
 
     //TODO: Support logic to mark a node as dead in NodeManager.
 
@@ -137,10 +137,9 @@ public class TestStatisticsUpdate {
     nodeManager.processHeartbeat(datanode2, layoutInfo);
     //THEN statistics in SCM should changed.
     stat = nodeManager.getStats();
-    Assertions.assertEquals(200L, stat.getCapacity().get());
-    Assertions.assertEquals(180L,
-        stat.getRemaining().get());
-    Assertions.assertEquals(20L, stat.getScmUsed().get());
+    assertEquals(200L, stat.getCapacity().get());
+    assertEquals(180L, stat.getRemaining().get());
+    assertEquals(20L, stat.getScmUsed().get());
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
@@ -41,18 +41,18 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
-import org.apache.hadoop.security.authentication.client
-    .AuthenticationException;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Verifies the statics in NodeManager.
@@ -74,7 +74,7 @@ public class TestStatisticsUpdate {
     final StorageContainerManager scm = HddsTestUtils.getScm(conf);
     nodeManager = scm.getScmNodeManager();
     final DeadNodeHandler deadNodeHandler = new DeadNodeHandler(
-        nodeManager, Mockito.mock(PipelineManager.class),
+        nodeManager, mock(PipelineManager.class),
         scm.getContainerManager());
     eventQueue.addHandler(SCMEvents.DEAD_NODE, deadNodeHandler);
     nodeReportHandler = new NodeReportHandler(nodeManager);
@@ -105,10 +105,10 @@ public class TestStatisticsUpdate {
 
     nodeReportHandler.onMessage(
         new NodeReportFromDatanode(datanode1, nodeReportProto1),
-        Mockito.mock(EventPublisher.class));
+        mock(EventPublisher.class));
     nodeReportHandler.onMessage(
         new NodeReportFromDatanode(datanode2, nodeReportProto2),
-        Mockito.mock(EventPublisher.class));
+        mock(EventPublisher.class));
 
     SCMNodeStat stat = nodeManager.getStats();
     Assertions.assertEquals(300L, stat.getCapacity().get());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/states/TestNode2ContainerMap.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/states/TestNode2ContainerMap.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.scm.node.states;
 
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +30,11 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test classes for Node2ContainerMap.
@@ -68,9 +72,9 @@ public class TestNode2ContainerMap {
     UUID unknownNode = UUID.randomUUID();
     Set<ContainerID> containerIDs = testData.get(knownNode);
     map.insertNewDatanode(knownNode, containerIDs);
-    Assertions.assertTrue(map.isKnownDatanode(knownNode),
+    assertTrue(map.isKnownDatanode(knownNode),
         "Not able to detect a known node");
-    Assertions.assertFalse(map.isKnownDatanode(unknownNode),
+    assertFalse(map.isKnownDatanode(unknownNode),
         "Unknown node detected");
   }
 
@@ -85,12 +89,12 @@ public class TestNode2ContainerMap {
     // Assert that all elements are present in the set that we read back from
     // node map.
     Set newSet = new TreeSet((readSet));
-    Assertions.assertTrue(newSet.removeAll(containerIDs));
-    Assertions.assertEquals(0, newSet.size());
+    assertTrue(newSet.removeAll(containerIDs));
+    assertEquals(0, newSet.size());
 
-    Throwable t = Assertions.assertThrows(SCMException.class,
+    Throwable t = assertThrows(SCMException.class,
         () -> map.insertNewDatanode(knownNode, containerIDs));
-    Assertions.assertEquals("Node already exists in the map", t.getMessage());
+    assertEquals("Node already exists in the map", t.getMessage());
 
     map.removeDatanode(knownNode);
     map.insertNewDatanode(knownNode, containerIDs);
@@ -103,10 +107,9 @@ public class TestNode2ContainerMap {
     Set<ContainerID> values = testData.get(key);
     Node2ContainerMap map = new Node2ContainerMap();
     map.insertNewDatanode(key, values);
-    Assertions.assertTrue(map.isKnownDatanode(key));
+    assertTrue(map.isKnownDatanode(key));
     ReportResult result = map.processReport(key, values);
-    Assertions.assertEquals(ReportResult.ReportStatus.ALL_IS_WELL,
-        result.getStatus());
+    assertEquals(ReportResult.ReportStatus.ALL_IS_WELL, result.getStatus());
   }
 
   @Test
@@ -115,22 +118,19 @@ public class TestNode2ContainerMap {
     Set<ContainerID> values = testData.get(datanodeId);
     Node2ContainerMap map = new Node2ContainerMap();
     map.insertNewDatanode(datanodeId, values);
-    Assertions.assertTrue(map.isKnownDatanode(datanodeId));
-    Assertions.assertEquals(CONTAINER_COUNT,
+    assertTrue(map.isKnownDatanode(datanodeId));
+    assertEquals(CONTAINER_COUNT,
         map.getContainers(datanodeId).size());
 
     //remove one container
     values.remove(values.iterator().next());
-    Assertions.assertEquals(CONTAINER_COUNT - 1,
-        values.size());
-    Assertions.assertEquals(CONTAINER_COUNT,
-        map.getContainers(datanodeId).size());
+    assertEquals(CONTAINER_COUNT - 1, values.size());
+    assertEquals(CONTAINER_COUNT, map.getContainers(datanodeId).size());
 
     map.setContainersForDatanode(datanodeId, values);
 
-    Assertions.assertEquals(values.size(),
-        map.getContainers(datanodeId).size());
-    Assertions.assertEquals(values, map.getContainers(datanodeId));
+    assertEquals(values.size(), map.getContainers(datanodeId).size());
+    assertEquals(values, map.getContainers(datanodeId));
   }
 
   @Test
@@ -142,7 +142,7 @@ public class TestNode2ContainerMap {
     }
     // Assert all Keys are known datanodes.
     for (UUID key : testData.keySet()) {
-      Assertions.assertTrue(map.isKnownDatanode(key));
+      assertTrue(map.isKnownDatanode(key));
     }
   }
 
@@ -175,9 +175,8 @@ public class TestNode2ContainerMap {
     UUID key = getFirstKey();
     TreeSet<ContainerID> values = testData.get(key);
     ReportResult result = map.processReport(key, values);
-    Assertions.assertEquals(ReportResult.ReportStatus.NEW_DATANODE_FOUND,
-        result.getStatus());
-    Assertions.assertEquals(result.getNewEntries().size(), values.size());
+    assertEquals(ReportResult.ReportStatus.NEW_DATANODE_FOUND, result.getStatus());
+    assertEquals(result.getNewEntries().size(), values.size());
   }
 
   /**
@@ -210,14 +209,12 @@ public class TestNode2ContainerMap {
     ReportResult result = map.processReport(key, newContainersSet);
 
     //Assert that expected size of missing container is same as addedContainers
-    Assertions.assertEquals(ReportResult.ReportStatus.NEW_ENTRIES_FOUND,
-        result.getStatus());
+    assertEquals(ReportResult.ReportStatus.NEW_ENTRIES_FOUND, result.getStatus());
 
-    Assertions.assertEquals(addedContainers.size(),
-        result.getNewEntries().size());
+    assertEquals(addedContainers.size(), result.getNewEntries().size());
 
     // Assert that the Container IDs are the same as we added new.
-    Assertions.assertTrue(result.getNewEntries().removeAll(addedContainers),
+    assertTrue(result.getNewEntries().removeAll(addedContainers),
         "All objects are not removed.");
   }
 
@@ -255,13 +252,11 @@ public class TestNode2ContainerMap {
 
 
     //Assert that expected size of missing container is same as addedContainers
-    Assertions.assertEquals(ReportResult.ReportStatus.MISSING_ENTRIES,
-        result.getStatus());
-    Assertions.assertEquals(removedContainers.size(),
-        result.getMissingEntries().size());
+    assertEquals(ReportResult.ReportStatus.MISSING_ENTRIES, result.getStatus());
+    assertEquals(removedContainers.size(), result.getMissingEntries().size());
 
     // Assert that the Container IDs are the same as we added new.
-    Assertions.assertTrue(
+    assertTrue(
         result.getMissingEntries().removeAll(removedContainers),
         "All missing containers not found.");
   }
@@ -301,23 +296,16 @@ public class TestNode2ContainerMap {
     ReportResult result = map.processReport(key, newSet);
 
 
-    Assertions.assertEquals(
-            ReportResult.ReportStatus.MISSING_AND_NEW_ENTRIES_FOUND,
-        result.getStatus());
-    Assertions.assertEquals(removedContainers.size(),
-        result.getMissingEntries().size());
+    assertEquals(ReportResult.ReportStatus.MISSING_AND_NEW_ENTRIES_FOUND, result.getStatus());
+    assertEquals(removedContainers.size(), result.getMissingEntries().size());
 
 
     // Assert that the Container IDs are the same as we added new.
-    Assertions.assertTrue(
-        result.getMissingEntries().removeAll(removedContainers),
-        "All missing containers not found.");
+    assertTrue(result.getMissingEntries().removeAll(removedContainers), "All missing containers not found.");
 
-    Assertions.assertEquals(insertedSet.size(),
-        result.getNewEntries().size());
+    assertEquals(insertedSet.size(), result.getNewEntries().size());
 
     // Assert that the Container IDs are the same as we added new.
-    Assertions.assertTrue(result.getNewEntries().removeAll(insertedSet),
-        "All inserted containers are not found.");
+    assertTrue(result.getNewEntries().removeAll(insertedSet), "All inserted containers are not found.");
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,8 +53,12 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.E
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.ALLOCATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test for the ECPipelineProvider.
@@ -64,10 +67,10 @@ public class TestECPipelineProvider {
 
   private PipelineProvider provider;
   private OzoneConfiguration conf;
-  private NodeManager nodeManager = Mockito.mock(NodeManager.class);
+  private NodeManager nodeManager = mock(NodeManager.class);
   private PipelineStateManager stateManager =
-      Mockito.mock(PipelineStateManager.class);
-  private PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
+      mock(PipelineStateManager.class);
+  private PlacementPolicy placementPolicy = mock(PlacementPolicy.class);
   private long containerSizeBytes;
   @BeforeEach
   public void setup() throws IOException, NodeNotFoundException {
@@ -79,9 +82,9 @@ public class TestECPipelineProvider {
         ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT,
         StorageUnit.BYTES);
     // Placement policy will always return EC number of random nodes.
-    when(placementPolicy.chooseDatanodes(Mockito.anyList(),
-        Mockito.anyList(), Mockito.anyInt(), Mockito.anyLong(),
-        Mockito.anyLong()))
+    when(placementPolicy.chooseDatanodes(anyList(),
+        anyList(), anyInt(), anyLong(),
+        anyLong()))
         .thenAnswer(invocation -> {
           List<DatanodeDetails> dns = new ArrayList<>();
           for (int i = 0; i < (int) invocation.getArguments()[2]; i++) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +51,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.ALLOCATED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -102,14 +103,13 @@ public class TestECPipelineProvider {
   public void testSimplePipelineCanBeCreatedWithIndexes() throws IOException {
     ECReplicationConfig ecConf = new ECReplicationConfig(3, 2);
     Pipeline pipeline = provider.create(ecConf);
-    Assertions.assertEquals(EC, pipeline.getType());
-    Assertions.assertEquals(ecConf.getData() + ecConf.getParity(),
-        pipeline.getNodes().size());
-    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    assertEquals(EC, pipeline.getType());
+    assertEquals(ecConf.getData() + ecConf.getParity(), pipeline.getNodes().size());
+    assertEquals(ALLOCATED, pipeline.getPipelineState());
     List<DatanodeDetails> dns = pipeline.getNodes();
     for (int i = 0; i < ecConf.getRequiredNodes(); i++) {
       // EC DN indexes are numbered starting from 1 to N.
-      Assertions.assertEquals(i + 1, pipeline.getReplicaIndex(dns.get(i)));
+      assertEquals(i + 1, pipeline.getReplicaIndex(dns.get(i)));
     }
   }
 
@@ -120,11 +120,11 @@ public class TestECPipelineProvider {
     Set<ContainerReplica> replicas = createContainerReplicas(4);
     Pipeline pipeline = provider.createForRead(ecConf, replicas);
 
-    Assertions.assertEquals(EC, pipeline.getType());
-    Assertions.assertEquals(4, pipeline.getNodes().size());
-    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    assertEquals(EC, pipeline.getType());
+    assertEquals(4, pipeline.getNodes().size());
+    assertEquals(ALLOCATED, pipeline.getPipelineState());
     for (ContainerReplica r : replicas) {
-      Assertions.assertEquals(r.getReplicaIndex(),
+      assertEquals(r.getReplicaIndex(),
           pipeline.getReplicaIndex(r.getDatanodeDetails()));
     }
   }
@@ -149,7 +149,7 @@ public class TestECPipelineProvider {
     Pipeline pipeline = provider.createForRead(ecConf, replicas);
 
     List<DatanodeDetails> nodes = pipeline.getNodes();
-    Assertions.assertEquals(replicas.size() - deadNodes.size(), nodes.size());
+    assertEquals(replicas.size() - deadNodes.size(), nodes.size());
     for (DatanodeDetails d : deadNodes) {
       assertThat(nodes).doesNotContain(d);
     }
@@ -182,10 +182,10 @@ public class TestECPipelineProvider {
     Pipeline pipeline = provider.createForRead(ecConf, replicas);
 
     List<DatanodeDetails> nodes = pipeline.getNodes();
-    Assertions.assertEquals(replicas.size(), nodes.size());
-    Assertions.assertEquals(healthyNodes, new HashSet<>(nodes.subList(0, 5)));
-    Assertions.assertEquals(decomNodes, new HashSet<>(nodes.subList(5, 10)));
-    Assertions.assertEquals(staleNodes, new HashSet<>(nodes.subList(10, 15)));
+    assertEquals(replicas.size(), nodes.size());
+    assertEquals(healthyNodes, new HashSet<>(nodes.subList(0, 5)));
+    assertEquals(decomNodes, new HashSet<>(nodes.subList(5, 10)));
+    assertEquals(staleNodes, new HashSet<>(nodes.subList(10, 15)));
   }
 
   @Test
@@ -200,9 +200,8 @@ public class TestECPipelineProvider {
     favoredNodes.add(MockDatanodeDetails.randomDatanodeDetails());
 
     Pipeline pipeline = provider.create(ecConf, excludedNodes, favoredNodes);
-    Assertions.assertEquals(EC, pipeline.getType());
-    Assertions.assertEquals(ecConf.getData() + ecConf.getParity(),
-        pipeline.getNodes().size());
+    assertEquals(EC, pipeline.getType());
+    assertEquals(ecConf.getData() + ecConf.getParity(), pipeline.getNodes().size());
 
     verify(placementPolicy).chooseDatanodes(excludedNodes, favoredNodes,
         ecConf.getRequiredNodes(), 0, containerSizeBytes);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -52,7 +52,6 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.E
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.ALLOCATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineActionHandler.java
@@ -28,9 +28,14 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.Pipeline
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
 
 /**
  * Test-cases to verify the functionality of PipelineActionHandler.
@@ -41,23 +46,22 @@ public class TestPipelineActionHandler {
   @Test
   public void testPipelineActionHandlerForValidPipeline() throws IOException {
 
-    final PipelineManager manager = Mockito.mock(PipelineManager.class);
-    final EventQueue queue = Mockito.mock(EventQueue.class);
+    final PipelineManager manager = mock(PipelineManager.class);
+    final EventQueue queue = mock(EventQueue.class);
     final PipelineActionHandler actionHandler = new PipelineActionHandler(
         manager, SCMContext.emptyContext(), null);
     final Pipeline pipeline = HddsTestUtils.getRandomPipeline();
 
     actionHandler.onMessage(getPipelineActionsFromDatanode(
         pipeline.getId()), queue);
-    Mockito.verify(manager, Mockito.times(1))
-        .closePipeline(pipeline.getId());
+    verify(manager, times(1)).closePipeline(pipeline.getId());
   }
 
   @Test
   public void testPipelineActionHandlerForValidPipelineInFollower()
       throws IOException {
-    final PipelineManager manager = Mockito.mock(PipelineManager.class);
-    final EventQueue queue = Mockito.mock(EventQueue.class);
+    final PipelineManager manager = mock(PipelineManager.class);
+    final EventQueue queue = mock(EventQueue.class);
     final SCMContext context = SCMContext.emptyContext();
     final PipelineActionHandler actionHandler = new PipelineActionHandler(
         manager, context, null);
@@ -66,49 +70,45 @@ public class TestPipelineActionHandler {
     context.updateLeaderAndTerm(false, 1);
     actionHandler.onMessage(getPipelineActionsFromDatanode(
         pipeline.getId()), queue);
-    Mockito.verify(manager, Mockito.times(0))
-        .closePipeline(pipeline.getId());
-    Mockito.verify(queue, Mockito.times(0))
-        .fireEvent(Mockito.eq(SCMEvents.DATANODE_COMMAND),
-            Mockito.any(CommandForDatanode.class));
+    verify(manager, times(0)).closePipeline(pipeline.getId());
+    verify(queue, times(0)).fireEvent(eq(SCMEvents.DATANODE_COMMAND),
+        any(CommandForDatanode.class));
   }
 
   @Test
   public void testPipelineActionHandlerForUnknownPipeline() throws IOException {
-    final PipelineManager manager = Mockito.mock(PipelineManager.class);
-    final EventQueue queue = Mockito.mock(EventQueue.class);
+    final PipelineManager manager = mock(PipelineManager.class);
+    final EventQueue queue = mock(EventQueue.class);
     final PipelineActionHandler actionHandler = new PipelineActionHandler(
         manager, SCMContext.emptyContext(), null);
     final Pipeline pipeline = HddsTestUtils.getRandomPipeline();
 
-    Mockito.doThrow(new PipelineNotFoundException())
+    doThrow(new PipelineNotFoundException())
         .when(manager).closePipeline(pipeline.getId());
     actionHandler.onMessage(getPipelineActionsFromDatanode(
         pipeline.getId()), queue);
-    Mockito.verify(queue, Mockito.times(1))
-        .fireEvent(Mockito.eq(SCMEvents.DATANODE_COMMAND),
-            Mockito.any(CommandForDatanode.class));
+    verify(queue, times(1)).fireEvent(eq(SCMEvents.DATANODE_COMMAND),
+        any(CommandForDatanode.class));
   }
 
   @Test
   public void testPipelineActionHandlerForUnknownPipelineInFollower()
       throws IOException {
 
-    final PipelineManager manager = Mockito.mock(PipelineManager.class);
-    final EventQueue queue = Mockito.mock(EventQueue.class);
+    final PipelineManager manager = mock(PipelineManager.class);
+    final EventQueue queue = mock(EventQueue.class);
     final SCMContext context = SCMContext.emptyContext();
     final PipelineActionHandler actionHandler = new PipelineActionHandler(
         manager, context, null);
     final Pipeline pipeline = HddsTestUtils.getRandomPipeline();
 
     context.updateLeaderAndTerm(false, 1);
-    Mockito.doThrow(new PipelineNotFoundException())
+    doThrow(new PipelineNotFoundException())
         .when(manager).closePipeline(pipeline.getId());
     actionHandler.onMessage(getPipelineActionsFromDatanode(
         pipeline.getId()), queue);
-    Mockito.verify(queue, Mockito.times(0))
-        .fireEvent(Mockito.eq(SCMEvents.DATANODE_COMMAND),
-            Mockito.any(CommandForDatanode.class));
+    verify(queue, times(0)).fireEvent(eq(SCMEvents.DATANODE_COMMAND),
+        any(CommandForDatanode.class));
 
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -49,6 +48,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE;
 
@@ -148,7 +148,7 @@ public class TestPipelineDatanodesIntersection {
       } catch (IOException e) {
         end = true;
         // Should not throw regular IOException.
-        Assertions.fail();
+        fail();
       }
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -61,7 +61,6 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.util.function.CheckedRunnable;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -94,8 +93,12 @@ import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.ratis.util.Preconditions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.any;
@@ -185,24 +188,24 @@ public class TestPipelineManagerImpl {
         new SCMHADBTransactionBufferStub(dbStore);
     PipelineManagerImpl pipelineManager =
         createPipelineManager(true, buffer1);
-    Assertions.assertTrue(pipelineManager.getPipelines().isEmpty());
+    assertTrue(pipelineManager.getPipelines().isEmpty());
     Pipeline pipeline1 = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
-    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
-    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline1.getId()));
+    assertEquals(1, pipelineManager.getPipelines().size());
+    assertTrue(pipelineManager.containsPipeline(pipeline1.getId()));
 
     Pipeline pipeline2 = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.ONE));
-    Assertions.assertEquals(2, pipelineManager.getPipelines().size());
-    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
+    assertEquals(2, pipelineManager.getPipelines().size());
+    assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
 
     Pipeline builtPipeline = pipelineManager.buildECPipeline(
         new ECReplicationConfig(3, 2),
         Collections.emptyList(), Collections.emptyList());
     pipelineManager.addEcPipeline(builtPipeline);
 
-    Assertions.assertEquals(3, pipelineManager.getPipelines().size());
-    Assertions.assertTrue(pipelineManager.containsPipeline(
+    assertEquals(3, pipelineManager.getPipelines().size());
+    assertTrue(pipelineManager.containsPipeline(
         builtPipeline.getId()));
 
     buffer1.close();
@@ -213,13 +216,13 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager2 =
         createPipelineManager(true, buffer2);
     // Should be able to load previous pipelines.
-    Assertions.assertFalse(pipelineManager2.getPipelines().isEmpty());
-    Assertions.assertEquals(3, pipelineManager.getPipelines().size());
+    assertFalse(pipelineManager2.getPipelines().isEmpty());
+    assertEquals(3, pipelineManager.getPipelines().size());
     Pipeline pipeline3 = pipelineManager2.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     buffer2.close();
-    Assertions.assertEquals(4, pipelineManager2.getPipelines().size());
-    Assertions.assertTrue(pipelineManager2.containsPipeline(pipeline3.getId()));
+    assertEquals(4, pipelineManager2.getPipelines().size());
+    assertTrue(pipelineManager2.containsPipeline(pipeline3.getId()));
 
     pipelineManager2.close();
   }
@@ -227,7 +230,7 @@ public class TestPipelineManagerImpl {
   @Test
   public void testCreatePipelineShouldFailOnFollower() throws Exception {
     try (PipelineManager pipelineManager = createPipelineManager(false)) {
-      Assertions.assertTrue(pipelineManager.getPipelines().isEmpty());
+      assertTrue(pipelineManager.getPipelines().isEmpty());
       assertFailsNotLeader(() -> pipelineManager.createPipeline(
               RatisReplicationConfig.getInstance(ReplicationFactor.THREE)));
     }
@@ -242,43 +245,40 @@ public class TestPipelineManagerImpl {
         SCMDBDefinition.PIPELINES.getTable(dbStore);
     Pipeline pipeline = assertAllocate(pipelineManager);
     buffer.flush();
-    Assertions.assertEquals(ALLOCATED,
-        pipelineStore.get(pipeline.getId()).getPipelineState());
+    assertEquals(ALLOCATED, pipelineStore.get(pipeline.getId()).getPipelineState());
     PipelineID pipelineID = pipeline.getId();
 
     pipelineManager.openPipeline(pipelineID);
     pipelineManager.addContainerToPipeline(pipelineID, ContainerID.valueOf(1));
-    Assertions.assertTrue(pipelineManager
+    assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
     buffer.flush();
-    Assertions.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
+    assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
 
     pipelineManager.deactivatePipeline(pipeline.getId());
-    Assertions.assertEquals(Pipeline.PipelineState.DORMANT,
-        pipelineManager.getPipeline(pipelineID).getPipelineState());
+    assertEquals(Pipeline.PipelineState.DORMANT, pipelineManager.getPipeline(pipelineID).getPipelineState());
     buffer.flush();
-    Assertions.assertEquals(Pipeline.PipelineState.DORMANT,
-        pipelineStore.get(pipeline.getId()).getPipelineState());
-    Assertions.assertFalse(pipelineManager
+    assertEquals(Pipeline.PipelineState.DORMANT, pipelineStore.get(pipeline.getId()).getPipelineState());
+    assertFalse(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
-    Assertions.assertEquals(1, pipelineManager.getPipelineCount(
+    assertEquals(1, pipelineManager.getPipelineCount(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.DORMANT));
 
     pipelineManager.activatePipeline(pipeline.getId());
-    Assertions.assertTrue(pipelineManager
+    assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
-    Assertions.assertEquals(1, pipelineManager.getPipelineCount(
+    assertEquals(1, pipelineManager.getPipelineCount(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN));
     buffer.flush();
-    Assertions.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
+    assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
     pipelineManager.close();
   }
 
@@ -307,7 +307,7 @@ public class TestPipelineManagerImpl {
     try (PipelineManagerImpl pipelineManager = createPipelineManager(true)) {
       Pipeline pipeline = assertAllocate(pipelineManager);
       changeToFollower(pipelineManager);
-      Assertions.assertThrows(SCMException.class,
+      assertThrows(SCMException.class,
           () -> pipelineManager.deactivatePipeline(pipeline.getId()));
     }
   }
@@ -328,7 +328,7 @@ public class TestPipelineManagerImpl {
           addContainer(containerInfo.getProtobuf());
       //Add Container to PipelineStateMap
       pipelineManager.addContainerToPipeline(pipeline.getId(), containerID);
-      Assertions.assertTrue(pipelineManager
+      assertTrue(pipelineManager
           .getPipelines(RatisReplicationConfig
                   .getInstance(ReplicationFactor.THREE),
               Pipeline.PipelineState.OPEN).contains(pipeline));
@@ -338,9 +338,9 @@ public class TestPipelineManagerImpl {
         fail();
       } catch (IOException ioe) {
         // Should not be able to remove the OPEN pipeline.
-        Assertions.assertEquals(1, pipelineManager.getPipelines().size());
+        assertEquals(1, pipelineManager.getPipelines().size());
       } catch (Exception e) {
-        Assertions.fail("Should not reach here.");
+        fail("Should not reach here.");
       }
 
       // Destroy pipeline
@@ -379,7 +379,7 @@ public class TestPipelineManagerImpl {
 
       // pipeline is not healthy until all dns report
       List<DatanodeDetails> nodes = pipeline.getNodes();
-      Assertions.assertFalse(
+      assertFalse(
           pipelineManager.getPipeline(pipeline.getId()).isHealthy());
       // get pipeline report from each dn in the pipeline
       PipelineReportHandler pipelineReportHandler =
@@ -391,10 +391,10 @@ public class TestPipelineManagerImpl {
           pipelineReportHandler, true);
 
       // pipeline is healthy when all dns report
-      Assertions.assertTrue(
+      assertTrue(
           pipelineManager.getPipeline(pipeline.getId()).isHealthy());
       // pipeline should now move to open state
-      Assertions.assertTrue(
+      assertTrue(
           pipelineManager.getPipeline(pipeline.getId()).isOpen());
 
       // close the pipeline
@@ -421,7 +421,7 @@ public class TestPipelineManagerImpl {
         SCMPipelineMetrics.class.getSimpleName());
     long numPipelineAllocated = getLongCounter("NumPipelineAllocated",
         metrics);
-    Assertions.assertEquals(0, numPipelineAllocated);
+    assertEquals(0, numPipelineAllocated);
 
     // 3 DNs are unhealthy.
     // Create 5 pipelines (Use up 15 Datanodes)
@@ -430,17 +430,17 @@ public class TestPipelineManagerImpl {
       Pipeline pipeline = pipelineManager
           .createPipeline(RatisReplicationConfig
               .getInstance(ReplicationFactor.THREE));
-      Assertions.assertNotNull(pipeline);
+      assertNotNull(pipeline);
     }
 
     metrics = getMetrics(
         SCMPipelineMetrics.class.getSimpleName());
     numPipelineAllocated = getLongCounter("NumPipelineAllocated", metrics);
-    Assertions.assertEquals(maxPipelineCount, numPipelineAllocated);
+    assertEquals(maxPipelineCount, numPipelineAllocated);
 
     long numPipelineCreateFailed = getLongCounter(
         "NumPipelineCreationFailed", metrics);
-    Assertions.assertEquals(0, numPipelineCreateFailed);
+    assertEquals(0, numPipelineCreateFailed);
 
     //This should fail...
     try {
@@ -450,7 +450,7 @@ public class TestPipelineManagerImpl {
       fail();
     } catch (SCMException ioe) {
       // pipeline creation failed this time.
-      Assertions.assertEquals(
+      assertEquals(
           ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
           ioe.getResult());
     }
@@ -458,11 +458,11 @@ public class TestPipelineManagerImpl {
     metrics = getMetrics(
         SCMPipelineMetrics.class.getSimpleName());
     numPipelineAllocated = getLongCounter("NumPipelineAllocated", metrics);
-    Assertions.assertEquals(maxPipelineCount, numPipelineAllocated);
+    assertEquals(maxPipelineCount, numPipelineAllocated);
 
     numPipelineCreateFailed = getLongCounter(
         "NumPipelineCreationFailed", metrics);
-    Assertions.assertEquals(1, numPipelineCreateFailed);
+    assertEquals(1, numPipelineCreateFailed);
 
     // clean up
     pipelineManager.close();
@@ -483,7 +483,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.close();
     // new pipeline manager loads the pipelines from the db in ALLOCATED state
     pipelineManager = createPipelineManager(true);
-    Assertions.assertEquals(Pipeline.PipelineState.ALLOCATED,
+    assertEquals(Pipeline.PipelineState.ALLOCATED,
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     SCMSafeModeManager scmSafeModeManager =
@@ -496,12 +496,12 @@ public class TestPipelineManagerImpl {
 
     // Report pipelines with leaders
     List<DatanodeDetails> nodes = pipeline.getNodes();
-    Assertions.assertEquals(3, nodes.size());
+    assertEquals(3, nodes.size());
     // Send report for all but no leader
     nodes.forEach(dn -> sendPipelineReport(dn, pipeline, pipelineReportHandler,
         false));
 
-    Assertions.assertEquals(Pipeline.PipelineState.ALLOCATED,
+    assertEquals(Pipeline.PipelineState.ALLOCATED,
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     nodes.subList(0, 2).forEach(dn -> sendPipelineReport(dn, pipeline,
@@ -509,7 +509,7 @@ public class TestPipelineManagerImpl {
     sendPipelineReport(nodes.get(nodes.size() - 1), pipeline,
         pipelineReportHandler, true);
 
-    Assertions.assertEquals(Pipeline.PipelineState.OPEN,
+    assertEquals(Pipeline.PipelineState.OPEN,
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     pipelineManager.close();
@@ -528,11 +528,11 @@ public class TestPipelineManagerImpl {
         .createPipeline(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE));
     // At this point, pipeline is not at OPEN stage.
-    Assertions.assertEquals(Pipeline.PipelineState.ALLOCATED,
+    assertEquals(Pipeline.PipelineState.ALLOCATED,
         allocatedPipeline.getPipelineState());
 
     // pipeline should be seen in pipelineManager as ALLOCATED.
-    Assertions.assertTrue(pipelineManager
+    assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(allocatedPipeline));
@@ -544,7 +544,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.closePipeline(closedPipeline, true);
 
     // pipeline should be seen in pipelineManager as CLOSED.
-    Assertions.assertTrue(pipelineManager
+    assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
@@ -556,14 +556,14 @@ public class TestPipelineManagerImpl {
 
     // The allocatedPipeline should not be scrubbed as the interval has not
     // yet passed.
-    Assertions.assertTrue(pipelineManager
+    assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(allocatedPipeline));
 
     // The closedPipeline should not be scrubbed as the interval has not
     // yet passed.
-    Assertions.assertTrue(pipelineManager
+    assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
@@ -573,13 +573,13 @@ public class TestPipelineManagerImpl {
     pipelineManager.scrubPipelines();
 
     // The allocatedPipeline should now be scrubbed as the interval has passed
-    Assertions.assertFalse(pipelineManager
+    assertFalse(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(allocatedPipeline));
 
     // The closedPipeline should now be scrubbed as the interval has passed
-    Assertions.assertFalse(pipelineManager
+    assertFalse(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
@@ -597,7 +597,7 @@ public class TestPipelineManagerImpl {
     // Scrubbing the pipelines should not affect this pipeline
     pipelineManager.scrubPipelines();
     pipeline = pipelineManager.getPipeline(pipeline.getId());
-    Assertions.assertEquals(Pipeline.PipelineState.OPEN,
+    assertEquals(Pipeline.PipelineState.OPEN,
         pipeline.getPipelineState());
 
     // Now, "unregister" one of the nodes in the pipeline
@@ -607,7 +607,7 @@ public class TestPipelineManagerImpl {
 
     pipelineManager.scrubPipelines();
     pipeline = pipelineManager.getPipeline(pipeline.getId());
-    Assertions.assertEquals(Pipeline.PipelineState.CLOSED,
+    assertEquals(Pipeline.PipelineState.CLOSED,
         pipeline.getPipelineState());
   }
 
@@ -620,7 +620,7 @@ public class TestPipelineManagerImpl {
       assertAllocate(pipelineManager);
       changeToFollower(pipelineManager);
       testClock.fastForward(20000);
-      Assertions.assertThrows(SCMException.class,
+      assertThrows(SCMException.class,
           pipelineManager::scrubPipelines);
     }
   }
@@ -643,7 +643,7 @@ public class TestPipelineManagerImpl {
       fail("Pipelines should not have been created");
     } catch (IOException e) {
       // No pipeline is created.
-      Assertions.assertTrue(pipelineManager.getPipelines().isEmpty());
+      assertTrue(pipelineManager.getPipelines().isEmpty());
     }
 
     // Ensure a pipeline of factor ONE can be created - no exceptions should be
@@ -651,7 +651,7 @@ public class TestPipelineManagerImpl {
     Pipeline pipeline = pipelineManager
         .createPipeline(RatisReplicationConfig
             .getInstance(ReplicationFactor.ONE));
-    Assertions.assertTrue(pipelineManager
+    assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.ONE))
         .contains(pipeline));
@@ -675,21 +675,21 @@ public class TestPipelineManagerImpl {
 
     scmContext.updateSafeModeStatus(
         new SCMSafeModeManager.SafeModeStatus(true, false));
-    Assertions.assertTrue(pipelineManager.getSafeModeStatus());
-    Assertions.assertFalse(pipelineManager.isPipelineCreationAllowed());
+    assertTrue(pipelineManager.getSafeModeStatus());
+    assertFalse(pipelineManager.isPipelineCreationAllowed());
 
     // First pass pre-check as true, but safemode still on
     // Simulate safemode check exiting.
     scmContext.updateSafeModeStatus(
         new SCMSafeModeManager.SafeModeStatus(true, true));
-    Assertions.assertTrue(pipelineManager.getSafeModeStatus());
-    Assertions.assertTrue(pipelineManager.isPipelineCreationAllowed());
+    assertTrue(pipelineManager.getSafeModeStatus());
+    assertTrue(pipelineManager.isPipelineCreationAllowed());
 
     // Then also turn safemode off
     scmContext.updateSafeModeStatus(
         new SCMSafeModeManager.SafeModeStatus(false, true));
-    Assertions.assertFalse(pipelineManager.getSafeModeStatus());
-    Assertions.assertTrue(pipelineManager.isPipelineCreationAllowed());
+    assertFalse(pipelineManager.getSafeModeStatus());
+    assertTrue(pipelineManager.isPipelineCreationAllowed());
     pipelineManager.close();
   }
 
@@ -710,7 +710,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.getStateManager().updatePipelineState(
             pipelineID.getProtobuf(), HddsProtos.PipelineState.PIPELINE_CLOSED);
     buffer.flush();
-    Assertions.assertTrue(pipelineStore.get(pipelineID).isClosed());
+    assertTrue(pipelineStore.get(pipelineID).isClosed());
     pipelineManager.addContainerToPipelineSCMStart(pipelineID,
             ContainerID.valueOf(2));
     assertThat(logCapturer.getOutput()).contains("Container " +
@@ -733,7 +733,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.getStateManager().updatePipelineState(
         pipelineID.getProtobuf(), HddsProtos.PipelineState.PIPELINE_CLOSED);
     buffer.flush();
-    Assertions.assertTrue(pipelineStore.get(pipelineID).isClosed());
+    assertTrue(pipelineStore.get(pipelineID).isClosed());
     assertThrows(InvalidPipelineStateException.class,
         () -> pipelineManager.addContainerToPipeline(pipelineID,
         ContainerID.valueOf(2)));
@@ -827,9 +827,9 @@ public class TestPipelineManagerImpl {
 
     // test IP change
     List<Pipeline> pipelineList1 = pipelineManager.getStalePipelines(node1);
-    Assertions.assertEquals(2, pipelineList1.size());
-    Assertions.assertEquals(pipelines.get(0), pipelineList1.get(0));
-    Assertions.assertEquals(pipelines.get(3), pipelineList1.get(1));
+    assertEquals(2, pipelineList1.size());
+    assertEquals(pipelines.get(0), pipelineList1.get(0));
+    assertEquals(pipelines.get(3), pipelineList1.get(1));
 
     // node with changed host name
     DatanodeDetails node2 = mock(DatanodeDetails.class);
@@ -839,9 +839,9 @@ public class TestPipelineManagerImpl {
 
     // test IP change
     List<Pipeline> pipelineList2 = pipelineManager.getStalePipelines(node2);
-    Assertions.assertEquals(2, pipelineList2.size());
-    Assertions.assertEquals(pipelines.get(0), pipelineList2.get(0));
-    Assertions.assertEquals(pipelines.get(3), pipelineList2.get(1));
+    assertEquals(2, pipelineList2.size());
+    assertEquals(pipelines.get(0), pipelineList2.get(0));
+    assertEquals(pipelines.get(3), pipelineList2.get(1));
   }
 
   @Test
@@ -910,9 +910,9 @@ public class TestPipelineManagerImpl {
         anyString(), eq(allocatedPipeline), any());
 
 
-    Assertions.assertTrue(pipelineManager.getPipelines(repConfig,  OPEN)
+    assertTrue(pipelineManager.getPipelines(repConfig,  OPEN)
         .isEmpty(), "No open pipelines exist");
-    Assertions.assertTrue(pipelineManager.getPipelines(repConfig,  ALLOCATED)
+    assertTrue(pipelineManager.getPipelines(repConfig,  ALLOCATED)
         .contains(allocatedPipeline), "An allocated pipeline exists");
 
     // Instrument waitOnePipelineReady to open pipeline a bit after it is called
@@ -932,7 +932,7 @@ public class TestPipelineManagerImpl {
     
     ContainerInfo c = provider.getContainer(1, repConfig,
         owner, new ExcludeList());
-    Assertions.assertEquals(c, container, "Expected container was returned");
+    assertEquals(c, container, "Expected container was returned");
 
     // Confirm that waitOnePipelineReady was called on allocated pipelines
     ArgumentCaptor<Collection<PipelineID>> captor =
@@ -956,7 +956,7 @@ public class TestPipelineManagerImpl {
     Set<ContainerReplica> replicas = createContainerReplicasList(dns);
     Pipeline pipeline = pipelineManager.createPipelineForRead(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE), replicas);
-    Assertions.assertEquals(3, pipeline.getNodes().size());
+    assertEquals(3, pipeline.getNodes().size());
     for (DatanodeDetails dn : pipeline.getNodes())  {
       assertThat(dns).contains(dn);
     }
@@ -993,12 +993,12 @@ public class TestPipelineManagerImpl {
   }
 
   private static Pipeline assertAllocate(PipelineManagerImpl pipelineManager) {
-    Pipeline pipeline = Assertions.assertDoesNotThrow(
+    Pipeline pipeline = assertDoesNotThrow(
         () -> pipelineManager.createPipeline(
             RatisReplicationConfig.getInstance(ReplicationFactor.THREE)));
-    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
-    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
-    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    assertEquals(1, pipelineManager.getPipelines().size());
+    assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
+    assertEquals(ALLOCATED, pipeline.getPipelineState());
     return pipeline;
   }
 
@@ -1008,8 +1008,8 @@ public class TestPipelineManagerImpl {
   }
 
   private static void assertFailsNotLeader(CheckedRunnable<?> block) {
-    SCMException e = Assertions.assertThrows(SCMException.class, block::run);
-    Assertions.assertEquals(ResultCodes.SCM_NOT_LEADER, e.getResult());
+    SCMException e = assertThrows(SCMException.class, block::run);
+    assertEquals(ResultCodes.SCM_NOT_LEADER, e.getResult());
     assertInstanceOf(NotLeaderException.class, e.getCause());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -57,7 +56,11 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEM
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -148,7 +151,7 @@ public class TestPipelinePlacementFactory {
   public void testDefaultPolicy() throws IOException {
     PlacementPolicy policy = PipelinePlacementPolicyFactory
         .getPolicy(null, null, conf);
-    Assertions.assertSame(PipelinePlacementPolicy.class, policy.getClass());
+    assertSame(PipelinePlacementPolicy.class, policy.getClass());
   }
 
   @Test
@@ -160,7 +163,7 @@ public class TestPipelinePlacementFactory {
     setupRacks(6, 3, false);
     PlacementPolicy policy = PipelinePlacementPolicyFactory
         .getPolicy(nodeManager, stateManager, conf);
-    Assertions.assertSame(SCMContainerPlacementRackScatter.class,
+    assertSame(SCMContainerPlacementRackScatter.class,
         policy.getClass());
   }
 
@@ -176,12 +179,12 @@ public class TestPipelinePlacementFactory {
     int nodeNum = 3;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(null, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(1),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
   }
 
@@ -202,12 +205,12 @@ public class TestPipelinePlacementFactory {
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(excludedNodes, excludedNodes, favoredNodes,
             nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertEquals(nodeNum, datanodeDetails.size());
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(1),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
   }
 
@@ -226,16 +229,16 @@ public class TestPipelinePlacementFactory {
     int nodeNum = 3;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(null, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
     // First anchor will be Node0, Since there is no more node available
     // on rack0, Anchor will change to Node1 and then Node2 will be selected
     // which is same rack as Node1.
-    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(1),
+    assertTrue(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
   }
 
@@ -254,9 +257,9 @@ public class TestPipelinePlacementFactory {
     int nodeNum = 2;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(usedNodes, null, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
 
-    Assertions.assertTrue(cluster.isSameParent(usedNodes.get(0),
+    assertTrue(cluster.isSameParent(usedNodes.get(0),
         datanodeDetails.get(0)) || cluster.isSameParent(usedNodes.get(0),
         datanodeDetails.get(1)));
 
@@ -268,9 +271,9 @@ public class TestPipelinePlacementFactory {
     nodeNum = 1;
     datanodeDetails =
         policy.chooseDatanodes(usedNodes, null, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
     // Node return by policy should have different parent as node0 and node1
-    Assertions.assertFalse(cluster.isSameParent(usedNodes.get(0),
+    assertFalse(cluster.isSameParent(usedNodes.get(0),
         datanodeDetails.get(0)) && cluster.isSameParent(usedNodes.get(1),
         datanodeDetails.get(0)));
 
@@ -282,9 +285,9 @@ public class TestPipelinePlacementFactory {
     nodeNum = 1;
     datanodeDetails =
         policy.chooseDatanodes(usedNodes, null, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
     // Node return by policy should have same parent as node0 or node3
-    Assertions.assertTrue(cluster.isSameParent(usedNodes.get(0),
+    assertTrue(cluster.isSameParent(usedNodes.get(0),
         datanodeDetails.get(0)) || cluster.isSameParent(usedNodes.get(3),
         datanodeDetails.get(0)));
 
@@ -293,7 +296,7 @@ public class TestPipelinePlacementFactory {
     nodeNum = 3;
     datanodeDetails =
         policy.chooseDatanodes(usedNodes, null, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
   }
 
   @Test
@@ -314,18 +317,18 @@ public class TestPipelinePlacementFactory {
     int nodeNum = 2;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(usedNodes, excludeNodes, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
     // policy should not return any of excluded node
-    Assertions.assertNotSame(datanodeDetails.get(0).getUuid(),
+    assertNotSame(datanodeDetails.get(0).getUuid(),
         excludeNodes.get(0).getUuid());
-    Assertions.assertNotSame(datanodeDetails.get(0).getUuid(),
+    assertNotSame(datanodeDetails.get(0).getUuid(),
         excludeNodes.get(1).getUuid());
-    Assertions.assertNotSame(datanodeDetails.get(1).getUuid(),
+    assertNotSame(datanodeDetails.get(1).getUuid(),
         excludeNodes.get(0).getUuid());
-    Assertions.assertNotSame(datanodeDetails.get(1).getUuid(),
+    assertNotSame(datanodeDetails.get(1).getUuid(),
         excludeNodes.get(1).getUuid());
     // One of the node should be in same rack as Node0
-    Assertions.assertTrue(cluster.isSameParent(usedNodes.get(0),
+    assertTrue(cluster.isSameParent(usedNodes.get(0),
         datanodeDetails.get(0)) || cluster.isSameParent(usedNodes.get(0),
         datanodeDetails.get(1)));
 
@@ -338,16 +341,16 @@ public class TestPipelinePlacementFactory {
     nodeNum = 1;
     datanodeDetails =
         policy.chooseDatanodes(usedNodes, excludeNodes, null, nodeNum, 15, 15);
-    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    assertEquals(nodeNum, datanodeDetails.size());
     // policy should not return any of excluded node
-    Assertions.assertNotSame(datanodeDetails.get(0).getUuid(),
+    assertNotSame(datanodeDetails.get(0).getUuid(),
         excludeNodes.get(0).getUuid());
-    Assertions.assertNotSame(datanodeDetails.get(0).getUuid(),
+    assertNotSame(datanodeDetails.get(0).getUuid(),
         excludeNodes.get(1).getUuid());
     // Since rack0 has not enough node (node0 is used and node1 is excluded),
     // Anchor will change to node4(rack2) and will return another node
     // from rack2
-    Assertions.assertTrue(cluster.isSameParent(usedNodes.get(1),
+    assertTrue(cluster.isSameParent(usedNodes.get(1),
         datanodeDetails.get(0)));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementFactory.java
@@ -51,13 +51,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_PLACEMENT_IMPL_KEY;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
+
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -125,7 +126,7 @@ public class TestPipelinePlacementFactory {
     }
     nodeManagerBase = new MockNodeManager(cluster, datanodes,
         false, 10);
-    nodeManager = Mockito.spy(nodeManagerBase);
+    nodeManager = spy(nodeManagerBase);
     for (DatanodeInfo dn: dnInfos) {
       when(nodeManager.getNodeByUuid(dn.getUuidString()))
           .thenReturn(dn);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -60,7 +60,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -76,6 +75,15 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for PipelinePlacementPolicy.
@@ -176,10 +184,9 @@ public class TestPipelinePlacementPolicy {
     //    nodeManager.getClusterNetworkTopologyMap(), anchor, excludedNodes);
     assertThat(excludedNodes).doesNotContain(nextNode);
     // next node should not be the same as anchor.
-    Assertions.assertNotSame(anchor.getUuid(), nextNode.getUuid());
+    assertNotSame(anchor.getUuid(), nextNode.getUuid());
     // next node should be on the same rack based on topology.
-    Assertions.assertEquals(anchor.getNetworkLocation(),
-        nextNode.getNetworkLocation());
+    assertEquals(anchor.getNetworkLocation(), nextNode.getNetworkLocation());
   }
 
   @Test
@@ -209,13 +216,13 @@ public class TestPipelinePlacementPolicy {
         new ArrayList<>(datanodes.size()),
         nodesRequired, 0, 0);
 
-    Assertions.assertEquals(nodesRequired, results.size());
+    assertEquals(nodesRequired, results.size());
     // 3 nodes should be on different racks.
-    Assertions.assertNotEquals(results.get(0).getNetworkLocation(),
+    assertNotEquals(results.get(0).getNetworkLocation(),
         results.get(1).getNetworkLocation());
-    Assertions.assertNotEquals(results.get(0).getNetworkLocation(),
+    assertNotEquals(results.get(0).getNetworkLocation(),
         results.get(2).getNetworkLocation());
-    Assertions.assertNotEquals(results.get(1).getNetworkLocation(),
+    assertNotEquals(results.get(1).getNetworkLocation(),
         results.get(2).getNetworkLocation());
   }
 
@@ -249,7 +256,7 @@ public class TestPipelinePlacementPolicy {
       localPlacementPolicy.chooseDatanodes(new ArrayList<>(datanodes.size()),
           new ArrayList<>(datanodes.size()), nodesRequired,
           0, 10 * OzoneConsts.TB);
-      Assertions.fail("SCMException should have been thrown.");
+      fail("SCMException should have been thrown.");
     } catch (SCMException ex) {
       assertThat(ex.getMessage()).contains(expectedMessageSubstring);
     }
@@ -259,7 +266,7 @@ public class TestPipelinePlacementPolicy {
       localPlacementPolicy.chooseDatanodes(new ArrayList<>(datanodes.size()),
           new ArrayList<>(datanodes.size()), nodesRequired, 10 * OzoneConsts.TB,
           0);
-      Assertions.fail("SCMException should have been thrown.");
+      fail("SCMException should have been thrown.");
     } catch (SCMException ex) {
       assertThat(ex.getMessage()).contains(expectedMessageSubstring);
     }
@@ -303,7 +310,7 @@ public class TestPipelinePlacementPolicy {
     }
     
     // Should max out pipeline usage.
-    Assertions.assertEquals(maxPipelineCount,
+    assertEquals(maxPipelineCount,
         stateManager
             .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE))
@@ -320,9 +327,9 @@ public class TestPipelinePlacementPolicy {
     DatanodeDetails nextNode = placementPolicy.chooseNodeBasedOnRackAwareness(
         healthyNodes, new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT),
         topologyWithDifRacks, anchor);
-    Assertions.assertNotNull(nextNode);
+    assertNotNull(nextNode);
     // next node should be on a different rack.
-    Assertions.assertNotEquals(anchor.getNetworkLocation(),
+    assertNotEquals(anchor.getNetworkLocation(),
         nextNode.getNetworkLocation());
   }
 
@@ -334,12 +341,12 @@ public class TestPipelinePlacementPolicy {
 
     // test no nodes are excluded
     node = placementPolicy.fallBackPickNodes(healthyNodes, null);
-    Assertions.assertNotNull(node);
+    assertNotNull(node);
 
     // when input nodeSet are all excluded.
     List<DatanodeDetails> exclude = healthyNodes;
     node = placementPolicy.fallBackPickNodes(healthyNodes, exclude);
-    Assertions.assertNull(node);
+    assertNull(node);
 
   }
 
@@ -350,8 +357,7 @@ public class TestPipelinePlacementPolicy {
     DatanodeDetails randomNode = placementPolicy
         .chooseNode(nodesWithOutRackAwareness);
     // rack awareness is not enabled.
-    Assertions.assertEquals(anchor.getNetworkLocation(),
-        randomNode.getNetworkLocation());
+    assertEquals(anchor.getNetworkLocation(), randomNode.getNetworkLocation());
 
     NetworkTopology topology =
         new NetworkTopologyImpl(new OzoneConfiguration());
@@ -359,19 +365,17 @@ public class TestPipelinePlacementPolicy {
         nodesWithOutRackAwareness, new ArrayList<>(
             PIPELINE_PLACEMENT_MAX_NODES_COUNT), topology, anchor);
     // RackAwareness should not be able to choose any node.
-    Assertions.assertNull(nextNode);
+    assertNull(nextNode);
 
     // PlacementPolicy should still be able to pick a set of 3 nodes.
     int numOfNodes = HddsProtos.ReplicationFactor.THREE.getNumber();
     List<DatanodeDetails> results = placementPolicy
         .getResultSet(numOfNodes, nodesWithOutRackAwareness);
     
-    Assertions.assertEquals(numOfNodes, results.size());
+    assertEquals(numOfNodes, results.size());
     // All nodes are on same rack.
-    Assertions.assertEquals(results.get(0).getNetworkLocation(),
-        results.get(1).getNetworkLocation());
-    Assertions.assertEquals(results.get(0).getNetworkLocation(),
-        results.get(2).getNetworkLocation());
+    assertEquals(results.get(0).getNetworkLocation(), results.get(1).getNetworkLocation());
+    assertEquals(results.get(0).getNetworkLocation(), results.get(2).getNetworkLocation());
   }
 
   private static final Node[] NODES = new NodeImpl[] {
@@ -440,15 +444,15 @@ public class TestPipelinePlacementPolicy {
     // modify node to pipeline mapping.
     insertHeavyNodesIntoNodeManager(healthyNodes, minorityHeavy);
     // NODES should be sufficient.
-    Assertions.assertEquals(nodesRequired, pickedNodes1.size());
+    assertEquals(nodesRequired, pickedNodes1.size());
     // make sure pipeline placement policy won't select duplicated NODES.
-    Assertions.assertTrue(checkDuplicateNodesUUID(pickedNodes1));
+    assertTrue(checkDuplicateNodesUUID(pickedNodes1));
 
     // majority of healthy NODES are heavily engaged in pipelines.
     int majorityHeavy = healthyNodes.size() / 2 + 2;
     insertHeavyNodesIntoNodeManager(healthyNodes, majorityHeavy);
     // NODES should NOT be sufficient and exception should be thrown.
-    Assertions.assertThrows(SCMException.class, () ->
+    assertThrows(SCMException.class, () ->
         placementPolicy.chooseDatanodes(
             new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT),
             new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT),
@@ -465,7 +469,7 @@ public class TestPipelinePlacementPolicy {
     int majorityHeavy = healthyNodes.size() / 2 + 2;
     insertHeavyNodesIntoNodeManager(healthyNodes, majorityHeavy);
     // NODES should NOT be sufficient and exception should be thrown.
-    Assertions.assertThrows(SCMException.class, () ->
+    assertThrows(SCMException.class, () ->
         placementPolicy.chooseDatanodes(
             new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT),
             new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT),
@@ -492,8 +496,8 @@ public class TestPipelinePlacementPolicy {
     }
     ContainerPlacementStatus status =
         placementPolicy.validateContainerPlacement(dns, 3);
-    Assertions.assertTrue(status.isPolicySatisfied());
-    Assertions.assertEquals(0, status.misReplicationCount());
+    assertTrue(status.isPolicySatisfied());
+    assertEquals(0, status.misReplicationCount());
 
 
     List<DatanodeDetails> subSet = new ArrayList<>();
@@ -501,28 +505,28 @@ public class TestPipelinePlacementPolicy {
     subSet.add(dns.get(0));
     subSet.add(dns.get(2));
     status = placementPolicy.validateContainerPlacement(subSet, 3);
-    Assertions.assertTrue(status.isPolicySatisfied());
-    Assertions.assertEquals(0, status.misReplicationCount());
+    assertTrue(status.isPolicySatisfied());
+    assertEquals(0, status.misReplicationCount());
 
     // Cut it down to two nodes, one racks
     subSet = new ArrayList<>();
     subSet.add(dns.get(0));
     subSet.add(dns.get(1));
     status = placementPolicy.validateContainerPlacement(subSet, 3);
-    Assertions.assertFalse(status.isPolicySatisfied());
-    Assertions.assertEquals(1, status.misReplicationCount());
+    assertFalse(status.isPolicySatisfied());
+    assertEquals(1, status.misReplicationCount());
 
     // One node, but only one replica
     subSet = new ArrayList<>();
     subSet.add(dns.get(0));
     status = placementPolicy.validateContainerPlacement(subSet, 1);
-    Assertions.assertTrue(status.isPolicySatisfied());
+    assertTrue(status.isPolicySatisfied());
 
     // three nodes, one dead, one rack
     cluster.remove(dns.get(2));
     status = placementPolicy.validateContainerPlacement(dns, 3);
-    Assertions.assertFalse(status.isPolicySatisfied());
-    Assertions.assertEquals(1, status.misReplicationCount());
+    assertFalse(status.isPolicySatisfied());
+    assertEquals(1, status.misReplicationCount());
   }
 
   @Test
@@ -545,8 +549,8 @@ public class TestPipelinePlacementPolicy {
     }
     ContainerPlacementStatus status =
         placementPolicy.validateContainerPlacement(dns, 3);
-    Assertions.assertTrue(status.isPolicySatisfied());
-    Assertions.assertEquals(0, status.misReplicationCount());
+    assertTrue(status.isPolicySatisfied());
+    assertEquals(0, status.misReplicationCount());
   }
 
   @Test
@@ -563,7 +567,7 @@ public class TestPipelinePlacementPolicy {
     List<DatanodeDetails> pickedDns =  placementPolicy.chooseDatanodes(
         new ArrayList<>(), new ArrayList<>(), nodesRequired, 0, 0);
 
-    Assertions.assertEquals(3, pickedDns.size());
+    assertEquals(3, pickedDns.size());
     assertThat(pickedDns).contains(dns.get(1));
     assertThat(pickedDns).contains(dns.get(2));
     assertThat(pickedDns).contains(dns.get(3));
@@ -580,11 +584,10 @@ public class TestPipelinePlacementPolicy {
     insertHeavyNodesIntoNodeManager(dns, 1);
     int nodesRequired = HddsProtos.ReplicationFactor.THREE.getNumber();
 
-    Throwable t = Assertions.assertThrows(SCMException.class, () ->
+    Throwable t = assertThrows(SCMException.class, () ->
         placementPolicy.chooseDatanodes(
             new ArrayList<>(), new ArrayList<>(), nodesRequired, 0, 0));
-    Assertions.assertEquals(PipelinePlacementPolicy.MULTIPLE_RACK_PIPELINE_MSG,
-        t.getMessage());
+    assertEquals(PipelinePlacementPolicy.MULTIPLE_RACK_PIPELINE_MSG, t.getMessage());
   }
 
   @Test
@@ -600,11 +603,10 @@ public class TestPipelinePlacementPolicy {
 
     List<DatanodeDetails> excluded = new ArrayList<>();
     excluded.add(dns.get(0));
-    Throwable t = Assertions.assertThrows(SCMException.class, () ->
+    Throwable t = assertThrows(SCMException.class, () ->
         placementPolicy.chooseDatanodes(
             excluded, new ArrayList<>(), nodesRequired, 0, 0));
-    Assertions.assertEquals(PipelinePlacementPolicy.MULTIPLE_RACK_PIPELINE_MSG,
-        t.getMessage());
+    assertEquals(PipelinePlacementPolicy.MULTIPLE_RACK_PIPELINE_MSG, t.getMessage());
   }
 
   private List<DatanodeDetails> setupSkewedRacks() {
@@ -700,7 +702,7 @@ public class TestPipelinePlacementPolicy {
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
         stateManager, healthyNodes.get(0));
-    Assertions.assertEquals(pipelineCount, 0);
+    assertEquals(pipelineCount, 0);
 
     // Check datanode with one RATIS/ONE pipeline
     List<DatanodeDetails> ratisOneDn = new ArrayList<>();
@@ -710,7 +712,7 @@ public class TestPipelinePlacementPolicy {
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
         stateManager, healthyNodes.get(1));
-    Assertions.assertEquals(pipelineCount, 0);
+    assertEquals(pipelineCount, 0);
 
     // Check datanode with one RATIS/THREE pipeline
     List<DatanodeDetails> ratisThreeDn = new ArrayList<>();
@@ -722,7 +724,7 @@ public class TestPipelinePlacementPolicy {
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
         stateManager, healthyNodes.get(2));
-    Assertions.assertEquals(pipelineCount, 1);
+    assertEquals(pipelineCount, 1);
 
     // Check datanode with one RATIS/ONE and one STANDALONE/ONE pipeline
     standaloneOneDn = new ArrayList<>();
@@ -732,7 +734,7 @@ public class TestPipelinePlacementPolicy {
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
         stateManager, healthyNodes.get(1));
-    Assertions.assertEquals(pipelineCount, 0);
+    assertEquals(pipelineCount, 0);
 
     // Check datanode with one RATIS/ONE and one STANDALONE/ONE pipeline and
     // two RATIS/THREE pipelines
@@ -746,7 +748,7 @@ public class TestPipelinePlacementPolicy {
     pipelineCount
         = placementPolicy.currentRatisThreePipelineCount(nodeManager,
         stateManager, healthyNodes.get(1));
-    Assertions.assertEquals(pipelineCount, 2);
+    assertEquals(pipelineCount, 2);
   }
 
   private void createPipelineWithReplicationConfig(List<DatanodeDetails> dnList,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -55,6 +55,10 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for PipelineStateManagerImpl.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,11 +53,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for PipelineStateManagerImpl.
@@ -120,7 +119,7 @@ public class TestPipelineStateManagerImpl {
 
   @Test
   public void testAddAndGetPipeline() throws IOException, TimeoutException {
-    Exception e = Assertions.assertThrows(SCMException.class,
+    Exception e = assertThrows(SCMException.class,
         () -> stateManager.addPipeline(createDummyPipeline(0)
             .getProtobufMessage(ClientVersion.CURRENT_VERSION)));
     // replication factor and number of nodes in the pipeline do not match
@@ -135,12 +134,12 @@ public class TestPipelineStateManagerImpl {
       stateManager.addPipeline(pipelineProto);
 
       // Cannot add a pipeline twice
-      e = Assertions.assertThrows(SCMException.class,
+      e = assertThrows(SCMException.class,
           () -> stateManager.addPipeline(pipelineProto));
       assertThat(e.getMessage()).contains("Duplicate pipeline ID");
 
       // verify pipeline returned is same
-      Assertions.assertEquals(pipeline.getId(),
+      assertEquals(pipeline.getId(),
           stateManager.getPipeline(pipeline.getId()).getId());
     } finally {
       // clean up
@@ -152,7 +151,7 @@ public class TestPipelineStateManagerImpl {
   @Test
   public void testGetPipelines() throws IOException, TimeoutException {
     // In start there should be no pipelines
-    Assertions.assertTrue(stateManager.getPipelines().isEmpty());
+    assertTrue(stateManager.getPipelines().isEmpty());
 
     Set<HddsProtos.Pipeline> pipelines = new HashSet<>();
     HddsProtos.Pipeline pipeline = createDummyPipeline(1).getProtobufMessage(
@@ -167,10 +166,10 @@ public class TestPipelineStateManagerImpl {
     Set<Pipeline> pipelines1 = new HashSet<>(stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.ONE)));
-    Assertions.assertEquals(pipelines1.size(), pipelines.size());
+    assertEquals(pipelines1.size(), pipelines.size());
 
     pipelines1 = new HashSet<>(stateManager.getPipelines());
-    Assertions.assertEquals(pipelines1.size(), pipelines.size());
+    assertEquals(pipelines1.size(), pipelines.size());
 
     // clean up
     for (HddsProtos.Pipeline pipeline1 : pipelines) {
@@ -218,9 +217,9 @@ public class TestPipelineStateManagerImpl {
         List<Pipeline> pipelines1 =
             stateManager.getPipelines(
                 ReplicationConfig.fromProtoTypeAndFactor(type, factor));
-        Assertions.assertEquals(15, pipelines1.size());
+        assertEquals(15, pipelines1.size());
         pipelines1.stream().forEach(p -> {
-          Assertions.assertEquals(type, p.getType());
+          assertEquals(type, p.getType());
         });
       }
     }
@@ -283,10 +282,10 @@ public class TestPipelineStateManagerImpl {
               stateManager.getPipelines(
                   ReplicationConfig.fromProtoTypeAndFactor(type, factor),
                   state);
-          Assertions.assertEquals(5, pipelines1.size());
+          assertEquals(5, pipelines1.size());
           pipelines1.forEach(p -> {
-            Assertions.assertEquals(type, p.getType());
-            Assertions.assertEquals(state, p.getPipelineState());
+            assertEquals(type, p.getType());
+            assertEquals(state, p.getPipelineState());
           });
         }
       }
@@ -320,14 +319,14 @@ public class TestPipelineStateManagerImpl {
     //verify the number of containers returned
     Set<ContainerID> containerIDs =
         stateManager.getContainers(pipeline.getId());
-    Assertions.assertEquals(containerIDs.size(), containerID);
+    assertEquals(containerIDs.size(), containerID);
 
     finalizePipeline(pipelineProto);
     removePipeline(pipelineProto);
     try {
       stateManager.addContainerToPipeline(pipeline.getId(),
           ContainerID.valueOf(++containerID));
-      Assertions.fail("Container should not have been added");
+      fail("Container should not have been added");
     } catch (IOException e) {
       // Can not add a container to removed pipeline
       assertThat(e.getMessage()).contains("not found");
@@ -347,7 +346,7 @@ public class TestPipelineStateManagerImpl {
 
     try {
       removePipeline(pipelineProto);
-      Assertions.fail("Pipeline should not have been removed");
+      fail("Pipeline should not have been removed");
     } catch (IOException e) {
       // can not remove a pipeline which already has containers
       assertThat(e.getMessage()).contains("not yet closed");
@@ -371,11 +370,11 @@ public class TestPipelineStateManagerImpl {
 
     stateManager.addContainerToPipeline(pipeline.getId(),
         ContainerID.valueOf(containerID));
-    Assertions.assertEquals(1,
+    assertEquals(1,
         stateManager.getContainers(pipeline.getId()).size());
     stateManager.removeContainerFromPipeline(pipeline.getId(),
         ContainerID.valueOf(containerID));
-    Assertions.assertEquals(0,
+    assertEquals(0,
         stateManager.getContainers(pipeline.getId()).size());
 
     // add two containers in the pipeline
@@ -383,7 +382,7 @@ public class TestPipelineStateManagerImpl {
         ContainerID.valueOf(++containerID));
     stateManager.addContainerToPipeline(pipeline.getId(),
         ContainerID.valueOf(++containerID));
-    Assertions.assertEquals(2,
+    assertEquals(2,
         stateManager.getContainers(pipeline.getId()).size());
 
     // move pipeline to closing state
@@ -393,7 +392,7 @@ public class TestPipelineStateManagerImpl {
         ContainerID.valueOf(containerID));
     stateManager.removeContainerFromPipeline(pipeline.getId(),
         ContainerID.valueOf(--containerID));
-    Assertions.assertEquals(0,
+    assertEquals(0,
         stateManager.getContainers(pipeline.getId()).size());
 
     // clean up
@@ -408,7 +407,7 @@ public class TestPipelineStateManagerImpl {
     stateManager.addPipeline(pipelineProto);
     // finalize on ALLOCATED pipeline
     finalizePipeline(pipelineProto);
-    Assertions.assertEquals(Pipeline.PipelineState.CLOSED,
+    assertEquals(Pipeline.PipelineState.CLOSED,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
     // clean up
     removePipeline(pipelineProto);
@@ -420,7 +419,7 @@ public class TestPipelineStateManagerImpl {
     openPipeline(pipelineProto);
     // finalize on OPEN pipeline
     finalizePipeline(pipelineProto);
-    Assertions.assertEquals(Pipeline.PipelineState.CLOSED,
+    assertEquals(Pipeline.PipelineState.CLOSED,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
     // clean up
     removePipeline(pipelineProto);
@@ -433,7 +432,7 @@ public class TestPipelineStateManagerImpl {
     finalizePipeline(pipelineProto);
     // finalize should work on already closed pipeline
     finalizePipeline(pipelineProto);
-    Assertions.assertEquals(Pipeline.PipelineState.CLOSED,
+    assertEquals(Pipeline.PipelineState.CLOSED,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
     // clean up
     removePipeline(pipelineProto);
@@ -447,12 +446,12 @@ public class TestPipelineStateManagerImpl {
     stateManager.addPipeline(pipelineProto);
     // open on ALLOCATED pipeline
     openPipeline(pipelineProto);
-    Assertions.assertEquals(Pipeline.PipelineState.OPEN,
+    assertEquals(Pipeline.PipelineState.OPEN,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
 
     openPipeline(pipelineProto);
     // open should work on already open pipeline
-    Assertions.assertEquals(Pipeline.PipelineState.OPEN,
+    assertEquals(Pipeline.PipelineState.OPEN,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
     // clean up
     finalizePipeline(pipelineProto);
@@ -467,7 +466,7 @@ public class TestPipelineStateManagerImpl {
     HddsProtos.Pipeline pipelineProto = pipeline
         .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
-    Assertions.assertEquals(0, stateManager
+    assertEquals(0, stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
@@ -475,7 +474,7 @@ public class TestPipelineStateManagerImpl {
 
     // pipeline in open state should be reported
     openPipeline(pipelineProto);
-    Assertions.assertEquals(1, stateManager
+    assertEquals(1, stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
@@ -490,7 +489,7 @@ public class TestPipelineStateManagerImpl {
         .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     // pipeline in open state should be reported
     stateManager.addPipeline(pipelineProto2);
-    Assertions.assertEquals(2, stateManager
+    assertEquals(2, stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
@@ -498,7 +497,7 @@ public class TestPipelineStateManagerImpl {
 
     // pipeline in closed state should not be reported
     finalizePipeline(pipelineProto2);
-    Assertions.assertEquals(1, stateManager
+    assertEquals(1, stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
@@ -67,6 +66,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for RatisPipelineProvider.
@@ -123,8 +124,7 @@ public class TestRatisPipelineProvider {
       Pipeline.PipelineState expectedState) {
     assertEquals(expectedState, pipeline.getPipelineState());
     assertEquals(expectedReplicationType, pipeline.getType());
-    assertEquals(expectedFactor.getNumber(),
-        pipeline.getReplicationConfig().getRequiredNodes());
+    assertEquals(expectedFactor.getNumber(), pipeline.getReplicationConfig().getRequiredNodes());
     assertEquals(expectedFactor.getNumber(), pipeline.getNodes().size());
   }
 
@@ -237,8 +237,8 @@ public class TestRatisPipelineProvider {
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
         replicas);
 
-    Assertions.assertEquals(pipeline1.getNodeSet(), pipeline2.getNodeSet());
-    Assertions.assertEquals(pipeline2.getNodeSet(), pipeline3.getNodeSet());
+    assertEquals(pipeline1.getNodeSet(), pipeline2.getNodeSet());
+    assertEquals(pipeline2.getNodeSet(), pipeline3.getNodeSet());
   }
 
   @Test
@@ -325,7 +325,7 @@ public class TestRatisPipelineProvider {
     init(0, conf);
     List<DatanodeDetails> excludedNodes = new ArrayList<>();
 
-    Assertions.assertThrows(SCMException.class, () ->
+    assertThrows(SCMException.class, () ->
         provider.create(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             excludedNodes, Collections.EMPTY_LIST));
@@ -347,7 +347,7 @@ public class TestRatisPipelineProvider {
       }
       try {
         provider.create(RatisReplicationConfig.getInstance(factor));
-        Assertions.fail("Expected SCMException for large container size with " +
+        fail("Expected SCMException for large container size with " +
             "replication factor " + factor.toString());
       } catch (SCMException ex) {
         assertThat(ex.getMessage()).contains(expectedErrorSubstring);
@@ -363,7 +363,7 @@ public class TestRatisPipelineProvider {
       }
       try {
         provider.create(RatisReplicationConfig.getInstance(factor));
-        Assertions.fail("Expected SCMException for large metadata size with " +
+        fail("Expected SCMException for large metadata size with " +
             "replication factor " + factor.toString());
       } catch (SCMException ex) {
         assertThat(ex.getMessage()).contains(expectedErrorSubstring);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +44,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for SimplePipelineProvider.
@@ -93,13 +94,10 @@ public class TestSimplePipelineProvider {
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
-    Assertions.assertEquals(pipeline.getType(),
-        HddsProtos.ReplicationType.STAND_ALONE);
-    Assertions.assertEquals(pipeline.getReplicationConfig().getRequiredNodes(),
-        factor.getNumber());
-    Assertions.assertEquals(pipeline.getPipelineState(),
-        Pipeline.PipelineState.OPEN);
-    Assertions.assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    assertEquals(pipeline.getType(), HddsProtos.ReplicationType.STAND_ALONE);
+    assertEquals(pipeline.getReplicationConfig().getRequiredNodes(), factor.getNumber());
+    assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
+    assertEquals(pipeline.getNodes().size(), factor.getNumber());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     Pipeline pipeline1 =
@@ -107,14 +105,12 @@ public class TestSimplePipelineProvider {
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto1);
-    Assertions.assertEquals(pipeline1.getType(),
-        HddsProtos.ReplicationType.STAND_ALONE);
-    Assertions.assertEquals(
+    assertEquals(pipeline1.getType(), HddsProtos.ReplicationType.STAND_ALONE);
+    assertEquals(
         ((StandaloneReplicationConfig) pipeline1.getReplicationConfig())
             .getReplicationFactor(), factor);
-    Assertions.assertEquals(pipeline1.getPipelineState(),
-        Pipeline.PipelineState.OPEN);
-    Assertions.assertEquals(pipeline1.getNodes().size(), factor.getNumber());
+    assertEquals(pipeline1.getPipelineState(), Pipeline.PipelineState.OPEN);
+    assertEquals(pipeline1.getNodes().size(), factor.getNumber());
   }
 
   private List<DatanodeDetails> createListOfNodes(int nodeCount) {
@@ -131,25 +127,22 @@ public class TestSimplePipelineProvider {
     Pipeline pipeline =
         provider.create(StandaloneReplicationConfig.getInstance(factor),
             createListOfNodes(factor.getNumber()));
-    Assertions.assertEquals(pipeline.getType(),
+    assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
-    Assertions.assertEquals(
+    assertEquals(
         ((StandaloneReplicationConfig) pipeline.getReplicationConfig())
             .getReplicationFactor(), factor);
-    Assertions.assertEquals(pipeline.getPipelineState(),
-        Pipeline.PipelineState.OPEN);
-    Assertions.assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
+    assertEquals(pipeline.getNodes().size(), factor.getNumber());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     pipeline = provider.create(StandaloneReplicationConfig.getInstance(factor),
         createListOfNodes(factor.getNumber()));
-    Assertions.assertEquals(pipeline.getType(),
-        HddsProtos.ReplicationType.STAND_ALONE);
-    Assertions.assertEquals(
+    assertEquals(pipeline.getType(), HddsProtos.ReplicationType.STAND_ALONE);
+    assertEquals(
         ((StandaloneReplicationConfig) pipeline.getReplicationConfig())
             .getReplicationFactor(), factor);
-    Assertions.assertEquals(pipeline.getPipelineState(),
-        Pipeline.PipelineState.OPEN);
-    Assertions.assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    assertEquals(pipeline.getPipelineState(), Pipeline.PipelineState.OPEN);
+    assertEquals(pipeline.getNodes().size(), factor.getNumber());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -43,8 +43,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -67,7 +65,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 
 /**
  * Tests to validate the WritableECContainerProvider works correctly.
@@ -77,7 +81,7 @@ public class TestWritableECContainerProvider {
   private static final String OWNER = "SCM";
   private PipelineManager pipelineManager;
   private final ContainerManager containerManager
-      = Mockito.mock(ContainerManager.class);
+      = mock(ContainerManager.class);
 
   private OzoneConfiguration conf;
   private DBStore dbStore;
@@ -112,7 +116,7 @@ public class TestWritableECContainerProvider {
     pipelineManager =
         new MockPipelineManager(dbStore, scmhaManager, nodeManager);
 
-    Mockito.doAnswer(call -> {
+    doAnswer(call -> {
       Pipeline pipeline = (Pipeline)call.getArguments()[2];
       ContainerInfo container = createContainer(pipeline,
           repConfig, System.nanoTime());
@@ -120,12 +124,12 @@ public class TestWritableECContainerProvider {
           pipeline.getId(), container.containerID());
       containers.put(container.containerID(), container);
       return container;
-    }).when(containerManager).getMatchingContainer(Mockito.anyLong(),
-        Mockito.anyString(), Mockito.any(Pipeline.class));
+    }).when(containerManager).getMatchingContainer(anyLong(),
+        anyString(), any(Pipeline.class));
 
-    Mockito.doAnswer(call ->
+    doAnswer(call ->
         containers.get((ContainerID)call.getArguments()[0]))
-        .when(containerManager).getContainer(Mockito.any(ContainerID.class));
+        .when(containerManager).getContainer(any(ContainerID.class));
 
   }
 
@@ -424,9 +428,9 @@ public class TestWritableECContainerProvider {
 
     // Ensure ContainerManager always throws when a container is requested so
     // existing pipelines cannot be used
-    Mockito.doAnswer(call -> {
+    doAnswer(call -> {
       throw new ContainerNotFoundException();
-    }).when(containerManager).getContainer(Mockito.any(ContainerID.class));
+    }).when(containerManager).getContainer(any(ContainerID.class));
 
     ContainerInfo newContainer =
         provider.getContainer(1, repConfig, OWNER, new ExcludeList());
@@ -508,7 +512,7 @@ public class TestWritableECContainerProvider {
   @MethodSource("policies")
   public void testExcludedNodesPassedToCreatePipelineIfProvided(
       PipelineChoosePolicy policy) throws IOException {
-    PipelineManager pipelineManagerSpy = Mockito.spy(pipelineManager);
+    PipelineManager pipelineManagerSpy = spy(pipelineManager);
     provider = createSubject(pipelineManagerSpy, policy);
     ExcludeList excludeList = new ExcludeList();
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestPipelineChoosePolicyFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestPipelineChoosePolicyFactory.java
@@ -23,13 +23,13 @@ import org.apache.hadoop.hdds.scm.PipelineRequestInformation;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.PipelineChoosePolicyFactory.OZONE_SCM_EC_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT;
 import static org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.PipelineChoosePolicyFactory.OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT;
 
@@ -53,7 +53,7 @@ public class TestPipelineChoosePolicyFactory {
   public void testDefaultPolicy() throws IOException {
     PipelineChoosePolicy policy = PipelineChoosePolicyFactory
         .getPolicy(scmConfig, false);
-    Assertions.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
   }
 
@@ -61,7 +61,7 @@ public class TestPipelineChoosePolicyFactory {
   public void testDefaultPolicyEC() throws IOException {
     PipelineChoosePolicy policy = PipelineChoosePolicyFactory
         .getPolicy(scmConfig, true);
-    Assertions.assertSame(OZONE_SCM_EC_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    assertSame(OZONE_SCM_EC_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
   }
 
@@ -70,7 +70,7 @@ public class TestPipelineChoosePolicyFactory {
     scmConfig.setECPipelineChoosePolicyName(DummyGoodImpl.class.getName());
     PipelineChoosePolicy policy = PipelineChoosePolicyFactory
         .getPolicy(scmConfig, true);
-    Assertions.assertSame(DummyGoodImpl.class, policy.getClass());
+    assertSame(DummyGoodImpl.class, policy.getClass());
   }
 
 
@@ -122,10 +122,10 @@ public class TestPipelineChoosePolicyFactory {
     scmConfig.setECPipelineChoosePolicyName(DummyImpl.class.getName());
     PipelineChoosePolicy policy =
         PipelineChoosePolicyFactory.getPolicy(scmConfig, false);
-    Assertions.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
     policy = PipelineChoosePolicyFactory.getPolicy(scmConfig, true);
-    Assertions.assertSame(OZONE_SCM_EC_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    assertSame(OZONE_SCM_EC_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
   }
 
@@ -138,10 +138,10 @@ public class TestPipelineChoosePolicyFactory {
         "org.apache.hadoop.hdds.scm.pipeline.choose.policy.HelloWorld");
     PipelineChoosePolicy policy =
         PipelineChoosePolicyFactory.getPolicy(scmConfig, false);
-    Assertions.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
     policy = PipelineChoosePolicyFactory.getPolicy(scmConfig, true);
-    Assertions.assertSame(OZONE_SCM_EC_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    assertSame(OZONE_SCM_EC_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/TestLeaderChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/TestLeaderChoosePolicy.java
@@ -24,11 +24,12 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManagerImpl;
 import org.apache.hadoop.hdds.scm.pipeline.RatisPipelineProvider;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for {@link LeaderChoosePolicy}.
@@ -50,7 +51,7 @@ public class TestLeaderChoosePolicy {
         conf,
         mock(EventPublisher.class),
         SCMContext.emptyContext());
-    Assertions.assertSame(
+    assertSame(
         ratisPipelineProvider.getLeaderChoosePolicy().getClass(),
         MinLeaderCountChoosePolicy.class);
   }
@@ -61,7 +62,7 @@ public class TestLeaderChoosePolicy {
     conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_LEADER_CHOOSING_POLICY,
         "org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms" +
             ".HelloWorld");
-    Assertions.assertThrows(RuntimeException.class, () ->
+    assertThrows(RuntimeException.class, () ->
         new RatisPipelineProvider(
             mock(NodeManager.class),
             mock(PipelineStateManagerImpl.class),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -46,10 +46,11 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManagerImpl;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.ozone.test.GenericTestUtils;
-
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * This class tests HealthyPipelineSafeMode rule.
@@ -102,7 +103,7 @@ public class TestHealthyPipelineSafeModeRule {
           scmSafeModeManager.getHealthyPipelineSafeModeRule();
 
       // This should be immediately satisfied, as no pipelines are there yet.
-      Assertions.assertTrue(healthyPipelineSafeModeRule.validate());
+      assertTrue(healthyPipelineSafeModeRule.validate());
     } finally {
       scmMetadataStore.getStore().close();
       FileUtil.fullyDelete(new File(storageDir));
@@ -183,7 +184,7 @@ public class TestHealthyPipelineSafeModeRule {
           scmSafeModeManager.getHealthyPipelineSafeModeRule();
 
       // No datanodes have sent pipelinereport from datanode
-      Assertions.assertFalse(healthyPipelineSafeModeRule.validate());
+      assertFalse(healthyPipelineSafeModeRule.validate());
 
       // Fire pipeline report from all datanodes in first pipeline, as here we
       // have 3 pipelines, 10% is 0.3, when doing ceil it is 1. So, we should
@@ -283,7 +284,7 @@ public class TestHealthyPipelineSafeModeRule {
 
 
       // No pipeline event have sent to SCMSafemodeManager
-      Assertions.assertFalse(healthyPipelineSafeModeRule.validate());
+      assertFalse(healthyPipelineSafeModeRule.validate());
 
 
       GenericTestUtils.LogCapturer logCapturer =
@@ -297,7 +298,7 @@ public class TestHealthyPipelineSafeModeRule {
       GenericTestUtils.waitFor(() -> logCapturer.getOutput().contains(
           "reported count is 1"),
           1000, 5000);
-      Assertions.assertFalse(healthyPipelineSafeModeRule.validate());
+      assertFalse(healthyPipelineSafeModeRule.validate());
 
       firePipelineEvent(pipeline2, eventQueue);
       firePipelineEvent(pipeline3, eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -53,10 +53,11 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.apache.ozone.test.TestClock;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * This class tests OneReplicaPipelineSafeModeRule.
@@ -145,7 +146,7 @@ public class TestOneReplicaPipelineSafeModeRule {
     GenericTestUtils.waitFor(() -> logCapturer.getOutput().contains(
         "reported count is 6"), 1000, 5000);
 
-    Assertions.assertFalse(rule.validate());
+    assertFalse(rule.validate());
 
     //Fire last pipeline event from datanode.
     firePipelineEvent(pipelines.subList(pipelineFactorThreeCount - 1,
@@ -179,7 +180,7 @@ public class TestOneReplicaPipelineSafeModeRule {
         "reported count is 0"), 1000, 5000);
 
     // fired events for one node ratis pipeline, so we will be still false.
-    Assertions.assertFalse(rule.validate());
+    assertFalse(rule.validate());
 
     pipelines =
         pipelineManager.getPipelines(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -64,13 +64,13 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /** Test class for SCMSafeModeManager.
  */
@@ -421,7 +421,7 @@ public class TestSCMSafeModeManager {
   public void testDisableSafeMode() {
     OzoneConfiguration conf = new OzoneConfiguration(config);
     conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
-    PipelineManager pipelineManager = Mockito.mock(PipelineManager.class);
+    PipelineManager pipelineManager = mock(PipelineManager.class);
     scmSafeModeManager = new SCMSafeModeManager(
         conf, containers, null, pipelineManager, queue, serviceManager,
         scmContext);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestCRLStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestCRLStatusReportHandler.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +45,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 
 /**
@@ -67,8 +68,8 @@ public class TestCRLStatusReportHandler implements EventPublisher {
         tempDir.toAbsolutePath().toString());
     config.setBoolean(OZONE_SECURITY_ENABLED_KEY, true);
 
-    SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
-    Mockito.when(storageConfig.getClusterID()).thenReturn("cluster1");
+    SCMStorageConfig storageConfig = mock(SCMStorageConfig.class);
+    when(storageConfig.getClusterID()).thenReturn("cluster1");
     scmMetadataStore = new SCMMetadataStoreImpl(config);
     certificateStore = new SCMCertStore.Builder()
         .setRatisServer(null)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestCRLStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestCRLStatusReportHandler.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hdds.security.x509.crl.CRLStatus;
 import org.apache.hadoop.hdds.server.events.Event;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -45,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
@@ -103,21 +103,21 @@ public class TestCRLStatusReportHandler implements EventPublisher {
     crlStatusReportHandler.onMessage(reportFromDatanode1, this);
     CRLStatus crlStatus = certificateStore.getCRLStatusForDN(dn1.getUuid());
     assertThat(crlStatus.getPendingCRLIds()).containsAll(pendingCRLIds1);
-    Assertions.assertEquals(5L, crlStatus.getReceivedCRLId());
+    assertEquals(5L, crlStatus.getReceivedCRLId());
 
     pendingCRLIds1.remove(0);
     reportFromDatanode1 = getCRLStatusReport(dn1, pendingCRLIds1, 6L);
     crlStatusReportHandler.onMessage(reportFromDatanode1, this);
     crlStatus = certificateStore.getCRLStatusForDN(dn1.getUuid());
-    Assertions.assertEquals(1, crlStatus.getPendingCRLIds().size());
-    Assertions.assertEquals(4L,
+    assertEquals(1, crlStatus.getPendingCRLIds().size());
+    assertEquals(4L,
         crlStatus.getPendingCRLIds().get(0).longValue());
-    Assertions.assertEquals(6L, crlStatus.getReceivedCRLId());
+    assertEquals(6L, crlStatus.getReceivedCRLId());
 
     crlStatusReportHandler.onMessage(reportFromDatanode2, this);
     crlStatus = certificateStore.getCRLStatusForDN(dn2.getUuid());
     assertThat(crlStatus.getPendingCRLIds()).containsAll(pendingCRLIds2);
-    Assertions.assertEquals(2L, crlStatus.getReceivedCRLId());
+    assertEquals(2L, crlStatus.getReceivedCRLId());
   }
 
   private CRLStatusReportFromDatanode getCRLStatusReport(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
@@ -55,6 +55,9 @@ import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ACK_TIMEOUT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_CHECK_INTERNAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ENABLED;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
@@ -40,7 +40,6 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,6 +71,9 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.anyObject;
 import static org.slf4j.event.Level.INFO;
 
 /**
@@ -108,40 +110,35 @@ public class TestRootCARotationManager {
     ozoneConfig
         .setBoolean(HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED, false);
     ozoneConfig.setBoolean(HDDS_X509_CA_ROTATION_ENABLED, true);
-    scm = Mockito.mock(StorageContainerManager.class);
+    scm = mock(StorageContainerManager.class);
     securityConfig = new SecurityConfig(ozoneConfig);
     scmCertClient = new SCMCertificateClient(securityConfig, null, scmID, cID,
         certID.toString(), "localhost");
     scmServiceManager = new SCMServiceManager();
-    scmContext = Mockito.mock(SCMContext.class);
-    scmhaManager = Mockito.mock(SCMHAManager.class);
-    sequenceIdGenerator = Mockito.mock(SequenceIdGenerator.class);
+    scmContext = mock(SCMContext.class);
+    scmhaManager = mock(SCMHAManager.class);
+    sequenceIdGenerator = mock(SequenceIdGenerator.class);
     scmStorageConfig = new SCMStorageConfig(ozoneConfig);
     scmStorageConfig.setScmId(scmID);
     scmStorageConfig.setClusterId(cID);
-    scmSecurityProtocolServer = Mockito.mock(SCMSecurityProtocolServer.class);
-    handler = Mockito.mock(RootCARotationHandlerImpl.class);
-    statefulServiceStateManager =
-        Mockito.mock(StatefulServiceStateManager.class);
+    scmSecurityProtocolServer = mock(SCMSecurityProtocolServer.class);
+    handler = mock(RootCARotationHandlerImpl.class);
+    statefulServiceStateManager = mock(StatefulServiceStateManager.class);
     when(scmContext.isLeader()).thenReturn(true);
     when(scm.getConfiguration()).thenReturn(ozoneConfig);
     when(scm.getScmCertificateClient()).thenReturn(scmCertClient);
     when(scm.getScmContext()).thenReturn(scmContext);
     when(scm.getSCMServiceManager()).thenReturn(scmServiceManager);
     when(scm.getScmHAManager()).thenReturn(scmhaManager);
-    when(scmhaManager.getRatisServer())
-        .thenReturn(Mockito.mock(SCMRatisServerImpl.class));
+    when(scmhaManager.getRatisServer()).thenReturn(mock(SCMRatisServerImpl.class));
     when(scm.getSequenceIdGen()).thenReturn(sequenceIdGenerator);
-    when(sequenceIdGenerator.getNextId(Mockito.anyString())).thenReturn(2L);
+    when(sequenceIdGenerator.getNextId(anyString())).thenReturn(2L);
     when(scm.getScmStorageConfig()).thenReturn(scmStorageConfig);
     when(scm.getSecurityProtocolServer()).thenReturn(scmSecurityProtocolServer);
-    Mockito.doNothing().when(scmSecurityProtocolServer)
-        .setRootCertificateServer(Mockito.anyObject());
-    Mockito.doNothing().when(handler).rotationPrepare(Mockito.anyString());
-    when(scm.getStatefulServiceStateManager())
-        .thenReturn(statefulServiceStateManager);
-    when(statefulServiceStateManager.readConfiguration(Mockito.anyString()))
-        .thenReturn(null);
+    doNothing().when(scmSecurityProtocolServer).setRootCertificateServer(anyObject());
+    doNothing().when(handler).rotationPrepare(anyString());
+    when(scm.getStatefulServiceStateManager()).thenReturn(statefulServiceStateManager);
+    when(statefulServiceStateManager.readConfiguration(anyString())).thenReturn(null);
   }
 
   @AfterEach
@@ -302,7 +299,7 @@ public class TestRootCARotationManager {
                 "configuration found in stateful storage"),
         100, 10000);
 
-    when(statefulServiceStateManager.readConfiguration(Mockito.anyString()))
+    when(statefulServiceStateManager.readConfiguration(anyString()))
         .thenReturn(new CertInfo.Builder().setX509Certificate(cert)
             .setTimestamp(cert.getNotBefore().getTime())
             .build().getProtobuf().toByteString());
@@ -330,14 +327,12 @@ public class TestRootCARotationManager {
         () -> logs.getOutput().contains("isPostProcessing is true for"),
         100, 20000);
 
-    doNothing().when(statefulServiceStateManager)
-        .deleteConfiguration(Mockito.anyString());
+    doNothing().when(statefulServiceStateManager).deleteConfiguration(anyString());
     GenericTestUtils.waitFor(
         () -> logs.getOutput().contains("isPostProcessing is false") &&
             logs.getOutput().contains("Stateful configuration is deleted"),
         100, 20000);
-    verify(statefulServiceStateManager, times(1))
-        .deleteConfiguration(Mockito.anyString());
+    verify(statefulServiceStateManager, times(1)).deleteConfiguration(anyString());
   }
 
   private X509Certificate generateX509Cert(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/security/TestRootCARotationManager.java
@@ -56,7 +56,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_ACK_TIMEOUT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_CA_ROTATION_CHECK_INTERNAL;
@@ -67,9 +66,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOK
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_RENEW_GRACE_DURATION;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_X509_ROOTCA_CERTIFICATE_POLLING_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -65,11 +64,14 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_LEVEL;
 import static org.apache.hadoop.ozone.OzoneConsts.MB;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -201,13 +203,12 @@ public class TestSCMBlockProtocolServer {
   void sortDatanodesRelativeToDatanode() {
     List<String> nodes = getNetworkNames();
     for (DatanodeDetails dn : nodeManager.getAllNodes()) {
-      Assertions.assertEquals(ROOT_LEVEL + 2, dn.getLevel());
+      assertEquals(ROOT_LEVEL + 2, dn.getLevel());
 
       List<DatanodeDetails> sorted =
           server.sortDatanodes(nodes, nodeAddress(dn));
 
-      Assertions.assertEquals(dn, sorted.get(0),
-          "Source node should be sorted very first");
+      assertEquals(dn, sorted.get(0), "Source node should be sorted very first");
 
       assertRackOrder(dn.getNetworkLocation(), sorted);
     }
@@ -227,12 +228,12 @@ public class TestSCMBlockProtocolServer {
     int size = list.size();
 
     for (int i = 0; i < size / 2; i++) {
-      Assertions.assertEquals(rack, list.get(i).getNetworkLocation(),
+      assertEquals(rack, list.get(i).getNetworkLocation(),
           "Nodes in the same rack should be sorted first");
     }
 
     for (int i = size / 2; i < size; i++) {
-      Assertions.assertNotEquals(rack, list.get(i).getNetworkLocation(),
+      assertNotEquals(rack, list.get(i).getNetworkLocation(),
           "Nodes in the other rack should be sorted last");
     }
   }
@@ -249,7 +250,7 @@ public class TestSCMBlockProtocolServer {
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assertions.assertEquals(NODE_COUNT, datanodeDetails.size());
+    assertEquals(NODE_COUNT, datanodeDetails.size());
 
     // illegal client 1
     client += "X";
@@ -257,14 +258,14 @@ public class TestSCMBlockProtocolServer {
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assertions.assertEquals(NODE_COUNT, datanodeDetails.size());
+    assertEquals(NODE_COUNT, datanodeDetails.size());
     // illegal client 2
     client = "/default-rack";
     datanodeDetails = server.sortDatanodes(nodes, client);
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assertions.assertEquals(NODE_COUNT, datanodeDetails.size());
+    assertEquals(NODE_COUNT, datanodeDetails.size());
 
     // unknown node to sort
     nodes.add(UUID.randomUUID().toString());
@@ -277,7 +278,7 @@ public class TestSCMBlockProtocolServer {
             .build();
     ScmBlockLocationProtocolProtos.SortDatanodesResponseProto resp =
         service.sortDatanodes(request, ClientVersion.CURRENT_VERSION);
-    Assertions.assertEquals(NODE_COUNT, resp.getNodeList().size());
+    assertEquals(NODE_COUNT, resp.getNodeList().size());
     System.out.println("client = " + client);
     resp.getNodeList().stream().forEach(
         node -> System.out.println(node.getNetworkName()));
@@ -294,7 +295,7 @@ public class TestSCMBlockProtocolServer {
         .build();
     resp = service.sortDatanodes(request, ClientVersion.CURRENT_VERSION);
     System.out.println("client = " + client);
-    Assertions.assertEquals(0, resp.getNodeList().size());
+    assertEquals(0, resp.getNodeList().size());
     resp.getNodeList().stream().forEach(
         node -> System.out.println(node.getNetworkName()));
   }
@@ -311,12 +312,12 @@ public class TestSCMBlockProtocolServer {
     List<AllocatedBlock> allocatedBlocks = server.allocateBlock(
         blockSize, numOfBlocks, replicationConfig, "o",
         new ExcludeList(), clientAddress);
-    Assertions.assertEquals(numOfBlocks, allocatedBlocks.size());
+    assertEquals(numOfBlocks, allocatedBlocks.size());
     for (AllocatedBlock allocatedBlock: allocatedBlocks) {
       List<DatanodeDetails> nodesInOrder =
           allocatedBlock.getPipeline().getNodesInOrder();
       if (nodesInOrder.contains(clientDatanode)) {
-        Assertions.assertEquals(clientDatanode, nodesInOrder.get(0),
+        assertEquals(clientDatanode, nodesInOrder.get(0),
             "Source node should be sorted very first");
       }
       String clientLocation = clientDatanode.getNetworkLocation();
@@ -332,7 +333,7 @@ public class TestSCMBlockProtocolServer {
           }
         } else {
           if (nodeLocation.equals(clientLocation)) {
-            Assertions.fail("Node in the same rack as client " +
+            fail("Node in the same rack as client " +
                 "should not be sorted after nodes under different rack");
           }
         }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -71,6 +70,7 @@ import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanode
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_LEVEL;
 import static org.apache.hadoop.ozone.OzoneConsts.MB;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test class for @{@link SCMBlockProtocolServer}.
@@ -133,7 +133,7 @@ public class TestSCMBlockProtocolServer {
 
     @Override
     public DeletedBlockLog getDeletedBlockLog() {
-      return Mockito.mock(DeletedBlockLogImpl.class);
+      return mock(DeletedBlockLogImpl.class);
     }
 
     @Override
@@ -186,8 +186,7 @@ public class TestSCMBlockProtocolServer {
     nodeManager = scm.getScmNodeManager();
     datanodes.forEach(dn -> nodeManager.register(dn, null, null));
     server = scm.getBlockProtocolServer();
-    service = new ScmBlockLocationProtocolServerSideTranslatorPB(server, scm,
-        Mockito.mock(ProtocolMessageMetrics.class));
+    service = new ScmBlockLocationProtocolServerSideTranslatorPB(server, scm, mock(ProtocolMessageMetrics.class));
   }
 
   @AfterEach

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
@@ -55,16 +55,16 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.DATANODE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.OM;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore.CertType.VALID_CERTS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.apache.hadoop.ozone.OzoneConsts.CRL_SEQUENCE_ID_KEY;
 
 /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
@@ -36,7 +36,6 @@ import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -56,16 +55,16 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.DATANODE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.OM;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore.CertType.VALID_CERTS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.apache.hadoop.ozone.OzoneConsts.CRL_SEQUENCE_ID_KEY;
 
 /**
@@ -342,6 +341,6 @@ public class TestSCMCertStore {
   private void checkListCerts(NodeType role, int expected) throws Exception {
     List<X509Certificate> certificateList = scmCertStore.listCertificate(role,
         BigInteger.valueOf(0), 10, VALID_CERTS);
-    Assertions.assertEquals(expected, certificateList.size());
+    assertEquals(expected, certificateList.size());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -31,11 +31,10 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.io.IOException;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_READONLY_ADMINISTRATORS;
+import static org.mockito.Mockito.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,7 +62,7 @@ public class TestSCMClientProtocolServer {
 
     server = scm.getClientProtocolServer();
     service = new StorageContainerLocationProtocolServerSideTranslatorPB(server,
-        scm, Mockito.mock(ProtocolMessageMetrics.class));
+        scm, mock(ProtocolMessageMetrics.class));
   }
 
   @AfterEach

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMDatanodeHeartbeatDispatcher.java
@@ -22,29 +22,26 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.
-    StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
-import org.apache.hadoop.hdds.scm.server.
-    SCMDatanodeHeartbeatDispatcher.CommandStatusReportFromDatanode;
-import org.apache.hadoop.hdds.protocol.proto
-    .StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
-import org.apache.hadoop.hdds.protocol.proto
-    .StorageContainerDatanodeProtocolProtos.NodeReportProto;
-import org.apache.hadoop.hdds.protocol.proto
-    .StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.CommandStatusReportFromDatanode;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher
-    .ContainerReportFromDatanode;
-import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher
-    .NodeReportFromDatanode;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReportFromDatanode;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.NodeReportFromDatanode;
 import org.apache.hadoop.hdds.server.events.Event;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.ReregisterCommand;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.any;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CONTAINER_REPORT;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.NODE_REPORT;
@@ -63,8 +60,8 @@ public class TestSCMDatanodeHeartbeatDispatcher {
 
     NodeReportProto nodeReport = NodeReportProto.getDefaultInstance();
 
-    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
-    Mockito.when(mockNodeManager.isNodeRegistered(Mockito.any()))
+    NodeManager mockNodeManager = mock(NodeManager.class);
+    when(mockNodeManager.isNodeRegistered(any()))
         .thenReturn(true);
 
     SCMDatanodeHeartbeatDispatcher dispatcher =
@@ -105,8 +102,8 @@ public class TestSCMDatanodeHeartbeatDispatcher {
     CommandStatusReportsProto commandStatusReport =
         CommandStatusReportsProto.getDefaultInstance();
 
-    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
-    Mockito.when(mockNodeManager.isNodeRegistered(Mockito.any()))
+    NodeManager mockNodeManager = mock(NodeManager.class);
+    when(mockNodeManager.isNodeRegistered(any()))
         .thenReturn(true);
 
     SCMDatanodeHeartbeatDispatcher dispatcher =
@@ -154,10 +151,10 @@ public class TestSCMDatanodeHeartbeatDispatcher {
   @Test
   public void testScmHeartbeatAfterRestart() throws Exception {
 
-    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
+    NodeManager mockNodeManager = mock(NodeManager.class);
     SCMDatanodeHeartbeatDispatcher dispatcher =
         new SCMDatanodeHeartbeatDispatcher(
-            mockNodeManager, Mockito.mock(EventPublisher.class));
+            mockNodeManager, mock(EventPublisher.class));
 
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
 
@@ -169,7 +166,7 @@ public class TestSCMDatanodeHeartbeatDispatcher {
     dispatcher.dispatch(heartbeat);
     // If SCM receives heartbeat from a node after it restarts and the node
     // is not registered, it should send a Re-Register command back to the node.
-    Mockito.verify(mockNodeManager, Mockito.times(1)).addDatanodeCommand(
-        Mockito.any(UUID.class), Mockito.any(ReregisterCommand.class));
+    verify(mockNodeManager, times(1)).addDatanodeCommand(
+        any(UUID.class), any(ReregisterCommand.class));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMDatanodeHeartbeatDispatcher.java
@@ -34,9 +34,10 @@ import org.apache.hadoop.hdds.server.events.Event;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.ReregisterCommand;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -70,11 +71,9 @@ public class TestSCMDatanodeHeartbeatDispatcher {
               @Override
               public <PAYLOAD, EVENT extends Event<PAYLOAD>> void fireEvent(
                   EVENT event, PAYLOAD payload) {
-                Assertions.assertEquals(event, NODE_REPORT);
+                assertEquals(event, NODE_REPORT);
                 eventReceived.incrementAndGet();
-                Assertions.assertEquals(nodeReport,
-                    ((NodeReportFromDatanode)payload).getReport());
-
+                assertEquals(nodeReport, ((NodeReportFromDatanode)payload).getReport());
               }
             });
 
@@ -86,7 +85,7 @@ public class TestSCMDatanodeHeartbeatDispatcher {
         .setNodeReport(nodeReport)
         .build();
     dispatcher.dispatch(heartbeat);
-    Assertions.assertEquals(1, eventReceived.get());
+    assertEquals(1, eventReceived.get());
 
 
   }
@@ -113,16 +112,16 @@ public class TestSCMDatanodeHeartbeatDispatcher {
               @Override
               public <PAYLOAD, EVENT extends Event<PAYLOAD>> void fireEvent(
                   EVENT event, PAYLOAD payload) {
-                Assertions.assertTrue(
+                assertTrue(
                     event.equals(CONTAINER_REPORT)
                         || event.equals(CMD_STATUS_REPORT));
 
                 if (payload instanceof ContainerReportFromDatanode) {
-                  Assertions.assertEquals(containerReport,
+                  assertEquals(containerReport,
                       ((ContainerReportFromDatanode) payload).getReport());
                 }
                 if (payload instanceof CommandStatusReportFromDatanode) {
-                  Assertions.assertEquals(commandStatusReport,
+                  assertEquals(commandStatusReport,
                       ((CommandStatusReportFromDatanode) payload).getReport());
                 }
                 eventReceived.incrementAndGet();
@@ -138,7 +137,7 @@ public class TestSCMDatanodeHeartbeatDispatcher {
             .addCommandStatusReports(commandStatusReport)
             .build();
     dispatcher.dispatch(heartbeat);
-    Assertions.assertEquals(2, eventReceived.get());
+    assertEquals(2, eventReceived.get());
 
 
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/update/server/TestSCMUpdateServiceGrpcServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/update/server/TestSCMUpdateServiceGrpcServer.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.update.client.UpdateServiceConfig;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -49,6 +48,8 @@ import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for SCM update Service.
  */
@@ -126,14 +127,14 @@ public class TestSCMUpdateServiceGrpcServer {
       server.notifyCrlUpdate();
 
       GenericTestUtils.waitFor(() -> client.getUpdateCount() == 4, 100, 2000);
-      Assertions.assertEquals(4, client.getUpdateCount());
-      Assertions.assertEquals(0, client.getErrorCount());
+      assertEquals(4, client.getUpdateCount());
+      assertEquals(0, client.getErrorCount());
 
       revokeCertNow(certIds.get(5));
       server.notifyCrlUpdate();
       GenericTestUtils.waitFor(() -> client.getUpdateCount() > 4, 100, 2000);
-      Assertions.assertEquals(5, client.getUpdateCount());
-      Assertions.assertEquals(0, client.getErrorCount());
+      assertEquals(5, client.getUpdateCount());
+      assertEquals(0, client.getErrorCount());
     } catch (Exception e) {
       e.printStackTrace();
     } finally {
@@ -176,8 +177,8 @@ public class TestSCMUpdateServiceGrpcServer {
 
       GenericTestUtils.waitFor(() -> client.getUpdateCount() == 1,
           100, 2000);
-      Assertions.assertEquals(1, client.getUpdateCount());
-      Assertions.assertEquals(0, client.getErrorCount());
+      assertEquals(1, client.getUpdateCount());
+      assertEquals(0, client.getErrorCount());
 
       // revoke cert 5 with 10 seconds delay
       revokeCert(certIds.get(5), Instant.now().plus(Duration.ofSeconds(5)));
@@ -185,13 +186,13 @@ public class TestSCMUpdateServiceGrpcServer {
       GenericTestUtils.waitFor(() -> client.getUpdateCount() > 1,
           100, 2000);
       assertThat(2L).isLessThanOrEqualTo(client.getUpdateCount());
-      Assertions.assertEquals(0, client.getErrorCount());
+      assertEquals(0, client.getErrorCount());
       assertThat(1).isGreaterThanOrEqualTo(client.getClientCRLStore()
           .getPendingCrlIds().size());
 
       GenericTestUtils.waitFor(() -> client.getPendingCrlRemoveCount() == 1,
           100, 20_000);
-      Assertions.assertTrue(client.getClientCRLStore()
+      assertTrue(client.getClientCRLStore()
           .getPendingCrlIds().isEmpty());
     } catch (Exception e) {
       e.printStackTrace();
@@ -242,7 +243,7 @@ public class TestSCMUpdateServiceGrpcServer {
       server.notifyCrlUpdate();
       GenericTestUtils.waitFor(() -> client.getUpdateCount() == 4,
           100, 2000);
-      Assertions.assertEquals(4, client.getUpdateCount());
+      assertEquals(4, client.getUpdateCount());
 
 
       // server restart
@@ -256,18 +257,18 @@ public class TestSCMUpdateServiceGrpcServer {
       server.start();
       GenericTestUtils.waitFor(() -> client.getErrorCount() == 1,
           100, 2000);
-      Assertions.assertEquals(4, client.getUpdateCount());
-      Assertions.assertEquals(1, client.getErrorCount());
-      Assertions.assertEquals(4, clientCRLStore.getLatestCrlId());
+      assertEquals(4, client.getUpdateCount());
+      assertEquals(1, client.getErrorCount());
+      assertEquals(4, clientCRLStore.getLatestCrlId());
       LOG.info("Test server restart end.");
 
       revokeCertNow(certIds.get(5));
       server.notifyCrlUpdate();
       GenericTestUtils.waitFor(() -> client.getUpdateCount() > 4,
           100, 5000);
-      Assertions.assertEquals(5, client.getUpdateCount());
-      Assertions.assertEquals(1, client.getErrorCount());
-      Assertions.assertEquals(5, clientCRLStore.getLatestCrlId());
+      assertEquals(5, client.getUpdateCount());
+      assertEquals(1, client.getErrorCount());
+      assertEquals(5, clientCRLStore.getLatestCrlId());
 
       // client restart
       // server onError->
@@ -278,7 +279,7 @@ public class TestSCMUpdateServiceGrpcServer {
       client.stop(true);
       client.createChannel();
       client.start();
-      Assertions.assertEquals(5, clientCRLStore.getLatestCrlId());
+      assertEquals(5, clientCRLStore.getLatestCrlId());
       GenericTestUtils.waitFor(() -> client.getUpdateCount() > 5,
           100, 2000);
       revokeCertNow(certIds.get(6));
@@ -289,8 +290,8 @@ public class TestSCMUpdateServiceGrpcServer {
       GenericTestUtils.waitFor(() -> client.getUpdateCount() > 6,
           100, 2000);
       assertThat(client.getUpdateCount()).isGreaterThanOrEqualTo(6);
-      Assertions.assertEquals(2, client.getErrorCount());
-      Assertions.assertEquals(6, clientCRLStore.getLatestCrlId());
+      assertEquals(2, client.getErrorCount());
+      assertEquals(6, clientCRLStore.getLatestCrlId());
     } catch (Exception e) {
       e.printStackTrace();
     } finally {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalizedStateValidationAction.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalizedStateValidationAction.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.upgrade.UpgradeException;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.ratis.util.ExitUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,6 +36,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import java.nio.file.Path;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that the SCM HA pre-finalize validation action is only triggered in
@@ -78,7 +81,7 @@ public class TestSCMHAUnfinalizedStateValidationAction {
     // This init should always succeed, since SCM is not pre-finalized yet.
     DefaultConfigManager.clearDefaultConfigs();
     boolean initResult1 = StorageContainerManager.scmInit(conf, CLUSTER_ID);
-    Assertions.assertTrue(initResult1);
+    assertTrue(initResult1);
 
     // Set up new pre-finalized SCM.
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY,
@@ -88,33 +91,33 @@ public class TestSCMHAUnfinalizedStateValidationAction {
      */
     if (haEnabledPreFinalized != haEnabledBefore) {
       if (haEnabledBefore) {
-        Assertions.assertThrows(ConfigurationException.class,
+        assertThrows(ConfigurationException.class,
             () -> StorageContainerManager.scmInit(conf, CLUSTER_ID));
       } else {
-        Assertions.assertThrows(UpgradeException.class,
+        assertThrows(UpgradeException.class,
             () -> StorageContainerManager.scmInit(conf, CLUSTER_ID));
       }
       return;
     }
     StorageContainerManager scm = HddsTestUtils.getScm(conf);
 
-    Assertions.assertEquals(UpgradeFinalizer.Status.FINALIZATION_REQUIRED,
+    assertEquals(UpgradeFinalizer.Status.FINALIZATION_REQUIRED,
         scm.getFinalizationManager().getUpgradeFinalizer().getStatus());
 
     final boolean shouldFail = !haEnabledBefore && haEnabledPreFinalized;
     DefaultConfigManager.clearDefaultConfigs();
     if (shouldFail) {
       // Start on its own should fail.
-      Assertions.assertThrows(UpgradeException.class, scm::start);
+      assertThrows(UpgradeException.class, scm::start);
 
       // Init followed by start should both fail.
       // Init is not necessary here, but is allowed to be run.
-      Assertions.assertThrows(UpgradeException.class,
+      assertThrows(UpgradeException.class,
           () -> StorageContainerManager.scmInit(conf, CLUSTER_ID));
-      Assertions.assertThrows(UpgradeException.class, scm::start);
+      assertThrows(UpgradeException.class, scm::start);
     } else {
       boolean initResult2 = StorageContainerManager.scmInit(conf, CLUSTER_ID);
-      Assertions.assertTrue(initResult2);
+      assertTrue(initResult2);
       scm.start();
       scm.stop();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.verification.VerificationMode;
 import org.slf4j.Logger;
@@ -58,6 +57,8 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.matches;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -250,9 +251,9 @@ public class TestScmFinalization {
 
     // First, SCM should mark that it is beginning finalization.
     inOrder.verify(buffer, count).addToBuffer(
-        ArgumentMatchers.eq(finalizationStore),
-        ArgumentMatchers.matches(OzoneConsts.FINALIZING_KEY),
-        ArgumentMatchers.matches(""));
+        eq(finalizationStore),
+        matches(OzoneConsts.FINALIZING_KEY),
+        matches(""));
 
     // Next, all pipeline creation should be stopped.
     inOrder.verify(pipelineManager, count).freezePipelineCreation();
@@ -274,9 +275,9 @@ public class TestScmFinalization {
           inOrder.verify(nodeManager, count).forceNodesToHealthyReadOnly();
         }
         inOrder.verify(buffer, count).addToBuffer(
-            ArgumentMatchers.eq(finalizationStore),
-            ArgumentMatchers.matches(OzoneConsts.LAYOUT_VERSION_KEY),
-            ArgumentMatchers.eq(String.valueOf(feature.layoutVersion())));
+            eq(finalizationStore),
+            matches(OzoneConsts.LAYOUT_VERSION_KEY),
+            eq(String.valueOf(feature.layoutVersion())));
       }
     }
     // If this was not called in the loop, there was an error. To detect this
@@ -290,8 +291,8 @@ public class TestScmFinalization {
     // Last, the finalizing mark is removed to indicate finalization is
     // complete.
     inOrder.verify(buffer, count).removeFromBuffer(
-        ArgumentMatchers.eq(finalizationStore),
-        ArgumentMatchers.matches(OzoneConsts.FINALIZING_KEY));
+        eq(finalizationStore),
+        matches(OzoneConsts.FINALIZING_KEY));
 
     // If the initial checkpoint was FINALIZATION_COMPLETE, no mocks should
     // have been invoked.
@@ -311,7 +312,7 @@ public class TestScmFinalization {
       FinalizationCheckpoint initialCheckpoint) throws Exception {
     Table<String, String> finalizationStore = mock(Table.class);
     when(finalizationStore
-            .isExist(ArgumentMatchers.eq(OzoneConsts.FINALIZING_KEY)))
+            .isExist(eq(OzoneConsts.FINALIZING_KEY)))
         .thenReturn(initialCheckpoint.needsFinalizingMark());
     return finalizationStore;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmFinalization.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
-import org.mockito.Mockito;
 import org.mockito.verification.VerificationMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +50,14 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -101,9 +108,9 @@ public class TestScmFinalization {
     // test.
     FinalizationStateManager stateManager =
         new FinalizationStateManagerTestImpl.Builder()
-            .setFinalizationStore(Mockito.mock(Table.class))
-            .setRatisServer(Mockito.mock(SCMRatisServer.class))
-            .setTransactionBuffer(Mockito.mock(DBTransactionBuffer.class))
+            .setFinalizationStore(mock(Table.class))
+            .setRatisServer(mock(SCMRatisServer.class))
+            .setTransactionBuffer(mock(DBTransactionBuffer.class))
             .setUpgradeFinalizer(new SCMUpgradeFinalizer(versionManager))
             .build();
 
@@ -115,11 +122,11 @@ public class TestScmFinalization {
         new SCMUpgradeFinalizationContext.Builder()
         .setConfiguration(new OzoneConfiguration())
         .setFinalizationStateManager(stateManager)
-        .setStorage(Mockito.mock(SCMStorageConfig.class))
+        .setStorage(mock(SCMStorageConfig.class))
         .setLayoutVersionManager(versionManager)
         .setSCMContext(scmContext)
         .setPipelineManager(pipelineManager)
-        .setNodeManager(Mockito.mock(NodeManager.class))
+        .setNodeManager(mock(NodeManager.class))
         .build();
     stateManager.setUpgradeContext(context);
 
@@ -194,11 +201,11 @@ public class TestScmFinalization {
         getMockTableFromCheckpoint(initialCheckpoint);
     HDDSLayoutVersionManager versionManager =
         getMockVersionManagerFromCheckpoint(initialCheckpoint);
-    SCMHAManager haManager = Mockito.mock(SCMHAManager.class);
-    DBTransactionBuffer buffer = Mockito.mock(DBTransactionBuffer.class);
-    Mockito.when(haManager.getDBTransactionBuffer()).thenReturn(buffer);
-    NodeManager nodeManager = Mockito.mock(NodeManager.class);
-    SCMStorageConfig storage = Mockito.mock(SCMStorageConfig.class);
+    SCMHAManager haManager = mock(SCMHAManager.class);
+    DBTransactionBuffer buffer = mock(DBTransactionBuffer.class);
+    when(haManager.getDBTransactionBuffer()).thenReturn(buffer);
+    NodeManager nodeManager = mock(NodeManager.class);
+    SCMStorageConfig storage = mock(SCMStorageConfig.class);
     SCMContext scmContext = SCMContext.emptyContext();
     scmContext.setFinalizationCheckpoint(initialCheckpoint);
     PipelineManager pipelineManager =
@@ -207,7 +214,7 @@ public class TestScmFinalization {
     FinalizationStateManager stateManager =
         new FinalizationStateManagerTestImpl.Builder()
             .setFinalizationStore(finalizationStore)
-            .setRatisServer(Mockito.mock(SCMRatisServer.class))
+            .setRatisServer(mock(SCMRatisServer.class))
             .setTransactionBuffer(buffer)
             .setUpgradeFinalizer(new SCMUpgradeFinalizer(versionManager))
             .build();
@@ -230,15 +237,15 @@ public class TestScmFinalization {
     assertEquals(getStatusFromCheckpoint(initialCheckpoint).status(),
         status.status());
 
-    InOrder inOrder = Mockito.inOrder(buffer, pipelineManager, nodeManager,
+    InOrder inOrder = inOrder(buffer, pipelineManager, nodeManager,
         storage);
 
     // Once the initial checkpoint's operations are crossed, this count will
     // be increased to 1 to indicate where finalization should have resumed
     // from.
-    VerificationMode count = Mockito.never();
+    VerificationMode count = never();
     if (initialCheckpoint == FinalizationCheckpoint.FINALIZATION_REQUIRED) {
-      count = Mockito.times(1);
+      count = times(1);
     }
 
     // First, SCM should mark that it is beginning finalization.
@@ -251,7 +258,7 @@ public class TestScmFinalization {
     inOrder.verify(pipelineManager, count).freezePipelineCreation();
 
     if (initialCheckpoint == FinalizationCheckpoint.FINALIZATION_STARTED) {
-      count = Mockito.times(1);
+      count = times(1);
     }
 
     // Next, each layout feature should be finalized.
@@ -274,10 +281,10 @@ public class TestScmFinalization {
     }
     // If this was not called in the loop, there was an error. To detect this
     // mistake, verify again here.
-    Mockito.verify(nodeManager, count).forceNodesToHealthyReadOnly();
+    verify(nodeManager, count).forceNodesToHealthyReadOnly();
 
     if (initialCheckpoint == FinalizationCheckpoint.MLV_EQUALS_SLV) {
-      count = Mockito.times(1);
+      count = times(1);
     }
 
     // Last, the finalizing mark is removed to indicate finalization is
@@ -302,8 +309,8 @@ public class TestScmFinalization {
    */
   private Table<String, String> getMockTableFromCheckpoint(
       FinalizationCheckpoint initialCheckpoint) throws Exception {
-    Table<String, String> finalizationStore = Mockito.mock(Table.class);
-    Mockito.when(finalizationStore
+    Table<String, String> finalizationStore = mock(Table.class);
+    when(finalizationStore
             .isExist(ArgumentMatchers.eq(OzoneConsts.FINALIZING_KEY)))
         .thenReturn(initialCheckpoint.needsFinalizingMark());
     return finalizationStore;
@@ -338,24 +345,24 @@ public class TestScmFinalization {
 
   private PipelineManager getMockPipelineManager(
       FinalizationCheckpoint inititalCheckpoint) {
-    PipelineManager pipelineManager = Mockito.mock(PipelineManager.class);
+    PipelineManager pipelineManager = mock(PipelineManager.class);
     // After finalization, SCM will wait for at least one pipeline to be
     // created. It does not care about the contents of the pipeline list, so
     // just return something with length >= 1.
-    Mockito.when(pipelineManager.getPipelines(Mockito.any(),
-        Mockito.any())).thenReturn(Arrays.asList(null, null, null));
+    when(pipelineManager.getPipelines(any(),
+        any())).thenReturn(Arrays.asList(null, null, null));
 
     // Set the initial value for pipeline creation based on the checkpoint.
     // In a real cluster, this would be set on startup of the
     // PipelineManagerImpl.
     pipelineCreationFrozen =
         !FinalizationManager.shouldCreateNewPipelines(inititalCheckpoint);
-    Mockito.doAnswer(args -> pipelineCreationFrozen = true)
+    doAnswer(args -> pipelineCreationFrozen = true)
         .when(pipelineManager).freezePipelineCreation();
-    Mockito.doAnswer(args -> pipelineCreationFrozen = false)
+    doAnswer(args -> pipelineCreationFrozen = false)
         .when(pipelineManager).resumePipelineCreation();
 
-    Mockito.doAnswer(args -> pipelineCreationFrozen)
+    doAnswer(args -> pipelineCreationFrozen)
         .when(pipelineManager).isPipelineCreationFrozen();
 
     return pipelineManager;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmStartupSlvLessThanMlv.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestScmStartupSlvLessThanMlv.java
@@ -24,13 +24,16 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.ozone.upgrade.LayoutFeature;
 import org.apache.hadoop.ozone.upgrade.UpgradeTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that SCM will throw an exception on creation when it reads in a
@@ -45,7 +48,7 @@ public class TestScmStartupSlvLessThanMlv {
     // Add subdirectories under the temporary folder where the version file
     // will be placed.
     File scmSubdir = tempDir.resolve("scm").resolve("current").toFile();
-    Assertions.assertTrue(scmSubdir.mkdirs());
+    assertTrue(scmSubdir.mkdirs());
 
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.OZONE_SCM_DB_DIRS,
@@ -62,11 +65,11 @@ public class TestScmStartupSlvLessThanMlv {
     // construction.
     UpgradeTestUtils.createVersionFile(scmSubdir, HddsProtos.NodeType.SCM, mlv);
 
-    Throwable t = Assertions.assertThrows(IOException.class,
+    Throwable t = assertThrows(IOException.class,
         () -> new StorageContainerManager(conf));
     String expectedMessage = String.format("Cannot initialize VersionManager." +
             " Metadata layout version (%s) > software layout version (%s)",
         mlv, largestSlv);
-    Assertions.assertEquals(expectedMessage, t.getMessage());
+    assertEquals(expectedMessage, t.getMessage());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -78,7 +78,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -426,14 +425,14 @@ public class TestEndPoint {
     when(ozoneContainer.getNodeReport()).thenReturn(HddsTestUtils
         .createNodeReport(Arrays.asList(getStorageReports(datanodeID)),
             Arrays.asList(getMetadataStorageReports(datanodeID))));
-    ContainerController controller = Mockito.mock(ContainerController.class);
+    ContainerController controller = mock(ContainerController.class);
     when(controller.getContainerReport()).thenReturn(
         HddsTestUtils.getRandomContainerReports(10));
     when(ozoneContainer.getController()).thenReturn(controller);
     when(ozoneContainer.getPipelineReport()).thenReturn(
         HddsTestUtils.getRandomPipelineReports());
     HDDSLayoutVersionManager versionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
+        mock(HDDSLayoutVersionManager.class);
     when(versionManager.getMetadataLayoutVersion())
         .thenReturn(maxLayoutVersion());
     when(versionManager.getSoftwareLayoutVersion())

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -74,7 +74,6 @@ import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayo
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createEndpoint;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -83,6 +82,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -131,11 +132,9 @@ public class TestEndPoint {
             serverAddress, 1000)) {
       SCMVersionResponseProto responseProto = rpcEndPoint.getEndPoint()
           .getVersion(null);
-      Assertions.assertNotNull(responseProto);
-      Assertions.assertEquals(VersionInfo.DESCRIPTION_KEY,
-          responseProto.getKeys(0).getKey());
-      Assertions.assertEquals(VersionInfo.getLatestVersion().getDescription(),
-          responseProto.getKeys(0).getValue());
+      assertNotNull(responseProto);
+      assertEquals(VersionInfo.DESCRIPTION_KEY, responseProto.getKeys(0).getKey());
+      assertEquals(VersionInfo.getLatestVersion().getDescription(), responseProto.getKeys(0).getValue());
     }
   }
 
@@ -162,11 +161,10 @@ public class TestEndPoint {
 
       // if version call worked the endpoint should automatically move to the
       // next state.
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
-          newState);
+      assertEquals(EndpointStateMachine.EndPointStates.REGISTER, newState);
 
       // Now rpcEndpoint should remember the version it got from SCM
-      Assertions.assertNotNull(rpcEndPoint.getVersion());
+      assertNotNull(rpcEndPoint.getVersion());
     }
   }
 
@@ -195,7 +193,7 @@ public class TestEndPoint {
           kvContainer.getContainerData(), hddsVolume);
       Path containerTmpPath = KeyValueContainerUtil.getTmpDirectoryPath(
           kvContainer.getContainerData(), hddsVolume);
-      Assertions.assertTrue(containerTmpPath.toFile().exists());
+      assertTrue(containerTmpPath.toFile().exists());
 
       rpcEndPoint.setState(EndpointStateMachine.EndPointStates.GETVERSION);
 
@@ -204,14 +202,13 @@ public class TestEndPoint {
           ozoneConf, ozoneContainer);
       EndpointStateMachine.EndPointStates newState = versionTask.call();
 
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
-          newState);
+      assertEquals(EndpointStateMachine.EndPointStates.REGISTER, newState);
 
       // assert that tmp dir is empty
       File[] leftoverContainers =
           hddsVolume.getDeletedContainerDir().listFiles();
-      Assertions.assertNotNull(leftoverContainers);
-      Assertions.assertEquals(0, leftoverContainers.length);
+      assertNotNull(leftoverContainers);
+      assertEquals(0, leftoverContainers.length);
     }
   }
 
@@ -237,11 +234,10 @@ public class TestEndPoint {
 
       // if version call worked the endpoint should automatically move to the
       // next state.
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
-          newState);
+      assertEquals(EndpointStateMachine.EndPointStates.REGISTER, newState);
 
       // Now rpcEndpoint should remember the version it got from SCM
-      Assertions.assertNotNull(rpcEndPoint.getVersion());
+      assertNotNull(rpcEndPoint.getVersion());
 
       // Now change server cluster ID, so datanode cluster ID will be
       // different from SCM server response cluster ID.
@@ -249,18 +245,15 @@ public class TestEndPoint {
       scmServerImpl.setClusterId(newClusterId);
       rpcEndPoint.setState(EndpointStateMachine.EndPointStates.GETVERSION);
       newState = versionTask.call();
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN,
-          newState);
+      assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN, newState);
       List<HddsVolume> volumesList = StorageVolumeUtil.getHddsVolumesList(
           ozoneContainer.getVolumeSet().getFailedVolumesList());
-      Assertions.assertEquals(1, volumesList.size());
+      assertEquals(1, volumesList.size());
       assertThat(logCapturer.getOutput())
           .contains("org.apache.hadoop.ozone.common" +
               ".InconsistentStorageStateException: Mismatched ClusterIDs");
-      Assertions.assertEquals(0,
-          ozoneContainer.getVolumeSet().getVolumesList().size());
-      Assertions.assertEquals(1,
-          ozoneContainer.getVolumeSet().getFailedVolumesList().size());
+      assertEquals(0, ozoneContainer.getVolumeSet().getVolumesList().size());
+      assertEquals(1, ozoneContainer.getVolumeSet().getFailedVolumesList().size());
     }
   }
 
@@ -338,8 +331,7 @@ public class TestEndPoint {
 
       // This version call did NOT work, so endpoint should remain in the same
       // state.
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
-          newState);
+      assertEquals(EndpointStateMachine.EndPointStates.GETVERSION, newState);
     }
   }
 
@@ -369,8 +361,7 @@ public class TestEndPoint {
       long end = Time.monotonicNow();
       scmServerImpl.setRpcResponseDelay(0);
       assertThat(end - start).isLessThanOrEqualTo(rpcTimeout + tolerance);
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
-          newState);
+      assertEquals(EndpointStateMachine.EndPointStates.GETVERSION, newState);
     }
   }
 
@@ -389,14 +380,11 @@ public class TestEndPoint {
               HddsTestUtils.getRandomContainerReports(10),
               HddsTestUtils.getRandomPipelineReports(),
               defaultLayoutVersionProto());
-      Assertions.assertNotNull(responseProto);
-      Assertions.assertEquals(nodeToRegister.getUuidString(),
-          responseProto.getDatanodeUUID());
-      Assertions.assertNotNull(responseProto.getClusterID());
-      Assertions.assertEquals(10, scmServerImpl.
-          getContainerCountsForDatanode(nodeToRegister));
-      Assertions.assertEquals(1,
-          scmServerImpl.getNodeReportsCount(nodeToRegister));
+      assertNotNull(responseProto);
+      assertEquals(nodeToRegister.getUuidString(), responseProto.getDatanodeUUID());
+      assertNotNull(responseProto.getClusterID());
+      assertEquals(10, scmServerImpl.getContainerCountsForDatanode(nodeToRegister));
+      assertEquals(1, scmServerImpl.getNodeReportsCount(nodeToRegister));
     }
   }
 
@@ -453,8 +441,7 @@ public class TestEndPoint {
     try (EndpointStateMachine rpcEndpoint =
         registerTaskHelper(serverAddress, 1000, false)) {
       // Successful register should move us to Heartbeat state.
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
-          rpcEndpoint.getState());
+      assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT, rpcEndpoint.getState());
     }
   }
 
@@ -463,8 +450,7 @@ public class TestEndPoint {
     InetSocketAddress address = SCMTestUtils.getReuseableAddress();
     try (EndpointStateMachine rpcEndpoint =
         registerTaskHelper(address, 1000, false)) {
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
-          rpcEndpoint.getState());
+      assertEquals(EndpointStateMachine.EndPointStates.REGISTER, rpcEndpoint.getState());
     }
   }
 
@@ -475,8 +461,7 @@ public class TestEndPoint {
         registerTaskHelper(address, 1000, true)) {
       // No Container ID, therefore we tell the datanode that we would like to
       // shutdown.
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN,
-          rpcEndpoint.getState());
+      assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN, rpcEndpoint.getState());
     }
   }
 
@@ -507,8 +492,8 @@ public class TestEndPoint {
 
       SCMHeartbeatResponseProto responseProto = rpcEndPoint.getEndPoint()
           .sendHeartbeat(request);
-      Assertions.assertNotNull(responseProto);
-      Assertions.assertEquals(0, responseProto.getCommandsCount());
+      assertNotNull(responseProto);
+      assertEquals(0, responseProto.getCommandsCount());
     }
   }
 
@@ -530,19 +515,19 @@ public class TestEndPoint {
 
       SCMHeartbeatResponseProto responseProto = rpcEndPoint.getEndPoint()
           .sendHeartbeat(request);
-      Assertions.assertNotNull(responseProto);
-      Assertions.assertEquals(3, responseProto.getCommandsCount());
-      Assertions.assertEquals(0, scmServerImpl.getCommandStatusReportCount());
+      assertNotNull(responseProto);
+      assertEquals(3, responseProto.getCommandsCount());
+      assertEquals(0, scmServerImpl.getCommandStatusReportCount());
 
       // Send heartbeat again from heartbeat endpoint task
       final StateContext stateContext = heartbeatTaskHelper(
           serverAddress, 3000);
       Map<Long, CommandStatus> map = stateContext.getCommandStatusMap();
-      Assertions.assertNotNull(map);
-      Assertions.assertEquals(1, map.size(), "Should have 1 objects");
+      assertNotNull(map);
+      assertEquals(1, map.size(), "Should have 1 objects");
       assertThat(map).containsKey(3L);
-      Assertions.assertEquals(Type.deleteBlocksCommand, map.get(3L).getType());
-      Assertions.assertEquals(Status.PENDING, map.get(3L).getStatus());
+      assertEquals(Type.deleteBlocksCommand, map.get(3L).getType());
+      assertEquals(Status.PENDING, map.get(3L).getStatus());
 
       scmServerImpl.clearScmCommandRequests();
     }
@@ -611,10 +596,9 @@ public class TestEndPoint {
               stateMachine.getLayoutVersionManager());
       endpointTask.setDatanodeDetailsProto(datanodeDetailsProto);
       endpointTask.call();
-      Assertions.assertNotNull(endpointTask.getDatanodeDetailsProto());
+      assertNotNull(endpointTask.getDatanodeDetailsProto());
 
-      Assertions.assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
-          rpcEndPoint.getState());
+      assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT, rpcEndPoint.getState());
       return stateContext;
     }
   }
@@ -655,7 +639,7 @@ public class TestEndPoint {
     ContainerTestUtils.createDbInstancesForTestIfNeeded(volumeSet,
         clusterId, clusterId, conf);
     // VolumeSet for this test, contains only 1 volume
-    Assertions.assertEquals(1, volumeSet.getVolumesList().size());
+    assertEquals(1, volumeSet.getVolumesList().size());
     StorageVolume volume = volumeSet.getVolumesList().get(0);
 
     // Check instanceof and typecast
@@ -671,8 +655,8 @@ public class TestEndPoint {
         addContainerToVolumeDir(hddsVolume, clusterId,
             conf, OzoneConsts.SCHEMA_V3);
     File containerDBFile = container.getContainerDBFile();
-    Assertions.assertTrue(container.getContainerFile().exists());
-    Assertions.assertTrue(containerDBFile.exists());
+    assertTrue(container.getContainerFile().exists());
+    assertTrue(containerDBFile.exists());
     return container;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestContainerPlacement.java
@@ -30,9 +30,10 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.junit.jupiter.api.Test;
 
 /**
  * Asserts that allocation strategy works as expected.
@@ -73,8 +74,7 @@ public class TestContainerPlacement {
     DescriptiveStatistics beforeRandom = computeStatistics(nodeManagerRandom);
 
     //Assert that our initial layout of clusters are similar.
-    assertEquals(beforeCapacity.getStandardDeviation(), beforeRandom
-        .getStandardDeviation(), 0.001);
+    assertEquals(beforeCapacity.getStandardDeviation(), beforeRandom.getStandardDeviation(), 0.001);
 
     SCMContainerPlacementCapacity capacityPlacer = new
         SCMContainerPlacementCapacity(nodeManagerCapacity,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -152,8 +151,7 @@ public class TestSCMNodeMetrics {
         .addStorageReport(storageReport).build();
 
     nodeManager.processNodeReport(registeredDatanode, nodeReport);
-    Assertions.assertEquals(nrProcessed + 1,
-        getCounter("NumNodeReportProcessed"),
+    assertEquals(nrProcessed + 1, getCounter("NumNodeReportProcessed"),
         "NumNodeReportProcessed");
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
@@ -40,20 +40,20 @@ import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static java.lang.Thread.sleep;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.test.MetricsAsserts.assertGauge;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-
-import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test cases to verify the metrics exposed by SCMNodeManager.
@@ -71,12 +71,9 @@ public class TestSCMNodeMetrics {
     EventQueue publisher = new EventQueue();
     SCMStorageConfig config =
         new SCMStorageConfig(NodeType.DATANODE, new File("/tmp"), "storage");
-    HDDSLayoutVersionManager versionManager =
-        Mockito.mock(HDDSLayoutVersionManager.class);
-    Mockito.when(versionManager.getMetadataLayoutVersion())
-        .thenReturn(maxLayoutVersion());
-    Mockito.when(versionManager.getSoftwareLayoutVersion())
-        .thenReturn(maxLayoutVersion());
+    HDDSLayoutVersionManager versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(versionManager.getSoftwareLayoutVersion()).thenReturn(maxLayoutVersion());
     nodeManager = new SCMNodeManager(source, config, publisher,
         new NetworkTopologyImpl(source), SCMContext.emptyContext(),
             versionManager);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add static import for assertions and mocks in hadoop-hdds/server-scm.
he goal of this task is to add import static for all assertions and interactions with mocks. Replacing:

Assertions.assert(...) -> assert(...)
Assertions.fail(...) -> fail(...)

and

Mockito.mock(...) -> mock(...)
Mockito.verify(...) -> verify(...)
Mockito.when(...) -> when(...)
...

and

ArgumentMatchers.any() -> any()
ArgumentMatchers.eq() -> eq()
ArgumentMatchers.matches() -> matches()
// also:
// Matchers.<...>()

- makes the code more readable (shorter lines, less wrapping).
- Corrected argument sequence at some places in assertEquals to expected, actual.
- Modified try{ fail() ) catch to assertThrows for the suitable cases.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9993

## How was this patch tested?

Tested the test cases in CI-CD pipeline.
