### PR TITLE
HDDS-10075. Simplify leftover assertions

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -193,8 +193,8 @@ public class TestKeyValueContainer {
     String chunksPath = keyValueContainerData.getChunksPath();
 
     // Check whether containerMetaDataPath and chunksPath exists or not.
-    assertTrue(containerMetaDataPath != null);
-    assertTrue(chunksPath != null);
+    assertNotNull(containerMetaDataPath);
+    assertNotNull(chunksPath);
     // Check whether container file and container db file exists or not.
     assertTrue(keyValueContainer.getContainerFile().exists(),
         ".Container File does not exist");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1999,7 +1999,7 @@ public abstract class TestOzoneRpcClientAbstract {
         byte[] content = new byte[100];
         is.read(content);
         String retValue = new String(content, UTF_8);
-        assertTrue(value.equals(retValue.trim()));
+        assertEquals(value, retValue.trim());
       }
     } catch (IOException e) {
       fail("Reading unhealthy replica should succeed.");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.container;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -66,6 +65,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -188,7 +188,7 @@ public final class TestHelper {
       sha1.update(data);
       MessageDigest sha2 = MessageDigest.getInstance(OzoneConsts.FILE_HASH);
       sha2.update(readData);
-      assertTrue(Arrays.equals(sha1.digest(), sha2.digest()));
+      assertArrayEquals(sha1.digest(), sha2.digest());
     }
   }
 
@@ -205,7 +205,7 @@ public final class TestHelper {
         containerIdList.add(id);
       }
     }
-    assertTrue(!containerIdList.isEmpty());
+    assertFalse(containerIdList.isEmpty());
     waitForContainerClose(cluster, containerIdList.toArray(new Long[0]));
   }
 
@@ -223,7 +223,7 @@ public final class TestHelper {
         containerIdList.add(id);
       }
     }
-    assertTrue(!containerIdList.isEmpty());
+    assertFalse(containerIdList.isEmpty());
     waitForContainerClose(cluster, containerIdList.toArray(new Long[0]));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -581,13 +581,13 @@ public class TestKeyManagerImpl {
     assertEquals(2, matchEntries);
 
     boolean result = writeClient.removeAcl(ozPrefix1, ozAcl4);
-    assertEquals(true, result);
+    assertTrue(result);
 
     ozAclGet = writeClient.getAcl(ozPrefix1);
     assertEquals(2, ozAclGet.size());
 
     result = writeClient.removeAcl(ozPrefix1, ozAcl3);
-    assertEquals(true, result);
+    assertTrue(result);
     ozAclGet = writeClient.getAcl(ozPrefix1);
     assertEquals(1, ozAclGet.size());
 
@@ -717,7 +717,7 @@ public class TestKeyManagerImpl {
     assertEquals(ozAcl1, prefixInfos.get(6).getAcls().get(0));
     // All other nodes don't have acl value associate with it
     for (int i = 0; i < 6; i++) {
-      assertEquals(null, prefixInfos.get(i));
+      assertNull(prefixInfos.get(i));
     }
     // cleanup
     writeClient.removeAcl(ozPrefix1, ozAcl1);
@@ -1523,13 +1523,10 @@ public class TestKeyManagerImpl {
     KeyManagerImpl keyManagerImpl =
         new KeyManagerImpl(ozoneManager, scmClientMock, conf, metrics);
 
-    try {
-      keyManagerImpl.refresh(omKeyInfo);
-      fail();
-    } catch (OMException omEx) {
-      assertEquals(SCM_GET_PIPELINE_EXCEPTION, omEx.getResult());
-      assertTrue(omEx.getMessage().equals(errorMessage));
-    }
+    OMException omEx = assertThrows(OMException.class,
+        () -> keyManagerImpl.refresh(omKeyInfo));
+    assertEquals(SCM_GET_PIPELINE_EXCEPTION, omEx.getResult());
+    assertEquals(errorMessage, omEx.getMessage());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -168,9 +168,9 @@ public class TestObjectStoreWithFSO {
 
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(volumeName, ozoneVolume.getName());
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
-    assertTrue(ozoneBucket.getName().equals(bucketName));
+    assertEquals(bucketName, ozoneBucket.getName());
 
     Table<String, OmKeyInfo> openFileTable =
         cluster.getOzoneManager().getMetadataManager()
@@ -303,9 +303,9 @@ public class TestObjectStoreWithFSO {
 
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(volumeName, ozoneVolume.getName());
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
-    assertTrue(ozoneBucket.getName().equals(bucketName));
+    assertEquals(bucketName, ozoneBucket.getName());
 
     Table<String, OmKeyInfo> openFileTable =
         cluster.getOzoneManager().getMetadataManager()
@@ -397,9 +397,9 @@ public class TestObjectStoreWithFSO {
   public void testListKeysAtDifferentLevels() throws Exception {
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(volumeName, ozoneVolume.getName());
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
-    assertTrue(ozoneBucket.getName().equals(bucketName));
+    assertEquals(bucketName, ozoneBucket.getName());
 
     String keyc1 = "/a/b1/c1/c1.tx";
     String keyc2 = "/a/b1/c2/c2.tx";
@@ -529,9 +529,9 @@ public class TestObjectStoreWithFSO {
   public void testListKeysWithNotNormalizedPath() throws Exception {
     ObjectStore objectStore = client.getObjectStore();
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(volumeName, ozoneVolume.getName());
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
-    assertTrue(ozoneBucket.getName().equals(bucketName));
+    assertEquals(bucketName, ozoneBucket.getName());
 
     String key1 = "/dir1///dir2/file1/";
     String key2 = "/dir1///dir2/file2/";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
@@ -116,7 +116,7 @@ public class TestOzoneManagerRestart {
     objectStore.createVolume(volumeName);
 
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertEquals(ozoneVolume.getName(), volumeName);
+    assertEquals(volumeName, ozoneVolume.getName());
 
     cluster.restartOzoneManager();
     cluster.restartStorageContainerManager(true);
@@ -127,7 +127,7 @@ public class TestOzoneManagerRestart {
 
     // Get Volume.
     ozoneVolume = objectStore.getVolume(volumeName);
-    assertEquals(ozoneVolume.getName(), volumeName);
+    assertEquals(volumeName, ozoneVolume.getName());
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
@@ -54,7 +54,6 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PART
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_ALREADY_EXISTS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test some client operations after cluster starts. And perform restart and
@@ -117,7 +116,7 @@ public class TestOzoneManagerRestart {
     objectStore.createVolume(volumeName);
 
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(ozoneVolume.getName(), volumeName);
 
     cluster.restartOzoneManager();
     cluster.restartStorageContainerManager(true);
@@ -128,7 +127,7 @@ public class TestOzoneManagerRestart {
 
     // Get Volume.
     ozoneVolume = objectStore.getVolume(volumeName);
-    assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(ozoneVolume.getName(), volumeName);
 
   }
 
@@ -143,12 +142,12 @@ public class TestOzoneManagerRestart {
     objectStore.createVolume(volumeName);
 
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(volumeName, ozoneVolume.getName());
 
     ozoneVolume.createBucket(bucketName);
 
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
-    assertTrue(ozoneBucket.getName().equals(bucketName));
+    assertEquals(bucketName, ozoneBucket.getName());
 
     cluster.restartOzoneManager();
     cluster.restartStorageContainerManager(true);
@@ -160,8 +159,7 @@ public class TestOzoneManagerRestart {
 
     // Get bucket.
     ozoneBucket = ozoneVolume.getBucket(bucketName);
-    assertTrue(ozoneBucket.getName().equals(bucketName));
-
+    assertEquals(bucketName, ozoneBucket.getName());
   }
 
 
@@ -180,12 +178,12 @@ public class TestOzoneManagerRestart {
     objectStore.createVolume(volumeName);
 
     OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
-    assertTrue(ozoneVolume.getName().equals(volumeName));
+    assertEquals(volumeName, ozoneVolume.getName());
 
     ozoneVolume.createBucket(bucketName);
 
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
-    assertTrue(ozoneBucket.getName().equals(bucketName));
+    assertEquals(bucketName, ozoneBucket.getName());
 
     String data = "random data";
     OzoneOutputStream ozoneOutputStream1 = ozoneBucket.createKey(key1,
@@ -221,9 +219,8 @@ public class TestOzoneManagerRestart {
 
     // Get newKey1.
     OzoneKey ozoneKey = ozoneBucket.getKey(newKey1);
-    assertTrue(ozoneKey.getName().equals(newKey1));
-    assertTrue(ozoneKey.getReplicationType().equals(
-        ReplicationType.RATIS));
+    assertEquals(newKey1, ozoneKey.getName());
+    assertEquals(ReplicationType.RATIS, ozoneKey.getReplicationType());
 
     // Get newKey2, it should not exist
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
@@ -203,8 +203,8 @@ public class TestFailoverWithSCMHA {
         scm.getReplicationManager().getMoveScheduler().getInflightMove();
     assertTrue(inflightMove.containsKey(id));
     MoveDataNodePair mp = inflightMove.get(id);
-    assertTrue(dn2.equals(mp.getTgt()));
-    assertTrue(dn1.equals(mp.getSrc()));
+    assertEquals(dn2, mp.getTgt());
+    assertEquals(dn1, mp.getSrc());
 
     //complete move in the new leader
     scm.getReplicationManager().getMoveScheduler()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMNodeManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMNodeManagerMXBean.java
@@ -98,7 +98,7 @@ public class TestSCMNodeManagerMXBean {
     Map<String, Map<String, Integer>> mbeanMap = convertNodeCountToMap(data);
     Map<String, Map<String, Integer>> nodeMap =
         scm.getScmNodeManager().getNodeCount();
-    assertTrue(nodeMap.equals(mbeanMap));
+    assertEquals(nodeMap, mbeanMap);
   }
 
   private Map<String, Map<String, Integer>> convertNodeCountToMap(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Assertions in the form:

```
assertTrue(<x> == <y>)
assertEquals(null, <x>) or assertTrue(<x> == null)
assertTrue(<x> != null)
assertEquals(<boolean>, <x>)
```

can be simplified to:

```
assertEquals(<x>, <y>)
assertNull(<x>)
assertNotNull(<x>)
assertTrue/assertFalse(<x>)
```

Not only are these simpler, some of them also provide more information in case of failure.

This PR updates such assertions missed by previous tasks (except `TestSecureOzoneCluster` is done in #5906).

https://issues.apache.org/jira/browse/HDDS-10075

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7427315061