### PR TITLE
HDDS-10178. Shaded Jar build failure in case insensitive filesystem

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -129,6 +129,12 @@
                   <groupId>org.apache.ozone</groupId>
                   <artifactId>ozone-filesystem-shaded</artifactId>
                   <version>${project.version}</version>
+                  <fileMappers>
+                    <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                      <pattern>META-INF/license/</pattern>
+                      <replacement>META-INF/licenses/</replacement>
+                    </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                  </fileMappers>
                 </artifactItem>
               </artifactItems>
               <outputDirectory>target/classes</outputDirectory>

--- a/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
@@ -60,6 +60,12 @@
                   <groupId>org.apache.ozone</groupId>
                   <artifactId>ozone-filesystem-shaded</artifactId>
                   <version>${project.version}</version>
+                  <fileMappers>
+                    <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                      <pattern>META-INF/license/</pattern>
+                      <replacement>META-INF/licenses/</replacement>
+                    </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                  </fileMappers>
                 </artifactItem>
               </artifactItems>
               <outputDirectory>target/classes</outputDirectory>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -80,6 +80,12 @@
                   <groupId>org.apache.ozone</groupId>
                   <artifactId>ozone-filesystem-shaded</artifactId>
                   <version>${project.version}</version>
+                  <fileMappers>
+                    <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                      <pattern>META-INF/license/</pattern>
+                      <replacement>META-INF/licenses/</replacement>
+                    </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                  </fileMappers>
                 </artifactItem>
               </artifactItems>
               <outputDirectory>target/classes</outputDirectory>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Maven build of shaded hadoop jar fails when trying to extract 

ozone-filesystem-shaded jar to classes since the jar has a directory called license containing many license files and a file LICENSE within the same directory, which interferes with one another when unpack module on the artifact runs.

The solution proposes to add a fileMapper which aims to rename the directory META-INF/license/ to META-INF/licenses/


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10178

## How was this patch tested?
Local mac(APFS case insensitve) code build succeeded.
