### PR TITLE
HDDS-10125. Verify config key does not duplicate prefix

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigFileGenerator.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigFileGenerator.java
@@ -138,7 +138,7 @@ public class ConfigFileGenerator extends AbstractProcessor {
                 "@%s(key = \"%s\") should not duplicate prefix from @%s(\"%s\")",
                 Config.class.getSimpleName(), configAnnotation.key(),
                 ConfigGroup.class.getSimpleName(), configGroup.prefix());
-            processingEnv.getMessager().printMessage(Kind.ERROR, msg, typeElement);
+            processingEnv.getMessager().printMessage(Kind.ERROR, msg, element);
             continue;
           }
 

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigFileGenerator.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigFileGenerator.java
@@ -127,13 +127,20 @@ public class ConfigFileGenerator extends AbstractProcessor {
   private void writeConfigAnnotations(ConfigGroup configGroup,
       ConfigFileAppender appender,
       TypeElement typeElement) {
-    //check if any of the setters are annotated with @Config
     for (Element element : typeElement.getEnclosedElements()) {
       if (element.getKind() == ElementKind.FIELD) {
         if (element.getAnnotation(Config.class) != null) {
 
-          //update the ozone-site-generated.xml
           Config configAnnotation = element.getAnnotation(Config.class);
+
+          if (configAnnotation.key().startsWith(configGroup.prefix())) {
+            String msg = String.format(
+                "@%s(key = \"%s\") should not duplicate prefix from @%s(\"%s\")",
+                Config.class.getSimpleName(), configAnnotation.key(),
+                ConfigGroup.class.getSimpleName(), configGroup.prefix());
+            processingEnv.getMessager().printMessage(Kind.ERROR, msg, typeElement);
+            continue;
+          }
 
           String key = configGroup.prefix() + "."
               + configAnnotation.key();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check fields annotated with `@Config` in classes with `@ConfigGroup` such that the `Config#key` field does not begin with the `ConfigGroup#prefix`.

https://issues.apache.org/jira/browse/HDDS-10125

## How was this patch tested?

Verified that build fails without the fix for HDDS-10105:

```
[INFO] --- maven-compiler-plugin:3.9.0:compile (default-compile) @ hdds-container-service ---
...
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java:[551,19] @Config(key = "hdds.datanode.check.empty.container.dir.on.delete") should not duplicate prefix from @ConfigGroup("hdds.datanode")
[INFO] 1 error
[INFO] -------------------------------------------------------------
```

https://github.com/adoroszlai/ozone/actions/runs/7517992062/job/20464810977#step:6:1511

and passes with the fix for HDDS-10105:
https://github.com/adoroszlai/ozone/actions/runs/7518332900