### PR TITLE
HDDS-9985. Do not use Guava Optional

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheValue.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/CacheValue.java
@@ -18,15 +18,14 @@
 
 package org.apache.hadoop.hdds.utils.db.cache;
 
-import com.google.common.base.Optional;
-
 import java.util.Objects;
 
 /**
  * CacheValue for the RocksDB Table.
  * @param <VALUE>
  */
-public class CacheValue<VALUE> {
+public final class CacheValue<VALUE> {
+
   /** @return a {@link CacheValue} with a non-null value. */
   public static <V> CacheValue<V> get(long epoch, V value) {
     Objects.requireNonNull(value, "value == null");
@@ -45,16 +44,6 @@ public class CacheValue<VALUE> {
 
   private CacheValue(long epoch, VALUE value) {
     this.value = value;
-    this.epoch = epoch;
-  }
-
-  /**
-   * @deprecated
-   * use {@link #get(long, Object)} or {@link #get(long)}.
-   */
-  @Deprecated
-  public CacheValue(Optional<VALUE> value, long epoch) {
-    this.value = value.orNull();
     this.epoch = epoch;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -20,8 +20,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -37,10 +37,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
-
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -80,6 +77,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 /**
@@ -833,7 +831,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
     OmDBAccessIdInfo omDBAccessIdInfo =
         omMetadataManager.getTenantAccessIdTable().get(accessID);
     if (omDBAccessIdInfo == null) {
-      return Optional.absent();
+      return Optional.empty();
     }
     return Optional.of(omDBAccessIdInfo.getTenantId());
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -51,7 +52,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
@@ -3495,7 +3495,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       // If S3 Multi-Tenancy is not enabled, all S3 requests will be redirected
       // to the default s3v for compatibility
       final Optional<String> optionalTenantId = isS3MultiTenancyEnabled() ?
-          multiTenantManager.getTenantForAccessID(accessId) : Optional.absent();
+          multiTenantManager.getTenantForAccessID(accessId) : Optional.empty();
 
       if (!optionalTenantId.isPresent()) {
         final UserGroupInformation s3gUGI =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -30,10 +30,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
@@ -284,7 +284,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
 
   protected static Optional<FileEncryptionInfo> getFileEncryptionInfo(
       OzoneManager ozoneManager, OmBucketInfo bucketInfo) throws IOException {
-    Optional<FileEncryptionInfo> encInfo = Optional.absent();
+    Optional<FileEncryptionInfo> encInfo = Optional.empty();
     BucketEncryptionKeyInfo ezInfo = bucketInfo.getEncryptionKeyInfo();
     if (ezInfo != null) {
       final String ezKeyName = ezInfo.getKeyName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3ExpiredMultipartUploadsAbortRequest.java
@@ -19,7 +19,6 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
-import com.google.common.base.Optional;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -312,11 +311,11 @@ public class S3ExpiredMultipartUploadsAbortRequest extends OMKeyRequest {
               .isExist(multipartOpenKey)) {
             omMetadataManager.getOpenKeyTable(bucketLayout)
                 .addCacheEntry(new CacheKey<>(multipartOpenKey),
-                    new CacheValue<>(Optional.absent(), trxnLogIndex));
+                    CacheValue.get(trxnLogIndex));
           }
           omMetadataManager.getMultipartInfoTable()
               .addCacheEntry(new CacheKey<>(expiredMPUKeyName),
-                  new CacheValue<>(Optional.absent(), trxnLogIndex));
+                  CacheValue.get(trxnLogIndex));
 
           long numParts = omMultipartKeyInfo.getPartKeyInfoMap().size();
           ozoneManager.getMetrics().incNumExpiredMPUAborted();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3SecretRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3SecretRequestHelper.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.request.s3.security;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -29,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.apache.hadoop.security.SaslRpcServer.AuthMethod.KERBEROS;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.hadoop.ozone.om.request.s3.tenant;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -48,6 +47,7 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.MULTITENANCY_SCHEMA;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.hadoop.ozone.om.request.s3.tenant;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -48,6 +47,7 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.MULTITENANCY_SCHEMA;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.hadoop.ozone.om.request.s3.tenant;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -52,6 +51,7 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.MULTITENANCY_SCHEMA;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -33,10 +33,9 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import com.google.common.base.Optional;
+
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -658,7 +658,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
     for (String mpuOpenKey: mpuOpenKeys) {
       omMetadataManager.getOpenKeyTable(getBucketLayout())
           .addCacheEntry(new CacheKey<>(mpuOpenKey),
-              new CacheValue<>(Optional.absent(), 100L));
+              CacheValue.get(100L));
       omMetadataManager.getOpenKeyTable(getBucketLayout())
           .delete(mpuOpenKey);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -67,9 +67,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.UUID;
-
-import com.google.common.base.Optional;
 
 import static org.apache.hadoop.security.authentication.util.KerberosName.DEFAULT_MECHANISM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -172,9 +171,9 @@ public class TestS3GetSecretRequest {
     when(omMultiTenantManager.getCacheOp()).thenReturn(cacheOp);
 
     when(omMultiTenantManager.getTenantForAccessID(USER_CAROL))
-        .thenReturn(Optional.absent());
+        .thenReturn(Optional.empty());
     when(omMultiTenantManager.getTenantForAccessID(USER_ALICE))
-        .thenReturn(Optional.absent());
+        .thenReturn(Optional.empty());
     when(omMultiTenantManager.getTenantForAccessID(ACCESS_ID_BOB))
         .thenReturn(Optional.of(ACCESS_ID_BOB));
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.request.security;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import com.google.common.base.Optional;
 import java.util.UUID;
 
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -44,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
@@ -188,10 +188,7 @@ public class TestOMGetDelegationTokenRequest extends
 
     OMClientResponse clientResponse = setValidateAndUpdateCache();
 
-    Optional<Long> responseRenewTime = Optional.fromNullable(
-        omMetadataManager.getDelegationTokenTable().get(identifier));
-    assertEquals(Optional.of(renewTime), responseRenewTime);
-
+    assertEquals(renewTime, omMetadataManager.getDelegationTokenTable().get(identifier));
     assertEquals(Status.OK, clientResponse.getOMResponse().getStatus());
   }
 
@@ -206,10 +203,7 @@ public class TestOMGetDelegationTokenRequest extends
         .getGetDelegationTokenResponse().hasResponse();
     assertFalse(hasResponse);
 
-    Optional<Long> responseRenewTime = Optional.fromNullable(
-        omMetadataManager.getDelegationTokenTable().get(identifier));
-    assertEquals(Optional.absent(), responseRenewTime);
-
+    assertNull(omMetadataManager.getDelegationTokenTable().get(identifier));
     assertEquals(Status.OK, clientResponse.getOMResponse().getStatus());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace Guava Optional with Java Optional, except two unnecessary usages where it's completely removed:

 * deprecated `CacheValue` constructor
 * `Optional<Long>` in `TestOMGetDelegationTokenRequest`

https://issues.apache.org/jira/browse/HDDS-9985

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7680017854