### PR TITLE
HDDS-10057. [Snapshot] 'ozone fs -ls' on '.snapshot' dir of a bucket should list only active snapshots

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -294,13 +294,16 @@ class TestOzoneFsSnapshot {
       Assertions.assertEquals(0, res);
 
       // Wait for the snapshot to be marked deleted.
-      SnapshotInfo snapshotInfo = ozoneManager.getMetadataManager()
-          .getSnapshotInfoTable()
-          .get(SnapshotInfo.getTableKey(VOLUME, BUCKET, snapshotName1));
-
-      GenericTestUtils.waitFor(() -> snapshotInfo.getSnapshotStatus().equals(
-              SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED),
-          200, 10000);
+      GenericTestUtils.waitFor(() -> {
+        try {
+          SnapshotInfo snapshotInfo = ozoneManager.getMetadataManager()
+              .getSnapshotInfoTable()
+              .get(SnapshotInfo.getTableKey(VOLUME, BUCKET, snapshotName1));
+          return snapshotInfo.getSnapshotStatus() == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }, 200, 10000);
 
       // Check for snapshot with "ozone fs -ls"
       String listSnapOut = execShellCommandAndGetOutput(0,
@@ -366,13 +369,16 @@ class TestOzoneFsSnapshot {
     Assertions.assertEquals(0, res);
 
     // Wait for the snapshot to be marked deleted.
-    SnapshotInfo snapshotInfo = ozoneManager.getMetadataManager()
-        .getSnapshotInfoTable()
-        .get(SnapshotInfo.getTableKey(VOLUME, BUCKET, snapshotName));
-
-    GenericTestUtils.waitFor(() -> snapshotInfo.getSnapshotStatus().equals(
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED),
-        200, 10000);
+    GenericTestUtils.waitFor(() -> {
+      try {
+        SnapshotInfo snapshotInfo = ozoneManager.getMetadataManager()
+            .getSnapshotInfoTable()
+            .get(SnapshotInfo.getTableKey(VOLUME, BUCKET, snapshotName));
+        return snapshotInfo.getSnapshotStatus() == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 200, 10000);
   }
 
   private static Stream<Arguments> deleteSnapshotFailureScenarios() {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
@@ -823,8 +824,10 @@ public class BasicRootedOzoneClientAdapterImpl
 
     while (snapshotIter.hasNext()) {
       OzoneSnapshot ozoneSnapshot = snapshotIter.next();
-      res.add(getFileStatusAdapterForBucketSnapshot(
-          ozoneBucket, ozoneSnapshot, uri, owner, group));
+      if (SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE.name().equalsIgnoreCase(ozoneSnapshot.getSnapshotStatus())) {
+        res.add(getFileStatusAdapterForBucketSnapshot(
+            ozoneBucket, ozoneSnapshot, uri, owner, group));
+      }
     }
 
     return res;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -824,7 +824,7 @@ public class BasicRootedOzoneClientAdapterImpl
 
     while (snapshotIter.hasNext()) {
       OzoneSnapshot ozoneSnapshot = snapshotIter.next();
-      if (SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE.name().equalsIgnoreCase(ozoneSnapshot.getSnapshotStatus())) {
+      if (SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE.name().equals(ozoneSnapshot.getSnapshotStatus())) {
         res.add(getFileStatusAdapterForBucketSnapshot(
             ozoneBucket, ozoneSnapshot, uri, owner, group));
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently when we do `ozone fs -ls` on `.snapshot` hidden dir of a bucket, it throws an error message if bucket contains deleted snapshot which are not be garbage collected as mentioned in HDDS-10057.
In this change, snapshot active check is added to make sure it lists only active snapshots and their content.
 
## What is the link to the Apache JIRA
HDDS-10057

## How was this patch tested?
Updated the unit test and tested it out on local cluster by increasing the run time of SnapshotDeletingService.