### PR TITLE
HDDS-10178. Shaded Jar build failure in case-insensitive filesystem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,13 +135,17 @@ jobs:
       - build-info
       - build
       - basic
-    runs-on: ubuntu-20.04
     timeout-minutes: 30
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
       matrix:
         java: [ 11, 17, 21 ]
+        include:
+          - os: ubuntu-20.04
+          - java: 8
+            os: macos-12
       fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Download Ozone source tarball
         uses: actions/download-artifact@v3

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
+    <plexus-archiver.version>4.2.2</plexus-archiver.version>
     <docker-maven-plugin.version>0.29.0</docker-maven-plugin.version>
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <license-maven-plugin.version>2.3.0</license-maven-plugin.version>
@@ -1731,6 +1732,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${maven-dependency-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.plexus</groupId>
+              <artifactId>plexus-archiver</artifactId>
+              <version>${plexus-archiver.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Use `plexus-archiver` 4.2.2 for `maven-dependency-plugin`.  4.2.3+ has broken behavior on case-insensitive filesystem (e.g. macOS).  https://github.com/codehaus-plexus/plexus-archiver/commit/efd980ddaf3d98ebb19e06805258f9f978c9ebc1
* Add compilation on macOS to the test matrix.

https://issues.apache.org/jira/browse/HDDS-10178

## How was this patch tested?

Compile on macOS failed without the fix:

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.6.1:unpack (include-dependencies) on project ozone-filesystem-hadoop2: Error unpacking file: /Users/runner/work/ozone/ozone/hadoop-ozone/ozonefs-shaded/target/ozone-filesystem-shaded-1.5.0-SNAPSHOT.jar to: /Users/runner/work/ozone/ozone/hadoop-ozone/ozonefs-hadoop2/target/classes: Error while expanding /Users/runner/work/ozone/ozone/hadoop-ozone/ozonefs-shaded/target/ozone-filesystem-shaded-1.5.0-SNAPSHOT.jar: /Users/runner/work/ozone/ozone/hadoop-ozone/ozonefs-hadoop2/target/classes/META-INF/LICENSE/LICENSE.aix-netbsd.txt: Not a directory -> [Help 1]
```

https://github.com/adoroszlai/ozone/actions/runs/7599905583/job/20697742175#step:7:3286

Passed with the fix:
https://github.com/adoroszlai/ozone/actions/runs/7602214715/job/20702677091