### PR TITLE
HDDS-9967. Intermittent failure in TestOzoneRpcClientAbstract.testListSnapshot.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1462,10 +1462,6 @@ public class KeyManagerImpl implements KeyManager {
         && omKeyInfoCacheValue.getCacheValue() == null;
   }
 
-  public static boolean isKeyInCache(String key, Table keyTable) {
-    return keyTable.getCacheValue(new CacheKey(key)) != null;
-  }
-
   /**
    * Helper function for listStatus to find key in TableCache.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -206,7 +206,7 @@ public class ListIterator {
 
       populateCacheMap(cacheIter);
 
-      cacheCreatedKeyIter = cacheKeyMap.entrySet().iterator();
+      cacheCreatedKeyIter = cacheKeyMap.entrySet().stream().filter(e -> e.getValue() != null).iterator();
     }
 
     private void populateCacheMap(Iterator<Map.Entry<CacheKey<String>,
@@ -247,9 +247,6 @@ public class ListIterator {
     private void getNextKey() throws IOException {
       while (cacheCreatedKeyIter.hasNext() && currentEntry == null) {
         Map.Entry<String, Value> entry = cacheCreatedKeyIter.next();
-        if (null == entry.getValue()) {
-          continue;
-        }
         currentEntry = new HeapEntry(this.entryIteratorId, this.tableName,
             entry.getKey(), entry.getValue());
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ListIterator.java
@@ -190,7 +190,6 @@ public class ListIterator {
     private final String prefixKey;
     private final String startKey;
     private final String tableName;
-    private HeapEntry currentEntry;
     private final int entryIteratorId;
 
     CacheIter(int entryIteratorId, String tableName,
@@ -198,7 +197,6 @@ public class ListIterator {
                   CacheValue<Value>>> cacheIter, String startKey,
               String prefixKey) {
       this.cacheKeyMap = new TreeMap<>();
-      this.currentEntry = null;
       this.startKey = startKey;
       this.prefixKey = prefixKey;
       this.tableName = tableName;
@@ -244,30 +242,14 @@ public class ListIterator {
       return cacheKeyMap.containsKey(key);
     }
 
-    private void getNextKey() throws IOException {
-      while (cacheCreatedKeyIter.hasNext() && currentEntry == null) {
-        Map.Entry<String, Value> entry = cacheCreatedKeyIter.next();
-        currentEntry = new HeapEntry(this.entryIteratorId, this.tableName,
-            entry.getKey(), entry.getValue());
-      }
-    }
-
     public boolean hasNext() {
-      try {
-        getNextKey();
-      } catch (IOException t) {
-        throw new UncheckedIOException(t);
-      }
-      return currentEntry != null;
+      return cacheCreatedKeyIter.hasNext();
     }
 
     public HeapEntry next() {
-      if (hasNext()) {
-        HeapEntry ret = currentEntry;
-        currentEntry = null;
-        return ret;
-      }
-      throw new NoSuchElementException();
+      Map.Entry<String, Value> entry = cacheCreatedKeyIter.next();
+      return new HeapEntry(this.entryIteratorId, this.tableName,
+          entry.getKey(), entry.getValue());
     }
 
     public void close() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1372,13 +1372,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
             bucketName, snapshotInfoTable)) {
       try {
         while (snapshotIterator.hasNext() && maxListResult > 0) {
-          Object value = snapshotIterator.next().getValue();
-          // value can be null for deleted snapshot key as CacheIterator from
-          // MinHeapIterator allows null (marked as deleted) values.
-          if (null == value) {
-            continue;
-          }
-          SnapshotInfo snapshotInfo = (SnapshotInfo) value;
+          SnapshotInfo snapshotInfo =
+              (SnapshotInfo) snapshotIterator.next().getValue();
           if (!snapshotInfo.getName().equals(prevSnapshot)) {
             snapshotInfos.add(snapshotInfo);
             maxListResult--;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1372,8 +1372,13 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
             bucketName, snapshotInfoTable)) {
       try {
         while (snapshotIterator.hasNext() && maxListResult > 0) {
-          SnapshotInfo snapshotInfo = (SnapshotInfo) snapshotIterator.next()
-              .getValue();
+          Object value = snapshotIterator.next().getValue();
+          // value can be null for deleted snapshot key as CacheIterator from
+          // MinHeapIterator allows null (marked as deleted) values.
+          if (null == value) {
+            continue;
+          }
+          SnapshotInfo snapshotInfo = (SnapshotInfo) value;
           if (!snapshotInfo.getName().equals(prevSnapshot)) {
             snapshotInfos.add(snapshotInfo);
             maxListResult--;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes the Intermittent failure in `TestOzoneRpcClientAbstract.testListSnapshot`.

`TestOzoneRpcClientAbstract.testListSnapshot` creates 20 snapshots using `createSnapshot` API and asserts the count of same using `listSnapshot` API. This assertion of count fails intermittently.

`listSnapshot` API uses the `org.apache.hadoop.ozone.om.ListIterator.MinHeapIterator` which internally uses both CacheIterator and DBIterator and DBIterator had the logic of checking if rocks DB key is present in cache in `org.apache.hadoop.ozone.om.ListIterator.DbTableIter#getNextKey`, this checks the cache from table cache which may be intermittently flushed which makes the addition of duplicate entry in `org.apache.hadoop.ozone.om.ListIterator.MinHeapIterator`.  So to fix this, we should use the pre-loaded keys in `org.apache.hadoop.ozone.om.ListIterator.CacheIter#cacheKeyMap` in `org.apache.hadoop.ozone.om.ListIterator.CacheIter`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9967

## How was this patch tested?

This patch is tested by repeated CI runs around 500 iterations and ZERO failure reported for this test case. Here is the green CI [link](https://github.com/devmadhuu/ozone/actions/runs/7470560512/job/20330782349).
