### PR TITLE
HDDS-10068. Add static import for assertions and mocks in OM integration tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -125,8 +125,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import org.mockito.Mockito;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -137,6 +135,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -202,7 +203,7 @@ public class TestKeyManagerImpl {
     conf.setLong(OZONE_KEY_PREALLOCATION_BLOCKS_MAX, 10);
 
     mockScmContainerClient =
-        Mockito.mock(StorageContainerLocationProtocol.class);
+        mock(StorageContainerLocationProtocol.class);
     
     OmTestManagers omTestManagers
         = new OmTestManagers(conf, scm.getBlockProtocolServer(),
@@ -215,12 +216,12 @@ public class TestKeyManagerImpl {
 
     mockContainerClient();
 
-    Mockito.when(mockScmBlockLocationProtocol
-        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(),
+    when(mockScmBlockLocationProtocol
+        .allocateBlock(anyLong(), anyInt(),
             any(ReplicationConfig.class),
-            Mockito.anyString(),
+            anyString(),
             any(ExcludeList.class),
-            Mockito.anyString())).thenThrow(
+            anyString())).thenThrow(
                 new SCMException("SafeModePrecheck failed for allocateBlock",
             ResultCodes.SAFE_MODE_EXCEPTION));
     createVolume(VOLUME_NAME);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -55,7 +55,6 @@ import org.apache.ozone.test.tag.Unhealthy;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -336,8 +335,8 @@ public class TestOMRatisSnapshots {
             keys.get(keys.size() - 1)).build();
     OmKeyInfo omKeyInfo;
     omKeyInfo = followerOM.lookupKey(omKeyArgs);
-    Assertions.assertNotNull(omKeyInfo);
-    Assertions.assertEquals(omKeyInfo.getKeyName(), omKeyArgs.getKeyName());
+    assertNotNull(omKeyInfo);
+    assertEquals(omKeyInfo.getKeyName(), omKeyArgs.getKeyName());
 
     // Confirm followers snapshot hard links are as expected
     File followerMetaDir = OMStorage.getOmDbDir(followerOM.getConfiguration());
@@ -370,7 +369,7 @@ public class TestOMRatisSnapshots {
                 Paths.get(followerSnapshotDir.toString(), fileName);
             Path followerActiveSST =
                 Paths.get(followerActiveDir.toString(), fileName);
-            Assertions.assertEquals(
+            assertEquals(
                 OmSnapshotUtils.getINode(followerActiveSST),
                 OmSnapshotUtils.getINode(followerSnapshotSST),
                 "Snapshot sst file is supposed to be a hard link");
@@ -505,7 +504,7 @@ public class TestOMRatisSnapshots {
         firstIncrement.getSnapshotInfo());
     checkSnapshot(leaderOM, followerOM, "snap240", secondIncrement.getKeys(),
         secondIncrement.getSnapshotInfo());
-    Assertions.assertEquals(
+    assertEquals(
         followerOM.getOmSnapshotProvider().getInitCount(), 2,
         "Only initialized twice");
   }
@@ -651,7 +650,7 @@ public class TestOMRatisSnapshots {
     assertThat(sstList.size()).isGreaterThan(0);
     for (int i = 0; i < sstList.size(); i += 2) {
       File victimSst = new File(followerCandidateDir, sstList.get(i));
-      Assertions.assertTrue(victimSst.delete());
+      assertTrue(victimSst.delete());
     }
 
     // Resume the follower thread, it would download the full snapshot again

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMStartupWithBucketLayout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMStartupWithBucketLayout.java
@@ -16,6 +16,8 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -23,7 +25,6 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -153,8 +154,8 @@ public class TestOMStartupWithBucketLayout {
 
   private void verifyBucketLayout(OzoneBucket bucket,
       BucketLayout metadataLayout) {
-    Assertions.assertNotNull(bucket);
-    Assertions.assertEquals(metadataLayout, bucket.getBucketLayout());
+    assertNotNull(bucket);
+    assertEquals(metadataLayout, bucket.getBucketLayout());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmConf.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmConf.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.TimeDuration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,7 +36,7 @@ public class TestOmConf {
     final OzoneConfiguration conf = new OzoneConfiguration();
     final OzoneManagerRatisServerConfig ratisConf = conf.getObject(
         OzoneManagerRatisServerConfig.class);
-    Assertions.assertEquals(0, ratisConf.getLogAppenderWaitTimeMin(),
+    assertEquals(0, ratisConf.getLogAppenderWaitTimeMin(),
         "getLogAppenderWaitTimeMin");
     assertWaitTimeMin(TimeDuration.ZERO, conf);
 
@@ -51,7 +51,7 @@ public class TestOmConf {
     final RaftProperties p = OzoneManagerRatisServer.newRaftProperties(
         conf, 1000, "dummy/dir");
     final TimeDuration t = RaftServerConfigKeys.Log.Appender.waitTimeMin(p);
-    Assertions.assertEquals(expected, t,
+    assertEquals(expected, t,
         RaftServerConfigKeys.Log.Appender.WAIT_TIME_MIN_KEY);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmContainerLocationCache.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmContainerLocationCache.java
@@ -82,7 +82,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -104,9 +103,14 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -157,7 +161,7 @@ public class TestOmContainerLocationCache {
 
     mockScmBlockLocationProtocol = mock(ScmBlockLocationProtocol.class);
     mockScmContainerClient =
-        Mockito.mock(StorageContainerLocationProtocol.class);
+        mock(StorageContainerLocationProtocol.class);
 
     OmTestManagers omTestManagers = new OmTestManagers(conf,
         mockScmBlockLocationProtocol, mockScmContainerClient);
@@ -194,7 +198,7 @@ public class TestOmContainerLocationCache {
     when(manager.acquireClient(argThat(matchEmptyPipeline())))
         .thenCallRealMethod();
     when(manager.acquireClient(argThat(matchEmptyPipeline()),
-        Mockito.anyBoolean())).thenCallRealMethod();
+        anyBoolean())).thenCallRealMethod();
     when(manager.acquireClientForReadData(argThat(matchEmptyPipeline())))
         .thenCallRealMethod();
 
@@ -245,7 +249,7 @@ public class TestOmContainerLocationCache {
   @BeforeEach
   public void beforeEach() {
     CONTAINER_ID.getAndIncrement();
-    Mockito.reset(mockScmBlockLocationProtocol, mockScmContainerClient,
+    reset(mockScmBlockLocationProtocol, mockScmContainerClient,
         mockDn1Protocol, mockDn2Protocol);
     when(mockDn1Protocol.getPipeline()).thenReturn(createPipeline(DN1));
     when(mockDn2Protocol.getPipeline()).thenReturn(createPipeline(DN2));
@@ -618,11 +622,11 @@ public class TestOmContainerLocationCache {
         .setContainerBlockID(blockId)
         .build();
     when(mockScmBlockLocationProtocol
-        .allocateBlock(Mockito.anyLong(), Mockito.anyInt(),
+        .allocateBlock(anyLong(), anyInt(),
             any(ReplicationConfig.class),
-            Mockito.anyString(),
+            anyString(),
             any(ExcludeList.class),
-            Mockito.anyString()))
+            anyString()))
         .thenReturn(Collections.singletonList(block));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmInit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmInit.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.om;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -23,7 +24,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -85,7 +85,7 @@ public class TestOmInit {
     // Stop the Ozone Manager
     cluster.getOzoneManager().stop();
     // Now try to init the OM again. It should succeed
-    Assertions.assertTrue(OzoneManager.omInit(conf));
+    assertTrue(OzoneManager.omInit(conf));
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -32,6 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -86,7 +89,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.Mockito;
 
 /**
  * Test for OM metrics.
@@ -142,7 +144,7 @@ public class TestOmMetrics {
     VolumeManager volumeManager =
         (VolumeManager) HddsWhiteboxTestUtils.getInternalState(
             ozoneManager, "volumeManager");
-    VolumeManager mockVm = Mockito.spy(volumeManager);
+    VolumeManager mockVm = spy(volumeManager);
 
     OmVolumeArgs volumeArgs = createVolumeArgs();
     doVolumeOps(volumeArgs);
@@ -170,8 +172,8 @@ public class TestOmMetrics {
 
 
     // inject exception to test for Failure Metrics on the read path
-    Mockito.doThrow(exception).when(mockVm).getVolumeInfo(any());
-    Mockito.doThrow(exception).when(mockVm).listVolumes(any(), any(),
+    doThrow(exception).when(mockVm).getVolumeInfo(any());
+    doThrow(exception).when(mockVm).listVolumes(any(), any(),
         any(), anyInt());
 
     HddsWhiteboxTestUtils.setInternalState(ozoneManager,
@@ -211,7 +213,7 @@ public class TestOmMetrics {
     BucketManager bucketManager =
         (BucketManager) HddsWhiteboxTestUtils.getInternalState(
             ozoneManager, "bucketManager");
-    BucketManager mockBm = Mockito.spy(bucketManager);
+    BucketManager mockBm = spy(bucketManager);
 
     OmBucketInfo bucketInfo = createBucketInfo(false);
     doBucketOps(bucketInfo);
@@ -245,8 +247,8 @@ public class TestOmMetrics {
     assertCounter("NumBuckets", 2L, omMetrics);
 
     // inject exception to test for Failure Metrics on the read path
-    Mockito.doThrow(exception).when(mockBm).getBucketInfo(any(), any());
-    Mockito.doThrow(exception).when(mockBm).listBuckets(any(), any(),
+    doThrow(exception).when(mockBm).getBucketInfo(any(), any());
+    doThrow(exception).when(mockBm).listBuckets(any(), any(),
         any(), anyInt(), eq(false));
 
     HddsWhiteboxTestUtils.setInternalState(
@@ -295,7 +297,7 @@ public class TestOmMetrics {
     String bucketName = UUID.randomUUID().toString();
     KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "keyManager");
-    KeyManager mockKm = Mockito.spy(keyManager);
+    KeyManager mockKm = spy(keyManager);
     // see HDDS-10078 for making this work with FILE_SYSTEM_OPTIMIZED layout
     TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
     OmKeyArgs keyArgs = createKeyArgs(volumeName, bucketName,
@@ -348,10 +350,10 @@ public class TestOmMetrics {
     assertCounter("NumBlockAllocationFails", 1L, omMetrics);
 
     // inject exception to test for Failure Metrics on the read path
-    Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any(), any());
-    Mockito.doThrow(exception).when(mockKm).listKeys(
+    doThrow(exception).when(mockKm).lookupKey(any(), any(), any());
+    doThrow(exception).when(mockKm).listKeys(
         any(), any(), any(), any(), anyInt());
-    Mockito.doThrow(exception).when(mockKm).listTrash(
+    doThrow(exception).when(mockKm).listTrash(
         any(), any(), any(), any(), anyInt());
     OmMetadataReader omMetadataReader =
         (OmMetadataReader) ozoneManager.getOmMetadataReader().get();
@@ -594,16 +596,16 @@ public class TestOmMetrics {
     }
     OMMetadataManager metadataManager = (OMMetadataManager)
         HddsWhiteboxTestUtils.getInternalState(ozoneManager, "metadataManager");
-    OMMetadataManager mockMm = Mockito.spy(metadataManager);
+    OMMetadataManager mockMm = spy(metadataManager);
     @SuppressWarnings("unchecked")
     Table<String, T> table = (Table<String, T>)
         HddsWhiteboxTestUtils.getInternalState(metadataManager, tableName);
-    Table<String, T> mockTable = Mockito.spy(table);
-    Mockito.doThrow(exception).when(mockTable).isExist(any());
+    Table<String, T> mockTable = spy(table);
+    doThrow(exception).when(mockTable).isExist(any());
     if (klass == OmBucketInfo.class) {
-      Mockito.doReturn(mockTable).when(mockMm).getBucketTable();
+      doReturn(mockTable).when(mockMm).getBucketTable();
     } else {
-      Mockito.doReturn(mockTable).when(mockMm).getVolumeTable();
+      doReturn(mockTable).when(mockMm).getVolumeTable();
     }
     HddsWhiteboxTestUtils.setInternalState(
         ozoneManager, "metadataManager", mockMm);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabled.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabled.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -38,6 +37,8 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FEATURE_NOT_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Integration test to verify Ozone snapshot RPCs throw exception when called.
@@ -95,12 +96,12 @@ public class TestOmSnapshotDisabled {
     volume.createBucket(bucketName);
 
     // create snapshot should throw
-    OMException omException = Assertions.assertThrows(OMException.class,
+    OMException omException = assertThrows(OMException.class,
         () -> store.createSnapshot(volumeName, bucketName, snapshotName));
-    Assertions.assertEquals(FEATURE_NOT_ENABLED, omException.getResult());
+    assertEquals(FEATURE_NOT_ENABLED, omException.getResult());
     // delete snapshot should throw
-    omException = Assertions.assertThrows(OMException.class,
+    omException = assertThrows(OMException.class,
         () -> store.deleteSnapshot(volumeName, bucketName, snapshotName));
-    Assertions.assertEquals(FEATURE_NOT_ENABLED, omException.getResult());
+    assertEquals(FEATURE_NOT_ENABLED, omException.getResult());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabledRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabledRestart.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -35,6 +34,8 @@ import org.junit.jupiter.api.Timeout;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Integration test to verify that if snapshot feature is disabled, OM start up
@@ -102,7 +103,7 @@ public class TestOmSnapshotDisabledRestart {
         om.getConfiguration().setBoolean(
             OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, false);
         // Restart OM, expect OM start up failure
-        RuntimeException rte = Assertions.assertThrows(RuntimeException.class,
+        RuntimeException rte = assertThrows(RuntimeException.class,
             () -> cluster.restartOzoneManager(om, true));
         assertThat(rte.getMessage()).contains("snapshots remaining");
         // Enable snapshot feature again
@@ -111,7 +112,7 @@ public class TestOmSnapshotDisabledRestart {
         // Should pass this time
         cluster.restartOzoneManager(om, true);
       } catch (Exception e) {
-        Assertions.fail("Failed to restart OM", e);
+        fail("Failed to restart OM", e);
       }
     });
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithAllRunning.java
@@ -49,7 +49,6 @@ import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.server.RaftServer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanInfo;
@@ -78,9 +77,12 @@ import static org.apache.ratis.metrics.RatisMetrics.RATIS_APPLICATION_NAME_METRI
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Ozone Manager HA tests where all OMs are running throughout all tests.
@@ -334,7 +336,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     omFailoverProxyProvider.performFailover(null);
 
     String newProxyNodeId = omFailoverProxyProvider.getCurrentProxyOMNodeId();
-    Assertions.assertNotEquals(leaderOMNodeId, newProxyNodeId);
+    assertNotEquals(leaderOMNodeId, newProxyNodeId);
 
     // Once another request is sent to this new proxy node, the leader
     // information must be returned via the response and a failover must
@@ -376,7 +378,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
       }
     }
     assertNotNull(followerOM);
-    Assertions.assertSame(followerOM.getOmRatisServer().checkLeaderStatus(),
+    assertSame(followerOM.getOmRatisServer().checkLeaderStatus(),
         OzoneManagerRatisServer.RaftServerStatus.NOT_LEADER);
 
     OzoneManagerProtocolProtos.OMRequest writeRequest =
@@ -685,20 +687,20 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     ObjectStore objectStore = getObjectStore();
 
     boolean result = objectStore.addAcl(ozoneObj, userAcl);
-    Assertions.assertTrue(result);
+    assertTrue(result);
 
     result = objectStore.addAcl(ozoneObj, userAcl1);
-    Assertions.assertTrue(result);
+    assertTrue(result);
 
     result = objectStore.removeAcl(ozoneObj, userAcl);
-    Assertions.assertTrue(result);
+    assertTrue(result);
 
     // try removing already removed acl.
     result = objectStore.removeAcl(ozoneObj, userAcl);
-    Assertions.assertFalse(result);
+    assertFalse(result);
 
     result = objectStore.removeAcl(ozoneObj, userAcl1);
-    Assertions.assertTrue(result);
+    assertTrue(result);
 
   }
 
@@ -726,13 +728,13 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     // Add ACL to the LINK and verify that it is added to the source bucket
     OzoneAcl acl1 = new OzoneAcl(USER, "remoteUser1", READ, DEFAULT);
     boolean addAcl = getObjectStore().addAcl(linkObj, acl1);
-    Assertions.assertTrue(addAcl);
+    assertTrue(addAcl);
     assertEqualsAcls(srcObj, linkObj);
 
     // Add ACL to the SOURCE and verify that it from link
     OzoneAcl acl2 = new OzoneAcl(USER, "remoteUser2", WRITE, DEFAULT);
     boolean addAcl2 = getObjectStore().addAcl(srcObj, acl2);
-    Assertions.assertTrue(addAcl2);
+    assertTrue(addAcl2);
     assertEqualsAcls(srcObj, linkObj);
 
   }
@@ -746,10 +748,10 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneObj srcObj = buildBucketObj(srcBucket);
     // As by default create will add some default acls in RpcClient.
     List<OzoneAcl> acls = getObjectStore().getAcl(linkObj);
-    Assertions.assertTrue(acls.size() > 0);
+    assertTrue(acls.size() > 0);
     // Remove an existing acl.
     boolean removeAcl = getObjectStore().removeAcl(linkObj, acls.get(0));
-    Assertions.assertTrue(removeAcl);
+    assertTrue(removeAcl);
     assertEqualsAcls(srcObj, linkObj);
 
     // case2 : test remove src acl
@@ -759,10 +761,10 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     OzoneObj srcObj2 = buildBucketObj(srcBucket2);
     // As by default create will add some default acls in RpcClient.
     List<OzoneAcl> acls2 = getObjectStore().getAcl(srcObj2);
-    Assertions.assertTrue(acls2.size() > 0);
+    assertTrue(acls2.size() > 0);
     // Remove an existing acl.
     boolean removeAcl2 = getObjectStore().removeAcl(srcObj2, acls.get(0));
-    Assertions.assertTrue(removeAcl2);
+    assertTrue(removeAcl2);
     assertEqualsAcls(srcObj2, linkObj2);
 
   }
@@ -779,14 +781,14 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     List<OzoneAcl> acl1 = Collections.singletonList(
         new OzoneAcl(USER, "remoteUser1", READ, DEFAULT));
     boolean setAcl1 = getObjectStore().setAcl(linkObj, acl1);
-    Assertions.assertTrue(setAcl1);
+    assertTrue(setAcl1);
     assertEqualsAcls(srcObj, linkObj);
 
     // Set ACL to the SOURCE and verify that it from link
     List<OzoneAcl> acl2 = Collections.singletonList(
         new OzoneAcl(USER, "remoteUser2", WRITE, DEFAULT));
     boolean setAcl2 = getObjectStore().setAcl(srcObj, acl2);
-    Assertions.assertTrue(setAcl2);
+    assertTrue(setAcl2);
     assertEqualsAcls(srcObj, linkObj);
 
   }
@@ -889,7 +891,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     if (linkObj.getResourceType() == OzoneObj.ResourceType.BUCKET) {
       linkObj = getSourceBucketObj(linkObj);
     }
-    Assertions.assertEquals(getObjectStore().getAcl(srcObj),
+    assertEquals(getObjectStore().getAcl(srcObj),
         getObjectStore().getAcl(linkObj));
   }
 
@@ -921,7 +923,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
         OzoneObj.ResourceType.PREFIX.name())) {
       List<OzoneAcl> acls = objectStore.getAcl(ozoneObj);
 
-      Assertions.assertTrue(acls.size() > 0);
+      assertTrue(acls.size() > 0);
     }
 
     OzoneAcl modifiedUserAcl = new OzoneAcl(USER, remoteUserName,
@@ -929,15 +931,15 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
 
     List<OzoneAcl> newAcls = Collections.singletonList(modifiedUserAcl);
     boolean setAcl = objectStore.setAcl(ozoneObj, newAcls);
-    Assertions.assertTrue(setAcl);
+    assertTrue(setAcl);
 
     // Get acls and check whether they are reset or not.
     List<OzoneAcl> getAcls = objectStore.getAcl(ozoneObj);
 
-    Assertions.assertEquals(newAcls.size(), getAcls.size());
+    assertEquals(newAcls.size(), getAcls.size());
     int i = 0;
     for (OzoneAcl ozoneAcl : newAcls) {
-      Assertions.assertTrue(compareAcls(getAcls.get(i++), ozoneAcl));
+      assertTrue(compareAcls(getAcls.get(i++), ozoneAcl));
     }
 
   }
@@ -946,42 +948,42 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
       OzoneAcl userAcl) throws Exception {
     ObjectStore objectStore = getObjectStore();
     boolean addAcl = objectStore.addAcl(ozoneObj, userAcl);
-    Assertions.assertTrue(addAcl);
+    assertTrue(addAcl);
 
     List<OzoneAcl> acls = objectStore.getAcl(ozoneObj);
 
-    Assertions.assertTrue(containsAcl(userAcl, acls));
+    assertTrue(containsAcl(userAcl, acls));
 
     // Add an already existing acl.
     addAcl = objectStore.addAcl(ozoneObj, userAcl);
-    Assertions.assertFalse(addAcl);
+    assertFalse(addAcl);
 
     // Add an acl by changing acl type with same type, name and scope.
     userAcl = new OzoneAcl(USER, remoteUserName,
         WRITE, DEFAULT);
     addAcl = objectStore.addAcl(ozoneObj, userAcl);
-    Assertions.assertTrue(addAcl);
+    assertTrue(addAcl);
   }
 
   private void testAddLinkAcl(String remoteUserName, OzoneObj ozoneObj,
       OzoneAcl userAcl) throws Exception {
     ObjectStore objectStore = getObjectStore();
     boolean addAcl = objectStore.addAcl(ozoneObj, userAcl);
-    Assertions.assertTrue(addAcl);
+    assertTrue(addAcl);
 
     List<OzoneAcl> acls = objectStore.getAcl(ozoneObj);
 
-    Assertions.assertTrue(containsAcl(userAcl, acls));
+    assertTrue(containsAcl(userAcl, acls));
 
     // Add an already existing acl.
     addAcl = objectStore.addAcl(ozoneObj, userAcl);
-    Assertions.assertFalse(addAcl);
+    assertFalse(addAcl);
 
     // Add an acl by changing acl type with same type, name and scope.
     userAcl = new OzoneAcl(USER, remoteUserName,
         WRITE, DEFAULT);
     addAcl = objectStore.addAcl(ozoneObj, userAcl);
-    Assertions.assertTrue(addAcl);
+    assertTrue(addAcl);
   }
 
   private void testRemoveAcl(String remoteUserName, OzoneObj ozoneObj,
@@ -991,30 +993,30 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
     // As by default create will add some default acls in RpcClient.
     List<OzoneAcl> acls = objectStore.getAcl(ozoneObj);
 
-    Assertions.assertTrue(acls.size() > 0);
+    assertTrue(acls.size() > 0);
 
     // Remove an existing acl.
     boolean removeAcl = objectStore.removeAcl(ozoneObj, acls.get(0));
-    Assertions.assertTrue(removeAcl);
+    assertTrue(removeAcl);
 
     // Trying to remove an already removed acl.
     removeAcl = objectStore.removeAcl(ozoneObj, acls.get(0));
-    Assertions.assertFalse(removeAcl);
+    assertFalse(removeAcl);
 
     boolean addAcl = objectStore.addAcl(ozoneObj, userAcl);
-    Assertions.assertTrue(addAcl);
+    assertTrue(addAcl);
 
     // Just changed acl type here to write, rest all is same as defaultUserAcl.
     OzoneAcl modifiedUserAcl = new OzoneAcl(USER, remoteUserName,
         WRITE, DEFAULT);
     addAcl = objectStore.addAcl(ozoneObj, modifiedUserAcl);
-    Assertions.assertTrue(addAcl);
+    assertTrue(addAcl);
 
     removeAcl = objectStore.removeAcl(ozoneObj, modifiedUserAcl);
-    Assertions.assertTrue(removeAcl);
+    assertTrue(removeAcl);
 
     removeAcl = objectStore.removeAcl(ozoneObj, userAcl);
-    Assertions.assertTrue(removeAcl);
+    assertTrue(removeAcl);
   }
 
   @Test
@@ -1058,7 +1060,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
           return true;
         }
       } catch (IOException ex) {
-        Assertions.fail("test failed during transactionInfo read");
+        fail("test failed during transactionInfo read");
       }
       return false;
     }, 1000, 100000);
@@ -1087,7 +1089,7 @@ class TestOzoneManagerHAWithAllRunning extends TestOzoneManagerHA {
           return true;
         }
       } catch (IOException ex) {
-        Assertions.fail("test failed during transactionInfo read");
+        fail("test failed during transactionInfo read");
       }
       return false;
     }, 1000, 100000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -44,7 +44,6 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -65,8 +64,11 @@ import static org.apache.hadoop.ozone.MiniOzoneHAClusterImpl.NODE_FAILURE_TIMEOU
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Ozone Manager HA tests that stop/restart one or more OM nodes.
@@ -174,7 +176,7 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
             ReplicationFactor.ONE);
 
     String uploadID = omMultipartInfo.getUploadID();
-    Assertions.assertNotNull(uploadID);
+    assertNotNull(uploadID);
     return uploadID;
   }
 
@@ -193,8 +195,8 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
     OmMultipartUploadCompleteInfo omMultipartUploadCompleteInfo =
         ozoneBucket.completeMultipartUpload(keyName, uploadID, partsMap);
 
-    Assertions.assertNotNull(omMultipartUploadCompleteInfo);
-    Assertions.assertNotNull(omMultipartUploadCompleteInfo.getHash());
+    assertNotNull(omMultipartUploadCompleteInfo);
+    assertNotNull(omMultipartUploadCompleteInfo.getHash());
 
 
     try (OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName)) {
@@ -364,7 +366,7 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
 
     }
 
-    Assertions.assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
+    assertFalse(ozoneMultipartUploadPartListParts.isTruncated());
   }
 
   /**
@@ -441,7 +443,7 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
         },
             10000, 120000);
       } catch (Exception ex) {
-        Assertions.fail("TestOzoneManagerHAKeyDeletion failed");
+        fail("TestOzoneManagerHAKeyDeletion failed");
       }
     });
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -46,8 +46,10 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -174,8 +176,7 @@ public class TestOzoneManagerListVolumes {
                                    String aclString) throws IOException {
     OzoneObj obj = OzoneObjInfo.Builder.newBuilder().setVolumeName(volumeName)
         .setResType(OzoneObj.ResourceType.VOLUME).setStoreType(OZONE).build();
-    Assertions.assertTrue(objectStore.setAcl(
-        obj, OzoneAcl.parseAcls(aclString)));
+    assertTrue(objectStore.setAcl(obj, OzoneAcl.parseAcls(aclString)));
   }
 
   /**
@@ -208,7 +209,7 @@ public class TestOzoneManagerListVolumes {
         String volumeName = vol.getName();
         accessibleVolumes.add(volumeName);
       }
-      Assertions.assertEquals(new HashSet<>(expectVol), accessibleVolumes);
+      assertEquals(new HashSet<>(expectVol), accessibleVolumes);
     } catch (RuntimeException ex) {
       if (expectListByUserSuccess) {
         throw ex;
@@ -234,11 +235,11 @@ public class TestOzoneManagerListVolumes {
         it.next();
         count++;
       }
-      Assertions.assertEquals(5, count);
+      assertEquals(5, count);
     } else {
       try {
         objectStore.listVolumes("volume");
-        Assertions.fail("listAllVolumes should fail for " + user.getUserName());
+        fail("listAllVolumes should fail for " + user.getUserName());
       } catch (RuntimeException ex) {
         // Current listAllVolumes throws RuntimeException
         if (ex.getCause() instanceof OMException) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionExcepti
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Unhealthy;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -159,7 +158,7 @@ public class TestScmSafeMode {
     StorageContainerManager scm;
 
     scm = cluster.getStorageContainerManager();
-    Assertions.assertTrue(scm.isInSafeMode());
+    assertTrue(scm.isInSafeMode());
 
     om = cluster.getOzoneManager();
 
@@ -182,20 +181,20 @@ public class TestScmSafeMode {
   @Test
   public void testIsScmInSafeModeAndForceExit() throws Exception {
     // Test 1: SCM should be out of safe mode.
-    Assertions.assertFalse(storageContainerLocationClient.inSafeMode());
+    assertFalse(storageContainerLocationClient.inSafeMode());
     cluster.stop();
     // Restart the cluster with same metadata dir.
 
     try {
       cluster = builder.build();
     } catch (IOException e) {
-      Assertions.fail("Cluster startup failed.");
+      fail("Cluster startup failed.");
     }
 
     // Test 2: Scm should be in safe mode as datanodes are not started yet.
     storageContainerLocationClient = cluster
         .getStorageContainerLocationClient();
-    Assertions.assertTrue(storageContainerLocationClient.inSafeMode());
+    assertTrue(storageContainerLocationClient.inSafeMode());
     // Force scm out of safe mode.
     cluster.getStorageContainerManager().getClientProtocolServer()
         .forceExitSafeMode();
@@ -205,7 +204,7 @@ public class TestScmSafeMode {
         return !cluster.getStorageContainerManager().getClientProtocolServer()
             .inSafeMode();
       } catch (IOException e) {
-        Assertions.fail("Cluster");
+        fail("Cluster");
         return false;
       }
     }, 10, 1000 * 5);
@@ -220,7 +219,7 @@ public class TestScmSafeMode {
     try {
       cluster = builder.build();
     } catch (IOException e) {
-      Assertions.fail("Cluster startup failed.");
+      fail("Cluster startup failed.");
     }
     assertTrue(cluster.getStorageContainerManager().isInSafeMode());
     cluster.startHddsDatanodes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotBackgroundServices.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotBackgroundServices.java
@@ -51,7 +51,6 @@ import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -81,6 +80,9 @@ import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPrefix;
 import static org.apache.hadoop.ozone.om.TestOzoneManagerHAWithStoppedNodes.createKey;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests snapshot background services.
@@ -222,7 +224,7 @@ public class TestSnapshotBackgroundServices {
         getNewLeader(leaderOM, followerOM.getOMNodeId(), followerOM);
     OzoneManager newFollowerOM =
         cluster.getOzoneManager(leaderOM.getOMNodeId());
-    Assertions.assertEquals(leaderOM, newFollowerOM);
+    assertEquals(leaderOM, newFollowerOM);
 
     SnapshotInfo newSnapshot = createOzoneSnapshot(newLeaderOM,
         SNAPSHOT_NAME_PREFIX + RandomStringUtils.randomNumeric(5));
@@ -247,12 +249,12 @@ public class TestSnapshotBackgroundServices {
         .getMetadataManager()
         .getKeyTable(ozoneBucket.getBucketLayout());
     OmKeyInfo keyInfoA = omKeyInfoTable.get(keyA);
-    Assertions.assertNotNull(keyInfoA);
+    assertNotNull(keyInfoA);
 
     // create snapshot b
     SnapshotInfo snapshotInfoB = createOzoneSnapshot(newLeaderOM,
         SNAPSHOT_NAME_PREFIX + RandomStringUtils.randomNumeric(5));
-    Assertions.assertNotNull(snapshotInfoB);
+    assertNotNull(snapshotInfoB);
 
     // delete key a
     ozoneBucket.deleteKey(keyNameA);
@@ -270,7 +272,7 @@ public class TestSnapshotBackgroundServices {
         .getOmSnapshotManager()
         .checkForSnapshot(volumeName, bucketName,
             getSnapshotPrefix(snapshotInfoC.getName()), true)) {
-      Assertions.assertNotNull(rcC);
+      assertNotNull(rcC);
       snapC = (OmSnapshot) rcC.get();
     }
 
@@ -296,7 +298,7 @@ public class TestSnapshotBackgroundServices {
         .getOmSnapshotManager()
         .checkForSnapshot(volumeName, bucketName,
             getSnapshotPrefix(snapshotInfoD.getName()), true)) {
-      Assertions.assertNotNull(rcD);
+      assertNotNull(rcD);
       snapD = (OmSnapshot) rcD.get();
     }
 
@@ -403,23 +405,23 @@ public class TestSnapshotBackgroundServices {
         getNewLeader(leaderOM, followerOM.getOMNodeId(), followerOM);
     OzoneManager newFollowerOM =
         cluster.getOzoneManager(leaderOM.getOMNodeId());
-    Assertions.assertEquals(leaderOM, newFollowerOM);
+    assertEquals(leaderOM, newFollowerOM);
 
     List<CompactionLogEntry> compactionLogEntriesOnPreviousLeader =
         getCompactionLogEntries(leaderOM);
 
     List<CompactionLogEntry> compactionLogEntriesOnNewLeader =
         getCompactionLogEntries(newLeaderOM);
-    Assertions.assertEquals(compactionLogEntriesOnPreviousLeader,
+    assertEquals(compactionLogEntriesOnPreviousLeader,
         compactionLogEntriesOnNewLeader);
 
-    Assertions.assertEquals(leaderOM.getMetadataManager().getStore()
+    assertEquals(leaderOM.getMetadataManager().getStore()
             .getRocksDBCheckpointDiffer().getForwardCompactionDAG().nodes()
             .stream().map(CompactionNode::getFileName).collect(toSet()),
         newLeaderOM.getMetadataManager().getStore()
             .getRocksDBCheckpointDiffer().getForwardCompactionDAG().nodes()
             .stream().map(CompactionNode::getFileName).collect(toSet()));
-    Assertions.assertEquals(leaderOM.getMetadataManager().getStore()
+    assertEquals(leaderOM.getMetadataManager().getStore()
             .getRocksDBCheckpointDiffer().getForwardCompactionDAG().edges()
             .stream().map(edge ->
                 edge.source().getFileName() + "-" + edge.target().getFileName())
@@ -467,13 +469,13 @@ public class TestSnapshotBackgroundServices {
         getNewLeader(leaderOM, followerOM.getOMNodeId(), followerOM);
     OzoneManager newFollowerOM =
         cluster.getOzoneManager(leaderOM.getOMNodeId());
-    Assertions.assertEquals(leaderOM, newFollowerOM);
+    assertEquals(leaderOM, newFollowerOM);
 
     createSnapshotsEachWithNewKeys(newLeaderOM);
 
     File sstBackupDir = getSstBackupDir(newLeaderOM);
     File[] files = sstBackupDir.listFiles();
-    Assertions.assertNotNull(files);
+    assertNotNull(files);
     int numberOfSstFiles = files.length;
 
     resumeBackupCompactionFilesPruning(newLeaderOM);
@@ -522,7 +524,7 @@ public class TestSnapshotBackgroundServices {
         getNewLeader(leaderOM, followerOM.getOMNodeId(), followerOM);
     OzoneManager newFollowerOM =
         cluster.getOzoneManager(leaderOM.getOMNodeId());
-    Assertions.assertEquals(leaderOM, newFollowerOM);
+    assertEquals(leaderOM, newFollowerOM);
 
     checkIfSnapshotGetsProcessedBySFS(newLeaderOM);
 
@@ -542,7 +544,7 @@ public class TestSnapshotBackgroundServices {
             RandomStringUtils.randomNumeric(10)).getName();
     SnapshotDiffReportOzone diff = getSnapDiffReport(volumeName, bucketName,
         firstSnapshot, secondSnapshot);
-    Assertions.assertEquals(Collections.singletonList(
+    assertEquals(Collections.singletonList(
             SnapshotDiffReportOzone.getDiffReportEntry(
                 SnapshotDiffReport.DiffType.CREATE, diffKey, null)),
         diff.getDiffList());
@@ -565,9 +567,9 @@ public class TestSnapshotBackgroundServices {
         .getStore()
         .getRocksDBCheckpointDiffer()
         .getSSTBackupDir();
-    Assertions.assertNotNull(sstBackupDirPath);
+    assertNotNull(sstBackupDirPath);
     File sstBackupDir = new File(sstBackupDirPath);
-    Assertions.assertNotNull(sstBackupDir);
+    assertNotNull(sstBackupDir);
     return sstBackupDir;
   }
 
@@ -577,7 +579,7 @@ public class TestSnapshotBackgroundServices {
     SnapshotInfo newSnapshot = createOzoneSnapshot(ozoneManager,
         TestSnapshotBackgroundServices.SNAPSHOT_NAME_PREFIX +
             RandomStringUtils.randomNumeric(5));
-    Assertions.assertNotNull(newSnapshot);
+    assertNotNull(newSnapshot);
     Table<String, SnapshotInfo> snapshotInfoTable =
         ozoneManager.getMetadataManager().getSnapshotInfoTable();
     GenericTestUtils.waitFor(() -> {
@@ -585,7 +587,7 @@ public class TestSnapshotBackgroundServices {
       try {
         snapshotInfo = snapshotInfoTable.get(newSnapshot.getTableKey());
       } catch (IOException e) {
-        Assertions.fail();
+        fail();
       }
       return snapshotInfo.isSstFiltered();
     }, 1000, 10000);
@@ -597,7 +599,7 @@ public class TestSnapshotBackgroundServices {
       throws IOException, TimeoutException, InterruptedException {
     verifyLeadershipTransfer(leaderOM, followerNodeId, followerOM);
     OzoneManager newLeaderOM = cluster.getOMLeader();
-    Assertions.assertEquals(followerOM, newLeaderOM);
+    assertEquals(followerOM, newLeaderOM);
     return newLeaderOM;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisRequest.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslat
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -45,6 +44,7 @@ import java.util.ArrayList;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.INVALID_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -62,7 +62,7 @@ public class TestOzoneManagerRatisRequest {
 
   @Test
   public void testRequestWithNonExistentBucket() throws Exception {
-    ozoneManager = Mockito.mock(OzoneManager.class);
+    ozoneManager = mock(OzoneManager.class);
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         folder.resolve("om").toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
@@ -103,7 +103,7 @@ public class TestOzoneManagerRatisRequest {
             .setClientId("test-client-id")
             .build();
 
-    ozoneManager = Mockito.mock(OzoneManager.class);
+    ozoneManager = mock(OzoneManager.class);
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         folder.resolve("om").toAbsolutePath().toString());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration,
@@ -111,10 +111,9 @@ public class TestOzoneManagerRatisRequest {
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     when(ozoneManager.getConfiguration()).thenReturn(ozoneConfiguration);
 
-    OzoneManagerRatisServer ratisServer =
-        Mockito.mock(OzoneManagerRatisServer.class);
+    OzoneManagerRatisServer ratisServer = mock(OzoneManagerRatisServer.class);
     ProtocolMessageMetrics<ProtocolMessageEnum> protocolMessageMetrics =
-        Mockito.mock(ProtocolMessageMetrics.class);
+        mock(ProtocolMessageMetrics.class);
     long lastTransactionIndexForNonRatis = 100L;
 
     OzoneManagerProtocolProtos.OMResponse expectedResponse =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/service/TestRangerBGSyncService.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -233,7 +232,7 @@ public class TestRangerBGSyncService {
         ozoneManager.getMetadataManager().getMetaTable().put(
             OzoneConsts.RANGER_OZONE_SERVICE_VERSION_KEY, String.valueOf(v));
         return null;
-      }).when(omRatisServer).submitRequest(Mockito.any(), Mockito.any());
+      }).when(omRatisServer).submitRequest(any(), any());
     } catch (ServiceException e) {
       throw new RuntimeException(e);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -50,7 +50,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -66,6 +65,9 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConsts.ADMIN;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
@@ -153,8 +155,7 @@ public class TestOzoneManagerSnapshotAcl {
     final OmKeyArgs snapshotKeyArgs = getOmKeyArgs(true);
 
     // WHEN-THEN
-    Assertions.assertDoesNotThrow(
-        () -> ozoneManager.lookupKey(snapshotKeyArgs));
+    assertDoesNotThrow(() -> ozoneManager.lookupKey(snapshotKeyArgs));
   }
 
   @ParameterizedTest
@@ -168,14 +169,14 @@ public class TestOzoneManagerSnapshotAcl {
 
     // when reading from snapshot, read disallowed.
     UserGroupInformation.setLoginUser(UGI2);
-    final OMException ex = Assertions.assertThrows(OMException.class,
+    final OMException ex = assertThrows(OMException.class,
         () -> ozoneManager.lookupKey(snapshotKeyArgs));
 
     // THEN
-    Assertions.assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
+    assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
         ex.getResult());
     // when same user reads same key from active fs, read allowed.
-    Assertions.assertDoesNotThrow(() -> ozoneManager.lookupKey(keyArgs));
+    assertDoesNotThrow(() -> ozoneManager.lookupKey(keyArgs));
   }
 
   @ParameterizedTest
@@ -188,7 +189,7 @@ public class TestOzoneManagerSnapshotAcl {
     final boolean assumeS3Context = false;
 
     // WHEN-THEN
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> ozoneManager.getKeyInfo(snapshotKeyArgs, assumeS3Context));
   }
 
@@ -205,15 +206,15 @@ public class TestOzoneManagerSnapshotAcl {
     // when reading from snapshot, read disallowed.
     UserGroupInformation.setLoginUser(UGI2);
     final OMException ex =
-        Assertions.assertThrows(OMException.class,
+        assertThrows(OMException.class,
             () -> ozoneManager.getKeyInfo(snapshotKeyOmKeyArgs,
                 assumeS3Context));
 
     // THEN
-    Assertions.assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
+    assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
         ex.getResult());
     // when same user reads same key from active fs, read allowed.
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> ozoneManager.getKeyInfo(omKeyArgs, assumeS3Context));
   }
 
@@ -228,7 +229,7 @@ public class TestOzoneManagerSnapshotAcl {
     final long numEntries = Long.parseLong(RandomStringUtils.randomNumeric(1));
 
     // WHEN-THEN
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> ozoneManager.listStatus(snapshotKeyArgs, recursive,
             snapshotKeyArgs.getKeyName(), numEntries,
             allowPartialPrefixes));
@@ -248,16 +249,16 @@ public class TestOzoneManagerSnapshotAcl {
     // when reading from snapshot, read disallowed.
     UserGroupInformation.setLoginUser(UGI2);
     final OMException ex =
-        Assertions.assertThrows(OMException.class,
+        assertThrows(OMException.class,
             () -> ozoneManager.listStatus(snapshotKeyArgs, recursive,
                 snapshotKeyArgs.getKeyName(), numEntries,
                 allowPartialPrefixes));
 
     // THEN
-    Assertions.assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
+    assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
         ex.getResult());
     // when same user reads same key from active fs, read allowed.
-    Assertions.assertDoesNotThrow(() -> ozoneManager.listStatus(keyArgs,
+    assertDoesNotThrow(() -> ozoneManager.listStatus(keyArgs,
         recursive, keyName, numEntries, allowPartialPrefixes));
   }
 
@@ -270,7 +271,7 @@ public class TestOzoneManagerSnapshotAcl {
     final OmKeyArgs snapshotKeyArgs = getOmKeyArgs(true);
 
     // WHEN-THEN
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> ozoneManager.lookupFile(snapshotKeyArgs));
   }
 
@@ -285,14 +286,14 @@ public class TestOzoneManagerSnapshotAcl {
 
     // when reading from snapshot, read disallowed.
     UserGroupInformation.setLoginUser(UGI2);
-    final OMException ex = Assertions.assertThrows(OMException.class,
+    final OMException ex = assertThrows(OMException.class,
         () -> ozoneManager.lookupFile(snapshotKeyArgs));
 
     // THEN
-    Assertions.assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
+    assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
         ex.getResult());
     // when same user reads same key from active fs, read allowed.
-    Assertions.assertDoesNotThrow(() -> ozoneManager.lookupFile(keyArgs));
+    assertDoesNotThrow(() -> ozoneManager.lookupFile(keyArgs));
   }
 
   @ParameterizedTest
@@ -305,7 +306,7 @@ public class TestOzoneManagerSnapshotAcl {
     final int maxKeys = Integer.parseInt(RandomStringUtils.randomNumeric(1));
 
     // WHEN-THEN
-    Assertions.assertDoesNotThrow(() -> ozoneManager.listKeys(volumeName,
+    assertDoesNotThrow(() -> ozoneManager.listKeys(volumeName,
         bucketName, snapshotKeyArgs.getKeyName(), snapshotKeyPrefix, maxKeys));
   }
 
@@ -322,10 +323,10 @@ public class TestOzoneManagerSnapshotAcl {
     UserGroupInformation.setLoginUser(UGI2);
 
     // THEN
-    Assertions.assertDoesNotThrow(
+    assertDoesNotThrow(
         () -> ozoneManager.listKeys(volumeName, bucketName,
             snapshotKeyArgs.getKeyName(), snapshotKeyPrefix, maxKeys));
-    Assertions.assertDoesNotThrow(() -> ozoneManager.listKeys(volumeName,
+    assertDoesNotThrow(() -> ozoneManager.listKeys(volumeName,
         bucketName, keyName, KEY_PREFIX, maxKeys));
   }
 
@@ -345,7 +346,7 @@ public class TestOzoneManagerSnapshotAcl {
         .build();
 
     // WHEN-THEN
-    Assertions.assertDoesNotThrow(() -> ozoneManager.getAcl(ozoneObj));
+    assertDoesNotThrow(() -> ozoneManager.getAcl(ozoneObj));
   }
 
   @ParameterizedTest
@@ -371,14 +372,14 @@ public class TestOzoneManagerSnapshotAcl {
 
     // when reading from snapshot, read disallowed.
     UserGroupInformation.setLoginUser(UGI2);
-    final OMException ex = Assertions.assertThrows(OMException.class,
+    final OMException ex = assertThrows(OMException.class,
         () -> ozoneManager.getAcl(snapshotObj));
 
     // THEN
-    Assertions.assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
+    assertEquals(OMException.ResultCodes.PERMISSION_DENIED,
         ex.getResult());
     // when same user reads same key from active fs, read allowed.
-    Assertions.assertDoesNotThrow(() -> ozoneManager.getAcl(keyObj));
+    assertDoesNotThrow(() -> ozoneManager.getAcl(keyObj));
   }
 
   private void setup(BucketLayout bucketLayout)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
@@ -64,6 +63,7 @@ import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
@@ -196,7 +196,7 @@ public class TestOzoneSnapshotRestore {
       // Copy key from source to destination path
       int res = ToolRunner.run(shell,
               new String[]{"-cp", sourcePath, destPath});
-      Assertions.assertEquals(0, res);
+      assertEquals(0, res);
     } finally {
       shell.close();
     }


### PR DESCRIPTION


## What changes were proposed in this pull request?
Add static import for assertions and mocks in client integration tests
The goal of this task is to add import static for all assertions and interactions with mocks. Replacing:
```
Assertions.assert<X>(...) -> assert<X>(...)
Assertions.fail(...) -> fail(...)
```
and
```
Mockito.mock(...) -> mock(...)
Mockito.verify(...) -> verify(...)
Mockito.when(...) -> when(...)
```
and
```
ArgumentMatchers.any() -> any()
ArgumentMatchers.eq() -> eq()
ArgumentMatchers.matches() -> matches()
// also:
// Matchers.<...>()
```
makes the code more readable (shorter lines, less wrapping).

## What is the link to the Apache JIRA

[HDDS-10068](https://issues.apache.org/jira/browse/HDDS-10068)

## CI
https://github.com/wzhallright/ozone/actions/runs/7460449894
