### PR TITLE
HDDS-10121. GenericTestUtils.getFieldReflection fails with Java 17.

### DIFF
--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/GenericTestUtils.java
@@ -24,6 +24,8 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -226,7 +228,7 @@ public abstract class GenericTestUtils {
     boolean isAccessible = field.isAccessible();
 
     field.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    Field modifiersField = ReflectionUtils.getModifiersField();
     boolean modifierFieldAccessible = modifiersField.isAccessible();
     modifiersField.setAccessible(true);
     int modifierVal = modifiersField.getInt(field);
@@ -246,7 +248,7 @@ public abstract class GenericTestUtils {
     boolean isAccessible = field.isAccessible();
 
     field.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    Field modifiersField = ReflectionUtils.getModifiersField();
     boolean modifierFieldAccessible = modifiersField.isAccessible();
     modifiersField.setAccessible(true);
     int modifierVal = modifiersField.getInt(field);
@@ -468,4 +470,48 @@ public abstract class GenericTestUtils {
     }
   }
 
+  /**
+   * This class is a utility class for java reflection operations.
+   */
+  public static final class ReflectionUtils {
+
+    /**
+     * This method provides the modifiers field using reflection approach which is compatible
+     * for both pre Java 9 and post java 9 versions.
+     * @return modifiers field
+     * @throws IllegalAccessException
+     * @throws NoSuchFieldException
+     */
+    public static Field getModifiersField() throws IllegalAccessException, NoSuchFieldException {
+      Field modifiersField = null;
+      try {
+        modifiersField = Field.class.getDeclaredField("modifiers");
+      } catch (NoSuchFieldException e) {
+        try {
+          Method getDeclaredFields0 = Class.class.getDeclaredMethod(
+              "getDeclaredFields0", boolean.class);
+          boolean accessibleBeforeSet = getDeclaredFields0.isAccessible();
+          getDeclaredFields0.setAccessible(true);
+          Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
+          getDeclaredFields0.setAccessible(accessibleBeforeSet);
+          for (Field field : fields) {
+            if ("modifiers".equals(field.getName())) {
+              modifiersField = field;
+              break;
+            }
+          }
+          if (modifiersField == null) {
+            throw e;
+          }
+        } catch (NoSuchMethodException ex) {
+          e.addSuppressed(ex);
+          throw e;
+        } catch (InvocationTargetException ex) {
+          e.addSuppressed(ex);
+          throw e;
+        }
+      }
+      return modifiersField;
+    }
+  }
 }

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -1433,7 +1433,7 @@ function ozone_set_module_access_args
     OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-exports java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED"
   fi
   if [[ "${JAVA_MAJOR_VERSION}" -ge 9 ]]; then
-    OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-opens java.base/java.nio=ALL-UNNAMED"
+    OZONE_MODULE_ACCESS_ARGS="${OZONE_MODULE_ACCESS_ARGS} --add-opens='java.base/java.nio=ALL-UNNAMED' --add-opens='java.base/java.lang=ALL-UNNAMED' --add-opens='java.base/java.lang.reflect=ALL-UNNAMED' --add-opens='java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED' --add-exports='java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED' --add-exports='java.base/sun.net.dns=ALL-UNNAMED' "
   fi
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR change is to fix the below java reflection error in `TestECContainerRecovery.testECContainerRecoveryWithTimedOutRecovery` test case:

```
NoSuchFieldException: modifiers
	at java.base/java.lang.Class.getDeclaredField(Class.java:2610)
	at org.apache.ozone.test.GenericTestUtils.getFieldReflection(GenericTestUtils.java:236)
	at org.apache.hadoop.ozone.container.TestECContainerRecovery.testECContainerRecoveryWithTimedOutRecovery(TestECContainerRecovery.java:304)
```
Java 9 onwards, packages are divided among modules and module based access is restricted by default. So application needs to provide and open explicit access to respective modules containing respective packages and needs to provide additional JVM arguments for that. This PR passes the explicit JVM args to open module access if the Java version is greater than 9.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10121

## How was this patch tested?

This patch was tested using existing Junit test run for both Java 8 and Java 17 environments. Below are test results:

`Java 17 run:`
<img width="599" alt="image" src="https://github.com/apache/ozone/assets/20607992/3d3813a6-1c07-4a42-9ea3-a41d86bb392f">
<img width="787" alt="image" src="https://github.com/apache/ozone/assets/20607992/b789c59c-5680-43a6-98c6-b4a3696c4704">
<img width="583" alt="image" src="https://github.com/apache/ozone/assets/20607992/5fc97a11-a278-4264-9721-0c1dbb20d300">

`Java 8 run with same changes:`
<img width="619" alt="image" src="https://github.com/apache/ozone/assets/20607992/483dbb5e-6c47-4065-8e50-6fa33fb400a6">


