### PR TITLE
HDDS-10157. Download zlib fails with 403 Forbidden in CI

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -56,6 +56,7 @@
 
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
+    <zlib.url>https://zlib.net/fossils/zlib-${zlib.version}.tar.gz</zlib.url>
   </properties>
 
   <build>
@@ -134,7 +135,7 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://zlib.net/fossils/zlib-${zlib.version}.tar.gz</url>
+                  <url>${zlib.url}</url>
                   <outputFileName>zlib-${zlib.version}.tar.gz</outputFileName>
                   <outputDirectory>${project.build.directory}/zlib</outputDirectory>
                 </configuration>

--- a/hadoop-ozone/dev-support/checks/native.sh
+++ b/hadoop-ozone/dev-support/checks/native.sh
@@ -19,6 +19,13 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CHECK=native
 
+zlib_version=$(mvn -N help:evaluate -Dexpression=zlib.version -q -DforceStdout)
+if [[ -z "${zlib_version}" ]]; then
+  echo "ERROR zlib.version not defined in pom.xml"
+  exit 1
+fi
+
 source "${DIR}/junit.sh" -Pnative -Drocks_tools_native \
+  -Dzlib.url="https://github.com/madler/zlib/releases/download/v${zlib_version}/zlib-${zlib_version}.tar.gz" \
   -DexcludedGroups="unhealthy" \
   "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Download of `zlib` fails with `403 Forbidden` in CI:

```
Failed to execute goal com.googlecode.maven-download-plugin:download-maven-plugin:1.7.1:wget (zlib source download) on project hdds-rocks-native: Download failed with code 403: Forbidden
```

The same goal works locally:

```
mvn -N com.googlecode.maven-download-plugin:download-maven-plugin:1.7.1:wget \
  -Ddownload.url=https://zlib.net/fossils/zlib-1.2.13.tar.gz \
  -Ddownload.outputDirectory=. \
  -Ddownload.outputFileName=zlib-1.2.13.tar.gz
```

The patch allows overriding the official URL by setting `-Dzlib.url`, and does so in `native.sh`, which is run in `unit (native)` check in CI.

https://issues.apache.org/jira/browse/HDDS-10157

## How was this patch tested?

CI (native only):
https://github.com/adoroszlai/ozone/actions/runs/7568517329/job/20609886518

Regular CI still in progress:
https://github.com/adoroszlai/ozone/actions/runs/7568646511