### PR TITLE
HDDS-10025. Add more function for freon OmMetadataGenerator

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/freon/metadata-generate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/metadata-generate.robot
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test freon ommg command
+Resource            ../ozone-lib/freon.robot
+Test Timeout        5 minutes
+
+*** Variables ***
+${PREFIX}    ${EMPTY}
+${n}    100
+${VOLUME}       volume1
+${BUCKET_FSO}       bucket-fso
+${BUCKET_OBJ}       bucket-obj
+
+*** Test Cases ***
+[Setup] Create Volume and Buckets
+    ${result} =     Execute             ozone sh volume create /${VOLUME}
+                    Should not contain  ${result}       Failed
+    ${result} =     Execute             ozone sh bucket create /${VOLUME}/${BUCKET_FSO} -l FILE_SYSTEM_OPTIMIZED
+                    Should not contain  ${result}       Failed
+    ${result} =     Execute             ozone sh bucket create /${VOLUME}/${BUCKET_OBJ} -l OBJECT_STORE
+                    Should not contain  ${result}       Failed
+
+[Read] Bucket Information
+    ${result} =        Execute          ozone freon ommg --operation INFO_BUCKET -n ${n} --bucket ${BUCKET_FSO}
+                       Should contain   ${result}   Successful executions: ${n}
+
+[Create] File in FILE_SYSTEM_OPTIMIZED Bucket
+    ${result} =        Execute          ozone freon ommg --operation CREATE_FILE -n ${n} --size 4096 --volume ${VOLUME} --bucket ${BUCKET_FSO}
+                       Should contain   ${result}   Successful executions: ${n}
+
+[Read] File in FILE_SYSTEM_OPTIMIZED Bucket
+    ${result} =        Execute          ozone freon ommg --operation READ_FILE -n ${n} --volume ${VOLUME} --bucket ${BUCKET_FSO} --size 4096
+                       Should contain   ${result}   Successful executions: ${n}
+
+[List] File Status in FILE_SYSTEM_OPTIMIZED Bucket
+    ${result} =        Execute          ozone freon ommg --operation LIST_STATUS -n 1 --volume ${VOLUME} --bucket ${BUCKET_FSO} --batch-size ${n}
+                       Should contain   ${result}   Successful executions: 1
+
+[List] light File status in FILE_SYSTEM_OPTIMIZED Bucket
+    ${result} =        Execute          ozone freon ommg --operation LIST_STATUS_LIGHT -n 1 --volume ${VOLUME} --bucket ${BUCKET_FSO} --batch-size ${n}
+                       Should contain   ${result}   Successful executions: 1
+
+[Create] Key in OBJECT_STORE Bucket
+    ${result} =        Execute          ozone freon ommg --operation CREATE_KEY -n ${n} --size 4096 --volume ${VOLUME} --bucket ${BUCKET_OBJ}
+                       Should contain   ${result}   Successful executions: ${n}
+
+[Read] Key in OBJECT_STORE Bucket
+    ${result} =        Execute          ozone freon ommg --operation READ_KEY -n ${n} --volume ${VOLUME} --bucket ${BUCKET_OBJ} --size 4096
+                       Should contain   ${result}   Successful executions: ${n}
+
+[List] Keys in OBJECT_STORE Bucket
+    ${result} =        Execute          ozone freon ommg --operation LIST_KEYS -n 1 --volume ${VOLUME} --bucket ${BUCKET_OBJ} --batch-size ${n}
+                       Should contain   ${result}   Successful executions: 1
+
+[List] Light Keys in OBJECT_STORE Bucket
+    ${result} =        Execute          ozone freon ommg --operation LIST_KEYS_LIGHT -n 1 --volume ${VOLUME} --bucket ${BUCKET_OBJ} --batch-size ${n}
+                       Should contain   ${result}   Successful executions: 1
+
+[Get] Key Information in OBJECT_STORE Bucket
+    ${result} =        Execute          ozone freon ommg --operation GET_KEYINFO -n ${n} --volume ${VOLUME} --bucket ${BUCKET_OBJ}
+                       Should contain   ${result}   Successful executions: ${n}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
@@ -89,8 +89,6 @@ public class OmMetadataGenerator extends BaseFreonGenerator
     LIST_KEYS_LIGHT,
     INFO_BUCKET,
     INFO_VOLUME,
-    EMPTY_RPC_WRITE_RATIS,
-    EMPTY_RPC,
     MIXED,
   }
 
@@ -416,12 +414,6 @@ public class OmMetadataGenerator extends BaseFreonGenerator
       break;
     case INFO_VOLUME:
       getMetrics().timer(operation.name()).time(() -> ozoneManagerClient.getVolumeInfo(volumeName));
-      break;
-    case EMPTY_RPC:
-      getMetrics().timer(operation.name()).time(() -> ozoneManagerClient.echoRPCReq(new byte[] {}, 0, false));
-      break;
-    case EMPTY_RPC_WRITE_RATIS:
-      getMetrics().timer(operation.name()).time(() -> ozoneManagerClient.echoRPCReq(new byte[] {}, 0, true));
       break;
     default:
       throw new IllegalStateException("Unrecognized write command " +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs.Builder;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.helpers.OzoneFileStatusLight;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 
 import com.codahale.metrics.Timer;
@@ -79,6 +80,7 @@ public class OmMetadataGenerator extends BaseFreonGenerator
     LOOKUP_FILE,
     READ_FILE,
     LIST_STATUS,
+    LIST_STATUS_LIGHT,
     CREATE_KEY,
     CREATE_STREAM_KEY,
     LOOKUP_KEY,
@@ -377,8 +379,8 @@ public class OmMetadataGenerator extends BaseFreonGenerator
         List<OmKeyInfo> keyInfoList =
             ozoneManagerClient.listKeys(volumeName, bucketName, startKeyName, "", batchSize).getKeys();
         if (keyInfoList.size() + 1 < batchSize) {
-          throw new NoSuchFileException("There are not enough files for testing you should use "
-                  + "CREATE_FILE to create at least batch-size * threads = " + batchSize * getThreadNo());
+          throw new NoSuchFileException("There are not enough keys for testing you should use "
+                  + "CREATE_KEY to create at least batch-size * threads = " + batchSize * getThreadNo());
         }
         return null;
       });
@@ -389,8 +391,8 @@ public class OmMetadataGenerator extends BaseFreonGenerator
         List<BasicOmKeyInfo> keyInfoList =
             ozoneManagerClient.listKeysLight(volumeName, bucketName, startKeyName, "", batchSize).getKeys();
         if (keyInfoList.size() + 1 < batchSize) {
-          throw new NoSuchFileException("There are not enough files for testing you should use "
-                  + "CREATE_FILE to create at least batch-size * threads = " + batchSize * getThreadNo());
+          throw new NoSuchFileException("There are not enough keys for testing you should use "
+                  + "CREATE_KEY to create at least batch-size * threads = " + batchSize * getThreadNo());
         }
         return null;
       });
@@ -404,6 +406,19 @@ public class OmMetadataGenerator extends BaseFreonGenerator
         if (fileStatusList.size() + 1 < batchSize) {
           throw new NoSuchFileException("There are not enough files for testing you should use "
                   + "CREATE_FILE to create at least batch-size * threads = " + batchSize * getThreadNo());
+        }
+        return null;
+      });
+      break;
+    case LIST_STATUS_LIGHT:
+      startKeyName = getPath(threadSeqId * batchSize);
+      keyArgs = omKeyArgsBuilder.get().setKeyName("").build();
+      getMetrics().timer(operation.name()).time(() -> {
+        List<OzoneFileStatusLight> fileStatusList = ozoneManagerClient.listStatusLight(
+            keyArgs, false, startKeyName, batchSize, false);
+        if (fileStatusList.size() + 1 < batchSize) {
+          throw new NoSuchFileException("There are not enough files for testing you should use "
+              + "CREATE_FILE to create at least batch-size * threads = " + batchSize * getThreadNo());
         }
         return null;
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add more function for freon OmMetadataGenerator
- CREATE_STREAM_FILE
- CREATE_STREAM_KEY
- LIST_KEYS_LIGHT
- LIST_STATUS_LIGHT

Such as:

```bash
[root@VM-7-9-centos ~/root/]$ ozone freon ommg --operation LIST_KEYS_LIGHT -t 10 --duration 30 --bucket bucket-obs
46.67% |████████████████                  |  14/30 Time: 0:00:14|   LIST_KEYS_LIGHT: rate 913 max 913
```


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10025


## How was this patch tested?
manually test.
