### PR TITLE
HDDS-10184. Fix ManagedStatistics not closed properly

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -118,9 +118,10 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
           OZONE_METADATA_STORE_ROCKSDB_STATISTICS_DEFAULT);
 
       if (!rocksDbStat.equals(OZONE_METADATA_STORE_ROCKSDB_STATISTICS_OFF)) {
-        ManagedStatistics statistics = new ManagedStatistics();
-        statistics.setStatsLevel(StatsLevel.valueOf(rocksDbStat));
-        options.setStatistics(statistics);
+        try (ManagedStatistics statistics = new ManagedStatistics()) {
+          statistics.setStatsLevel(StatsLevel.valueOf(rocksDbStat));
+          options.setStatistics(statistics);
+        }
       }
 
       DatanodeConfiguration dc =

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -415,9 +415,10 @@ public final class DBStoreBuilder {
 
     // Create statistics.
     if (!rocksDbStat.equals(OZONE_METADATA_STORE_ROCKSDB_STATISTICS_OFF)) {
-      ManagedStatistics statistics = new ManagedStatistics();
-      statistics.setStatsLevel(StatsLevel.valueOf(rocksDbStat));
-      dbOptions.setStatistics(statistics);
+      try (ManagedStatistics statistics = new ManagedStatistics()) {
+        statistics.setStatsLevel(StatsLevel.valueOf(rocksDbStat));
+        dbOptions.setStatistics(statistics);
+      }
     }
 
     return dbOptions;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -65,7 +65,7 @@ public class TestRDBStore {
       Set<TableConfig> families,
       long maxDbUpdatesSizeThreshold)
       throws IOException {
-    return new RDBStore(dbFile, options, new ManagedWriteOptions(), families,
+    return new RDBStore(dbFile, options, null, new ManagedWriteOptions(), families,
         CodecRegistry.newBuilder().build(), false, 1000, null, false,
         maxDbUpdatesSizeThreshold, true, null, "");
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/utils/db/managed/TestRocksObjectLeakDetector.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/utils/db/managed/TestRocksObjectLeakDetector.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -49,6 +50,7 @@ public class TestRocksObjectLeakDetector {
   static void setUp() throws IOException, InterruptedException,
       TimeoutException {
     OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_METADATA_STORE_ROCKSDB_STATISTICS, "ALL");
     String clusterId = UUID.randomUUID().toString();
     String scmId = UUID.randomUUID().toString();
     String omServiceId = "omServiceId1";


### PR DESCRIPTION
## What changes were proposed in this pull request?
When config set: 
```xml
   <property>
      <name>ozone.metastore.rocksdb.statistics</name>
      <value>ALL</value>
   </property> 
```
ManagedStatistics not closed properly in OM and DN:
```java
2024-01-22 18:34:22,137 [LeakDetector-ManagedRocksObject0] WARN org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils: ManagedStatistics is not closed properly
StackTrace for unclosed instance: org.apache.hadoop.hdds.utils.db.managed.ManagedStatistics.<init>(ManagedStatistics.java:30)
org.apache.hadoop.hdds.utils.db.DBStoreBuilder.getDefaultDBOptions(DBStoreBuilder.java:418)
org.apache.hadoop.hdds.utils.db.DBStoreBuilder.build(DBStoreBuilder.java:209)
org.apache.hadoop.ozone.om.OmMetadataManagerImpl.loadDB(OmMetadataManagerImpl.java:607)
org.apache.hadoop.ozone.om.OmMetadataManagerImpl.loadDB(OmMetadataManagerImpl.java:570)
org.apache.hadoop.ozone.om.OmMetadataManagerImpl.start(OmMetadataManagerImpl.java:560)
org.apache.hadoop.ozone.om.OmMetadataManagerImpl.<init>(OmMetadataManagerImpl.java:342)
org.apache.hadoop.ozone.om.OzoneManager.instantiateServices(OzoneManager.java:803)
org.apache.hadoop.ozone.om.OzoneManager.<init>(OzoneManager.java:683)
org.apache.hadoop.ozone.om.OzoneManager.createOm(OzoneManager.java:768)
org.apache.hadoop.ozone.om.OzoneManagerStarter$OMStarterHelper.start(OzoneManagerStarter.java:189)
org.apache.hadoop.ozone.om.OzoneManagerStarter.startOm(OzoneManagerStarter.java:86)

```
```java
2024-01-22 19:51:22,414 [LeakDetector-ManagedRocksObject0] WARN org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils: ManagedStatistics is not closed properly
StackTrace for unclosed instance: org.apache.hadoop.hdds.utils.db.managed.ManagedStatistics.<init>(ManagedStatistics.java:30)
org.apache.hadoop.ozone.container.metadata.AbstractDatanodeStore.start(AbstractDatanodeStore.java:121)
org.apache.hadoop.ozone.container.metadata.AbstractDatanodeStore.<init>(AbstractDatanodeStore.java:99)
org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl.<init>(DatanodeStoreSchemaThreeImpl.java:66)
org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils.getUncachedDatanodeStore(BlockUtils.java:85)
org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.initPerDiskDBStore(HddsVolumeUtil.java:74)
org.apache.hadoop.ozone.container.common.volume.HddsVolume.loadDbStore(HddsVolume.java:365)
org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.loadVolume(HddsVolumeUtil.java:111)
org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.lambda$loadAllHddsVolumeDbStore$0(HddsVolumeUtil.java:97)
java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1626)
java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1618)
java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)

```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10184

## How was this patch tested?

- origin exist test
- start om and dn in test cluster, not reproduce after fixed
