### PR TITLE
HDDS-10224. Speed up TestRocksDBCheckpointDiffer

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1350,10 +1350,10 @@ public class TestRocksDBCheckpointDiffer {
           });
       // Confirm that the consumer doesn't finish with lock taken.
       assertThrows(TimeoutException.class,
-          () -> future.get(5000, TimeUnit.MILLISECONDS));
+          () -> future.get(1000, TimeUnit.MILLISECONDS));
     }
     // Confirm consumer finishes when unlocked.
-    assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
+    assertTrue(future.get(100, TimeUnit.MILLISECONDS));
   }
 
   private static Stream<Arguments> sstFilePruningScenarios() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce "sleep" time in `TestRocksDBCheckpointDiffer`.  This code path is used in two parameterized tests, executed 14 times in total.

```
[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 74.812 s - in org.apache.ozone.rocksdiff.TestRocksDBCheckpointDiffer
```

https://issues.apache.org/jira/browse/HDDS-10224

## How was this patch tested?

```
[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.81 s - in org.apache.ozone.rocksdiff.TestRocksDBCheckpointDiffer
```

https://github.com/adoroszlai/ozone/actions/runs/7677809640

Tested in 10x50 runs to confirm that the change does not introduce flakiness:
https://github.com/adoroszlai/ozone/actions/runs/7678240439