### PR TITLE
HDDS-10123. InaccessibleObjectException in tests using ChecksumByteBufferImpl with Java 17

### DIFF
--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -31,7 +31,7 @@ if [[ ${ITERATIONS} -le 0 ]]; then
 fi
 
 export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
-MAVEN_OPTIONS='-B -Dskip.npx -Dskip.installnpx -Dnative.lib.tmp.dir=/tmp --no-transfer-progress'
+MAVEN_OPTIONS="-B -V -Dskip.npx -Dskip.installnpx -Dnative.lib.tmp.dir=/tmp --no-transfer-progress"
 
 if [[ "${OZONE_WITH_COVERAGE}" != "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"
@@ -41,6 +41,13 @@ if [[ "${FAIL_FAST}" == "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-fast -Dsurefire.skipAfterFailureCount=1"
 else
   MAVEN_OPTIONS="${MAVEN_OPTIONS} --fail-at-end"
+fi
+
+# apply module access args (for Java 9+)
+OZONE_MODULE_ACCESS_ARGS=""
+if [[ -f hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh ]]; then
+  source hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+  ozone_java_setup
 fi
 
 if [[ "${CHECK}" == "integration" ]] || [[ ${ITERATIONS} -gt 1 ]]; then
@@ -61,7 +68,7 @@ for i in $(seq 1 ${ITERATIONS}); do
     mkdir -p "${REPORT_DIR}"
   fi
 
-  mvn ${MAVEN_OPTIONS} "$@" test \
+  mvn ${MAVEN_OPTIONS} -Dmaven-surefire-plugin.argLineAccessArgs="${OZONE_MODULE_ACCESS_ARGS}" "$@" test \
     | tee "${REPORT_DIR}/output.log"
   irc=$?
 

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -79,22 +79,6 @@ function ozonecmd_case
   # This parameter significantly reduces GC pressure for Datanode.
   # Corresponding Ratis issue https://issues.apache.org/jira/browse/RATIS-534.
   RATIS_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false ${RATIS_OPTS}"
-  # Add JVM parameter for Java 17
-  OZONE_MODULE_ACCESS_ARGS=""
-
-  # Get the version string
-  JAVA_VERSION_STRING=$(java -version 2>&1 | head -n 1)
-
-  # Extract the major version number
-  JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION_STRING" | sed -E -n 's/.* version "([^.-]*).*"/\1/p' | cut -d' ' -f1)
-
-  # populate JVM args based on java version
-  if [[ "${JAVA_MAJOR_VERSION}" == "17" ]]; then
-      OZONE_MODULE_ACCESS_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED --add-exports java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED"
-  fi
-  if [[ "${JAVA_MAJOR_VERSION}" -ge 9 ]]; then
-    OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-opens java.base/java.nio=ALL-UNNAMED"
-  fi
 
   case ${subcmd} in
     auditparser)

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1406,6 +1406,35 @@ function ozone_java_setup
     ozone_error "ERROR: $JAVA is not executable."
     exit 1
   fi
+
+  # Get the version string
+  JAVA_VERSION_STRING=$(${JAVA} -version 2>&1 | head -n 1)
+
+  # Extract the major version number
+  JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION_STRING" | sed -E -n 's/.* version "([^.-]*).*"/\1/p' | cut -d' ' -f1)
+
+  ozone_set_module_access_args
+}
+
+## @description  Set OZONE_MODULE_ACCESS_ARGS based on Java version
+## @audience     private
+## @stability    evolving
+## @replaceable  yes
+function ozone_set_module_access_args
+{
+  if [[ -z "${JAVA_MAJOR_VERSION}" ]]; then
+    return
+  fi
+
+  # populate JVM args based on java version
+  if [[ "${JAVA_MAJOR_VERSION}" -ge 17 ]]; then
+    OZONE_MODULE_ACCESS_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED"
+    OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-opens java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED"
+    OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-exports java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED"
+  fi
+  if [[ "${JAVA_MAJOR_VERSION}" -ge 9 ]]; then
+    OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-opens java.base/java.nio=ALL-UNNAMED"
+  fi
 }
 
 ## @description  Finish Java JNI paths prior to execution

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
+    <maven-surefire-plugin.argLineAccessArgs></maven-surefire-plugin.argLineAccessArgs>
     <unstable-test-groups>flaky | slow | unhealthy</unstable-test-groups>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
@@ -1973,7 +1974,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <reuseForks>false</reuseForks>
           <forkedProcessTimeoutInSeconds>${surefire.fork.timeout}</forkedProcessTimeoutInSeconds>
           <!-- @argLine is filled by jacoco maven plugin. @{} means late evaluation -->
-          <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
+          <argLine>${maven-surefire-plugin.argLine} ${maven-surefire-plugin.argLineAccessArgs} @{argLine}</argLine>
           <environmentVariables>
             <MALLOC_ARENA_MAX>4</MALLOC_ARENA_MAX>
           </environmentVariables>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Several tests fail when run with Java 17 due to:

```
java.lang.ExceptionInInitializerError
	at org.apache.hadoop.ozone.common.TestChecksumImplsComputeSameValues.testCRC32CImplsMatch(TestChecksumImplsComputeSameValues.java:66)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field boolean java.nio.ByteBuffer.isReadOnly accessible: module java.base does not "opens java.nio" to unnamed module @75eeccf5
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at org.apache.hadoop.ozone.common.ChecksumByteBufferImpl.<clinit>(ChecksumByteBufferImpl.java:44)
	... 4 more
```

`ozone` command does open some packages for `ChecksumByteBufferImpl` to work (see #3759).  This change applies the same logic (extracted to `ozone-functions.sh`) in `junit.sh` to Surefire `argLine`.

https://issues.apache.org/jira/browse/HDDS-10123

## How was this patch tested?

Ran tests that failed previously with Java 17.

Example:

```
$ JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./hadoop-ozone/dev-support/checks/junit.sh -am -pl :hdds-common -Dtest='TestChecksumImplsComputeSameValues'
...
Java version: 17.0.9
...
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.206 s -- in org.apache.hadoop.ozone.common.TestChecksumImplsComputeSameValues
```

CI (also verifies that refactoring `bin/ozone` did not cause regression):
https://github.com/adoroszlai/ozone/actions/runs/7505840912