### PR TITLE
HDDS-10199. Node.js 16 actions are deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,11 @@ jobs:
       needs-kubernetes-tests: ${{ steps.selective-checks.outputs.needs-kubernetes-tests }}
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Fetch incoming commit ${{ github.sha }} with its parent
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
           fetch-depth: 2
@@ -81,9 +81,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache for npm dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.pnpm-store
@@ -92,7 +92,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository
@@ -101,7 +101,7 @@ jobs:
           restore-keys: |
             maven-repo-
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -110,7 +110,7 @@ jobs:
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Store binaries for tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ozone-bin
           path: |
@@ -118,13 +118,13 @@ jobs:
             !hadoop-ozone/dist/target/ozone-*-src.tar.gz
           retention-days: 1
       - name: Store source tarball for compilation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ozone-src
           path: hadoop-ozone/dist/target/ozone-*-src.tar.gz
           retention-days: 1
       - name: Store Maven repo for tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ozone-repo
           path: |
@@ -148,7 +148,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Download Ozone source tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ozone-src
       - name: Untar sources
@@ -161,7 +161,7 @@ jobs:
           git config user.email 'noreply@github.com'
           git commit --allow-empty -a -m 'workaround for HADOOP-19011'
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository
@@ -170,7 +170,7 @@ jobs:
           restore-keys: |
             maven-repo-
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -191,15 +191,15 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: matrix.check != 'bats'
       - name: Checkout project with history
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
         if: matrix.check == 'bats'
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository
@@ -209,7 +209,7 @@ jobs:
             maven-repo-
         if: ${{ !contains('author,bats,docs', matrix.check) }}
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
@@ -222,7 +222,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: ${{ matrix.check }}
@@ -241,9 +241,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository
@@ -252,7 +252,7 @@ jobs:
           restore-keys: |
             maven-repo-
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
@@ -265,7 +265,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: ${{ matrix.check }}
@@ -280,9 +280,9 @@ jobs:
     if: needs.build-info.outputs.needs-dependency-check == 'true'
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ozone-bin
       - name: Untar binaries
@@ -294,7 +294,7 @@ jobs:
           export OZONE_DIST_DIR=`pwd`/dist
           ./hadoop-ozone/dev-support/checks/dependency.sh
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: dependency
@@ -309,9 +309,9 @@ jobs:
     if: needs.build-info.outputs.needs-dependency-check == 'true'
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository
@@ -321,7 +321,7 @@ jobs:
             maven-repo-
       - name: Download Ozone repo
         id: download-ozone-repo
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ozone-repo
           path: |
@@ -334,7 +334,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ github.job }}
@@ -354,9 +354,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ozone-bin
       - name: Untar binaries
@@ -380,7 +380,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: acceptance-${{ matrix.suite }}
@@ -396,9 +396,9 @@ jobs:
     if: needs.build-info.outputs.needs-kubernetes-tests == 'true'
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ozone-bin
       - name: Untar binaries
@@ -416,7 +416,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: kubernetes
@@ -444,9 +444,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository
@@ -456,14 +456,14 @@ jobs:
             maven-repo-
       - name: Download Ozone repo
         id: download-ozone-repo
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ozone-repo
           path: |
             ~/.m2/repository/org/apache/ozone
         continue-on-error: true
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
@@ -486,7 +486,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: it-${{ matrix.profile }}
@@ -502,11 +502,11 @@ jobs:
       - integration
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository
@@ -515,7 +515,7 @@ jobs:
           restore-keys: |
             maven-repo-
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: target/artifacts
       - name: Untar binaries
@@ -525,7 +525,7 @@ jobs:
       - name: Calculate combined coverage
         run: ./hadoop-ozone/dev-support/checks/coverage.sh
       - name: Setup java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
@@ -536,7 +536,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: target/coverage

--- a/.github/workflows/close-pending.yaml
+++ b/.github/workflows/close-pending.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Execute close-pending script
         if: github.repository == 'apache/ozone'
         run: ./.github/close-pending.sh

--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Execute process-comment script
         run: ./.github/process-comment.sh
         env:

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -49,7 +49,7 @@ jobs:
           #Delete the lockfile created by dependabot
           rm -rf hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/pnpm-lock.yaml
       - name: Install NodeJS v${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install pnpm v${{ env.PNPM_VERSION }} and recreate lockfile

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -54,7 +54,7 @@ jobs:
       matrix: ${{steps.generate.outputs.matrix}}
       test_type: ${{steps.check-test-existence.outputs.test_type}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Check for Test File
@@ -99,9 +99,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository
@@ -110,14 +110,14 @@ jobs:
           restore-keys: |
             maven-repo-
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
       - name: Build (most) of Ozone
         run: hadoop-ozone/dev-support/checks/build.sh -Dskip.npx -Dskip.installnpx -DskipShade
       - name: Store Maven repo for tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ozone-repo
           path: |
@@ -134,11 +134,11 @@ jobs:
         split: ${{fromJson(needs.prepare-job.outputs.matrix)}}  # Define  splits
       fail-fast: ${{ fromJson(github.event.inputs.fail-fast) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Cache for maven dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository
@@ -148,14 +148,14 @@ jobs:
             maven-repo-
       - name: Download Ozone repo
         id: download-ozone-repo
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ozone-repo
           path: |
             ~/.m2/repository/org/apache/ozone
         continue-on-error: true
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
@@ -185,7 +185,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ needs.prepare-job.outputs.test_type }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: result-${{ env.TEST_CLASS }}-split-${{ matrix.split }}
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download build results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Count failures
         run: |
           failures=$(find . -name 'summary.txt' | grep -v 'iteration' | xargs grep -v 'exit code: 0' | wc -l)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check pull request title
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/repeat-acceptance.yml
+++ b/.github/workflows/repeat-acceptance.yml
@@ -55,7 +55,7 @@ jobs:
     outputs:
       matrix: ${{steps.generate.outputs.matrix}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Verify Test Filter
@@ -80,9 +80,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache for npm dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.pnpm-store
@@ -91,7 +91,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Cache for maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ env.JAVA_VERSION }}
@@ -99,7 +99,7 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
@@ -108,7 +108,7 @@ jobs:
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Store binaries for tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ozone-bin
           path: |
@@ -132,11 +132,11 @@ jobs:
         split: ${{ fromJson(needs.prepare-job.outputs.matrix) }}
       fail-fast: ${{ fromJson(github.event.inputs.fail-fast) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ozone-bin
       - name: Untar binaries
@@ -159,7 +159,7 @@ jobs:
         run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: acceptance-${{ matrix.split }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade all GitHub actions to `v4` (which happens to be the version using Node.js 20 for all of them):

  * https://github.com/actions/cache/releases/tag/v4.0.0
  * https://github.com/actions/checkout/releases/tag/v4.0.0
  * https://github.com/actions/download-artifact/releases/tag/v4.0.0
  * https://github.com/actions/setup-java/releases/tag/v4.0.0
  * https://github.com/actions/setup-node/releases/tag/v4.0.0
  * https://github.com/actions/upload-artifact/releases/tag/v4.0.0

https://issues.apache.org/jira/browse/HDDS-10199

## How was this patch tested?

CI run completed normally, artifacts are available.

https://github.com/adoroszlai/ozone/actions/runs/7641885304