### PR TITLE
HDDS-10116. Rename mockito2.version to mockito.version in pom.xml and fix typos

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
@@ -37,7 +37,7 @@ import static org.apache.ratis.server.metrics.SegmentedRaftLogMetrics.RAFT_LOG_S
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Test RatisDropwizardExporter.
+ * Test {@link RatisDropwizardExports}.
  */
 public class TestRatisDropwizardExports {
   static Timer findTimer(String name, MetricRegistry registry) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
@@ -37,7 +37,7 @@ import static org.apache.ratis.server.metrics.SegmentedRaftLogMetrics.RAFT_LOG_S
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Test RatisDropwizardRexporter.
+ * Test RatisDropwizardExporter.
  */
 public class TestRatisDropwizardExports {
   static Timer findTimer(String name, MetricRegistry registry) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/GrpcOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/GrpcOMFailoverProxyProvider.java
@@ -49,7 +49,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 
 /**
  * The Grpc s3gateway om transport failover proxy provider implementation
- * extending the ozone client OM failover proxy provider.  This implmentation
+ * extending the ozone client OM failover proxy provider.  This implementation
  * allows the Grpc OMTransport reuse OM failover retry policies and
  * getRetryAction methods.  In case of OM failover, client can try
  * connecting to another OM node from the list of proxies.
@@ -123,7 +123,7 @@ public class GrpcOMFailoverProxyProvider<T> extends
 
   /**
    * Get the proxy object which should be used until the next failover event
-   * occurs. RPC proxy object is intialized lazily.
+   * occurs. RPC proxy object is initialized lazily.
    * @return the OM proxy object to invoke methods upon
    */
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProviderBase.java
@@ -150,7 +150,7 @@ public abstract class OMFailoverProxyProviderBase<T> implements
 
   @VisibleForTesting
   public RetryPolicy getRetryPolicy(int maxFailovers) {
-    // Client will attempt upto maxFailovers number of failovers between
+    // Client will attempt up to maxFailovers number of failovers between
     // available OMs before throwing exception.
     RetryPolicy retryPolicy = new RetryPolicy() {
       @Override

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <objenesis.version>1.0</objenesis.version>
     <okhttp.version>2.7.5</okhttp.version>
     <okio.version>3.6.0</okio.version>
-    <mockito3.version>3.5.9</mockito3.version>
+    <mockito.version>3.5.9</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <jmockit.version>1.24</jmockit.version>
     <junit4.version>4.13.1</junit4.version>
@@ -1292,12 +1292,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>${mockito3.version}</version>
+        <version>${mockito.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
-        <version>${mockito3.version}</version>
+        <version>${mockito.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.testing.compile</groupId>
@@ -1561,7 +1561,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>${mockito3.version}</version>
+        <version>${mockito.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <objenesis.version>1.0</objenesis.version>
     <okhttp.version>2.7.5</okhttp.version>
     <okio.version>3.6.0</okio.version>
-    <mockito2.version>3.5.9</mockito2.version>
+    <mockito3.version>3.5.9</mockito3.version>
     <hamcrest.version>2.2</hamcrest.version>
     <jmockit.version>1.24</jmockit.version>
     <junit4.version>4.13.1</junit4.version>
@@ -1292,12 +1292,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>${mockito2.version}</version>
+        <version>${mockito3.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
-        <version>${mockito2.version}</version>
+        <version>${mockito3.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.testing.compile</groupId>
@@ -1561,7 +1561,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>${mockito2.version}</version>
+        <version>${mockito3.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Mockito has been upgraded to 3.x,  but the `pom.xml` tag still named mockito2.version. Maybe it should be renamed to mockito3.version.And fixed some typos in this PR.
## What is the link to the Apache JIRA

[HDDS-10116](https://issues.apache.org/jira/browse/HDDS-10116)

## CI

https://github.com/wzhallright/ozone/actions/runs/7497056961
