### PR TITLE
HDDS-10077. Add hsync metadata to hsync'ed keys in OpenKeyTable as well

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -26,6 +26,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -65,6 +66,7 @@ import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyCommitRequestWithFSO;
@@ -74,13 +76,17 @@ import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -88,6 +94,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -100,6 +107,7 @@ import static org.mockito.Mockito.when;
  * Test HSync.
  */
 @Timeout(value = 300)
+@TestMethodOrder(OrderAnnotation.class)
 public class TestHSync {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestHSync.class);
@@ -109,6 +117,7 @@ public class TestHSync {
 
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
   private static OzoneClient client;
+  private static final BucketLayout BUCKET_LAYOUT = BucketLayout.FILE_SYSTEM_OPTIMIZED;
 
   @BeforeAll
   public static void init() throws Exception {
@@ -116,11 +125,13 @@ public class TestHSync {
     final int flushSize = 2 * chunkSize;
     final int maxFlushSize = 2 * flushSize;
     final int blockSize = 2 * maxFlushSize;
-    final BucketLayout layout = BucketLayout.FILE_SYSTEM_OPTIMIZED;
+    final BucketLayout layout = BUCKET_LAYOUT;
 
     CONF.setBoolean(OZONE_OM_RATIS_ENABLE_KEY, false);
     CONF.set(OZONE_DEFAULT_BUCKET_LAYOUT, layout.name());
     CONF.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
+    // Reduce KeyDeletingService interval
+    CONF.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
     cluster = MiniOzoneCluster.newBuilder(CONF)
         .setNumDatanodes(5)
         .setTotalPipelineNumLimit(10)
@@ -150,6 +161,83 @@ public class TestHSync {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
       cluster.shutdown();
+    }
+  }
+
+  @Test
+  // Making this the first test to be run to avoid db key composition headaches
+  @Order(1)
+  public void testKeyMetadata() throws Exception {
+    // Tests key metadata behavior upon create(), hsync() and close():
+    // 1. When a key is create()'d, neither OpenKeyTable nor KeyTable entry shall have hsync metadata.
+    // 2. When the key is hsync()'ed, both OpenKeyTable and KeyTable shall have hsync metadata.
+    // 3. When the key is hsync()'ed again, both OpenKeyTable and KeyTable shall have hsync metadata.
+    // 4. When the key is close()'d, KeyTable entry shall not have hsync metadata. Key shall not exist in OpenKeyTable.
+
+    final String rootPath = String.format("%s://%s/",
+        OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
+    CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName()
+        + OZONE_URI_DELIMITER + bucket.getName();
+    final String keyName = "file-test-key-metadata";
+    final Path file = new Path(dir, keyName);
+
+    OMMetadataManager omMetadataManager =
+        cluster.getOzoneManager().getMetadataManager();
+
+    // Expect empty OpenKeyTable and KeyTable before key creation
+    Table<String, OmKeyInfo> openKeyTable = omMetadataManager.getOpenKeyTable(BUCKET_LAYOUT);
+    assertTrue(openKeyTable.isEmpty());
+    Table<String, OmKeyInfo> keyTable = omMetadataManager.getKeyTable(BUCKET_LAYOUT);
+    assertTrue(keyTable.isEmpty());
+
+    try (FileSystem fs = FileSystem.get(CONF)) {
+      try (FSDataOutputStream os = fs.create(file, true)) {
+        // Wait for double buffer flush to avoid flakiness because RDB iterator bypasses table cache
+        cluster.getOzoneManager().awaitDoubleBufferFlush();
+        // OpenKeyTable key should NOT have HSYNC_CLIENT_ID
+        OmKeyInfo keyInfo = getFirstKeyInTable(keyName, openKeyTable);
+        assertFalse(keyInfo.getMetadata().containsKey(OzoneConsts.HSYNC_CLIENT_ID));
+        // KeyTable should still be empty
+        assertTrue(keyTable.isEmpty());
+
+        os.hsync();
+        cluster.getOzoneManager().awaitDoubleBufferFlush();
+        // OpenKeyTable key should have HSYNC_CLIENT_ID now
+        keyInfo = getFirstKeyInTable(keyName, openKeyTable);
+        assertTrue(keyInfo.getMetadata().containsKey(OzoneConsts.HSYNC_CLIENT_ID));
+        // KeyTable key should be there and have HSYNC_CLIENT_ID
+        keyInfo = getFirstKeyInTable(keyName, keyTable);
+        assertTrue(keyInfo.getMetadata().containsKey(OzoneConsts.HSYNC_CLIENT_ID));
+
+        // hsync again, metadata should not change
+        os.hsync();
+        cluster.getOzoneManager().awaitDoubleBufferFlush();
+        keyInfo = getFirstKeyInTable(keyName, openKeyTable);
+        assertTrue(keyInfo.getMetadata().containsKey(OzoneConsts.HSYNC_CLIENT_ID));
+        keyInfo = getFirstKeyInTable(keyName, keyTable);
+        assertTrue(keyInfo.getMetadata().containsKey(OzoneConsts.HSYNC_CLIENT_ID));
+      }
+      // key is closed, OpenKeyTable should be empty
+      cluster.getOzoneManager().awaitDoubleBufferFlush();
+      assertTrue(openKeyTable.isEmpty());
+      // KeyTable should have the key. But the key shouldn't have metadata HSYNC_CLIENT_ID anymore
+      OmKeyInfo keyInfo = getFirstKeyInTable(keyName, keyTable);
+      assertFalse(keyInfo.getMetadata().containsKey(OzoneConsts.HSYNC_CLIENT_ID));
+
+      // Clean up
+      assertTrue(fs.delete(file, false));
+      // Wait for KeyDeletingService to finish to avoid interfering other tests
+      Table<String, RepeatedOmKeyInfo> deletedTable = omMetadataManager.getDeletedTable();
+      GenericTestUtils.waitFor(
+          () -> {
+            try {
+              return deletedTable.isEmpty();
+            } catch (IOException e) {
+              return false;
+            }
+          }, 250, 10000);
     }
   }
 
@@ -553,6 +641,23 @@ public class TestHSync {
     } finally {
       // re-enable the feature flag
       CONF.setBoolean(OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
+    }
+  }
+
+  /**
+   * Helper method to check and get the first key in the OpenKeyTable.
+   * @param keyName expect key name to contain this string
+   * @param openKeyTable Table<String, OmKeyInfo>
+   * @return OmKeyInfo
+   */
+  private OmKeyInfo getFirstKeyInTable(String keyName, Table<String, OmKeyInfo> openKeyTable) throws IOException {
+    try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> it = openKeyTable.iterator()) {
+      assertTrue(it.hasNext());
+      Table.KeyValue<String, OmKeyInfo> kv = it.next();
+      String dbOpenKey = kv.getKey();
+      assertNotNull(dbOpenKey);
+      assertTrue(dbOpenKey.contains(keyName));
+      return kv.getValue();
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1836,7 +1836,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         String dbOpenKeyName = openKeyValue.getKey();
 
         final int lastPrefix = dbOpenKeyName.lastIndexOf(OM_KEY_PREFIX);
-        final String dbKeyName = dbOpenKeyName.substring(0, lastPrefix);
         OmKeyInfo openKeyInfo = openKeyValue.getValue();
 
         if (isOpenMultipartKey(openKeyInfo, dbOpenKeyName)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -22,8 +22,6 @@ import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenSecretManager;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -238,7 +236,7 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
       openKeyInfo.setModificationTime(Time.now());
       // add to cache.
       omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(
-          new CacheKey<>(dbOpenFileKey), CacheValue.get(transactionLogIndex, openKeyInfo));
+          dbOpenFileKey, openKeyInfo, transactionLogIndex);
     }
     // override key name with normalizedKeyPath
     keyInfo.setKeyName(keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -260,8 +260,6 @@ public class OMKeyCommitRequest extends OMKeyRequest {
               " metadata while recovery flag is not set in request", KEY_UNDER_LEASE_RECOVERY);
         }
       }
-      omKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
-          commitKeyArgs.getMetadataList()));
 
       // non-null indicates it is necessary to update the open key
       OmKeyInfo newOpenKeyInfo = null;
@@ -275,6 +273,9 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         omKeyInfo.getMetadata().remove(OzoneConsts.HSYNC_CLIENT_ID);
         omKeyInfo.getMetadata().remove(OzoneConsts.LEASE_RECOVERY);
       }
+
+      omKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
+          commitKeyArgs.getMetadataList()));
       omKeyInfo.setDataSize(commitKeyArgs.getDataSize());
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
       // Update the block length for each block, return the allocated but

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -172,24 +172,23 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         }
       }
 
+      omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
+
       final String clientIdString = String.valueOf(writerClientId);
       // non-null indicates it is necessary to update the open key
       OmKeyInfo newOpenKeyInfo = null;
 
       if (isHSync) {
         if (!OmKeyHSyncUtil.isHSyncedPreviously(omKeyInfo, clientIdString, dbOpenFileKey)) {
+          // Update open key as well if it is the first hsync of this key
           omKeyInfo.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID, clientIdString);
           newOpenKeyInfo = omKeyInfo.copyObject();
         }
-      } else if (isRecovery) {
-        omKeyInfo.getMetadata().remove(OzoneConsts.HSYNC_CLIENT_ID);
-        omKeyInfo.getMetadata().remove(OzoneConsts.LEASE_RECOVERY);
       }
 
       omKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
           commitKeyArgs.getMetadataList()));
       omKeyInfo.setDataSize(commitKeyArgs.getDataSize());
-      omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
 
       List<OmKeyLocationInfo> uncommitted =
           omKeyInfo.updateLocationInfoList(locationInfoList, false);
@@ -277,6 +276,9 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
         // Prevent hsync metadata from getting committed to the final key
         omKeyInfo.getMetadata().remove(OzoneConsts.HSYNC_CLIENT_ID);
+        if (isRecovery) {
+          omKeyInfo.getMetadata().remove(OzoneConsts.LEASE_RECOVERY);
+        }
       } else if (newOpenKeyInfo != null) {
         // isHSync is true and newOpenKeyInfo is set, update OpenKeyTable
         OMFileRequest.addOpenFileTableCacheEntry(omMetadataManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -172,9 +172,6 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         }
       }
 
-      omKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
-          commitKeyArgs.getMetadataList()));
-
       final String clientIdString = String.valueOf(writerClientId);
       // non-null indicates it is necessary to update the open key
       OmKeyInfo newOpenKeyInfo = null;
@@ -189,6 +186,8 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         omKeyInfo.getMetadata().remove(OzoneConsts.LEASE_RECOVERY);
       }
 
+      omKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
+          commitKeyArgs.getMetadataList()));
       omKeyInfo.setDataSize(commitKeyArgs.getDataSize());
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OmKeyHSyncUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OmKeyHSyncUtil.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.request.util;
+
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper methods related to OM key HSync.
+ */
+public final class OmKeyHSyncUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(OmKeyHSyncUtil.class);
+
+  private OmKeyHSyncUtil() {
+  }
+
+  /**
+   * Returns true if the key has been hsync'ed before (has metadata HSYNC_CLIENT_ID).
+   * @param omKeyInfo OmKeyInfo
+   * @param clientIdString Client ID String
+   * @param dbOpenKey dbOpenKey
+   */
+  public static boolean isHSyncedPreviously(OmKeyInfo omKeyInfo, String clientIdString, String dbOpenKey) {
+    // Check whether the key has been hsync'ed before
+    final String previousHsyncClientId = omKeyInfo.getMetadata().get(OzoneConsts.HSYNC_CLIENT_ID);
+    if (previousHsyncClientId != null) {
+      if (clientIdString.equals(previousHsyncClientId)) {
+        // Same client ID, no need to update OpenKeyTable. One less DB write
+        return true;
+      } else {
+        // Sanity check. Should never enter
+        LOG.warn("Client ID '{}' currently hsync'ing key does not match previous hsync client ID '{}'. dbOpenKey='{}'",
+            clientIdString, previousHsyncClientId, dbOpenKey);
+      }
+    }
+    return false;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -49,7 +49,8 @@ public class OMKeyCommitResponse extends OmKeyResponse {
   private String openKeyName;
   private OmBucketInfo omBucketInfo;
   private Map<String, RepeatedOmKeyInfo> keyToDeleteMap;
-  private boolean isHSync, updateOpenKeyTable;
+  private boolean isHSync;
+  private OmKeyInfo newOpenKeyInfo;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public OMKeyCommitResponse(
@@ -58,7 +59,7 @@ public class OMKeyCommitResponse extends OmKeyResponse {
       @Nonnull OmBucketInfo omBucketInfo,
       Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
       boolean isHSync,
-      boolean updateOpenKeyTable) {
+      OmKeyInfo newOpenKeyInfo) {
     super(omResponse, omBucketInfo.getBucketLayout());
     this.omKeyInfo = omKeyInfo;
     this.ozoneKeyName = ozoneKeyName;
@@ -66,7 +67,7 @@ public class OMKeyCommitResponse extends OmKeyResponse {
     this.omBucketInfo = omBucketInfo;
     this.keyToDeleteMap = keyToDeleteMap;
     this.isHSync = isHSync;
-    this.updateOpenKeyTable = updateOpenKeyTable;
+    this.newOpenKeyInfo = newOpenKeyInfo;
   }
 
   /**
@@ -87,9 +88,9 @@ public class OMKeyCommitResponse extends OmKeyResponse {
     if (!isHSync()) {
       omMetadataManager.getOpenKeyTable(getBucketLayout())
           .deleteWithBatch(batchOperation, openKeyName);
-    } else if (needToUpdateOpenKeyTable()) {
+    } else if (newOpenKeyInfo != null) {
       omMetadataManager.getOpenKeyTable(getBucketLayout()).putWithBatch(
-          batchOperation, openKeyName, omKeyInfo);
+          batchOperation, openKeyName, newOpenKeyInfo);
     }
 
     omMetadataManager.getKeyTable(getBucketLayout())
@@ -139,7 +140,7 @@ public class OMKeyCommitResponse extends OmKeyResponse {
     return isHSync;
   }
 
-  protected boolean needToUpdateOpenKeyTable() {
-    return updateOpenKeyTable;
+  public OmKeyInfo getNewOpenKeyInfo() {
+    return newOpenKeyInfo;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -49,15 +49,16 @@ public class OMKeyCommitResponse extends OmKeyResponse {
   private String openKeyName;
   private OmBucketInfo omBucketInfo;
   private Map<String, RepeatedOmKeyInfo> keyToDeleteMap;
+  private boolean isHSync, updateOpenKeyTable;
 
-  private boolean isHSync;
-
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public OMKeyCommitResponse(
       @Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, String ozoneKeyName, String openKeyName,
       @Nonnull OmBucketInfo omBucketInfo,
       Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
-      boolean isHSync) {
+      boolean isHSync,
+      boolean updateOpenKeyTable) {
     super(omResponse, omBucketInfo.getBucketLayout());
     this.omKeyInfo = omKeyInfo;
     this.ozoneKeyName = ozoneKeyName;
@@ -65,6 +66,7 @@ public class OMKeyCommitResponse extends OmKeyResponse {
     this.omBucketInfo = omBucketInfo;
     this.keyToDeleteMap = keyToDeleteMap;
     this.isHSync = isHSync;
+    this.updateOpenKeyTable = updateOpenKeyTable;
   }
 
   /**
@@ -85,6 +87,9 @@ public class OMKeyCommitResponse extends OmKeyResponse {
     if (!isHSync()) {
       omMetadataManager.getOpenKeyTable(getBucketLayout())
           .deleteWithBatch(batchOperation, openKeyName);
+    } else if (needToUpdateOpenKeyTable()) {
+      omMetadataManager.getOpenKeyTable(getBucketLayout()).putWithBatch(
+          batchOperation, openKeyName, omKeyInfo);
     }
 
     omMetadataManager.getKeyTable(getBucketLayout())
@@ -132,5 +137,9 @@ public class OMKeyCommitResponse extends OmKeyResponse {
 
   protected boolean isHSync() {
     return isHSync;
+  }
+
+  protected boolean needToUpdateOpenKeyTable() {
+    return updateOpenKeyTable;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
@@ -55,9 +55,9 @@ public class OMKeyCommitResponseWithFSO extends OMKeyCommitResponse {
       @Nonnull OmBucketInfo omBucketInfo,
       Map<String, RepeatedOmKeyInfo> deleteKeyMap, long volumeId,
       boolean isHSync,
-      boolean updateOpenKeyTable) {
+      OmKeyInfo newOpenKeyInfo) {
     super(omResponse, omKeyInfo, ozoneKeyName, openKeyName,
-            omBucketInfo, deleteKeyMap, isHSync, updateOpenKeyTable);
+            omBucketInfo, deleteKeyMap, isHSync, newOpenKeyInfo);
     this.volumeId = volumeId;
   }
 
@@ -79,9 +79,9 @@ public class OMKeyCommitResponseWithFSO extends OMKeyCommitResponse {
     if (!this.isHSync()) {
       omMetadataManager.getOpenKeyTable(getBucketLayout())
           .deleteWithBatch(batchOperation, getOpenKeyName());
-    } else if (needToUpdateOpenKeyTable()) {
+    } else if (getNewOpenKeyInfo() != null) {
       omMetadataManager.getOpenKeyTable(getBucketLayout()).putWithBatch(
-          batchOperation, getOpenKeyName(), getOmKeyInfo());
+          batchOperation, getOpenKeyName(), getNewOpenKeyInfo());
     }
 
     OMFileRequest.addToFileTable(omMetadataManager, batchOperation,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
@@ -47,16 +47,17 @@ public class OMKeyCommitResponseWithFSO extends OMKeyCommitResponse {
 
   private long volumeId;
 
-  @SuppressWarnings("parameternumber")
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public OMKeyCommitResponseWithFSO(
       @Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo,
       String ozoneKeyName, String openKeyName,
       @Nonnull OmBucketInfo omBucketInfo,
       Map<String, RepeatedOmKeyInfo> deleteKeyMap, long volumeId,
-      boolean isHSync) {
+      boolean isHSync,
+      boolean updateOpenKeyTable) {
     super(omResponse, omKeyInfo, ozoneKeyName, openKeyName,
-            omBucketInfo, deleteKeyMap, isHSync);
+            omBucketInfo, deleteKeyMap, isHSync, updateOpenKeyTable);
     this.volumeId = volumeId;
   }
 
@@ -78,6 +79,9 @@ public class OMKeyCommitResponseWithFSO extends OMKeyCommitResponse {
     if (!this.isHSync()) {
       omMetadataManager.getOpenKeyTable(getBucketLayout())
           .deleteWithBatch(batchOperation, getOpenKeyName());
+    } else if (needToUpdateOpenKeyTable()) {
+      omMetadataManager.getOpenKeyTable(getBucketLayout()).putWithBatch(
+          batchOperation, getOpenKeyName(), getOmKeyInfo());
     }
 
     OMFileRequest.addToFileTable(omMetadataManager, batchOperation,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -45,14 +45,10 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CommitKeyRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .KeyArgs;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .KeyLocation;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CommitKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -65,7 +65,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
     String ozoneKey = getOzoneKey();
     OMKeyCommitResponse omKeyCommitResponse = getOmKeyCommitResponse(
-            omKeyInfo, omResponse, openKey, ozoneKey, keysToDelete, false);
+            omKeyInfo, omResponse, openKey, ozoneKey, keysToDelete, false, false);
 
     omKeyCommitResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -94,7 +94,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     String ozoneKey = getOzoneKey();
 
     OMKeyCommitResponse omKeyCommitResponse = getOmKeyCommitResponse(
-            omKeyInfo, omResponse, openKey, ozoneKey, null, false);
+            omKeyInfo, omResponse, openKey, ozoneKey, null, false, false);
 
     // As during commit Key, entry will be already there in openKeyTable.
     // Adding it here.
@@ -148,7 +148,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
   @NotNull
   protected OMKeyCommitResponse getOmKeyCommitResponse(OmKeyInfo omKeyInfo,
           OzoneManagerProtocolProtos.OMResponse omResponse, String openKey,
-          String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync)
+          String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync, Boolean updateOpenKeyTable)
           throws IOException {
     assertNotNull(omBucketInfo);
     Map<String, RepeatedOmKeyInfo> deleteKeyMap = new HashMap<>();
@@ -158,6 +158,6 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
           new RepeatedOmKeyInfo(e)));
     }
     return new OMKeyCommitResponse(omResponse, omKeyInfo, ozoneKey, openKey,
-        omBucketInfo, deleteKeyMap, isHSync);
+        omBucketInfo, deleteKeyMap, isHSync, updateOpenKeyTable);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -65,7 +65,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
     String ozoneKey = getOzoneKey();
     OMKeyCommitResponse omKeyCommitResponse = getOmKeyCommitResponse(
-            omKeyInfo, omResponse, openKey, ozoneKey, keysToDelete, false, false);
+            omKeyInfo, omResponse, openKey, ozoneKey, keysToDelete, false, null);
 
     omKeyCommitResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -94,7 +94,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     String ozoneKey = getOzoneKey();
 
     OMKeyCommitResponse omKeyCommitResponse = getOmKeyCommitResponse(
-            omKeyInfo, omResponse, openKey, ozoneKey, null, false, false);
+            omKeyInfo, omResponse, openKey, ozoneKey, null, false, null);
 
     // As during commit Key, entry will be already there in openKeyTable.
     // Adding it here.
@@ -148,7 +148,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
   @NotNull
   protected OMKeyCommitResponse getOmKeyCommitResponse(OmKeyInfo omKeyInfo,
           OzoneManagerProtocolProtos.OMResponse omResponse, String openKey,
-          String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync, Boolean updateOpenKeyTable)
+          String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync, OmKeyInfo newOpenKeyInfo)
           throws IOException {
     assertNotNull(omBucketInfo);
     Map<String, RepeatedOmKeyInfo> deleteKeyMap = new HashMap<>();
@@ -158,6 +158,6 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
           new RepeatedOmKeyInfo(e)));
     }
     return new OMKeyCommitResponse(omResponse, omKeyInfo, ozoneKey, openKey,
-        omBucketInfo, deleteKeyMap, isHSync, updateOpenKeyTable);
+        omBucketInfo, deleteKeyMap, isHSync, newOpenKeyInfo);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -42,7 +42,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   @Override
   protected OMKeyCommitResponse getOmKeyCommitResponse(OmKeyInfo omKeyInfo,
       OzoneManagerProtocolProtos.OMResponse omResponse, String openKey,
-      String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync, Boolean updateOpenKeyTable)
+      String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync, OmKeyInfo newOpenKeyInfo)
           throws IOException {
     assertNotNull(omBucketInfo);
     long volumeId = omMetadataManager.getVolumeId(omKeyInfo.getVolumeName());
@@ -55,7 +55,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
           new RepeatedOmKeyInfo(e)));
     }
     return new OMKeyCommitResponseWithFSO(omResponse, omKeyInfo, ozoneKey,
-        openKey, omBucketInfo, deleteKeyMap, volumeId, isHSync, updateOpenKeyTable);
+        openKey, omBucketInfo, deleteKeyMap, volumeId, isHSync, newOpenKeyInfo);
   }
 
   @NotNull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -42,7 +42,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   @Override
   protected OMKeyCommitResponse getOmKeyCommitResponse(OmKeyInfo omKeyInfo,
       OzoneManagerProtocolProtos.OMResponse omResponse, String openKey,
-      String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync)
+      String ozoneKey, RepeatedOmKeyInfo deleteKeys, Boolean isHSync, Boolean updateOpenKeyTable)
           throws IOException {
     assertNotNull(omBucketInfo);
     long volumeId = omMetadataManager.getVolumeId(omKeyInfo.getVolumeName());
@@ -55,7 +55,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
           new RepeatedOmKeyInfo(e)));
     }
     return new OMKeyCommitResponseWithFSO(omResponse, omKeyInfo, ozoneKey,
-        openKey, omBucketInfo, deleteKeyMap, volumeId, isHSync);
+        openKey, omBucketInfo, deleteKeyMap, volumeId, isHSync, updateOpenKeyTable);
   }
 
   @NotNull


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, only those keys in `KeyTable` would have metadata `HSYNC_CLIENT_ID` when those keys have been hsync'ed (and not closed/committed yet). One problem with this is that it makes `getExpiredOpenKeys()` and `listOpenKeys()` (HDDS-8830) inefficient by forcing them to look up `KeyTable` while they could have just used `OpenKeyTable` solely to determine whether an open key is hsync'ed or not.

### Changes

1. During key `hsync()`, persist metadata `HSYNC_CLIENT_ID` to `OmKeyInfo` in `OpenKeyTable` as well, in addition to `KeyTable`. Only write when the client ID changes so it doesn't lead to excessive writes. Ideally, only the first hsync() would lead to a `OpenKeyTable` write of that key.
2. During key `close()`, remove `HSYNC_CLIENT_ID` from OpenKeyTable if any, so that `HSYNC_CLIENT_ID` isn't unnecessarily written to the final key (which is useless when the key is committed/finalized.
3. Adopt the more efficient approach in `getExpiredOpenKeys()` and `listOpenKeys()`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10077

## How was this patch tested?

- [x] Existing tests that cover the changes shall pass.
- [x] Add new test `testKeyMetadata` to check the intended behavior.
  - When a key is newly created, neither OpenKeyTable nor KeyTable should have hsync metadata.
  - When the key is hsync'ed, both OpenKeyTable and KeyTable should have hsync metadata.
  - When the key is hsync'ed again, both OpenKeyTable and KeyTable should still have hsync metadata.
  - When the key is closed, KeyTable entry should no longer have hsync metadata. Key should not exist in OpenKeyTable anymore.
  - All three types of buckets (LEGACY/OBS/FSO) should behave the same.