### PR TITLE
HDDS-10093. Make recoverLease call idempotent

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -150,6 +150,9 @@ public class TestLeaseRecovery {
       }
       // The lease should have been recovered.
       assertTrue("File should be closed", fs.isFileClosed(file));
+
+      // A second call to recoverLease should succeed too.
+      assertTrue(fs.recoverLease(file));
     } finally {
       closeIgnoringKeyNotFound(stream);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLeaseRecoverer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLeaseRecoverer.java
@@ -146,5 +146,9 @@ public class TestLeaseRecoverer {
     // make sure length remains the same
     fileStatus = fs.getFileStatus(file);
     assertEquals(dataSize, fileStatus.getLen());
+
+    // recover the same file second time should succeed
+    cmd.execute(args);
+    assertEquals("", stderr.toString());
   }
 }

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
@@ -132,7 +133,16 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
     LOG.trace("recoverLease() path:{}", f);
     Path qualifiedPath = makeQualified(f);
     String key = pathToKey(qualifiedPath);
-    List<OmKeyInfo> infoList = getAdapter().recoverFilePrepare(key);
+    List<OmKeyInfo> infoList = null;
+    try {
+      infoList = getAdapter().recoverFilePrepare(key);
+    } catch (OMException e) {
+      if (e.getResult() == OMException.ResultCodes.KEY_ALREADY_CLOSED) {
+        // key is already closed, let's just return success
+        return true;
+      }
+      throw e;
+    }
     // TODO: query DN to get the final block length
     OmKeyInfo keyInfo = infoList.get(0);
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(keyInfo.getVolumeName())

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
@@ -132,7 +133,16 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
     LOG.trace("isFileClosed() path:{}", f);
     Path qualifiedPath = makeQualified(f);
     String key = pathToKey(qualifiedPath);
-    List<OmKeyInfo> infoList = getAdapter().recoverFilePrepare(key);
+    List<OmKeyInfo> infoList = null;
+    try {
+      infoList = getAdapter().recoverFilePrepare(key);
+    } catch (OMException e) {
+      if (e.getResult() == OMException.ResultCodes.KEY_ALREADY_CLOSED) {
+        // key is already closed, let's just return success
+        return true;
+      }
+      throw e;
+    }
     // TODO: query DN to get the final block length
     OmKeyInfo keyInfo = infoList.get(0);
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(keyInfo.getVolumeName())

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
@@ -131,7 +132,16 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     LOG.trace("recoverLease() path:{}", f);
     Path qualifiedPath = makeQualified(f);
     String key = pathToKey(qualifiedPath);
-    List<OmKeyInfo> infoList = getAdapter().recoverFilePrepare(key);
+    List<OmKeyInfo> infoList = null;
+    try {
+      infoList = getAdapter().recoverFilePrepare(key);
+    } catch (OMException e) {
+      if (e.getResult() == OMException.ResultCodes.KEY_ALREADY_CLOSED) {
+        // key is already closed, let's just return success
+        return true;
+      }
+      throw e;
+    }
     // TODO: query DN to get the final block length
     OmKeyInfo keyInfo = infoList.get(0);
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(keyInfo.getVolumeName())


### PR DESCRIPTION
## What changes were proposed in this pull request?

To be compatible with HDFS behavior, once a file is recovered by calling recoverLease, next time call recoverLease with same path will succeed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10093

## How was this patch tested?

new unit test case