### PR TITLE
HDDS-9958. Improve log for container not found in CloseContainerCommandHandler

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -102,7 +102,12 @@ public class CloseContainerCommandHandler implements CommandHandler {
         final Container container = controller.getContainer(containerId);
 
         if (container == null) {
-          LOG.error("Container #{} does not exist in datanode. "
+          // Change the log level from error to info,
+          // since the container may not have been created
+          // due to issue documented in HDDS-9550/HDDS-9600
+          // currently the error log stands out when it is 
+          // probably not a real issue.
+          LOG.info("Container #{} does not exist in datanode. "
               + "Container close failed.", containerId);
           return;
         }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -102,12 +102,8 @@ public class CloseContainerCommandHandler implements CommandHandler {
         final Container container = controller.getContainer(containerId);
 
         if (container == null) {
-          // Change the log level from error to info,
-          // since the container may not have been created
-          // due to issue documented in HDDS-9550/HDDS-9600.
-          // Currently the error log stands out when it is
-          // probably not a real issue.
           LOG.info("Container #{} does not exist in datanode. "
+              + "Its pipeline may have closed before it was created. "
               + "Container close failed.", containerId);
           return;
         }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -104,8 +104,8 @@ public class CloseContainerCommandHandler implements CommandHandler {
         if (container == null) {
           // Change the log level from error to info,
           // since the container may not have been created
-          // due to issue documented in HDDS-9550/HDDS-9600
-          // currently the error log stands out when it is 
+          // due to issue documented in HDDS-9550/HDDS-9600.
+          // Currently the error log stands out when it is
           // probably not a real issue.
           LOG.info("Container #{} does not exist in datanode. "
               + "Container close failed.", containerId);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently CloseContainerCommandHandler reports error in log when its ContainerController.getContainer() returns null. This was probably a container that never got created as documented in [HDDS-9550](https://issues.apache.org/jira/browse/HDDS-9550)/[HDDS-9600](https://issues.apache.org/jira/browse/HDDS-9600). Thus we'd like to change [this log message](https://github.com/apache/ozone/blob/52236b152ba4529cf3050d2baee4d50c6722d73b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java#L105) to info with a note that the container may not have been created. (currently the error log stands out when it is probably not a real issue.) We could revisit this log later when issue [HDDS-9600](https://issues.apache.org/jira/browse/HDDS-9600) is resolved.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9958

## How was this patch tested?
original CI pipeline tests.
