### PR TITLE
HDDS-10227. Intermittent timeout in TestReconAndAdminContainerCLI

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -103,7 +103,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * with the "ozone admin container" CLI.
  */
 @Timeout(300)
-public class TestReconAndAdminContainerCLI {
+class TestReconAndAdminContainerCLI {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestReconAndAdminContainerCLI.class);
 
@@ -126,7 +126,7 @@ public class TestReconAndAdminContainerCLI {
   }
 
   @BeforeAll
-  public static void init() throws Exception {
+  static void init() throws Exception {
     setupConfigKeys();
     cluster = MiniOzoneCluster.newBuilder(CONF)
                   .setNumDatanodes(5)
@@ -176,7 +176,7 @@ public class TestReconAndAdminContainerCLI {
   }
 
   @AfterAll
-  public static void shutdown() {
+  static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -187,7 +187,7 @@ public class TestReconAndAdminContainerCLI {
    * but it's easier to test with Ratis ONE.
    */
   @Test
-  public void testMissingContainer() throws Exception {
+  void testMissingContainer() throws Exception {
     String keyNameR1 = "key2";
     long containerID = setupRatisKey(keyNameR1,
         HddsProtos.ReplicationFactor.ONE);
@@ -221,7 +221,7 @@ public class TestReconAndAdminContainerCLI {
 
   @ParameterizedTest
   @MethodSource("outOfServiceNodeStateArgs")
-  public void testNodesInDecommissionOrMaintenance(
+  void testNodesInDecommissionOrMaintenance(
       NodeOperationalState initialState, NodeOperationalState finalState,
       boolean isMaintenance) throws Exception {
     Pipeline pipeline =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -333,19 +333,10 @@ class TestReconAndAdminContainerCLI {
       reconResponse = TestReconEndpointUtil
           .getUnhealthyContainersFromRecon(CONF, state);
 
-      long rmMissingCounter = rmReport.getStat(
-          ReplicationManagerReport.HealthState.MISSING);
-      long rmUnderReplCounter = rmReport.getStat(
-          ReplicationManagerReport.HealthState.UNDER_REPLICATED);
-      long rmOverReplCounter = rmReport.getStat(
-          ReplicationManagerReport.HealthState.OVER_REPLICATED);
-      long rmMisReplCounter = rmReport.getStat(
-          ReplicationManagerReport.HealthState.MIS_REPLICATED);
-
-      assertEquals(rmMissingCounter, reconResponse.getMissingCount());
-      assertEquals(rmUnderReplCounter, reconResponse.getUnderReplicatedCount());
-      assertEquals(rmOverReplCounter, reconResponse.getOverReplicatedCount());
-      assertEquals(rmMisReplCounter, reconResponse.getMisReplicatedCount());
+      assertEquals(rmReport.getStat(HealthState.MISSING), reconResponse.getMissingCount());
+      assertEquals(rmReport.getStat(HealthState.UNDER_REPLICATED), reconResponse.getUnderReplicatedCount());
+      assertEquals(rmReport.getStat(HealthState.OVER_REPLICATED), reconResponse.getOverReplicatedCount());
+      assertEquals(rmReport.getStat(HealthState.MIS_REPLICATED), reconResponse.getMisReplicatedCount());
     } catch (IOException e) {
       LOG.info("Error getting report", e);
       return false;
@@ -354,31 +345,22 @@ class TestReconAndAdminContainerCLI {
       return false;
     }
 
-    long rmMissingCounter = rmReport.getStat(
-        ReplicationManagerReport.HealthState.MISSING);
-    long rmUnderReplCounter = rmReport.getStat(
-        ReplicationManagerReport.HealthState.UNDER_REPLICATED);
-    long rmOverReplCounter = rmReport.getStat(
-        ReplicationManagerReport.HealthState.OVER_REPLICATED);
-    long rmMisReplCounter = rmReport.getStat(
-        ReplicationManagerReport.HealthState.MIS_REPLICATED);
-
     // Recon's UnhealthyContainerResponse contains a list of containers
     // for a particular state. Check if RMs sample of containers can be
     // found in Recon's list of containers for a particular state.
     HealthState rmState = HealthState.UNHEALTHY;
 
     if (state.equals(UnHealthyContainerStates.MISSING) &&
-        rmMissingCounter > 0) {
+        reconResponse.getMissingCount() > 0) {
       rmState = HealthState.MISSING;
     } else if (state.equals(UnHealthyContainerStates.UNDER_REPLICATED) &&
-               rmUnderReplCounter > 0) {
+               reconResponse.getUnderReplicatedCount() > 0) {
       rmState = HealthState.UNDER_REPLICATED;
     } else if (state.equals(UnHealthyContainerStates.OVER_REPLICATED) &&
-               rmOverReplCounter > 0) {
+               reconResponse.getOverReplicatedCount() > 0) {
       rmState = HealthState.OVER_REPLICATED;
     } else if (state.equals(UnHealthyContainerStates.MIS_REPLICATED) &&
-               rmMisReplCounter > 0) {
+               reconResponse.getMisReplicatedCount() > 0) {
       rmState = HealthState.MIS_REPLICATED;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconEndpointUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconEndpointUtil.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.ozone.recon.api.types.UnhealthyContainersResponse;
+import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,7 @@ public final class TestReconEndpointUtil {
   }
 
   public static UnhealthyContainersResponse getUnhealthyContainersFromRecon(
-      OzoneConfiguration conf, String containerState)
+      OzoneConfiguration conf, ContainerSchemaDefinition.UnHealthyContainerStates containerState)
       throws JsonProcessingException {
     StringBuilder urlBuilder = new StringBuilder();
     urlBuilder.append(getReconWebAddress(conf))


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestReconAndAdminContainerCLI` intermittently fails (in 8/100 [runs](https://github.com/adoroszlai/ozone/actions/runs/7680318420)) with timeout at:

```
  at org.apache.ozone.test.GenericTestUtils.waitFor(GenericTestUtils.java:204)
  at org.apache.hadoop.ozone.recon.TestReconAndAdminContainerCLI.compareRMReportToReconResponse(TestReconAndAdminContainerCLI.java:335)
```

The test gets reports from SCM and Recon, and then waits for the values to be equal.  The problem is that the report values are "fixed", updates are done at the server-side.  The operation repeated by `waitFor` should include getting the reports, too.

Some additional cleanup in separate commits.

https://issues.apache.org/jira/browse/HDDS-10227

## How was this patch tested?

Passed in 100 runs:
https://github.com/adoroszlai/ozone/actions/runs/7684474778

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/7684851679