### PR TITLE
HDDS-8941. Intermittent timeout in TestContainerBalancerTask

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -1066,7 +1066,7 @@ public class TestContainerBalancerTask {
      This is the delay before it starts balancing.
      */
     GenericTestUtils.waitFor(
-        () -> balancingThread.getState() == Thread.State.TIMED_WAITING, 1, 20);
+        () -> balancingThread.getState() == Thread.State.TIMED_WAITING, 1, 40);
     assertEquals(Thread.State.TIMED_WAITING,
         balancingThread.getState());
 
@@ -1074,7 +1074,7 @@ public class TestContainerBalancerTask {
     // STOPPED
     balancingThread.interrupt();
     GenericTestUtils.waitFor(() -> containerBalancerTask.getBalancerStatus() ==
-        ContainerBalancerTask.Status.STOPPED, 1, 20);
+        ContainerBalancerTask.Status.STOPPED, 1, 40);
     assertEquals(ContainerBalancerTask.Status.STOPPED, containerBalancerTask.getBalancerStatus());
 
     // ensure the thread dies

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -1065,7 +1065,7 @@ public class TestContainerBalancerTask {
      This is the delay before it starts balancing.
      */
     GenericTestUtils.waitFor(
-        () -> balancingThread.getState() == Thread.State.TIMED_WAITING, 1, 20);
+        () -> balancingThread.getState() == Thread.State.TIMED_WAITING, 1, 40);
     assertEquals(Thread.State.TIMED_WAITING,
         balancingThread.getState());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -1048,7 +1048,6 @@ public class TestContainerBalancerTask {
     stopBalancer();
   }
 
-  @Unhealthy("HDDS-8941")
   @Test
   public void testDelayedStart() throws InterruptedException, TimeoutException {
     conf.setTimeDuration("hdds.scm.wait.time.after.safemode.exit", 10,
@@ -1066,7 +1065,7 @@ public class TestContainerBalancerTask {
      This is the delay before it starts balancing.
      */
     GenericTestUtils.waitFor(
-        () -> balancingThread.getState() == Thread.State.TIMED_WAITING, 1, 40);
+        () -> balancingThread.getState() == Thread.State.TIMED_WAITING, 1, 20);
     assertEquals(Thread.State.TIMED_WAITING,
         balancingThread.getState());
 
@@ -1074,7 +1073,7 @@ public class TestContainerBalancerTask {
     // STOPPED
     balancingThread.interrupt();
     GenericTestUtils.waitFor(() -> containerBalancerTask.getBalancerStatus() ==
-        ContainerBalancerTask.Status.STOPPED, 1, 40);
+        ContainerBalancerTask.Status.STOPPED, 1, 20);
     assertEquals(ContainerBalancerTask.Status.STOPPED, containerBalancerTask.getBalancerStatus());
 
     // ensure the thread dies


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Enabled the test method `TestContainerBalancerTask` with a fix.
- The small change fixes the testDelayedStart of TestContainerBalancerTask method timing out, the reason why its timing out is because of the fact that sometimes it takes more than 20millisecond to go into waiting state.
So by increasing the waiting time to 40 seconds, I was able to run the test successfully 600 times.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8941

## How was this patch tested?

I was able to run the test successfully 600 times.
https://github.com/ArafatKhan2198/ozone/actions/runs/7617671268
https://github.com/ArafatKhan2198/ozone/actions/runs/7617674689
https://github.com/ArafatKhan2198/ozone/actions/runs/7617675944