### PR TITLE
HDDS-9852. Intermittent timeout in testCorruptionDetected waiting for container to become unhealthy

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/AbstractBackgroundContainerScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/AbstractBackgroundContainerScanner.java
@@ -39,6 +39,7 @@ public abstract class AbstractBackgroundContainerScanner extends Thread {
   private final long dataScanInterval;
 
   private final AtomicBoolean stopping;
+  private final AtomicBoolean pausing = new AtomicBoolean();
 
   public AbstractBackgroundContainerScanner(String name,
       long dataScanInterval) {
@@ -69,30 +70,44 @@ public abstract class AbstractBackgroundContainerScanner extends Thread {
 
   @VisibleForTesting
   public final void runIteration() {
+    final boolean paused = pausing.get();
     long startTime = System.nanoTime();
-    scanContainers();
+    if (!paused) {
+      scanContainers();
+    }
     long totalDuration = System.nanoTime() - startTime;
     if (stopping.get()) {
       return;
     }
-    AbstractContainerScannerMetrics metrics = getMetrics();
-    metrics.incNumScanIterations();
-    LOG.info("Completed an iteration in {} minutes." +
-            " Number of iterations (since the data-node restart) : {}" +
-            ", Number of containers scanned in this iteration : {}" +
-            ", Number of unhealthy containers found in this iteration : {}",
-        TimeUnit.NANOSECONDS.toMinutes(totalDuration),
-        metrics.getNumScanIterations(),
-        metrics.getNumContainersScanned(),
-        metrics.getNumUnHealthyContainers());
+    if (paused) {
+      LOG.debug("Skipped iteration due to pause");
+    } else {
+      AbstractContainerScannerMetrics metrics = getMetrics();
+      metrics.incNumScanIterations();
+      LOG.info("Completed an iteration in {} minutes." +
+              " Number of iterations (since the data-node restart) : {}" +
+              ", Number of containers scanned in this iteration : {}" +
+              ", Number of unhealthy containers found in this iteration : {}",
+          TimeUnit.NANOSECONDS.toMinutes(totalDuration),
+          metrics.getNumScanIterations(),
+          metrics.getNumContainersScanned(),
+          metrics.getNumUnHealthyContainers());
+    }
     long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(totalDuration);
     long remainingSleep = dataScanInterval - elapsedMillis;
     handleRemainingSleep(remainingSleep);
   }
 
-  public final void scanContainers() {
+  private void scanContainers() {
     Iterator<Container<?>> itr = getContainerIterator();
-    while (!stopping.get() && itr.hasNext()) {
+    while (itr.hasNext()) {
+      final boolean stopped = stopping.get();
+      final boolean paused = pausing.get();
+      if (stopped || paused) {
+        LOG.info("{} exits scan loop stop={} pause={}", this, stopped, paused);
+        break;
+      }
+
       Container<?> c = itr.next();
       try {
         scanContainer(c);
@@ -137,6 +152,14 @@ public abstract class AbstractBackgroundContainerScanner extends Thread {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+  public void pause() {
+    pausing.getAndSet(true);
+  }
+
+  public void unpause() {
+    pausing.getAndSet(false);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestBackgroundContainerDataScannerIntegration.java
@@ -71,6 +71,8 @@ class TestBackgroundContainerDataScannerIntegration
   @EnumSource
   void testCorruptionDetected(ContainerCorruptions corruption)
       throws Exception {
+    pauseScanner();
+
     long containerID = writeDataThenCloseContainer();
     // Container corruption has not yet been introduced.
     Container<?> container = getDnContainer(containerID);
@@ -78,10 +80,12 @@ class TestBackgroundContainerDataScannerIntegration
 
     corruption.applyTo(container);
 
+    resumeScanner();
+
     // Wait for the scanner to detect corruption.
     GenericTestUtils.waitFor(
         () -> container.getContainerState() == State.UNHEALTHY,
-        500, 5000);
+        500, 15_000);
 
     // Wait for SCM to get a report of the unhealthy replica.
     waitForScmToSeeUnhealthyReplica(containerID);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestContainerScannerIntegrationAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scanner/TestContainerScannerIntegrationAbstract.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.ozone.dn.scanner;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -52,15 +53,16 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -320,7 +322,6 @@ public abstract class TestContainerScannerIntegrationAbstract {
 
     private final Consumer<Container<?>> corruption;
     private final ScanResult.FailureType expectedResult;
-    private static final Random RANDOM = new Random();
 
     ContainerCorruptions(Consumer<Container<?>> corruption,
                          ScanResult.FailureType expectedResult) {
@@ -357,11 +358,21 @@ public abstract class TestContainerScannerIntegrationAbstract {
      * Overwrite the file with random bytes.
      */
     private static void corruptFile(File file) {
-      byte[] corruptedBytes = new byte[(int)file.length()];
-      RANDOM.nextBytes(corruptedBytes);
       try {
-        Files.write(file.toPath(), corruptedBytes,
+        final int length = (int) file.length();
+
+        Path path = file.toPath();
+        final byte[] original = IOUtils.readFully(Files.newInputStream(path), length);
+
+        final byte[] corruptedBytes = new byte[length];
+        ThreadLocalRandom.current().nextBytes(corruptedBytes);
+
+        Files.write(path, corruptedBytes,
             StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
+
+        assertThat(IOUtils.readFully(Files.newInputStream(path), length))
+            .isEqualTo(corruptedBytes)
+            .isNotEqualTo(original);
       } catch (IOException ex) {
         // Fail the test.
         throw new UncheckedIOException(ex);
@@ -373,8 +384,10 @@ public abstract class TestContainerScannerIntegrationAbstract {
      */
     private static void truncateFile(File file) {
       try {
-        Files.write(file.toPath(), new byte[]{},
+        Files.write(file.toPath(), new byte[0],
             StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
+
+        assertEquals(0, file.length());
       } catch (IOException ex) {
         // Fail the test.
         throw new UncheckedIOException(ex);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestBackgroundContainerDataScannerIntegration` may fail intermittently.

Example:

```
TestBackgroundContainerDataScannerIntegration.testCorruptionDetected(ContainerCorruptions)[1] -- Time elapsed: 13.31 s <<< FAILURE!

Expected: a string containing "MISSING_CHUNKS_DIR"
     but: was "ID=1 | Index=0 | BCSID=4 | State=UNHEALTHY | MISSING_CHUNK_FILE for file /home/runner/work/ozone/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-7b4415b0-8a9a-489f-9f19-6b15e56f000b/datanode-0/data-0/containers/hdds/7b4415b0-8a9a-489f-9f19-6b15e56f000b/current/containerDir0/1/chunks/111677748019200001.block. Message: /home/runner/work/ozone/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-7b4415b0-8a9a-489f-9f19-6b15e56f000b/datanode-0/data-0/containers/hdds/7b4415b0-8a9a-489f-9f19-6b15e56f000b/current/containerDir0/1/chunks/111677748019200001.block
```

One possible problem is that the scanner may already be checking the new container when the corruption is applied.  For example if the scanner is already checking blocks when chunks directory is deleted, it will report `MISSING_CHUNK_FILE` as the reason instead of `MISSING_CHUNKS_DIR`, which it only checks at the start of the process.

```
2023-12-06 16:49:35,580 [ContainerDataScanner(/home/runner/work/ozone/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-7b4415b0-8a9a-489f-9f19-6b15e56f000b/datanode-0/data-0/containers/hdds)] ERROR ozoneimpl.BackgroundContainerDataScanner (BackgroundContainerDataScanner.java:scanContainer(91)) - Corruption detected in container [1]. Marking it UNHEALTHY.
java.nio.file.NoSuchFileException: /home/runner/work/ozone/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-7b4415b0-8a9a-489f-9f19-6b15e56f000b/datanode-0/data-0/containers/hdds/7b4415b0-8a9a-489f-9f19-6b15e56f000b/current/containerDir0/1/chunks/111677748019200001.block
	...
	at java.nio.channels.FileChannel.open(FileChannel.java:287)
	at org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerCheck.verifyChecksum(KeyValueContainerCheck.java:373)
	at org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerCheck.scanBlock(KeyValueContainerCheck.java:350)
	at org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerCheck.scanData(KeyValueContainerCheck.java:259)
	at org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerCheck.fullCheck(KeyValueContainerCheck.java:157)
	at org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer.scanData(KeyValueContainer.java:983)
	at org.apache.hadoop.ozone.container.ozoneimpl.BackgroundContainerDataScanner.scanContainer(BackgroundContainerDataScanner.java:89)
```

The problem is fixed by letting the test pause the background scanner before creating the container, and resume it only after the corruption is applied.  This ensures the scanner performs all checks from the start on the corrupt container, thus finding the problem induced, not another one that is implied (e.g. if the chunks directory is deleted, any specific chunk file will be missing, too).

The test may also time out intermittently, waiting for container to become unhealthy:

```
TestBackgroundContainerDataScannerIntegration.testCorruptionDetected(ContainerCorruptions)[7] -- Time elapsed: 9.145 s <<< ERROR!
TimeoutException: 
  ...
  at org.apache.ozone.test.GenericTestUtils.waitFor(GenericTestUtils.java:231)
  at org.apache.hadoop.ozone.dn.scanner.TestBackgroundContainerDataScannerIntegration.testCorruptionDetected(TestBackgroundContainerDataScannerIntegration.java:82)
```

Timeout is increased for this wait.

Further improvements in `ContainerCorruptions`:

 * verify that corruptions were effective (contents changed / file deleted)
 * set `SYNC` when writing the files

https://issues.apache.org/jira/browse/HDDS-9852

## How was this patch tested?

Test passed in 2x200 runs:
https://github.com/adoroszlai/ozone/actions/runs/7449863110
https://github.com/adoroszlai/ozone/actions/runs/7450532753

while it failed in 3/200 runs previously:
https://github.com/adoroszlai/ozone/actions/runs/7449847722/job/20269118137#step:3:19

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/7450506376