### PR TITLE
HDDS-10198. Improve Logging in AbstractFindTargetGreedy

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
@@ -228,6 +228,9 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
       if (totalEnteringSize < config.getMaxSizeEnteringTarget()) {
         //reorder
         potentialTargets.add(nodeManager.getUsageInfo(target));
+      } else {
+        logger.debug("Datanode {} removed from the list of potential targets. The total size of data entering it in " +
+            "this iteration is {}.", target, totalEnteringSize);
       }
       return;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByNetworkTopology.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByNetworkTopology.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
@@ -41,6 +42,8 @@ import java.util.List;
  */
 public class FindTargetGreedyByNetworkTopology
     extends AbstractFindTargetGreedy {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(FindTargetGreedyByNetworkTopology.class);
 
   private NetworkTopology networkTopology;
   private List potentialTargets;
@@ -51,7 +54,7 @@ public class FindTargetGreedyByNetworkTopology
       NodeManager nodeManager,
       NetworkTopology networkTopology) {
     super(containerManager, placementPolicyValidateProxy, nodeManager);
-    setLogger(LoggerFactory.getLogger(FindTargetGreedyByNetworkTopology.class));
+    setLogger(LOG);
     potentialTargets = new LinkedList<>();
     setPotentialTargets(potentialTargets);
     this.networkTopology = networkTopology;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetGreedyByUsageInfo.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
@@ -37,12 +38,15 @@ import java.util.TreeSet;
  * target with the lowest space usage.
  */
 public class FindTargetGreedyByUsageInfo extends AbstractFindTargetGreedy {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(FindTargetGreedyByUsageInfo.class);
+
   public FindTargetGreedyByUsageInfo(
       ContainerManager containerManager,
       PlacementPolicyValidateProxy placementPolicyValidateProxy,
       NodeManager nodeManager) {
     super(containerManager, placementPolicyValidateProxy, nodeManager);
-    setLogger(LoggerFactory.getLogger(FindTargetGreedyByUsageInfo.class));
+    setLogger(LOG);
     setPotentialTargets(new TreeSet<>((a, b) -> compareByUsage(a, b)));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Simple DEBUG level logging improvement for Container Balancer.

This jira is to improve logging around a Datanode being removed from the collection of potential targets in ContainerBalancer. This can help us understand why a particular Datanode wasn't chosen as a target for container move when we think it's the optimal choice.

A Datanode may not be selected in multiple situations - it has already had enough size moved into it and has reached the limit, doesn't follow placement policy, already has the container's replica etc. I saw a situation in which a particular Datanode was the best choice when considering network distance and was also a potential target, but balancer did not choose it. I want to debug why this happened and more logging will help with this.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10198

## How was this patch tested?

Existing tests.