### PR TITLE
HDDS-10063. NumKeys metric not decremented on FSO directory delete.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -52,7 +52,7 @@ public final class TestDataUtil {
   public static OzoneBucket createVolumeAndBucket(OzoneClient client,
       String volumeName, String bucketName) throws IOException {
     return createVolumeAndBucket(client, volumeName, bucketName,
-        BucketLayout.LEGACY);
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   public static OzoneBucket createVolumeAndBucket(OzoneClient client,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -52,7 +52,7 @@ public final class TestDataUtil {
   public static OzoneBucket createVolumeAndBucket(OzoneClient client,
       String volumeName, String bucketName) throws IOException {
     return createVolumeAndBucket(client, volumeName, bucketName,
-        BucketLayout.FILE_SYSTEM_OPTIMIZED);
+        BucketLayout.LEGACY);
   }
 
   public static OzoneBucket createVolumeAndBucket(OzoneClient client,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -65,6 +66,8 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
     Set<Pair<String, String>> lockSet = new HashSet<>();
     Map<Pair<String, String>, OmBucketInfo> volBucketInfoMap = new HashMap<>();
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+
+    OMMetrics omMetrics = ozoneManager.getMetrics();
     try {
       if (fromSnapshot != null) {
         fromSnapshotInfo = ozoneManager.getMetadataManager()
@@ -84,7 +87,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
                 volumeName, bucketName);
             lockSet.add(volBucketPair);
           }
-          
+          omMetrics.decNumKeys();
           OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
               volumeName, bucketName);
           // bucketInfo can be null in case of delete volume or bucket
@@ -107,6 +110,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
                 volumeName, bucketName);
             lockSet.add(volBucketPair);
           }
+          omMetrics.decNumKeys();
           OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
               volumeName, bucketName);
           // bucketInfo can be null in case of delete volume or bucket


### PR DESCRIPTION
## What changes were proposed in this pull request?

Directory and file count is included in the OM NumKeys metric. When a directory is deleted from OM, its subdirectories and files are not subtracted from the current key count held by the NumKeys metric. We can decrement this metric in the OMDirectoriesPurgeRequestWithFSO sent out by the leader's directory deleting service so that the metric is updated asynchronously on the leader and all followers.

## What is the link to the Apache JIRA

HDDS-10063

## How was this patch tested?

New integration test for directory related metrics added to the existing test class for OM Metrics.
