### PR TITLE
HDDS-10110. Use RocksDB key count estimates instead of OM metrics file.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -367,10 +367,6 @@ public final class OzoneConsts {
   // Tenant admin role. All tenant admins are assigned this role
   public static final String DEFAULT_TENANT_ROLE_ADMIN_SUFFIX = "-AdminRole";
 
-  // For OM metrics saving to a file
-  public static final String OM_METRICS_FILE = "omMetrics";
-  public static final String OM_METRICS_TEMP_FILE = OM_METRICS_FILE + ".tmp";
-
   // For Multipart upload
   public static final int OM_MULTIPART_MIN_SIZE = 5 * 1024 * 1024;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -166,9 +166,10 @@ public final class OMConfigKeys {
   public static final int OZONE_OM_MPU_PARTS_CLEANUP_LIMIT_PER_TASK_DEFAULT =
       1000;
 
-  public static final String OZONE_OM_METRICS_SAVE_INTERVAL =
-      "ozone.om.save.metrics.interval";
-  public static final String OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT = "5m";
+  // TODO deprecate this config
+//  public static final String OZONE_OM_METRICS_SAVE_INTERVAL =
+//      "ozone.om.save.metrics.interval";
+//  public static final String OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT = "5m";
 
   /**
    * OM Ratis related configurations.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -113,8 +113,6 @@ public class TestOmMetrics {
   @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
-    conf.setTimeDuration(OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL,
-        1000, TimeUnit.MILLISECONDS);
     clusterBuilder = MiniOzoneCluster.newBuilder(conf).withoutDatanodes();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -327,15 +327,6 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     this.numDirs.incr(val);
   }
 
-  public void setNumFiles(long val) {
-    long oldVal = this.numFiles.value();
-    this.numFiles.incr(val - oldVal);
-  }
-
-  public void incNumFiles(long val) {
-    this.numFiles.incr(val);
-  }
-
   public void decNumDirs() {
     this.numDirs.incr(-1);
   }
@@ -344,12 +335,9 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     numDirs.incr(-val);
   }
 
-  public long getNumDirs() {
-    return numDirs.value();
-  }
-
-  public long getNumFiles() {
-    return numFiles.value();
+  public void setNumFiles(long val) {
+    long oldVal = this.numFiles.value();
+    this.numFiles.incr(val - oldVal);
   }
 
   public void incNumFiles() {
@@ -363,7 +351,6 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   public void decNumFiles(long val) {
     numFiles.incr(-val);
   }
-
 
   public void decNumKeys(long val) {
     this.numKeys.incr(-val);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -327,8 +327,16 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   }
 
   public void setNumFiles(long val) {
-    long oldVal = this.numDirs.value();
-    this.numDirs.incr(val - oldVal);
+    long oldVal = this.numFiles.value();
+    this.numFiles.incr(val - oldVal);
+  }
+
+  public long getNumDirs() {
+    return numDirs.value();
+  }
+
+  public long getNumFiles() {
+    return numFiles.value();
   }
 
   public void decNumKeys(long val) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -189,9 +189,6 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   private @Metric MutableCounterLong numBuckets;
   private @Metric MutableCounterLong numS3Buckets;
 
-  //TODO: This metric is an estimate and it may be inaccurate on restart if the
-  // OM process was not shutdown cleanly. Key creations/deletions in the last
-  // few minutes before restart may not be included in this count.
   private @Metric MutableCounterLong numKeys;
 
   private @Metric MutableCounterLong numBucketS3Creates;
@@ -326,9 +323,25 @@ public class OMMetrics implements OmMetadataReaderMetrics {
     this.numDirs.incr(val - oldVal);
   }
 
+  public void incNumDirs(long val) {
+    this.numDirs.incr(val);
+  }
+
   public void setNumFiles(long val) {
     long oldVal = this.numFiles.value();
     this.numFiles.incr(val - oldVal);
+  }
+
+  public void incNumFiles(long val) {
+    this.numFiles.incr(val);
+  }
+
+  public void decNumDirs() {
+    this.numDirs.incr(-1);
+  }
+
+  public void decNumDirs(long val) {
+    numDirs.incr(-val);
   }
 
   public long getNumDirs() {
@@ -338,6 +351,19 @@ public class OMMetrics implements OmMetadataReaderMetrics {
   public long getNumFiles() {
     return numFiles.value();
   }
+
+  public void incNumFiles() {
+    numFiles.incr();
+  }
+
+  public void decNumFiles() {
+    numFiles.incr(-1);
+  }
+
+  public void decNumFiles(long val) {
+    numFiles.incr(-val);
+  }
+
 
   public void decNumKeys(long val) {
     this.numKeys.incr(-val);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1673,9 +1673,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .countEstimatedRowsInTable(metadataManager.getFileTable()));
 
     // Returns total number of LEGACY and OBS keys.
-    long numObjects = metadataManager.countEstimatedRowsInTable(metadataManager.getKeyTable(BucketLayout.OBJECT_STORE));
-    // TODO should numKeys remain the total of these values, or should it only count non-FSO objects?
-    metrics.setNumKeys(numObjects + metrics.getNumFiles() + metrics.getNumDirs());
+    metrics.setNumKeys(
+        metadataManager.countEstimatedRowsInTable(metadataManager.getKeyTable(BucketLayout.OBJECT_STORE)));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -88,7 +88,7 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();
     String keyName = keyArgs.getKeyName();
-    int numKeysCreated = 0;
+    int numDirsCreated = 0;
 
     OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
         getOmRequest());
@@ -154,9 +154,9 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
                 .getBucketId(volumeName, bucketName);
 
         // total number of keys created.
-        numKeysCreated = missingParentInfos.size() + 1;
-        checkBucketQuotaInNamespace(omBucketInfo, numKeysCreated);
-        omBucketInfo.incrUsedNamespace(numKeysCreated);
+        numDirsCreated = missingParentInfos.size() + 1;
+        checkBucketQuotaInNamespace(omBucketInfo, numDirsCreated);
+        omBucketInfo.incrUsedNamespace(numDirsCreated);
 
         // prepare leafNode dir
         OmDirectoryInfo dirInfo = createDirectoryInfoWithACL(
@@ -196,14 +196,14 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
     auditLog(auditLogger, buildAuditMessage(OMAction.CREATE_DIRECTORY,
         auditMap, exception, userInfo));
 
-    logResult(createDirectoryRequest, keyArgs, omMetrics, numKeysCreated,
+    logResult(createDirectoryRequest, keyArgs, omMetrics, numDirsCreated,
             result, exception);
 
     return omClientResponse;
   }
 
   private void logResult(CreateDirectoryRequest createDirectoryRequest,
-                         KeyArgs keyArgs, OMMetrics omMetrics, int numKeys,
+                         KeyArgs keyArgs, OMMetrics omMetrics, int numDirs,
                          Result result,
                          Exception exception) {
 
@@ -213,7 +213,7 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
 
     switch (result) {
     case SUCCESS:
-      omMetrics.incNumKeys(numKeys);
+      omMetrics.incNumDirs(numDirs);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Directory created. Volume:{}, Bucket:{}, Key:{}",
             volumeName, bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -87,7 +87,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
                 volumeName, bucketName);
             lockSet.add(volBucketPair);
           }
-          omMetrics.decNumKeys();
+          omMetrics.decNumDirs();
           OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
               volumeName, bucketName);
           // bucketInfo can be null in case of delete volume or bucket
@@ -110,7 +110,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
                 volumeName, bucketName);
             lockSet.add(volBucketPair);
           }
-          omMetrics.decNumKeys();
+          omMetrics.decNumFiles();
           OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
               volumeName, bucketName);
           // bucketInfo can be null in case of delete volume or bucket


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Use RocksDB column family key count estimates to initialize OM metrics that need to survive restarts or be updated on snapshot install.
- Remove OM metrics json file
- Clarify usage of existing OM count metrics. Previous definitions of these metrics were inconsistent.
  - numKeys: The number of entries in OBS or Legacy buckets, regardless of the value of `ozone.om.enable.filesystem.paths`.
  - numDirs: The number of directories in FSO buckets.
  - numFiles: The number of files in FSO buckets.

See the Jira description for history and details of changes to these OM metrics. With this solution, all metrics should be corrected on OM restart without repairs required. Opening this as a draft PR to get comments on the approach while tests are being finished.

## What is the link to the Apache JIRA

HDDS-10110

## How was this patch tested?

- [ ] WIP
