### PR TITLE
HDDS-10070. Intermittent failure in TestWritableRatisContainerProvider

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableRatisContainerProvider.java
@@ -27,12 +27,16 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -49,6 +53,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class TestWritableRatisContainerProvider {
 
   private static final ReplicationConfig REPLICATION_CONFIG =
@@ -80,7 +85,7 @@ class TestWritableRatisContainerProvider {
     verifyPipelineNotCreated();
   }
 
-  @Test
+  @RepeatedTest(100)
   void skipsPipelineWithoutContainer() throws Exception {
     Pipeline pipeline = MockPipeline.createPipeline(3);
     ContainerInfo existingContainer = pipelineHasContainer(pipeline);
@@ -115,7 +120,7 @@ class TestWritableRatisContainerProvider {
   }
 
   private void existingPipelines(Pipeline... pipelines) {
-    existingPipelines(asList(pipelines));
+    existingPipelines(new ArrayList<>(asList(pipelines)));
   }
 
   private void existingPipelines(List<Pipeline> pipelines) {
@@ -142,7 +147,7 @@ class TestWritableRatisContainerProvider {
 
     when(pipelineManager.getPipelines(REPLICATION_CONFIG, OPEN, emptySet(), emptySet()))
         .thenReturn(emptyList())
-        .thenReturn(singletonList(newPipeline));
+        .thenReturn(new ArrayList<>(singletonList(newPipeline)));
 
     return pipelineHasContainer(newPipeline);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in `TestWritableRatisContainerProvider#skipsPipelineWithoutContainer`.

One of the pipelines has a container (stubbing for `getMatchingContainer`), the other doesn't.  Mocks return `null` for calls without stubbing, and the test relies on that for the pipeline without container.  The problem is that Mockito is also strict by default.  When it sees the non-stubbed pipeline, it reports this error.  Pipelines are returned by `getPipelines` in the right order (one without container first), but the order in which they are actually checked depends on `PipelineChoosePolicy`.

The problem can be reproduced by changing the test case to `@RepeatedTest(100)`.

The fix sets lenient mode for Mockito in the test class to be able to rely on the default.

This also exposed another problem: lists used by the test as return value for stubbed `getPipelines` do not support `remove` (invoked by `WritableRatisContainerProvider` during iteration of pipelines).  This is fixed by wrapping in `ArrayList`.

https://issues.apache.org/jira/browse/HDDS-10070

## How was this patch tested?

Unit test passes with `@RepeatedTest(100)` (which is left in place to catch such problems in the future).

CI: (pending)