### PR TITLE
HDDS-10228. Intermittent failure downloading bzip2 from sourceware.org

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -55,6 +55,7 @@
 
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
+    <bzip2.url>https://sourceware.org/pub/bzip2/bzip2-${bzip2.version}.tar.gz</bzip2.url>
     <zlib.url>https://zlib.net/fossils/zlib-${zlib.version}.tar.gz</zlib.url>
   </properties>
 
@@ -146,7 +147,7 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://sourceware.org/pub/bzip2/bzip2-${bzip2.version}.tar.gz</url>
+                  <url>${bzip2.url}</url>
                   <outputFileName>bzip2-v${bzip2.version}.tar.gz</outputFileName>
                   <outputDirectory>${project.build.directory}/bzip2</outputDirectory>
                 </configuration>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -221,6 +221,7 @@
                     <untar src="${project.build.directory}/rocksdb/rocksdb-v${rocksdb.version}.tar.gz" compression="gzip" dest="${project.build.directory}/rocksdb/" />
                     <untar src="${project.build.directory}/zlib/zlib-${zlib.version}.tar.gz" compression="gzip" dest="${project.build.directory}/zlib/" />
                     <untar src="${project.build.directory}/bzip2/bzip2-v${bzip2.version}.tar.gz" compression="gzip" dest="${project.build.directory}/bzip2/" />
+                    <move file="${project.build.directory}/bzip2/bzip2-bzip2-${bzip2.version}" tofile="${project.build.directory}/bzip2/bzip2-${bzip2.version}" failonerror="false" />
                     <untar src="${project.build.directory}/lz4/lz4-v${lz4.version}.tar.gz" compression="gzip" dest="${project.build.directory}/lz4/" />
                     <untar src="${project.build.directory}/snappy/snappy-v${snappy.version}.tar.gz" compression="gzip" dest="${project.build.directory}/snappy/" />
                     <untar src="${project.build.directory}/zstd/zstd-v${zstd.version}.tar.gz" compression="gzip" dest="${project.build.directory}/zstd/" />

--- a/hadoop-ozone/dev-support/checks/native.sh
+++ b/hadoop-ozone/dev-support/checks/native.sh
@@ -25,7 +25,14 @@ if [[ -z "${zlib_version}" ]]; then
   exit 1
 fi
 
+bzip2_version=$(mvn -N help:evaluate -Dexpression=bzip2.version -q -DforceStdout)
+if [[ -z "${bzip2_version}" ]]; then
+  echo "ERROR bzip2.version not defined in pom.xml"
+  exit 1
+fi
+
 source "${DIR}/junit.sh" -Pnative -Drocks_tools_native \
+  -Dbzip2.url="https://github.com/libarchive/bzip2/archive/refs/tags/bzip2-${bzip2_version}.tar.gz" \
   -Dzlib.url="https://github.com/madler/zlib/releases/download/v${zlib_version}/zlib-${zlib_version}.tar.gz" \
   -DexcludedGroups="unhealthy" \
   "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure downloading `bzip2` due to `Network is unreachable`.

The fix is similar to HDDS-10157: download from GitHub in CI.  The tarballs from these two sources are a bit different: contents are in `bzip2-bzip2-1.0.8/` in the one from GitHub, `bzip2-1.0.8/` in the original one.  So an additional `move` Ant task renames the GitHub-specific dir to the original one.  `failonerror=false` ensures it passes with the original tarball, too.

https://issues.apache.org/jira/browse/HDDS-10228

## How was this patch tested?

Tested locally for the original URL:

```
# install dependencies
$ mvn -DskipTests -am -pl :hdds-rocks-native clean install
...

# test
$ mvn -Drocks_tools_native -pl :hdds-rocks-native clean generate-sources
...
[INFO] BUILD SUCCESS

$ ls -1 hadoop-hdds/rocks-native/target/bzip2
bzip2-1.0.8
bzip2-v1.0.8.tar.gz
```

CI (with the CI-specific URL):
https://github.com/adoroszlai/ozone/actions/runs/7681371921/job/20934591236