### PR TITLE
HDDS-10160. Cache sort results in ContainerBalancerSelectionCriteria

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
@@ -96,7 +96,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
    * Find a {@link ContainerMoveSelection} consisting of a target and
    * container to move for a source datanode. Favours more under-utilized nodes.
    * @param source Datanode to find a target for
-   * @param candidateContainers Set of candidate containers satisfying
+   * @param container candidate container satisfying
    *                            selection criteria
    *                            {@link ContainerBalancerSelectionCriteria}
    * (DatanodeDetails, Long) method returns true if the size specified in the
@@ -105,29 +105,27 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
    */
   @Override
   public ContainerMoveSelection findTargetForContainerMove(
-      DatanodeDetails source, Set<ContainerID> candidateContainers) {
+      DatanodeDetails source, ContainerID container) {
     sortTargetForSource(source);
     for (DatanodeUsageInfo targetInfo : potentialTargets) {
       DatanodeDetails target = targetInfo.getDatanodeDetails();
-      for (ContainerID container : candidateContainers) {
-        Set<ContainerReplica> replicas;
-        ContainerInfo containerInfo;
-        try {
-          replicas = containerManager.getContainerReplicas(container);
-          containerInfo = containerManager.getContainer(container);
-        } catch (ContainerNotFoundException e) {
-          logger.warn("Could not get Container {} from Container Manager for " +
-              "obtaining replicas in Container Balancer.", container, e);
-          continue;
-        }
+      Set<ContainerReplica> replicas;
+      ContainerInfo containerInfo;
+      try {
+        replicas = containerManager.getContainerReplicas(container);
+        containerInfo = containerManager.getContainer(container);
+      } catch (ContainerNotFoundException e) {
+        logger.warn("Could not get Container {} from Container Manager for " +
+            "obtaining replicas in Container Balancer.", container, e);
+        return null;
+      }
 
-        if (replicas.stream().noneMatch(
-            replica -> replica.getDatanodeDetails().equals(target)) &&
-            containerMoveSatisfiesPlacementPolicy(container, replicas, source,
-            target) &&
-            canSizeEnterTarget(target, containerInfo.getUsedBytes())) {
-          return new ContainerMoveSelection(target, container);
-        }
+      if (replicas.stream().noneMatch(
+          replica -> replica.getDatanodeDetails().equals(target)) &&
+          containerMoveSatisfiesPlacementPolicy(container, replicas, source,
+          target) &&
+          canSizeEnterTarget(target, containerInfo.getUsedBytes())) {
+        return new ContainerMoveSelection(target, container);
       }
     }
     logger.info("Container Balancer could not find a target for " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
@@ -258,7 +258,14 @@ public class ContainerBalancerSelectionCriteria {
       throws NodeNotFoundException {
     NavigableSet<ContainerID> newSet =
         new TreeSet<>(orderContainersByUsedBytes().reversed());
-    newSet.addAll(nodeManager.getContainers(node));
+    Set<ContainerID> idSet = nodeManager.getContainers(node);
+    if (excludeContainers != null) {
+      idSet.removeAll(excludeContainers);
+    }
+    if (selectedContainers != null) {
+      idSet.removeAll(selectedContainers);
+    }
+    newSet.addAll(idSet);
     setMap.put(node, newSet);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerSelectionCriteria.java
@@ -155,16 +155,14 @@ public class ContainerBalancerSelectionCriteria {
   /**
    * Gets containers that are suitable for moving based on the following
    * required criteria:
-   * 1. Container must not be in ExcludedContainers.
-   * 2. Container must not be in SelectedContainers.
-   * 3. Container must not be undergoing replication.
-   * 4. Container must not already be selected for balancing.
-   * 5. Container size should be closer to 5GB.
-   * 6. Container must not be in the configured exclude containers list.
-   * 7. Container should be closed.
-   * 8. If the {@link LegacyReplicationManager} is enabled, then the container should not be an EC container.
+   * 1. Container must not be undergoing replication.
+   * 2. Container must not already be selected for balancing.
+   * 3. Container size should be closer to 5GB.
+   * 4. Container must not be in the configured exclude containers list.
+   * 5. Container should be closed.
+   * 6. If the {@link LegacyReplicationManager} is enabled, then the container should not be an EC container.
    * @param node DatanodeDetails for which to find candidate containers.
-   * @return Set of candidate containers that satisfy the criteria.
+   * @return true if the container should be excluded, else false
    */
   public boolean shouldBeExcluded(ContainerID containerID,
       DatanodeDetails node, long sizeMovedAlready) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -708,11 +708,11 @@ public class ContainerBalancerTask implements Runnable {
     }
 
     ContainerMoveSelection moveSelection = null;
-    Set<ContainerID> toRemoveContainers = new HashSet<>();
+    Set<ContainerID> toRemoveContainerIds = new HashSet<>();
     for (ContainerID containerId: sourceContainerIDSet) {
       if (selectionCriteria.shouldBeExcluded(containerId, source,
           sizeScheduledForMoveInLatestIteration)) {
-        toRemoveContainers.add(containerId);
+        toRemoveContainerIds.add(containerId);
         continue;
       }
       moveSelection = findTargetStrategy.findTargetForContainerMove(source,
@@ -721,7 +721,7 @@ public class ContainerBalancerTask implements Runnable {
         break;
       }
     }
-    sourceContainerIDSet.removeAll(toRemoveContainers);
+    sourceContainerIDSet.removeAll(toRemoveContainerIds);
 
     if (moveSelection == null) {
       if (LOG.isDebugEnabled()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -721,6 +721,7 @@ public class ContainerBalancerTask implements Runnable {
         break;
       }
     }
+    // Update cached containerIDSet in setMap
     sourceContainerIDSet.removeAll(toRemoveContainerIds);
 
     if (moveSelection == null) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -708,9 +708,11 @@ public class ContainerBalancerTask implements Runnable {
     }
 
     ContainerMoveSelection moveSelection = null;
+    Set<ContainerID> toRemoveContainers = new HashSet<>();
     for (ContainerID containerId: sourceContainerIDSet) {
       if (selectionCriteria.shouldBeExcluded(containerId, source,
           sizeScheduledForMoveInLatestIteration)) {
+        toRemoveContainers.add(containerId);
         continue;
       }
       moveSelection = findTargetStrategy.findTargetForContainerMove(source,
@@ -719,6 +721,7 @@ public class ContainerBalancerTask implements Runnable {
         break;
       }
     }
+    sourceContainerIDSet.removeAll(toRemoveContainers);
 
     if (moveSelection == null) {
       if (LOG.isDebugEnabled()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -50,7 +50,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -692,7 +691,7 @@ public class ContainerBalancerTask implements Runnable {
    * @return ContainerMoveSelection containing the selected target and container
    */
   private ContainerMoveSelection matchSourceWithTarget(DatanodeDetails source) {
-    NavigableSet<ContainerID> candidateContainers =
+    Set<ContainerID> candidateContainers =
         selectionCriteria.getCandidateContainers(source,
             sizeScheduledForMoveInLatestIteration);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetStrategy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetStrategy.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /**
  * This interface can be used to implement strategies to find a target for a
@@ -40,7 +39,7 @@ public interface FindTargetStrategy {
    * enter a potential target.
    *
    * @param source Datanode to find a target for
-   * @param candidateContainers Set of candidate containers satisfying
+   * @param candidateContainer candidate containers satisfying
    *                            selection criteria
    *                            {@link ContainerBalancerSelectionCriteria}
    * (DatanodeDetails, Long) method returns true if the size specified in the
@@ -49,7 +48,7 @@ public interface FindTargetStrategy {
    * selected container
    */
   ContainerMoveSelection findTargetForContainerMove(
-      DatanodeDetails source, Set<ContainerID> candidateContainers);
+      DatanodeDetails source, ContainerID candidateContainer);
 
   /**
    * increase the Entering size of a candidate target data node.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -786,7 +786,7 @@ public class MockNodeManager implements NodeManager {
   @Override
   public Boolean isNodeRegistered(
       DatanodeDetails datanodeDetails) {
-    return false;
+    return healthyNodes.contains(datanodeDetails);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-10160](https://issues.apache.org/jira/browse/HDDS-10160). Cache sort results in ContainerBalancerSelectionCriteria

The sort of all the containers is very time consuming, this patch is to cache the sort result and improve the balancer speed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10160

## How was this patch tested?

Original balancer tests running successfully would be enough.
