### PR TITLE
HDDS-10171. Fix checkstyle:parameternumber in OzoneManagerDoubleBuffer.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -97,7 +97,7 @@ public final class OzoneManagerDoubleBuffer {
   /**
    *  Builder for creating OzoneManagerDoubleBuffer.
    */
-  public static class Builder {
+  public static final class Builder {
     private OMMetadataManager omMetadataManager;
     private Consumer<TermIndex> updateLastAppliedIndex = termIndex -> { };
     private boolean isRatisEnabled = false;
@@ -107,7 +107,7 @@ public final class OzoneManagerDoubleBuffer {
     private S3SecretManager s3SecretManager;
     private String threadPrefix = "";
 
-    private Builder() {}
+    private Builder() { }
 
     public Builder setOmMetadataManager(OMMetadataManager omMetadataManager) {
       this.omMetadataManager = omMetadataManager;
@@ -166,7 +166,7 @@ public final class OzoneManagerDoubleBuffer {
   }
 
   static Semaphore newSemaphore(int permits) {
-    return permits > 0? new Semaphore(permits) : null;
+    return permits > 0 ? new Semaphore(permits) : null;
   }
 
   private Queue<Entry> currentBuffer;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -392,11 +392,11 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   public synchronized void pause() {
     LOG.info("OzoneManagerStateMachine is pausing");
     statePausedCount.incrementAndGet();
-    if (getLifeCycleState() == LifeCycle.State.PAUSED) {
+    final LifeCycle.State state = getLifeCycleState();
+    if (state == LifeCycle.State.PAUSED) {
       return;
     }
-    final LifeCycle lc = getLifeCycle();
-    if (lc.getCurrentState() != LifeCycle.State.NEW) {
+    if (state != LifeCycle.State.NEW) {
       getLifeCycle().transition(LifeCycle.State.PAUSING);
       getLifeCycle().transition(LifeCycle.State.PAUSED);
     }
@@ -423,13 +423,13 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   }
 
   public OzoneManagerDoubleBuffer buildDoubleBufferForRatis() {
-    int maxUnflushedTransactionSize = ozoneManager.getConfiguration()
+    final int maxUnFlushedTransactionCount = ozoneManager.getConfiguration()
         .getInt(OMConfigKeys.OZONE_OM_UNFLUSHED_TRANSACTION_MAX_COUNT,
             OMConfigKeys.OZONE_OM_UNFLUSHED_TRANSACTION_MAX_COUNT_DEFAULT);
-    return new OzoneManagerDoubleBuffer.Builder()
+    return OzoneManagerDoubleBuffer.newBuilder()
         .setOmMetadataManager(ozoneManager.getMetadataManager())
         .setUpdateLastAppliedIndex(this::updateLastAppliedTermIndex)
-        .setmaxUnFlushedTransactionCount(maxUnflushedTransactionSize)
+        .setMaxUnFlushedTransactionCount(maxUnFlushedTransactionCount)
         .setThreadPrefix(threadPrefix)
         .setS3SecretManager(ozoneManager.getS3SecretManager())
         .enableRatis(true)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -105,7 +105,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
     this.transactionIndex = new AtomicLong(lastTransactionIndexForNonRatis);
 
     // When ratis is enabled, the handler does not require a double-buffer since it only handle read requests.
-    this.ozoneManagerDoubleBuffer = enableRatis? null
+    this.ozoneManagerDoubleBuffer = enableRatis ? null
         : OzoneManagerDoubleBuffer.newBuilder()
           .setOmMetadataManager(ozoneManager.getMetadataManager())
           .enableTracing(TracingUtil.isTracingEnabled(ozoneManager.getConfiguration()))

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -75,9 +75,9 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
         folder.toAbsolutePath().toString());
     omMetadataManager =
         new OmMetadataManagerImpl(configuration, null);
-    doubleBuffer = new OzoneManagerDoubleBuffer.Builder()
+    doubleBuffer = OzoneManagerDoubleBuffer.newBuilder()
         .setOmMetadataManager(omMetadataManager)
-        .setmaxUnFlushedTransactionCount(10000)
+        .setMaxUnFlushedTransactionCount(10000)
         .enableRatis(true)
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -107,9 +107,9 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
     auditLogger = mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
-    doubleBuffer = new OzoneManagerDoubleBuffer.Builder()
+    doubleBuffer = OzoneManagerDoubleBuffer.newBuilder()
         .setOmMetadataManager(omMetadataManager)
-        .setmaxUnFlushedTransactionCount(100000)
+        .setMaxUnFlushedTransactionCount(100000)
         .enableRatis(true)
         .build();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/ozone/blob/6f6ec580743208ba4c09e9b55b94f68cfefd2d5d/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java#L195-L201
The OzoneManagerDoubleBuffer constructor above has many parameter.  We may reduce it by passing the Builder.

We will also clean up the code, add javadoc and fix typos.

## What is the link to the Apache JIRA

HDDS-10171

## How was this patch tested?

By updating existing tests.