### PR TITLE
HDDS-9835. Migrate simple datanode integration tests to JUnit5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -46,11 +46,11 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.apache.ozone.test.JUnit5AwareTimeout;
@@ -69,7 +69,7 @@ public class TestCloseContainerHandler {
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     //setup a cluster (1G free space is enough for a unit test)
     conf = new OzoneConfiguration();
@@ -83,7 +83,7 @@ public class TestCloseContainerHandler {
     cluster.waitForPipelineTobeReady(ONE, 30000);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -125,7 +125,7 @@ public class TestCloseContainerHandler {
     Pipeline pipeline = cluster.getStorageContainerManager()
         .getPipelineManager().getPipeline(container.getPipelineID());
 
-    Assert.assertFalse(isContainerClosed(cluster, containerId.getId()));
+    Assertions.assertFalse(isContainerClosed(cluster, containerId.getId()));
 
     DatanodeDetails datanodeDetails =
         cluster.getHddsDatanodes().get(0).getDatanodeDetails();
@@ -143,7 +143,7 @@ public class TestCloseContainerHandler {
             5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    Assert.assertTrue(isContainerClosed(cluster, containerId.getId()));
+    Assertions.assertTrue(isContainerClosed(cluster, containerId.getId()));
   }
 
   private static Boolean isContainerClosed(MiniOzoneCluster cluster,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -49,22 +49,14 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test to behaviour of the datanode when receive close container command.
  */
+@Timeout(300)
 public class TestCloseContainerHandler {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -56,14 +56,11 @@ import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.JUnit5AwareTimeout;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -84,16 +81,10 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVI
 /**
  * Tests DeleteContainerCommand Handler.
  */
+@Timeout(300)
 public class TestDeleteContainerHandler {
 
   private static OzoneClient client;
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
-
-
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
   private static ObjectStore objectStore;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -57,11 +57,11 @@ import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.JUnit5AwareTimeout;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
@@ -100,7 +100,7 @@ public class TestDeleteContainerHandler {
   private static String volumeName = UUID.randomUUID().toString();
   private static String bucketName = UUID.randomUUID().toString();
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(OZONE_SCM_CONTAINER_SIZE, "1GB");
@@ -129,7 +129,7 @@ public class TestDeleteContainerHandler {
     objectStore.getVolume(volumeName).createBucket(bucketName);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -174,7 +174,7 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    Assert.assertFalse(isContainerClosed(hddsDatanodeService,
+    Assertions.assertFalse(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
@@ -198,7 +198,7 @@ public class TestDeleteContainerHandler {
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    Assert.assertTrue(isContainerClosed(hddsDatanodeService,
+    Assertions.assertTrue(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     // Delete key, which will make isEmpty flag to true in containerData
@@ -226,7 +226,7 @@ public class TestDeleteContainerHandler {
     lingeringBlock.createNewFile();
 
     // Check container exists before sending delete container command
-    Assert.assertFalse(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertFalse(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
     // Set container blockCount to 0 to mock that it is empty as per RocksDB
@@ -252,9 +252,9 @@ public class TestDeleteContainerHandler {
                 contains("Files still part of the container on delete"),
         500,
         5 * 2000);
-    Assert.assertTrue(!isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(!isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
-    Assert.assertTrue(beforeDeleteFailedCount <
+    Assertions.assertTrue(beforeDeleteFailedCount <
         metrics.getContainerDeleteFailedNonEmpty());
     // Send the delete command. It should pass with force flag.
     // Deleting a non-empty container should pass on the DN when the force flag
@@ -269,9 +269,9 @@ public class TestDeleteContainerHandler {
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
         500, 5 * 1000);
-    Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
-    Assert.assertTrue(beforeForceCount <
+    Assertions.assertTrue(beforeForceCount <
         metrics.getContainerForceDelete());
 
     kv.setCheckChunksFilePath(false);
@@ -306,7 +306,7 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    Assert.assertFalse(isContainerClosed(hddsDatanodeService,
+    Assertions.assertFalse(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
@@ -322,7 +322,7 @@ public class TestDeleteContainerHandler {
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    Assert.assertTrue(isContainerClosed(hddsDatanodeService,
+    Assertions.assertTrue(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     // Delete key, which will make isEmpty flag to true in containerData
@@ -350,7 +350,7 @@ public class TestDeleteContainerHandler {
     lingeringBlock.createNewFile();
 
     // Check container exists before sending delete container command
-    Assert.assertFalse(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertFalse(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
     // send delete container to the datanode
@@ -366,7 +366,7 @@ public class TestDeleteContainerHandler {
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
         500, 5 * 1000);
-    Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
   }
 
@@ -393,7 +393,7 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    Assert.assertFalse(isContainerClosed(hddsDatanodeService,
+    Assertions.assertFalse(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
@@ -427,11 +427,11 @@ public class TestDeleteContainerHandler {
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    Assert.assertTrue(isContainerClosed(hddsDatanodeService,
+    Assertions.assertTrue(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     // Check container exists before sending delete container command
-    Assert.assertFalse(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertFalse(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
     long containerDeleteFailedNonEmptyBlockDB =
@@ -455,9 +455,9 @@ public class TestDeleteContainerHandler {
                 contains("the container is not empty with blockCount"),
         500,
         5 * 2000);
-    Assert.assertTrue(!isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(!isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
-    Assert.assertTrue(containerDeleteFailedNonEmptyBlockDB <
+    Assertions.assertTrue(containerDeleteFailedNonEmptyBlockDB <
         metrics.getContainerDeleteFailedNonEmpty());
 
     // Now empty the container Dir and try with a non-empty block table
@@ -479,7 +479,7 @@ public class TestDeleteContainerHandler {
         cluster.getStorageContainerManager().getScmContext().getTermOfLeader());
     nodeManager.addDatanodeCommand(datanodeDetails.getUuid(), command);
     Thread.sleep(5000);
-    Assert.assertTrue(!isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(!isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
     // Send the delete command. It should pass with force flag.
     long beforeForceCount = metrics.getContainerForceDelete();
@@ -492,9 +492,9 @@ public class TestDeleteContainerHandler {
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
         500, 5 * 1000);
-    Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
-    Assert.assertTrue(beforeForceCount <
+    Assertions.assertTrue(beforeForceCount <
         metrics.getContainerForceDelete());
   }
 
@@ -516,7 +516,7 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    Assert.assertFalse(isContainerClosed(hddsDatanodeService,
+    Assertions.assertFalse(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
@@ -534,11 +534,11 @@ public class TestDeleteContainerHandler {
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    Assert.assertTrue(isContainerClosed(hddsDatanodeService,
+    Assertions.assertTrue(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     // Check container exists before sending delete container command
-    Assert.assertFalse(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertFalse(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
     // Clear block table
@@ -570,7 +570,7 @@ public class TestDeleteContainerHandler {
     GenericTestUtils.waitFor(() ->
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
         500, 5 * 1000);
-    Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
   }
@@ -621,7 +621,7 @@ public class TestDeleteContainerHandler {
     HddsDatanodeService hddsDatanodeService =
         cluster.getHddsDatanodes().get(0);
 
-    Assert.assertFalse(isContainerClosed(hddsDatanodeService,
+    Assertions.assertFalse(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     DatanodeDetails datanodeDetails = hddsDatanodeService.getDatanodeDetails();
@@ -639,11 +639,11 @@ public class TestDeleteContainerHandler {
         500, 5 * 1000);
 
     //double check if it's really closed (waitFor also throws an exception)
-    Assert.assertTrue(isContainerClosed(hddsDatanodeService,
+    Assertions.assertTrue(isContainerClosed(hddsDatanodeService,
         containerId.getId()));
 
     // Check container exists before sending delete container command
-    Assert.assertFalse(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertFalse(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
     // send delete container to the datanode
@@ -665,7 +665,7 @@ public class TestDeleteContainerHandler {
     ContainerMetrics metrics =
         hddsDatanodeService
             .getDatanodeStateMachine().getContainer().getMetrics();
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         metrics.getContainerDeleteFailedNonEmpty());
 
     // Delete key, which will make isEmpty flag to true in containerData
@@ -687,7 +687,7 @@ public class TestDeleteContainerHandler {
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
         500, 5 * 1000);
 
-    Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
   }
 
@@ -732,7 +732,7 @@ public class TestDeleteContainerHandler {
       }
     }
 
-    Assert.assertFalse(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertFalse(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
 
@@ -747,7 +747,7 @@ public class TestDeleteContainerHandler {
             isContainerDeleted(hddsDatanodeService, containerId.getId()),
         500, 5 * 1000);
 
-    Assert.assertTrue(isContainerDeleted(hddsDatanodeService,
+    Assertions.assertTrue(isContainerDeleted(hddsDatanodeService,
         containerId.getId()));
 
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
@@ -29,11 +29,11 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.apache.ozone.test.JUnit5AwareTimeout;
@@ -61,7 +61,7 @@ public class TestRefreshVolumeUsageHandler {
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     //setup a cluster (1G free space is enough for a unit test)
     conf = new OzoneConfiguration();
@@ -78,7 +78,7 @@ public class TestRefreshVolumeUsageHandler {
     cluster.waitForPipelineTobeReady(ONE, 30000);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -108,7 +108,7 @@ public class TestRefreshVolumeUsageHandler {
       //a new key is created, but the datanode default REFRESH_PERIOD is 1 hour,
       //still the cache is updated, so the scm will eventually get the new
       //used space from the datanode through node report.
-      Assert.assertTrue(cluster.getStorageContainerManager()
+      Assertions.assertTrue(cluster.getStorageContainerManager()
           .getScmNodeManager().getUsageInfo(datanodeDetails)
           .getScmNodeStat().getScmUsed().isEqual(currentScmUsed));
 
@@ -123,7 +123,7 @@ public class TestRefreshVolumeUsageHandler {
 
       //after waiting for several node report , this usage info
       //in SCM should be updated as we have updated the DN's cached usage info.
-      Assert.assertTrue(cluster.getStorageContainerManager()
+      Assertions.assertTrue(cluster.getStorageContainerManager()
           .getScmNodeManager().getUsageInfo(datanodeDetails)
           .getScmNodeStat().getScmUsed().isGreater(currentScmUsed));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
@@ -32,11 +32,8 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.HashMap;
 import java.util.concurrent.TimeoutException;
@@ -51,12 +48,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
  * Test the behaviour of the datanode and scm when communicating
  * with refresh volume usage command.
  */
+@Timeout(300)
 public class TestRefreshVolumeUsageHandler {
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
@@ -53,8 +53,8 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.util.ExitUtils;
@@ -64,9 +64,9 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 
 import org.apache.ratis.util.function.CheckedBiFunction;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * This class tests the metrics of ContainerStateMachine.
@@ -76,7 +76,7 @@ public class TestCSMMetrics {
       GenericTestUtils.getTestDir("dfs").getAbsolutePath()
           + File.separator;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     ExitUtils.disableSystemExit();
   }
@@ -142,7 +142,7 @@ public class TestCSMMetrics {
               pipeline, blockID, 1024);
       ContainerCommandResponseProto response =
           client.sendCommand(writeChunkRequest);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS,
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
           response.getResult());
 
       metric = getMetrics(CSMMetrics.SOURCE_NAME +
@@ -160,7 +160,7 @@ public class TestCSMMetrics {
           ContainerTestHelper.getReadChunkRequest(pipeline, writeChunkRequest
               .getWriteChunk());
       response = client.sendCommand(readChunkRequest);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS,
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
           response.getResult());
 
       metric = getMetrics(CSMMetrics.SOURCE_NAME +

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
@@ -55,9 +55,9 @@ import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanode
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.apache.ozone.test.JUnit5AwareTimeout;
@@ -129,7 +129,7 @@ public class TestContainerMetrics {
               pipeline, blockID, 1024);
       ContainerCommandResponseProto response =
               client.sendCommand(writeChunkRequest);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS,
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
           response.getResult());
 
       //Read Chunk
@@ -137,7 +137,7 @@ public class TestContainerMetrics {
           ContainerTestHelper.getReadChunkRequest(pipeline, writeChunkRequest
               .getWriteChunk());
       response = client.sendCommand(readChunkRequest);
-      Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
 
       MetricsRecordBuilder containerMetrics = getMetrics(
           "StorageContainerMetrics");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
@@ -56,22 +56,14 @@ import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import org.junit.jupiter.api.Assertions;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test for metrics published by storage containers.
  */
+@Timeout(300)
 public class TestContainerMetrics {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   @Test
   public void testContainerMetrics() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestDatanodeQueueMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestDatanodeQueueMetrics.java
@@ -24,13 +24,10 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeQueueMetrics;
-import org.junit.Rule;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +42,7 @@ import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 /**
  * Test for queue metrics of datanodes.
  */
+@Timeout(300)
 public class TestDatanodeQueueMetrics {
 
   private MiniOzoneHAClusterImpl cluster = null;
@@ -58,9 +56,6 @@ public class TestDatanodeQueueMetrics {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(TestDatanodeQueueMetrics.class);
-
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(new Timeout(300_000));
 
   /**
    * Create a MiniDFSCluster for testing.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -101,17 +101,17 @@ import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.apache.ratis.util.function.CheckedBiFunction;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Container servers when security is enabled.
@@ -125,7 +125,7 @@ public class TestSecureContainerServer {
   private static OzoneBlockTokenSecretManager blockTokenSecretManager;
   private static ContainerTokenSecretManager containerTokenSecretManager;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     DefaultMetricsSystem.setMiniClusterMode(true);
     ExitUtils.disableSystemExit();
@@ -144,12 +144,12 @@ public class TestSecureContainerServer {
         tokenLifetime, secretKeyClient);
   }
 
-  @AfterClass
+  @AfterAll
   public static void deleteTestDir() {
     FileUtils.deleteQuietly(new File(TEST_DIR));
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws IOException {
     FileUtils.deleteQuietly(new File(CONF.get(HDDS_DATANODE_DIR_KEY)));
   }
@@ -318,9 +318,9 @@ public class TestSecureContainerServer {
       ContainerCommandResponseProto response = client.sendCommand(request);
       assertNotEquals(response.getResult(), ContainerProtos.Result.SUCCESS);
       String msg = response.getMessage();
-      assertTrue(msg, msg.contains(BLOCK_TOKEN_VERIFICATION_FAILED.name()));
+      assertTrue(msg.contains(BLOCK_TOKEN_VERIFICATION_FAILED.name()), msg);
     } else {
-      final Throwable t = Assert.assertThrows(Throwable.class,
+      final Throwable t = Assertions.assertThrows(Throwable.class,
           () -> client.sendCommand(request));
       assertRootCauseMessage(BLOCK_TOKEN_VERIFICATION_FAILED.name(), t);
     }
@@ -331,7 +331,7 @@ public class TestSecureContainerServer {
     Throwable rootCause = ExceptionUtils.getRootCause(t);
     assertNotNull(rootCause);
     String msg = rootCause.getMessage();
-    assertTrue(msg, msg.contains(contained));
+    assertTrue(msg.contains(contained), msg);
   }
 
   private static String getToken(ContainerID containerID) throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
@@ -32,24 +32,16 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Timeout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Test Datanode Ratis log parser.
  */
+@Timeout(300)
 public class TestDnRatisLogParser {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
 
   private MiniOzoneCluster cluster = null;
   private final ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
@@ -29,11 +29,11 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.segmentparser.DatanodeRatisLogParser;
 
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.apache.ozone.test.JUnit5AwareTimeout;
@@ -55,7 +55,7 @@ public class TestDnRatisLogParser {
   private final ByteArrayOutputStream out = new ByteArrayOutputStream();
   private final ByteArrayOutputStream err = new ByteArrayOutputStream();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf)
@@ -65,7 +65,7 @@ public class TestDnRatisLogParser {
     System.setErr(new PrintStream(err, false, UTF_8.name()));
   }
 
-  @After
+  @AfterEach
   public void destroy() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -86,14 +86,14 @@ public class TestDnRatisLogParser {
     File currentDir = new File(pipelineDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");
     GenericTestUtils.waitFor(logFile::exists, 100, 15000);
-    Assert.assertTrue(logFile.isFile());
+    Assertions.assertTrue(logFile.isFile());
 
     DatanodeRatisLogParser datanodeRatisLogParser =
         new DatanodeRatisLogParser();
     datanodeRatisLogParser.setSegmentFile(logFile);
     datanodeRatisLogParser.parseRatisLogs(
         DatanodeRatisLogParser::smToContainerLogString);
-    Assert.assertTrue(out.toString(StandardCharsets.UTF_8.name())
+    Assertions.assertTrue(out.toString(StandardCharsets.UTF_8.name())
         .contains("Num Total Entries:"));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
@@ -36,11 +36,8 @@ import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
-import org.apache.ozone.test.JUnit5AwareTimeout;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -63,12 +60,9 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 /**
  * This class tests datanode can tolerate configured num of failed volumes.
  */
+@Timeout(300)
 public class TestDatanodeHddsVolumeFailureToleration {
-  /**
-   * Set a timeout for each test.
-   */
-  @Rule
-  public TestRule timeout = new JUnit5AwareTimeout(Timeout.seconds(300));
+
   private MiniOzoneCluster cluster;
   private OzoneConfiguration ozoneConfig;
   private List<HddsDatanodeService> datanodes;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
@@ -33,11 +33,11 @@ import org.apache.hadoop.ozone.dn.DatanodeTestUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 import org.apache.ozone.test.JUnit5AwareTimeout;
@@ -73,7 +73,7 @@ public class TestDatanodeHddsVolumeFailureToleration {
   private OzoneConfiguration ozoneConfig;
   private List<HddsDatanodeService> datanodes;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     ozoneConfig = new OzoneConfiguration();
     ozoneConfig.set(OZONE_SCM_CONTAINER_SIZE, "1GB");
@@ -102,7 +102,7 @@ public class TestDatanodeHddsVolumeFailureToleration {
     datanodes = cluster.getHddsDatanodes();
   }
 
-  @After
+  @AfterEach
   public void shutdown() throws IOException {
     if (cluster != null) {
       cluster.shutdown();
@@ -147,7 +147,7 @@ public class TestDatanodeHddsVolumeFailureToleration {
     // cluster.
     GenericTestUtils.waitFor(() -> exitCapturer.getOutput()
         .contains("Exiting with status 1: ExitException"), 500, 60000);
-    Assert.assertTrue(dsmCapturer.getOutput()
+    Assertions.assertTrue(dsmCapturer.getOutput()
         .contains("DatanodeStateMachine Shutdown due to too many bad volumes"));
 
     // restore bad volumes


### PR DESCRIPTION
## What changes were proposed in this pull request?
=> Migrate Junit4 to Junit5

Please describe your PR in detail:
=> Migrated the following test classes to JUnit5
++++
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
++++

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9835


## How was this patch tested?

Ran Unit Test