### PR TITLE
HDDS-10138. NPE for SstFilteringService in OMDBCheckpointServlet.Lock

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -198,6 +198,7 @@ public class RDBStore implements DBStore {
     return snapshotsParentDir;
   }
 
+  @Override
   public RocksDBCheckpointDiffer getRocksDBCheckpointDiffer() {
     return rocksDBCheckpointDiffer;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -697,10 +697,12 @@ public class KeyManagerImpl implements KeyManager {
     return multipartUploadCleanupService;
   }
 
+  @Override
   public SstFilteringService getSnapshotSstFilteringService() {
     return snapshotSstFilteringService;
   }
 
+  @Override
   public SnapshotDeletingService getSnapshotDeletingService() {
     return snapshotDeletingService;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -664,7 +664,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         throws InterruptedException {
       // First lock all the handlers.
       keyDeletingService.getBootstrapStateLock().lock();
-      sstFilteringService.getBootstrapStateLock().lock();
+      if (sstFilteringService != null) {
+        sstFilteringService.getBootstrapStateLock().lock();
+      }
       rocksDbCheckpointDiffer.getBootstrapStateLock().lock();
       snapshotDeletingService.getBootstrapStateLock().lock();
 
@@ -677,7 +679,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     public void unlock() {
       snapshotDeletingService.getBootstrapStateLock().unlock();
       rocksDbCheckpointDiffer.getBootstrapStateLock().unlock();
-      sstFilteringService.getBootstrapStateLock().unlock();
+      if (sstFilteringService != null) {
+        sstFilteringService.getBootstrapStateLock().unlock();
+      }
       keyDeletingService.getBootstrapStateLock().unlock();
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -667,8 +667,12 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       if (sstFilteringService != null) {
         sstFilteringService.getBootstrapStateLock().lock();
       }
-      rocksDbCheckpointDiffer.getBootstrapStateLock().lock();
-      snapshotDeletingService.getBootstrapStateLock().lock();
+      if (rocksDbCheckpointDiffer != null) {
+        rocksDbCheckpointDiffer.getBootstrapStateLock().lock();
+      }
+      if (snapshotDeletingService != null) {
+        snapshotDeletingService.getBootstrapStateLock().lock();
+      }
 
       // Then wait for the double buffer to be flushed.
       om.awaitDoubleBufferFlush();
@@ -677,8 +681,12 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
     @Override
     public void unlock() {
-      snapshotDeletingService.getBootstrapStateLock().unlock();
-      rocksDbCheckpointDiffer.getBootstrapStateLock().unlock();
+      if (snapshotDeletingService != null) {
+        snapshotDeletingService.getBootstrapStateLock().unlock();
+      }
+      if (rocksDbCheckpointDiffer != null) {
+        rocksDbCheckpointDiffer.getBootstrapStateLock().unlock();
+      }
       if (sstFilteringService != null) {
         sstFilteringService.getBootstrapStateLock().unlock();
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 
-import org.apache.ratis.thirdparty.com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix NPE on OMDBCheckpointServlet caused by possible null SstFilteringService. The null SstFilteringService is due to configuration ozone.filesystem.snapshot.enabled=false or ozone.snapshot.filtering.service.interval=-1. 

When NPE is thrown in the call of OMDBCheckpointServlet.Lock, this cause the subsequent call to OMDBCheckpointServlet.Lock.lock to block indefinitely since the previous call that triggered the NPE did not release the lock held on keyDeletingService.

The current solution is a simple nullity check. There might be better solution to prevent the NPE than just a nullity check.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10138

## How was this patch tested?

Manual test.

Clean CI: https://github.com/ivandika3/ozone/actions/runs/7550769000
