### PR TITLE
HDDS-10225. Speed up TestSCMHAManagerImpl

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -130,10 +130,7 @@ class TestSCMHAManagerImpl {
 
     follower.start();
     final AddSCMRequest request = new AddSCMRequest(
-        clusterID, FOLLOWER_SCM_ID,
-        "localhost:" + follower
-            .getDivision().getRaftServer().getServerRpc()
-            .getInetSocketAddress().getPort());
+        clusterID, FOLLOWER_SCM_ID, getFollowerAddress());
     primarySCMHAManager.addSCM(request);
     assertEquals(2, primarySCMHAManager.getRatisServer()
         .getDivision().getGroup().getPeers().size());
@@ -146,12 +143,16 @@ class TestSCMHAManagerImpl {
         .getDivision().getGroup().getPeers().size()).isEqualTo(2);
 
     final RemoveSCMRequest removeSCMRequest = new RemoveSCMRequest(
-        clusterID, FOLLOWER_SCM_ID, "localhost:" +
-        follower.getDivision()
-            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
+        clusterID, FOLLOWER_SCM_ID, getFollowerAddress());
     primarySCMHAManager.removeSCM(removeSCMRequest);
     assertEquals(1, primarySCMHAManager.getRatisServer()
         .getDivision().getGroup().getPeers().size());
+  }
+
+  private String getFollowerAddress() {
+    return "localhost:" +
+        follower.getDivision()
+            .getRaftServer().getServerRpc().getInetSocketAddress().getPort();
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -109,7 +109,7 @@ class TestSCMHAManagerImpl {
     return conf;
   }
 
-  public void waitForSCMToBeReady(DivisionInfo ratisDivision)
+  private void waitForSCMToBeReady(DivisionInfo ratisDivision)
       throws TimeoutException,
       InterruptedException {
     GenericTestUtils.waitFor(ratisDivision::isLeaderReady,
@@ -124,7 +124,7 @@ class TestSCMHAManagerImpl {
 
   @Test
   @Order(1)
-  public void testAddSCM() throws IOException, InterruptedException {
+  void testAddSCM() throws IOException, InterruptedException {
     assertEquals(1, primarySCMHAManager.getRatisServer()
         .getDivision().getGroup().getPeers().size());
 
@@ -140,7 +140,7 @@ class TestSCMHAManagerImpl {
   }
 
   @Test
-  public void testHARingRemovalErrors() throws IOException,
+  void testHARingRemovalErrors() throws IOException,
       AuthenticationException {
     OzoneConfiguration config = new OzoneConfiguration();
     config.set(ScmConfigKeys.OZONE_SCM_PRIMORDIAL_NODE_ID_KEY, "scm1");
@@ -170,7 +170,7 @@ class TestSCMHAManagerImpl {
   }
   @Test
   @Order(2) // requires testAddSCM
-  public void testRemoveSCM() throws IOException, InterruptedException {
+  void testRemoveSCM() throws IOException, InterruptedException {
     assumeThat(primarySCMHAManager.getRatisServer()
         .getDivision().getGroup().getPeers().size()).isEqualTo(2);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -125,28 +125,29 @@ class TestSCMHAManagerImpl {
   @Test
   @Order(1)
   void testAddSCM() throws IOException {
-    assertEquals(1, primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size());
+    assertEquals(1, getPeerCount());
 
     follower.start();
     final AddSCMRequest request = new AddSCMRequest(
         clusterID, FOLLOWER_SCM_ID, getFollowerAddress());
     primarySCMHAManager.addSCM(request);
-    assertEquals(2, primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size());
+    assertEquals(2, getPeerCount());
   }
 
   @Test
   @Order(2) // requires testAddSCM
   void testRemoveSCM() throws IOException {
-    assumeThat(primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size()).isEqualTo(2);
+    assumeThat(getPeerCount()).isEqualTo(2);
 
     final RemoveSCMRequest removeSCMRequest = new RemoveSCMRequest(
         clusterID, FOLLOWER_SCM_ID, getFollowerAddress());
     primarySCMHAManager.removeSCM(removeSCMRequest);
-    assertEquals(1, primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size());
+    assertEquals(1, getPeerCount());
+  }
+
+  private int getPeerCount() {
+    return primarySCMHAManager.getRatisServer()
+        .getDivision().getGroup().getPeers().size();
   }
 
   private String getFollowerAddress() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -140,6 +140,21 @@ class TestSCMHAManagerImpl {
   }
 
   @Test
+  @Order(2) // requires testAddSCM
+  void testRemoveSCM() throws IOException {
+    assumeThat(primarySCMHAManager.getRatisServer()
+        .getDivision().getGroup().getPeers().size()).isEqualTo(2);
+
+    final RemoveSCMRequest removeSCMRequest = new RemoveSCMRequest(
+        clusterID, FOLLOWER_SCM_ID, "localhost:" +
+        follower.getDivision()
+            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
+    primarySCMHAManager.removeSCM(removeSCMRequest);
+    assertEquals(1, primarySCMHAManager.getRatisServer()
+        .getDivision().getGroup().getPeers().size());
+  }
+
+  @Test
   void testHARingRemovalErrors() throws IOException,
       AuthenticationException {
     OzoneConfiguration config = new OzoneConfiguration();
@@ -167,20 +182,6 @@ class TestSCMHAManagerImpl {
     } finally {
       scm2.getScmHAManager().getRatisServer().stop();
     }
-  }
-  @Test
-  @Order(2) // requires testAddSCM
-  void testRemoveSCM() throws IOException {
-    assumeThat(primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size()).isEqualTo(2);
-
-    final RemoveSCMRequest removeSCMRequest = new RemoveSCMRequest(
-        clusterID, FOLLOWER_SCM_ID, "localhost:" +
-        follower.getDivision()
-            .getRaftServer().getServerRpc().getInetSocketAddress().getPort());
-    primarySCMHAManager.removeSCM(removeSCMRequest);
-    assertEquals(1, primarySCMHAManager.getRatisServer()
-        .getDivision().getGroup().getPeers().size());
   }
 
   private StorageContainerManager getMockStorageContainerManager(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -89,8 +89,8 @@ class TestSCMHAManagerImpl {
     final StorageContainerManager scm = getMockStorageContainerManager(conf);
     SCMRatisServerImpl.initialize(clusterID, scm.getScmId(),
         scm.getScmNodeDetails(), conf);
-    scm.getScmHAManager().start();
     primarySCMHAManager = scm.getScmHAManager();
+    primarySCMHAManager.start();
     final DivisionInfo ratisDivision = primarySCMHAManager.getRatisServer()
         .getDivision().getInfo();
     // Wait for Ratis Server to be ready

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAManagerImpl.java
@@ -124,7 +124,7 @@ class TestSCMHAManagerImpl {
 
   @Test
   @Order(1)
-  void testAddSCM() throws IOException, InterruptedException {
+  void testAddSCM() throws IOException {
     assertEquals(1, primarySCMHAManager.getRatisServer()
         .getDivision().getGroup().getPeers().size());
 
@@ -170,7 +170,7 @@ class TestSCMHAManagerImpl {
   }
   @Test
   @Order(2) // requires testAddSCM
-  void testRemoveSCM() throws IOException, InterruptedException {
+  void testRemoveSCM() throws IOException {
     assumeThat(primarySCMHAManager.getRatisServer()
         .getDivision().getGroup().getPeers().size()).isEqualTo(2);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestSCMHAManagerImpl` has three test cases, each starting new leader SCM from scratch:
 * add SCM
 * remove SCM
 * invalid scenarios

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 47.041 s - in org.apache.hadoop.hdds.scm.ha.TestSCMHAManagerImpl
```

This change reduces test execution time by starting a single leader SCM.

1. Testing removal of peer requires adding it first, so `testRemoveSCM` already depends on "add SCM" functionality working correctly.  The patch deletes "add SCM" setup from `testRemoveSCM`, now it relies on the state left by `testAddSCM`.
2. Testing invalid scenarios does not need a fresh SCM leader, requests being tested are invalid either way.

Also, some additional code cleanup, performed in separate commits for easier review.

https://issues.apache.org/jira/browse/HDDS-10225

## How was this patch tested?

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.489 s - in org.apache.hadoop.hdds.scm.ha.TestSCMHAManagerImpl
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7678209884