### PR TITLE
HDDS-10080. Let junit.sh fail if no tests were matched in repeated run

### DIFF
--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -79,6 +79,12 @@ for i in $(seq 1 ${ITERATIONS}); do
   fi
 
   if [[ ${ITERATIONS} -gt 1 ]]; then
+    if ! grep -q "Tests run: [^0]" "${REPORT_DIR}/output.log"; then
+      echo "No tests were run" >> "${REPORT_DIR}/summary.txt"
+      irc=1
+      FAIL_FAST=true
+    fi
+
     REPORT_DIR="${original_report_dir}"
     echo "Iteration ${i} exit code: ${irc}" | tee -a "${REPORT_FILE}"
   fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Repeated tests in `junit.sh` should fail fast if no tests are executed in the first iteration.  The goal is to indicate if the wrong test filter was used (e.g. abstract test class).

https://issues.apache.org/jira/browse/HDDS-10080

## How was this patch tested?

### Local tests

Non-existent class:

```
$ ITERATIONS=3 OZONE_REPO_CACHED=true \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :hdds-config -Dtest='NoSuchTest'
...
[INFO] BUILD SUCCESS
...
Iteration 1 exit code: 1

$ cat target/unit/iteration1/summary.txt 
No tests were run
```

Non-existent method in existing class:

```
$ ITERATIONS=3 OZONE_REPO_CACHED=true \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :hdds-config -Dtest='TestConfigFileAppender#noSuchTest'
...
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
...
[INFO] BUILD SUCCESS
...
Iteration 1 exit code: 1

$ cat target/unit/iteration1/summary.txt 
No tests were run
```

Valid test class:

```
$ ITERATIONS=3 OZONE_REPO_CACHED=true \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :hdds-config -Dtest='TestConfigFileAppender'
...

$ cat target/unit/summary.txt                                                                                                                   
Iteration 1 exit code: 0
Iteration 2 exit code: 0
Iteration 3 exit code: 0
```

### flaky-test-check

Used flaky-test-check from HDDS-10079.

Non-existent test method:
https://github.com/adoroszlai/ozone/actions/runs/7584500146/job/20658460541

Abstract test class:
https://github.com/adoroszlai/ozone/actions/runs/7584281925/job/20657631720

Specific method in abstract test class:
https://github.com/adoroszlai/ozone/actions/runs/7584288405/job/20657650841

Valid test class and method:
https://github.com/adoroszlai/ozone/actions/runs/7584274733/job/20657610659

### Regular CI

https://github.com/adoroszlai/ozone/actions/runs/7584240425