### PR TITLE
HDDS-10131. TestTarContainerPacker fails with Java 17

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -382,7 +382,7 @@ public class TestTarContainerPacker {
 
   private File writeSingleFile(Path parentPath, String fileName,
       String content) throws IOException {
-    Path path = parentPath.resolve(fileName);
+    Path path = parentPath.resolve(fileName).normalize();
     Files.createDirectories(path.getParent());
     File file = path.toFile();
     FileOutputStream fileStream = new FileOutputStream(file);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `TestTarContainerPacker` for Java 17:

```
FileNotFoundException: target/test/data/packer-source-dir/111/metadata/db/../db_file (No such file or directory)
  at java.base/java.io.FileOutputStream.open0(Native Method)
  ...
  at org.apache.hadoop.ozone.container.keyvalue.TestTarContainerPacker.writeSingleFile(TestTarContainerPacker.java:388)
  at org.apache.hadoop.ozone.container.keyvalue.TestTarContainerPacker.writeDbFile(TestTarContainerPacker.java:379)
  at org.apache.hadoop.ozone.container.keyvalue.TestTarContainerPacker.unpackContainerDataWithInvalidRelativeDbFilePath(TestTarContainerPacker.java:319)
```

https://issues.apache.org/jira/browse/HDDS-10131

## How was this patch tested?

```
$ JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
  ./hadoop-ozone/dev-support/checks/junit.sh -DexcludedGroups=unhealthy \
  -am -pl :hdds-container-service -Dtest='TestTarContainerPacker'
...
[INFO] Tests run: 200, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.977 s -- in org.apache.hadoop.ozone.container.keyvalue.TestTarContainerPacker
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7538141502