### PR TITLE
HDDS-8005. Fixed intermittent failure in TestOmSnapshot.testSnapDiffWithMultipleSSTs

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -87,7 +87,6 @@ import org.apache.log4j.Logger;
 import org.apache.ozone.rocksdiff.CompactionNode;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Slow;
-import org.apache.ozone.test.tag.Unhealthy;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -1784,9 +1783,7 @@ public abstract class TestOmSnapshot {
    * sst filtering code path.
    */
   @Test
-  @Unhealthy("HDDS-8005")
-  public void testSnapDiffWithMultipleSSTs()
-      throws Exception {
+  public void testSnapDiffWithMultipleSSTs() throws Exception {
     // Create a volume and 2 buckets
     String volumeName1 = "vol-" + counter.incrementAndGet();
     String bucketName1 = "buck1";
@@ -1800,29 +1797,27 @@ public abstract class TestOmSnapshot {
     String keyPrefix = "key-";
     // add file to bucket1 and take snapshot
     createFileKeyWithPrefix(bucket1, keyPrefix);
+    int keyTableSize = getKeyTableSstFiles().size();
     String snap1 = "snap" + counter.incrementAndGet();
     createSnapshot(volumeName1, bucketName1, snap1); // 1.sst
-    assertEquals(1, getKeyTableSstFiles().size());
+    assertEquals(1, (getKeyTableSstFiles().size() - keyTableSize));
     // add files to bucket2 and flush twice to create 2 sst files
     for (int i = 0; i < 5; i++) {
       createFileKeyWithPrefix(bucket2, keyPrefix);
     }
     flushKeyTable(); // 1.sst 2.sst
-    assertEquals(2, getKeyTableSstFiles().size());
+    assertEquals(2, (getKeyTableSstFiles().size() - keyTableSize));
     for (int i = 0; i < 5; i++) {
       createFileKeyWithPrefix(bucket2, keyPrefix);
     }
     flushKeyTable(); // 1.sst 2.sst 3.sst
-    assertEquals(3, getKeyTableSstFiles().size());
+    assertEquals(3, (getKeyTableSstFiles().size() - keyTableSize));
     // add a file to bucket1 and take second snapshot
     createFileKeyWithPrefix(bucket1, keyPrefix);
     String snap2 = "snap" + counter.incrementAndGet();
     createSnapshot(volumeName1, bucketName1, snap2); // 1.sst 2.sst 3.sst 4.sst
-    assertEquals(4, getKeyTableSstFiles().size());
-    SnapshotDiffReportOzone diff1 =
-        store.snapshotDiff(volumeName1, bucketName1, snap1, snap2,
-                null, 0, forceFullSnapshotDiff, disableNativeDiff)
-            .getSnapshotDiffReport();
+    assertEquals(4, (getKeyTableSstFiles().size() - keyTableSize));
+    SnapshotDiffReportOzone diff1 = getSnapDiffReport(volumeName1, bucketName1, snap1, snap2);
     assertEquals(1, diff1.getDiffList().size());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
`TestOmSnapshot.testSnapDiffWithMultipleSSTs` was failing all the time because snapshot diff is an async API and when a job is submitted for the first time, it always returns empty diff list with IN_PROGRESS status. User is supposed to make second call to fetch the results, once job is DONE. TestOmSnapshot.testSnapDiffWithMultipleSSTs was only making one call which only submits the request and returned empty diff response as mentioned above.
This change is to call snap diff after job to DONE to fetch complete diff report.

## What is the link to the Apache JIRA
HDDS-8005

## How was this patch tested?
* Ran the test locally and on fork: https://github.com/hemantk-12/ozone/actions/runs/7620429542
* Flaky-test-check workflow run: https://github.com/hemantk-12/ozone/actions/runs/7630045775
