### PR TITLE
HDDS-10190. [hsync] Handle lease recovery for file without blocks.

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -155,15 +155,17 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
 
     // finalize the final block and get block length
     List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
-    OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
-    try {
-      block.setLength(getAdapter().finalizeBlock(block));
-    } catch (Throwable e) {
-      if (!forceRecovery) {
-        throw e;
+    if (locationInfoList.size() > 0) {
+      OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
+      try {
+        block.setLength(getAdapter().finalizeBlock(block));
+      } catch (Throwable e) {
+        if (!forceRecovery) {
+          throw e;
+        }
+        LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+            FORCE_LEASE_RECOVERY_ENV, e);
       }
-      LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-          FORCE_LEASE_RECOVERY_ENV, e);
     }
 
     // recover and commit file

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -155,7 +155,7 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
 
     // finalize the final block and get block length
     List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
-    if (locationInfoList.size() > 0) {
+    if (!locationInfoList.isEmpty()) {
       OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
       try {
         block.setLength(getAdapter().finalizeBlock(block));

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -159,7 +159,7 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
     // finalize the final block and get block length
     List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
-    if (locationInfoList.size() > 0) {
+    if (!locationInfoList.isEmpty()) {
       OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
       try {
         block.setLength(getAdapter().finalizeBlock(block));

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -159,15 +159,17 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
     // finalize the final block and get block length
     List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
-    OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
-    try {
-      block.setLength(getAdapter().finalizeBlock(block));
-    } catch (Throwable e) {
-      if (!forceRecovery) {
-        throw e;
+    if (locationInfoList.size() > 0) {
+      OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
+      try {
+        block.setLength(getAdapter().finalizeBlock(block));
+      } catch (Throwable e) {
+        if (!forceRecovery) {
+          throw e;
+        }
+        LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+            FORCE_LEASE_RECOVERY_ENV, e);
       }
-      LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-          FORCE_LEASE_RECOVERY_ENV, e);
     }
 
     // recover and commit file

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -155,15 +155,17 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
 
     // finalize the final block and get block length
     List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
-    OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
-    try {
-      block.setLength(getAdapter().finalizeBlock(block));
-    } catch (Throwable e) {
-      if (!forceRecovery) {
-        throw e;
+    if (locationInfoList.size() > 0) {
+      OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
+      try {
+        block.setLength(getAdapter().finalizeBlock(block));
+      } catch (Throwable e) {
+        if (!forceRecovery) {
+          throw e;
+        }
+        LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+            FORCE_LEASE_RECOVERY_ENV, e);
       }
-      LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-          FORCE_LEASE_RECOVERY_ENV, e);
     }
 
     // recover and commit file

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -155,7 +155,7 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
 
     // finalize the final block and get block length
     List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
-    if (locationInfoList.size() > 0) {
+    if (!locationInfoList.isEmpty()) {
       OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
       try {
         block.setLength(getAdapter().finalizeBlock(block));

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -152,15 +152,17 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
     // finalize the final block and get block length
     List<OmKeyLocationInfo> keyLocationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
-    OmKeyLocationInfo block = keyLocationInfoList.get(keyLocationInfoList.size() - 1);
-    try {
-      block.setLength(getAdapter().finalizeBlock(block));
-    } catch (Throwable e) {
-      if (!forceRecovery) {
-        throw e;
+    if (keyLocationInfoList.size() > 0) {
+      OmKeyLocationInfo block = keyLocationInfoList.get(keyLocationInfoList.size() - 1);
+      try {
+        block.setLength(getAdapter().finalizeBlock(block));
+      } catch (Throwable e) {
+        if (!forceRecovery) {
+          throw e;
+        }
+        LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+            FORCE_LEASE_RECOVERY_ENV, e);
       }
-      LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-          FORCE_LEASE_RECOVERY_ENV, e);
     }
 
     // recover and commit file

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -152,7 +152,7 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
     // finalize the final block and get block length
     List<OmKeyLocationInfo> keyLocationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
-    if (keyLocationInfoList.size() > 0) {
+    if (!keyLocationInfoList.isEmpty()) {
       OmKeyLocationInfo block = keyLocationInfoList.get(keyLocationInfoList.size() - 1);
       try {
         block.setLength(getAdapter().finalizeBlock(block));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle lease recovery for the file which don't have any blocks. Once after file is created and hsync is called the lease recovery can be called before any block allocation after the soft limit period. In this case recovery should work and file should get closed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10190

## How was this patch tested?

Unit test