### PR TITLE
HDDS-10210. Ensure atomic update in StateContext#updateCommandStatus

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -893,18 +893,21 @@ public class StateContext {
   }
 
   /**
-   * Updates status of a pending status command.
+   * Updates the command status of a pending command.
    * @param cmdId       command id
    * @param cmdStatusUpdater Consumer to update command status.
-   * @return true if command status updated successfully else false.
+   * @return true if command status updated successfully else if the command
+   * associated with the command id does not exist in the context.
    */
   public boolean updateCommandStatus(Long cmdId,
       Consumer<CommandStatus> cmdStatusUpdater) {
-    if (cmdStatusMap.containsKey(cmdId)) {
-      cmdStatusUpdater.accept(cmdStatusMap.get(cmdId));
-      return true;
-    }
-    return false;
+    CommandStatus updatedCommandStatus = cmdStatusMap.computeIfPresent(cmdId,
+        (key, value) -> {
+          cmdStatusUpdater.accept(value);
+          return value;
+        }
+    );
+    return updatedCommandStatus != null;
   }
 
   public void configureHeartbeatFrequency() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

While tracing the block deletion logic, I found a possible problem regarding command status update logic.

The cmdStatusMap in StateContext is a ConcurrentHashMap

Currently the update logic for command status is as follows:

```java
public boolean updateCommandStatus(Long cmdId,
    Consumer<CommandStatus> cmdStatusUpdater) {
  if (cmdStatusMap.containsKey(cmdId)) {
    cmdStatusUpdater.accept(cmdStatusMap.get(cmdId));
    return true;
  }
  return false;
}
```

It does not seem correct. Although the get containsKey and get is protected by the ConcurrentHashMap, the CommandStatus retrieved is mutated directly using the cmdStatusUpdater and not protected by the ConcurrentHashMap (Please correct me if I'm mistaken). This might trigger race condition.

We should use atomic operation like computeIfPresent.

Note: The cmdStatusMap is also exposed to public (getCommandStatusMap) which might not be a good idea since we cannot guarantee correct usage of the map. We might need to encapsulate it properly inside StateContext. Also we might want to add `@VisibleForTesting` for `getCmdStatus` and/or make defensive copies of the `CommandStatus`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10210

## How was this patch tested?

Existing tests.

Clean CI: https://github.com/ivandika3/ozone/actions/runs/7650123708
