### PR TITLE
HDDS-10084. Replace LEGACY in integration test with default layout from config

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -40,6 +40,8 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT;
 
 /**
  * Utility to help to generate test data.
@@ -51,8 +53,7 @@ public final class TestDataUtil {
 
   public static OzoneBucket createVolumeAndBucket(OzoneClient client,
       String volumeName, String bucketName) throws IOException {
-    return createVolumeAndBucket(client, volumeName, bucketName,
-        BucketLayout.LEGACY);
+    return createVolumeAndBucket(client, volumeName, bucketName, getDefaultBucketLayout(client));
   }
 
   public static OzoneBucket createVolumeAndBucket(OzoneClient client,
@@ -141,7 +142,13 @@ public final class TestDataUtil {
 
   public static OzoneBucket createVolumeAndBucket(OzoneClient client)
       throws IOException {
-    return createVolumeAndBucket(client, BucketLayout.LEGACY);
+    return createVolumeAndBucket(client, getDefaultBucketLayout(client));
+  }
+
+  private static BucketLayout getDefaultBucketLayout(OzoneClient client) {
+    return BucketLayout.fromString(client
+        .getConfiguration()
+        .get(OZONE_DEFAULT_BUCKET_LAYOUT, OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT));
   }
 
   public static OzoneBucket createBucket(OzoneClient client,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -282,6 +282,7 @@ public class TestOmMetrics {
     KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "keyManager");
     KeyManager mockKm = Mockito.spy(keyManager);
+    // see HDDS-10078 for making this work with FILE_SYSTEM_OPTIMIZED layout
     TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
     OmKeyArgs keyArgs = createKeyArgs(volumeName, bucketName,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
@@ -281,7 +282,7 @@ public class TestOmMetrics {
     KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "keyManager");
     KeyManager mockKm = Mockito.spy(keyManager);
-    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName);
+    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
     OmKeyArgs keyArgs = createKeyArgs(volumeName, bucketName,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
     doKeyOps(keyArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.debug.OzoneDebug;
 import org.apache.hadoop.ozone.debug.RDBParser;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMStorage;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.test.GenericTestUtils;
@@ -185,7 +186,7 @@ public class TestOzoneDebugShell {
   private static void writeKey(String volumeName, String bucketName,
       String keyName) throws IOException {
     try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
-      TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName);
+      TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
       TestDataUtil.createKey(
           client.getObjectStore().getVolume(volumeName).getBucket(bucketName),
           keyName, ReplicationFactor.THREE, ReplicationType.RATIS, "test");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -186,6 +186,7 @@ public class TestOzoneDebugShell {
   private static void writeKey(String volumeName, String bucketName,
       String keyName) throws IOException {
     try (OzoneClient client = OzoneClientFactory.getRpcClient(conf)) {
+      // see HDDS-10091 for making this work with FILE_SYSTEM_OPTIMIZED layout
       TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
       TestDataUtil.createKey(
           client.getObjectStore().getVolume(volumeName).getBucket(bucketName),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace hard-coded `BucketLayout.LEGACY` with the configured default bucket layout:

https://github.com/apache/ozone/blob/48ea0bb94b22cb9584de3c2b1d6757d1d1f64969/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java#L142-L145

and similarly here:

https://github.com/apache/ozone/blob/48ea0bb94b22cb9584de3c2b1d6757d1d1f64969/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java#L52-L55

Keep using `LEGACY` in two tests that fail with the default `FILE_SYSTEM_OPTIMIZED` layout.

https://issues.apache.org/jira/browse/HDDS-10084

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7440054515