### PR TITLE
HDDS-10215. Speed up some tests that use OmTestManagers

### DIFF
--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/NamedTestsBase.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/NamedTestsBase.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+import java.lang.reflect.Method;
+
+/**
+ * Base class for JUnit tests.  Provides test method name, which can be used to create unique items.
+ */
+public abstract class NamedTestsBase {
+
+  private TestInfo info;
+
+  @BeforeEach
+  void storeTestInfo(TestInfo testInfo) {
+    this.info = testInfo;
+  }
+
+  protected String getTestName() {
+    // FIXME parameterized tests?
+    return info.getTestMethod().map(Method::getName).orElse("unknown");
+  }
+
+}

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/OzoneTestBase.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/OzoneTestBase.java
@@ -23,9 +23,10 @@ import org.junit.jupiter.api.TestInfo;
 import java.lang.reflect.Method;
 
 /**
- * Base class for JUnit tests.  Provides test method name, which can be used to create unique items.
+ * Base class for Ozone JUnit tests.
+ * Provides test method name, which can be used to create unique items.
  */
-public abstract class NamedTestsBase {
+public abstract class OzoneTestBase {
 
   private TestInfo info;
 
@@ -35,8 +36,9 @@ public abstract class NamedTestsBase {
   }
 
   protected String getTestName() {
-    // FIXME parameterized tests?
-    return info.getTestMethod().map(Method::getName).orElse("unknown");
+    return info.getTestMethod()
+        .map(Method::getName)
+        .orElse("unknown");
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -18,7 +18,6 @@ package org.apache.hadoop.ozone.om;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -43,9 +42,11 @@ import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.jupiter.api.AfterEach;
+import org.apache.ozone.test.NamedTestsBase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -66,40 +67,36 @@ import static org.mockito.Mockito.when;
  * This class tests the Bucket Manager Implementation using Mockito.
  */
 @ExtendWith(MockitoExtension.class)
-public class TestBucketManagerImpl {
-
-  @TempDir
-  private Path folder;
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestBucketManagerImpl extends NamedTestsBase {
 
   private OmTestManagers omTestManagers;
   private OzoneManagerProtocol writeClient;
 
-  @AfterEach
-  public void cleanup() throws Exception {
-    OzoneManager om = omTestManagers.getOzoneManager();
-    om.stop();
-  }
-
-  private OzoneConfiguration createNewTestPath() throws IOException {
+  @BeforeAll
+  void setup(@TempDir File folder) throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
-    File newFolder = folder.toFile();
-    if (!newFolder.exists()) {
-      assertTrue(newFolder.mkdirs());
-    }
-    ServerUtils.setOzoneMetaDirPath(conf, newFolder.toString());
-    return conf;
-  }
+    ServerUtils.setOzoneMetaDirPath(conf, folder.toString());
 
-  private void createSampleVol() throws IOException, AuthenticationException {
-    OzoneConfiguration conf = createNewTestPath();
     omTestManagers = new OmTestManagers(conf);
     writeClient = omTestManagers.getWriteClient();
+  }
 
+  @AfterAll
+  void cleanup() throws Exception {
+    omTestManagers.getOzoneManager().stop();
+  }
+
+  public String volumeName() {
+    return getTestName().toLowerCase();
+  }
+
+  private void createSampleVol(String volume) throws IOException {
     // This is a simple hack for testing, we just test if the volume via a
     // null check, do not parse the value part. So just write some dummy value.
     OmVolumeArgs args =
         OmVolumeArgs.newBuilder()
-            .setVolume("sample-vol")
+            .setVolume(volume)
             .setAdminName("bilbo")
             .setOwnerName("bilbo")
             .build();
@@ -107,25 +104,20 @@ public class TestBucketManagerImpl {
   }
 
   @Test
-  public void testCreateBucketWithoutVolume() throws Exception {
-    OzoneConfiguration conf = createNewTestPath();
-    omTestManagers = new OmTestManagers(conf);
-    OMException omEx = assertThrows(OMException.class, () -> {
-      writeClient = omTestManagers.getWriteClient();
-
-      OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-          .setVolumeName("sample-vol")
-          .setBucketName("bucket-one")
-          .build();
-      writeClient.createBucket(bucketInfo);
-    });
+  void testCreateBucketWithoutVolume() {
+    OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName())
+        .setBucketName("bucket-one")
+        .build();
+    OMException omEx = assertThrows(OMException.class, () -> writeClient.createBucket(bucketInfo));
     assertEquals(ResultCodes.VOLUME_NOT_FOUND, omEx.getResult());
     assertEquals("Volume doesn't exist", omEx.getMessage());
   }
 
   @Test
-  public void testCreateEncryptedBucket() throws Exception {
-    createSampleVol();
+  void testCreateEncryptedBucket() throws Exception {
+    String volume = volumeName();
+    createSampleVol(volume);
     KeyProviderCryptoExtension kmsProvider = omTestManagers.kmsProviderInit();
 
     String testBekName = "key1";
@@ -138,17 +130,16 @@ public class TestBucketManagerImpl {
     BucketManager bucketManager = omTestManagers.getBucketManager();
 
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("bucket-one")
         .setBucketEncryptionKey(new
             BucketEncryptionKeyInfo.Builder().setKeyName("key1").build())
         .build();
     writeClient.createBucket(bucketInfo);
-    assertNotNull(bucketManager.getBucketInfo("sample-vol",
-        "bucket-one"));
+    assertNotNull(bucketManager.getBucketInfo(volume, "bucket-one"));
 
     OmBucketInfo bucketInfoRead =
-        bucketManager.getBucketInfo("sample-vol", "bucket-one");
+        bucketManager.getBucketInfo(volume, "bucket-one");
 
     assertEquals(bucketInfoRead.getEncryptionKeyInfo().getKeyName(),
         bucketInfo.getEncryptionKeyInfo().getKeyName());
@@ -157,67 +148,62 @@ public class TestBucketManagerImpl {
 
   @Test
   public void testCreateBucket() throws Exception {
-    createSampleVol();
+    String volume = volumeName();
+    createSampleVol(volume);
 
     BucketManager bucketManager = omTestManagers.getBucketManager();
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("bucket-one")
         .build();
     writeClient.createBucket(bucketInfo);
-    assertNotNull(bucketManager.getBucketInfo("sample-vol",
-        "bucket-one"));
+    assertNotNull(bucketManager.getBucketInfo(volume, "bucket-one"));
   }
 
   @Test
   public void testCreateAlreadyExistingBucket() throws Exception {
-    createSampleVol();
+    String volume = volumeName();
+    createSampleVol(volume);
 
-    OMException omEx = assertThrows(OMException.class, () -> {
-      OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-          .setVolumeName("sample-vol")
-          .setBucketName("bucket-one")
-          .build();
-      writeClient.createBucket(bucketInfo);
-      writeClient.createBucket(bucketInfo);
-    });
-    assertEquals(ResultCodes.BUCKET_ALREADY_EXISTS,
-          omEx.getResult());
+    OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volume)
+        .setBucketName("bucket-one")
+        .build();
+    writeClient.createBucket(bucketInfo);
+
+    OMException omEx = assertThrows(OMException.class,
+        () -> writeClient.createBucket(bucketInfo));
+    assertEquals(ResultCodes.BUCKET_ALREADY_EXISTS, omEx.getResult());
     assertEquals("Bucket already exist", omEx.getMessage());
   }
 
   @Test
   public void testGetBucketInfoForInvalidBucket() throws Exception {
-    createSampleVol();
-    OMException exception = assertThrows(OMException.class, () -> {
-      BucketManager bucketManager = omTestManagers.getBucketManager();
-      bucketManager.getBucketInfo("sample-vol", "bucket-one");
-    });
+    String volume = volumeName();
+    createSampleVol(volume);
+
+    BucketManager bucketManager = omTestManagers.getBucketManager();
+
+    OMException exception = assertThrows(OMException.class,
+        () -> bucketManager.getBucketInfo(volume, "bucket-one"));
     assertThat(exception.getMessage()).contains("Bucket not found");
-    assertEquals(ResultCodes.BUCKET_NOT_FOUND,
-        exception.getResult());
+    assertEquals(ResultCodes.BUCKET_NOT_FOUND, exception.getResult());
   }
 
   @Test
-  public void testGetBucketInfo() throws Exception {
-    final String volumeName = "sample-vol";
+  void testGetBucketInfo() throws Exception {
+    final String volumeName = volumeName();
     final String bucketName = "bucket-one";
-
-    OzoneConfiguration conf = createNewTestPath();
-    omTestManagers = new OmTestManagers(conf);
-    writeClient = omTestManagers.getWriteClient();
 
     OMMetadataManager metaMgr = omTestManagers.getMetadataManager();
     BucketManager bucketManager = omTestManagers.getBucketManager();
     // Check exception thrown when volume does not exist
-    try {
-      bucketManager.getBucketInfo(volumeName, bucketName);
-      fail("Should have thrown OMException");
-    } catch (OMException omEx) {
-      assertEquals(ResultCodes.VOLUME_NOT_FOUND, omEx.getResult(),
-          "getBucketInfo() should have thrown " +
-              "VOLUME_NOT_FOUND as the parent volume is not created!");
-    }
+    OMException omEx = assertThrows(OMException.class,
+        () -> bucketManager.getBucketInfo(volumeName, bucketName));
+    assertEquals(ResultCodes.VOLUME_NOT_FOUND, omEx.getResult(),
+        "getBucketInfo() should have thrown " +
+            "VOLUME_NOT_FOUND as the parent volume is not created!");
+
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -235,16 +221,12 @@ public class TestBucketManagerImpl {
     writeClient.createVolume(args);
     // Create bucket
     createBucket(metaMgr, bucketInfo);
+
     // Check exception thrown when bucket does not exist
-    try {
-      bucketManager.getBucketInfo(volumeName, "bucketNotExist");
-      fail("Should have thrown OMException");
-    } catch (OMException omEx) {
-      assertEquals(
-          ResultCodes.BUCKET_NOT_FOUND, omEx.getResult(),
-          "getBucketInfo() should have thrown BUCKET_NOT_FOUND " +
-              "as the parent volume exists but bucket doesn't!");
-    }
+    OMException e2 = assertThrows(OMException.class,
+        () -> bucketManager.getBucketInfo(volumeName, "bucketNotExist"));
+    assertEquals(ResultCodes.BUCKET_NOT_FOUND, e2.getResult());
+
     OmBucketInfo result = bucketManager.getBucketInfo(volumeName, bucketName);
     assertEquals(volumeName, result.getVolumeName());
     assertEquals(bucketName, result.getBucketName());
@@ -259,64 +241,68 @@ public class TestBucketManagerImpl {
 
   @Test
   public void testSetBucketPropertyChangeStorageType() throws Exception {
+    String volume = volumeName();
+    createSampleVol(volume);
 
-    createSampleVol();
     OMMetadataManager metaMgr = omTestManagers.getMetadataManager();
     BucketManager bucketManager = omTestManagers.getBucketManager();
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("bucket-one")
         .setStorageType(StorageType.DISK)
         .build();
     createBucket(metaMgr, bucketInfo);
     OmBucketInfo result = bucketManager.getBucketInfo(
-        "sample-vol", "bucket-one");
+        volume, "bucket-one");
     assertEquals(StorageType.DISK,
         result.getStorageType());
     OmBucketArgs bucketArgs = OmBucketArgs.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("bucket-one")
         .setStorageType(StorageType.SSD)
         .build();
     writeClient.setBucketProperty(bucketArgs);
     OmBucketInfo updatedResult = bucketManager.getBucketInfo(
-        "sample-vol", "bucket-one");
+        volume, "bucket-one");
     assertEquals(StorageType.SSD,
         updatedResult.getStorageType());
   }
 
   @Test
   public void testSetBucketPropertyChangeVersioning() throws Exception {
-    createSampleVol();
+    String volume = volumeName();
+    createSampleVol(volume);
 
     BucketManager bucketManager = omTestManagers.getBucketManager();
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("bucket-one")
         .setIsVersionEnabled(false)
         .build();
     writeClient.createBucket(bucketInfo);
     OmBucketInfo result = bucketManager.getBucketInfo(
-        "sample-vol", "bucket-one");
+        volume, "bucket-one");
     assertFalse(result.getIsVersionEnabled());
     OmBucketArgs bucketArgs = OmBucketArgs.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("bucket-one")
         .setIsVersionEnabled(true)
         .build();
     writeClient.setBucketProperty(bucketArgs);
     OmBucketInfo updatedResult = bucketManager.getBucketInfo(
-        "sample-vol", "bucket-one");
+        volume, "bucket-one");
     assertTrue(updatedResult.getIsVersionEnabled());
   }
 
   @Test
   public void testDeleteBucket() throws Exception {
-    createSampleVol();
+    String volume = volumeName();
+    createSampleVol(volume);
+
     BucketManager bucketManager = omTestManagers.getBucketManager();
     for (int i = 0; i < 5; i++) {
       OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-          .setVolumeName("sample-vol")
+          .setVolumeName(volume)
           .setBucketName("bucket-" + i)
           .build();
       writeClient.createBucket(bucketInfo);
@@ -324,17 +310,17 @@ public class TestBucketManagerImpl {
     for (int i = 0; i < 5; i++) {
       assertEquals("bucket-" + i,
           bucketManager.getBucketInfo(
-              "sample-vol", "bucket-" + i).getBucketName());
+              volume, "bucket-" + i).getBucketName());
     }
     try {
-      writeClient.deleteBucket("sample-vol", "bucket-1");
+      writeClient.deleteBucket(volume, "bucket-1");
       assertNotNull(bucketManager.getBucketInfo(
-          "sample-vol", "bucket-2"));
+          volume, "bucket-2"));
     } catch (IOException ex) {
       fail(ex.getMessage());
     }
     OMException omEx = assertThrows(OMException.class, () -> {
-      bucketManager.getBucketInfo("sample-vol", "bucket-1");
+      bucketManager.getBucketInfo(volume, "bucket-1");
     });
     assertEquals(ResultCodes.BUCKET_NOT_FOUND,
           omEx.getResult());
@@ -343,15 +329,17 @@ public class TestBucketManagerImpl {
 
   @Test
   public void testDeleteNonEmptyBucket() throws Exception {
-    createSampleVol();
+    String volume = volumeName();
+    createSampleVol(volume);
+
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("bucket-one")
         .build();
     writeClient.createBucket(bucketInfo);
     //Create keys in bucket
     OmKeyArgs args1 = new OmKeyArgs.Builder()
-            .setVolumeName("sample-vol")
+            .setVolumeName(volume)
             .setBucketName("bucket-one")
             .setKeyName("key-one")
             .setAcls(Collections.emptyList())
@@ -364,7 +352,7 @@ public class TestBucketManagerImpl {
     writeClient.commitKey(args1, session1.getId());
 
     OmKeyArgs args2 = new OmKeyArgs.Builder()
-            .setVolumeName("sample-vol")
+            .setVolumeName(volume)
             .setBucketName("bucket-one")
             .setKeyName("key-two")
             .setAcls(Collections.emptyList())
@@ -376,7 +364,7 @@ public class TestBucketManagerImpl {
     OpenKeySession session2 = writeClient.openKey(args2);
     writeClient.commitKey(args2, session2.getId());
     OMException omEx = assertThrows(OMException.class, () -> {
-      writeClient.deleteBucket("sample-vol", "bucket-one");
+      writeClient.deleteBucket(volume, "bucket-one");
     });
     assertEquals(ResultCodes.BUCKET_NOT_EMPTY,
           omEx.getResult());
@@ -385,10 +373,12 @@ public class TestBucketManagerImpl {
 
   @Test
   public void testLinkedBucketResolution() throws Exception {
-    createSampleVol();
+    String volume = volumeName();
+    createSampleVol(volume);
+
     ECReplicationConfig ecConfig = new ECReplicationConfig(3, 2);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("bucket-one")
         .setDefaultReplicationConfig(
             new DefaultReplicationConfig(
@@ -405,23 +395,23 @@ public class TestBucketManagerImpl {
     writeClient.createBucket(bucketInfo);
 
     OmBucketInfo bucketLinkInfo = OmBucketInfo.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("link-one")
-        .setSourceVolume("sample-vol")
+        .setSourceVolume(volume)
         .setSourceBucket("bucket-one")
         .build();
     writeClient.createBucket(bucketLinkInfo);
 
     OmBucketInfo bucketLink2 = OmBucketInfo.newBuilder()
-        .setVolumeName("sample-vol")
+        .setVolumeName(volume)
         .setBucketName("link-two")
-        .setSourceVolume("sample-vol")
+        .setSourceVolume(volume)
         .setSourceBucket("link-one")
         .build();
     writeClient.createBucket(bucketLink2);
 
     OmBucketInfo storedLinkBucket =
-        writeClient.getBucketInfo("sample-vol", "link-two");
+        writeClient.getBucketInfo(volume, "link-two");
     assertNotNull(storedLinkBucket.getDefaultReplicationConfig(),
         "Replication config is not set");
     assertEquals(ecConfig,
@@ -432,12 +422,12 @@ public class TestBucketManagerImpl {
     assertEquals(
         "link-two", storedLinkBucket.getBucketName());
     assertEquals(
-        "sample-vol", storedLinkBucket.getVolumeName());
+        volume, storedLinkBucket.getVolumeName());
 
     assertEquals(
         "link-one", storedLinkBucket.getSourceBucket());
     assertEquals(
-        "sample-vol", storedLinkBucket.getSourceVolume());
+        volume, storedLinkBucket.getSourceVolume());
 
     assertEquals(
         bucketInfo.getBucketLayout(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.ozone.test.NamedTestsBase;
+import org.apache.ozone.test.OzoneTestBase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ import static org.mockito.Mockito.when;
  */
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TestBucketManagerImpl extends NamedTestsBase {
+class TestBucketManagerImpl extends OzoneTestBase {
 
   private OmTestManagers omTestManagers;
   private OzoneManagerProtocol writeClient;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -72,7 +72,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.apache.hadoop.util.Time;
-import org.apache.ozone.test.NamedTestsBase;
+import org.apache.ozone.test.OzoneTestBase;
 import org.apache.ratis.util.ExitUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -102,7 +102,7 @@ import static org.mockito.Mockito.when;
  * Unit test key manager.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TestKeyManagerUnit extends NamedTestsBase {
+class TestKeyManagerUnit extends OzoneTestBase {
 
   private static final AtomicLong CONTAINER_ID = new AtomicLong();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
-import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ratis.util.ExitUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -87,7 +86,7 @@ public class TestSstFilteringService {
   }
 
   @BeforeEach
-  public void init() throws AuthenticationException, IOException {
+  void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(OZONE_METADATA_DIRS, folder.getAbsolutePath());
     conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestTrashService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestTrashService.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ratis.util.ExitUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +65,7 @@ public class TestTrashService {
   private String bucketName;
 
   @BeforeEach
-  public void setup() throws IOException, AuthenticationException {
+  void setup() throws Exception {
     ExitUtils.disableSystemExit();
     OzoneConfiguration configuration = new OzoneConfiguration();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestMultipartUploadCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestMultipartUploadCleanupService.java
@@ -36,23 +36,23 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.ozone.test.GenericTestUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExpiredMultipartUploadsBucket;
 import org.apache.ratis.util.ExitUtils;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -60,31 +60,27 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MPU_CLEANUP_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MPU_PARTS_CLEANUP_LIMIT_PER_TASK;
+import static org.apache.ozone.test.GenericTestUtils.waitFor;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Multipart Upload Cleanup Service.
  */
-public class TestMultipartUploadCleanupService {
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Timeout(300)
+class TestMultipartUploadCleanupService {
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestMultipartUploadCleanupService.class);
 
-  private static final Duration SERVICE_INTERVAL = Duration.ofMillis(500);
-  private static final Duration EXPIRE_THRESHOLD = Duration.ofMillis(1000);
+  private static final Duration SERVICE_INTERVAL = Duration.ofMillis(100);
+  private static final Duration EXPIRE_THRESHOLD = Duration.ofMillis(200);
   private KeyManager keyManager;
   private OMMetadataManager omMetadataManager;
 
   @BeforeAll
-  public static void setup() {
+  void setup(@TempDir Path tempDir) throws Exception {
     ExitUtils.disableSystemExit();
-  }
 
-  @BeforeEach
-  public void createConfAndInitValues(@TempDir Path tempDir) throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     System.setProperty(DBConfigFromFile.CONFIG_DIR, "/");
     ServerUtils.setOzoneMetaDirPath(conf, tempDir.toString());
@@ -101,8 +97,8 @@ public class TestMultipartUploadCleanupService {
     om = omTestManagers.getOzoneManager();
   }
 
-  @AfterEach
-  public void cleanup() throws Exception {
+  @AfterAll
+  void cleanup() {
     om.stop();
   }
 
@@ -110,7 +106,6 @@ public class TestMultipartUploadCleanupService {
    * Create a bunch incomplete/inflight multipart upload info. Then we start
    * the MultipartUploadCleanupService. We make sure that all the multipart
    * upload info is picked up and aborted by OzoneManager.
-   * @throws Exception
    */
   @ParameterizedTest
   @CsvSource({
@@ -118,9 +113,7 @@ public class TestMultipartUploadCleanupService {
       "0, 88",
       "66, 77"
   })
-  @Timeout(300)
-  public void checkIfCleanupServiceIsDeletingExpiredMultipartUpload(
-      int numDEFKeys, int numFSOKeys) throws Exception {
+  void deletesExpiredUpload(int numDEFKeys, int numFSOKeys) throws Exception {
 
     MultipartUploadCleanupService multipartUploadCleanupService =
         (MultipartUploadCleanupService)
@@ -140,24 +133,27 @@ public class TestMultipartUploadCleanupService {
     // wait for MPU info to expire
     Thread.sleep(EXPIRE_THRESHOLD.toMillis());
 
-    assertFalse(keyManager.getExpiredMultipartUploads(EXPIRE_THRESHOLD,
-        10000).isEmpty());
+    assertThat(getExpiredMultipartUploads()).isNotEmpty();
 
     multipartUploadCleanupService.resume();
 
-    GenericTestUtils.waitFor(() -> multipartUploadCleanupService
-            .getRunCount() > oldRunCount,
-        (int) SERVICE_INTERVAL.toMillis(),
-        5 * (int) SERVICE_INTERVAL.toMillis());
-
     // wait for requests to complete
-    Thread.sleep(10 * SERVICE_INTERVAL.toMillis());
+    waitFor(() -> getExpiredMultipartUploads().isEmpty(),
+        (int) SERVICE_INTERVAL.toMillis(),
+        15 * (int) SERVICE_INTERVAL.toMillis());
 
+    assertThat(multipartUploadCleanupService.getRunCount())
+        .isGreaterThan(oldRunCount);
     assertThat(multipartUploadCleanupService.getSubmittedMpuInfoCount())
         .isGreaterThanOrEqualTo(oldMpuInfoCount + numDEFKeys + numFSOKeys);
-    assertTrue(keyManager.getExpiredMultipartUploads(EXPIRE_THRESHOLD,
-        10000).isEmpty());
+  }
 
+  private List<ExpiredMultipartUploadsBucket> getExpiredMultipartUploads() {
+    try {
+      return keyManager.getExpiredMultipartUploads(EXPIRE_THRESHOLD, 10000);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private void createIncompleteMPUKeys(int mpuKeyCount,
@@ -202,10 +198,6 @@ public class TestMultipartUploadCleanupService {
 
   /**
    * Create inflight multipart upload that are not completed / aborted yet.
-   * @param volumeName
-   * @param bucketName
-   * @param keyName
-   * @throws IOException
    */
   private void createIncompleteMPUKey(String volumeName, String bucketName,
       String keyName, int numParts) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -275,9 +275,7 @@ class TestOpenKeyCleanupService {
     LOG.info("oldMpuKeyCount={}, oldMpuRunCount={}", oldkeyCount, oldrunCount);
 
     final OMMetrics metrics = om.getMetrics();
-    long numKeyHSyncs = metrics.getNumKeyHSyncs();
     long numOpenKeysCleaned = metrics.getNumOpenKeysCleaned();
-    long numOpenKeysHSyncCleaned = metrics.getNumOpenKeysHSyncCleaned();
     final int keyCount = numDEFKeys + numFSOKeys;
     final int partCount = NUM_MPU_PARTS * keyCount;
     createIncompleteMPUKeys(numDEFKeys, BucketLayout.DEFAULT, NUM_MPU_PARTS,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestOpenKeyCleanupService.java
@@ -43,9 +43,9 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.util.ExitUtils;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -67,6 +67,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_T
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TestOpenKeyCleanupService {
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
@@ -83,12 +84,9 @@ class TestOpenKeyCleanupService {
   private OMMetadataManager omMetadataManager;
 
   @BeforeAll
-  public static void setup() {
+  void setup(@TempDir Path tempDir) throws Exception {
     ExitUtils.disableSystemExit();
-  }
 
-  @BeforeEach
-  public void createConfAndInitValues(@TempDir Path tempDir) throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     System.setProperty(DBConfigFromFile.CONFIG_DIR, "/");
     ServerUtils.setOzoneMetaDirPath(conf, tempDir.toString());
@@ -105,8 +103,8 @@ class TestOpenKeyCleanupService {
     om = omTestManagers.getOzoneManager();
   }
 
-  @AfterEach
-  public void cleanup() throws Exception {
+  @AfterAll
+  void cleanup() {
     if (om.stop()) {
       om.join();
     }
@@ -144,12 +142,11 @@ class TestOpenKeyCleanupService {
     final long oldkeyCount = openKeyCleanupService.getSubmittedOpenKeyCount();
     final long oldrunCount = openKeyCleanupService.getRunCount();
     LOG.info("oldkeyCount={}, oldrunCount={}", oldkeyCount, oldrunCount);
-    assertEquals(0, oldkeyCount);
 
     final OMMetrics metrics = om.getMetrics();
-    assertEquals(0, metrics.getNumKeyHSyncs());
-    assertEquals(0, metrics.getNumOpenKeysCleaned());
-    assertEquals(0, metrics.getNumOpenKeysHSyncCleaned());
+    long numKeyHSyncs = metrics.getNumKeyHSyncs();
+    long numOpenKeysCleaned = metrics.getNumOpenKeysCleaned();
+    long numOpenKeysHSyncCleaned = metrics.getNumOpenKeysHSyncCleaned();
     final int keyCount = numDEFKeys + numFSOKeys;
     createOpenKeys(numDEFKeys, false, BucketLayout.DEFAULT);
     createOpenKeys(numFSOKeys, hsync, BucketLayout.FILE_SYSTEM_OPTIMIZED);
@@ -164,7 +161,7 @@ class TestOpenKeyCleanupService {
     openKeyCleanupService.resume();
 
     GenericTestUtils.waitFor(
-        () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= keyCount,
+        () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= oldkeyCount + keyCount,
         SERVICE_INTERVAL, WAIT_TIME);
     GenericTestUtils.waitFor(
         () -> openKeyCleanupService.getRunCount() >= oldrunCount + 2,
@@ -174,13 +171,13 @@ class TestOpenKeyCleanupService {
     waitForOpenKeyCleanup(hsync, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     if (hsync) {
-      assertAtLeast(numDEFKeys, metrics.getNumOpenKeysCleaned());
-      assertAtLeast(numFSOKeys, metrics.getNumOpenKeysHSyncCleaned());
-      assertEquals(numFSOKeys, metrics.getNumKeyHSyncs());
+      assertAtLeast(numOpenKeysCleaned + numDEFKeys, metrics.getNumOpenKeysCleaned());
+      assertAtLeast(numOpenKeysHSyncCleaned + numFSOKeys, metrics.getNumOpenKeysHSyncCleaned());
+      assertEquals(numKeyHSyncs + numFSOKeys, metrics.getNumKeyHSyncs());
     } else {
-      assertAtLeast(keyCount, metrics.getNumOpenKeysCleaned());
-      assertEquals(0, metrics.getNumOpenKeysHSyncCleaned());
-      assertEquals(0, metrics.getNumKeyHSyncs());
+      assertAtLeast(numOpenKeysCleaned + keyCount, metrics.getNumOpenKeysCleaned());
+      assertEquals(numOpenKeysHSyncCleaned, metrics.getNumOpenKeysHSyncCleaned());
+      assertEquals(numKeyHSyncs, metrics.getNumKeyHSyncs());
     }
   }
 
@@ -211,12 +208,11 @@ class TestOpenKeyCleanupService {
     final long oldkeyCount = openKeyCleanupService.getSubmittedOpenKeyCount();
     final long oldrunCount = openKeyCleanupService.getRunCount();
     LOG.info("oldMpuKeyCount={}, oldMpuRunCount={}", oldkeyCount, oldrunCount);
-    assertEquals(0, oldkeyCount);
 
     final OMMetrics metrics = om.getMetrics();
-    assertEquals(0, metrics.getNumKeyHSyncs());
-    assertEquals(0, metrics.getNumOpenKeysCleaned());
-    assertEquals(0, metrics.getNumOpenKeysHSyncCleaned());
+    long numKeyHSyncs = metrics.getNumKeyHSyncs();
+    long numOpenKeysCleaned = metrics.getNumOpenKeysCleaned();
+    long numOpenKeysHSyncCleaned = metrics.getNumOpenKeysHSyncCleaned();
     createIncompleteMPUKeys(numDEFKeys, BucketLayout.DEFAULT, NUM_MPU_PARTS,
         true);
     createIncompleteMPUKeys(numFSOKeys, BucketLayout.FILE_SYSTEM_OPTIMIZED,
@@ -245,7 +241,9 @@ class TestOpenKeyCleanupService {
     assertExpiredOpenKeys(true, false,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
-    assertEquals(0, metrics.getNumOpenKeysCleaned());
+    assertEquals(numKeyHSyncs, metrics.getNumKeyHSyncs());
+    assertEquals(numOpenKeysCleaned, metrics.getNumOpenKeysCleaned());
+    assertEquals(numOpenKeysHSyncCleaned, metrics.getNumOpenKeysHSyncCleaned());
   }
 
   /**
@@ -275,12 +273,11 @@ class TestOpenKeyCleanupService {
     final long oldkeyCount = openKeyCleanupService.getSubmittedOpenKeyCount();
     final long oldrunCount = openKeyCleanupService.getRunCount();
     LOG.info("oldMpuKeyCount={}, oldMpuRunCount={}", oldkeyCount, oldrunCount);
-    assertEquals(0, oldkeyCount);
 
     final OMMetrics metrics = om.getMetrics();
-    assertEquals(0, metrics.getNumKeyHSyncs());
-    assertEquals(0, metrics.getNumOpenKeysCleaned());
-    assertEquals(0, metrics.getNumOpenKeysHSyncCleaned());
+    long numKeyHSyncs = metrics.getNumKeyHSyncs();
+    long numOpenKeysCleaned = metrics.getNumOpenKeysCleaned();
+    long numOpenKeysHSyncCleaned = metrics.getNumOpenKeysHSyncCleaned();
     final int keyCount = numDEFKeys + numFSOKeys;
     final int partCount = NUM_MPU_PARTS * keyCount;
     createIncompleteMPUKeys(numDEFKeys, BucketLayout.DEFAULT, NUM_MPU_PARTS,
@@ -300,7 +297,7 @@ class TestOpenKeyCleanupService {
     openKeyCleanupService.resume();
 
     GenericTestUtils.waitFor(
-        () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= partCount,
+        () -> openKeyCleanupService.getSubmittedOpenKeyCount() >= oldkeyCount + partCount,
         SERVICE_INTERVAL, WAIT_TIME);
     GenericTestUtils.waitFor(
         () -> openKeyCleanupService.getRunCount() >= oldrunCount + 2,
@@ -309,7 +306,7 @@ class TestOpenKeyCleanupService {
     // No expired MPU parts fetched
     waitForOpenKeyCleanup(false, BucketLayout.DEFAULT);
     waitForOpenKeyCleanup(false, BucketLayout.FILE_SYSTEM_OPTIMIZED);
-    assertAtLeast(partCount, metrics.getNumOpenKeysCleaned());
+    assertAtLeast(numOpenKeysCleaned + partCount, metrics.getNumOpenKeysCleaned());
   }
 
   private static void assertAtLeast(long expectedMinimum, long actual) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Unhealthy;
 import org.junit.jupiter.api.AfterAll;
@@ -95,7 +94,7 @@ public class TestParentAcl {
   private static File testDir;
 
   @BeforeAll
-  public static void setup() throws IOException, AuthenticationException {
+  static void setup() throws Exception {
     ozConfig = new OzoneConfiguration();
     ozConfig.set(OZONE_ACL_AUTHORIZER_CLASS,
         OZONE_ACL_AUTHORIZER_CLASS_NATIVE);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -77,7 +76,7 @@ public class TestVolumeOwner {
   private static File testDir;
 
   @BeforeAll
-  public static void setup() throws IOException, AuthenticationException {
+  static void setup() throws Exception {
     ozoneConfig = new OzoneConfiguration();
     ozoneConfig.set(OZONE_ACL_AUTHORIZER_CLASS,
         OZONE_ACL_AUTHORIZER_CLASS_NATIVE);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some of the slowest unit tests use `OmTestManagers` to launch OM.  It takes ~10 seconds to initialize (half of that is Ratis leader election).  The test cases are pretty quick after that.

```
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 148.9 s -- in org.apache.hadoop.ozone.om.service.TestOpenKeyCleanupService
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 133.0 s -- in org.apache.hadoop.ozone.om.TestBucketManagerImpl
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 108.3 s -- in org.apache.hadoop.ozone.om.TestKeyManagerUnit
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 83.42 s -- in org.apache.hadoop.ozone.om.TestOmSnapshotManager
```

This change speeds up four of these tests, mostly by converting per-method setup to per-class, to reduce the overhead.

Also, wait for OM leader election before proceeding with the test, to avoid an exception related to failover retry while trying to create the RPC client.

Use test method name as volume name to avoid conflicts, and unexpected number of buckets/keys.

Some of the assertions need to be tweaked to account for objects left over and operations performed by other test cases.

https://issues.apache.org/jira/browse/HDDS-10215

## How was this patch tested?

```
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.262 s - in org.apache.hadoop.ozone.om.service.TestOpenKeyCleanupService
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.457 s - in org.apache.hadoop.ozone.om.TestBucketManagerImpl
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.444 s - in org.apache.hadoop.ozone.om.TestKeyManagerUnit
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.75 s - in org.apache.hadoop.ozone.om.TestOmSnapshotManager
```

https://github.com/adoroszlai/ozone/actions/runs/7670459056/job/20907076486