### PR TITLE
HDDS-9997. Add static import for assertions and mocks in misc. integration tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -52,9 +52,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
 
 import static org.apache.hadoop.hdds.StringUtils.string2Bytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Test OzoneFSInputStream by reading through multiple interfaces.
@@ -147,11 +148,11 @@ public class TestOzoneFSInputStream {
           break;
         }
         value[i] = (byte) val;
-        Assertions.assertEquals(value[i], data[i], "value mismatch at:" + i);
+        assertEquals(value[i], data[i], "value mismatch at:" + i);
         i++;
       }
-      Assertions.assertEquals(i, data.length);
-      Assertions.assertArrayEquals(value, data);
+      assertEquals(i, data.length);
+      assertArrayEquals(value, data);
     }
   }
 
@@ -169,8 +170,8 @@ public class TestOzoneFSInputStream {
         System.arraycopy(tmp, 0, value, i * tmp.length, tmp.length);
         i++;
       }
-      Assertions.assertEquals((long) i * tmp.length, data.length);
-      Assertions.assertArrayEquals(value, data);
+      assertEquals((long) i * tmp.length, data.length);
+      assertArrayEquals(value, data);
     }
   }
 
@@ -181,12 +182,12 @@ public class TestOzoneFSInputStream {
       ByteBuffer buffer = ByteBuffer.allocate(1024 * 1024);
       int byteRead = inputStream.read(buffer);
 
-      Assertions.assertEquals(byteRead, 1024 * 1024);
+      assertEquals(byteRead, 1024 * 1024);
 
       byte[] value = new byte[1024 * 1024];
       System.arraycopy(data, 0, value, 0, value.length);
 
-      Assertions.assertArrayEquals(value, buffer.array());
+      assertArrayEquals(value, buffer.array());
     }
   }
 
@@ -208,7 +209,7 @@ public class TestOzoneFSInputStream {
     in.sync(0);
     blockStart = in.getPosition();
     // The behavior should be consistent with HDFS
-    Assertions.assertEquals(srcfile.length(), blockStart);
+    assertEquals(srcfile.length(), blockStart);
     in.close();
   }
 
@@ -230,7 +231,7 @@ public class TestOzoneFSInputStream {
     in.sync(0);
     blockStart = in.getPosition();
     // The behavior should be consistent with HDFS
-    Assertions.assertEquals(srcfile.length(), blockStart);
+    assertEquals(srcfile.length(), blockStart);
     in.close();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -35,10 +35,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Ozone Prefix Parser.
@@ -115,18 +116,12 @@ public class TestOzoneFileSystemPrefixParser {
   private void assertPrefixStats(PrefixParser parser, int volumeCount,
       int bucketCount, int intermediateDirCount, int nonExistentDirCount,
       int fileCount, int dirCount) {
-    Assertions.assertEquals(volumeCount,
-        parser.getParserStats(PrefixParser.Types.VOLUME));
-    Assertions.assertEquals(bucketCount,
-        parser.getParserStats(PrefixParser.Types.BUCKET));
-    Assertions.assertEquals(intermediateDirCount,
-        parser.getParserStats(PrefixParser.Types.INTERMEDIATE_DIRECTORY));
-    Assertions.assertEquals(nonExistentDirCount,
-        parser.getParserStats(PrefixParser.Types.NON_EXISTENT_DIRECTORY));
-    Assertions.assertEquals(fileCount,
-        parser.getParserStats(PrefixParser.Types.FILE));
-    Assertions.assertEquals(dirCount,
-        parser.getParserStats(PrefixParser.Types.DIRECTORY));
+    assertEquals(volumeCount, parser.getParserStats(PrefixParser.Types.VOLUME));
+    assertEquals(bucketCount, parser.getParserStats(PrefixParser.Types.BUCKET));
+    assertEquals(intermediateDirCount, parser.getParserStats(PrefixParser.Types.INTERMEDIATE_DIRECTORY));
+    assertEquals(nonExistentDirCount, parser.getParserStats(PrefixParser.Types.NON_EXISTENT_DIRECTORY));
+    assertEquals(fileCount, parser.getParserStats(PrefixParser.Types.FILE));
+    assertEquals(dirCount, parser.getParserStats(PrefixParser.Types.DIRECTORY));
   }
 
   private void testPrefixParseWithInvalidPaths() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithStreaming.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithStreaming.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.SelectorOutputStream;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -55,6 +54,9 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOU
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Ozone file system tests with Streaming.
@@ -152,7 +154,7 @@ public class TestOzoneFileSystemWithStreaming {
 
     final OutputStream wrapped = out.getWrappedStream();
     LOG.info("wrapped: {}", wrapped.getClass());
-    Assertions.assertEquals(SelectorOutputStream.class, wrapped.getClass());
+    assertEquals(SelectorOutputStream.class, wrapped.getClass());
     final SelectorOutputStream<?> selector = (SelectorOutputStream<?>) wrapped;
     final boolean belowThreshold = data.length <= AUTO_THRESHOLD;
     LOG.info("data.length={}, threshold={}, belowThreshold? {}",
@@ -161,13 +163,12 @@ public class TestOzoneFileSystemWithStreaming {
 
     out.close();
     final OutputStream underlying = selector.getUnderlying();
-    Assertions.assertNotNull(underlying);
+    assertNotNull(underlying);
     LOG.info("underlying after close: {}", underlying.getClass());
     if (belowThreshold) {
-      Assertions.assertTrue(underlying instanceof OzoneFSOutputStream);
+      assertInstanceOf(OzoneFSOutputStream.class, underlying);
     } else {
-      Assertions.assertEquals(OzoneFSDataStreamOutput.class,
-          underlying.getClass());
+      assertEquals(OzoneFSDataStreamOutput.class, underlying.getClass());
     }
   }
 
@@ -177,10 +178,10 @@ public class TestOzoneFileSystemWithStreaming {
     LOG.info("underlying before close: {}", underlying != null ?
         underlying.getClass() : null);
     if (belowThreshold) {
-      Assertions.assertNull(underlying);
+      assertNull(underlying);
     } else {
-      Assertions.assertNotNull(underlying);
-      Assertions.assertEquals(OzoneFSDataStreamOutput.class,
+      assertNotNull(underlying);
+      assertEquals(OzoneFSDataStreamOutput.class,
           underlying.getClass());
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.upgrade.UpgradeTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,6 +55,11 @@ import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.CLOSED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests upgrade finalization failure scenarios and corner cases specific to SCM
@@ -167,7 +171,7 @@ public class TestScmHAFinalization {
 
     // Make sure the original SCM leader is not the leader anymore.
     StorageContainerManager newLeaderScm  = cluster.getActiveSCM();
-    Assertions.assertNotEquals(newLeaderScm.getSCMNodeId(),
+    assertNotEquals(newLeaderScm.getSCMNodeId(),
         oldLeaderScm.getSCMNodeId());
 
     // Resume finalization from the new leader.
@@ -288,7 +292,7 @@ public class TestScmHAFinalization {
         inactiveScm, 0, NUM_DATANODES);
 
     // Use log to verify a snapshot was installed.
-    Assertions.assertTrue(logCapture.getOutput().contains("New SCM snapshot " +
+    assertTrue(logCapture.getOutput().contains("New SCM snapshot " +
         "received with metadata layout version"));
   }
 
@@ -319,35 +323,31 @@ public class TestScmHAFinalization {
     for (StorageContainerManager scm: scms) {
       switch (haltingPoint) {
       case BEFORE_PRE_FINALIZE_UPGRADE:
-        Assertions.assertFalse(
-            scm.getPipelineManager().isPipelineCreationFrozen());
-        Assertions.assertEquals(
+        assertFalse(scm.getPipelineManager().isPipelineCreationFrozen());
+        assertEquals(
             scm.getScmContext().getFinalizationCheckpoint(),
             FinalizationCheckpoint.FINALIZATION_REQUIRED);
         break;
       case AFTER_PRE_FINALIZE_UPGRADE:
-        Assertions.assertTrue(
-            scm.getPipelineManager().isPipelineCreationFrozen());
-        Assertions.assertEquals(
+        assertTrue(scm.getPipelineManager().isPipelineCreationFrozen());
+        assertEquals(
             scm.getScmContext().getFinalizationCheckpoint(),
             FinalizationCheckpoint.FINALIZATION_STARTED);
         break;
       case AFTER_COMPLETE_FINALIZATION:
-        Assertions.assertFalse(
-            scm.getPipelineManager().isPipelineCreationFrozen());
-        Assertions.assertEquals(
+        assertFalse(scm.getPipelineManager().isPipelineCreationFrozen());
+        assertEquals(
             scm.getScmContext().getFinalizationCheckpoint(),
             FinalizationCheckpoint.MLV_EQUALS_SLV);
         break;
       case AFTER_POST_FINALIZE_UPGRADE:
-        Assertions.assertFalse(
-            scm.getPipelineManager().isPipelineCreationFrozen());
-        Assertions.assertEquals(
+        assertFalse(scm.getPipelineManager().isPipelineCreationFrozen());
+        assertEquals(
             scm.getScmContext().getFinalizationCheckpoint(),
             FinalizationCheckpoint.FINALIZATION_COMPLETE);
         break;
       default:
-        Assertions.fail("Unknown halting point in test: " + haltingPoint);
+        fail("Unknown halting point in test: " + haltingPoint);
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -35,8 +35,10 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils.VoidCallable;
 import org.apache.ratis.util.function.CheckedConsumer;
-import org.junit.jupiter.api.Assertions;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Helper class for Tests.
@@ -92,7 +94,7 @@ public final class OzoneTestUtils {
             .updateContainerState(ContainerID.valueOf(blockID.getContainerID()),
                 HddsProtos.LifeCycleEvent.CLOSE);
       }
-      Assertions.assertFalse(scm.getContainerManager()
+      assertFalse(scm.getContainerManager()
           .getContainer(ContainerID.valueOf(blockID.getContainerID()))
           .isOpen());
     }, omKeyLocationInfoGroups);
@@ -140,14 +142,10 @@ public final class OzoneTestUtils {
 
   public static <E extends Throwable> void expectOmException(
       OMException.ResultCodes code,
-      VoidCallable eval)
-      throws Exception {
-    try {
-      eval.call();
-      Assertions.fail("OMException is expected");
-    } catch (OMException ex) {
-      Assertions.assertEquals(code, ex.getResult());
-    }
+      VoidCallable eval) {
+
+    OMException ex = assertThrows(OMException.class, () -> eval.call(), "OMException is expected");
+    assertEquals(code, ex.getResult());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokensCLI.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokensCLI.java
@@ -71,11 +71,13 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_F
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
+
 /**
  * Integration test class to verify block token CLI commands functionality in a
  * secure cluster.
@@ -264,7 +266,7 @@ public final class TestBlockTokensCLI {
     // rotating.
     String currentKey =
         getScmSecretKeyManager().getCurrentSecretKey().toString();
-    Assertions.assertEquals(initialKey, currentKey);
+    assertEquals(initialKey, currentKey);
 
     // Rotate the secret key.
     ozoneAdmin.execute(args);
@@ -280,9 +282,9 @@ public final class TestBlockTokensCLI {
     // Otherwise, both keys should be the same.
     if (isForceFlagPresent(args) ||
         shouldRotate(getScmSecretKeyManager().getCurrentSecretKey())) {
-      Assertions.assertNotEquals(initialKey, newKey);
+      assertNotEquals(initialKey, newKey);
     } else {
-      Assertions.assertEquals(initialKey, newKey);
+      assertEquals(initialKey, newKey);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerOperations.java
@@ -40,9 +40,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This class tests container operations (TODO currently only supports create)
@@ -93,13 +95,13 @@ public class TestContainerOperations {
   public void testGetPipeline() throws Exception {
     try {
       storageClient.getPipeline(PipelineID.randomId().getProtobuf());
-      Assertions.fail("Get Pipeline should fail");
+      fail("Get Pipeline should fail");
     } catch (Exception e) {
       assertTrue(
           SCMHAUtils.unwrapException(e) instanceof PipelineNotFoundException);
     }
 
-    Assertions.assertFalse(storageClient.listPipelines().isEmpty());
+    assertFalse(storageClient.listPipelines().isEmpty());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
@@ -41,11 +41,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests the idempotent operations in ContainerStateMachine.
@@ -115,7 +115,7 @@ public class TestContainerStateMachineIdempotency {
       ContainerProtocolCalls.closeContainer(client, containerID, null);
       ContainerProtocolCalls.closeContainer(client, containerID, null);
     } catch (IOException ioe) {
-      Assertions.fail("Container operation failed" + ioe);
+      fail("Container operation failed" + ioe);
     }
     xceiverClientManager.releaseClient(client, false);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneOMHACluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneOMHACluster.java
@@ -29,12 +29,13 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * This class tests MiniOzoneHAClusterImpl.
@@ -52,7 +53,7 @@ public class TestMiniOzoneOMHACluster {
   /**
    * Create a MiniOzoneHAClusterImpl for testing.
    *
-   * @throws IOException
+   * @throws Exception
    */
   @BeforeEach
   public void init() throws Exception {
@@ -91,9 +92,8 @@ public class TestMiniOzoneOMHACluster {
       ozoneManager.set(om);
       return om != null;
     }, 100, 120000);
-    Assertions.assertNotNull(ozoneManager, "Timed out waiting OM leader election to finish: "
+    assertNotNull(ozoneManager, "Timed out waiting OM leader election to finish: "
             + "no leader or more than one leader.");
-    Assertions.assertTrue(ozoneManager.get().isLeaderReady(),
-            "Should have gotten the leader!");
+    assertTrue(ozoneManager.get().isLeaderReady(), "Should have gotten the leader!");
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +52,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -89,13 +89,13 @@ public class TestMultipartObjectGet {
     client = cluster.newClient();
     client.getObjectStore().createS3Bucket(BUCKET);
 
-    headers = Mockito.mock(HttpHeaders.class);
+    headers = mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(
         "STANDARD");
 
-    context = Mockito.mock(ContainerRequestContext.class);
-    Mockito.when(context.getUriInfo()).thenReturn(Mockito.mock(UriInfo.class));
-    Mockito.when(context.getUriInfo().getQueryParameters())
+    context = mock(ContainerRequestContext.class);
+    when(context.getUriInfo()).thenReturn(mock(UriInfo.class));
+    when(context.getUriInfo().getQueryParameters())
         .thenReturn(new MultivaluedHashMap<>());
 
     REST.setHeaders(headers);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -62,6 +61,8 @@ import java.util.TreeMap;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class tests `ozone debug ldb` CLI that reads from a RocksDB directory.
@@ -218,7 +219,7 @@ public class TestLDBCli {
     int exitCode = cmd.execute(completeScanArgs.toArray(new String[0]));
     // Check exit code. Print stderr if not expected
     int expectedExitCode = expectedExitCodeStderrPair.getLeft();
-    Assertions.assertEquals(expectedExitCode, exitCode, stderr.toString());
+    assertEquals(expectedExitCode, exitCode, stderr.toString());
 
     // Construct expected result map given test param input
     Map<String, Map<String, ?>> expectedMap;
@@ -235,7 +236,7 @@ public class TestLDBCli {
 
     // Check stderr
     final String stderrShouldContain = expectedExitCodeStderrPair.getRight();
-    Assertions.assertTrue(stderr.toString().contains(stderrShouldContain));
+    assertTrue(stderr.toString().contains(stderrShouldContain));
   }
 
   @Test
@@ -251,13 +252,13 @@ public class TestLDBCli {
 
     int exitCode = cmd.execute(completeScanArgs.toArray(new String[0]));
     // Check exit code. Print stderr if not expected
-    Assertions.assertEquals(0, exitCode, stderr.toString());
+    assertEquals(0, exitCode, stderr.toString());
 
     // Check stdout
-    Assertions.assertEquals("{  }\n", stdout.toString());
+    assertEquals("{  }\n", stdout.toString());
 
     // Check stderr
-    Assertions.assertEquals("", stderr.toString());
+    assertEquals("", stderr.toString());
   }
 
   /**
@@ -271,7 +272,7 @@ public class TestLDBCli {
     Map<Object, ? extends Map<Object, ?>> actualMap = MAPPER.readValue(
         actualStr, new TypeReference<Map<Object, Map<Object, ?>>>() { });
 
-    Assertions.assertEquals(expected, actualMap);
+    assertEquals(expected, actualMap);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidate.java
@@ -23,11 +23,14 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests Freon, with MiniOzoneCluster and validate data.
@@ -76,10 +79,10 @@ public abstract class TestDataValidate {
         "--validate-writes"
     );
 
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
-    Assertions.assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
+    assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
   }
 
   @Test
@@ -95,14 +98,12 @@ public abstract class TestDataValidate {
         "--validate-writes"
     );
 
-    Assertions.assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assertions.assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assertions.assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
-    Assertions.assertTrue(randomKeyGenerator.getValidateWrites());
-    Assertions.assertNotEquals(0, randomKeyGenerator.getTotalKeysValidated());
-    Assertions.assertNotEquals(0, randomKeyGenerator
-        .getSuccessfulValidationCount());
-    Assertions.assertEquals(0, randomKeyGenerator
-        .getUnsuccessfulValidationCount());
+    assertEquals(2, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(10, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(100, randomKeyGenerator.getNumberOfKeysAdded());
+    assertTrue(randomKeyGenerator.getValidateWrites());
+    assertNotEquals(0, randomKeyGenerator.getTotalKeysValidated());
+    assertNotEquals(0, randomKeyGenerator.getSuccessfulValidationCount());
+    assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithDatanodeFastRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithDatanodeFastRestart.java
@@ -28,13 +28,14 @@ import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import picocli.CommandLine;
-
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests Freon with Datanode restarts without waiting for pipeline to close.
@@ -86,14 +87,13 @@ public class TestFreonWithDatanodeFastRestart {
     String expectedSnapFile =
         storage.getSnapshotFile(termIndexBeforeRestart.getTerm(),
             termIndexBeforeRestart.getIndex()).getAbsolutePath();
-    Assertions.assertEquals(expectedSnapFile,
-        snapshotInfo.getFile().getPath().toString());
-    Assertions.assertEquals(termInSnapshot, termIndexBeforeRestart);
+    assertEquals(expectedSnapFile, snapshotInfo.getFile().getPath().toString());
+    assertEquals(termInSnapshot, termIndexBeforeRestart);
 
     // After restart the term index might have progressed to apply pending
     // transactions.
     TermIndex termIndexAfterRestart = sm.getLastAppliedTermIndex();
-    Assertions.assertTrue(termIndexAfterRestart.getIndex() >=
+    assertTrue(termIndexAfterRestart.getIndex() >=
         termIndexBeforeRestart.getIndex());
     // TODO: fix me
     // Give some time for the datanode to register again with SCM.
@@ -119,10 +119,10 @@ public class TestFreonWithDatanodeFastRestart {
         "--validate-writes"
     );
 
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
-    Assertions.assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
+    assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
   }
 
   private StateMachine getStateMachine() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithPipelineDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithPipelineDestroy.java
@@ -31,13 +31,13 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
-
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests Freon with Pipeline destroy.
@@ -114,11 +114,10 @@ public class TestFreonWithPipelineDestroy {
         "--validate-writes"
     );
 
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
-    Assertions.assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
-    Assertions.assertEquals(0,
-        randomKeyGenerator.getUnsuccessfulValidationCount());
+    assertEquals(1, randomKeyGenerator.getNumberOfVolumesCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfBucketsCreated());
+    assertEquals(1, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(0, randomKeyGenerator.getUnsuccessfulValidationCount());
   }
 
   private void destroyPipeline() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -46,6 +45,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test for HadoopDirTreeGenerator.
@@ -157,7 +159,7 @@ public class TestHadoopDirTreeGenerator {
       int actualDepth =
           traverseToLeaf(fileSystem, fileStatus.getPath(), 1, depth, span,
               fileCount, StorageSize.parse(perFileSize, StorageUnit.BYTES));
-      Assertions.assertEquals(depth, actualDepth, "Mismatch depth in a path");
+      assertEquals(depth, actualDepth, "Mismatch depth in a path");
     }
   }
 
@@ -179,16 +181,16 @@ public class TestHadoopDirTreeGenerator {
         return traverseToLeaf(fs, fileStatus.getPath(), depth, expectedDepth,
                 expectedSpanCnt, expectedFileCnt, perFileSize);
       } else {
-        Assertions.assertEquals(perFileSize.toBytes(), fileStatus.getLen(), "Mismatches file len");
+        assertEquals(perFileSize.toBytes(), fileStatus.getLen(), "Mismatches file len");
         String fName = fileStatus.getPath().getName();
-        Assertions.assertFalse(files.contains(fName), actualNumFiles + "actualNumFiles:" + fName +
+        assertFalse(files.contains(fName), actualNumFiles + "actualNumFiles:" + fName +
                 ", fName:" + expectedFileCnt + ", expectedFileCnt:" + depth
                 + ", depth:");
         files.add(fName);
         actualNumFiles++;
       }
     }
-    Assertions.assertEquals(expectedFileCnt, actualNumFiles, "Mismatches files count in a directory");
+    assertEquals(expectedFileCnt, actualNumFiles, "Mismatches files count in a directory");
     return depth;
   }
 
@@ -200,7 +202,7 @@ public class TestHadoopDirTreeGenerator {
         ++actualSpan;
       }
     }
-    Assertions.assertEquals(expectedSpanCnt, actualSpan, "Mismatches subdirs count in a directory");
+    assertEquals(expectedSpanCnt, actualSpan, "Mismatches subdirs count in a directory");
     return actualSpan;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
@@ -32,7 +32,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
 import java.util.LinkedList;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -44,6 +43,7 @@ import java.io.IOException;
 import java.net.URI;
 
 import static org.apache.ozone.test.GenericTestUtils.getTempPath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for HadoopNestedDirGenerator.
@@ -142,7 +142,7 @@ public class TestHadoopNestedDirGenerator {
       // verify the num of peer directories and span directories
       p = depthBFS(fileSystem, fileStatuses, span, actualDepth);
       int actualSpan = spanCheck(fileSystem, span, p);
-      Assertions.assertEquals(span, actualSpan, "Mismatch span in a path");
+      assertEquals(span, actualSpan, "Mismatch span in a path");
     }
   }
 
@@ -182,7 +182,7 @@ public class TestHadoopNestedDirGenerator {
         p = f.getPath().getParent();
       }
     }
-    Assertions.assertEquals(depth, actualDepth, "Mismatch depth in a path");
+    assertEquals(depth, actualDepth, "Mismatch depth in a path");
     return p;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
@@ -46,7 +46,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -70,6 +69,10 @@ import static org.apache.hadoop.ozone.OzoneConsts.DB_COMPACTION_SST_BACKUP_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_DIFF_DIR;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.getColumnFamilyToKeyPrefixMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 
 /**
  * Tests Freon, with MiniOzoneCluster.
@@ -178,9 +181,8 @@ public class TestOMSnapshotDAG {
         "--validate-writes"
     );
 
-    Assertions.assertEquals(500L, randomKeyGenerator.getNumberOfKeysAdded());
-    Assertions.assertEquals(500L,
-        randomKeyGenerator.getSuccessfulValidationCount());
+    assertEquals(500L, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(500L, randomKeyGenerator.getSuccessfulValidationCount());
 
     List<OmVolumeArgs> volList = cluster.getOzoneManager()
         .listAllVolumes("", "", 2);
@@ -263,7 +265,7 @@ public class TestOMSnapshotDAG {
 
     // Same snapshot. Result should be empty list
     List<String> sstDiffList22 = differ.getSSTDiffList(snap2, snap2);
-    Assertions.assertTrue(sstDiffList22.isEmpty());
+    assertThat(sstDiffList22).isEmpty();
     snapDB1.close();
     snapDB2.close();
     snapDB3.close();
@@ -292,13 +294,13 @@ public class TestOMSnapshotDAG {
         ((RDBStore)((OmSnapshot)snapDB3.get())
             .getMetadataManager().getStore()).getDb().getManagedRocksDb());
     List<String> sstDiffList21Run2 = differ.getSSTDiffList(snap2, snap1);
-    Assertions.assertEquals(sstDiffList21, sstDiffList21Run2);
+    assertEquals(sstDiffList21, sstDiffList21Run2);
 
     List<String> sstDiffList32Run2 = differ.getSSTDiffList(snap3, snap2);
-    Assertions.assertEquals(sstDiffList32, sstDiffList32Run2);
+    assertEquals(sstDiffList32, sstDiffList32Run2);
 
     List<String> sstDiffList31Run2 = differ.getSSTDiffList(snap3, snap1);
-    Assertions.assertEquals(sstDiffList31, sstDiffList31Run2);
+    assertEquals(sstDiffList31, sstDiffList31Run2);
     snapDB1.close();
     snapDB2.close();
     snapDB3.close();
@@ -324,9 +326,8 @@ public class TestOMSnapshotDAG {
         "--validate-writes"
     );
 
-    Assertions.assertEquals(1000L, randomKeyGenerator.getNumberOfKeysAdded());
-    Assertions.assertEquals(1000L,
-        randomKeyGenerator.getSuccessfulValidationCount());
+    assertEquals(1000L, randomKeyGenerator.getNumberOfKeysAdded());
+    assertEquals(1000L, randomKeyGenerator.getSuccessfulValidationCount());
 
     String omMetadataDir =
         cluster.getOzoneManager().getConfiguration().get(OZONE_METADATA_DIRS);
@@ -338,7 +339,7 @@ public class TestOMSnapshotDAG {
     if (fileList != null) {
       for (File file : fileList) {
         if (file != null && file.isFile() && file.getName().endsWith(".log")) {
-          Assertions.assertEquals(0L, file.length());
+          assertEquals(0L, file.length());
         }
       }
     }
@@ -346,8 +347,8 @@ public class TestOMSnapshotDAG {
     Path sstBackupPath = Paths.get(omMetadataDir, OM_SNAPSHOT_DIFF_DIR,
         DB_COMPACTION_SST_BACKUP_DIR);
     fileList = sstBackupPath.toFile().listFiles();
-    Assertions.assertNotNull(fileList);
-    Assertions.assertEquals(0L, fileList.length);
+    assertNotNull(fileList);
+    assertEquals(0L, fileList.length);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.om.lock.OMLockMetrics;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -44,6 +43,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for OmBucketReadWriteKeyOps.
@@ -193,7 +195,7 @@ public class TestOmBucketReadWriteKeyOps {
       ozoneKeyIterator.next();
       ++actual;
     }
-    Assertions.assertEquals(expectedCount, actual, "Mismatch Count!");
+    assertEquals(expectedCount, actual, "Mismatch Count!");
   }
 
   private void verifyOMLockMetrics(OMLockMetrics omLockMetrics) {
@@ -204,7 +206,7 @@ public class TestOmBucketReadWriteKeyOps {
         omLockMetrics.getLongestReadLockWaitingTimeMs());
     int readWaitingSamples =
         Integer.parseInt(readLockWaitingTimeMsStat.split(" ")[2]);
-    Assertions.assertTrue(readWaitingSamples > 0, "Read Lock Waiting Samples should be positive");
+    assertTrue(readWaitingSamples > 0, "Read Lock Waiting Samples should be positive");
 
     String readLockHeldTimeMsStat = omLockMetrics.getReadLockHeldTimeMsStat();
     LOG.info("Read Lock Held Time Stat: " + readLockHeldTimeMsStat);
@@ -212,7 +214,7 @@ public class TestOmBucketReadWriteKeyOps {
         omLockMetrics.getLongestReadLockHeldTimeMs());
     int readHeldSamples =
         Integer.parseInt(readLockHeldTimeMsStat.split(" ")[2]);
-    Assertions.assertTrue(readHeldSamples > 0, "Read Lock Held Samples should be positive");
+    assertTrue(readHeldSamples > 0, "Read Lock Held Samples should be positive");
 
     String writeLockWaitingTimeMsStat =
         omLockMetrics.getWriteLockWaitingTimeMsStat();
@@ -221,7 +223,7 @@ public class TestOmBucketReadWriteKeyOps {
         omLockMetrics.getLongestWriteLockWaitingTimeMs());
     int writeWaitingSamples =
         Integer.parseInt(writeLockWaitingTimeMsStat.split(" ")[2]);
-    Assertions.assertTrue(writeWaitingSamples > 0, "Write Lock Waiting Samples should be positive");
+    assertTrue(writeWaitingSamples > 0, "Write Lock Waiting Samples should be positive");
 
     String writeLockHeldTimeMsStat = omLockMetrics.getWriteLockHeldTimeMsStat();
     LOG.info("Write Lock Held Time Stat: " + writeLockHeldTimeMsStat);
@@ -229,7 +231,7 @@ public class TestOmBucketReadWriteKeyOps {
         omLockMetrics.getLongestWriteLockHeldTimeMs());
     int writeHeldSamples =
         Integer.parseInt(writeLockHeldTimeMsStat.split(" ")[2]);
-    Assertions.assertTrue(writeHeldSamples > 0, "Write Lock Held Samples should be positive");
+    assertTrue(writeHeldSamples > 0, "Write Lock Held Samples should be positive");
   }
 
   private static class ParameterBuilder {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.segmentparser.SCMRatisLogParser;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -46,6 +45,9 @@ import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test Ozone OM and SCM HA Ratis log parser.
@@ -113,20 +115,20 @@ class TestOzoneHARatisLogParser {
 
     File omMetaDir = new File(ozoneConfiguration.get(OZONE_METADATA_DIRS),
         "ratis");
-    Assertions.assertTrue(omMetaDir.isDirectory());
+    assertThat(omMetaDir).isDirectory();
 
     String[] ratisDirs = omMetaDir.list();
-    Assertions.assertNotNull(ratisDirs);
-    Assertions.assertEquals(1, ratisDirs.length);
+    assertNotNull(ratisDirs);
+    assertEquals(1, ratisDirs.length);
 
     File groupDir = new File(omMetaDir, ratisDirs[0]);
 
-    Assertions.assertNotNull(groupDir);
-    Assertions.assertTrue(groupDir.isDirectory());
+    assertNotNull(groupDir);
+    assertThat(groupDir).isDirectory();
     File currentDir = new File(groupDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");
     GenericTestUtils.waitFor(logFile::exists, 100, 15000);
-    Assertions.assertTrue(logFile.isFile());
+    assertThat(logFile).isFile();
 
     OMRatisLogParser omRatisLogParser = new OMRatisLogParser();
     omRatisLogParser.setSegmentFile(logFile);
@@ -135,27 +137,26 @@ class TestOzoneHARatisLogParser {
 
     // Not checking total entry count, because of not sure of exact count of
     // metadata entry changes.
-    Assertions.assertTrue(out.toString(UTF_8.name())
-        .contains("Num Total Entries:"));
+    assertThat(out.toString(UTF_8.name())).contains("Num Total Entries:");
     out.reset();
 
     // Now check for SCM.
     File scmMetadataDir =
         new File(SCMHAUtils.getRatisStorageDir(leaderSCMConfig));
-    Assertions.assertTrue(scmMetadataDir.isDirectory());
+    assertThat(scmMetadataDir).isDirectory();
 
     ratisDirs = scmMetadataDir.list();
-    Assertions.assertNotNull(ratisDirs);
-    Assertions.assertEquals(1, ratisDirs.length);
+    assertNotNull(ratisDirs);
+    assertEquals(1, ratisDirs.length);
 
     groupDir = new File(scmMetadataDir, ratisDirs[0]);
 
-    Assertions.assertNotNull(groupDir);
-    Assertions.assertTrue(groupDir.isDirectory());
+    assertNotNull(groupDir);
+    assertThat(groupDir).isDirectory();
     currentDir = new File(groupDir, "current");
     logFile = new File(currentDir, "log_inprogress_1");
     GenericTestUtils.waitFor(logFile::exists, 100, 15000);
-    Assertions.assertTrue(logFile.isFile());
+    assertThat(logFile).isFile();
 
     SCMRatisLogParser scmRatisLogParser = new SCMRatisLogParser();
     scmRatisLogParser.setSegmentFile(logFile);
@@ -163,7 +164,6 @@ class TestOzoneHARatisLogParser {
 
     // Not checking total entry count, because of not sure of exact count of
     // metadata entry changes.
-    Assertions.assertTrue(out.toString(UTF_8.name())
-        .contains("Num Total Entries:"));
+    assertThat(out.toString(UTF_8.name())).contains("Num Total Entries:");
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +61,9 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZ
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_PATH_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -132,7 +134,7 @@ public class TestReconInsightsForDeletedDirectories {
         fs.delete(fileStatus.getPath(), true);
       }
     } catch (IOException ex) {
-      Assertions.fail("Failed to cleanup files.");
+      fail("Failed to cleanup files.");
     }
   }
 
@@ -201,7 +203,7 @@ public class TestReconInsightsForDeletedDirectories {
     }
 
     if (directoryObjectId == null) {
-      Assertions.fail("directoryObjectId is null. Test case cannot proceed.");
+      fail("directoryObjectId is null. Test case cannot proceed.");
     } else {
       // Retrieve Namespace Summary for dir1 from Recon.
       ReconNamespaceSummaryManagerImpl namespaceSummaryManager =
@@ -210,8 +212,8 @@ public class TestReconInsightsForDeletedDirectories {
       NSSummary summary =
           namespaceSummaryManager.getNSSummary(directoryObjectId);
       // Assert that the directory dir1 has 10 sub-files and size of 1000 bytes.
-      Assertions.assertEquals(10, summary.getNumOfFiles());
-      Assertions.assertEquals(10, summary.getSizeOfFiles());
+      assertEquals(10, summary.getNumOfFiles());
+      assertEquals(10, summary.getSizeOfFiles());
     }
 
     // Delete the entire directory dir1.
@@ -238,7 +240,7 @@ public class TestReconInsightsForDeletedDirectories {
     KeyInsightInfoResponse entity =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
     // Assert the size of deleted directory is 10.
-    Assertions.assertEquals(10, entity.getUnreplicatedDataSize());
+    assertEquals(10, entity.getUnreplicatedDataSize());
 
     // Cleanup the tables.
     cleanupTables();
@@ -327,7 +329,7 @@ public class TestReconInsightsForDeletedDirectories {
     KeyInsightInfoResponse entity =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
     // Assert the size of deleted directory is 3.
-    Assertions.assertEquals(3, entity.getUnreplicatedDataSize());
+    assertEquals(3, entity.getUnreplicatedDataSize());
 
     // Cleanup the tables.
     cleanupTables();
@@ -368,7 +370,7 @@ public class TestReconInsightsForDeletedDirectories {
     fs.delete(rootDir, true);
 
     // Verify that the directory is deleted
-    Assertions.assertFalse(fs.exists(rootDir), "Directory was not deleted");
+    assertFalse(fs.exists(rootDir), "Directory was not deleted");
 
     // Sync data from Ozone Manager to Recon.
     syncDataFromOM();
@@ -389,7 +391,7 @@ public class TestReconInsightsForDeletedDirectories {
     KeyInsightInfoResponse entity =
         (KeyInsightInfoResponse) deletedDirInfo.getEntity();
     // Assert the size of deleted directory is 100.
-    Assertions.assertEquals(100, entity.getUnreplicatedDataSize());
+    assertEquals(100, entity.getUnreplicatedDataSize());
 
     // Cleanup the tables.
     cleanupTables();
@@ -471,7 +473,7 @@ public class TestReconInsightsForDeletedDirectories {
       LOG.info("{} actual row count={}, expectedCount={}", table.getName(),
           count, expectedCount);
     } catch (IOException ex) {
-      Assertions.fail("Test failed with: " + ex);
+      fail("Test failed with: " + ex);
     }
     return count == expectedCount;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add static import for assertions and mocks in hadoop-hdds (only after all other subtasks for specific hadoop-hdds submodules are done).
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithStreaming.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestBlockTokensCLI.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerOperations.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneOMHACluster.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestDataValidate.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithDatanodeFastRestart.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestFreonWithPipelineDestroy.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOMSnapshotDAG.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/parser/TestOzoneHARatisLogParser.java
- hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconInsightsForDeletedDirectories.java

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9997

## How was this patch tested?
Tested the changes in ci-cd pipeline. 
Also converted some assertTrue to assertThat at some places
