### PR TITLE
HDDS-10186. Add missing static import for assertions and mocks

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestRatisUnderReplicationHandler.java
@@ -39,11 +39,9 @@ import org.apache.hadoop.hdds.scm.pipeline.InsufficientDatanodesException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -605,11 +603,11 @@ public class TestRatisUnderReplicationHandler {
         DECOMMISSIONING, State.UNHEALTHY, sequenceID);
     replicas.add(unhealthyReplica);
     UnderReplicatedHealthResult result = getUnderReplicatedHealthResult();
-    Mockito.when(result.hasVulnerableUnhealthy()).thenReturn(true);
+    when(result.hasVulnerableUnhealthy()).thenReturn(true);
 
     final Set<Pair<DatanodeDetails, SCMCommand<?>>> commands = testProcessing(replicas, Collections.emptyList(),
         result, 2, 1);
-    Assertions.assertEquals(unhealthyReplica.getDatanodeDetails(), commands.iterator().next().getKey());
+    assertEquals(unhealthyReplica.getDatanodeDetails(), commands.iterator().next().getKey());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -56,7 +56,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -530,7 +529,7 @@ public class TestReplicationManager {
             ContainerReplicaProto.State.UNHEALTHY);
     replicas.add(unhealthy);
     storeContainerAndReplicas(container, replicas);
-    Mockito.when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
+    when(replicationManager.getNodeStatus(any(DatanodeDetails.class)))
         .thenAnswer(invocation -> {
           DatanodeDetails dn = invocation.getArgument(0);
           if (dn.equals(unhealthy.getDatanodeDetails())) {
@@ -550,9 +549,9 @@ public class TestReplicationManager {
     assertEquals(0, repQueue.overReplicatedQueueSize());
 
     // next, this test sets up some mocks to test if RatisUnderReplicationHandler will handle this container correctly
-    Mockito.when(ratisPlacementPolicy.chooseDatanodes(anyList(), anyList(), eq(null), eq(1), anyLong(),
+    when(ratisPlacementPolicy.chooseDatanodes(anyList(), anyList(), eq(null), eq(1), anyLong(),
         anyLong())).thenAnswer(invocation -> ImmutableList.of(MockDatanodeDetails.randomDatanodeDetails()));
-    Mockito.when(nodeManager.getTotalDatanodeCommandCounts(any(DatanodeDetails.class), any(), any()))
+    when(nodeManager.getTotalDatanodeCommandCounts(any(DatanodeDetails.class), any(), any()))
         .thenAnswer(invocation -> {
           Map<SCMCommandProto.Type, Integer> map = new HashMap<>();
           map.put(SCMCommandProto.Type.replicateContainerCommand, 0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
@@ -66,7 +66,6 @@ import java.util.function.BiConsumer;
 import org.apache.ratis.util.function.CheckedBiFunction;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
 
 /**
  * This class tests the metrics of ContainerStateMachine.
@@ -142,7 +141,7 @@ public class TestCSMMetrics {
               pipeline, blockID, 1024);
       ContainerCommandResponseProto response =
           client.sendCommand(writeChunkRequest);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
+      assertEquals(ContainerProtos.Result.SUCCESS,
           response.getResult());
 
       metric = getMetrics(CSMMetrics.SOURCE_NAME +
@@ -160,7 +159,7 @@ public class TestCSMMetrics {
           ContainerTestHelper.getReadChunkRequest(pipeline, writeChunkRequest
               .getWriteChunk());
       response = client.sendCommand(readChunkRequest);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
+      assertEquals(ContainerProtos.Result.SUCCESS,
           response.getResult());
 
       metric = getMetrics(CSMMetrics.SOURCE_NAME +

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
@@ -55,7 +55,8 @@ import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanode
 import static org.apache.ozone.test.MetricsAsserts.assertCounter;
 import static org.apache.ozone.test.MetricsAsserts.assertQuantileGauges;
 import static org.apache.ozone.test.MetricsAsserts.getMetrics;
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -121,7 +122,7 @@ public class TestContainerMetrics {
               pipeline, blockID, 1024);
       ContainerCommandResponseProto response =
               client.sendCommand(writeChunkRequest);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS,
+      assertEquals(ContainerProtos.Result.SUCCESS,
           response.getResult());
 
       //Read Chunk
@@ -129,7 +130,7 @@ public class TestContainerMetrics {
           ContainerTestHelper.getReadChunkRequest(pipeline, writeChunkRequest
               .getWriteChunk());
       response = client.sendCommand(readChunkRequest);
-      Assertions.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
+      assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
 
       MetricsRecordBuilder containerMetrics = getMetrics(
           "StorageContainerMetrics");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestDatanodeQueueMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestDatanodeQueueMetrics.java
@@ -17,14 +17,12 @@
 
 package org.apache.hadoop.ozone.container.metrics;
 
-import org.apache.commons.text.WordUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeQueueMetrics;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -34,10 +32,12 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.UUID;
 
+import static org.apache.commons.text.WordUtils.capitalize;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeQueueMetrics.COMMAND_DISPATCHER_QUEUE_PREFIX;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeQueueMetrics.STATE_CONTEXT_COMMAND_QUEUE_PREFIX;
 import static org.apache.ozone.test.MetricsAsserts.getLongGauge;
 import static org.apache.ozone.test.MetricsAsserts.getMetrics;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for queue metrics of datanodes.
@@ -89,14 +89,12 @@ public class TestDatanodeQueueMetrics {
 
   @Test
   public void testQueueMetrics() {
-
     for (SCMCommandProto.Type type: SCMCommandProto.Type.values()) {
-      Assertions.assertTrue(
-          getGauge(STATE_CONTEXT_COMMAND_QUEUE_PREFIX +
-              WordUtils.capitalize(String.valueOf(type)) + "Size") >= 0);
-      Assertions.assertTrue(
-          getGauge(COMMAND_DISPATCHER_QUEUE_PREFIX +
-              WordUtils.capitalize(String.valueOf(type)) + "Size") >= 0);
+      String typeSize = capitalize(String.valueOf(type)) + "Size";
+      assertThat(getGauge(STATE_CONTEXT_COMMAND_QUEUE_PREFIX + typeSize))
+          .isGreaterThanOrEqualTo(0);
+      assertThat(getGauge(COMMAND_DISPATCHER_QUEUE_PREFIX + typeSize))
+          .isGreaterThanOrEqualTo(0);
     }
 
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.container.replication.SimpleContainerDownloader;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -352,20 +351,15 @@ public class TestOzoneContainerWithTLS {
   }
 
   private long createAndCloseContainer(
-      XceiverClientSpi client, boolean useToken) {
+      XceiverClientSpi client, boolean useToken) throws IOException {
     long id = getTestContainerID();
-    try {
-      Token<ContainerTokenIdentifier>
-          token = createContainer(client, useToken, id);
+    Token<ContainerTokenIdentifier> token = createContainer(client, useToken, id);
 
-      ContainerCommandRequestProto request =
-          getCloseContainer(client.getPipeline(), id, token);
-      ContainerCommandResponseProto response = client.sendCommand(request);
-      assertNotNull(response);
-      assertSame(response.getResult(), ContainerProtos.Result.SUCCESS);
-    } catch (Exception e) {
-      Assertions.fail(e);
-    }
+    ContainerCommandRequestProto request =
+        getCloseContainer(client.getPipeline(), id, token);
+    ContainerCommandResponseProto response = client.sendCommand(request);
+    assertNotNull(response);
+    assertSame(response.getResult(), ContainerProtos.Result.SUCCESS);
     return id;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
@@ -67,7 +67,6 @@ import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.apache.ratis.util.function.CheckedBiFunction;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -75,6 +74,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test Containers.
@@ -170,7 +170,7 @@ public class TestContainerServer {
           ContainerTestHelper
               .getCreateContainerRequest(
                   ContainerTestHelper.getTestContainerID(), pipeline);
-      Assertions.assertNotNull(request.getTraceID());
+      assertNotNull(request.getTraceID());
 
       client.sendCommand(request);
     } finally {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -95,23 +95,21 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.ratis.rpc.RpcType;
-
-import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
-
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.apache.ratis.util.function.CheckedBiFunction;
-import org.junit.jupiter.api.AfterEach;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.ratis.rpc.SupportedRpcType.GRPC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 /**
  * Test Container servers when security is enabled.
@@ -320,7 +318,7 @@ public class TestSecureContainerServer {
       String msg = response.getMessage();
       assertTrue(msg.contains(BLOCK_TOKEN_VERIFICATION_FAILED.name()), msg);
     } else {
-      final Throwable t = Assertions.assertThrows(Throwable.class,
+      final Throwable t = assertThrows(Throwable.class,
           () -> client.sendCommand(request));
       assertRootCauseMessage(BLOCK_TOKEN_VERIFICATION_FAILED.name(), t);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
@@ -30,12 +30,12 @@ import org.apache.hadoop.ozone.segmentparser.DatanodeRatisLogParser;
 
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test Datanode Ratis log parser.
@@ -78,14 +78,14 @@ public class TestDnRatisLogParser {
     File currentDir = new File(pipelineDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");
     GenericTestUtils.waitFor(logFile::exists, 100, 15000);
-    Assertions.assertTrue(logFile.isFile());
+    assertThat(logFile).isFile();
 
     DatanodeRatisLogParser datanodeRatisLogParser =
         new DatanodeRatisLogParser();
     datanodeRatisLogParser.setSegmentFile(logFile);
     datanodeRatisLogParser.parseRatisLogs(
         DatanodeRatisLogParser::smToContainerLogString);
-    Assertions.assertTrue(out.toString(StandardCharsets.UTF_8.name())
-        .contains("Num Total Entries:"));
+    assertThat(out.toString(StandardCharsets.UTF_8.name()))
+        .contains("Num Total Entries:");
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.util.ExitUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -56,6 +55,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERV
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This class tests datanode can tolerate configured num of failed volumes.
@@ -141,8 +141,8 @@ public class TestDatanodeHddsVolumeFailureToleration {
     // cluster.
     GenericTestUtils.waitFor(() -> exitCapturer.getOutput()
         .contains("Exiting with status 1: ExitException"), 500, 60000);
-    Assertions.assertTrue(dsmCapturer.getOutput()
-        .contains("DatanodeStateMachine Shutdown due to too many bad volumes"));
+    assertThat(dsmCapturer.getOutput())
+        .contains("DatanodeStateMachine Shutdown due to too many bad volumes");
 
     // restore bad volumes
     DatanodeTestUtils.restoreBadRootDir(volRootDir0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.om.lock.OMLockMetrics;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -45,6 +44,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for OmBucketReadWriteFileOps.
@@ -207,7 +209,7 @@ public class TestOmBucketReadWriteFileOps {
         }
       }
     }
-    Assertions.assertEquals(expectedCount, actual, "Mismatch Count!");
+    assertEquals(expectedCount, actual, "Mismatch Count!");
   }
 
   private void verifyOMLockMetrics(OMLockMetrics omLockMetrics) {
@@ -218,7 +220,7 @@ public class TestOmBucketReadWriteFileOps {
         omLockMetrics.getLongestReadLockWaitingTimeMs());
     int readWaitingSamples =
         Integer.parseInt(readLockWaitingTimeMsStat.split(" ")[2]);
-    Assertions.assertTrue(readWaitingSamples > 0, "Read Lock Waiting Samples should be positive");
+    assertThat(readWaitingSamples).isPositive();
 
     String readLockHeldTimeMsStat = omLockMetrics.getReadLockHeldTimeMsStat();
     LOG.info("Read Lock Held Time Stat: " + readLockHeldTimeMsStat);
@@ -226,7 +228,7 @@ public class TestOmBucketReadWriteFileOps {
         omLockMetrics.getLongestReadLockHeldTimeMs());
     int readHeldSamples =
         Integer.parseInt(readLockHeldTimeMsStat.split(" ")[2]);
-    Assertions.assertTrue(readHeldSamples > 0, "Read Lock Held Samples should be positive");
+    assertThat(readHeldSamples).isPositive();
 
     String writeLockWaitingTimeMsStat =
         omLockMetrics.getWriteLockWaitingTimeMsStat();
@@ -235,7 +237,7 @@ public class TestOmBucketReadWriteFileOps {
         omLockMetrics.getLongestWriteLockWaitingTimeMs());
     int writeWaitingSamples =
         Integer.parseInt(writeLockWaitingTimeMsStat.split(" ")[2]);
-    Assertions.assertTrue(writeWaitingSamples > 0, "Write Lock Waiting Samples should be positive");
+    assertThat(writeWaitingSamples).isPositive();
 
     String writeLockHeldTimeMsStat = omLockMetrics.getWriteLockHeldTimeMsStat();
     LOG.info("Write Lock Held Time Stat: " + writeLockHeldTimeMsStat);
@@ -243,7 +245,7 @@ public class TestOmBucketReadWriteFileOps {
         omLockMetrics.getLongestWriteLockHeldTimeMs());
     int writeHeldSamples =
         Integer.parseInt(writeLockHeldTimeMsStat.split(" ")[2]);
-    Assertions.assertTrue(writeHeldSamples > 0, "Write Lock Held Samples should be positive");
+    assertThat(writeHeldSamples).isPositive();
   }
 
   private static class ParameterBuilder {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestDeletedBlocksTxnShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestDeletedBlocksTxnShell.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.admin.scm.GetFailedDeletedBlocksTxnSubcommand;
 import org.apache.hadoop.ozone.admin.scm.ResetDeletedBlockRetryCountSubcommand;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -61,6 +60,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for DeletedBlocksTxnSubcommand Cli.
@@ -193,7 +194,7 @@ public class TestDeletedBlocksTxnShell {
     flush();
     currentValidTxnNum = deletedBlockLog.getNumOfValidTransactions();
     LOG.info("Valid num of txns: {}", currentValidTxnNum);
-    Assertions.assertEquals(30, currentValidTxnNum);
+    assertEquals(30, currentValidTxnNum);
 
     // let the first 20 txns be failed
     List<Long> txIds = new ArrayList<>();
@@ -207,7 +208,7 @@ public class TestDeletedBlocksTxnShell {
     flush();
     currentValidTxnNum = deletedBlockLog.getNumOfValidTransactions();
     LOG.info("Valid num of txns: {}", currentValidTxnNum);
-    Assertions.assertEquals(10, currentValidTxnNum);
+    assertEquals(10, currentValidTxnNum);
 
     ContainerOperationClient scmClient = new ContainerOperationClient(conf);
     CommandLine cmd;
@@ -223,12 +224,12 @@ public class TestDeletedBlocksTxnShell {
     while (m.find()) {
       matchCount += 1;
     }
-    Assertions.assertEquals(20, matchCount);
+    assertEquals(20, matchCount);
 
     // print the first 10 failed txns info into file
     cmd.parseArgs("-o", txnFile.getAbsolutePath(), "-c", "10");
     getCommand.execute(scmClient);
-    Assertions.assertTrue(txnFile.exists());
+    assertThat(txnFile).exists();
 
     ResetDeletedBlockRetryCountSubcommand resetCommand =
         new ResetDeletedBlockRetryCountSubcommand();
@@ -240,7 +241,7 @@ public class TestDeletedBlocksTxnShell {
     flush();
     currentValidTxnNum = deletedBlockLog.getNumOfValidTransactions();
     LOG.info("Valid num of txns: {}", currentValidTxnNum);
-    Assertions.assertEquals(20, currentValidTxnNum);
+    assertEquals(20, currentValidTxnNum);
 
     // reset the given txIds list
     cmd.parseArgs("-l", "11,12,13,14,15");
@@ -248,7 +249,7 @@ public class TestDeletedBlocksTxnShell {
     flush();
     currentValidTxnNum = deletedBlockLog.getNumOfValidTransactions();
     LOG.info("Valid num of txns: {}", currentValidTxnNum);
-    Assertions.assertEquals(25, currentValidTxnNum);
+    assertEquals(25, currentValidTxnNum);
 
     // reset the non-existing txns and valid txns, should do nothing
     cmd.parseArgs("-l", "1,2,3,4,5,100,101,102,103,104,105");
@@ -256,7 +257,7 @@ public class TestDeletedBlocksTxnShell {
     flush();
     currentValidTxnNum = deletedBlockLog.getNumOfValidTransactions();
     LOG.info("Valid num of txns: {}", currentValidTxnNum);
-    Assertions.assertEquals(25, currentValidTxnNum);
+    assertEquals(25, currentValidTxnNum);
 
     // reset all the result expired txIds, all transactions should be available
     cmd.parseArgs("-a");
@@ -264,6 +265,6 @@ public class TestDeletedBlocksTxnShell {
     flush();
     currentValidTxnNum = deletedBlockLog.getNumOfValidTransactions();
     LOG.info("Valid num of txns: {}", currentValidTxnNum);
-    Assertions.assertEquals(30, currentValidTxnNum);
+    assertEquals(30, currentValidTxnNum);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneContainerUpgradeShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneContainerUpgradeShell.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -72,6 +71,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVA
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.CONTAINER_SCHEMA_V3_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Ozone Container upgrade shell.
@@ -157,7 +158,7 @@ public class TestOzoneContainerUpgradeShell {
 
     String[] args = new String[]{"upgrade", "--yes"};
     int exitCode = commandLine.execute(args);
-    Assertions.assertEquals(0, exitCode);
+    assertEquals(0, exitCode);
 
     // datanode2 NodeOperationalState is IN_SERVICE upgrade fail.
     OzoneConfiguration datanode2Conf = datanodeConfigs.get(1);
@@ -169,9 +170,9 @@ public class TestOzoneContainerUpgradeShell {
     String[] args2 = new String[]{"upgrade", "--yes"};
     int exit2Code = commandLine2.execute(args2);
 
-    Assertions.assertEquals(0, exit2Code);
+    assertEquals(0, exit2Code);
     String cmdOut = stdout2.toString();
-    Assertions.assertTrue(cmdOut.contains("IN_MAINTENANCE"));
+    assertThat(cmdOut).contains("IN_MAINTENANCE");
   }
 
   private CommandLine upgradeCommand(PrintWriter pstdout) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneDebugShell.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
@@ -69,6 +68,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCE
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_CHECKPOINT_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Ozone Debug shell.
@@ -127,12 +128,12 @@ public class TestOzoneDebugShell {
     writeKey(volumeName, bucketName, keyName);
 
     int exitCode = runChunkInfoCommand(volumeName, bucketName, keyName);
-    Assertions.assertEquals(0, exitCode);
+    assertEquals(0, exitCode);
 
     closeContainerForKey(volumeName, bucketName, keyName);
 
     exitCode = runChunkInfoCommand(volumeName, bucketName, keyName);
-    Assertions.assertEquals(0, exitCode);
+    assertEquals(0, exitCode);
   }
 
   @Test
@@ -142,7 +143,7 @@ public class TestOzoneDebugShell {
     final String keyName = UUID.randomUUID().toString();
     writeKey(volumeName, bucketName, keyName);
     int exitCode = runChunkInfoAndVerifyPaths(volumeName, bucketName, keyName);
-    Assertions.assertEquals(0, exitCode);
+    assertEquals(0, exitCode);
   }
 
   @Test
@@ -163,7 +164,7 @@ public class TestOzoneDebugShell {
     OzoneSnapshot snapshot =
         client.getObjectStore().listSnapshot(volumeName, bucketName, null, null)
             .next();
-    Assertions.assertEquals(snapshotName, snapshot.getName());
+    assertEquals(snapshotName, snapshot.getName());
     String dbPath = getSnapshotDBPath(snapshot.getCheckpointDir());
     String snapshotCurrent = dbPath + OM_KEY_PREFIX + "CURRENT";
     GenericTestUtils
@@ -171,9 +172,9 @@ public class TestOzoneDebugShell {
     String[] args =
         new String[] {"--db=" + dbPath, "scan", "--cf", "keyTable"};
     int exitCode = cmd.execute(args);
-    Assertions.assertEquals(0, exitCode);
+    assertEquals(0, exitCode);
     String cmdOut = stdout.toString();
-    Assertions.assertTrue(cmdOut.contains(keyName));
+    assertThat(cmdOut).contains(keyName);
   }
 
   private static String getSnapshotDBPath(String checkPointDir) {
@@ -233,7 +234,7 @@ public class TestOzoneDebugShell {
       // DN storage directories are set differently for each DN
       // in MiniOzoneCluster as datanode-0,datanode-1,datanode-2 which is why
       // we expect 3 paths here in the set.
-      Assertions.assertEquals(3, blockFilePaths.size());
+      assertEquals(3, blockFilePaths.size());
     }
     return exitCode;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestTransferLeadershipShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestTransferLeadershipShell.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.ratis.protocol.RaftPeer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Test transferLeadership with SCM HA setup.
@@ -90,7 +94,7 @@ public class TestTransferLeadershipShell {
   public void testOmTransfer() throws Exception {
     OzoneManager oldLeader = cluster.getOMLeader();
     List<OzoneManager> omList = new ArrayList<>(cluster.getOzoneManagersList());
-    Assertions.assertTrue(omList.contains(oldLeader));
+    assertThat(omList).contains(oldLeader);
     omList.remove(oldLeader);
     OzoneManager newLeader = omList.get(0);
     cluster.waitForClusterToBeReady();
@@ -98,14 +102,14 @@ public class TestTransferLeadershipShell {
     String[] args1 = {"om", "transfer", "-n", newLeader.getOMNodeId()};
     ozoneAdmin.execute(args1);
     Thread.sleep(3000);
-    Assertions.assertEquals(newLeader, cluster.getOMLeader());
+    assertEquals(newLeader, cluster.getOMLeader());
     assertOMResetPriorities();
 
     oldLeader = cluster.getOMLeader();
     String[] args3 = {"om", "transfer", "-r"};
     ozoneAdmin.execute(args3);
     Thread.sleep(3000);
-    Assertions.assertNotSame(oldLeader, cluster.getOMLeader());
+    assertNotSame(oldLeader, cluster.getOMLeader());
     assertOMResetPriorities();
   }
 
@@ -114,7 +118,7 @@ public class TestTransferLeadershipShell {
     StorageContainerManager oldLeader = getScmLeader(cluster);
     List<StorageContainerManager> scmList = new ArrayList<>(cluster.
         getStorageContainerManagersList());
-    Assertions.assertTrue(scmList.contains(oldLeader));
+    assertThat(scmList).contains(oldLeader);
     scmList.remove(oldLeader);
     StorageContainerManager newLeader = scmList.get(0);
 
@@ -122,14 +126,14 @@ public class TestTransferLeadershipShell {
     String[] args1 = {"scm", "transfer", "-n", newLeader.getScmId()};
     ozoneAdmin.execute(args1);
     cluster.waitForClusterToBeReady();
-    Assertions.assertEquals(newLeader, getScmLeader(cluster));
+    assertEquals(newLeader, getScmLeader(cluster));
     assertSCMResetPriorities();
 
     oldLeader = getScmLeader(cluster);
     String[] args3 = {"scm", "transfer", "-r"};
     ozoneAdmin.execute(args3);
     cluster.waitForClusterToBeReady();
-    Assertions.assertNotSame(oldLeader, getScmLeader(cluster));
+    assertNotSame(oldLeader, getScmLeader(cluster));
     assertSCMResetPriorities();
   }
 
@@ -141,14 +145,14 @@ public class TestTransferLeadershipShell {
         .getPeers();
 
     for (RaftPeer raftPeer: raftPeers) {
-      Assertions.assertEquals(RatisHelper.NEUTRAL_PRIORITY,
+      assertEquals(RatisHelper.NEUTRAL_PRIORITY,
           raftPeer.getPriority());
     }
   }
 
   private void assertSCMResetPriorities() {
     StorageContainerManager scm = getScmLeader(cluster);
-    Assertions.assertNotNull(scm);
+    assertNotNull(scm);
     Collection<RaftPeer> raftPeers = scm
         .getScmHAManager()
         .getRatisServer()
@@ -156,7 +160,7 @@ public class TestTransferLeadershipShell {
         .getGroup()
         .getPeers();
     for (RaftPeer raftPeer: raftPeers) {
-      Assertions.assertEquals(RatisHelper.NEUTRAL_PRIORITY,
+      assertEquals(RatisHelper.NEUTRAL_PRIORITY,
           raftPeer.getPriority());
     }
   }

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfoCodec.java
@@ -23,13 +23,14 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.Proto2CodecTestBase;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test {@link OmMultipartKeyInfo#getCodec()}.
@@ -58,7 +59,7 @@ public class TestOmMultipartKeyInfoCodec
     } catch (java.io.IOException e) {
       e.printStackTrace();
     }
-    Assertions.assertNotNull(data);
+    assertNotNull(data);
 
     OmMultipartKeyInfo multipartKeyInfo = null;
     try {
@@ -66,7 +67,7 @@ public class TestOmMultipartKeyInfoCodec
     } catch (java.io.IOException e) {
       e.printStackTrace();
     }
-    Assertions.assertEquals(omMultipartKeyInfo, multipartKeyInfo);
+    assertEquals(omMultipartKeyInfo, multipartKeyInfo);
 
     // When random byte data passed returns null.
     try {

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
@@ -23,14 +23,14 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 
-
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Class to test OmPrefixInfo.
@@ -91,7 +91,7 @@ public class TestOmPrefixInfo {
         ACCESS);
     OmPrefixInfo clonePrefixInfo = omPrefixInfo.copyObject();
 
-    Assertions.assertEquals(omPrefixInfo, clonePrefixInfo);
+    assertEquals(omPrefixInfo, clonePrefixInfo);
 
 
     // Change acls and check.
@@ -99,7 +99,7 @@ public class TestOmPrefixInfo {
         IAccessAuthorizer.ACLIdentityType.USER, username,
         IAccessAuthorizer.ACLType.READ, ACCESS));
 
-    Assertions.assertNotEquals(omPrefixInfo, clonePrefixInfo);
+    assertNotEquals(omPrefixInfo, clonePrefixInfo);
 
   }
 
@@ -116,10 +116,10 @@ public class TestOmPrefixInfo {
 
     OmPrefixInfo ompri = OmPrefixInfo.getFromProtobuf(prefixInfo);
 
-    Assertions.assertEquals(prefixInfoPath, ompri.getName());
-    Assertions.assertEquals(1, ompri.getMetadata().size());
-    Assertions.assertEquals(metaval, ompri.getMetadata().get(metakey));
-    Assertions.assertEquals(1, ompri.getAcls().size());
+    assertEquals(prefixInfoPath, ompri.getName());
+    assertEquals(1, ompri.getMetadata().size());
+    assertEquals(metaval, ompri.getMetadata().get(metakey));
+    assertEquals(1, ompri.getAcls().size());
   }
 
   @Test
@@ -133,8 +133,8 @@ public class TestOmPrefixInfo {
     omPrefixInfo.getMetadata().put("key", "value");
     OzoneManagerStorageProtos.PersistedPrefixInfo pi =
         omPrefixInfo.getProtobuf();
-    Assertions.assertEquals(testPath, pi.getName());
-    Assertions.assertEquals(1, pi.getAclsCount());
-    Assertions.assertEquals(1, pi.getMetadataCount());
+    assertEquals(testPath, pi.getName());
+    assertEquals(1, pi.getAclsCount());
+    assertEquals(1, pi.getMetadataCount());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add static import for assertions and mocks in all classes missed by other subtasks.

https://issues.apache.org/jira/browse/HDDS-10186

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7617089021