### PR TITLE
HDDS-10018. Fix search function don't show on the first page about Node Status for SCM webUI

### DIFF
--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -40,7 +40,7 @@
         </select>
     </div>
     <div class="col-md-6 text-right">
-        <label>Search: </label> <input type="text" ng-model="search">
+        <label>Search: </label> <input type="text" ng-model="search" ng-change="UpdateRecordsToShow()">
     </div>
 </div>
 <table class="table table-bordered table-striped col-md-6">

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -82,16 +82,17 @@
                 });
             /*if option is 'All' display all records else display specified record on page*/
             $scope.UpdateRecordsToShow = () => {
-                if($scope.search){
+                // First, handle search filtering
+                if ($scope.search) {
                     $scope.nodeStatus = nodeStatusCopy.filter(item => item.hostname.includes($scope.search));
-                }else {
-                    if ($scope.RecordsToDisplay == 'All') {
-                        $scope.lastIndex = 1;
+                } else {
+                    // Then handle record display based on 'All' or a specific number
+                    if ($scope.RecordsToDisplay === 'All') {
                         $scope.nodeStatus = nodeStatusCopy;
                     } else {
-                        $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
                         $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
                     }
+                    $scope.lastIndex = $scope.RecordsToDisplay === 'All' ? 1 : Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
                 }
                 $scope.currentPage = 1;
             }

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -82,12 +82,16 @@
                 });
             /*if option is 'All' display all records else display specified record on page*/
             $scope.UpdateRecordsToShow = () => {
-                if($scope.RecordsToDisplay == 'All') {
-                    $scope.lastIndex = 1;
-                    $scope.nodeStatus = nodeStatusCopy;
-                } else {
-                    $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
-                    $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+                if($scope.search){
+                    $scope.nodeStatus = nodeStatusCopy.filter(item => item.hostname.includes($scope.search));
+                }else {
+                    if ($scope.RecordsToDisplay == 'All') {
+                        $scope.lastIndex = 1;
+                        $scope.nodeStatus = nodeStatusCopy;
+                    } else {
+                        $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
+                        $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+                    }
                 }
                 $scope.currentPage = 1;
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix search function don't show on the first page about Node Status for SCM webUI

Please describe your PR in detail:

In the Node Status column of SCM's webUI, when I searched for datanode, the detailed information of the datanode was not displayed on the first page, so I fixed it. After fixing, perform a search operation and the detailed information of the datanode will be displayed on the first page.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10018

## How was this patch tested?
This is a screenshot of the fixed version:

<img width="1400" alt="图片" src="https://github.com/apache/ozone/assets/56783384/fa3ada62-ded4-4cb1-a09c-cc646e88640e">

when I search conway-hadoop4：
<img width="1403" alt="图片" src="https://github.com/apache/ozone/assets/56783384/a60da81f-4b6b-4bac-bffd-2cec11b9f5db">
