### PR TITLE
HDDS-9944. NSSummary commands should close OzoneClient.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -106,7 +106,7 @@ public class DiskUsageSubCommand implements Callable {
     if (duResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
-      if (parent.isOBSBucketOrNotPresentInPath(path)) {
+      if (parent.isNotValidBucketOrOBSBucket(path)) {
         printBucketReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -106,8 +106,7 @@ public class DiskUsageSubCommand implements Callable {
     if (duResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
-      if (parent.isObjectStoreBucket(path) ||
-          !parent.bucketIsPresentInThePath(path)) {
+      if (parent.isOBSBucketOrNotPresentInPath(path)) {
         printBucketReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -80,7 +80,7 @@ public class FileSizeDistSubCommand implements Callable {
     } else if (distResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("File Size Distribution");
     } else {
-      if (parent.isOBSBucketOrNotPresentInPath(path)) {
+      if (parent.isNotValidBucketOrOBSBucket(path)) {
         printBucketReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -80,8 +80,7 @@ public class FileSizeDistSubCommand implements Callable {
     } else if (distResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("File Size Distribution");
     } else {
-      if (parent.isObjectStoreBucket(path) ||
-          !parent.bucketIsPresentInThePath(path)) {
+      if (parent.isOBSBucketOrNotPresentInPath(path)) {
         printBucketReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -37,7 +37,6 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Objects;
 
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_DEFAULT;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
@@ -111,7 +110,7 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
    * @return true if bucket is OBS bucket or not part of provided path.
    * @throws IOException
    */
-  public boolean isOBSBucketOrNotPresentInPath(String path) throws IOException {
+  public boolean isNotValidBucketOrOBSBucket(String path) throws IOException {
     OFSPath ofsPath = new OFSPath(path,
         OzoneConfiguration.of(getOzoneConfig()));
 
@@ -130,8 +129,7 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
     } finally {
       ozoneClient.close();
     }
-    boolean isOBSBucket = bucket != null ? isObjectStoreBucket(bucket, objectStore) : false;
-    return isOBSBucket || !Objects.nonNull(bucket);
+    return (null == bucket) || isObjectStoreBucket(bucket, objectStore);
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -113,11 +113,10 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
   public boolean isNotValidBucketOrOBSBucket(String path) {
     OFSPath ofsPath = new OFSPath(path,
         OzoneConfiguration.of(getOzoneConfig()));
-    OzoneBucket bucket;
     try (OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(getOzoneConfig())) {
       ObjectStore objectStore = ozoneClient.getObjectStore();
       // Checks if the bucket is part of the path.
-      bucket = objectStore.getVolume(ofsPath.getVolumeName())
+      OzoneBucket bucket = objectStore.getVolume(ofsPath.getVolumeName())
           .getBucket(ofsPath.getBucketName());
       return isObjectStoreBucket(bucket, objectStore);
     } catch (IOException e) {
@@ -125,7 +124,7 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
           "Bucket layout couldn't be verified for path: " + ofsPath +
               ". Exception: " + e);
     }
-    return false;
+    return true;
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -110,26 +110,22 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
    * @return true if bucket is OBS bucket or not part of provided path.
    * @throws IOException
    */
-  public boolean isNotValidBucketOrOBSBucket(String path) throws IOException {
+  public boolean isNotValidBucketOrOBSBucket(String path) {
     OFSPath ofsPath = new OFSPath(path,
         OzoneConfiguration.of(getOzoneConfig()));
-
-    OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(getOzoneConfig());
-    ObjectStore objectStore = ozoneClient.getObjectStore();
     OzoneBucket bucket;
-    try {
+    try (OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(getOzoneConfig())) {
+      ObjectStore objectStore = ozoneClient.getObjectStore();
       // Checks if the bucket is part of the path.
       bucket = objectStore.getVolume(ofsPath.getVolumeName())
           .getBucket(ofsPath.getBucketName());
+      return isObjectStoreBucket(bucket, objectStore);
     } catch (IOException e) {
       System.out.println(
           "Bucket layout couldn't be verified for path: " + ofsPath +
               ". Exception: " + e);
-      bucket = null;
-    } finally {
-      ozoneClient.close();
     }
-    return (null == bucket) || isObjectStoreBucket(bucket, objectStore);
+    return false;
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -108,6 +108,8 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
           "Bucket layout couldn't be verified for path: " + ofsPath +
               ". Exception: " + e);
       return false;
+    } finally {
+      ozoneClient.close();
     }
   }
 
@@ -137,6 +139,8 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
           "Bucket layout couldn't be verified for path: " + ofsPath +
               ". Exception: " + e);
       return false;
+    } finally {
+      ozoneClient.close();
     }
   }
 
@@ -165,6 +169,8 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
           "Bucket layout couldn't be verified for path: " + ofsPath +
               ". Exception: " + e);
       return false;
+    } finally {
+      ozoneClient.close();
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -80,8 +80,7 @@ public class QuotaUsageSubCommand implements Callable {
     } else if (quotaResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("Quota");
     } else {
-      if (parent.isObjectStoreBucket(path) ||
-          !parent.bucketIsPresentInThePath(path)) {
+      if (parent.isOBSBucketOrNotPresentInPath(path)) {
         printBucketReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -80,7 +80,7 @@ public class QuotaUsageSubCommand implements Callable {
     } else if (quotaResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("Quota");
     } else {
-      if (parent.isOBSBucketOrNotPresentInPath(path)) {
+      if (parent.isNotValidBucketOrOBSBucket(path)) {
         printBucketReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -76,8 +76,7 @@ public class SummarySubCommand implements Callable<Void> {
     if (summaryResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
-      if (parent.isObjectStoreBucket(path) ||
-          !parent.bucketIsPresentInThePath(path)) {
+      if (parent.isOBSBucketOrNotPresentInPath(path)) {
         printBucketReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -76,7 +76,7 @@ public class SummarySubCommand implements Callable<Void> {
     if (summaryResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
-      if (parent.isOBSBucketOrNotPresentInPath(path)) {
+      if (parent.isNotValidBucketOrOBSBucket(path)) {
         printBucketReminder();
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes the Ozone Client connection leak by closing all opened client connections in NSSummaryAdmin.java

NSSummaryAdmin commands leaves the Ozone client connections open which is not a good practice and may consume resources. So. this PR fixes that by closing all opened Ozone client connections.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9944

## How was this patch tested?

This patch was tested using existing integration test `org.apache.hadoop.ozone.shell.TestNSSummaryAdmin`
