### PR TITLE
HDDS-10154. isKeyPresentInTable should use the constructor with prefix

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1032,10 +1032,13 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
    */
   private <T> boolean isKeyPresentInTable(String keyPrefix,
                                           Table<String, T> table)
-      throws IOException {
+          throws IOException {
     try (TableIterator<String, ? extends KeyValue<String, T>>
-             keyIter = table.iterator()) {
-      KeyValue<String, T> kv = keyIter.seek(keyPrefix);
+                 keyIter = table.iterator(keyPrefix)) {
+      KeyValue<String, T> kv = null;
+      if (keyIter.hasNext()) {
+        kv = keyIter.next();
+      }
 
       // Iterate through all the entries in the table which start with
       // the current bucket's prefix.


### PR DESCRIPTION
## What changes were proposed in this pull request?
isKeyPresentInTable should use the constructor with prefix. 

The table iterator implemented over rocksDB can seek to the prefix if provided at the time to construction. This can avoid wasteful seekToFirst behavior that is part of the construction of the iterator.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10154

## How was this patch tested?

Existing tests
