### PR TITLE
HDDS-8830. Add admin CLI to list open files

### DIFF
--- a/hadoop-hdds/docs/content/tools/Admin.md
+++ b/hadoop-hdds/docs/content/tools/Admin.md
@@ -171,4 +171,4 @@ $ ozone admin om lof --service-id=om-service-test1 --length=3 --prefix=/volumelo
 }
 ```
 
-Note in JSON output mode, field `contToken` won't show up at all in the result if there are no more entries to be after the batch.
+Note in JSON output mode, field `contToken` won't show up at all in the result if there are no more entries after the batch (i.e. when `hasMore` is `false`).

--- a/hadoop-hdds/docs/content/tools/Admin.md
+++ b/hadoop-hdds/docs/content/tools/Admin.md
@@ -32,4 +32,141 @@ And quick overview about the available functionalities:
  * `ozone admin replicationmanager`: Can be used to check the status of the replications (and start / stop replication in case of emergency).
  * `ozone admin om`: Ozone Manager HA related tool to get information about the current cluster.
 
-For more detailed usage see the output of the `--help`.
+For more detailed usage see the output of `--help`.
+
+```bash
+$ ozone admin --help
+Usage: ozone admin [-hV] [--verbose] [-conf=<configurationPath>]
+                   [-D=<String=String>]... [COMMAND]
+Developer tools for Ozone Admin operations
+      -conf=<configurationPath>
+
+  -D, --set=<String=String>
+
+  -h, --help      Show this help message and exit.
+  -V, --version   Print version information and exit.
+      --verbose   More verbose output. Show the stack trace of the errors.
+Commands:
+  containerbalancer   ContainerBalancer specific operations
+  replicationmanager  ReplicationManager specific operations
+  safemode            Safe mode specific operations
+  printTopology       Print a tree of the network topology as reported by SCM
+  cert                Certificate related operations
+  container           Container specific operations
+  datanode            Datanode specific operations
+  pipeline            Pipeline specific operations
+  namespace           Namespace Summary specific admin operations
+  om                  Ozone Manager specific admin operations
+  reconfig            Dynamically reconfigure server without restarting it
+  scm                 Ozone Storage Container Manager specific admin operations
+```
+
+Some of those subcommand usages has been detailed in their dedicated feature documentation pages. For instance, [Decommissioning]({{<ref "feature/Decommission.md">}}), [Non-Rolling Upgrades and Downgrades]({{<ref "feature/Nonrolling-Upgrade.md">}}).
+
+
+## List open files
+
+List open files admin command lists open keys in Ozone Manager's `OpenKeyTable`.
+Works for all bucket types.
+Argument `--prefix` could point to root (`/`), path to a bucket (`/vol1/buck`) or a key prefix.
+
+```bash
+$ ozone admin om lof --help
+Usage: ozone admin om list-open-files [-hV] [--json] [-host=<omHost>]
+                                      [-id=<omServiceId>] [-l=<limit>]
+                                      [-p=<pathPrefix>] [-s=<startItem>]
+Lists open files (keys) in Ozone Manager.
+  -h, --help                Show this help message and exit.
+      -host, --service-host=<omHost>
+                            Ozone Manager Host. If OM HA is enabled, use -id
+                              instead. If insists on using -host with OM HA,
+                              this must point directly to the leader OM. This
+                              option is required when -id is not provided or
+                              when HA is not enabled.
+      -id, --service-id=<omServiceId>
+                            Ozone Manager Service ID
+      --json                Format output as JSON
+  -l, --length=<limit>      Maximum number of items to list
+  -p, --prefix=<pathPrefix> Filter results by the specified path on the server
+                              side.
+  -s, --start=<startItem>   The item to start the listing from.
+                            i.e. continuation token. This will be excluded from
+                              the result.
+  -V, --version             Print version information and exit.
+```
+
+### Example usages
+
+- In human-readable format, list open files (keys) under bucket `/volumelof/buck1` with a batch size of 3:
+
+```bash
+$ ozone admin om lof -id=om-service-test1 --length=3 --prefix=/volumelof/buck1
+```
+
+```bash
+5 total open files (est.). Showing 3 open files (limit 3) under path prefix:
+  /volume-lof/buck1
+
+Client ID		Creation time	Hsync'ed	Open File Path
+111726338148007937	1704808626523	No		/volume-lof/buck1/-9223372036854774527/key0
+111726338151415810	1704808626578	No		/volume-lof/buck1/-9223372036854774527/key1
+111726338152071171	1704808626588	No		/volume-lof/buck1/-9223372036854774527/key2
+
+To get the next batch of open keys, run:
+  ozone admin om lof -id=om-service-test1 --length=3 --prefix=/volume-lof/buck1 --start=/-9223372036854775552/-9223372036854775040/-9223372036854774527/key2/111726338152071171
+```
+
+- In JSON, list open files (keys) under bucket `/volumelof/buck1` with a batch size of 3:
+
+```bash
+$ ozone admin om lof -id=om-service-test1 --length=3 --prefix=/volumelof/buck1 --json
+```
+
+```json
+{
+  "openKeys" : [ {
+    "keyInfo" : {
+      "metadata" : { },
+      "objectID" : -9223372036854774015,
+      "updateID" : 7,
+      "parentObjectID" : -9223372036854774527,
+      "volumeName" : "volume-lof",
+      "bucketName" : "buck1",
+      "keyName" : "key0",
+      "dataSize" : 4194304,
+      "keyLocationVersions" : [ ... ],
+      "creationTime" : 1704808722487,
+      "modificationTime" : 1704808722487,
+      "replicationConfig" : {
+        "replicationFactor" : "THREE",
+        "requiredNodes" : 3,
+        "replicationType" : "RATIS"
+      },
+      "fileName" : "key0",
+      "acls" : [ ... ],
+      "path" : "-9223372036854774527/key0",
+      "file" : true,
+      "replicatedSize" : 12582912,
+      "objectInfo" : "OMKeyInfo{volume='volume-lof', bucket='buck1', key='key0', dataSize='4194304', creationTime='1704808722487', objectID='-9223372036854774015', parentID='-9223372036854774527', replication='RATIS/THREE', fileChecksum='null}",
+      "hsync" : false,
+      "latestVersionLocations" : { ... },
+      "updateIDset" : true
+    },
+    "openVersion" : 0,
+    "clientId" : 111726344437039105
+  }, {
+    "keyInfo" : { ... },
+    "openVersion" : 0,
+    "clientId" : 111726344440578050
+  }, {
+    "keyInfo" : { ... },
+    "openVersion" : 0,
+    "clientId" : 111726344441233411
+  } ],
+  "totalOpenKeyCount" : 5,
+  "hasMore" : true,
+  "contToken" : "/-9223372036854775552/-9223372036854775040/-9223372036854774527/key2/111726344441233411"
+}
+```
+
+Note in JSON output mode, field `contToken` won't show up at all in the result if there are no more entries to be after the batch.

--- a/hadoop-hdds/docs/content/tools/Admin.md
+++ b/hadoop-hdds/docs/content/tools/Admin.md
@@ -68,7 +68,7 @@ Some of those subcommand usages has been detailed in their dedicated feature doc
 
 List open files admin command lists open keys in Ozone Manager's `OpenKeyTable`.
 Works for all bucket types.
-Argument `--prefix` could point to root (`/`), path to a bucket (`/vol1/buck`) or a key prefix.
+Argument `--prefix` could be root (`/`), path to a bucket (`/vol1/buck`) or a key prefix (for FSO buckets the key prefix could contain parent object ID). But it can't be a volume.
 
 ```bash
 $ ozone admin om lof --help

--- a/hadoop-hdds/docs/content/tools/Admin.md
+++ b/hadoop-hdds/docs/content/tools/Admin.md
@@ -72,19 +72,12 @@ Argument `--prefix` could be root (`/`), path to a bucket (`/vol1/buck`) or a ke
 
 ```bash
 $ ozone admin om lof --help
-Usage: ozone admin om list-open-files [-hV] [--json] [-host=<omHost>]
-                                      [-id=<omServiceId>] [-l=<limit>]
+Usage: ozone admin om list-open-files [-hV] [--json] [-l=<limit>]
                                       [-p=<pathPrefix>] [-s=<startItem>]
+                                      [--service-host=<omHost>]
+                                      [--service-id=<omServiceId>]
 Lists open files (keys) in Ozone Manager.
   -h, --help                Show this help message and exit.
-      -host, --service-host=<omHost>
-                            Ozone Manager Host. If OM HA is enabled, use -id
-                              instead. If insists on using -host with OM HA,
-                              this must point directly to the leader OM. This
-                              option is required when -id is not provided or
-                              when HA is not enabled.
-      -id, --service-id=<omServiceId>
-                            Ozone Manager Service ID
       --json                Format output as JSON
   -l, --length=<limit>      Maximum number of items to list
   -p, --prefix=<pathPrefix> Filter results by the specified path on the server
@@ -92,6 +85,15 @@ Lists open files (keys) in Ozone Manager.
   -s, --start=<startItem>   The item to start the listing from.
                             i.e. continuation token. This will be excluded from
                               the result.
+      --service-host=<omHost>
+                            Ozone Manager Host. If OM HA is enabled, use
+                              --service-id instead. If you must use
+                              --service-host with OM HA, this must point
+                              directly to the leader OM. This option is
+                              required when --service-id is not provided or
+                              when HA is not enabled.
+      --service-id, --om-service-id=<omServiceId>
+                            Ozone Manager Service ID
   -V, --version             Print version information and exit.
 ```
 
@@ -100,7 +102,7 @@ Lists open files (keys) in Ozone Manager.
 - In human-readable format, list open files (keys) under bucket `/volumelof/buck1` with a batch size of 3:
 
 ```bash
-$ ozone admin om lof -id=om-service-test1 --length=3 --prefix=/volumelof/buck1
+$ ozone admin om lof --service-id=om-service-test1 --length=3 --prefix=/volumelof/buck1
 ```
 
 ```bash
@@ -119,7 +121,7 @@ To get the next batch of open keys, run:
 - In JSON, list open files (keys) under bucket `/volumelof/buck1` with a batch size of 3:
 
 ```bash
-$ ozone admin om lof -id=om-service-test1 --length=3 --prefix=/volumelof/buck1 --json
+$ ozone admin om lof --service-id=om-service-test1 --length=3 --prefix=/volumelof/buck1 --json
 ```
 
 ```json

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockOmTransport.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockOmTransport.java
@@ -45,6 +45,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoVol
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocationList;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListOpenFilesRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListOpenFilesResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LookupKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.LookupKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -125,6 +127,10 @@ public class MockOmTransport implements OmTransport {
       return response(payload,
           r -> r.setServiceListResponse(
               serviceList(payload.getServiceListRequest())));
+    case ListOpenFiles:
+      return response(payload,
+          r -> r.setListOpenFilesResponse(
+              listOpenFiles(payload.getListOpenFilesRequest())));
     case AllocateBlock:
       return response(payload, r -> r.setAllocateBlockResponse(
           allocateBlock(payload.getAllocateBlockRequest())));
@@ -322,6 +328,11 @@ public class MockOmTransport implements OmTransport {
       ServiceListRequest serviceListRequest) {
     return ServiceListResponse.newBuilder()
         .build();
+  }
+
+  private ListOpenFilesResponse listOpenFiles(
+      ListOpenFilesRequest listOpenFilesRequest) {
+    return ListOpenFilesResponse.newBuilder().build();
   }
 
   private OMResponse response(OMRequest payload,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -244,6 +244,7 @@ public final class OmUtils {
     case ListKeysLight:
     case ListTrash:
     case ServiceList:
+    case ListOpenFiles:
     case ListMultiPartUploadParts:
     case GetFileStatus:
     case LookupFile:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ListOpenFilesResult.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ListOpenFilesResult.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Encapsulates the result of listOpenFiles. It has a list of
+ * {@link OpenKeySession} and a boolean flag indicating if there
+ * are more entries that are not fetched after the current batch of result.
+ */
+public class ListOpenFilesResult {
+  /**
+   * List of open files. Each has client ID and OmKeyInfo.
+   */
+  private final List<OpenKeySession> openKeySessionList;
+  /**
+   * True if there are more entries after this batch under the given path.
+   */
+  private final boolean hasMore;
+  /**
+   * Number of total open files globally.
+   */
+  private final long globalTotal;
+
+  public ListOpenFilesResult(List<OpenKeySession> openKeySessionList,
+                             boolean hasMore, long globalTotal) {
+    this.openKeySessionList = openKeySessionList;
+    this.hasMore = hasMore;
+    this.globalTotal = globalTotal;
+  }
+
+  public ListOpenFilesResult(List<Long> clientIDsList,
+                             List<KeyInfo> keyInfosList,
+                             boolean hasMore, long globalTotal)
+      throws IOException {
+    this.openKeySessionList = getOpenKeySessionListFromPB(clientIDsList,
+        keyInfosList);
+    this.hasMore = hasMore;
+    this.globalTotal = globalTotal;
+  }
+
+  private List<OpenKeySession> getOpenKeySessionListFromPB(
+      List<Long> clientIDsList, List<KeyInfo> keyInfosList)
+      throws IOException {
+
+    Preconditions.checkArgument(clientIDsList.size() == keyInfosList.size(),
+        "clientIDsList size (" + clientIDsList.size() + ") should be " +
+            "the same as keyInfosList's (" + keyInfosList.size() + ")");
+
+    List<OpenKeySession> res = new ArrayList<>();
+
+    for (int i = 0; i < clientIDsList.size(); i++) {
+      OmKeyInfo omKeyInfo = OmKeyInfo.getFromProtobuf(keyInfosList.get(i));
+      res.add(new OpenKeySession(clientIDsList.get(i),
+          omKeyInfo,
+          omKeyInfo.getLatestVersionLocations().getVersion()));
+    }
+    return res;
+  }
+
+  public List<OpenKeySession> getOpenFiles() {
+    return openKeySessionList;
+  }
+
+  public boolean hasMore() {
+    return hasMore;
+  }
+
+  public long getGlobalTotal() {
+    return globalTotal;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ListOpenFilesResult.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ListOpenFilesResult.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
 
@@ -37,27 +38,29 @@ public class ListOpenFilesResult {
   /**
    * True if there are more entries after this batch under the given path.
    */
+  @JsonProperty("hasMore")
   private final boolean hasMore;
   /**
    * Number of total open files globally.
    */
-  private final long globalTotal;
+  @JsonProperty("totalOpenKeyCount")
+  private final long totalOpenKeyCount;
 
   public ListOpenFilesResult(List<OpenKeySession> openKeySessionList,
-                             boolean hasMore, long globalTotal) {
+                             boolean hasMore, long totalOpenKeyCount) {
     this.openKeySessionList = openKeySessionList;
     this.hasMore = hasMore;
-    this.globalTotal = globalTotal;
+    this.totalOpenKeyCount = totalOpenKeyCount;
   }
 
   public ListOpenFilesResult(List<Long> clientIDsList,
                              List<KeyInfo> keyInfosList,
-                             boolean hasMore, long globalTotal)
+                             boolean hasMore, long totalOpenKeyCount)
       throws IOException {
     this.openKeySessionList = getOpenKeySessionListFromPB(clientIDsList,
         keyInfosList);
     this.hasMore = hasMore;
-    this.globalTotal = globalTotal;
+    this.totalOpenKeyCount = totalOpenKeyCount;
   }
 
   private List<OpenKeySession> getOpenKeySessionListFromPB(
@@ -79,7 +82,7 @@ public class ListOpenFilesResult {
     return res;
   }
 
-  public List<OpenKeySession> getOpenFiles() {
+  public List<OpenKeySession> getOpenKeys() {
     return openKeySessionList;
   }
 
@@ -87,7 +90,7 @@ public class ListOpenFilesResult {
     return hasMore;
   }
 
-  public long getGlobalTotal() {
-    return globalTotal;
+  public long getTotalOpenKeyCount() {
+    return totalOpenKeyCount;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ListOpenFilesResult.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ListOpenFilesResult.java
@@ -32,37 +32,52 @@ import java.util.List;
  */
 public class ListOpenFilesResult {
   /**
-   * List of open files. Each has client ID and OmKeyInfo.
+   * Number of total open files globally.
    */
-  private final List<OpenKeySession> openKeySessionList;
+  @JsonProperty("totalOpenKeyCount")
+  private final long totalOpenKeyCount;
   /**
    * True if there are more entries after this batch under the given path.
    */
   @JsonProperty("hasMore")
   private final boolean hasMore;
   /**
-   * Number of total open files globally.
+   * True if there are more entries after this batch under the given path.
    */
-  @JsonProperty("totalOpenKeyCount")
-  private final long totalOpenKeyCount;
+  @JsonProperty("contToken")
+  private final String continuationToken;
+  /**
+   * List of open files. Each has client ID and OmKeyInfo.
+   */
+  private final List<OpenKeySession> openKeySessionList;
 
-  public ListOpenFilesResult(List<OpenKeySession> openKeySessionList,
-                             boolean hasMore, long totalOpenKeyCount) {
+  public ListOpenFilesResult(long totalOpenKeyCount,
+                             boolean hasMore,
+                             String continuationToken,
+                             List<OpenKeySession> openKeySessionList) {
     this.openKeySessionList = openKeySessionList;
     this.hasMore = hasMore;
+    this.continuationToken = continuationToken;
     this.totalOpenKeyCount = totalOpenKeyCount;
   }
 
-  public ListOpenFilesResult(List<Long> clientIDsList,
-                             List<KeyInfo> keyInfosList,
-                             boolean hasMore, long totalOpenKeyCount)
+  public ListOpenFilesResult(long totalOpenKeyCount,
+                             boolean hasMore,
+                             String continuationToken,
+                             List<Long> clientIDsList,
+                             List<KeyInfo> keyInfosList)
       throws IOException {
     this.openKeySessionList = getOpenKeySessionListFromPB(clientIDsList,
         keyInfosList);
     this.hasMore = hasMore;
+    this.continuationToken = continuationToken;
     this.totalOpenKeyCount = totalOpenKeyCount;
   }
 
+  /**
+   * Combines clientIDsList and keyInfosList into OpenKeySessionList for
+   * transfer to the client.
+   */
   private List<OpenKeySession> getOpenKeySessionListFromPB(
       List<Long> clientIDsList, List<KeyInfo> keyInfosList)
       throws IOException {
@@ -82,15 +97,19 @@ public class ListOpenFilesResult {
     return res;
   }
 
-  public List<OpenKeySession> getOpenKeys() {
-    return openKeySessionList;
+  public long getTotalOpenKeyCount() {
+    return totalOpenKeyCount;
   }
 
   public boolean hasMore() {
     return hasMore;
   }
 
-  public long getTotalOpenKeyCount() {
-    return totalOpenKeyCount;
+  public String getContinuationToken() {
+    return continuationToken;
+  }
+
+  public List<OpenKeySession> getOpenKeys() {
+    return openKeySessionList;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OpenKeySession.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OpenKeySession.java
@@ -17,12 +17,15 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * This class represents a open key "session". A session here means a key is
  * opened by a specific client, the client sends the handler to server, such
  * that servers can recognize this client, and thus know how to close the key.
  */
 public class OpenKeySession {
+  @JsonProperty("clientId")
   private final long id;
   private final OmKeyInfo keyInfo;
   // the version of the key when it is being opened in this session.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -417,7 +417,7 @@ public interface OzoneManagerProtocol
    * @return ListOpenFilesResult
    * @throws IOException
    */
-  ListOpenFilesResult listOpenFiles(String path, long maxKeys, String contToken)
+  ListOpenFilesResult listOpenFiles(String path, int maxKeys, String contToken)
       throws IOException;
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
+import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
@@ -407,6 +408,9 @@ public interface OzoneManagerProtocol
   List<ServiceInfo> getServiceList() throws IOException;
 
   ServiceInfoEx getServiceInfo() throws IOException;
+
+  ListOpenFilesResult listOpenFiles(String path, long maxKeys, String contToken)
+      throws IOException;
 
   /**
    * Transfer the raft leadership.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -409,7 +409,14 @@ public interface OzoneManagerProtocol
 
   ServiceInfoEx getServiceInfo() throws IOException;
 
-  // TODO: Rename arg list
+  /**
+   * List open files in OM.
+   * @param path root "/", path to a bucket, key path, or key prefix
+   * @param maxKeys Limit the number of keys that can be returned in this batch.
+   * @param contToken Continuation token.
+   * @return ListOpenFilesResult
+   * @throws IOException
+   */
   ListOpenFilesResult listOpenFiles(String path, long maxKeys, String contToken)
       throws IOException;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -409,6 +409,7 @@ public interface OzoneManagerProtocol
 
   ServiceInfoEx getServiceInfo() throws IOException;
 
+  // TODO: Rename arg list
   ListOpenFilesResult listOpenFiles(String path, long maxKeys, String contToken)
       throws IOException;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -411,7 +411,7 @@ public interface OzoneManagerProtocol
 
   /**
    * List open files in OM.
-   * @param path root "/", path to a bucket, key path, or key prefix
+   * @param path One of: root "/", path to a bucket, key path, or key prefix
    * @param maxKeys Limit the number of keys that can be returned in this batch.
    * @param contToken Continuation token.
    * @return ListOpenFilesResult

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1815,7 +1815,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     return new ListOpenFilesResult(resp.getClientIDList(),
         resp.getKeyInfoList(),
         resp.getHasMore(),
-        resp.getGlobalTotal());
+        resp.getTotalOpenKeyCount());
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
+import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
@@ -134,6 +135,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListKey
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListKeysLightResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListMultipartUploadsRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListMultipartUploadsResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListOpenFilesRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListOpenFilesResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListStatusRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListStatusResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListStatusLightResponse;
@@ -1789,6 +1792,30 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             .map(ServiceInfo::getFromProtobuf)
             .collect(Collectors.toList()),
         resp.getCaCertificate(), resp.getCaCertsList());
+  }
+
+  @Override
+  public ListOpenFilesResult listOpenFiles(String path,
+                                           long maxKeys,
+                                           String contToken)
+      throws IOException {
+    ListOpenFilesRequest req = ListOpenFilesRequest.newBuilder()
+        .setPath(path)
+        .setCount(maxKeys)
+        .setToken(contToken)
+        .build();
+
+    OMRequest omRequest = createOMRequest(Type.ListOpenFiles)
+        .setListOpenFilesRequest(req)
+        .build();
+
+    final ListOpenFilesResponse resp = handleError(submitRequest(omRequest))
+        .getListOpenFilesResponse();
+
+    return new ListOpenFilesResult(resp.getClientIDList(),
+        resp.getKeyInfoList(),
+        resp.getHasMore(),
+        resp.getGlobalTotal());
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1796,7 +1796,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
   @Override
   public ListOpenFilesResult listOpenFiles(String path,
-                                           long maxKeys,
+                                           int maxKeys,
                                            String contToken)
       throws IOException {
     ListOpenFilesRequest req = ListOpenFilesRequest.newBuilder()

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1812,10 +1812,12 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     final ListOpenFilesResponse resp = handleError(submitRequest(omRequest))
         .getListOpenFilesResponse();
 
-    return new ListOpenFilesResult(resp.getClientIDList(),
-        resp.getKeyInfoList(),
+    return new ListOpenFilesResult(
+        resp.getTotalOpenKeyCount(),
         resp.getHasMore(),
-        resp.getTotalOpenKeyCount());
+        resp.hasContinuationToken() ? resp.getContinuationToken() : null,
+        resp.getClientIDList(),
+        resp.getKeyInfoList());
   }
 
   @Override

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -54,6 +54,8 @@ OZONE-SITE.XML_hdds.scm.wait.time.after.safemode.exit=30s
 
 OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
 
+OZONE-SITE.XML_ozone.fs.hsync.enabled=true
+
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -287,7 +287,7 @@ public class TestOmMetrics {
     doKeyOps(keyArgs);
 
     MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeyOps", 7L, omMetrics);
+    assertCounter("NumKeyOps", 8L, omMetrics);
     assertCounter("NumKeyAllocate", 1L, omMetrics);
     assertCounter("NumKeyLookup", 1L, omMetrics);
     assertCounter("NumKeyDeletes", 1L, omMetrics);
@@ -295,12 +295,13 @@ public class TestOmMetrics {
     assertCounter("NumTrashKeyLists", 1L, omMetrics);
     assertCounter("NumKeys", 0L, omMetrics);
     assertCounter("NumInitiateMultipartUploads", 1L, omMetrics);
+    assertCounter("NumListOpenFiles", 1L, omMetrics);
 
     keyArgs = createKeyArgs(volumeName, bucketName,
         new ECReplicationConfig("rs-3-2-1024K"));
     doKeyOps(keyArgs);
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeyOps", 14L, omMetrics);
+    assertCounter("NumKeyOps", 16L, omMetrics);
     assertCounter("EcKeyCreateTotal", 1L, omMetrics);
 
     keyArgs = createKeyArgs(volumeName, bucketName,
@@ -352,7 +353,7 @@ public class TestOmMetrics {
     doKeyOps(keyArgs);
 
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeyOps", 28L, omMetrics);
+    assertCounter("NumKeyOps", 31L, omMetrics);
     assertCounter("NumKeyAllocate", 6L, omMetrics);
     assertCounter("NumKeyLookup", 3L, omMetrics);
     assertCounter("NumKeyDeletes", 4L, omMetrics);
@@ -692,6 +693,11 @@ public class TestOmMetrics {
 
     try {
       writeClient.initiateMultipartUpload(keyArgs);
+    } catch (IOException ignored) {
+    }
+
+    try {
+      writeClient.listOpenFiles("", 100, "");
     } catch (IOException ignored) {
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -563,9 +563,11 @@ public class TestOzoneShellHA {
     OzoneConfiguration clientConf = getClientConfForOFS(hostPrefix, conf);
     FileSystem fs = FileSystem.get(clientConf);
 
-    final String volumeName = "volumelof";
+    final String volumeName = "volume-lof";
+    final String bucketName = "buck1";
+
     String dir1 = hostPrefix + OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX +
-        "buck1" + OM_KEY_PREFIX + "dir1";
+        bucketName + OM_KEY_PREFIX + "dir1";
     // Create volume, bucket, dir
     assertTrue(fs.mkdirs(new Path(dir1)));
     String keyPrefix = OM_KEY_PREFIX + "key";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -586,14 +586,15 @@ public class TestOzoneShellHA {
       streams[i].write(1);
     }
 
+    String path = "/" +  volumeName + "/" + bucketName;
     try {
-      // Wait for flush to DB table
+      // Wait for DB flush
       cluster.getOzoneManager().awaitDoubleBufferFlush();
 
-      String[] args = new String[] {"om", "listopenfiles",
+      String[] args = new String[] {"om", "lof",
           "-id", omServiceId,
           "-l", String.valueOf(numKeys + 1),  // pagination
-          "-p", "/volumelof/buck1"};
+          "-p", path};
       // Run listopenfiles
       execute(ozoneAdminShell, args);
       String cmdRes = getStdOut();
@@ -603,10 +604,10 @@ public class TestOzoneShellHA {
       }
 
       // Try pagination
-      args = new String[] {"om", "listopenfiles",
+      args = new String[] {"om", "lof",
           "-id", omServiceId,
           "-l", String.valueOf(pageSize),  // pagination
-          "-p", "/volumelof/buck1"};
+          "-p", path};
       execute(ozoneAdminShell, args);
       cmdRes = getStdOut();
 
@@ -627,10 +628,10 @@ public class TestOzoneShellHA {
       String contToken =
           nextCmd.substring(nextCmd.lastIndexOf(kw) + kw.length());
 
-      args = new String[] {"om", "listopenfiles",
+      args = new String[] {"om", "lof",
           "-id", omServiceId,
           "-l", String.valueOf(pageSize),  // pagination
-          "-p", "/volumelof/buck1",
+          "-p", path,
           "-s", contToken};
       execute(ozoneAdminShell, args);
       cmdRes = getStdOut();
@@ -646,6 +647,8 @@ public class TestOzoneShellHA {
 
       // hsync last key
       streams[numKeys - 1].hsync();
+      // Wait for flush
+      cluster.getOzoneManager().awaitDoubleBufferFlush();
 
       execute(ozoneAdminShell, args);
       cmdRes = getStdOut();
@@ -660,7 +663,6 @@ public class TestOzoneShellHA {
       }
     }
 
-    // TODO: In UT, test with OBS/LEGACY bucket
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -582,9 +582,11 @@ public class TestOzoneShellHA {
       execute(ozoneAdminShell, args);
       // Verify that result has key1
 
-    }
+      // TODO: Test hsync
+      out.hsync();
 
-    // TODO: Test with hsync
+      out.hsync();
+    }
 
     // TODO: Test pagination
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -73,6 +73,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 
@@ -83,6 +84,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLU
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -143,7 +145,7 @@ public class TestOzoneShellHA {
   @BeforeAll
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
+    conf.setBoolean(OZONE_FS_HSYNC_ENABLED, true);
     startCluster(conf);
   }
 
@@ -563,6 +565,10 @@ public class TestOzoneShellHA {
     OzoneConfiguration clientConf = getClientConfForOFS(hostPrefix, conf);
     clientConf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     FileSystem fs = FileSystem.get(clientConf);
+
+    assertNotEquals(fs.getConf().get(OZONE_FS_HSYNC_ENABLED),
+        "false", OZONE_FS_HSYNC_ENABLED + " is set to false " +
+            "by external force. Must be true to allow hsync to function");
 
     final String volumeName = "volume-lof";
     final String bucketName = "buck1";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -668,7 +668,7 @@ public class TestOzoneShellHA {
   }
 
   /**
-   * Return stdout as a String, then clears exising output.
+   * Return stdout as a String, then clears existing output.
    */
   private String getStdOut() throws UnsupportedEncodingException {
     String res = out.toString(UTF_8.name());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -557,9 +557,10 @@ public class TestOzoneShellHA {
     final String volumeName = "volumelof";
 
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
-//    final String hostPrefix = OZONE_OFS_URI_SCHEME + "://localhost:9862";
     OzoneConfiguration clientConf =
         getClientConfForOFS(hostPrefix, cluster.getConf());
+//    final String hostPrefix = OZONE_OFS_URI_SCHEME + "://localhost:9862";
+//    OzoneConfiguration clientConf =
 //        getClientConfForOFS(hostPrefix, new OzoneConfiguration());
     FileSystem fs = FileSystem.get(clientConf);
 
@@ -579,8 +580,11 @@ public class TestOzoneShellHA {
           "-p", "/volumelof/buck1"};
       // TODO: Possible to make this work under volume level as well?
       execute(ozoneAdminShell, args);
-      // Check result
+      // Verify that result has key1
+
     }
+
+    // TODO: Test with hsync
 
     // TODO: Test pagination
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -561,6 +561,7 @@ public class TestOzoneShellHA {
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
 
     OzoneConfiguration clientConf = getClientConfForOFS(hostPrefix, conf);
+    clientConf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     FileSystem fs = FileSystem.get(clientConf);
 
     final String volumeName = "volume-lof";
@@ -656,8 +657,8 @@ public class TestOzoneShellHA {
       cmdRes = getStdOut();
 
       // Verify that only one key is hsync'ed
-      assertTrue(cmdRes.contains("\tYes\t"));
-      assertTrue(cmdRes.contains("\tNo\t"));
+      assertTrue(cmdRes.contains("\tYes\t"), "One key should be hsync'ed");
+      assertTrue(cmdRes.contains("\tNo\t"), "One key should not be hsync'ed");
     } finally {
       // Cleanup
       for (int i = 0; i < numKeys; i++) {
@@ -1578,7 +1579,7 @@ public class TestOzoneShellHA {
   }
 
   @Test
-  public void testRecursiveBucketDelete()
+  public void testZRecursiveBucketDelete()
       throws Exception {
     String volume1 = "volume50";
     String bucket1 = "bucketfso";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHAWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHAWithFSO.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.shell;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -37,6 +38,7 @@ public class TestOzoneShellHAWithFSO extends TestOzoneShellHA {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
         OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED);
+    conf.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
     startCluster(conf);
   }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1531,7 +1531,7 @@ message CancelPrepareResponse {
 
 message ListOpenFilesRequest {
   optional string path = 1;
-  optional uint64 count = 2;
+  optional uint32 count = 2;
   optional string token = 3;
 }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1537,8 +1537,8 @@ message ListOpenFilesRequest {
 
 message ListOpenFilesResponse {
   // size of openKeyTable and openFileTable combined
-  optional uint64 globalTotal = 1;  // TODO: Rename to totalOpenKeyCount
-  // if true, indicates that there are remaining entries under the path
+  optional uint64 totalOpenKeyCount = 1;
+  // indicates if there are more entries to be retrieved under the given path
   optional bool hasMore = 2;
   // result
   repeated uint64 clientID = 3;

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1540,9 +1540,11 @@ message ListOpenFilesResponse {
   optional uint64 totalOpenKeyCount = 1;
   // indicates if there are more entries to be retrieved under the given path
   optional bool hasMore = 2;
+  // continuation token should match a dbKey in openKeyTable or openFileTable
+  optional string continuationToken = 3;
   // result
-  repeated uint64 clientID = 3;
-  repeated KeyInfo keyInfo = 4;
+  repeated uint64 clientID = 4;
+  repeated KeyInfo keyInfo = 5;
 }
 
 message ServicePort {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1536,24 +1536,14 @@ message ListOpenFilesRequest {
 }
 
 message ListOpenFilesResponse {
-  // size of openKeyTable (may not be reliable due to how RocksDB returns count)
-  optional uint64 globalTotal = 1;
+  // size of openKeyTable and openFileTable combined
+  optional uint64 globalTotal = 1;  // TODO: Rename to totalOpenKeyCount
   // if true, indicates that there are remaining entries under the path
   optional bool hasMore = 2;
   // result
   repeated uint64 clientID = 3;
   repeated KeyInfo keyInfo = 4;
-  // row count with the path prefix
-//  optional uint64 totalUnderPath = 2;
-  // remaining rows that are not returned after this batch of result
-//  optional uint64 remainingUnderPath = 3;
-//  repeated OpenKeyInfoWithClientID openFiles = 4;
 }
-
-//message OpenKeyInfoWithClientID {
-//  optional uint64 clientID = 1;
-//  optional KeyInfo keyInfo = 2;
-//}
 
 message ServicePort {
     enum Type {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -146,6 +146,8 @@ enum Type {
   SetSnapshotProperty = 128;
   ListStatusLight = 129;
   GetSnapshotInfo = 130;
+
+  ListOpenFiles = 132;
 }
 
 enum SafeMode {
@@ -281,6 +283,8 @@ message OMRequest {
   optional MultipartUploadsExpiredAbortRequest multipartUploadsExpiredAbortRequest = 126;
   optional SetSnapshotPropertyRequest       SetSnapshotPropertyRequest     = 127;
   optional SnapshotInfoRequest              SnapshotInfoRequest            = 128;
+
+  optional ListOpenFilesRequest             ListOpenFilesRequest           = 132;
 }
 
 message OMResponse {
@@ -403,6 +407,8 @@ message OMResponse {
   optional ListStatusLightResponse           listStatusLightResponse       = 129;
   optional SnapshotInfoResponse              SnapshotInfoResponse          = 130;
   optional OMLockDetailsProto                omLockDetails                 = 131;
+
+  optional ListOpenFilesResponse             ListOpenFilesResponse         = 132;
 }
 
 enum Status {
@@ -1522,6 +1528,32 @@ message CancelPrepareRequest {
 message CancelPrepareResponse {
 
 }
+
+message ListOpenFilesRequest {
+  optional string path = 1;
+  optional uint64 count = 2;
+  optional string token = 3;
+}
+
+message ListOpenFilesResponse {
+  // size of openKeyTable (may not be reliable due to how RocksDB returns count)
+  optional uint64 globalTotal = 1;
+  // if true, indicates that there are remaining entries under the path
+  optional bool hasMore = 2;
+  // result
+  repeated uint64 clientID = 3;
+  repeated KeyInfo keyInfo = 4;
+  // row count with the path prefix
+//  optional uint64 totalUnderPath = 2;
+  // remaining rows that are not returned after this batch of result
+//  optional uint64 remainingUnderPath = 3;
+//  repeated OpenKeyInfoWithClientID openFiles = 4;
+}
+
+//message OpenKeyInfoWithClientID {
+//  optional uint64 clientID = 1;
+//  optional KeyInfo keyInfo = 2;
+//}
 
 message ServicePort {
     enum Type {

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -292,6 +292,12 @@ public interface OMMetadataManager extends DBStoreHAManager {
       String startKey, int maxKeys) throws IOException;
 
   /**
+   * Get total open key count (estimated, due to the nature of RocksDB impl)
+   * of both OpenKeyTable and OpenFileTable.
+   */
+  long getOpenKeyCount() throws IOException;
+
+  /**
    * Returns the names of up to {@code count} open keys whose age is
    * greater than or equal to {@code expireThreshold}.
    *

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -128,6 +128,11 @@ public interface OMMetadataManager extends DBStoreHAManager {
 
   String getOzoneKey(String volume, String bucket, String key);
 
+  String getOzoneKeyFSO(String volumeName,
+                        String bucketName,
+                        String keyPrefix)
+      throws IOException;
+
   /**
    * Given a volume, bucket and a key, return the corresponding DB directory
    * key.
@@ -314,7 +319,7 @@ public interface OMMetadataManager extends DBStoreHAManager {
    * Get total open key count (estimated, due to the nature of RocksDB impl)
    * of both OpenKeyTable and OpenFileTable.
    */
-  long getOpenKeyCount() throws IOException;
+  long getTotalOpenKeyCount() throws IOException;
 
   /**
    * Returns the names of up to {@code count} open keys whose age is

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -125,9 +125,12 @@ public interface OMMetadataManager extends DBStoreHAManager {
    * @param key    - key name
    * @return DB key as String.
    */
-
   String getOzoneKey(String volume, String bucket, String key);
 
+  /**
+   * Get DB key for a key or prefix in an FSO bucket given existing
+   * volume and bucket names.
+   */
   String getOzoneKeyFSO(String volumeName,
                         String bucketName,
                         String keyPrefix)

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -222,7 +222,7 @@ public interface OMMetadataManager extends DBStoreHAManager {
    * @throws IOException
    */
   ListOpenFilesResult listOpenFiles(BucketLayout bucketLayout,
-                                    long maxKeys,
+                                    int maxKeys,
                                     String dbOpenKeyPrefix,
                                     boolean hasContToken,
                                     String dbContTokenPrefix)

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -55,6 +55,8 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.ozone.compaction.log.CompactionLogEntry;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+
 /**
  * OM metadata manager interface.
  */
@@ -148,6 +150,17 @@ public interface OMMetadataManager extends DBStoreHAManager {
    * @return bytes of DB key.
    */
   String getOpenKey(String volume, String bucket, String key, long id);
+
+  /**
+   * Returns client ID in Long of an OpenKeyTable DB Key String.
+   * @param dbOpenKeyName An OpenKeyTable DB Key String.
+   * @return Client ID (Long)
+   */
+  static long getClientIDFromOpenKeyDBKey(String dbOpenKeyName) {
+    final int lastPrefix = dbOpenKeyName.lastIndexOf(OM_KEY_PREFIX);
+    final String clientIdString = dbOpenKeyName.substring(lastPrefix + 1);
+    return Long.parseLong(clientIdString);
+  }
 
   /**
    * Given a volume, check if it is empty, i.e there are no buckets inside it.

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.helpers.ListKeysResult;
+import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
@@ -199,6 +200,24 @@ public interface OMMetadataManager extends DBStoreHAManager {
   List<OmBucketInfo> listBuckets(String volumeName, String startBucket,
                                  String bucketPrefix, int maxNumOfBuckets,
                                  boolean hasSnapshot)
+      throws IOException;
+
+  /**
+   * Inner implementation of listOpenFiles. Called after all the arguments are
+   * checked and processed by Ozone Manager.
+   * @param bucketLayout
+   * @param maxKeys
+   * @param dbOpenKeyPrefix
+   * @param hasContToken
+   * @param dbContTokenPrefix
+   * @return ListOpenFilesResult
+   * @throws IOException
+   */
+  ListOpenFilesResult listOpenFiles(BucketLayout bucketLayout,
+                                    long maxKeys,
+                                    String dbOpenKeyPrefix,
+                                    boolean hasContToken,
+                                    String dbContTokenPrefix)
       throws IOException;
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -102,7 +102,9 @@ public enum OMAction implements AuditAction {
   SNAPSHOT_INFO,
   SET_TIMES,
 
-  ABORT_EXPIRED_MULTIPART_UPLOAD;
+  ABORT_EXPIRED_MULTIPART_UPLOAD,
+
+  LIST_OPEN_FILES;
 
   @Override
   public String getAction() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -80,6 +80,7 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numCreateFile;
   private @Metric MutableCounterLong numLookupFile;
   private @Metric MutableCounterLong numListStatus;
+  private @Metric MutableCounterLong numListOpenFiles;
 
   private @Metric MutableCounterLong numOpenKeyDeleteRequests;
   private @Metric MutableCounterLong numOpenKeysSubmittedForDeletion;
@@ -176,6 +177,7 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numCreateFileFails;
   private @Metric MutableCounterLong numLookupFileFails;
   private @Metric MutableCounterLong numListStatusFails;
+  private @Metric MutableCounterLong numListOpenFilesFails;
   private @Metric MutableCounterLong getNumGetKeyInfoFails;
 
   private @Metric MutableCounterLong numRecoverLeaseFails;
@@ -428,8 +430,17 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   }
 
   public void incNumListS3BucketsFails() {
-    numBucketOps.incr();
     numBucketS3ListFails.incr();
+  }
+
+  public void incNumListOpenFiles() {
+    // TODO: Reconsider if this should increment key ops
+    numKeyOps.incr();
+    numListOpenFiles.incr();
+  }
+
+  public void incNumListOpenFilesFails() {
+    numListOpenFilesFails.incr();
   }
 
   public void incNumInitiateMultipartUploads() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -434,7 +434,6 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   }
 
   public void incNumListOpenFiles() {
-    // TODO: Reconsider if this should increment key ops
     numKeyOps.incr();
     numListOpenFiles.incr();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1733,6 +1733,13 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   @Override
+  public long getOpenKeyCount() throws IOException {
+    // Get an estimated key count of OpenKeyTable + OpenFileTable
+    return openKeyTable.getEstimatedKeyCount()
+        + openFileTable.getEstimatedKeyCount();
+  }
+
+  @Override
   public ExpiredOpenKeys getExpiredOpenKeys(Duration expireThreshold,
       int count, BucketLayout bucketLayout) throws IOException {
     final ExpiredOpenKeys expiredKeys = new ExpiredOpenKeys();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -846,6 +846,18 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   @Override
+  public String getOzoneKeyFSO(String volumeName,
+                               String bucketName,
+                               String keyPrefix)
+      throws IOException {
+    final long volumeId = getVolumeId(volumeName);
+    final long bucketId = getBucketId(volumeName, bucketName);
+    // FSO keyPrefix could look like: -9223372036854774527/key1
+    return getOzoneKey(Long.toString(volumeId),
+        Long.toString(bucketId), keyPrefix);
+  }
+
+  @Override
   public String getOzoneDirKey(String volume, String bucket, String key) {
     key = OzoneFSUtils.addTrailingSlashIfNeeded(key);
     return getOzoneKey(volume, bucket, key);
@@ -1245,7 +1257,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     return new ListOpenFilesResult(
         openKeySessionList,
         hasMore,
-        getOpenKeyCount());
+        getTotalOpenKeyCount());
   }
 
   /**
@@ -1257,6 +1269,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
                                                 KeyValue<String, OmKeyInfo>>
                                                 keyIter)
       throws IOException {
+    // TODO: do keyTable.get() directly
     KeyValue<String, OmKeyInfo> kv = keyIter.seek(dbKey);
     if (kv != null && kv.getKey().equals(dbKey)) {
       // The same key in OpenKeyTable also exists in KeyTable, indicating
@@ -1826,7 +1839,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
   }
 
   @Override
-  public long getOpenKeyCount() throws IOException {
+  public long getTotalOpenKeyCount() throws IOException {
     // Get an estimated key count of OpenKeyTable + OpenFileTable
     return openKeyTable.getEstimatedKeyCount()
         + openFileTable.getEstimatedKeyCount();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1192,7 +1192,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   @Override
   public ListOpenFilesResult listOpenFiles(BucketLayout bucketLayout,
-                                           long maxKeys,
+                                           int maxKeys,
                                            String dbOpenKeyPrefix,
                                            boolean hasContToken,
                                            String dbContTokenPrefix)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3193,7 +3193,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @Override
   public ListOpenFilesResult listOpenFiles(String path,
-                                           long maxKeys,
+                                           int maxKeys,
                                            String contToken)
       throws IOException {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3269,34 +3269,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       // if a continuation token is not specified
       dbContTokenPrefix = dbOpenKeyPrefix;
     } else {
-      // need to translate FSO bucket cont. token's volume and bucket names
-      // into object IDs
-
-      StringTokenizer tokenizer = new StringTokenizer(contToken, OM_KEY_PREFIX);
-      // Validate cont. token to avoid NoSuchElementException
-      if (tokenizer.countTokens() < 2) {
-        metrics.incNumListOpenFilesFails();
-        throw new OMException("Invalid continuation token: " + contToken,
-            INVALID_PATH);
-      }
-      final String ctVolumeName = tokenizer.nextToken();
-      final String ctBucketName = tokenizer.nextToken();
-      // Validate that path and cont. token refers to the same bucket
-      Preconditions.checkArgument(volumeName.equals(ctVolumeName),
-          "Path volume name '" + volumeName +
-              "' and token volume name '" + ctVolumeName + "' does not match");
-      Preconditions.checkArgument(bucketName.equals(ctBucketName),
-          "Path bucket name '" + bucketName +
-              "' and token bucket name '" + ctBucketName + "' does not match");
-
-      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
-        final String ctKeyPrefix = tokenizer.hasMoreTokens() ?
-            tokenizer.nextToken("").substring(1) : "";
-        dbContTokenPrefix = metadataManager.getOzoneKeyFSO(
-            ctVolumeName, ctBucketName, ctKeyPrefix);
-      } else {
-        dbContTokenPrefix = contToken;
-      }
+      dbContTokenPrefix = contToken;
     }
 
     // arg processing done. call inner impl (table iteration)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3232,9 +3232,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       try {
         // as expected, getBucketInfo throws if volume or bucket does not exist
         bucketInfo = getBucketInfo(volumeName, bucketName);
-      } catch (Exception ex) {
+      } catch (OMException ex) {
         metrics.incNumListOpenFilesFails();
         throw ex;
+      } catch (IOException ex) {
+        // Wrap IOException in OMException
+        metrics.incNumListOpenFilesFails();
+        throw new OMException(ex.getMessage(), NOT_SUPPORTED_OPERATION);
       }
 
       final String keyPrefix;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -941,6 +941,9 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
     resp.setTotalOpenKeyCount(res.getTotalOpenKeyCount());
     resp.setHasMore(res.hasMore());
+    if (res.getContinuationToken() != null) {
+      resp.setContinuationToken(res.getContinuationToken());
+    }
 
     for (OpenKeySession e : res.getOpenKeys()) {
       resp.addClientID(e.getId());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -937,9 +937,9 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
     ListOpenFilesResult res =
         impl.listOpenFiles(req.getPath(), req.getCount(), req.getToken());
-    // TODO: Is there a way to avoid ser-de in this case:
-    //  OM:     ListOpenFilesResult -> ListOpenFilesResponse
-    //  Client: ListOpenFilesResponse -> ListOpenFilesResult
+    // TODO: Is there a clean way to avoid ser-de for responses:
+    //  OM does: ListOpenFilesResult -> ListOpenFilesResponse
+    //  Client : ListOpenFilesResponse -> ListOpenFilesResult
 
     resp.setTotalOpenKeyCount(res.getTotalOpenKeyCount());
     resp.setHasMore(res.hasMore());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -939,7 +939,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         impl.listOpenFiles(req.getPath(), req.getCount(), req.getToken());
     // TODO: Avoid unnecessary ser-de?
 
-    resp.setGlobalTotal(res.getTotalOpenKeyCount());
+    resp.setTotalOpenKeyCount(res.getTotalOpenKeyCount());
     resp.setHasMore(res.hasMore());
 
     for (OpenKeySession e : res.getOpenKeys()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -937,7 +937,9 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
     ListOpenFilesResult res =
         impl.listOpenFiles(req.getPath(), req.getCount(), req.getToken());
-    // TODO: Avoid unnecessary ser-de?
+    // TODO: Is there a way to avoid ser-de in this case:
+    //  OM:     ListOpenFilesResult -> ListOpenFilesResponse
+    //  Client: ListOpenFilesResponse -> ListOpenFilesResult
 
     resp.setTotalOpenKeyCount(res.getTotalOpenKeyCount());
     resp.setHasMore(res.hasMore());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -939,10 +939,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         impl.listOpenFiles(req.getPath(), req.getCount(), req.getToken());
     // TODO: Avoid unnecessary ser-de?
 
-    resp.setGlobalTotal(res.getGlobalTotal());
+    resp.setGlobalTotal(res.getTotalOpenKeyCount());
     resp.setHasMore(res.hasMore());
 
-    for (OpenKeySession e : res.getOpenFiles()) {
+    for (OpenKeySession e : res.getOpenKeys()) {
       resp.addClientID(e.getId());
       resp.addKeyInfo(e.getKeyInfo().getProtobuf(clientVersion));
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -634,7 +634,7 @@ public class TestOmMetadataManager {
 
     // Without pagination
     ListOpenFilesResult res = omMetadataManager.listOpenFiles(
-        bucketLayout, 100L, dbPrefix, false, dbPrefix);
+        bucketLayout, 100, dbPrefix, false, dbPrefix);
 
     assertEquals(numOpenKeys, res.getTotalOpenKeyCount());
     assertEquals(false, res.hasMore());
@@ -649,11 +649,10 @@ public class TestOmMetadataManager {
     }
 
     // With pagination
-    long pageSize = 2;
-    int numExpectedKeys = (int)pageSize;
+    int pageSize = 2;
+    int numExpectedKeys = pageSize;
     res = omMetadataManager.listOpenFiles(
         bucketLayout, pageSize, dbPrefix, false, dbPrefix);
-
     // total open key count should still be 3
     assertEquals(numOpenKeys, res.getTotalOpenKeyCount());
     // hasMore should have been set
@@ -668,21 +667,9 @@ public class TestOmMetadataManager {
     }
 
     // Get the second page
-    OmKeyInfo lastKeyInfo = keySessionList.get((int)pageSize - 1).getKeyInfo();
-    String dbContTokenPrefix;
-    if (bucketLayout.isFileSystemOptimized()) {
-      dbContTokenPrefix = OM_KEY_PREFIX + volumeId +
-          OM_KEY_PREFIX + bucketId +
-          OM_KEY_PREFIX + lastKeyInfo.getPath();
-    } else {
-      dbContTokenPrefix = OM_KEY_PREFIX + volumeName +
-          OM_KEY_PREFIX + bucketName +
-          OM_KEY_PREFIX + lastKeyInfo.getFileName();
-    }
     res = omMetadataManager.listOpenFiles(
-        bucketLayout, pageSize, dbPrefix, true, dbContTokenPrefix);
-
-    numExpectedKeys = numOpenKeys - (int)pageSize;
+        bucketLayout, pageSize, dbPrefix, true, res.getContinuationToken());
+    numExpectedKeys = numOpenKeys - pageSize;
     // total open key count should still be 3
     assertEquals(numOpenKeys, res.getTotalOpenKeyCount());
     assertEquals(false, res.hasMore());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -64,7 +64,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
@@ -561,29 +562,14 @@ public class TestOmMetadataManager {
 
   }
 
-  @Test
-  public void testListOpenFilesFSO() throws Exception {
-    testListOpenFiles(BucketLayout.FILE_SYSTEM_OPTIMIZED);
-  }
-
-  @Test
-  public void testListOpenFilesOBS() throws Exception {
-    testListOpenFiles(BucketLayout.OBJECT_STORE);
-  }
-
-  @Test
-  public void testListOpenFilesLegacy() throws Exception {
-    // OBS and LEGACY should share the same internal structure for the most part
-    // still, testing both here for the sake of completeness
-    testListOpenFiles(BucketLayout.LEGACY);
-  }
-
   /**
    * Tests inner impl of listOpenFiles with different bucket types with and
-   * without pagination. NOTE: This UT does NOT test hsync in this since hsync
+   * without pagination. NOTE: This UT does NOT test hsync here since the hsync
    * status check is done purely on the client side.
    * @param bucketLayout BucketLayout
    */
+  @ParameterizedTest
+  @EnumSource
   public void testListOpenFiles(BucketLayout bucketLayout) throws Exception {
     final long clientID = 1000L;
 
@@ -687,32 +673,9 @@ public class TestOmMetadataManager {
     return BucketLayout.DEFAULT;
   }
 
-  @Test
-  public void testGetExpiredOpenKeys() throws Exception {
-    testGetExpiredOpenKeys(BucketLayout.DEFAULT);
-  }
-
-  @Test
-  public void testGetExpiredOpenKeysExcludeMPUs() throws Exception {
-    testGetExpiredOpenKeysExcludeMPUKeys(BucketLayout.DEFAULT);
-  }
-
-  @Test
-  public void testGetExpiredOpenKeysFSO() throws Exception {
-    testGetExpiredOpenKeys(BucketLayout.FILE_SYSTEM_OPTIMIZED);
-  }
-
-  @Test
-  public void testGetExpiredOpenKeysExcludeMPUsFSO() throws Exception {
-    testGetExpiredOpenKeysExcludeMPUKeys(BucketLayout.FILE_SYSTEM_OPTIMIZED);
-  }
-
-  @Test
-  public void testGetExpiredMultipartUploads() throws Exception {
-    testGetExpiredMPUs();
-  }
-
-  private void testGetExpiredOpenKeys(BucketLayout bucketLayout)
+  @ParameterizedTest
+  @EnumSource
+  public void testGetExpiredOpenKeys(BucketLayout bucketLayout)
       throws Exception {
     final String bucketName = UUID.randomUUID().toString();
     final String volumeName = UUID.randomUUID().toString();
@@ -790,7 +753,9 @@ public class TestOmMetadataManager {
     assertThat(expiredKeys).containsAll(names);
   }
 
-  private void testGetExpiredOpenKeysExcludeMPUKeys(
+  @ParameterizedTest
+  @EnumSource
+  public void testGetExpiredOpenKeysExcludeMPUKeys(
       BucketLayout bucketLayout) throws Exception {
     final String bucketName = UUID.randomUUID().toString();
     final String volumeName = UUID.randomUUID().toString();
@@ -878,7 +843,8 @@ public class TestOmMetadataManager {
         .isEmpty());
   }
 
-  private void testGetExpiredMPUs() throws Exception {
+  @Test
+  public void testGetExpiredMPUs() throws Exception {
     final String bucketName = UUID.randomUUID().toString();
     final String volumeName = UUID.randomUUID().toString();
     final int numExpiredMPUs = 4;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -68,7 +68,8 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
       description = "Format output as JSON")
   private boolean json;
 
-  // TODO: Use {@link org.apache.hadoop.ozone.shell.ListOptions}?
+  // Conforms to ListOptions, but not all in ListOptions applies here so
+  // not using that directly
   @CommandLine.Option(
       names = {"-p", "--prefix"},
       description = "Filter results by the specified path on the server side.",

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -163,9 +163,7 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
 
     // Compose next batch's command
     if (res.hasMore()) {
-      OpenKeySession lastElement = openFileList.get(openFileList.size() - 1);
-      String nextBatchCmd =
-          getCmdForNextBatch(getFullPathFromKeyInfo(lastElement.getKeyInfo()));
+      String nextBatchCmd = getCmdForNextBatch(res.getContinuationToken());
 
       System.out.println("\n" +
           "To get the next batch of open keys, run:\n  " + nextBatchCmd);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -82,7 +82,7 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
       description = "Maximum number of items to list",
       defaultValue = "100"
   )
-  private long limit;
+  private int limit;
 
   @CommandLine.Option(
       names = {"-s", "--start"},

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -37,7 +37,7 @@ import java.util.concurrent.Callable;
 @CommandLine.Command(
     name = "listopenfiles",
     aliases = {"listopenkeys", "lof", "lok"},
-    description = "Lists open keys in Ozone Manager.",
+    description = "Lists open files (keys) in Ozone Manager.",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
@@ -135,7 +135,7 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
     if (startItem != null && !startItem.isEmpty()) {
       msg += "\nafter continuation token:\n  " + startItem;
     }
-    msg += "\nClient ID\t\tHsync'ed\t\tPath";
+    msg += "\n\nClient ID\t\tHsync'ed\tPath";  // TODO: Add creation time
     System.out.println(msg);
 
     for (OpenKeySession e : openFileList) {
@@ -158,8 +158,9 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
         line += "No\t\t";
       }
 
-      System.out.println(line + getFullPathFromKeyInfo(omKeyInfo) +
-          "\t" + omKeyInfo);  // TODO: Remove full KeyInfo print
+      System.out.println(line + getFullPathFromKeyInfo(omKeyInfo)
+//          + "\t" + omKeyInfo  // TODO: Remove full KeyInfo print
+      );
     }
 
     // Compose next batch's command

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -182,20 +182,20 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
   private String getCmdForNextBatch(String lastElementFullPath) {
     String nextBatchCmd = "ozone admin om lof";
     if (!omServiceId.isEmpty()) {
-      nextBatchCmd += " -id " + omServiceId;
+      nextBatchCmd += " -id=" + omServiceId;
     }
     if (!omHost.isEmpty()) {
-      nextBatchCmd += " -host " + omHost;
+      nextBatchCmd += " -host=" + omHost;
     }
     if (json) {
       nextBatchCmd += " --json";
     }
-    nextBatchCmd += " -n " + limit;
+    nextBatchCmd += " --length=" + limit;
     if (!pathPrefix.isEmpty()) {
-      nextBatchCmd += " -p " + pathPrefix;
+      nextBatchCmd += " --prefix=" + pathPrefix;
     }
     if (!startItem.isEmpty()) {
-      nextBatchCmd += " -t " + lastElementFullPath;
+      nextBatchCmd += " --start=" + lastElementFullPath;
     }
     return nextBatchCmd;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -158,9 +158,9 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
         line += "No\t\t";
       }
 
-      System.out.println(line + getFullPathFromKeyInfo(omKeyInfo)
-//          + "\t" + omKeyInfo  // TODO: Remove full KeyInfo print
-      );
+      line += getFullPathFromKeyInfo(omKeyInfo);
+
+      System.out.println(line);
     }
 
     // Compose next batch's command
@@ -181,22 +181,20 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
    */
   private String getCmdForNextBatch(String lastElementFullPath) {
     String nextBatchCmd = "ozone admin om lof";
-    if (!omServiceId.isEmpty()) {
+    if (omServiceId != null && !omServiceId.isEmpty()) {
       nextBatchCmd += " -id=" + omServiceId;
     }
-    if (!omHost.isEmpty()) {
+    if (omHost != null && !omHost.isEmpty()) {
       nextBatchCmd += " -host=" + omHost;
     }
     if (json) {
       nextBatchCmd += " --json";
     }
     nextBatchCmd += " --length=" + limit;
-    if (!pathPrefix.isEmpty()) {
+    if (pathPrefix != null && !pathPrefix.isEmpty()) {
       nextBatchCmd += " --prefix=" + pathPrefix;
     }
-    if (!startItem.isEmpty()) {
-      nextBatchCmd += " --start=" + lastElementFullPath;
-    }
+    nextBatchCmd += " --start=" + lastElementFullPath;
     return nextBatchCmd;
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -32,11 +32,11 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
- * Handler of ozone admin om listopenfiles command.
+ * Handler of ozone admin om list-open-files command.
  */
 @CommandLine.Command(
-    name = "listopenfiles",
-    aliases = {"listopenkeys", "lof", "lok"},
+    name = "list-open-files",
+    aliases = {"list-open-keys", "lof", "lok"},
     description = "Lists open files (keys) in Ozone Manager.",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
@@ -119,29 +119,27 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
 
   private void printOpenKeysListAsJson(ListOpenFilesResult res)
       throws IOException {
-    // TODO: Untested
     System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(res));
   }
 
   private void printOpenKeysList(ListOpenFilesResult res) {
 
-    List<OpenKeySession> openFileList = res.getOpenFiles();
+    List<OpenKeySession> openFileList = res.getOpenKeys();
 
-    // TODO: Conform to HDFS style output?
-    String msg = res.getGlobalTotal() + " global open files (estimated). " +
-        "Showing " + openFileList.size() + " open files (limit " + limit + ") " +
-        "under path prefix:\n  " + pathPrefix;
+    String msg = res.getTotalOpenKeyCount() +
+        " total open files (est.). Showing " + openFileList.size() +
+        " open files (limit " + limit + ") under path prefix:\n  " + pathPrefix;
 
     if (startItem != null && !startItem.isEmpty()) {
       msg += "\nafter continuation token:\n  " + startItem;
     }
-    msg += "\n\nClient ID\t\tHsync'ed\tPath";  // TODO: Add creation time
+    msg += "\n\nClient ID\t\tCreation time\tHsync'ed\tOpen File Path";
     System.out.println(msg);
 
     for (OpenKeySession e : openFileList) {
       long clientId = e.getId();
-      String line = clientId + "\t";
       OmKeyInfo omKeyInfo = e.getKeyInfo();
+      String line = clientId + "\t" + omKeyInfo.getCreationTime() + "\t";
 
       if (omKeyInfo.isHsync()) {
         String hsyncClientIdStr =

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -47,19 +47,17 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
   private OMAdmin parent;
 
   @CommandLine.Option(
-      names = {"-id", "--service-id"},
+      names = {"--service-id", "--om-service-id"},
       description = "Ozone Manager Service ID",
       required = false
   )
   private String omServiceId;
 
   @CommandLine.Option(
-      names = {"-host", "--service-host"},
-      description = "Ozone Manager Host. If OM HA is enabled, use -id instead. "
-          + "If insists on using -host with OM HA, this must point directly "
-          + "to the leader OM. "
-          + "This option is required when -id is not provided or "
-          + "when HA is not enabled."
+      names = {"--service-host"},
+      description = "Ozone Manager Host. If OM HA is enabled, use --service-id instead. "
+          + "If you must use --service-host with OM HA, this must point directly to the leader OM. "
+          + "This option is required when --service-id is not provided or when HA is not enabled."
   )
   private String omHost;
 
@@ -68,7 +66,7 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
       description = "Format output as JSON")
   private boolean json;
 
-  // Conforms to ListOptions, but not all in ListOptions applies here so
+  // Conforms to ListOptions, but not all in ListOptions applies here thus
   // not using that directly
   @CommandLine.Option(
       names = {"-p", "--prefix"},

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.admin.om;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.server.JsonUtils;
+import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Handler of ozone admin om listopenfiles command.
+ */
+@CommandLine.Command(
+    name = "listopenfiles",
+    aliases = {"listopenkeys", "lof", "lok"},
+    description = "Lists open keys in Ozone Manager.",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+public class ListOpenFilesSubCommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private OMAdmin parent;
+
+  @CommandLine.Option(
+      names = {"-id", "--service-id"},
+      description = "Ozone Manager Service ID",
+      required = false
+  )
+  private String omServiceId;
+
+  @CommandLine.Option(
+      names = {"-host", "--service-host"},
+      description = "Ozone Manager Host. If OM HA is enabled, use -id instead. "
+          + "If insists on using -host with OM HA, this must point directly "
+          + "to the leader OM. "
+          + "This option is required when -id is not provided or "
+          + "when HA is not enabled."
+  )
+  private String omHost;
+
+  @CommandLine.Option(names = { "--json" },
+      defaultValue = "false",
+      description = "Format output as JSON")
+  private boolean json;
+
+  @CommandLine.Option(
+      names = {"-p", "--path"},
+      description = "Show only open files under this path.",
+      defaultValue = "/",
+      hidden = false
+  )
+  private String path;
+
+  @CommandLine.Option(
+      names = {"-n"},
+      description = "Numerical limit of open files/keys to return.",
+      defaultValue = "1000",
+      hidden = false
+  )
+  private long count;
+
+  @CommandLine.Option(
+      names = {"-t", "--token"},  // TODO: Conform to Ozone CLI convention
+      description = "Previous/last file/key path as the continuation token.",
+      defaultValue = "",
+      hidden = false
+  )
+  private String cToken;
+
+  @Override
+  public Void call() throws Exception {
+
+    if (StringUtils.isEmpty(omServiceId) && StringUtils.isEmpty(omHost)) {
+      System.err.println("Error: Please specify -id or -host");
+      return null;
+    }
+
+    OzoneManagerProtocol ozoneManagerClient =
+        parent.createOmClient(omServiceId, omHost, false);
+
+    ListOpenFilesResult res =
+        ozoneManagerClient.listOpenFiles(path, count, cToken);
+
+    if (json) {
+      // Print detailed JSON
+      printOpenKeysListAsJson(res);
+    } else {
+      // Human friendly output
+      printOpenKeysList(res);
+    }
+
+    return null;
+  }
+
+  private void printOpenKeysListAsJson(ListOpenFilesResult res)
+      throws IOException {
+    // TODO: Untested
+    System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(res));
+  }
+
+  private void printOpenKeysList(ListOpenFilesResult res) {
+
+    List<OpenKeySession> openFileList = res.getOpenFiles();
+
+    // TODO: Conform to HDFS style output
+    String msg = res.getGlobalTotal() + " global open files (estimated). " +
+        "Showing " + openFileList.size() + " open files (limit " + count + ") " +
+        "under path prefix:\n  " + path;
+
+    if (cToken != null && !cToken.isEmpty()) {
+      msg += "\nafter continuation token:\n  " + cToken;
+    }
+    msg += "\nClient ID\t\tPath";
+    System.out.println(msg);
+
+    for (OpenKeySession e : openFileList) {
+      System.out.println(e.getId() +
+          "\t" + getFullPathFromKeyInfo(e.getKeyInfo()) +
+          "\t" + e.getKeyInfo().toString());  // TODO: Remove full KeyInfo print
+    }
+
+    // Compose next batch's command
+    if (res.hasMore()) {
+      OpenKeySession lastElement = openFileList.get(openFileList.size() - 1);
+      String nextBatchCmd =
+          getCmdForNextBatch(getFullPathFromKeyInfo(lastElement.getKeyInfo()));
+
+      System.out.println("\n" +
+          "To get the next batch of open keys, run:\n  " + nextBatchCmd);
+    } else {
+      System.out.println("\nReached the end of the list.");
+    }
+  }
+
+  /**
+   * @return the command to get the next batch of open keys
+   */
+  private String getCmdForNextBatch(String lastElementFullPath) {
+    String nextBatchCmd = "ozone admin om lof";
+    if (!omServiceId.isEmpty()) {
+      nextBatchCmd += " -id " + omServiceId;
+    }
+    if (!omHost.isEmpty()) {
+      nextBatchCmd += " -host " + omHost;
+    }
+    if (json) {
+      nextBatchCmd += " --json";
+    }
+    nextBatchCmd += " -n " + count;
+    if (!path.isEmpty()) {
+      nextBatchCmd += " -p " + path;
+    }
+    if (!cToken.isEmpty()) {
+      nextBatchCmd += " -t " + lastElementFullPath;
+    }
+    return nextBatchCmd;
+  }
+
+  private String getFullPathFromKeyInfo(OmKeyInfo oki) {
+    return "/" + oki.getVolumeName() +
+        "/" + oki.getBucketName() +
+        "/" + oki.getPath();
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -53,6 +53,7 @@ import java.util.Collection;
     versionProvider = HddsVersionProvider.class,
     subcommands = {
         FinalizeUpgradeSubCommand.class,
+        ListOpenFilesSubCommand.class,
         GetServiceRolesSubcommand.class,
         PrepareSubCommand.class,
         CancelPrepareSubCommand.class,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Ozone Admin CLI `listopenfiles` as a debug command for admins and devs. e.g.

```bash
# First, auth as Ozone admin
$ ozone admin om lof --service-id=om-service-test1 --length=3 --prefix=/volumelof/buck1
5 total open files (est.). Showing 3 open files (limit 3) under path prefix:
  /volume-lof/buck1

Client ID		Creation time	Hsync'ed	Open File Path
111726338148007937	1704808626523	No		/volume-lof/buck1/-9223372036854774527/key0
111726338151415810	1704808626578	No		/volume-lof/buck1/-9223372036854774527/key1
111726338152071171	1704808626588	No		/volume-lof/buck1/-9223372036854774527/key2

To get the next batch of open keys, run:
  ozone admin om lof -id=om-service-test1 --length=3 --prefix=/volume-lof/buck1 --start=/-9223372036854775552/-9223372036854775040/-9223372036854774527/key2/111726338152071171
```

JSON output:

```bash
$ ozone admin om lof --service-id=om-service-test1 --length=3 --prefix=/volumelof/buck1 --json
```
```json
{
  "openKeys" : [ {
    "keyInfo" : {
      "metadata" : { },
      "objectID" : -9223372036854774015,
      "updateID" : 7,
      "parentObjectID" : -9223372036854774527,
      "volumeName" : "volume-lof",
      "bucketName" : "buck1",
      "keyName" : "key0",
      "dataSize" : 4194304,
      "keyLocationVersions" : [ ... ],
      "creationTime" : 1704808722487,
      "modificationTime" : 1704808722487,
      "replicationConfig" : {
        "replicationFactor" : "THREE",
        "requiredNodes" : 3,
        "replicationType" : "RATIS"
      },
      "fileName" : "key0",
      "acls" : [ ... ],
      "path" : "-9223372036854774527/key0",
      "file" : true,
      "replicatedSize" : 12582912,
      "objectInfo" : "OMKeyInfo{volume='volume-lof', bucket='buck1', key='key0', dataSize='4194304', creationTime='1704808722487', objectID='-9223372036854774015', parentID='-9223372036854774527', replication='RATIS/THREE', fileChecksum='null}",
      "hsync" : false,
      "latestVersionLocations" : { ... },
      "updateIDset" : true
    },
    "openVersion" : 0,
    "clientId" : 111726344437039105
  }, {
    "keyInfo" : { ... },
    "openVersion" : 0,
    "clientId" : 111726344440578050
  }, {
    "keyInfo" : { ... },
    "openVersion" : 0,
    "clientId" : 111726344441233411
  } ],
  "totalOpenKeyCount" : 5,
  "hasMore" : true,
  "contToken" : "/-9223372036854775552/-9223372036854775040/-9223372036854774527/key2/111726344441233411"
}
```

- [x] Optional filter by bucket or key prefix
- [x] Pagination support
- [x] JSON output
- [x] Documentation

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8830

## How was this patch tested?

- [x] Integration test addition.
- [x] Unit test addition.