### PR TITLE
HDDS-10168. Add Ozone 1.4.0 to compatibility acceptance tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -35,8 +35,9 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-export OZONE_CURRENT_VERSION=1.4.0
-run_test ha non-rolling-upgrade 1.3.0 "$OZONE_CURRENT_VERSION"
+export OZONE_CURRENT_VERSION=1.5.0
+run_test ha non-rolling-upgrade 1.4.0 "$OZONE_CURRENT_VERSION"
+# run_test ha non-rolling-upgrade 1.3.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.2.1 "$OZONE_CURRENT_VERSION"
 # run_test om-ha non-rolling-upgrade 1.1.0 "$OZONE_CURRENT_VERSION"
 

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -45,6 +45,13 @@ services:
     volumes:
       - ../..:/opt/ozone
     command: ["sleep","1000000"]
+  old_client_1_4_0:
+    image: apache/ozone:1.4.0
+    env_file:
+      - docker-config
+    volumes:
+      - ../..:/opt/ozone
+    command: ["sleep","1000000"]
   new_client:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     env_file:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -21,8 +21,8 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 basename=$(basename ${COMPOSE_DIR})
 
-current_version=1.4.0
-old_versions="1.0.0 1.1.0 1.2.1 1.3.0" # container is needed for each version in clients.yaml
+current_version=1.5.0
+old_versions="1.0.0 1.1.0 1.2.1 1.3.0 1.4.0" # container is needed for each version in clients.yaml
 
 # shellcheck source=hadoop-ozone/dist/src/main/compose/testlib.sh
 source "${COMPOSE_DIR}/../testlib.sh"
@@ -77,7 +77,7 @@ test_cross_compatibility() {
 
 test_ec_cross_compatibility() {
   echo "Running Erasure Coded storage backward compatibility tests."
-  local cluster_versions_with_ec="1.3.0"
+  local cluster_versions_with_ec="1.3.0 1.4.0"
   local non_ec_client_versions="1.0.0 1.1.0 1.2.1"
 
   for cluster_version in ${cluster_versions_with_ec}; do


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add 1.4.0 to `xcompat` test matrix.

Change `upgrade` test to start from 1.4.0 instead of 1.3.0.

https://issues.apache.org/jira/browse/HDDS-10168

## How was this patch tested?

```
OZONE_ACCEPTANCE_SUITE=compat ./hadoop-ozone/dev-support/checks/acceptance.sh
open target/acceptance/log.html
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7593375483