### PR TITLE
HDDS-10197. Increase timeout for compile check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - build-info
       - build
       - basic
-    timeout-minutes: 30
+    timeout-minutes: 45
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
       matrix:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase timeout for `compile` check, which seems to take a lot more time on MacOS, and may intermittently run a bit over 30 minutes.  

Mac: https://github.com/apache/ozone/actions/runs/7631717145/job/20790957028
Linux: https://github.com/apache/ozone/actions/runs/7631717145/job/20790956625

https://issues.apache.org/jira/browse/HDDS-10197

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7638587571/job/20811157503