### PR TITLE
HDDS-10072. Update Container interface for named RwLock operations

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
@@ -26,21 +26,18 @@ import java.time.Instant;
 import java.util.Map;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.protocol.proto
-    .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
-import org.apache.hadoop.hdds.scm.container.common.helpers
-    .StorageContainerException;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 
 import org.apache.hadoop.hdfs.util.Canceler;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
-import org.apache.hadoop.hdfs.util.RwLock;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 
 /**
  * Interface for Container Operations.
  */
-public interface Container<CONTAINERDATA extends ContainerData> extends RwLock {
+public interface Container<CONTAINERDATA extends ContainerData> {
   /**
    * Encapsulates the result of a container scan.
    */
@@ -262,4 +259,28 @@ public interface Container<CONTAINERDATA extends ContainerData> extends RwLock {
    */
   ScanResult scanData(DataTransferThrottler throttler, Canceler canceler)
       throws InterruptedException;
+
+  /** Acquire read lock. */
+  void readLock();
+
+  /** Acquire read lock, unless interrupted while waiting. */
+  void readLockInterruptibly() throws InterruptedException;
+
+  /** Release read lock. */
+  void readUnlock();
+
+  /** Check if the current thread holds read lock. */
+  boolean hasReadLock();
+
+  /** Acquire write lock. */
+  void writeLock();
+
+  /** Acquire write lock, unless interrupted while waiting. */
+  void writeLockInterruptibly() throws InterruptedException;
+
+  /** Release write lock. */
+  void writeUnlock();
+
+  /** Check if the current thread holds write lock. */
+  boolean hasWriteLock();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Container` extends the `RwLock` interface from Hadoop, probably only for convenience.  Hadoop 3.4 adds two new methods in `RwLock` (HDFS-16434) without default implementation.  We need to
1. either implement these new methods,
2. or inline the methods used into `Container`.

No code in Ozone makes use of the `RwLock` abstraction, so I think we can go with (2).

Q: should we keep methods implemented but not used in Ozone? (`readLockInterruptibly`, `writeLockInterruptibly`, `hasReadLock`)

https://issues.apache.org/jira/browse/HDDS-10072

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7426301421