### PR TITLE
HDDS-10162. Correct the metric names within OMPerformanceMetrics

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPerformanceMetrics.java
@@ -108,10 +108,10 @@ public class OMPerformanceMetrics {
   private MutableRate createRatisRequestLatencyNs;
 
   @Metric(about = "Convert ratis response to om response nano seconds")
-  private MutableRate createOmResoonseLatencyNs;
+  private MutableRate createOmResponseLatencyNs;
 
   @Metric(about = "Ratis local command execution latency in nano seconds")
-  private MutableRate validateAndUpdateCacneLatencyNs;
+  private MutableRate validateAndUpdateCacheLatencyNs;
 
   @Metric(about = "ACLs check latency in listKeys")
   private MutableRate listKeysAclCheckLatencyNs;
@@ -209,11 +209,11 @@ public class OMPerformanceMetrics {
   }
 
   public MutableRate getCreateOmResponseLatencyNs() {
-    return createOmResoonseLatencyNs;
+    return createOmResponseLatencyNs;
   }
 
-  public MutableRate getValidateAndUpdateCacneLatencyNs() {
-    return validateAndUpdateCacneLatencyNs;
+  public MutableRate getValidateAndUpdateCacheLatencyNs() {
+    return validateAndUpdateCacheLatencyNs;
   }
 
   public MutableRate getListKeysAclCheckLatencyNs() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -397,7 +397,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     OMClientRequest omClientRequest =
         OzoneManagerRatisUtils.createClientRequest(omRequest, impl);
     return captureLatencyNs(
-        impl.getPerfMetrics().getValidateAndUpdateCacneLatencyNs(),
+        impl.getPerfMetrics().getValidateAndUpdateCacheLatencyNs(),
         () -> {
           OMClientResponse omClientResponse =
               omClientRequest.validateAndUpdateCache(getOzoneManager(), termIndex);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Correct two metric names within OMPerformanceMetrics:

- `createOmResoonseLatencyNs` -> `createOmResponseLatencyNs`
- `validateAndUpdateCacneLatencyNs` -> `validateAndUpdateCacheLatencyNs`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10162

## How was this patch tested?

No need
