### PR TITLE
HDDS-10187. Update hdds-interface-client proto.lock for 1.4

### DIFF
--- a/hadoop-hdds/interface-client/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/resources/proto.lock
@@ -78,6 +78,14 @@
               {
                 "name": "GetCommittedBlockLength",
                 "integer": 18
+              },
+              {
+                "name": "StreamInit",
+                "integer": 19
+              },
+              {
+                "name": "StreamWrite",
+                "integer": 20
               }
             ]
           },
@@ -346,6 +354,31 @@
               {
                 "name": "V1",
                 "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "CopyContainerCompressProto",
+            "enum_fields": [
+              {
+                "name": "NO_COMPRESSION",
+                "integer": 1
+              },
+              {
+                "name": "GZIP",
+                "integer": 2
+              },
+              {
+                "name": "LZ4",
+                "integer": 3
+              },
+              {
+                "name": "SNAPPY",
+                "integer": 4
+              },
+              {
+                "name": "ZSTD",
+                "integer": 5
               }
             ]
           }
@@ -1100,6 +1133,12 @@
                 "name": "checksumData",
                 "type": "ChecksumData",
                 "required": true
+              },
+              {
+                "id": 6,
+                "name": "stripeChecksum",
+                "type": "bytes",
+                "optional": true
               }
             ]
           },
@@ -1150,7 +1189,7 @@
                 "id": 2,
                 "name": "chunkData",
                 "type": "ChunkInfo",
-                "required": true
+                "optional": true
               },
               {
                 "id": 3,
@@ -1366,6 +1405,12 @@
                 "name": "version",
                 "type": "uint32",
                 "optional": true
+              },
+              {
+                "id": 5,
+                "name": "compression",
+                "type": "CopyContainerCompressProto",
+                "optional": true
               }
             ]
           },
@@ -1409,6 +1454,44 @@
                 "optional": true
               }
             ]
+          },
+          {
+            "name": "SendContainerRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "offset",
+                "type": "uint64",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "data",
+                "type": "bytes",
+                "required": true
+              },
+              {
+                "id": 4,
+                "name": "checksum",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 5,
+                "name": "compression",
+                "type": "CopyContainerCompressProto",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "SendContainerResponse"
           }
         ],
         "services": [
@@ -1432,6 +1515,12 @@
                 "in_type": "CopyContainerRequestProto",
                 "out_type": "CopyContainerResponseProto",
                 "out_streamed": true
+              },
+              {
+                "name": "upload",
+                "in_type": "SendContainerRequest",
+                "out_type": "SendContainerResponse",
+                "in_streamed": true
               }
             ]
           }
@@ -1447,6 +1536,150 @@
           {
             "name": "java_outer_classname",
             "value": "ContainerProtos"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "ReconfigureProtocol.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "GetServerNameRequestProto"
+          },
+          {
+            "name": "GetServerNameResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "StartReconfigureRequestProto"
+          },
+          {
+            "name": "StartReconfigureResponseProto"
+          },
+          {
+            "name": "GetReconfigureStatusRequestProto"
+          },
+          {
+            "name": "GetConfigurationChangeProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "oldValue",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "newValue",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "errorMessage",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "GetReconfigureStatusResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "startTime",
+                "type": "int64",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "endTime",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "changes",
+                "type": "GetConfigurationChangeProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ListReconfigurePropertiesRequestProto"
+          },
+          {
+            "name": "ListReconfigurePropertiesResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "ReconfigureProtocolService",
+            "rpcs": [
+              {
+                "name": "getServerName",
+                "in_type": "GetServerNameRequestProto",
+                "out_type": "GetServerNameResponseProto"
+              },
+              {
+                "name": "getReconfigureStatus",
+                "in_type": "GetReconfigureStatusRequestProto",
+                "out_type": "GetReconfigureStatusResponseProto"
+              },
+              {
+                "name": "startReconfigure",
+                "in_type": "StartReconfigureRequestProto",
+                "out_type": "StartReconfigureResponseProto"
+              },
+              {
+                "name": "listReconfigureProperties",
+                "in_type": "ListReconfigurePropertiesRequestProto",
+                "out_type": "ListReconfigurePropertiesResponseProto"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "ReconfigureProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
           },
           {
             "name": "java_generate_equals_and_hash",
@@ -2192,6 +2425,12 @@
                 "name": "node",
                 "type": "DatanodeDetailsProto",
                 "optional": true
+              },
+              {
+                "id": 5,
+                "name": "containerCount",
+                "type": "int64",
+                "optional": true
               }
             ]
           },
@@ -2348,6 +2587,46 @@
           },
           {
             "name": "AddScmResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "scmId",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "RemoveScmRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusterId",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 2,
+                "name": "scmId",
+                "type": "string",
+                "required": true
+              },
+              {
+                "id": 3,
+                "name": "ratisAddr",
+                "type": "string",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "RemoveScmResponseProto",
             "fields": [
               {
                 "id": 1,
@@ -2538,7 +2817,13 @@
                 "id": 4,
                 "name": "omCertSerialId",
                 "type": "string",
-                "required": true
+                "optional": true,
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 5,
@@ -2551,6 +2836,12 @@
                 "name": "maxLength",
                 "type": "uint64",
                 "required": true
+              },
+              {
+                "id": 7,
+                "name": "secretKeyId",
+                "type": "UUID",
+                "optional": true
               }
             ]
           },
@@ -2671,6 +2962,12 @@
                 "name": "bcsId",
                 "type": "int64",
                 "required": true
+              },
+              {
+                "id": 5,
+                "name": "state",
+                "type": "string",
+                "optional": true
               }
             ]
           },
@@ -2875,6 +3172,119 @@
                 "id": 19,
                 "name": "nextIterationIndex",
                 "type": "int32",
+                "optional": true
+              },
+              {
+                "id": 20,
+                "name": "moveReplicationTimeout",
+                "type": "int64",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "TransferLeadershipRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "newLeaderId",
+                "type": "string",
+                "required": true
+              }
+            ]
+          },
+          {
+            "name": "TransferLeadershipResponseProto"
+          },
+          {
+            "name": "DeletedBlocksTransactionInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "txID",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "containerID",
+                "type": "int64",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "localID",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "count",
+                "type": "int32",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "CompactionFileInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fileName",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "startKey",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "endKey",
+                "type": "string",
+                "optional": true
+              },
+              {
+                "id": 4,
+                "name": "columnFamily",
+                "type": "string",
+                "optional": true
+              }
+            ]
+          },
+          {
+            "name": "CompactionLogEntryProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "dbSequenceNumber",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 2,
+                "name": "compactionTime",
+                "type": "uint64",
+                "optional": true
+              },
+              {
+                "id": 3,
+                "name": "inputFileIntoList",
+                "type": "CompactionFileInfoProto",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "outputFileIntoList",
+                "type": "CompactionFileInfoProto",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "compactionReason",
+                "type": "string",
                 "optional": true
               }
             ]

--- a/hadoop-hdds/interface-client/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/resources/proto.lock
@@ -1243,12 +1243,14 @@
               {
                 "id": 3,
                 "name": "data",
-                "type": "bytes"
+                "type": "bytes",
+                "oneof_parent": "responseData"
               },
               {
                 "id": 4,
                 "name": "dataBuffers",
-                "type": "DataBuffers"
+                "type": "DataBuffers",
+                "oneof_parent": "responseData"
               }
             ]
           },

--- a/hadoop-ozone/csi/src/main/resources/proto.lock
+++ b/hadoop-ozone/csi/src/main/resources/proto.lock
@@ -204,12 +204,14 @@
               {
                 "id": 1,
                 "name": "service",
-                "type": "Service"
+                "type": "Service",
+                "oneof_parent": "type"
               },
               {
                 "id": 2,
                 "name": "volume_expansion",
-                "type": "VolumeExpansion"
+                "type": "VolumeExpansion",
+                "oneof_parent": "type"
               }
             ],
             "messages": [
@@ -302,12 +304,14 @@
               {
                 "id": 1,
                 "name": "snapshot",
-                "type": "SnapshotSource"
+                "type": "SnapshotSource",
+                "oneof_parent": "type"
               },
               {
                 "id": 2,
                 "name": "volume",
-                "type": "VolumeSource"
+                "type": "VolumeSource",
+                "oneof_parent": "type"
               }
             ],
             "messages": [
@@ -349,12 +353,14 @@
               {
                 "id": 1,
                 "name": "block",
-                "type": "BlockVolume"
+                "type": "BlockVolume",
+                "oneof_parent": "access_type"
               },
               {
                 "id": 2,
                 "name": "mount",
-                "type": "MountVolume"
+                "type": "MountVolume",
+                "oneof_parent": "access_type"
               },
               {
                 "id": 3,
@@ -793,7 +799,8 @@
               {
                 "id": 1,
                 "name": "rpc",
-                "type": "RPC"
+                "type": "RPC",
+                "oneof_parent": "type"
               }
             ],
             "messages": [
@@ -1243,7 +1250,8 @@
               {
                 "id": 1,
                 "name": "rpc",
-                "type": "RPC"
+                "type": "RPC",
+                "oneof_parent": "type"
               }
             ],
             "messages": [


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some `proto.lock` files were not updated for the 1.4.0 release.  This happened because the new v0.17.0 version of `protolock` introduced a new check, which is failing for `DatanodeClientProtocol.proto` and `csi.proto`:

```
CONFLICT: "data" was moved into oneof "responseData" [DatanodeClientProtocol.proto]
CONFLICT: "dataBuffers" was moved into oneof "responseData" [DatanodeClientProtocol.proto]
CONFLICT: "block" was moved into oneof "access_type" [csi.proto]
CONFLICT: "mount" was moved into oneof "access_type" [csi.proto]
CONFLICT: "rpc" was moved into oneof "type" [csi.proto]
CONFLICT: "rpc" was moved into oneof "type" [csi.proto]
CONFLICT: "service" was moved into oneof "type" [csi.proto]
CONFLICT: "snapshot" was moved into oneof "type" [csi.proto]
CONFLICT: "volume" was moved into oneof "type" [csi.proto]
CONFLICT: "volume_expansion" was moved into oneof "type" [csi.proto]
```

This PR updates `proto.lock` files:

1. eb4eaa6e8a: using v0.16.0, which can be done without conflicts
2. 42544f0712: using v0.17.0 with `--force` option, done separately for easier review

https://issues.apache.org/jira/browse/HDDS-10187

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7622797005