### PR TITLE
HDDS-10117. ChunkKeyHandler does not close XceiverClient in case of exception

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientFactory.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -25,7 +24,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 /**
  * Interface to provide XceiverClient when needed.
  */
-public interface XceiverClientFactory extends Closeable {
+public interface XceiverClientFactory extends AutoCloseable {
 
   XceiverClientSpi acquireClient(Pipeline pipeline) throws IOException;
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hdds.scm;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -62,7 +61,7 @@ import org.slf4j.LoggerFactory;
  * without reestablishing connection. But the connection will be closed if
  * not being used for a period of time.
  */
-public class XceiverClientManager implements Closeable, XceiverClientFactory {
+public class XceiverClientManager implements XceiverClientFactory {
   private static final Logger LOG =
       LoggerFactory.getLogger(XceiverClientManager.class);
   //TODO : change this to SCM configuration class

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/IOUtils.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.utils;
 
 import org.slf4j.Logger;
 
-import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -40,11 +39,11 @@ public final class IOUtils {
    *                   null.
    * @param closeables the objects to close
    */
-  public static void cleanupWithLogger(Logger logger, Closeable... closeables) {
+  public static void cleanupWithLogger(Logger logger, AutoCloseable... closeables) {
     if (closeables == null) {
       return;
     }
-    for (Closeable c : closeables) {
+    for (AutoCloseable c : closeables) {
       if (c != null) {
         try {
           c.close();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/replication/TestContainerReplication.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
@@ -88,13 +89,8 @@ class TestContainerReplication {
   }
 
   @AfterAll
-  static void tearDown() throws IOException {
-    if (clientFactory != null) {
-      clientFactory.close();
-    }
-    if (cluster != null) {
-      cluster.shutdown();
-    }
+  static void tearDown() {
+    IOUtils.closeQuietly(clientFactory, cluster);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ChunkKeyHandler` may not release `xceiverClient` (and thus close `ManagedChannel`) if exception is encountered.

This can be reproduced by running `TestOzoneDebugShell` with Java 17 with the fix for HDDS-10123.  `ChunkKeyHandler` throws exception due to GSON not being able to set some fields via reflection (HDDS-10122).  `xceiverClient` is not released, and test log shows:

```
SEVERE: *~*~*~ Previous channel ManagedChannelImpl{logId=209, target=127.0.0.1:15011} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
	at org.apache.ratis.thirdparty.io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:102)
	at org.apache.ratis.thirdparty.io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:60)
	at org.apache.ratis.thirdparty.io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:51)
	at org.apache.ratis.thirdparty.io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:631)
	at org.apache.ratis.thirdparty.io.grpc.internal.AbstractManagedChannelImplBuilder.build(AbstractManagedChannelImplBuilder.java:297)
	at org.apache.hadoop.hdds.scm.XceiverClientGrpc.connectToDatanode(XceiverClientGrpc.java:178)
	at org.apache.hadoop.hdds.scm.XceiverClientGrpc.reconnect(XceiverClientGrpc.java:574)
	at org.apache.hadoop.hdds.scm.XceiverClientGrpc.checkOpen(XceiverClientGrpc.java:565)
	at org.apache.hadoop.hdds.scm.XceiverClientGrpc.sendCommandAsync(XceiverClientGrpc.java:495)
	at org.apache.hadoop.hdds.scm.XceiverClientGrpc.sendCommandOnAllNodes(XceiverClientGrpc.java:279)
	at org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls.getBlockFromAllNodes(ContainerProtocolCalls.java:690)
	at org.apache.hadoop.ozone.debug.ChunkKeyHandler.execute(ChunkKeyHandler.java:141)
```

https://issues.apache.org/jira/browse/HDDS-10117

## How was this patch tested?

Tested the fix on top of HDDS-10123.  GSON still doesn't work, but `xceiverClient` is no longer leaked.

CI:
https://github.com/adoroszlai/ozone/actions/runs/7510787779