### PR TITLE
HDDS-10101. Set sonar.coverage.jacoco.xmlReportPaths

### DIFF
--- a/hadoop-ozone/dev-support/checks/sonar.sh
+++ b/hadoop-ozone/dev-support/checks/sonar.sh
@@ -23,11 +23,8 @@ if [ ! "$SONAR_TOKEN" ]; then
   exit 1
 fi
 
-#Workaround: Sonar expects per-project Sonar XML report, but we have one, combined. Sonar seems to handle it well.
-# Only the classes from the current project will be used. We can copy the same, combined report to all the subprojects.
-if [ -f "$PROJECT_DIR/target/coverage/all.xml" ]; then
-   find "$PROJECT_DIR" -name pom.xml | grep -v target | xargs dirname | xargs -n1 -IDIR mkdir -p DIR/target/coverage/
-   find "$PROJECT_DIR" -name pom.xml | grep -v target | xargs dirname | xargs -n1 -IDIR cp "$PROJECT_DIR/target/coverage/all.xml" DIR/target/coverage/
-fi
 
-mvn -B verify -DskipShade -DskipTests -Dskip.npx -Dskip.installnpx org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=hadoop-ozone
+mvn -V -B -DskipShade -DskipTests -Dskip.npx -Dskip.installnpx --no-transfer-progress \
+  -Dsonar.coverage.jacoco.xmlReportPaths="$(pwd)/target/coverage/all.xml" \
+  -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=hadoop-ozone \
+  verify org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar


### PR DESCRIPTION
## What changes were proposed in this pull request?

`sonar.sh` copies the combined coverage report to all submodules:

https://github.com/apache/ozone/blob/2ae531b0f6a069db5a46bd486bb50225a168485d/hadoop-ozone/dev-support/checks/sonar.sh#L26-L31

We can avoid the need for this hack by setting `sonar.coverage.jacoco.xmlReportPaths`.

https://issues.apache.org/jira/browse/HDDS-10101

## How was this patch tested?

After [CI run](https://github.com/apache/ozone/actions/runs/7466669266) in `apache/ozone` repo, [coverage for the branch](https://sonarcloud.io/component_measures?metric=coverage&view=list&branch=HDDS-10101&id=hadoop-ozone) is available in SonarCloud.