### PR TITLE
HDDS-10067. Add static import for assertions and mocks in SCM integration tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
@@ -33,12 +33,14 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverSe
 import org.apache.ozone.test.GenericTestUtils;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_RATIS_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.GroupInfoReply;
 import org.apache.ratis.protocol.GroupInfoRequest;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -79,11 +81,11 @@ public class TestRatisPipelineLeader {
     List<Pipeline> pipelines = cluster.getStorageContainerManager()
         .getPipelineManager().getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
-    Assertions.assertFalse(pipelines.isEmpty());
+    assertFalse(pipelines.isEmpty());
     Optional<Pipeline> optional = pipelines.stream()
         .filter(Pipeline::isHealthy)
         .findFirst();
-    Assertions.assertTrue(optional.isPresent());
+    assertTrue(optional.isPresent());
     Pipeline ratisPipeline = optional.get();
     // Verify correct leader info populated
     GenericTestUtils.waitFor(() -> {
@@ -91,7 +93,7 @@ public class TestRatisPipelineLeader {
         return verifyLeaderInfo(ratisPipeline);
       } catch (Exception e) {
         LOG.error("Failed verifying the leader info.", e);
-        Assertions.fail("Failed verifying the leader info.");
+        fail("Failed verifying the leader info.");
         return false;
       }
     }, 200, 20000);
@@ -107,7 +109,7 @@ public class TestRatisPipelineLeader {
       ContainerProtocolCalls.createContainer(xceiverClientRatis, 1L, null);
     }
     logCapturer.stopCapturing();
-    Assertions.assertFalse(
+    assertFalse(
         logCapturer.getOutput().contains(
             "org.apache.ratis.protocol.NotLeaderException"),
         "Client should connect to pipeline leader on first try.");
@@ -118,17 +120,17 @@ public class TestRatisPipelineLeader {
     List<Pipeline> pipelines = cluster.getStorageContainerManager()
         .getPipelineManager().getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
-    Assertions.assertFalse(pipelines.isEmpty());
+    assertFalse(pipelines.isEmpty());
     Optional<Pipeline> optional = pipelines.stream()
         .filter(Pipeline::isHealthy)
         .findFirst();
-    Assertions.assertTrue(optional.isPresent());
+    assertTrue(optional.isPresent());
     Pipeline ratisPipeline = optional.get();
     Optional<HddsDatanodeService> dnToStop =
         cluster.getHddsDatanodes().stream().filter(s ->
             !s.getDatanodeStateMachine().getDatanodeDetails().getUuid().equals(
                 ratisPipeline.getLeaderId())).findAny();
-    Assertions.assertTrue(dnToStop.isPresent());
+    assertTrue(dnToStop.isPresent());
     dnToStop.get().stop();
     // wait long enough based on leader election min timeout
     Thread.sleep(4000 * conf.getTimeDuration(
@@ -139,7 +141,7 @@ public class TestRatisPipelineLeader {
         return verifyLeaderInfo(ratisPipeline);
       } catch (Exception e) {
         LOG.error("Failed verifying the leader info.", e);
-        Assertions.fail("Failed getting leader info.");
+        fail("Failed getting leader info.");
         return false;
       }
     }, 200, 20000);
@@ -150,7 +152,7 @@ public class TestRatisPipelineLeader {
         cluster.getHddsDatanodes().stream().filter(s ->
             s.getDatanodeStateMachine().getDatanodeDetails().getUuid()
                 .equals(ratisPipeline.getLeaderId())).findFirst();
-    Assertions.assertTrue(hddsDatanodeService.isPresent());
+    assertTrue(hddsDatanodeService.isPresent());
 
     XceiverServerRatis serverRatis =
         (XceiverServerRatis) hddsDatanodeService.get()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDatanodeProtocolServer.java
@@ -21,12 +21,12 @@ import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test for StorageContainerDatanodeProtocolProtos.
@@ -37,7 +37,7 @@ public class TestSCMDatanodeProtocolServer {
   public void ensureTermAndDeadlineOnCommands()
       throws IOException, TimeoutException {
     OzoneStorageContainerManager scm =
-        Mockito.mock(OzoneStorageContainerManager.class);
+        mock(OzoneStorageContainerManager.class);
 
     ReplicateContainerCommand command = ReplicateContainerCommand.forTest(1);
     command.setTerm(5L);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
@@ -50,7 +50,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.MULTIPART_FORM_DATA_BOUNDARY;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -58,17 +57,19 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_TO_EXCLUDE_SST;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -166,8 +167,7 @@ public class TestSCMDbCheckpointServlet {
     setupHttpMethod(toExcludeList);
 
     doNothing().when(responseMock).setContentType("application/x-tgz");
-    doNothing().when(responseMock).setHeader(Mockito.anyString(),
-        Mockito.anyString());
+    doNothing().when(responseMock).setHeader(anyString(), anyString());
 
     final Path outputPath = tempDir.resolve("testEndpoint.tar");
     when(responseMock.getOutputStream()).thenReturn(
@@ -203,17 +203,17 @@ public class TestSCMDbCheckpointServlet {
 
     doEndpoint();
 
-    Assertions.assertTrue(outputPath.toFile().length() > 0);
-    Assertions.assertTrue(
+    assertTrue(outputPath.toFile().length() > 0);
+    assertTrue(
         scmMetrics.getDBCheckpointMetrics().
             getLastCheckpointCreationTimeTaken() > 0);
-    Assertions.assertTrue(
+    assertTrue(
         scmMetrics.getDBCheckpointMetrics().
             getLastCheckpointStreamingTimeTaken() > 0);
-    Assertions.assertTrue(scmMetrics.getDBCheckpointMetrics().
+    assertTrue(scmMetrics.getDBCheckpointMetrics().
         getNumCheckpoints() > initialCheckpointCount);
 
-    Mockito.verify(scmDbCheckpointServletMock).writeDbDataToStream(any(),
+    verify(scmDbCheckpointServletMock).writeDbDataToStream(any(),
         any(), any(), eq(toExcludeList), any(), any());
   }
 
@@ -225,7 +225,7 @@ public class TestSCMDbCheckpointServlet {
 
     scmDbCheckpointServletMock.doPost(requestMock, responseMock);
 
-    Mockito.verify(responseMock).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    verify(responseMock).setStatus(HttpServletResponse.SC_BAD_REQUEST);
   }
 
   /**
@@ -288,7 +288,7 @@ public class TestSCMDbCheckpointServlet {
     // Use generated form data as input stream to the HTTP request
     InputStream input = new ByteArrayInputStream(
         sb.toString().getBytes(StandardCharsets.UTF_8));
-    ServletInputStream inputStream = Mockito.mock(ServletInputStream.class);
+    ServletInputStream inputStream = mock(ServletInputStream.class);
     when(requestMock.getInputStream()).thenReturn(inputStream);
     when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
         .thenAnswer(invocation -> {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +33,8 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests snapshots in SCM HA.
@@ -75,18 +76,17 @@ public class TestSCMSnapshot {
     long snapshotInfo2 = scm.getScmHAManager().asSCMHADBTransactionBuffer()
         .getLatestTrxInfo().getTransactionIndex();
 
-    Assertions.assertTrue(snapshotInfo2 > snapshotInfo1,
+    assertTrue(snapshotInfo2 > snapshotInfo1,
         String.format("Snapshot index 2 %d should greater than Snapshot " +
             "index 1 %d", snapshotInfo2, snapshotInfo1));
 
     cluster.restartStorageContainerManager(false);
     TransactionInfo trxInfoAfterRestart =
         scm.getScmHAManager().asSCMHADBTransactionBuffer().getLatestTrxInfo();
-    Assertions.assertTrue(
-        trxInfoAfterRestart.getTransactionIndex() >= snapshotInfo2);
-    Assertions.assertDoesNotThrow(() ->
+    assertTrue(trxInfoAfterRestart.getTransactionIndex() >= snapshotInfo2);
+    assertDoesNotThrow(() ->
         pipelineManager.getPipeline(ratisPipeline1.getId()));
-    Assertions.assertDoesNotThrow(() ->
+    assertDoesNotThrow(() ->
         pipelineManager.getPipeline(ratisPipeline2.getId()));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -49,6 +48,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERV
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Class used to test {@link SCMContainerManagerMetrics}.
@@ -91,18 +92,18 @@ public class TestSCMContainerManagerMetrics {
             HddsProtos.ReplicationFactor.ONE), OzoneConsts.OZONE);
 
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assertions.assertEquals(getLongCounter("NumSuccessfulCreateContainers",
+    assertEquals(getLongCounter("NumSuccessfulCreateContainers",
         metrics), ++numSuccessfulCreateContainers);
 
-    Assertions.assertThrows(IOException.class, () ->
+    assertThrows(IOException.class, () ->
         containerManager.allocateContainer(
             RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.THREE), OzoneConsts.OZONE));
     // allocateContainer should fail, so it should have the old metric value.
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assertions.assertEquals(getLongCounter("NumSuccessfulCreateContainers",
+    assertEquals(getLongCounter("NumSuccessfulCreateContainers",
         metrics), numSuccessfulCreateContainers);
-    Assertions.assertEquals(getLongCounter("NumFailureCreateContainers",
+    assertEquals(getLongCounter("NumFailureCreateContainers",
         metrics), 1);
 
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
@@ -113,24 +114,24 @@ public class TestSCMContainerManagerMetrics {
         ContainerID.valueOf(containerInfo.getContainerID()));
 
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assertions.assertEquals(getLongCounter("NumSuccessfulDeleteContainers",
+    assertEquals(getLongCounter("NumSuccessfulDeleteContainers",
         metrics), numSuccessfulDeleteContainers + 1);
 
-    Assertions.assertThrows(ContainerNotFoundException.class, () ->
+    assertThrows(ContainerNotFoundException.class, () ->
         containerManager.deleteContainer(
             ContainerID.valueOf(RandomUtils.nextLong(10000, 20000))));
     // deleteContainer should fail, so it should have the old metric value.
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assertions.assertEquals(getLongCounter("NumSuccessfulDeleteContainers",
+    assertEquals(getLongCounter("NumSuccessfulDeleteContainers",
         metrics), numSuccessfulCreateContainers);
-    Assertions.assertEquals(getLongCounter("NumFailureDeleteContainers",
+    assertEquals(getLongCounter("NumFailureDeleteContainers",
         metrics), 1);
 
     long currentValue = getLongCounter("NumListContainerOps", metrics);
     containerManager.getContainers(
         ContainerID.valueOf(containerInfo.getContainerID()), 1);
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assertions.assertEquals(currentValue + 1,
+    assertEquals(currentValue + 1,
         getLongCounter("NumListContainerOps", metrics));
 
   }
@@ -143,7 +144,7 @@ public class TestSCMContainerManagerMetrics {
 
     MetricsRecordBuilder metrics =
         getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assertions.assertEquals(1L,
+    assertEquals(1L,
         getLongCounter("NumContainerReportsProcessedSuccessful", metrics));
 
     // Create key should create container on DN.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
@@ -17,6 +17,10 @@
  */
 package org.apache.hadoop.hdds.scm.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -30,7 +34,6 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -86,7 +89,7 @@ public class  TestMultiRaftSetup {
         false);
     init(3, conf);
     waitForPipelineCreated(2);
-    Assertions.assertEquals(2, pipelineManager.getPipelines(ReplicationConfig
+    assertEquals(2, pipelineManager.getPipelines(ReplicationConfig
         .fromProtoTypeAndFactor(HddsProtos.ReplicationType.RATIS,
             ReplicationFactor.THREE)).size());
     assertNotSamePeers();
@@ -102,10 +105,8 @@ public class  TestMultiRaftSetup {
     waitForPipelineCreated(1);
     // datanode pipeline limit is set to 2, but only one set of 3 pipelines
     // will be created. Further pipeline creation should fail
-    Assertions.assertEquals(1,
-        pipelineManager.getPipelines(RATIS_THREE).size());
-    Assertions.assertThrows(IOException.class, () ->
-        pipelineManager.createPipeline(RATIS_THREE));
+    assertEquals(1, pipelineManager.getPipelines(RATIS_THREE).size());
+    assertThrows(IOException.class, () -> pipelineManager.createPipeline(RATIS_THREE));
     shutdown();
   }
 
@@ -121,18 +122,16 @@ public class  TestMultiRaftSetup {
     // For example, with d1,d2, d3, d4, d5, only d1 d2 d3 and d1 d4 d5 can form
     // pipeline as the none of peers from any of existing pipelines will be
     // repeated
-    Assertions.assertEquals(2,
-        pipelineManager.getPipelines(RATIS_THREE).size());
+    assertEquals(2, pipelineManager.getPipelines(RATIS_THREE).size());
     List<DatanodeDetails> dns = nodeManager.getAllNodes().stream()
         .filter((dn) -> nodeManager.getPipelinesCount(dn) > 2).collect(
             Collectors.toList());
-    Assertions.assertEquals(1, dns.size());
-    Assertions.assertThrows(IOException.class, () ->
-        pipelineManager.createPipeline(RATIS_THREE));
+    assertEquals(1, dns.size());
+    assertThrows(IOException.class, () -> pipelineManager.createPipeline(RATIS_THREE));
     Collection<PipelineID> pipelineIds = nodeManager.getPipelines(dns.get(0));
     // Only one dataode should have 3 pipelines in total, 1 RATIS ONE pipeline
     // and 2 RATIS 3 pipeline
-    Assertions.assertEquals(3, pipelineIds.size());
+    assertEquals(3, pipelineIds.size());
     List<Pipeline> pipelines = new ArrayList<>();
     pipelineIds.forEach((id) -> {
       try {
@@ -140,10 +139,10 @@ public class  TestMultiRaftSetup {
       } catch (PipelineNotFoundException pnfe) {
       }
     });
-    Assertions.assertEquals(1, pipelines.stream()
+    assertEquals(1, pipelines.stream()
         .filter((p) -> (p.getReplicationConfig().getRequiredNodes() == 1))
         .count());
-    Assertions.assertEquals(2, pipelines.stream()
+    assertEquals(2, pipelines.stream()
         .filter((p) -> (p.getReplicationConfig().getRequiredNodes() == 3))
         .count());
     shutdown();
@@ -151,10 +150,10 @@ public class  TestMultiRaftSetup {
   private void assertNotSamePeers() {
     nodeManager.getAllNodes().forEach((dn) -> {
       Collection<DatanodeDetails> peers = nodeManager.getPeerList(dn);
-      Assertions.assertFalse(peers.contains(dn));
+      assertFalse(peers.contains(dn));
       List<DatanodeDetails> trimList = nodeManager.getAllNodes();
       trimList.remove(dn);
-      Assertions.assertTrue(peers.containsAll(trimList));
+      assertTrue(peers.containsAll(trimList));
     });
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hdds.scm.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -30,7 +33,6 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -93,18 +95,16 @@ public class TestNode2PipelineMap {
         .getContainersInPipeline(ratisContainer.getPipeline().getId());
 
     ContainerID cId = ratisContainer.getContainerInfo().containerID();
-    Assertions.assertEquals(1, set.size());
-    set.forEach(containerID ->
-        Assertions.assertEquals(containerID, cId));
+    assertEquals(1, set.size());
+    set.forEach(containerID -> assertEquals(containerID, cId));
 
     List<DatanodeDetails> dns = ratisContainer.getPipeline().getNodes();
-    Assertions.assertEquals(3, dns.size());
+    assertEquals(3, dns.size());
 
     // get pipeline details by dnid
     Set<PipelineID> pipelines = scm.getScmNodeManager()
         .getPipelines(dns.get(0));
-    Assertions.assertTrue(
-        pipelines.contains(ratisContainer.getPipeline().getId()));
+    assertTrue(pipelines.contains(ratisContainer.getPipeline().getId()));
 
     // Now close the container and it should not show up while fetching
     // containers by pipeline
@@ -114,13 +114,12 @@ public class TestNode2PipelineMap {
         .updateContainerState(cId, HddsProtos.LifeCycleEvent.CLOSE);
     Set<ContainerID> set2 = pipelineManager.getContainersInPipeline(
         ratisContainer.getPipeline().getId());
-    Assertions.assertEquals(0, set2.size());
+    assertEquals(0, set2.size());
 
     pipelineManager.closePipeline(ratisContainer.getPipeline().getId());
     pipelineManager.deletePipeline(ratisContainer.getPipeline().getId());
     pipelines = scm.getScmNodeManager()
         .getPipelines(dns.get(0));
-    Assertions.assertFalse(
-        pipelines.contains(ratisContainer.getPipeline().getId()));
+    assertFalse(pipelines.contains(ratisContainer.getPipeline().getId()));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.pipeline;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -28,7 +29,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -104,7 +104,7 @@ public class TestNodeFailure {
           }
         }, timeForFailure / 2, timeForFailure * 3);
       } catch (Exception e) {
-        Assertions.fail("Test Failed: " + e.getMessage());
+        fail("Test Failed: " + e.getMessage());
       }
     });
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.List;
@@ -64,6 +63,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for Pipeline Closing.
@@ -213,7 +216,7 @@ public class TestPipelineClose {
       throws IOException, TimeoutException {
     EventQueue eventQ = (EventQueue) scm.getEventQueue();
     PipelineActionHandler pipelineActionTest =
-        Mockito.mock(PipelineActionHandler.class);
+        mock(PipelineActionHandler.class);
     eventQ.addHandler(SCMEvents.PIPELINE_ACTIONS, pipelineActionTest);
     ArgumentCaptor<PipelineActionsFromDatanode> actionCaptor =
         ArgumentCaptor.forClass(PipelineActionsFromDatanode.class);
@@ -245,10 +248,10 @@ public class TestPipelineClose {
      * This is expected to trigger an immediate pipeline actions report to SCM
      */
     xceiverRatis.handleNodeLogFailure(groupId, null);
-    Mockito.verify(pipelineActionTest, Mockito.timeout(1500).atLeastOnce())
+    verify(pipelineActionTest, timeout(1500).atLeastOnce())
         .onMessage(
             actionCaptor.capture(),
-            Mockito.any(EventPublisher.class));
+            any(EventPublisher.class));
 
     PipelineActionsFromDatanode actionsFromDatanode =
         actionCaptor.getValue();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -42,6 +41,8 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for RatisPipelineUtils.
@@ -80,7 +81,7 @@ public class TestRatisPipelineCreateAndDestroy {
     init(numOfDatanodes);
     // make sure two pipelines are created
     waitForPipelines(2);
-    Assertions.assertEquals(numOfDatanodes, pipelineManager.getPipelines(
+    assertEquals(numOfDatanodes, pipelineManager.getPipelines(
         RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
@@ -102,7 +103,7 @@ public class TestRatisPipelineCreateAndDestroy {
     // make sure two pipelines are created
     waitForPipelines(2);
     // No Factor ONE pipeline is auto created.
-    Assertions.assertEquals(0, pipelineManager.getPipelines(
+    assertEquals(0, pipelineManager.getPipelines(
         RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
@@ -139,12 +140,11 @@ public class TestRatisPipelineCreateAndDestroy {
                     100, 10 * 1000);
 
     // try creating another pipeline now
-    SCMException ioe = Assertions.assertThrows(SCMException.class, () ->
+    SCMException ioe = assertThrows(SCMException.class, () ->
         pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE)),
         "pipeline creation should fail after shutting down pipeline");
-    Assertions.assertEquals(
-        SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES, ioe.getResult());
+    assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES, ioe.getResult());
 
     // make sure pipelines is destroyed
     waitForPipelines(0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -37,6 +36,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Test SCM restart and recovery wrt pipelines.
@@ -112,17 +113,16 @@ public class TestSCMRestart {
         pipelineManager.getPipeline(ratisPipeline1.getId());
     Pipeline ratisPipeline2AfterRestart =
         pipelineManager.getPipeline(ratisPipeline2.getId());
-    Assertions.assertNotSame(ratisPipeline1AfterRestart, ratisPipeline1);
-    Assertions.assertNotSame(ratisPipeline2AfterRestart, ratisPipeline2);
-    Assertions.assertEquals(ratisPipeline1AfterRestart, ratisPipeline1);
-    Assertions.assertEquals(ratisPipeline2AfterRestart, ratisPipeline2);
+    assertNotSame(ratisPipeline1AfterRestart, ratisPipeline1);
+    assertNotSame(ratisPipeline2AfterRestart, ratisPipeline2);
+    assertEquals(ratisPipeline1AfterRestart, ratisPipeline1);
+    assertEquals(ratisPipeline2AfterRestart, ratisPipeline2);
 
     // Try creating a new container, it should be from the same pipeline
     // as was before restart
     ContainerInfo containerInfo = newContainerManager
         .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "Owner1");
-    Assertions.assertEquals(ratisPipeline1.getId(),
-        containerInfo.getPipelineID());
+    assertEquals(ratisPipeline1.getId(), containerInfo.getPipelineID());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeWithPipelineRules.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeWithPipelineRules.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -46,6 +45,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVA
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -131,7 +132,7 @@ public class TestSCMSafeModeWithPipelineRules {
         !scmSafeModeManager.getOneReplicaPipelineSafeModeRule()
             .validate(), 1000, 60000);
 
-    Assertions.assertTrue(cluster.getStorageContainerManager().isInSafeMode());
+    assertTrue(cluster.getStorageContainerManager().isInSafeMode());
 
     DatanodeDetails restartedDatanode = pipelineList.get(1).getFirstNode();
     // Now restart one datanode from the 2nd pipeline
@@ -152,8 +153,7 @@ public class TestSCMSafeModeWithPipelineRules {
 
     // As after safeMode wait time is not completed, we should have total
     // pipeline's as original count 6(1 node pipelines) + 2 (3 node pipeline)
-    Assertions.assertEquals(totalPipelineCount,
-        pipelineManager.getPipelines().size());
+    assertEquals(totalPipelineCount, pipelineManager.getPipelines().size());
 
     // The below check calls pipelineManager.getPipelines()
     // which is a call to the SCM to get the list of pipeline infos.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.ozone.scm;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -26,7 +28,6 @@ import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolCli
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -68,14 +69,14 @@ public class TestAllocateContainer {
             SCMTestUtils.getReplicationType(conf),
             SCMTestUtils.getReplicationFactor(conf),
             OzoneConsts.OZONE);
-    Assertions.assertNotNull(container);
-    Assertions.assertNotNull(container.getPipeline().getFirstNode());
+    assertNotNull(container);
+    assertNotNull(container.getPipeline().getFirstNode());
 
   }
 
   @Test
   public void testAllocateNull() {
-    Assertions.assertThrows(NullPointerException.class, () ->
+    assertThrows(NullPointerException.class, () ->
         storageContainerLocationClient.allocateContainer(
             SCMTestUtils.getReplicationType(conf),
             SCMTestUtils.getReplicationFactor(conf), null));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerReportWithKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerReportWithKeys.java
@@ -43,13 +43,14 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * This class tests container report with DN container state info.
@@ -128,9 +129,9 @@ public class TestContainerReportWithKeys {
     Set<ContainerReplica> replicas =
         scm.getContainerManager().getContainerReplicas(
             ContainerID.valueOf(keyInfo.getContainerID()));
-    Assertions.assertEquals(1, replicas.size());
+    assertEquals(1, replicas.size());
     replicas.stream().forEach(rp ->
-        Assertions.assertNotNull(rp.getDatanodeDetails().getParent()));
+        assertNotNull(rp.getDatanodeDetails().getParent()));
 
     LOG.info("SCM Container Info keyCount: {} usedBytes: {}",
         cinfo.getNumberOfKeys(), cinfo.getUsedBytes());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
@@ -37,12 +37,15 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 /**
  * Test Container calls.
@@ -96,7 +99,7 @@ public class TestContainerSmallFile {
         ContainerProtocolCalls.readSmallFile(client, blockID, null);
     String readData = response.getData().getDataBuffers().getBuffersList()
         .get(0).toStringUtf8();
-    Assertions.assertEquals("data123", readData);
+    assertEquals("data123", readData);
     xceiverClientManager.releaseClient(client, false);
   }
 
@@ -114,7 +117,7 @@ public class TestContainerSmallFile {
     BlockID blockID = ContainerTestHelper.getTestBlockID(
         container.getContainerInfo().getContainerID());
     // Try to read a Key Container Name
-    Assertions.assertThrowsExactly(StorageContainerException.class,
+    assertThrowsExactly(StorageContainerException.class,
         () -> ContainerProtocolCalls.readSmallFile(client, blockID, null),
         "Unable to find the block");
     xceiverClientManager.releaseClient(client, false);
@@ -136,7 +139,7 @@ public class TestContainerSmallFile {
     ContainerProtocolCalls.writeSmallFile(client, blockID,
         "data123".getBytes(UTF_8), null);
 
-    Assertions.assertThrowsExactly(StorageContainerException.class,
+    assertThrowsExactly(StorageContainerException.class,
         () -> ContainerProtocolCalls.readSmallFile(client,
             ContainerTestHelper.getTestBlockID(nonExistContainerID),
             null),
@@ -166,10 +169,9 @@ public class TestContainerSmallFile {
     blockID1.setBlockCommitSequenceId(bcsId + 1);
     //read a file with higher bcsId than the container bcsId
     StorageContainerException sce =
-        Assertions.assertThrows(StorageContainerException.class, () ->
+        assertThrows(StorageContainerException.class, () ->
             ContainerProtocolCalls.readSmallFile(client, blockID1, null));
-    Assertions.assertSame(ContainerProtos.Result.UNKNOWN_BCSID,
-        sce.getResult());
+    assertSame(ContainerProtos.Result.UNKNOWN_BCSID, sce.getResult());
 
     // write a new block again to bump up the container bcsId
     BlockID blockID2 = ContainerTestHelper
@@ -179,17 +181,16 @@ public class TestContainerSmallFile {
 
     blockID1.setBlockCommitSequenceId(bcsId + 1);
     //read a file with higher bcsId than the committed bcsId for the block
-    sce = Assertions.assertThrows(StorageContainerException.class, () ->
+    sce = assertThrows(StorageContainerException.class, () ->
         ContainerProtocolCalls.readSmallFile(client, blockID1, null));
-    Assertions.assertSame(ContainerProtos.Result.BCSID_MISMATCH,
-        sce.getResult());
+    assertSame(ContainerProtos.Result.BCSID_MISMATCH, sce.getResult());
 
     blockID1.setBlockCommitSequenceId(bcsId);
     ContainerProtos.GetSmallFileResponseProto response =
         ContainerProtocolCalls.readSmallFile(client, blockID1, null);
     String readData = response.getData().getDataBuffers().getBuffersList()
         .get(0).toStringUtf8();
-    Assertions.assertEquals("data123", readData);
+    assertEquals("data123", readData);
     xceiverClientManager.releaseClient(client, false);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -55,6 +54,9 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Container calls.
@@ -127,9 +129,8 @@ public class TestGetCommittedBlockLengthAndPutKey {
       return true;
     }, 500, 5000);
     // make sure the block ids in the request and response are same.
-    Assertions.assertEquals(blockID,
-        BlockID.getFromProtobuf(response.get().getBlockID()));
-    Assertions.assertEquals(data.length, response.get().getBlockLength());
+    assertEquals(blockID, BlockID.getFromProtobuf(response.get().getBlockID()));
+    assertEquals(data.length, response.get().getBlockLength());
     xceiverClientManager.releaseClient(client, false);
   }
 
@@ -148,10 +149,10 @@ public class TestGetCommittedBlockLengthAndPutKey {
     ContainerProtocolCalls.closeContainer(client, containerID, null);
 
     // There is no block written inside the container. The request should fail.
-    Throwable t = Assertions.assertThrows(StorageContainerException.class,
+    Throwable t = assertThrows(StorageContainerException.class,
         () -> ContainerProtocolCalls.getCommittedBlockLength(client, blockID,
             null));
-    Assertions.assertTrue(t.getMessage().contains("Unable to find the block"));
+    assertTrue(t.getMessage().contains("Unable to find the block"));
 
     xceiverClientManager.releaseClient(client, false);
   }
@@ -181,9 +182,8 @@ public class TestGetCommittedBlockLengthAndPutKey {
         ContainerTestHelper
             .getPutBlockRequest(pipeline, writeChunkRequest.getWriteChunk());
     response = client.sendCommand(putKeyRequest).getPutBlock();
-    Assertions.assertEquals(
-        response.getCommittedBlockLength().getBlockLength(), data.length);
-    Assertions.assertTrue(response.getCommittedBlockLength().getBlockID()
+    assertEquals(response.getCommittedBlockLength().getBlockLength(), data.length);
+    assertTrue(response.getCommittedBlockLength().getBlockID()
         .getBlockCommitSequenceId() > 0);
     BlockID responseBlockID = BlockID
         .getFromProtobuf(response.getCommittedBlockLength().getBlockID());
@@ -192,7 +192,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
     // make sure the block ids in the request and response are same.
     // This will also ensure that closing the container committed the block
     // on the Datanodes.
-    Assertions.assertEquals(responseBlockID, blockID);
+    assertEquals(responseBlockID, blockID);
     xceiverClientManager.releaseClient(client, false);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManager.java
@@ -150,9 +150,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -215,7 +218,7 @@ public class TestStorageContainerManager {
 
   private void testRpcPermission(MiniOzoneCluster cluster,
       String fakeRemoteUsername, boolean expectPermissionDenied) {
-    SCMClientProtocolServer mockClientServer = Mockito.spy(
+    SCMClientProtocolServer mockClientServer = spy(
         cluster.getStorageContainerManager().getClientProtocolServer());
 
     mockRemoteUser(UserGroupInformation.createRemoteUser(fakeRemoteUsername));
@@ -943,8 +946,8 @@ public class TestStorageContainerManager {
     ContainerReportFromDatanode dndata
         = new ContainerReportFromDatanode(dn, report);
     ContainerReportHandler containerReportHandler =
-        Mockito.mock(ContainerReportHandler.class);
-    Mockito.doAnswer((inv) -> {
+        mock(ContainerReportHandler.class);
+    doAnswer((inv) -> {
       Thread.currentThread().sleep(500);
       return null;
     }).when(containerReportHandler).onMessage(dndata, eventQueue);
@@ -985,13 +988,12 @@ public class TestStorageContainerManager {
     Semaphore semaphore = new Semaphore(2);
     semaphore.acquire(2);
     ContainerReportHandler containerReportHandler =
-        Mockito.mock(ContainerReportHandler.class);
-    Mockito.doAnswer((inv) -> {
+        mock(ContainerReportHandler.class);
+    doAnswer((inv) -> {
       Thread.currentThread().sleep(1000);
       semaphore.release(1);
       return null;
-    }).when(containerReportHandler).onMessage(Mockito.any(),
-        Mockito.eq(eventQueue));
+    }).when(containerReportHandler).onMessage(any(), eq(eventQueue));
     List<ThreadPoolExecutor> executors = FixedThreadPoolWithAffinityExecutor
         .initializeExecutorPool(queues);
     Map<String, FixedThreadPoolWithAffinityExecutor> reportExecutorMap

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.ozone.scm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -31,7 +34,6 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -78,9 +80,9 @@ public class TestXceiverClientGrpc {
 
   @Test
   public void testCorrectDnsReturnedFromPipeline() throws IOException {
-    Assertions.assertEquals(dnsInOrder.get(0), pipeline.getClosestNode());
-    Assertions.assertEquals(dns.get(0), pipeline.getFirstNode());
-    Assertions.assertNotEquals(dns.get(0), dnsInOrder.get(0));
+    assertEquals(dnsInOrder.get(0), pipeline.getClosestNode());
+    assertEquals(dns.get(0), pipeline.getFirstNode());
+    assertNotEquals(dns.get(0), dnsInOrder.get(0));
   }
 
   @Test
@@ -112,7 +114,7 @@ public class TestXceiverClientGrpc {
   @Timeout(5)
   public void testGetBlockRetryAlNodes() {
     final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
-    Assertions.assertTrue(allDNs.size() > 1);
+    assertTrue(allDNs.size() > 1);
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
       public XceiverClientReply sendCommandAsync(
@@ -126,14 +128,14 @@ public class TestXceiverClientGrpc {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    Assertions.assertEquals(0, allDNs.size());
+    assertEquals(0, allDNs.size());
   }
 
   @Test
   @Timeout(5)
   public void testReadChunkRetryAllNodes() {
     final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
-    Assertions.assertTrue(allDNs.size() > 1);
+    assertTrue(allDNs.size() > 1);
     try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
       @Override
       public XceiverClientReply sendCommandAsync(
@@ -147,7 +149,7 @@ public class TestXceiverClientGrpc {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    Assertions.assertEquals(0, allDNs.size());
+    assertEquals(0, allDNs.size());
   }
 
   @Test
@@ -172,7 +174,7 @@ public class TestXceiverClientGrpc {
         invokeXceiverClientGetBlock(client);
       }
     }
-    Assertions.assertEquals(1, seenDNs.size());
+    assertEquals(1, seenDNs.size());
   }
 
   @Test
@@ -195,7 +197,7 @@ public class TestXceiverClientGrpc {
         invokeXceiverClientReadChunk(client);
         invokeXceiverClientReadSmallFile(client);
       }
-      Assertions.assertEquals(1, seenDNs.size());
+      assertEquals(1, seenDNs.size());
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -54,6 +53,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_L
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test cases to verify the SCM pipeline bytesWritten metrics.
@@ -106,8 +106,8 @@ public class TestSCMPipelineBytesWrittenMetrics {
         .setKeyName(keyName);
 
     OzoneKeyDetails keyDetails = bucket.getKey(keyName);
-    Assertions.assertEquals(keyName, keyDetails.getName());
-    Assertions.assertEquals(value.getBytes(UTF_8).length, keyDetails
+    assertEquals(keyName, keyDetails.getName());
+    assertEquals(value.getBytes(UTF_8).length, keyDetails
         .getOzoneKeyLocations().get(0).getLength());
   }
 
@@ -126,7 +126,7 @@ public class TestSCMPipelineBytesWrittenMetrics {
     List<Pipeline> pipelines = cluster.getStorageContainerManager()
         .getPipelineManager().getPipelines();
 
-    Assertions.assertEquals(1, pipelines.size());
+    assertEquals(1, pipelines.size());
     Pipeline pipeline = pipelines.get(0);
 
     final String metricName =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -43,6 +42,10 @@ import java.util.concurrent.TimeoutException;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test cases to verify the metrics exposed by SCMPipelineManager.
@@ -73,7 +76,7 @@ public class TestSCMPipelineMetrics {
     long numPipelineCreated =
         getLongCounter("NumPipelineCreated", metrics);
     // Pipelines are created in background when the cluster starts.
-    Assertions.assertTrue(numPipelineCreated > 0);
+    assertTrue(numPipelineCreated > 0);
   }
 
   /**
@@ -85,8 +88,8 @@ public class TestSCMPipelineMetrics {
         .getStorageContainerManager().getPipelineManager();
     Optional<Pipeline> pipeline = pipelineManager
         .getPipelines().stream().findFirst();
-    Assertions.assertTrue(pipeline.isPresent());
-    Assertions.assertDoesNotThrow(() -> {
+    assertTrue(pipeline.isPresent());
+    assertDoesNotThrow(() -> {
       PipelineManager pm = cluster.getStorageContainerManager()
           .getPipelineManager();
       pm.closePipeline(pipeline.get().getId());
@@ -109,19 +112,19 @@ public class TestSCMPipelineMetrics {
     Pipeline pipeline = block.getPipeline();
     long numBlocksAllocated = getLongCounter(
         SCMPipelineMetrics.getBlockAllocationMetricName(pipeline), metrics);
-    Assertions.assertEquals(1, numBlocksAllocated);
+    assertEquals(1, numBlocksAllocated);
 
     // destroy the pipeline
-    Assertions.assertDoesNotThrow(() ->
+    assertDoesNotThrow(() ->
         cluster.getStorageContainerManager().getClientProtocolServer()
             .closePipeline(pipeline.getId().getProtobuf()));
 
     MetricsRecordBuilder finalMetrics =
         getMetrics(SCMPipelineMetrics.class.getSimpleName());
-    Throwable t = Assertions.assertThrows(AssertionError.class, () ->
+    Throwable t = assertThrows(AssertionError.class, () ->
         getLongCounter(SCMPipelineMetrics
             .getBlockAllocationMetricName(pipeline), finalMetrics));
-    Assertions.assertTrue(t.getMessage().contains(
+    assertTrue(t.getMessage().contains(
         "Expected exactly one metric for name " + SCMPipelineMetrics
             .getBlockAllocationMetricName(block.getPipeline())));
   }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Add static import for assertions and mocks in client integration tests
The goal of this task is to add import static for all assertions and interactions with mocks. Replacing:
```
Assertions.assert<X>(...) -> assert<X>(...)
Assertions.fail(...) -> fail(...)
```
and
```
Mockito.mock(...) -> mock(...)
Mockito.verify(...) -> verify(...)
Mockito.when(...) -> when(...)
```
and
```
ArgumentMatchers.any() -> any()
ArgumentMatchers.eq() -> eq()
ArgumentMatchers.matches() -> matches()
// also:
// Matchers.<...>()
```
makes the code more readable (shorter lines, less wrapping).
## What is the link to the Apache JIRA

[HDDS-10067](https://issues.apache.org/jira/browse/HDDS-10067)

## CI

https://github.com/wzhallright/ozone/actions/runs/7459952726