### PR TITLE
HDDS-9524. Clean up wait for leader OM in integration tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -170,19 +170,15 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
         .findFirst().orElse(null);
   }
 
-  private OzoneManager getOMLeader(boolean waitForLeaderElection)
+  public OzoneManager waitForLeaderOM()
       throws TimeoutException, InterruptedException {
-    if (waitForLeaderElection) {
       final OzoneManager[] om = new OzoneManager[1];
       GenericTestUtils.waitFor(() -> {
         om[0] = getOMLeader();
         return om[0] != null;
       }, 200, waitForClusterToBeReadyTimeout);
       return om[0];
-    } else {
-      return getOMLeader();
     }
-  }
 
   /**
    * Get OzoneManager leader object.
@@ -731,7 +727,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     int retryCount = 0;
     OzoneManager om = null;
 
-    OzoneManager omLeader = getOMLeader(true);
+    OzoneManager omLeader = waitForLeaderOM();
     long leaderSnapshotIndex = omLeader.getRatisSnapshotIndex();
 
     while (true) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -172,13 +172,13 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
   public OzoneManager waitForLeaderOM()
       throws TimeoutException, InterruptedException {
-      final OzoneManager[] om = new OzoneManager[1];
-      GenericTestUtils.waitFor(() -> {
-        om[0] = getOMLeader();
-        return om[0] != null;
-      }, 200, waitForClusterToBeReadyTimeout);
-      return om[0];
-    }
+    final OzoneManager[] om = new OzoneManager[1];
+    GenericTestUtils.waitFor(() -> {
+      om[0] = getOMLeader();
+      return om[0] != null;
+    }, 200, waitForClusterToBeReadyTimeout);
+    return om[0];
+  }
 
   /**
    * Get OzoneManager leader object.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -206,7 +206,7 @@ public class TestAddRemoveOzoneManager {
         .toLong(TimeUnit.MILLISECONDS) * 3);
 
     // Verify that one of the new OMs is the leader
-    GenericTestUtils.waitFor(() -> cluster.getOMLeader() != null, 500, 30000);
+    cluster.waitForLeaderOM();
     OzoneManager omLeader = cluster.getOMLeader();
 
     assertThat(newOMNodeIds)
@@ -434,6 +434,6 @@ public class TestAddRemoveOzoneManager {
     }, 100, 100000);
 
     // Wait for new leader election if required
-    GenericTestUtils.waitFor(() -> cluster.getOMLeader() != null, 500, 30000);
+    cluster.waitForLeaderOM();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -462,7 +462,6 @@ public abstract class TestOzoneManagerHA {
     // Wait for Leader Election timeout
     int timeout = OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT
         .toIntExact(TimeUnit.MILLISECONDS);
-    GenericTestUtils.waitFor(() ->
-        getCluster().getOMLeader() != null, 500, timeout);
+    cluster.waitForLeaderOM();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
-import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -50,7 +50,6 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -64,7 +63,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -459,8 +457,6 @@ public abstract class TestOzoneManagerHA {
   protected void waitForLeaderToBeReady()
       throws InterruptedException, TimeoutException {
     // Wait for Leader Election timeout
-    int timeout = OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT
-        .toIntExact(TimeUnit.MILLISECONDS);
     cluster.waitForLeaderOM();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
@@ -123,7 +123,7 @@ public class TestOzoneManagerHASnapshot {
     cluster.shutdownOzoneManager(omLeader);
     cluster.restartOzoneManager(omLeader, true);
 
-    await(120_000, 100, () -> cluster.getOMLeader() != null);
+    cluster.waitForLeaderOM();
 
     String newLeader = cluster.getOMLeader().getOMNodeId();
 
@@ -250,7 +250,7 @@ public class TestOzoneManagerHASnapshot {
     cluster.shutdownOzoneManager(omLeader);
     cluster.restartOzoneManager(omLeader, true);
 
-    await(180_000, 100, () -> cluster.getOMLeader() != null);
+    cluster.waitForLeaderOM();
     assertNotNull(cluster.getOMLeader());
     OmMetadataManagerImpl metadataManager = (OmMetadataManagerImpl) cluster
         .getOMLeader().getMetadataManager();


### PR DESCRIPTION
## What changes were proposed in this pull request?
MiniOzoneHAClusterImpl:

getOMLeader() returns current OM leader.
getOMLeader(boolean) optionally waits until OM leader is elected
There are some tests that implement the same "wait for leader OM" logic using the non-waiting getOMLeader(). 

```
hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
209:    GenericTestUtils.waitFor(() -> cluster.getOMLeader() != null, 500, 30000);
437:    GenericTestUtils.waitFor(() -> cluster.getOMLeader() != null, 500, 30000);

hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
466:        getCluster().getOMLeader() != null, 500, timeout);

hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
126:    await(120_000, 100, () -> cluster.getOMLeader() != null);
253:    await(180_000, 100, () -> cluster.getOMLeader() != null);
```

Goals of this task:
rename getOMLeader(boolean) to waitForLeaderOM() (the method is only called with true)
make waitForLeaderOM() public
replace duplicated wait logic in tests with a call to waitForLeaderOM()

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9524

## How was this patch tested?
Made changes and ran unit test.
