### PR TITLE
HDDS-10214. Update supported versions in security policy up to 1.4.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@ The first stable release of Apache Ozone is 1.0, the previous alpha and beta rel
 | 0.4.0 (alpha) | :x:                |
 | 0.4.1 (alpha) | :x:                |
 | 0.5.0 (beta)  | :x:                |
-| 1.0.0         | :white_check_mark: |
-| 1.1.0         | :white_check_mark: |
+| 1.0.0         | :x: |
+| 1.1.0         | :x: |
 | 1.2.1         | :white_check_mark: |
 | 1.3.0         | :white_check_mark: |
 | 1.4.0         | :white_check_mark: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@ The first stable release of Apache Ozone is 1.0, the previous alpha and beta rel
 | 0.4.0 (alpha) | :x:                |
 | 0.4.1 (alpha) | :x:                |
 | 0.5.0 (beta)  | :x:                |
-| 1.0.0         | :x: |
-| 1.1.0         | :x: |
+| 1.0.0         | :x:                |
+| 1.1.0         | :x:                |
 | 1.2.1         | :white_check_mark: |
 | 1.3.0         | :white_check_mark: |
 | 1.4.0         | :white_check_mark: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,6 @@ The first stable release of Apache Ozone is 1.0, the previous alpha and beta rel
 | 0.5.0 (beta)  | :x:                |
 | 1.0.0         | :white_check_mark: |
 | 1.1.0         | :white_check_mark: |
-| 1.2.0         | :white_check_mark: |
 | 1.2.1         | :white_check_mark: |
 | 1.3.0         | :white_check_mark: |
 | 1.4.0         | :white_check_mark: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,13 +5,17 @@
 The first stable release of Apache Ozone is 1.0, the previous alpha and beta releases are not supported by the community.
 
 | Version       | Supported          |
-| ------------- | ------------------ |
+|---------------| ------------------ |
 | 0.3.0 (alpha) | :x:                |
 | 0.4.0 (alpha) | :x:                |
 | 0.4.1 (alpha) | :x:                |
 | 0.5.0 (beta)  | :x:                |
-| 1.0           | :white_check_mark: |
-| 1.1           | :white_check_mark: |
+| 1.0.0         | :white_check_mark: |
+| 1.1.0         | :white_check_mark: |
+| 1.2.0         | :white_check_mark: |
+| 1.2.1         | :white_check_mark: |
+| 1.3.0         | :white_check_mark: |
+| 1.4.0         | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ The first stable release of Apache Ozone is 1.0, the previous alpha and beta rel
 | 0.5.0 (beta)  | :x:                |
 | 1.0.0         | :x:                |
 | 1.1.0         | :x:                |
-| 1.2.1         | :white_check_mark: |
-| 1.3.0         | :white_check_mark: |
+| 1.2.1         | :x:                |
+| 1.3.0         | :x:                |
 | 1.4.0         | :white_check_mark: |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Security.md only contains Ozone version up to 1.1

This patches include version up to 1.4.

It is also a good idea to add information to the Ozone wiki release guide to update the security.md during the release process.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10214

## How was this patch tested?

NA