### PR TITLE
HDDS-10194. Upgrade Bouncy Castle to 1.77

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -101,7 +101,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </exclusion>
         <exclusion>
           <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk15on</artifactId>
+          <artifactId>bcprov-jdk18on</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -137,7 +137,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
     <dependency>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -112,7 +112,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </exclusion>
         <exclusion>
           <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk15on</artifactId>
+          <artifactId>bcprov-jdk18on</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateSignRequest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateSignRequest.java
@@ -290,7 +290,7 @@ public class TestCertificateSignRequest {
             assertEquals("2.16.840.1.113730.3.1.34", oid);
           }
           if (o instanceof DERTaggedObject) {
-            String serviceName = ((DERTaggedObject)o).getObject().toString();
+            String serviceName = ((DERTaggedObject)o).toASN1Primitive().toString();
             assertEquals("OzoneMarketingCluster003", serviceName);
           }
         }

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -67,7 +67,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -449,6 +449,7 @@ MIT
    com.kstruct:gethostname4j
    org.bouncycastle:bcpkix-jdk18on
    org.bouncycastle:bcprov-jdk18on
+   org.bouncycastle:bcutil-jdk18on
    org.checkerframework:checker-qual
    org.codehaus.mojo:animal-sniffer-annotations
    org.kohsuke.metainf-services:metainf-services

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -447,8 +447,8 @@ MIT
 
    com.bettercloud:vault-java-driver
    com.kstruct:gethostname4j
-   org.bouncycastle:bcpkix-jdk15on
-   org.bouncycastle:bcprov-jdk15on
+   org.bouncycastle:bcpkix-jdk18on
+   org.bouncycastle:bcprov-jdk18on
    org.checkerframework:checker-qual
    org.codehaus.mojo:animal-sniffer-annotations
    org.kohsuke.metainf-services:metainf-services

--- a/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
@@ -482,10 +482,10 @@ For additional credits (generally to people who reported problems)
 see CREDITS file.
 
 
-org.bouncycastle:bcprov-jdk15on
+org.bouncycastle:bcpkix-jdk18on
 ====================
 
-Copyright (c) 2000 - 2019 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+Copyright (c) 2000 - 2023 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -11,6 +11,7 @@ share/ozone/lib/aws-java-sdk-kms.jar
 share/ozone/lib/aws-java-sdk-s3.jar
 share/ozone/lib/bcpkix-jdk18on.jar
 share/ozone/lib/bcprov-jdk18on.jar
+share/ozone/lib/bcutil-jdk18on.jar
 share/ozone/lib/bonecp.RELEASE.jar
 share/ozone/lib/cdi-api.jar
 share/ozone/lib/checker-qual.jar

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -9,8 +9,8 @@ share/ozone/lib/aspectjweaver.jar
 share/ozone/lib/aws-java-sdk-core.jar
 share/ozone/lib/aws-java-sdk-kms.jar
 share/ozone/lib/aws-java-sdk-s3.jar
-share/ozone/lib/bcpkix-jdk15on.jar
-share/ozone/lib/bcprov-jdk15on.jar
+share/ozone/lib/bcpkix-jdk18on.jar
+share/ozone/lib/bcprov-jdk18on.jar
 share/ozone/lib/bonecp.RELEASE.jar
 share/ozone/lib/cdi-api.jar
 share/ozone/lib/checker-qual.jar

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -87,7 +87,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <assertj.version>3.12.2</assertj.version>
     <asm.version>5.0.4</asm.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
-    <bouncycastle.version>1.67</bouncycastle.version>
+    <bouncycastle.version>1.77</bouncycastle.version>
     <cglib.version>3.3.0</cglib.version>
     <derby.version>10.14.2.0</derby.version>
     <codahale-metrics.version>3.0.2</codahale-metrics.version>
@@ -1432,17 +1432,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
+        <artifactId>bcprov-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk16</artifactId>
+        <artifactId>bcutil-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
       </dependency>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Bouncy Castle to 1.77 (current latest release).  Dependabot would not upgrade it due to a packaging change in 1.71.

1.74 fixes CVE-2023-33201, which does not affect Ozone since we don't use LDAP.

https://bouncycastle.org/latest_releases.html

https://issues.apache.org/jira/browse/HDDS-10194

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7630191546