### PR TITLE
HDDS-10088. Refine the number of handlers for each RPC of SCM

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
@@ -334,5 +335,28 @@ public class OzoneConfiguration extends Configuration
         new DeprecationDelta("hdds.datanode.replication.work.dir",
             OZONE_CONTAINER_COPY_WORKDIR)
     });
+  }
+
+  /**
+   * Gets backwards-compatible configuration property values.
+   * @param name Primary configuration attribute key name.
+   * @param fallbackName The key name of the configuration property that needs
+   *                     to be backward compatible.
+   * @param defaultValue The default value to be returned.
+   */
+  public int getInt(String name, String fallbackName, int defaultValue,
+      Consumer<String> log) {
+    String value = this.getTrimmed(name);
+    if (value == null) {
+      value = this.getTrimmed(fallbackName);
+      if (log != null) {
+        log.accept(name + " is not set.  Fallback to " + fallbackName +
+            ", which is set to " + value);
+      }
+    }
+    if (value == null) {
+      return defaultValue;
+    }
+    return Integer.parseInt(value);
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -236,6 +236,12 @@ public final class ScmConfigKeys {
 
   public static final String OZONE_SCM_HANDLER_COUNT_KEY =
       "ozone.scm.handler.count.key";
+  public static final String OZONE_SCM_CLIENT_HANDLER_COUNT_KEY =
+      "ozone.scm.client.handler.count.key";
+  public static final String OZONE_SCM_BLOCK_HANDLER_COUNT_KEY =
+      "ozone.scm.block.handler.count.key";
+  public static final String OZONE_SCM_DATANODE_HANDLER_COUNT_KEY =
+      "ozone.scm.datanode.handler.count.key";
   public static final int OZONE_SCM_HANDLER_COUNT_DEFAULT = 100;
 
   public static final String OZONE_SCM_SECURITY_HANDLER_COUNT_KEY =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1090,15 +1090,41 @@
     <value>100</value>
     <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
     <description>
-      The number of RPC handler threads for each SCM service
-      endpoint.
-
-      The default is appropriate for small clusters (tens of nodes).
-
-      Set a value that is appropriate for the cluster size. Generally, HDFS
-      recommends RPC handler count is set to 20 * log2(Cluster Size) with an
-      upper limit of 200. However, SCM will not have the same amount of
-      traffic as Namenode, so a value much smaller than that will work well too.
+      Used to set the default number of handler threads for
+      RPC of the SCM service.
+      If you need to set different handlers for a specific RPC,
+      you can refer to the following mapping relationship:
+          ---- RPC type ---- : ---- Configuration items ----
+      SCMClientProtocolServer: 'ozone.scm.client.handler.count.key'
+      SCMBlockProtocolServer: 'ozone.scm.block.handler.count.key'
+      SCMDatanodeProtocolServer: 'ozone.scm.datanode.handler.count.key'
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.client.handler.count.key</name>
+    <value>100</value>
+    <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
+    <description>
+      Used to set the number of RPC handlers used by Client to access SCM.
+      The default value is 100.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.block.handler.count.key</name>
+    <value>100</value>
+    <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
+    <description>
+      Used to set the number of RPC handlers when accessing blocks.
+      The default value is 100.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.datanode.handler.count.key</name>
+    <value>100</value>
+    <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
+    <description>
+      Used to set the number of RPC handlers used by DataNode to access SCM.
+      The default value is 100.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1090,13 +1090,21 @@
     <value>100</value>
     <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
     <description>
-      Used to set the default number of handler threads for
-      RPC of the SCM service.
-      If you need to set different handlers for a specific RPC,
-      you can refer to the following mapping relationship:
-          ---- RPC type ---- : ---- Configuration items ----
-      SCMClientProtocolServer: 'ozone.scm.client.handler.count.key'
-      SCMBlockProtocolServer: 'ozone.scm.block.handler.count.key'
+      The number of RPC handler threads for each SCM service
+      endpoint.
+
+      The default is appropriate for small clusters (tens of nodes).
+
+      Set a value that is appropriate for the cluster size. Generally, HDFS
+      recommends RPC handler count is set to 20 * log2(Cluster Size) with an
+      upper limit of 200. However, Ozone SCM will not have the same amount of
+      traffic as HDFS Namenode, so a value much smaller than that will work well too.
+
+      To specify handlers for individual RPC servers,
+      set the following configuration properties instead:
+      ---- RPC type ----       : ---- Configuration properties ----
+      SCMClientProtocolServer  : 'ozone.scm.client.handler.count.key'
+      SCMBlockProtocolServer   : 'ozone.scm.block.handler.count.key'
       SCMDatanodeProtocolServer: 'ozone.scm.datanode.handler.count.key'
     </description>
   </property>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -34,8 +35,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -47,6 +53,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * Test class for OzoneConfiguration.
  */
 public class TestOzoneConfiguration {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      TestOzoneConfiguration.class);
 
   private OzoneConfiguration conf;
 
@@ -248,6 +257,30 @@ public class TestOzoneConfiguration {
     assertEquals(0, subject.getInt("test.scm.client.port", 123));
     assertEquals(0, subject.getTimeDuration("test.scm.client.wait", 555, TimeUnit.SECONDS));
     assertEquals(0, subject.getDouble("test.scm.client.threshold", 20.5));
+  }
+
+  private static Stream<Arguments> getIntBackwardCompatibilityScenarios() {
+    return Stream.of(
+        Arguments.of(OZONE_SCM_CLIENT_HANDLER_COUNT_KEY, 10, true,
+            OZONE_SCM_HANDLER_COUNT_KEY, 10, OZONE_SCM_HANDLER_COUNT_DEFAULT),
+        Arguments.of(OZONE_SCM_BLOCK_HANDLER_COUNT_KEY, -1, false,
+            OZONE_SCM_HANDLER_COUNT_KEY, OZONE_SCM_HANDLER_COUNT_DEFAULT,
+                OZONE_SCM_HANDLER_COUNT_DEFAULT),
+        Arguments.of(OZONE_SCM_DATANODE_HANDLER_COUNT_KEY, 105, true,
+            OZONE_SCM_HANDLER_COUNT_KEY, 105, OZONE_SCM_HANDLER_COUNT_DEFAULT)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("getIntBackwardCompatibilityScenarios")
+  public void testGetIntBackwardCompatibility(String name, int newVal,
+      boolean isGen, String fallbackName, int targetVal, int defaultVal) {
+    OzoneConfiguration ozoneConfig = new OzoneConfiguration();
+    if (isGen) {
+      ozoneConfig.setInt(name, newVal);
+    }
+    int value = ozoneConfig.getInt(name, fallbackName,defaultVal, LOG::info);
+    assertEquals(value, targetVal);
   }
 
   @Test

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
@@ -41,7 +41,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.*;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_HANDLER_COUNT_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
@@ -283,7 +283,7 @@ public class TestOzoneConfiguration {
     if (isGen) {
       ozoneConfig.setInt(name, newVal);
     }
-    int value = ozoneConfig.getInt(name, fallbackName,defaultVal, LOG::info);
+    int value = ozoneConfig.getInt(name, fallbackName, defaultVal, LOG::info);
     assertEquals(value, targetVal);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -70,6 +70,7 @@ import com.google.protobuf.BlockingService;
 import com.google.protobuf.ProtocolMessageEnum;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.IO_EXCEPTION;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.NODE_COST_DEFAULT;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer;
@@ -106,9 +107,9 @@ public class SCMBlockProtocolServer implements
       StorageContainerManager scm) throws IOException {
     this.scm = scm;
     this.conf = conf;
-    final int handlerCount =
+    final int handlerCount = conf.getInt(OZONE_SCM_BLOCK_HANDLER_COUNT_KEY,
         conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
-            OZONE_SCM_HANDLER_COUNT_DEFAULT);
+            OZONE_SCM_HANDLER_COUNT_DEFAULT));
 
     RPC.setProtocolEngine(conf, ScmBlockLocationProtocolPB.class,
         ProtobufRpcEngine.class);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -108,8 +108,8 @@ public class SCMBlockProtocolServer implements
     this.scm = scm;
     this.conf = conf;
     final int handlerCount = conf.getInt(OZONE_SCM_BLOCK_HANDLER_COUNT_KEY,
-        conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
-            OZONE_SCM_HANDLER_COUNT_DEFAULT));
+        OZONE_SCM_HANDLER_COUNT_KEY, OZONE_SCM_HANDLER_COUNT_DEFAULT,
+            LOG::info);
 
     RPC.setProtocolEngine(conf, ScmBlockLocationProtocolPB.class,
         ProtobufRpcEngine.class);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -142,8 +142,8 @@ public class SCMClientProtocolServer implements
     this.scm = scm;
     this.config = conf;
     final int handlerCount = conf.getInt(OZONE_SCM_CLIENT_HANDLER_COUNT_KEY,
-        conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
-            OZONE_SCM_HANDLER_COUNT_DEFAULT));
+        OZONE_SCM_HANDLER_COUNT_KEY, OZONE_SCM_HANDLER_COUNT_DEFAULT,
+            LOG::info);
     RPC.setProtocolEngine(conf, StorageContainerLocationProtocolPB.class,
         ProtobufRpcEngine.class);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -113,6 +113,7 @@ import java.util.stream.Stream;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StorageContainerLocationProtocolService.newReflectiveBlockingService;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmUtils.checkIfCertSignRequestAllowed;
 import static org.apache.hadoop.hdds.scm.ha.HASecurityUtils.createSCMRatisTLSConfig;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer;
@@ -140,9 +141,9 @@ public class SCMClientProtocolServer implements
       ReconfigurationHandler reconfigurationHandler) throws IOException {
     this.scm = scm;
     this.config = conf;
-    final int handlerCount =
+    final int handlerCount = conf.getInt(OZONE_SCM_CLIENT_HANDLER_COUNT_KEY,
         conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
-            OZONE_SCM_HANDLER_COUNT_DEFAULT);
+            OZONE_SCM_HANDLER_COUNT_DEFAULT));
     RPC.setProtocolEngine(conf, StorageContainerLocationProtocolPB.class,
         ProtobufRpcEngine.class);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -101,6 +101,7 @@ import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProt
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.setNodeOperationalStateCommand;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CONTAINER_REPORT;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.PIPELINE_REPORT;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer;
@@ -158,8 +159,9 @@ public class SCMDatanodeProtocolServer implements
 
     protocolMessageMetrics = getProtocolMessageMetrics();
 
-    final int handlerCount = conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
-        OZONE_SCM_HANDLER_COUNT_DEFAULT);
+    final int handlerCount = conf.getInt(OZONE_SCM_DATANODE_HANDLER_COUNT_KEY,
+        conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
+            OZONE_SCM_HANDLER_COUNT_DEFAULT));
 
     RPC.setProtocolEngine(conf, getProtocolClass(), ProtobufRpcEngine.class);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -158,10 +158,9 @@ public class SCMDatanodeProtocolServer implements
         conf, scm.getScmNodeDetails());
 
     protocolMessageMetrics = getProtocolMessageMetrics();
-
     final int handlerCount = conf.getInt(OZONE_SCM_DATANODE_HANDLER_COUNT_KEY,
-        conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
-            OZONE_SCM_HANDLER_COUNT_DEFAULT));
+        OZONE_SCM_HANDLER_COUNT_KEY, OZONE_SCM_HANDLER_COUNT_DEFAULT,
+            LOG::info);
 
     RPC.setProtocolEngine(conf, getProtocolClass(), ProtobufRpcEngine.class);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The SCM service contains multiple RPC types, they are: SCMClientProtocolServer, SCMBlockProtocolServer, SCMDatanodeProtocolServer.
When initializing these RPCs, the same configuration is used to define the number of handlers.
"ozone.scm.handler.count.key"
Different configurations should be used in different environments, which will be more friendly.
for example:
"ozone.scm.client.handler.count.key"
"ozone.scm.block.handler.count.key"
"ozone.scm.datanode.handler.count.key"

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10088

## How was this patch tested?
It is necessary to ensure that the unit test passes successfully.
