### PR TITLE
HDDS-10058. Replace Hamcrest assertions

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/client/TestHddsClientUtils.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/client/TestHddsClientUtils.java
@@ -36,6 +36,8 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT;
@@ -43,17 +45,12 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_PORT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This test class verifies the parsing of SCM endpoint config settings. The
@@ -130,8 +127,8 @@ public class TestHddsClientUtils {
         HddsUtils.getScmAddressForClients(conf).iterator();
     assertTrue(scmAddrIterator.hasNext());
     InetSocketAddress scmAddr = scmAddrIterator.next();
-    assertThat(scmAddr.getHostString(), is(address));
-    assertThat(scmAddr.getPort(), is(port));
+    assertEquals(address, scmAddr.getHostString());
+    assertEquals(port, scmAddr.getPort());
   }
 
   @Test

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/Proto2CodecTestBase.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/Proto2CodecTestBase.java
@@ -21,8 +21,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -36,8 +35,8 @@ public abstract class Proto2CodecTestBase<T> {
     InvalidProtocolBufferException exception =
         assertThrows(InvalidProtocolBufferException.class,
             () -> getCodec().fromPersistedFormat("random".getBytes(UTF_8)));
-    assertThat(exception.getMessage(),
-        containsString("the input ended unexpectedly"));
+    assertThat(exception.getMessage())
+        .contains("the input ended unexpectedly");
   }
 
   @Test

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileAppender.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileAppender.java
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test the utility which loads/writes the config file fragments.
@@ -40,11 +39,9 @@ public class TestConfigFileAppender {
 
     StringWriter builder = new StringWriter();
     appender.write(builder);
-    assertThat("Generated config should contain property key entry",
-        builder.toString(),
-        containsString("<name>hadoop.scm.enabled</name>"));
-    assertThat("Generated config should contain tags",
-        builder.toString(),
-        containsString("<tag>OZONE, SECURITY</tag>"));
+
+    assertThat(builder.toString())
+        .contains("<name>hadoop.scm.enabled</name>")
+        .contains("<tag>OZONE, SECURITY</tag>");
   }
 }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileGenerator.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/TestConfigFileGenerator.java
@@ -24,8 +24,7 @@ import java.util.Scanner;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test the ConfigFileGenerator.
@@ -44,22 +43,19 @@ public class TestConfigFileGenerator {
             .useDelimiter("//Z")
             .next();
 
-    assertThat("Generated config should have entry based on the annotation",
-        generatedXml,
-        containsString("<name>ozone.scm.client.bind.host</name>"));
+    assertThat(generatedXml)
+        .as("annotation in ConfigurationExample")
+        .contains("<name>ozone.scm.client.bind.host</name>");
 
-    assertThat("Generated config should have entry based on the annotation " +
-            "from the parent class",
-        generatedXml,
-        containsString("<name>ozone.scm.client.secure</name>"));
+    assertThat(generatedXml)
+        .as("annotation in ConfigurationExampleParent")
+        .contains("<name>ozone.scm.client.secure</name>");
 
-    assertThat("Generated config should have entry based on the annotation " +
-            "from the grand-parent class.",
-        generatedXml,
-        containsString("<name>ozone.scm.client.number</name>"));
+    assertThat(generatedXml)
+        .as("annotation in ConfigurationExampleGrandParent")
+        .contains("<name>ozone.scm.client.number</name>");
 
-    assertThat("Generated config should contain tags",
-        generatedXml,
-        containsString("<tag>MANAGEMENT</tag>"));
+    assertThat(generatedXml)
+        .contains("<tag>MANAGEMENT</tag>");
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -77,19 +77,20 @@ import org.apache.ozone.test.GenericTestUtils;
 
 import com.google.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.BCSID_MISMATCH;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNKNOWN_BCSID;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getChunk;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getData;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.setDataChecksum;
-
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.AfterAll;
-
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -100,12 +101,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Simple tests to verify that container persistence works as expected. Some of
@@ -290,8 +285,8 @@ public class TestContainerPersistence {
     someKey.setChunks(new LinkedList<>());
     Exception exception = assertThrows(StorageContainerException.class,
         () -> blockManager.putBlock(container, someKey));
-    assertThat(exception.getMessage(),
-        Matchers.containsString("Error opening DB."));
+    assertThat(exception.getMessage())
+        .contains("Error opening DB.");
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -327,9 +322,8 @@ public class TestContainerPersistence {
         () -> kvHandler.deleteContainer(container, false));
     assertThat(containerSet.getContainerMapCopy())
         .containsKey(testContainerID);
-    assertThat(exception.getMessage(),
-        Matchers.containsString(
-            "Non-force deletion of non-empty container is not allowed."));
+    assertThat(exception.getMessage())
+        .contains("Non-force deletion of non-empty container is not allowed.");
   }
 
   @ContainerTestVersionInfo.ContainerTest
@@ -1016,7 +1010,7 @@ public class TestContainerPersistence {
     // Count must be >0
     Exception exception = assertThrows(IllegalArgumentException.class,
         () -> blockManager.listBlock(container, 0, -1));
-    assertThat(exception.getMessage(),
-        Matchers.containsString("Count must be a positive number."));
+    assertThat(exception.getMessage())
+        .contains("Count must be a positive number.");
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisherFactory.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisherFactory.java
@@ -23,10 +23,9 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -75,7 +74,7 @@ public class TestReportPublisherFactory {
         RuntimeException.class,
         () -> factory.getPublisherFor(HddsProtos.DatanodeDetailsProto.class)
     );
-    MatcherAssert.assertThat(runtimeException.getMessage(),
-        Matchers.containsString("No publisher found for report"));
+    assertThat(runtimeException.getMessage())
+        .contains("No publisher found for report");
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolumeChecker.java
@@ -60,8 +60,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult.FAILED;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.anyObject;
@@ -151,11 +150,11 @@ public class TestStorageVolumeChecker {
           numCallbackInvocations.incrementAndGet();
           if (expectedVolumeHealth != null &&
               expectedVolumeHealth != FAILED) {
-            assertThat(healthyVolumes.size(), is(1));
-            assertThat(failedVolumes.size(), is(0));
+            assertThat(healthyVolumes.size()).isEqualTo(1);
+            assertThat(failedVolumes.size()).isEqualTo(0);
           } else {
-            assertThat(healthyVolumes.size(), is(0));
-            assertThat(failedVolumes.size(), is(1));
+            assertThat(healthyVolumes.size()).isEqualTo(0);
+            assertThat(failedVolumes.size()).isEqualTo(1);
           }
         });
 
@@ -164,7 +163,7 @@ public class TestStorageVolumeChecker {
     // Ensure that the check was invoked at least once.
     verify(volume, times(1)).check(anyObject());
     if (result) {
-      assertThat(numCallbackInvocations.get(), is(1L));
+      assertThat(numCallbackInvocations.get()).isEqualTo(1L);
     }
 
     checker.shutdownAndWait(0, TimeUnit.SECONDS);
@@ -194,7 +193,7 @@ public class TestStorageVolumeChecker {
     LOG.info("Got back {} failed volumes", failedVolumes.size());
 
     if (expectedVolumeHealth == null || expectedVolumeHealth == FAILED) {
-      assertThat(failedVolumes.size(), is(NUM_VOLUMES));
+      assertThat(failedVolumes.size()).isEqualTo(NUM_VOLUMES);
     } else {
       assertTrue(failedVolumes.isEmpty());
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -56,14 +56,13 @@ import org.apache.hadoop.util.Timer;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.apache.commons.io.FileUtils;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -108,9 +107,8 @@ public class TestVolumeSetDiskChecks {
         new MutableVolumeSet(UUID.randomUUID().toString(), conf,
             null, StorageVolume.VolumeType.DATA_VOLUME, null);
 
-    MatcherAssert.assertThat(volumeSet.getVolumesList().size(), is(numVolumes));
-    MatcherAssert.assertThat(
-        volumeSet.getFailedVolumesList().size(), is(0));
+    assertThat(volumeSet.getVolumesList().size()).isEqualTo(numVolumes);
+    assertThat(volumeSet.getFailedVolumesList().size()).isEqualTo(0);
 
     // Verify that the Ozone dirs were created during initialization.
     Collection<String> dirs = conf.getTrimmedStringCollection(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
@@ -41,8 +41,7 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.OPEN;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -122,16 +121,16 @@ public class TestKeyValueContainerMarkUnhealthy {
   @ContainerLayoutTestInfo.ContainerTest
   public void testMarkContainerUnhealthy(ContainerLayoutVersion layoutVersion) throws Exception {
     initTestData(layoutVersion);
-    assertThat(keyValueContainerData.getState(), is(OPEN));
+    assertThat(keyValueContainerData.getState()).isEqualTo(OPEN);
     keyValueContainer.markContainerUnhealthy();
-    assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
+    assertThat(keyValueContainerData.getState()).isEqualTo(UNHEALTHY);
 
     // Check metadata in the .container file
     File containerFile = keyValueContainer.getContainerFile();
 
     keyValueContainerData = (KeyValueContainerData) ContainerDataYaml
         .readContainerFile(containerFile);
-    assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
+    assertThat(keyValueContainerData.getState()).isEqualTo(UNHEALTHY);
   }
 
   /**
@@ -159,7 +158,7 @@ public class TestKeyValueContainerMarkUnhealthy {
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
     keyValueContainer.close();
     keyValueContainer.markContainerUnhealthy();
-    assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
+    assertThat(keyValueContainerData.getState()).isEqualTo(UNHEALTHY);
   }
 
   /**
@@ -173,7 +172,7 @@ public class TestKeyValueContainerMarkUnhealthy {
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
     keyValueContainer.quasiClose();
     keyValueContainer.markContainerUnhealthy();
-    assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
+    assertThat(keyValueContainerData.getState()).isEqualTo(UNHEALTHY);
   }
 
   /**
@@ -184,6 +183,6 @@ public class TestKeyValueContainerMarkUnhealthy {
     initTestData(layoutVersion);
     keyValueContainer.markContainerForClose();
     keyValueContainer.markContainerUnhealthy();
-    assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
+    assertThat(keyValueContainerData.getState()).isEqualTo(UNHEALTHY);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/ssl/TestReloadingX509TrustManager.java
@@ -26,10 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.security.cert.X509Certificate;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItemInArray;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -53,17 +50,16 @@ public class TestReloadingX509TrustManager {
         (ReloadingX509TrustManager) caClient.getServerKeyStoresFactory()
             .getTrustManagers()[0];
     X509Certificate cert1 = caClient.getRootCACertificate();
-    assertThat(tm.getAcceptedIssuers(), arrayContaining(cert1));
+    assertThat(tm.getAcceptedIssuers()).containsOnly(cert1);
 
     caClient.renewRootCA();
     caClient.renewKey();
     X509Certificate cert2 = caClient.getRootCACertificate();
     assertNotEquals(cert1, cert2);
 
-    assertThat(tm.getAcceptedIssuers(), hasItemInArray(cert1));
-    assertThat(tm.getAcceptedIssuers(), hasItemInArray(cert2));
-    assertThat(reloaderLog.getOutput(),
-        containsString("ReloadingX509TrustManager is reloaded"));
+    assertThat(tm.getAcceptedIssuers()).contains(cert1, cert2);
+    assertThat(reloaderLog.getOutput())
+        .contains("ReloadingX509TrustManager is reloaded");
 
     // Make sure there are two reload happened, one for server, one for client
     assertEquals(2, StringUtils.countMatches(reloaderLog.getOutput(),

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
@@ -48,8 +48,7 @@ import static org.apache.hadoop.ozone.container.ContainerTestHelper.getBlockRequ
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getReadChunkRequest;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.newPutBlockRequestBuilder;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.newWriteChunkRequestBuilder;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -174,10 +173,10 @@ public class TestOzoneBlockTokenSecretManager {
     BlockTokenException e = assertThrows(BlockTokenException.class,
         () -> tokenVerifier.verify("testUser", token, writeChunkRequest));
 
-    assertThat(e.getMessage(), containsString("Token for ID: " +
+    assertThat(e.getMessage()).contains("Token for ID: " +
         OzoneBlockTokenIdentifier.getTokenService(blockID) +
         " can't be used to access: " +
-        OzoneBlockTokenIdentifier.getTokenService(otherBlockID)));
+        OzoneBlockTokenIdentifier.getTokenService(otherBlockID));
   }
 
   @Test
@@ -202,8 +201,8 @@ public class TestOzoneBlockTokenSecretManager {
     BlockTokenException e = assertThrows(BlockTokenException.class,
         () -> tokenVerifier.verify(testUser1, token, putBlockCommand));
 
-    assertThat(e.getMessage(),
-        containsString("doesn't have WRITE permission"));
+    assertThat(e.getMessage())
+        .contains("doesn't have WRITE permission");
 
     tokenVerifier.verify(testUser1, token, getBlockCommand);
   }
@@ -227,8 +226,8 @@ public class TestOzoneBlockTokenSecretManager {
 
     BlockTokenException e = assertThrows(BlockTokenException.class,
         () -> tokenVerifier.verify(testUser2, token, readChunkRequest));
-    assertThat(e.getMessage(),
-        containsString("doesn't have READ permission"));
+    assertThat(e.getMessage())
+        .contains("doesn't have READ permission");
   }
 
   @Test
@@ -251,8 +250,8 @@ public class TestOzoneBlockTokenSecretManager {
 
     BlockTokenException e = assertThrows(BlockTokenException.class,
         () -> tokenVerifier.verify(user, token, writeChunkRequest));
-    assertThat(e.getMessage(),
-        containsString("Token can't be verified due to expired secret key"));
+    assertThat(e.getMessage())
+        .contains("Token can't be verified due to expired secret key");
   }
 
   private ManagedSecretKey generateValidSecretKey()

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
@@ -38,8 +38,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -132,7 +131,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     Token<T> token = secretManager.generateToken(tokenId);
     BlockTokenException ex = assertThrows(BlockTokenException.class, () ->
         subject.verify("anyUser", token, cmd));
-    assertThat(ex.getMessage(), containsString("expired secret key"));
+    assertThat(ex.getMessage()).contains("expired secret key");
   }
 
   @Test
@@ -151,8 +150,8 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     Token<T> token = secretManager.generateToken(tokenId);
     BlockTokenException ex = assertThrows(BlockTokenException.class, () ->
         subject.verify("anyUser", token, cmd));
-    assertThat(ex.getMessage(),
-        containsString("Can't find the signing secret key"));
+    assertThat(ex.getMessage())
+        .contains("Can't find the signing secret key");
   }
 
   @Test
@@ -171,8 +170,8 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     BlockTokenException ex =
         assertThrows(BlockTokenException.class, () ->
             subject.verify("anyUser", invalidToken, cmd));
-    assertThat(ex.getMessage(),
-        containsString("Invalid token for user"));
+    assertThat(ex.getMessage())
+        .contains("Invalid token for user");
   }
 
   @NotNull
@@ -203,8 +202,8 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     BlockTokenException ex =
         assertThrows(BlockTokenException.class, () ->
             subject.verify("anyUser", token, cmd));
-    assertThat(ex.getMessage(),
-        containsString("Expired token for user"));
+    assertThat(ex.getMessage())
+        .contains("Expired token for user");
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -66,8 +66,6 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -597,7 +595,7 @@ public class TestDefaultCertificateClient {
     long monitorThreadCount = Arrays.stream(threads)
         .filter(monitorFilterPredicate)
         .count();
-    assertThat(monitorThreadCount, is(1L));
+    assertThat(monitorThreadCount).isEqualTo(1L);
     Thread monitor = Arrays.stream(threads)
         .filter(monitorFilterPredicate)
         .findFirst()
@@ -610,6 +608,6 @@ public class TestDefaultCertificateClient {
     monitorThreadCount = Arrays.stream(threads)
         .filter(monitorFilterPredicate)
         .count();
-    assertThat(monitorThreadCount, is(0L));
+    assertThat(monitorThreadCount).isEqualTo(0L);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -27,20 +27,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.audit.AuditEventStatus.FAILURE;
 import static org.apache.hadoop.ozone.audit.AuditEventStatus.SUCCESS;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.hamcrest.Matcher;
-import org.hamcrest.collection.IsIterableContainingInOrder;
 
 
 /**
@@ -235,8 +228,7 @@ public class TestOzoneAuditLogger {
     File file = new File("audit.log");
     List<String> lines = FileUtils.readLines(file, (String)null);
     final int retry = 5;
-    int i = 0;
-    while (lines.isEmpty() && i < retry) {
+    for (int i = 0; lines.isEmpty() && i < retry; i++) {
       lines = FileUtils.readLines(file, (String)null);
       try {
         Thread.sleep(500 * (i + 1));
@@ -244,13 +236,12 @@ public class TestOzoneAuditLogger {
         Thread.currentThread().interrupt();
         break;
       }
-      i++;
     }
     //check if every expected string can be found in the log entry
-    assertThat(
-        lines.subList(0, expectedStrings.length),
-        containsInOrder(expectedStrings)
-    );
+    for (int i = 0; i < expectedStrings.length; i++) {
+      String line = lines.get(i);
+      assertThat(line).contains(expectedStrings[i]);
+    }
     //empty the file
     lines.clear();
     FileUtils.writeLines(file, lines, false);
@@ -260,21 +251,12 @@ public class TestOzoneAuditLogger {
     File file = new File("audit.log");
     List<String> lines = FileUtils.readLines(file, (String)null);
     // When no log entry is expected, the log file must be empty
-    assertEquals(0, lines.size());
+    assertThat(lines).isEmpty();
   }
 
   private static class TestException extends Exception {
     TestException(String message) {
       super(message);
     }
-  }
-
-  private Matcher<Iterable<? extends String>> containsInOrder(
-      String[] expectedStrings) {
-    return IsIterableContainingInOrder.contains(
-        Arrays.stream(expectedStrings)
-            .map(str -> containsString(str))
-            .collect(Collectors.toList())
-    );
   }
 }

--- a/hadoop-hdds/hadoop-dependency-test/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-test/pom.xml
@@ -73,11 +73,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -65,8 +65,6 @@ import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.FAI
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.matchesPattern;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -767,8 +765,8 @@ public class TestSCMContainerPlacementRackScatter {
     SCMException exception = Assertions.assertThrows(SCMException.class, () ->
         policy.chooseDatanodes(usedDns, excludedDns,
             null, 3, 0, 5));
-    assertThat(exception.getMessage(),
-        matchesPattern("^No enough datanodes to choose.*"));
+    assertThat(exception.getMessage())
+        .matches("^No enough datanodes to choose.*");
     assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
         exception.getResult());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcProtocolService.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestInterSCMGrpcProtocolService.java
@@ -54,8 +54,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.security.x509.CertificateTestUtils.createSelfSignedCert;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
@@ -120,8 +119,8 @@ class TestInterSCMGrpcProtocolService {
     verify(serverTrustManager, never()).checkServerTrusted(any(), any());
     verify(serverTrustManager, times(1))
         .checkClientTrusted(capturedCerts.capture(), any());
-    assertThat(capturedCerts.getValue().length, is(1));
-    assertThat(capturedCerts.getValue()[0], is(clientCert));
+    assertThat(capturedCerts.getValue().length).isEqualTo(1);
+    assertThat(capturedCerts.getValue()[0]).isEqualTo(clientCert);
   }
 
   private void verifyClientUsedItsCertAndValidatedServerCert()
@@ -132,8 +131,8 @@ class TestInterSCMGrpcProtocolService {
     verify(clientTrustManager, times(1))
         .checkServerTrusted(capturedCerts.capture(), any());
     verify(clientTrustManager, never()).checkClientTrusted(any(), any());
-    assertThat(capturedCerts.getValue().length, is(1));
-    assertThat(capturedCerts.getValue()[0], is(serviceCert));
+    assertThat(capturedCerts.getValue().length).isEqualTo(1);
+    assertThat(capturedCerts.getValue()[0]).isEqualTo(serviceCert);
   }
 
   private void verifyDownloadedCheckPoint(Path downloaded) throws IOException {
@@ -143,8 +142,8 @@ class TestInterSCMGrpcProtocolService {
          BufferedReader reader =
              new BufferedReader(new InputStreamReader(in, UTF_8))
     ) {
-      assertThat(in.getNextTarEntry().getName(), is(CP_FILE_NAME));
-      assertThat(reader.readLine(), is(CP_CONTENTS));
+      assertThat(in.getNextTarEntry().getName()).isEqualTo(CP_FILE_NAME);
+      assertThat(reader.readLine()).isEqualTo(CP_CONTENTS);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -59,8 +59,6 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.CLOSED;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -312,8 +310,8 @@ public class TestWritableECContainerProvider {
 
     IOException ioException = assertThrows(IOException.class,
         () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
-    assertThat(ioException.getMessage(),
-        containsString("Cannot create pipelines"));
+    assertThat(ioException.getMessage())
+        .contains("Cannot create pipelines");
   }
 
   @ParameterizedTest
@@ -341,14 +339,14 @@ public class TestWritableECContainerProvider {
 
     IOException ioException = assertThrows(IOException.class,
         () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
-    assertThat(ioException.getMessage(),
-        containsString("Cannot create pipelines"));
+    assertThat(ioException.getMessage())
+        .contains("Cannot create pipelines");
 
     for (int i = 0; i < 5; i++) {
       ioException = assertThrows(IOException.class,
           () -> provider.getContainer(1, repConfig, OWNER, new ExcludeList()));
-      assertThat(ioException.getMessage(),
-          containsString("Cannot create pipelines"));
+      assertThat(ioException.getMessage())
+          .contains("Cannot create pipelines");
     }
   }
 

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/cert/TestCleanExpiredCertsSubcommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/cert/TestCleanExpiredCertsSubcommand.java
@@ -26,7 +26,6 @@ import static org.apache.hadoop.hdds.security.x509.CertificateTestUtils.createSe
 
 import org.apache.hadoop.hdds.security.x509.CertificateTestUtils;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
-import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +38,7 @@ import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -81,6 +80,6 @@ class TestCleanExpiredCertsSubcommand {
     String certInfo = String.format(OUTPUT_FORMAT, cert.getSerialNumber(),
         cert.getNotBefore(), cert.getNotAfter(), cert.getSubjectDN(),
         cert.getIssuerDN());
-    assertThat(cliOutPut, new StringContains(true, certInfo));
+    assertThat(cliOutPut).contains(certInfo);
   }
 }

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -423,7 +423,7 @@ Apache License 2.0
    org.eclipse.jetty:jetty-util-ajax
    org.eclipse.jetty:jetty-webapp
    org.eclipse.jetty:jetty-xml
-   org.hamcrest:hamcrest-all
+   org.hamcrest:hamcrest
    org.javassist:javassist
    org.jetbrains:annotations
    org.jetbrains.kotlin:kotlin-stdlib

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -254,6 +254,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSBucketLayout.java
@@ -17,41 +17,38 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.TestDataUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collection;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Ozone file system tests to validate default bucket layout configuration
@@ -127,8 +124,8 @@ class TestOzoneFSBucketLayout {
 
     OMException e = assertThrows(OMException.class,
         () -> FileSystem.newInstance(conf));
-    assertThat(e.getMessage(),
-        containsString(ERROR_MAP.get(layout)));
+    assertThat(e.getMessage())
+        .contains(ERROR_MAP.get(layout));
   }
   @ParameterizedTest
   @MethodSource("validDefaultBucketLayouts")

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
@@ -41,8 +41,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.ratis.util.LifeCycle;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +55,7 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsUtils.getHostName;
 import static org.apache.hadoop.hdds.HddsUtils.getHostPort;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -253,11 +252,9 @@ public class TestOzoneFsHAURLs {
           new GenericTestUtils.SystemErrCapturer()) {
         res = ToolRunner.run(shell, new String[] {"-ls", unqualifiedPath1});
         // Check stderr, inspired by testDFSWithInvalidCommmand
-        MatcherAssert.assertThat("Command did not print the error message " +
-                "correctly for test case: ozone fs -ls o3fs://bucket.volume/",
-            capture.getOutput(), StringContains.containsString(
-                "-ls: Service ID or host name must not"
-                    + " be omitted when ozone.om.service.ids is defined."));
+        assertThat(capture.getOutput())
+            .as("ozone fs -ls o3fs://bucket.volume/")
+            .contains("-ls: Service ID or host name must not be omitted when ozone.om.service.ids is defined.");
       }
       // Check return value, should be -1 (failure)
       assertEquals(-1, res);
@@ -297,11 +294,9 @@ public class TestOzoneFsHAURLs {
           new GenericTestUtils.SystemErrCapturer()) {
         res = ToolRunner.run(shell, new String[] {"-ls", unqualifiedPath2});
         // Check stderr
-        MatcherAssert.assertThat("Command did not print the error message " +
-                "correctly for test case: "
-                + "ozone fs -ls o3fs://bucket.volume.id1:port/",
-            capture.getOutput(), StringContains.containsString(
-                "does not use port information"));
+        assertThat(capture.getOutput())
+            .as("ozone fs -ls o3fs://bucket.volume.id1:port/")
+            .contains("does not use port information");
       }
       // Check return value, should be -1 (failure)
       assertEquals(-1, res);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestContainerScannerIntegrationAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestContainerScannerIntegrationAbstract.java
@@ -69,8 +69,7 @@ import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.client.ReplicationType.RATIS;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import static org.apache.hadoop.ozone.container.common.interfaces.Container.ScanResult;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -326,8 +325,8 @@ public abstract class TestContainerScannerIntegrationAbstract {
      * Check that the correct corruption type was written to the container log.
      */
     public void assertLogged(LogCapturer logCapturer) {
-      assertThat(logCapturer.getOutput(),
-          containsString(expectedResult.toString()));
+      assertThat(logCapturer.getOutput())
+          .contains(expectedResult.toString());
     }
 
     /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -135,10 +135,8 @@ import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DO
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.COLUMN_FAMILIES_TO_TRACK_IN_DAG;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.with;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -146,8 +144,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Abstract class to test OmSnapshot.
@@ -275,8 +273,8 @@ public abstract class TestOmSnapshot {
   private static void assertFinalizationException(OMException omException) {
     assertEquals(NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION,
         omException.getResult());
-    assertThat(omException.getMessage(),
-        containsString("cannot be invoked before finalization."));
+    assertThat(omException.getMessage())
+        .contains("cannot be invoked before finalization.");
   }
 
   /**
@@ -1434,9 +1432,9 @@ public abstract class TestOmSnapshot {
     IOException ioException = assertThrows(IOException.class,
         () -> store.snapshotDiff(volume, bucket, snap6,
             snap7, "3", 0, forceFullSnapshotDiff, disableNativeDiff));
-    assertThat(ioException.getMessage(), containsString("Index (given: 3) " +
+    assertThat(ioException.getMessage()).contains("Index (given: 3) " +
         "should be a number >= 0 and < totalDiffEntries: 2. Page size " +
-        "(given: 1000) should be a positive number > 0."));
+        "(given: 1000) should be a positive number > 0.");
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMStorage.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMStorage.java
@@ -36,13 +36,12 @@ import static org.apache.hadoop.ozone.om.OMStorage.ERROR_UNEXPECTED_OM_NODE_ID_T
 import static org.apache.hadoop.ozone.om.OMStorage.OM_CERT_SERIAL_ID;
 import static org.apache.hadoop.ozone.om.OMStorage.OM_ID;
 import static org.apache.hadoop.ozone.om.OMStorage.OM_NODE_ID;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -82,9 +81,9 @@ public class TestOMStorage {
     final File metaDir = new File(testDir, "metaDir");
     OzoneConfiguration conf = confWithHDDSMetaAndOMDBDir(metaDir, dbDir);
 
-    assertThat(dbDir, equalTo(OMStorage.getOmDbDir(conf)));
-    assertThat(dbDir.exists(), is(true));
-    assertThat(metaDir.exists(), is(false));
+    assertEquals(dbDir, OMStorage.getOmDbDir(conf));
+    assertTrue(dbDir.exists());
+    assertFalse(metaDir.exists());
   }
 
   @Test
@@ -92,8 +91,8 @@ public class TestOMStorage {
     File metaDir = tmpFolder.toFile();
     OzoneConfiguration conf = confWithHDDSMetadataDir(metaDir);
 
-    assertThat(metaDir, equalTo(OMStorage.getOmDbDir(conf)));
-    assertThat(metaDir.exists(), is(true));
+    assertEquals(metaDir, OMStorage.getOmDbDir(conf));
+    assertTrue(metaDir.exists());
   }
 
   @Test
@@ -106,7 +105,7 @@ public class TestOMStorage {
   @Test
   public void testSetOmIdOnNotInitializedStorage() throws Exception {
     OMStorage storage = new OMStorage(configWithOMDBDir());
-    assertThat(storage.getState(), is(not(INITIALIZED)));
+    assertNotEquals(INITIALIZED, storage.getState());
 
     String omId = "omId";
     try {
@@ -114,7 +113,7 @@ public class TestOMStorage {
     } catch (IOException e) {
       fail("Can not set OmId on a Storage that is not initialized.");
     }
-    assertThat(storage.getOmId(), is(omId));
+    assertEquals(omId, storage.getOmId());
     assertGetNodeProperties(storage, omId);
   }
 
@@ -135,20 +134,20 @@ public class TestOMStorage {
     OzoneConfiguration conf = configWithOMDBDir();
     OMStorage storage = new OMStorage(conf);
 
-    assertThat(storage.getState(), is(not(INITIALIZED)));
+    assertNotEquals(INITIALIZED, storage.getState());
     assertCertOps(storage);
     storage.initialize();
     storage.persistCurrentState();
 
     storage = new OMStorage(conf);
-    assertThat(storage.getState(), is(INITIALIZED));
+    assertEquals(INITIALIZED, storage.getState());
     assertCertOps(storage);
   }
 
   @Test
   public void testSetOmNodeIdOnNotInitializedStorage() throws Exception {
     OMStorage storage = new OMStorage(configWithOMDBDir());
-    assertThat(storage.getState(), is(not(INITIALIZED)));
+    assertNotEquals(INITIALIZED, storage.getState());
 
     String nodeId = "nodeId";
     try {
@@ -156,7 +155,7 @@ public class TestOMStorage {
     } catch (IOException e) {
       fail("Can not set OmNodeId on a Storage that is not initialized.");
     }
-    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertEquals(nodeId, storage.getOmNodeId());
     assertGetNodeProperties(storage, null, nodeId);
   }
 
@@ -193,15 +192,15 @@ public class TestOMStorage {
     setupAPersistedVersionFile(conf);
 
     OMStorage storage = new OMStorage(conf);
-    assertThat(storage.getState(), is(INITIALIZED));
-    assertThat(storage.getOmNodeId(), is(nullValue()));
+    assertEquals(INITIALIZED, storage.getState());
+    assertNull(storage.getOmNodeId());
 
     storage.validateOrPersistOmNodeId(nodeId);
-    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertEquals(nodeId, storage.getOmNodeId());
     assertGetNodeProperties(storage, OM_ID_STR, nodeId);
 
     storage = new OMStorage(conf);
-    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertEquals(nodeId, storage.getOmNodeId());
     assertGetNodeProperties(storage, OM_ID_STR, nodeId);
   }
 
@@ -213,13 +212,13 @@ public class TestOMStorage {
     setupAPersistedVersionFileWithNodeId(conf, nodeId);
 
     OMStorage storage = new OMStorage(conf);
-    assertThat(storage.getState(), is(INITIALIZED));
-    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertEquals(INITIALIZED, storage.getState());
+    assertEquals(nodeId, storage.getOmNodeId());
     assertGetNodeProperties(storage, OM_ID_STR, nodeId);
 
     storage.validateOrPersistOmNodeId(nodeId);
 
-    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertEquals(nodeId, storage.getOmNodeId());
     assertGetNodeProperties(storage, OM_ID_STR, nodeId);
   }
 
@@ -232,8 +231,8 @@ public class TestOMStorage {
     setupAPersistedVersionFileWithNodeId(conf, nodeId);
 
     OMStorage storage = new OMStorage(conf);
-    assertThat(storage.getState(), is(INITIALIZED));
-    assertThat(storage.getOmNodeId(), is(nodeId));
+    assertEquals(INITIALIZED, storage.getState());
+    assertEquals(nodeId, storage.getOmNodeId());
 
     String expectedMsg =
         String.format(ERROR_UNEXPECTED_OM_NODE_ID_TEMPLATE, newId, nodeId);
@@ -247,15 +246,15 @@ public class TestOMStorage {
     String certSerialId = "12345";
     String certSerialId2 = "54321";
     storage.setOmCertSerialId(certSerialId);
-    assertThat(storage.getOmCertSerialId(), is(certSerialId));
+    assertEquals(certSerialId, storage.getOmCertSerialId());
     assertGetNodeProperties(storage, null, null, certSerialId);
 
     storage.setOmCertSerialId(certSerialId2);
-    assertThat(storage.getOmCertSerialId(), is(certSerialId2));
+    assertEquals(certSerialId2, storage.getOmCertSerialId());
     assertGetNodeProperties(storage, null, null, certSerialId2);
 
     storage.unsetOmCertSerialId();
-    assertThat(storage.getOmCertSerialId(), is(nullValue()));
+    assertNull(storage.getOmCertSerialId());
     assertGetNodeProperties(storage, null, null, null);
   }
 
@@ -264,13 +263,13 @@ public class TestOMStorage {
     Map<String, String> e = toExpectedPropertyMapping(values);
 
     if (e.get(OM_ID) != null) {
-      assertThat(p.getProperty(OM_ID), is(e.get(OM_ID)));
+      assertEquals(e.get(OM_ID), p.getProperty(OM_ID));
     }
     if (e.get(OM_NODE_ID) != null) {
-      assertThat(p.get(OM_NODE_ID), is(e.get(OM_NODE_ID)));
+      assertEquals(e.get(OM_NODE_ID), p.get(OM_NODE_ID));
     }
     if (e.get(OM_CERT_SERIAL_ID) != null) {
-      assertThat(p.get(OM_CERT_SERIAL_ID), is(e.get(OM_CERT_SERIAL_ID)));
+      assertEquals(e.get(OM_CERT_SERIAL_ID), p.get(OM_CERT_SERIAL_ID));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestServiceInfoProvider.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestServiceInfoProvider.java
@@ -42,13 +42,7 @@ import static org.apache.hadoop.hdds.security.x509.CertificateTestUtils.aKeyPair
 import static org.apache.hadoop.hdds.security.x509.CertificateTestUtils.createSelfSignedCert;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -88,9 +82,9 @@ public class TestServiceInfoProvider {
     public void test() throws Exception {
       ServiceInfoEx info = provider.provide();
 
-      assertThat(info.getServiceInfoList(), sameInstance(emptyList()));
-      assertThat(info.getCaCertificate(), is(nullValue()));
-      assertThat(info.getCaCertPemList(), is(empty()));
+      assertThat(info.getServiceInfoList()).isSameAs(emptyList());
+      assertThat(info.getCaCertificate()).isNull();
+      assertThat(info.getCaCertPemList()).isEmpty();
     }
   }
 
@@ -125,24 +119,24 @@ public class TestServiceInfoProvider {
     public void withoutRootCARenew() throws Exception {
       ServiceInfoEx info = provider.provide();
 
-      assertThat(info.getServiceInfoList(), sameInstance(emptyList()));
-      assertThat(info.getCaCertificate(), is(equalTo(pem2)));
-      assertThat(info.getCaCertPemList(), containsInAnyOrder(pem1, pem2));
+      assertThat(info.getServiceInfoList()).isSameAs(emptyList());
+      assertThat(info.getCaCertificate()).isEqualTo(pem2);
+      assertThat(info.getCaCertPemList()).contains(pem1, pem2);
 
       info = provider.provide();
 
-      assertThat(info.getServiceInfoList(), sameInstance(emptyList()));
-      assertThat(info.getCaCertificate(), is(equalTo(pem2)));
-      assertThat(info.getCaCertPemList(), containsInAnyOrder(pem1, pem2));
+      assertThat(info.getServiceInfoList()).isSameAs(emptyList());
+      assertThat(info.getCaCertificate()).isEqualTo(pem2);
+      assertThat(info.getCaCertPemList()).contains(pem1, pem2);
     }
 
     @Test
     public void withRootCARenew() throws Exception {
       ServiceInfoEx info = provider.provide();
 
-      assertThat(info.getServiceInfoList(), sameInstance(emptyList()));
-      assertThat(info.getCaCertificate(), is(equalTo(pem2)));
-      assertThat(info.getCaCertPemList(), containsInAnyOrder(pem1, pem2));
+      assertThat(info.getServiceInfoList()).isSameAs(emptyList());
+      assertThat(info.getCaCertificate()).isEqualTo(pem2);
+      assertThat(info.getCaCertPemList()).contains(pem1, pem2);
 
       X509Certificate cert3 =
           createSelfSignedCert(aKeyPair(conf), "cn", Duration.ofDays(3));
@@ -155,9 +149,9 @@ public class TestServiceInfoProvider {
 
       info = provider.provide();
 
-      assertThat(info.getServiceInfoList(), sameInstance(emptyList()));
-      assertThat(info.getCaCertificate(), is(equalTo(pem3)));
-      assertThat(info.getCaCertPemList(), containsInAnyOrder(pem2, pem3));
+      assertThat(info.getServiceInfoList()).isSameAs(emptyList());
+      assertThat(info.getCaCertificate()).isEqualTo(pem3);
+      assertThat(info.getCaCertPemList()).contains(pem2, pem3);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMUpgradeFinalizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOMUpgradeFinalizer.java
@@ -42,10 +42,10 @@ import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.ALREADY_FI
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_DONE;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_REQUIRED;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.STARTING_FINALIZATION;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -55,7 +55,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * {@link OMUpgradeFinalizer} tests.
@@ -146,7 +145,7 @@ public class TestOMUpgradeFinalizer {
         UpgradeException.class, () -> {
           finalizer.reportStatus(OTHER_CLIENT_ID, false);
         });
-    assertThat(exception.getMessage(), containsString("Unknown client"));
+    assertThat(exception.getMessage()).contains("Unknown client");
   }
 
   @Test
@@ -200,8 +199,8 @@ public class TestOMUpgradeFinalizer {
       finalizer.finalize(CLIENT_ID, om);
       fail();
     } catch (Exception e) {
-      assertThat(e, instanceOf(UpgradeException.class));
-      assertThat(e.getMessage(), containsString(lfs.iterator().next().name()));
+      assertInstanceOf(UpgradeException.class, e);
+      assertThat(e.getMessage()).contains(lfs.iterator().next().name());
       assertEquals(
           ((UpgradeException) e).getResult(),
           LAYOUT_FEATURE_FINALIZATION_FAILED

--- a/pom.xml
+++ b/pom.xml
@@ -1282,7 +1282,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-all</artifactId>
+        <artifactId>hamcrest-core</artifactId>
         <version>${hamcrest.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace Hamcrest `assertThat` and matchers with JUnit or AssertJ assertions, to reduce the number of test dependencies a bit.

https://issues.apache.org/jira/browse/HDDS-10058

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7409626572