### PR TITLE
HDDS-9999. Add static import for assertions and mocks in ozonefs-common

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestBasicOzoneFileSystems.java
@@ -22,10 +22,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageSize;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -35,7 +33,14 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit test for Basic*OzoneFileSystem.
@@ -74,11 +79,11 @@ public class TestBasicOzoneFileSystems {
   @MethodSource("data")
   public void testFileSystemPosixSymlinkSupport(FileSystem subject) {
     if (subject instanceof BasicRootedOzoneFileSystem) {
-      Assertions.assertTrue(subject.supportsSymlinks());
+      assertTrue(subject.supportsSymlinks());
     } else if (subject instanceof BasicOzoneFileSystem) {
-      Assertions.assertFalse(subject.supportsSymlinks());
+      assertFalse(subject.supportsSymlinks());
     } else {
-      Assertions.fail("Test case not implemented for FileSystem: " +
+      fail("Test case not implemented for FileSystem: " +
           subject.getClass().getSimpleName());
     }
   }
@@ -91,12 +96,12 @@ public class TestBasicOzoneFileSystems {
 
     if (subject instanceof BasicRootedOzoneFileSystem) {
       BasicRootedOzoneClientAdapterImpl adapter =
-          Mockito.mock(BasicRootedOzoneClientAdapterImpl.class);
-      Mockito.doReturn(snapshotName).when(adapter).createSnapshot(any(), any());
+          mock(BasicRootedOzoneClientAdapterImpl.class);
+      doReturn(snapshotName).when(adapter).createSnapshot(any(), any());
 
       BasicRootedOzoneFileSystem ofs =
-          Mockito.spy((BasicRootedOzoneFileSystem) subject);
-      Mockito.when(ofs.getAdapter()).thenReturn(adapter);
+          spy((BasicRootedOzoneFileSystem) subject);
+      when(ofs.getAdapter()).thenReturn(adapter);
 
       Path ofsBucketStr = new Path("ofs://om/vol1/buck1/");
       Path ofsDir1 = new Path(ofsBucketStr, "dir1");
@@ -107,14 +112,14 @@ public class TestBasicOzoneFileSystems {
 
       // Return value path should be "ofs://om/vol1/buck1/.snapshot/snap1"
       // without the subdirectory "dir1" in the Path.
-      Assertions.assertEquals(expectedSnapshotPath, res);
+      assertEquals(expectedSnapshotPath, res);
     } else if (subject instanceof BasicOzoneFileSystem) {
       BasicOzoneClientAdapterImpl adapter =
-          Mockito.mock(BasicOzoneClientAdapterImpl.class);
-      Mockito.doReturn(snapshotName).when(adapter).createSnapshot(any(), any());
+          mock(BasicOzoneClientAdapterImpl.class);
+      doReturn(snapshotName).when(adapter).createSnapshot(any(), any());
 
-      BasicOzoneFileSystem o3fs = Mockito.spy((BasicOzoneFileSystem) subject);
-      Mockito.when(o3fs.getAdapter()).thenReturn(adapter);
+      BasicOzoneFileSystem o3fs = spy((BasicOzoneFileSystem) subject);
+      when(o3fs.getAdapter()).thenReturn(adapter);
 
       Path o3fsBucketStr = new Path("o3fs://buck1.vol1.om/");
       Path o3fsDir1 = new Path(o3fsBucketStr, "dir1");
@@ -126,9 +131,9 @@ public class TestBasicOzoneFileSystems {
 
       // Return value path should be "o3fs://buck1.vol1.om/.snapshot/snap1"
       // without the subdirectory "dir1" in the Path.
-      Assertions.assertEquals(expectedSnapshotPath, res);
+      assertEquals(expectedSnapshotPath, res);
     } else {
-      Assertions.fail("Test case not implemented for FileSystem: " +
+      fail("Test case not implemented for FileSystem: " +
           subject.getClass().getSimpleName());
     }
   }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -19,10 +19,14 @@ package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OFSPath;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Testing basic functions of utility class OFSPath.
@@ -35,13 +39,13 @@ public class TestOFSPath {
   public void testParsingPathWithSpace() {
     // Two most common cases: file key and dir key inside a bucket
     OFSPath ofsPath = new OFSPath("/volume1/bucket2/dir3/key4 space", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
-    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
-    Assertions.assertEquals("dir3/key4 space", ofsPath.getKeyName());
-    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("/volume1/bucket2/dir3/key4 space",
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals("volume1", ofsPath.getVolumeName());
+    assertEquals("bucket2", ofsPath.getBucketName());
+    assertEquals("dir3/key4 space", ofsPath.getKeyName());
+    assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    assertFalse(ofsPath.isMount());
+    assertEquals("/volume1/bucket2/dir3/key4 space",
         ofsPath.toString());
   }
 
@@ -49,103 +53,103 @@ public class TestOFSPath {
   public void testParsingVolumeBucketWithKey() {
     // Two most common cases: file key and dir key inside a bucket
     OFSPath ofsPath = new OFSPath("/volume1/bucket2/dir3/key4", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
-    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
-    Assertions.assertEquals("dir3/key4", ofsPath.getKeyName());
-    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("/volume1/bucket2/dir3/key4", ofsPath.toString());
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals("volume1", ofsPath.getVolumeName());
+    assertEquals("bucket2", ofsPath.getBucketName());
+    assertEquals("dir3/key4", ofsPath.getKeyName());
+    assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    assertFalse(ofsPath.isMount());
+    assertEquals("/volume1/bucket2/dir3/key4", ofsPath.toString());
 
     // The ending '/' matters for key inside a bucket, indicating directory
     ofsPath = new OFSPath("/volume1/bucket2/dir3/dir5/", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
-    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals("volume1", ofsPath.getVolumeName());
+    assertEquals("bucket2", ofsPath.getBucketName());
     // Check the key must end with '/' (dir5 is a directory)
-    Assertions.assertEquals("dir3/dir5/", ofsPath.getKeyName());
-    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("/volume1/bucket2/dir3/dir5/", ofsPath.toString());
+    assertEquals("dir3/dir5/", ofsPath.getKeyName());
+    assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    assertFalse(ofsPath.isMount());
+    assertEquals("/volume1/bucket2/dir3/dir5/", ofsPath.toString());
   }
 
   @Test
   public void testParsingVolumeBucketOnly() {
     // Volume and bucket only
     OFSPath ofsPath = new OFSPath("/volume1/bucket2/", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
-    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
-    Assertions.assertEquals("", ofsPath.getMountName());
-    Assertions.assertEquals("", ofsPath.getKeyName());
-    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("/volume1/bucket2/", ofsPath.toString());
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals("volume1", ofsPath.getVolumeName());
+    assertEquals("bucket2", ofsPath.getBucketName());
+    assertEquals("", ofsPath.getMountName());
+    assertEquals("", ofsPath.getKeyName());
+    assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    assertFalse(ofsPath.isMount());
+    assertEquals("/volume1/bucket2/", ofsPath.toString());
 
     // The trailing '/' doesn't matter when parsing a bucket path
     ofsPath = new OFSPath("/volume1/bucket2", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
-    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
-    Assertions.assertEquals("", ofsPath.getMountName());
-    Assertions.assertEquals("", ofsPath.getKeyName());
-    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("/volume1/bucket2/", ofsPath.toString());
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals("volume1", ofsPath.getVolumeName());
+    assertEquals("bucket2", ofsPath.getBucketName());
+    assertEquals("", ofsPath.getMountName());
+    assertEquals("", ofsPath.getKeyName());
+    assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    assertFalse(ofsPath.isMount());
+    assertEquals("/volume1/bucket2/", ofsPath.toString());
   }
 
   @Test
   public void testParsingVolumeOnly() {
     // Volume only
     OFSPath ofsPath = new OFSPath("/volume1/", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
-    Assertions.assertEquals("", ofsPath.getBucketName());
-    Assertions.assertEquals("", ofsPath.getMountName());
-    Assertions.assertEquals("", ofsPath.getKeyName());
-    Assertions.assertEquals("/volume1/", ofsPath.getNonKeyPath());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("/volume1/", ofsPath.toString());
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals("volume1", ofsPath.getVolumeName());
+    assertEquals("", ofsPath.getBucketName());
+    assertEquals("", ofsPath.getMountName());
+    assertEquals("", ofsPath.getKeyName());
+    assertEquals("/volume1/", ofsPath.getNonKeyPath());
+    assertFalse(ofsPath.isMount());
+    assertEquals("/volume1/", ofsPath.toString());
 
     // The trailing '/' doesn't matter when parsing a volume path
     ofsPath = new OFSPath("/volume1", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
-    Assertions.assertEquals("", ofsPath.getBucketName());
-    Assertions.assertEquals("", ofsPath.getMountName());
-    Assertions.assertEquals("", ofsPath.getKeyName());
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals("volume1", ofsPath.getVolumeName());
+    assertEquals("", ofsPath.getBucketName());
+    assertEquals("", ofsPath.getMountName());
+    assertEquals("", ofsPath.getKeyName());
     // Note: currently getNonKeyPath() returns with '/' if input is volume only.
     //  There is no use case for this for now.
     //  The behavior might change in the future.
-    Assertions.assertEquals("/volume1/", ofsPath.getNonKeyPath());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("/volume1/", ofsPath.toString());
+    assertEquals("/volume1/", ofsPath.getNonKeyPath());
+    assertFalse(ofsPath.isMount());
+    assertEquals("/volume1/", ofsPath.toString());
   }
 
   @Test
   public void testParsingEmptyInput() {
     OFSPath ofsPath = new OFSPath("", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals("", ofsPath.getVolumeName());
-    Assertions.assertEquals("", ofsPath.getBucketName());
-    Assertions.assertEquals("", ofsPath.getKeyName());
-    Assertions.assertEquals("", ofsPath.getNonKeyPath());
-    Assertions.assertEquals("", ofsPath.getNonKeyPathNoPrefixDelim());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("", ofsPath.toString());
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals("", ofsPath.getVolumeName());
+    assertEquals("", ofsPath.getBucketName());
+    assertEquals("", ofsPath.getKeyName());
+    assertEquals("", ofsPath.getNonKeyPath());
+    assertEquals("", ofsPath.getNonKeyPathNoPrefixDelim());
+    assertFalse(ofsPath.isMount());
+    assertEquals("", ofsPath.toString());
   }
 
   @Test
   public void testParsingWithAuthority() {
     OFSPath ofsPath = new OFSPath("ofs://svc1:9876/volume1/bucket2/dir3/",
         conf);
-    Assertions.assertEquals("svc1:9876", ofsPath.getAuthority());
-    Assertions.assertEquals("volume1", ofsPath.getVolumeName());
-    Assertions.assertEquals("bucket2", ofsPath.getBucketName());
-    Assertions.assertEquals("dir3/", ofsPath.getKeyName());
-    Assertions.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
-    Assertions.assertFalse(ofsPath.isMount());
-    Assertions.assertEquals("ofs://svc1:9876/volume1/bucket2/dir3/",
+    assertEquals("svc1:9876", ofsPath.getAuthority());
+    assertEquals("volume1", ofsPath.getVolumeName());
+    assertEquals("bucket2", ofsPath.getBucketName());
+    assertEquals("dir3/", ofsPath.getKeyName());
+    assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    assertFalse(ofsPath.isMount());
+    assertEquals("ofs://svc1:9876/volume1/bucket2/dir3/",
         ofsPath.toString());
   }
 
@@ -155,32 +159,32 @@ public class TestOFSPath {
     try {
       bucketName = OFSPath.getTempMountBucketNameOfCurrentUser();
     } catch (IOException ex) {
-      Assertions.fail("Failed to get the current user name, "
+      fail("Failed to get the current user name, "
           + "thus failed to get temp bucket name.");
       bucketName = "";  // Make javac happy
     }
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals(
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
-    Assertions.assertEquals(bucketName, ofsPath.getBucketName());
-    Assertions.assertEquals("tmp", ofsPath.getMountName());
-    Assertions.assertEquals("", ofsPath.getKeyName());
-    Assertions.assertEquals("/tmp", ofsPath.getNonKeyPath());
-    Assertions.assertTrue(ofsPath.isMount());
-    Assertions.assertEquals("/tmp/", ofsPath.toString());
+    assertEquals(bucketName, ofsPath.getBucketName());
+    assertEquals("tmp", ofsPath.getMountName());
+    assertEquals("", ofsPath.getKeyName());
+    assertEquals("/tmp", ofsPath.getNonKeyPath());
+    assertTrue(ofsPath.isMount());
+    assertEquals("/tmp/", ofsPath.toString());
 
     // Mount with key
     ofsPath = new OFSPath("/tmp/key1", conf);
-    Assertions.assertEquals("", ofsPath.getAuthority());
-    Assertions.assertEquals(
+    assertEquals("", ofsPath.getAuthority());
+    assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
-    Assertions.assertEquals(bucketName, ofsPath.getBucketName());
-    Assertions.assertEquals("tmp", ofsPath.getMountName());
-    Assertions.assertEquals("key1", ofsPath.getKeyName());
-    Assertions.assertEquals("/tmp", ofsPath.getNonKeyPath());
-    Assertions.assertTrue(ofsPath.isMount());
-    Assertions.assertEquals("/tmp/key1", ofsPath.toString());
+    assertEquals(bucketName, ofsPath.getBucketName());
+    assertEquals("tmp", ofsPath.getMountName());
+    assertEquals("key1", ofsPath.getKeyName());
+    assertEquals("/tmp", ofsPath.getNonKeyPath());
+    assertTrue(ofsPath.isMount());
+    assertEquals("/tmp/key1", ofsPath.toString());
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
@@ -28,12 +28,13 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -53,7 +54,7 @@ public class TestOzoneClientUtils {
     OzoneBucket bucket = mock(OzoneBucket.class);
     String keyName = "dummy";
     ClientProtocol clientProtocol = mock(ClientProtocol.class);
-    Assertions.assertThrows(IllegalArgumentException.class, () ->
+    assertThrows(IllegalArgumentException.class, () ->
         OzoneClientUtils.getFileChecksumWithCombineMode(volume, bucket, keyName,
         -1, OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC,
         clientProtocol));
@@ -80,7 +81,7 @@ public class TestOzoneClientUtils {
             (short) 3, null,
             ecReplicationConfig, new OzoneConfiguration());
     // Bucket default is EC.
-    Assertions.assertEquals(ecReplicationConfig, replicationConfig);
+    assertEquals(ecReplicationConfig, replicationConfig);
   }
 
   /**
@@ -93,7 +94,7 @@ public class TestOzoneClientUtils {
             (short) 3, null, null,
             new OzoneConfiguration());
     // Passed replication is 3 - Ozone mapped replication is ratis THREE
-    Assertions.assertEquals(ratis3ReplicationConfig, replicationConfig);
+    assertEquals(ratis3ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -108,7 +109,7 @@ public class TestOzoneClientUtils {
             new OzoneConfiguration());
     // client configured value also null.
     // This API caller should leave the decision to server.
-    Assertions.assertNull(replicationConfig);
+    assertNull(replicationConfig);
   }
 
   /**
@@ -122,7 +123,7 @@ public class TestOzoneClientUtils {
             (short) -1, null, ratis3ReplicationConfig,
             new OzoneConfiguration());
     // Configured client config also null.
-    Assertions.assertNull(replicationConfig);
+    assertNull(replicationConfig);
   }
 
   /**
@@ -136,7 +137,7 @@ public class TestOzoneClientUtils {
             (short) 1, null, ratis3ReplicationConfig,
             new OzoneConfiguration());
     // Passed value is replication one - Ozone mapped value is ratis ONE
-    Assertions.assertEquals(ratis1ReplicationConfig, replicationConfig);
+    assertEquals(ratis1ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -150,7 +151,7 @@ public class TestOzoneClientUtils {
             (short) 3, ratis3ReplicationConfig,
             ecReplicationConfig, new OzoneConfiguration());
     // Bucket default is EC
-    Assertions.assertEquals(ecReplicationConfig, replicationConfig);
+    assertEquals(ecReplicationConfig, replicationConfig);
   }
 
   /**
@@ -164,7 +165,7 @@ public class TestOzoneClientUtils {
             (short) -1, ratis3ReplicationConfig, ratis1ReplicationConfig,
             new OzoneConfiguration());
     // Configured value is ratis THREE
-    Assertions.assertEquals(ratis3ReplicationConfig, replicationConfig);
+    assertEquals(ratis3ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -177,7 +178,7 @@ public class TestOzoneClientUtils {
         .validateAndGetClientReplicationConfig(ReplicationType.RATIS, "1",
             new OzoneConfiguration());
     // Configured value is ratis ONE
-    Assertions.assertEquals(ratis1ReplicationConfig, replicationConfig);
+    assertEquals(ratis1ReplicationConfig, replicationConfig);
   }
 
   /**
@@ -188,7 +189,7 @@ public class TestOzoneClientUtils {
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, null,
             new OzoneConfiguration());
-    Assertions.assertNull(replicationConfig);
+    assertNull(replicationConfig);
   }
 
   /**
@@ -202,7 +203,7 @@ public class TestOzoneClientUtils {
     clientSideConfig.set(OzoneConfigKeys.OZONE_REPLICATION, "rs-3-2-1024K");
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, null, clientSideConfig);
-    Assertions.assertEquals(ecReplicationConfig, replicationConfig);
+    assertEquals(ecReplicationConfig, replicationConfig);
   }
 
   /**
@@ -214,7 +215,7 @@ public class TestOzoneClientUtils {
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, "3",
             new OzoneConfiguration());
-    Assertions.assertNull(replicationConfig);
+    assertNull(replicationConfig);
   }
 
   /**
@@ -226,7 +227,7 @@ public class TestOzoneClientUtils {
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(ReplicationType.EC, null,
             new OzoneConfiguration());
-    Assertions.assertNull(replicationConfig);
+    assertNull(replicationConfig);
   }
 
   /**
@@ -241,7 +242,7 @@ public class TestOzoneClientUtils {
     // null.
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, null, clientSideConfig);
-    Assertions.assertNull(replicationConfig);
+    assertNull(replicationConfig);
   }
 
   /**
@@ -256,7 +257,7 @@ public class TestOzoneClientUtils {
     // as null.
     ReplicationConfig replicationConfig = OzoneClientUtils
         .validateAndGetClientReplicationConfig(null, null, clientSideConfig);
-    Assertions.assertNull(replicationConfig);
+    assertNull(replicationConfig);
   }
 
 }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsShell.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsShell.java
@@ -27,8 +27,9 @@ import java.io.PrintStream;
 import java.util.Arrays;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 
@@ -55,12 +56,12 @@ public class TestOzoneFsShell {
     } finally {
       // test command bindings for "rm" command handled by OzoneDelete class
       CommandFactory factory = shell.getCommandFactory();
-      Assertions.assertEquals(1, Arrays.stream(factory.getNames())
+      assertEquals(1, Arrays.stream(factory.getNames())
           .filter(c -> c.equals(rmCmd)).count());
       Command instance = factory.getInstance(rmCmd);
-      Assertions.assertNotNull(instance);
-      Assertions.assertEquals(OzoneFsDelete.Rm.class, instance.getClass());
-      Assertions.assertEquals(rmCmdName, instance.getCommandName());
+      assertNotNull(instance);
+      assertEquals(OzoneFsDelete.Rm.class, instance.getClass());
+      assertEquals(rmCmdName, instance.getCommandName());
       shell.close();
       System.setErr(oldErr);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The goal of this task is to add import static for all assertions and interactions with mocks. Replacing:

Assertions.assert<X>(...) -> assert<X>(...)
Assertions.fail(...) -> fail(...)

and

Mockito.mock(...) -> mock(...)
Mockito.verify(...) -> verify(...)
Mockito.when(...) -> when(...)
...

and

ArgumentMatchers.any() -> any()
ArgumentMatchers.eq() -> eq()
ArgumentMatchers.matches() -> matches()
// also:
// Matchers.<...>()



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9999

## How was this patch tested?
Ran unit tests
