### PR TITLE
HDDS-10124. Compile Ozone with JDK 21 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
       fail-fast: false
     steps:
       - name: Download Ozone source tarball


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Java 21 to `compile` check's version matrix.

https://issues.apache.org/jira/browse/HDDS-10124

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7505641674/job/20435976432