### PR TITLE
HDDS-10183. Dynamic reconfiguration replication stream limit

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -82,6 +82,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_WORKERS;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
 import static org.apache.hadoop.ozone.common.Storage.StorageState.INITIALIZED;
+import static org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig.REPLICATION_STREAMS_LIMIT_KEY;
 import static org.apache.hadoop.security.UserGroupInformation.getCurrentUser;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_BLOCK_DELETE_THREAD_MAX;
 import static org.apache.hadoop.util.ExitUtil.terminate;
@@ -291,7 +292,9 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
               .register(HDDS_DATANODE_BLOCK_DELETE_THREAD_MAX,
                   this::reconfigBlockDeleteThreadMax)
               .register(OZONE_BLOCK_DELETING_SERVICE_WORKERS,
-                  this::reconfigDeletingServiceWorkers);
+                  this::reconfigDeletingServiceWorkers)
+              .register(REPLICATION_STREAMS_LIMIT_KEY,
+                  this::reconfigReplicationStreamsLimit);
 
       datanodeStateMachine = new DatanodeStateMachine(datanodeDetails, conf,
           dnCertClient, secretKeyClient, this::terminateDatanode, dnCRLStore,
@@ -664,6 +667,14 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     getConf().set(OZONE_BLOCK_DELETING_SERVICE_WORKERS, value);
 
     getDatanodeStateMachine().getContainer().getBlockDeletingService()
+        .setPoolSize(Integer.parseInt(value));
+    return value;
+  }
+
+  private String reconfigReplicationStreamsLimit(String value) {
+    getConf().set(REPLICATION_STREAMS_LIMIT_KEY, value);
+
+    getDatanodeStateMachine().getContainer().getReplicationServer()
         .setPoolSize(Integer.parseInt(value));
     return value;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -584,4 +584,8 @@ public class OzoneContainer {
     return blockDeletingService;
   }
 
+  public ReplicationServer getReplicationServer() {
+    return replicationServer;
+  }
+
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.PostConstruct;
-import org.apache.hadoop.hdds.conf.ReconfigurableConfig;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.tracing.GrpcServerInterceptor;
@@ -185,7 +184,7 @@ public class ReplicationServer {
    * Replication-related configuration.
    */
   @ConfigGroup(prefix = ReplicationConfig.PREFIX)
-  public static final class ReplicationConfig extends ReconfigurableConfig {
+  public static final class ReplicationConfig {
 
     public static final String PREFIX = "hdds.datanode.replication";
     public static final String STREAMS_LIMIT_KEY = "streams.limit";
@@ -211,7 +210,6 @@ public class ReplicationServer {
     @Config(key = STREAMS_LIMIT_KEY,
         type = ConfigType.INT,
         defaultValue = "10",
-        reconfigurable = true,
         tags = {DATANODE},
         description = "The maximum number of replication commands a single " +
             "datanode can execute simultaneously"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dynamic reconfiguration replication stream limit.

Control the replication load while the datanode is running.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10183

## How was this patch tested?

UT
