### PR TITLE
HDDS-9758. Intermittent failure in testValidateBlockLengthWithCommitKey.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1528,7 +1528,7 @@ public abstract class TestOzoneRpcClientAbstract {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    String value = RandomStringUtils.random(RandomUtils.nextInt(0, 1024));
+    String value = RandomStringUtils.random(RandomUtils.nextInt(1, 1024));
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes intermittent failure in `TestSecureOzoneRpcClient.testValidateBlockLengthWithCommitKey` test case.

This test case validates the committed block length for committed key on OM side, but this test case generates the key content randomly using `RandomStringUtils.random(RandomUtils.nextInt(0, 1024))` and this caused the intermittent failure as sometimes seed value of 0 being used to generate key content due to which empty block gets written in key. This PR fixed the issue by changing the range (1, 1024) so that empty key block never gets committed.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9758

## How was this patch tested?

This patch is tested by running repeated CI runs of multiple iterations (100 iterations in CI flaky workflow). Here is the green CI [link](https://github.com/devmadhuu/ozone/actions/runs/7408849132).
