### PR TITLE
HDDS-10196. Group dependabot PRs for frontend dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[Recon] Dependabot Package Upgrade: "
+    groups:
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    commit-message:
-      prefix: "[Java] Dependabot Package Upgrade: "
     pull-request-branch-name:
       separator: "-"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Attempt to configure dependabot to have only one PR open for all Recon dependencies at the same time ([docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-version-updates-into-one-pull-request)).

Also drop the prefix for Java package updates.  The prefix for Recon is used in the `dependabot-ci` [workflow](https://github.com/apache/ozone/blob/51a7eaec39b7bc61f280bd5512bc184774e2254b/.github/workflows/dependabot-ci.yml#L24), but the one for Java is unnecessary, causing too long titles.

https://issues.apache.org/jira/browse/HDDS-10196

## How was this patch tested?

Not yet.