### PR TITLE
HDDS-9658. NPE while cleanup deleted container data

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -88,6 +88,9 @@ public class VersionEndpointTask implements
           // Check HddsVolumes
           checkVolumeSet(ozoneContainer.getVolumeSet(), scmId, clusterId);
 
+          // build container set
+          ozoneContainer.buildContainerSet();
+
           DatanodeLayoutStorage layoutStorage
               = new DatanodeLayoutStorage(configuration);
           layoutStorage.setClusterId(clusterId);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -88,9 +88,6 @@ public class VersionEndpointTask implements
           // Check HddsVolumes
           checkVolumeSet(ozoneContainer.getVolumeSet(), scmId, clusterId);
 
-          // build container set
-          ozoneContainer.buildContainerSet();
-
           DatanodeLayoutStorage layoutStorage
               = new DatanodeLayoutStorage(configuration);
           layoutStorage.setClusterId(clusterId);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -148,7 +148,18 @@ public class ContainerReader implements Runnable {
       LOG.info("Start to verify containers on volume {}", hddsVolumeRootDir);
       File currentDir = new File(idDir, Storage.STORAGE_DIR_CURRENT);
       File[] containerTopDirs = currentDir.listFiles();
-      if (containerTopDirs != null) {
+      if (containerTopDirs != null && containerTopDirs.length > 0) {
+        try {
+          // idDir is working directory having data
+          // and volume is initialized with temp path
+          hddsVolume.createTmpDirs(idDir.getName());
+        } catch (IOException e) {
+          LOG.error("Volume {} dir path {} can not be accessed to create " +
+              "temp dirs.", hddsVolumeRootDir, idDir.getName(), e);
+          volumeSet.failVolume(hddsVolumeRootDir.getPath());
+          return;
+        }
+
         for (File containerTopDir : containerTopDirs) {
           if (containerTopDir.isDirectory()) {
             File[] containerDirs = containerTopDir.listFiles();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -149,19 +149,6 @@ public class ContainerReader implements Runnable {
       File currentDir = new File(idDir, Storage.STORAGE_DIR_CURRENT);
       File[] containerTopDirs = currentDir.listFiles();
       if (containerTopDirs != null && containerTopDirs.length > 0) {
-        if (shouldDelete) {
-          try {
-            // idDir is working directory having data
-            // and volume is initialized with temp path
-            hddsVolume.createTmpDirs(idDir.getName());
-          } catch (IOException e) {
-            LOG.error("Tmp directory can not be created inside {}" +
-                " for Volume {}.", idDir.getName(), hddsVolumeRootDir, e);
-            volumeSet.failVolume(hddsVolumeRootDir.getPath());
-            return;
-          }
-        }
-
         for (File containerTopDir : containerTopDirs) {
           if (containerTopDir.isDirectory()) {
             File[] containerDirs = containerTopDir.listFiles();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -287,6 +287,7 @@ public class OzoneContainer {
   /**
    * Build's container map after volume format.
    */
+  @VisibleForTesting
   public void buildContainerSet() {
     Iterator<StorageVolume> volumeSetIterator = volumeSet.getVolumesList()
         .iterator();
@@ -440,6 +441,8 @@ public class OzoneContainer {
       LOG.info("Ignore. OzoneContainer already started.");
       return;
     }
+
+    buildContainerSet();
 
     // Start background volume checks, which will begin after the configured
     // delay.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -169,7 +169,6 @@ public class OzoneContainer {
     containerSet = new ContainerSet(recoveringContainerTimeout);
     metadataScanner = null;
 
-    buildContainerSet();
     metrics = ContainerMetrics.create(conf);
     handlers = Maps.newHashMap();
 
@@ -286,9 +285,9 @@ public class OzoneContainer {
   }
 
   /**
-   * Build's container map.
+   * Build's container map after volume format.
    */
-  private void buildContainerSet() {
+  public void buildContainerSet() {
     Iterator<StorageVolume> volumeSetIterator = volumeSet.getVolumesList()
         .iterator();
     ArrayList<Thread> volumeThreads = new ArrayList<>();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
+import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.util.FileUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -558,6 +559,16 @@ public class TestContainerReader {
       // add db entry for the container ID 101 for V3
       baseCount = addDbEntry(containerData);
     }
+
+    // create hdds volume with re-build and reloading db for v3 schema
+    // to simulate restart case and dn not registered
+    hddsVolume = new HddsVolume.Builder(hddsVolume.getVolumeRootDir())
+        .conf(conf).datanodeUuid(datanodeId
+            .toString()).clusterID(clusterId).build();
+    if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
+      hddsVolume.loadDbStore(true);
+    }
+    // verify container data and perform cleanup
     ContainerReader containerReader = new ContainerReader(volumeSet,
         hddsVolume, containerSet, conf, false);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -570,7 +570,7 @@ public class TestContainerReader {
     }
     // verify container data and perform cleanup
     ContainerReader containerReader = new ContainerReader(volumeSet,
-        hddsVolume, containerSet, conf, false);
+        hddsVolume, containerSet, conf, true);
 
     containerReader.run();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
-import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.util.FileUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -560,14 +559,6 @@ public class TestContainerReader {
       baseCount = addDbEntry(containerData);
     }
 
-    // create hdds volume with re-build and reloading db for v3 schema
-    // to simulate restart case and dn not registered
-    hddsVolume = new HddsVolume.Builder(hddsVolume.getVolumeRootDir())
-        .conf(conf).datanodeUuid(datanodeId
-            .toString()).clusterID(clusterId).build();
-    if (VersionedDatanodeFeatures.SchemaV3.isFinalizedAndEnabled(conf)) {
-      hddsVolume.loadDbStore(true);
-    }
     // verify container data and perform cleanup
     ContainerReader containerReader = new ContainerReader(volumeSet,
         hddsVolume, containerSet, conf, true);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -153,6 +153,7 @@ public class TestOzoneContainer {
     OzoneContainer ozoneContainer = ContainerTestUtils
         .getOzoneContainer(datanodeDetails, conf);
 
+    ozoneContainer.buildContainerSet();
     ContainerSet containerset = ozoneContainer.getContainerSet();
     assertEquals(numTestContainers, containerset.containerCount());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -375,7 +375,7 @@ public class TestContainerStateMachineFailures {
     int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
     // restart the hdds datanode and see if the container is listed in the
     // in the missing container set and not in the regular set
-    cluster.restartHddsDatanode(dn.getDatanodeDetails(), false);
+    cluster.restartHddsDatanode(dn.getDatanodeDetails(), true);
     // make sure the container state is still marked unhealthy after restart
     keyValueContainerData = (KeyValueContainerData) ContainerDataYaml
         .readContainerFile(containerFile);


### PR DESCRIPTION
## What changes were proposed in this pull request?

volume is not fully initialized when ContainerReader is performing verify and cleanup container data. So causing NPE for temp directory and container deleted path.

while reading volume, temp dir and deleted container dir is initialized before reading container with working dir (as one used for reading container data at same co-location).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9658

## How was this patch tested?

- test case updated to cover same scenario
