### PR TITLE
HDDS-10099. TestHddsConfServlet unnecessarily depends on hadoop-thirdparty

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
@@ -25,9 +25,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import org.apache.hadoop.hdds.server.http.HttpServer2;
-import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
 import org.apache.hadoop.util.XMLUtils;
 import org.eclipse.jetty.util.ajax.JSON;
 import org.junit.jupiter.api.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -1810,12 +1810,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                     <reason>Use directly from Guava</reason>
                     <bannedImports>
                       <bannedImport>org.apache.ratis.thirdparty.com.google.common.**</bannedImport>
-                    </bannedImports>
-                  </restrictImports>
-                  <restrictImports>
-                    <includeTestCode>true</includeTestCode>
-                    <reason>Use directly from Guava</reason>
-                    <bannedImports>
                       <bannedImport>org.apache.hadoop.thirdparty.com.google.common.**</bannedImport>
                     </bannedImports>
                   </restrictImports>

--- a/pom.xml
+++ b/pom.xml
@@ -1814,6 +1814,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                   </restrictImports>
                   <restrictImports>
                     <includeTestCode>true</includeTestCode>
+                    <reason>Use directly from Guava</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.hadoop.thirdparty.com.google.common.**</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
                     <reason>Disable with @Unhealthy or @Slow instead (see HDDS-9276)</reason>
                     <bannedImports>
                       <bannedImport>org.junit.Ignore</bannedImport>


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestHddsConfServlet has an unnecessary dependency on hadoop-thirdparty.

```
...
import org.apache.hadoop.http.HttpServer2;
import org.apache.hadoop.thirdparty.com.google.common.base.Strings;
import org.apache.hadoop.util.XMLUtils;
...
```
Ozone code is supposed to use guava directly and from hadoop-thirdparty.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10099

## How was this patch tested?

CI.
