### PR TITLE
HDDS-10130. TestSecureOzoneManager.testSecureOmInitFailure fails with Java 17

### DIFF
--- a/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
@@ -106,10 +106,6 @@
     <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
   </Match>
   <Match>
-    <Class name="org.apache.hadoop.ozone.om.TestSecureOzoneManager"/>
-    <Bug pattern="UWF_NULL_FIELD" />
-  </Match>
-  <Match>
     <Class name="org.apache.hadoop.ozone.om.TestOmMetrics"/>
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
   </Match>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -51,6 +51,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
 import static org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import static org.apache.ozone.test.GenericTestUtils.getTempPath;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -224,8 +225,9 @@ public class TestSecureOzoneManager {
     config.set(OZONE_OM_ADDRESS_KEY, "om-unknown");
     RuntimeException rte = assertThrows(RuntimeException.class,
         () -> OzoneManager.initializeSecurity(config, omStorage, scmId));
-    assertEquals("Can't get SCM signed certificate. omRpcAdd:" +
-        " om-unknown:9862", rte.getMessage());
+    assertThat(rte)
+        .hasMessageStartingWith("Can't get SCM signed certificate. omRpcAdd: om-unknown")
+        .hasMessageEndingWith(":9862");
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -48,7 +48,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
-import static org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -93,12 +92,9 @@ class TestSecureOzoneManager {
   void testSecureOmInitFailures() throws Exception {
     PrivateKey privateKey;
     PublicKey publicKey;
-    LogCapturer omLogs =
-        LogCapturer.captureLogs(OzoneManager.getLogger());
     OMStorage omStorage = new OMStorage(conf);
     omStorage.setClusterId(clusterId);
     omStorage.setOmId(omId);
-    omLogs.clearOutput();
 
     // Case 1: When keypair as well as certificate is missing. Initial keypair
     // boot-up. Get certificate will fail when SCM is not running.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.security.OMCertificateClient;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -64,7 +63,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class TestSecureOzoneManager {
 
   private static final String COMPONENT = "om";
-  private MiniOzoneCluster cluster = null;
   private OzoneConfiguration conf;
   private String clusterId;
   private String scmId;
@@ -100,9 +98,6 @@ public class TestSecureOzoneManager {
    */
   @AfterEach
   public void shutdown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
     FileUtils.deleteQuietly(metaDir.toFile());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Test secure Ozone Manager operation in distributed handler scenario.
  */
 @Timeout(25)
-public class TestSecureOzoneManager {
+class TestSecureOzoneManager {
 
   private static final String COMPONENT = "om";
   private OzoneConfiguration conf;
@@ -71,7 +71,7 @@ public class TestSecureOzoneManager {
   private HddsProtos.OzoneManagerDetailsProto omInfo;
 
   @BeforeEach
-  public void init() throws Exception {
+  void init() throws Exception {
     conf = new OzoneConfiguration();
     clusterId = UUID.randomUUID().toString();
     scmId = UUID.randomUUID().toString();
@@ -89,7 +89,7 @@ public class TestSecureOzoneManager {
   }
 
   @AfterEach
-  public void shutdown() {
+  void shutdown() {
     FileUtils.deleteQuietly(metaDir.toFile());
   }
 
@@ -97,7 +97,7 @@ public class TestSecureOzoneManager {
    * Test failure cases for secure OM initialization.
    */
   @Test
-  public void testSecureOmInitFailures() throws Exception {
+  void testSecureOmInitFailures() throws Exception {
     PrivateKey privateKey;
     PublicKey publicKey;
     LogCapturer omLogs =
@@ -204,7 +204,7 @@ public class TestSecureOzoneManager {
    * Test om bind socket address.
    */
   @Test
-  public void testSecureOmInitFailure() throws Exception {
+  void testSecureOmInitFailure() throws Exception {
     OzoneConfiguration config = new OzoneConfiguration(conf);
     OMStorage omStorage = new OMStorage(config);
     omStorage.setClusterId(clusterId);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -70,11 +70,6 @@ public class TestSecureOzoneManager {
   private Path metaDir;
   private HddsProtos.OzoneManagerDetailsProto omInfo;
 
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   * Ozone is made active by setting OZONE_ENABLED = true
-   */
   @BeforeEach
   public void init() throws Exception {
     conf = new OzoneConfiguration();
@@ -93,9 +88,6 @@ public class TestSecureOzoneManager {
     omInfo = OzoneManager.getOmDetailsProto(conf, omId);
   }
 
-  /**
-   * Shutdown MiniDFSCluster.
-   */
   @AfterEach
   public void shutdown() {
     FileUtils.deleteQuietly(metaDir.toFile());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -28,10 +28,10 @@ import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.apache.hadoop.ozone.security.OMCertificateClient;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.bouncycastle.cert.X509CertificateHolder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,7 +49,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
 import static org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import static org.apache.ozone.test.GenericTestUtils.getTempPath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -67,6 +66,7 @@ class TestSecureOzoneManager {
   private String clusterId;
   private String scmId;
   private String omId;
+  @TempDir
   private Path metaDir;
   private HddsProtos.OzoneManagerDetailsProto omInfo;
 
@@ -81,16 +81,9 @@ class TestSecureOzoneManager {
     conf.set(HADOOP_SECURITY_AUTHENTICATION, KERBEROS.toString());
     conf.setInt(IPC_CLIENT_CONNECT_MAX_RETRIES_KEY, 2);
     conf.set(OZONE_SCM_NAMES, "localhost");
-    final String path = getTempPath(UUID.randomUUID().toString());
-    metaDir = Paths.get(path, "om-meta");
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDir.toString());
     OzoneManager.setTestSecureOmFlag(true);
     omInfo = OzoneManager.getOmDetailsProto(conf, omId);
-  }
-
-  @AfterEach
-  void shutdown() {
-    FileUtils.deleteQuietly(metaDir.toFile());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `TestSecureOzoneManager` failure when run with Java 17 (see HADOOP-17910 for similar issue):

```
AssertionFailedError: expected: <Can't get SCM signed certificate. omRpcAdd: om-unknown:9862> but was: <Can't get SCM signed certificate. omRpcAdd: om-unknown/<unresolved>:9862>
```

Additionally, some cleanup (as separate commits).

https://issues.apache.org/jira/browse/HDDS-10130

## How was this patch tested?

```
$ JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
  ./hadoop-ozone/dev-support/checks/junit.sh -DexcludedGroups=unhealthy \
  -am -pl :ozone-integration-test -Dtest='TestSecureOzoneManager'
...
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.891 s -- in org.apache.hadoop.ozone.om.TestSecureOzoneManager
```

CI (still with Java 8):
https://github.com/adoroszlai/ozone/actions/runs/7538490881