### PR TITLE
HDDS-10191. Fix some mismatches in LICENSE

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -222,6 +222,8 @@ EPL 2.0
    jakarta.ws.rs:jakarta.ws.rs-api
    org.aspectj:aspectjrt
    org.aspectj:aspectjweaver
+   org.jgrapht:jgrapht-core
+   org.jgrapht:jgrapht-ext
 
 
 CDDL 1.1 + GPLv2 with classpath exception
@@ -454,15 +456,6 @@ MIT
    org.kohsuke.metainf-services:metainf-services
    org.slf4j:slf4j-api
    org.slf4j:slf4j-reload4j
-
-
-EPL 2.0
-=====================
-
-   jakarta.annotation:jakarta.annotation-api
-   jakarta.ws.rs:jakarta.ws.rs-api
-   org.jgrapht:jgrapht-core
-   org.jgrapht:jgrapht-ext
 
 
 CDDL + GPLv2 with classpath exception

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -222,6 +222,14 @@ EPL 2.0
    jakarta.ws.rs:jakarta.ws.rs-api
    org.aspectj:aspectjrt
    org.aspectj:aspectjweaver
+   org.glassfish.hk2.external:aopalliance-repackaged
+   org.glassfish.hk2.external:jakarta.inject
+   org.glassfish.hk2.external:javax.inject
+   org.glassfish.hk2:guice-bridge
+   org.glassfish.hk2:hk2-api
+   org.glassfish.hk2:hk2-locator
+   org.glassfish.hk2:hk2-utils
+   org.glassfish.hk2:osgi-resource-locator
    org.glassfish.jersey.containers:jersey-container-servlet
    org.glassfish.jersey.containers:jersey-container-servlet-core
    org.glassfish.jersey.core:jersey-client
@@ -251,14 +259,6 @@ CDDL 1.1 + GPLv2 with classpath exception
    javax.servlet:javax.servlet-api
    javax.servlet.jsp:jsp-api
    javax.ws.rs:jsr311-api
-   org.glassfish.hk2.external:aopalliance-repackaged
-   org.glassfish.hk2.external:jakarta.inject
-   org.glassfish.hk2.external:javax.inject
-   org.glassfish.hk2:guice-bridge
-   org.glassfish.hk2:hk2-api
-   org.glassfish.hk2:hk2-locator
-   org.glassfish.hk2:hk2-utils
-   org.glassfish.hk2:osgi-resource-locator
    org.glassfish.jaxb:jaxb-runtime
    org.glassfish.jaxb:txw2
 

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -458,15 +458,6 @@ MIT
    org.slf4j:slf4j-reload4j
 
 
-CDDL + GPLv2 with classpath exception
-=====================
-
-   javax.annotation:javax.annotation-api
-   javax.el:javax.el-api
-   javax.interceptor:javax.interceptor-api
-   javax.servlet:javax.servlet-api
-
-
 Public Domain
 =====================
 

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -222,6 +222,16 @@ EPL 2.0
    jakarta.ws.rs:jakarta.ws.rs-api
    org.aspectj:aspectjrt
    org.aspectj:aspectjweaver
+   org.glassfish.jersey.containers:jersey-container-servlet
+   org.glassfish.jersey.containers:jersey-container-servlet-core
+   org.glassfish.jersey.core:jersey-client
+   org.glassfish.jersey.core:jersey-common
+   org.glassfish.jersey.core:jersey-server
+   org.glassfish.jersey.ext.cdi:jersey-cdi1x
+   org.glassfish.jersey.ext:jersey-entity-filtering
+   org.glassfish.jersey.inject:jersey-hk2
+   org.glassfish.jersey.media:jersey-media-jaxb
+   org.glassfish.jersey.media:jersey-media-json-jackson
    org.jgrapht:jgrapht-core
    org.jgrapht:jgrapht-ext
 
@@ -251,16 +261,6 @@ CDDL 1.1 + GPLv2 with classpath exception
    org.glassfish.hk2:osgi-resource-locator
    org.glassfish.jaxb:jaxb-runtime
    org.glassfish.jaxb:txw2
-   org.glassfish.jersey.containers:jersey-container-servlet
-   org.glassfish.jersey.containers:jersey-container-servlet-core
-   org.glassfish.jersey.core:jersey-client
-   org.glassfish.jersey.core:jersey-common
-   org.glassfish.jersey.core:jersey-server
-   org.glassfish.jersey.ext.cdi:jersey-cdi1x
-   org.glassfish.jersey.ext:jersey-entity-filtering
-   org.glassfish.jersey.inject:jersey-hk2
-   org.glassfish.jersey.media:jersey-media-jaxb
-   org.glassfish.jersey.media:jersey-media-json-jackson
 
 
 Apache License 2.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

`hadoop-ozone/dist/src/main/license/bin/LICENSE.txt` has some packages under the wrong license (CDDL instead of EPL):

  * [Jersey](https://github.com/eclipse-ee4j/jersey/blob/2.x/README.md#licensing-and-governance)
  * [HK2](https://github.com/eclipse-ee4j/glassfish-hk2?tab=License-1-ov-file#readme)

Also, there are duplicate sections for "EPL 2.0" and "CDDL".

https://issues.apache.org/jira/browse/HDDS-10191