### PR TITLE
HDDS-10035. Bump Ratis to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- HDDS Rocks Native dependency version-->
     <hdds.rocks.native.version>${hdds.version}</hdds.rocks.native.version>
     <!-- Apache Ratis version -->
-    <ratis.version>3.0.0</ratis.version>
+    <ratis.version>3.0.1</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>1.0.5</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Ratis from 3.0.0 to 3.0.1.

https://issues.apache.org/jira/browse/HDDS-10035

## How was this patch tested?

Tested in CI (for `master` branch) while validating the Ratis release candidate:
https://github.com/adoroszlai/ozone/actions/runs/7424798081
https://github.com/adoroszlai/ozone/actions/runs/7355126097

CI in fork is in progress:
https://github.com/adoroszlai/ozone/actions/runs/7460198373