### PR TITLE
HDDS-10076. SnapshotCache closes RocksDB instance with Reference.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotCache.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotCache.java
@@ -307,7 +307,12 @@ public class SnapshotCache implements ReferenceCountedCallback {
           rcOmSnapshot, omSnapshot.getSnapshotTableKey());
 
       final String key = omSnapshot.getSnapshotTableKey();
-      dbMap.computeIfPresent(key, (k, v) -> {
+      dbMap.compute(key, (k, v) -> {
+        if (v == null) {
+          throw new IllegalStateException("Key '" + k + "' does not exist in cache. The RocksDB " +
+              "instance of the Snapshot may not be closed properly.");
+        }
+
         // Sanity check
         Preconditions.checkState(rcOmSnapshot == v,
             "Cache map entry removal failure. The cache is in an inconsistent "

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotCache.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotCache.java
@@ -186,7 +186,7 @@ public class SnapshotCache implements ReferenceCountedCallback {
               throw new IllegalStateException(ex);
             }
           }
-          LOG.info("Getting Snapshot {} from Snapshot Cache", k);
+          LOG.debug("Got snapshot {} from SnapshotCache", k);
           return v;
         });
 
@@ -323,6 +323,8 @@ public class SnapshotCache implements ReferenceCountedCallback {
           }
           return null;
         }
+        LOG.warn("Snapshot {} is still being referenced ({}), skipping its clean up",
+            k, rcOmSnapshot.getTotalRefCount());
         return v;
       });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
While accessing snapshots, We use `SnapshotCache` to load and retrieve a snapshot's RocksDB instance. The function call is as follows `get()->cleanup()`, When multiple background process calls `get()` some threads can also be doing the`cleanup()` of pending eviction list. 

There is a scenario, where Thread 1(KeyDeletingService) is executing `get()->cleanup()` method and Thread 2(SSTFilteringService) is executing `get()` (Hasn't reached `cleanup()` yet), The reference count of the snapshot is incremented by `get()`(`Thread 2`) but we still close the rocksDB instance because the `cleanup()`(`Thread1`) method assumes everything in the pending eviction list has a reference count of 0. This is not the case in the above-mentioned scenario, We need to recheck if the reference count is still 0 when closing the RocksDB instance.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10076

## How was this patch tested?

Manually tested with an existing test.  