### PR TITLE
HDDS-10105. Remove duplicate hdds.datanode. prefix from check.empty.container.dir.on.delete

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -108,8 +108,7 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
       ROCKSDB_DELETE_OBSOLETE_FILES_PERIOD_MICRO_SECONDS_KEY =
       "hdds.datanode.rocksdb.delete_obsolete_files_period";
   public static final Boolean
-      OZONE_DATANODE_CHECK_EMPTY_CONTAINER_DIR_ON_DELETE_DEFAULT =
-      false;
+      OZONE_DATANODE_CHECK_EMPTY_CONTAINER_DIR_ON_DELETE_DEFAULT = false;
 
   /**
    * Number of threads per volume that Datanode will use for chunk read.
@@ -541,7 +540,7 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
    * Whether to check container directory or not to determine
    * container is empty.
    */
-  @Config(key = "hdds.datanode.check.empty.container.dir.on.delete",
+  @Config(key = "check.empty.container.dir.on.delete",
       type = ConfigType.BOOLEAN,
       defaultValue = "false",
       tags = { DATANODE },


### PR DESCRIPTION
## What changes were proposed in this pull request?

`hdds.datanode` is a default prefix. Repeated declarations lead to duplicate. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10105

## How was this patch tested?

no need
