### PR TITLE
HDDS-6796. Extract method for building OMRequest in TrashOzoneFileSystem

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -460,6 +460,18 @@ public class TrashOzoneFileSystem extends FileSystem {
     }
   }
 
+  /**
+   * Returns a OMRequest builder with specified type.
+   * @param cmdType type of the request
+   */
+  private OzoneManagerProtocolProtos.OMRequest.Builder
+       createOMRequest(OzoneManagerProtocolProtos.Type cmdType) throws IOException {
+    return OzoneManagerProtocolProtos.OMRequest.newBuilder()
+        .setClientId(CLIENT_ID.toString())
+        .setVersion(ClientVersion.CURRENT_VERSION)
+        .setUserInfo(getUserInfo())
+        .setCmdType(cmdType);
+  }
 
   private OzoneManagerProtocolProtos.OMRequest
       getRenameKeyRequest(
@@ -483,12 +495,8 @@ public class TrashOzoneFileSystem extends FileSystem {
     OzoneManagerProtocolProtos.OMRequest omRequest =
         null;
     try {
-      omRequest = OzoneManagerProtocolProtos.OMRequest.newBuilder()
-              .setClientId(CLIENT_ID.toString())
-              .setVersion(ClientVersion.CURRENT_VERSION)
-              .setUserInfo(getUserInfo())
+      omRequest = createOMRequest(OzoneManagerProtocolProtos.Type.RenameKey)
               .setRenameKeyRequest(renameKeyRequest)
-              .setCmdType(OzoneManagerProtocolProtos.Type.RenameKey)
               .build();
     } catch (IOException e) {
       LOG.error("Couldn't get userinfo", e);
@@ -549,13 +557,8 @@ public class TrashOzoneFileSystem extends FileSystem {
     OzoneManagerProtocolProtos.OMRequest omRequest =
         null;
     try {
-      omRequest =
-          OzoneManagerProtocolProtos.OMRequest.newBuilder()
-              .setClientId(CLIENT_ID.toString())
-              .setVersion(ClientVersion.CURRENT_VERSION)
-              .setUserInfo(getUserInfo())
+      omRequest = createOMRequest(OzoneManagerProtocolProtos.Type.DeleteKey)
               .setDeleteKeyRequest(deleteKeyRequest)
-              .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey)
               .build();
     } catch (IOException e) {
       LOG.error("Couldn't get userinfo", e);
@@ -619,12 +622,8 @@ public class TrashOzoneFileSystem extends FileSystem {
       OzoneManagerProtocolProtos.OMRequest omRequest =
           null;
       try {
-        omRequest = OzoneManagerProtocolProtos.OMRequest.newBuilder()
-            .setClientId(CLIENT_ID.toString())
-            .setVersion(ClientVersion.CURRENT_VERSION)
-            .setUserInfo(getUserInfo())
+        omRequest = createOMRequest(OzoneManagerProtocolProtos.Type.DeleteKeys)
             .setDeleteKeysRequest(deleteKeysRequest)
-            .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKeys)
             .build();
       } catch (IOException e) {
         LOG.error("Couldn't get userinfo", e);


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-6796. Extract method for building OMRequest in TrashOzoneFileSystem

Please describe your PR in detail:
- Declare the createOMRequest Throws IOException
- In the calling method:
```
omRequest = createOMRequest(OzoneManagerProtocolProtos.Type.RenameKey)
              .setRenameKeyRequest(renameKeyRequest)
              .build();
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6796

## How was this patch tested?
Locally build successfully by:
mvn clean install -DskipTests -DskipShade
CI passed on the fork git repo.)
