### PR TITLE
HDDS-10102. Replace Awaitility with existing utils

### DIFF
--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -254,6 +254,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -257,11 +257,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.snapshot;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.Duration;
 import java.util.List;
 
 import com.google.common.collect.Lists;
@@ -134,9 +133,8 @@ import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.CA
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
 import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.COLUMN_FAMILIES_TO_TRACK_IN_DAG;
+import static org.apache.ozone.test.LambdaTestUtils.await;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -163,8 +161,8 @@ public abstract class TestOmSnapshot {
   private static final String SNAPSHOT_KEY_PATTERN_STRING = "(.+)/(.+)/(.+)";
   private static final Pattern SNAPSHOT_KEY_PATTERN =
       Pattern.compile(SNAPSHOT_KEY_PATTERN_STRING);
-  private static final Duration POLL_INTERVAL_DURATION = Duration.ofMillis(500);
-  private static final Duration POLL_MAX_DURATION = Duration.ofSeconds(10);
+  private static final int POLL_INTERVAL_MILLIS = 500;
+  private static final int POLL_MAX_WAIT_MILLIS = 120_000;
 
   private MiniOzoneCluster cluster;
   private OzoneClient client;
@@ -294,15 +292,12 @@ public abstract class TestOmSnapshot {
     // Wait for the finalization to be marked as done.
     // 10s timeout should be plenty.
     try {
-      with().atMost(POLL_MAX_DURATION)
-          .pollInterval(POLL_INTERVAL_DURATION)
-          .await()
-          .until(() -> {
-            final UpgradeFinalizer.StatusAndMessages progress =
-                omClient.queryUpgradeFinalizationProgress(
-                    upgradeClientID, false, false);
-            return isDone(progress.status());
-          });
+      await(POLL_MAX_WAIT_MILLIS, POLL_INTERVAL_MILLIS, () -> {
+        final UpgradeFinalizer.StatusAndMessages progress =
+            omClient.queryUpgradeFinalizationProgress(
+                upgradeClientID, false, false);
+        return isDone(progress.status());
+      });
     } catch (Exception e) {
       fail("Unexpected exception while waiting for "
           + "the OM upgrade to finalize: " + e.getMessage());
@@ -2079,8 +2074,8 @@ public abstract class TestOmSnapshot {
     // job finishes.
     cluster.restartOzoneManager();
     stopKeyManager();
-    await().atMost(Duration.ofSeconds(120)).
-        until(() -> cluster.getOzoneManager().isRunning());
+    await(POLL_MAX_WAIT_MILLIS, POLL_INTERVAL_MILLIS,
+        () -> cluster.getOzoneManager().isRunning());
 
     response = store.snapshotDiff(volumeName, bucketName,
         snapshot1, snapshot2, null, 0, forceFullSnapshotDiff,
@@ -2124,8 +2119,8 @@ public abstract class TestOmSnapshot {
     // the restart.
     cluster.restartOzoneManager();
     stopKeyManager();
-    await().atMost(Duration.ofSeconds(120)).
-        until(() -> cluster.getOzoneManager().isRunning());
+    await(POLL_MAX_WAIT_MILLIS, POLL_INTERVAL_MILLIS,
+        () -> cluster.getOzoneManager().isRunning());
 
     while (nextToken == null || StringUtils.isNotEmpty(nextToken)) {
       diffReport = fetchReportPage(volumeName, bucketName, snapshot1,

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -233,11 +233,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <okhttp.version>2.7.5</okhttp.version>
     <okio.version>3.6.0</okio.version>
     <mockito2.version>3.5.9</mockito2.version>
+    <hamcrest.version>2.2</hamcrest.version>
     <jmockit.version>1.24</jmockit.version>
     <junit4.version>4.13.1</junit4.version>
     <junit5.version>5.10.1</junit5.version>
@@ -1164,6 +1165,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <artifactId>hamcrest-core</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>${hamcrest.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <aspectj.version>1.9.7</aspectj.version>
     <aspectj-plugin.version>1.14.0</aspectj-plugin.version>
     <restrict-imports.enforcer.version>2.4.0</restrict-imports.enforcer.version>
-    <awaitility.version>4.2.0</awaitility.version>
     <bzip2.version>1.0.8</bzip2.version>
     <zlib.version>1.2.13</zlib.version>
     <lz4.version>1.9.3</lz4.version>
@@ -1487,11 +1486,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.xerial</groupId>
         <artifactId>sqlite-jdbc</artifactId>
         <version>${sqlite.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>${awaitility.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.activation</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Awaitility (third-party library) is used 7 times in 4 test classes.

Alternatives:
 * `GenericTestUtils.waitFor`, used by 268 callers.
 * `LambdaTestUtils.await`, used by 19 callers.
 * `JavaUtils.attempt` (prod. utility in Ratis)

This PR replaces most `Awaitility.await` calls with `LambdaTestUtils.await` (which most resembles Awaitility of the three alternatives), and one call (where a void assertion is used) with `attempt`.

We can then remove this dependency (and need to add `hamcrest`, which is also required by other tests, and was a transitive dependency of Awaitility).

https://issues.apache.org/jira/browse/HDDS-10102

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7478683757