### PR TITLE
HDDS-10231. ContainerStateManager should not finalize the OPEN containers without a Pipeline.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
@@ -74,7 +74,10 @@ public class ReplicationManagerReport {
         "OpenUnhealthyContainers"),
     QUASI_CLOSED_STUCK(
         "Containers QuasiClosed with insufficient datanode origins",
-        "StuckQuasiClosedContainers");
+        "StuckQuasiClosedContainers"),
+    OPEN_WITHOUT_PIPELINE(
+        "Containers in OPEN state without any healthy Pipeline",
+        "OpenContainersWithoutPipeline");
 
     private String description;
     private String metricName;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
@@ -112,6 +112,7 @@ class TestReplicationManagerReport {
     assertEquals(0, stats.get("EMPTY").longValue());
     assertEquals(0, stats.get("OPEN_UNHEALTHY").longValue());
     assertEquals(0, stats.get("QUASI_CLOSED_STUCK").longValue());
+    assertEquals(0, stats.get("OPEN_WITHOUT_PIPELINE").longValue());
 
     JsonNode samples = json.get("samples");
     assertEquals(ARRAY, samples.get("UNDER_REPLICATED").getNodeType());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -251,16 +251,12 @@ public final class ContainerStateManagerImpl
             pipelineManager.addContainerToPipelineSCMStart(
                 container.getPipelineID(), container.containerID());
           } catch (PipelineNotFoundException ex) {
+            // We are ignoring this here. The container will be moved to
+            // CLOSING state by ReplicationManager's OpenContainerHandler
+            // For more info: HDDS-10231
             LOG.warn("Found container {} which is in OPEN state with " +
                 "pipeline {} that does not exist. Marking container for " +
                 "closing.", container, container.getPipelineID());
-            try {
-              updateContainerState(container.containerID().getProtobuf(),
-                  LifeCycleEvent.FINALIZE);
-            } catch (InvalidStateTransitionException e) {
-              // This cannot happen.
-              LOG.warn("Unable to finalize Container {}.", container);
-            }
           }
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMService;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
@@ -1544,6 +1545,15 @@ public class ReplicationManager implements SCMService {
 
   private static boolean isEC(ReplicationConfig replicationConfig) {
     return replicationConfig.getReplicationType() == EC;
+  }
+
+  public boolean hasHealthyPipeline(ContainerInfo container) {
+    try {
+      return scmContext.getScm().getPipelineManager()
+          .getPipeline(container.getPipelineID()) != null;
+    } catch (PipelineNotFoundException e) {
+      return false;
+    }
   }
 }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/OpenContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/health/OpenContainerHandler.java
@@ -53,20 +53,26 @@ public class OpenContainerHandler extends AbstractCheck {
     if (containerInfo.getState() == HddsProtos.LifeCycleState.OPEN) {
       LOG.debug("Checking open container {} in OpenContainerHandler",
           containerInfo);
-      if (!isOpenContainerHealthy(
-          containerInfo, request.getContainerReplicas())) {
-        // This is an unhealthy open container, so we need to trigger the
-        // close process on it.
-        LOG.debug("Container {} is open but unhealthy. Triggering close.",
-            containerInfo);
-        request.getReport().incrementAndSample(
-            ReplicationManagerReport.HealthState.OPEN_UNHEALTHY,
+      final boolean noPipeline = !replicationManager.hasHealthyPipeline(containerInfo);
+      // Minor optimization. If noPipeline is true, isOpenContainerHealthy will not
+      // be called.
+      final boolean unhealthy = noPipeline || !isOpenContainerHealthy(containerInfo,
+          request.getContainerReplicas());
+      if (unhealthy) {
+        // For an OPEN container, we close the container
+        // if the container has no Pipeline or if the container is unhealthy.
+        LOG.info("Container {} is open but {}. Triggering close.",
+            containerInfo, noPipeline ? "has no Pipeline" : "unhealthy");
+
+        request.getReport().incrementAndSample(noPipeline ?
+                ReplicationManagerReport.HealthState.OPEN_WITHOUT_PIPELINE :
+                ReplicationManagerReport.HealthState.OPEN_UNHEALTHY,
             containerInfo.containerID());
+
         if (!request.isReadOnly()) {
           replicationManager
               .sendCloseContainerEvent(containerInfo.containerID());
         }
-        return true;
       }
       // For open containers we do not want to do any further processing in RM
       // so return true to stop the command chain.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -43,6 +44,9 @@ import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.security.token.ContainerTokenGenerator;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
@@ -174,6 +178,16 @@ public class TestReplicationManager {
     // Ensure that RM will run when asked.
     when(scmContext.isLeaderReady()).thenReturn(true);
     when(scmContext.isInSafeMode()).thenReturn(false);
+
+    PipelineManager pipelineManager = mock(PipelineManager.class);
+    when(pipelineManager.getPipeline(any()))
+        .thenReturn(HddsTestUtils.getRandomPipeline());
+
+    StorageContainerManager scm = mock(StorageContainerManager.class);
+    when(scm.getPipelineManager()).thenReturn(pipelineManager);
+    when(scm.getContainerTokenGenerator()).thenReturn(ContainerTokenGenerator.DISABLED);
+
+    when(scmContext.getScm()).thenReturn(scm);
   }
 
   private ReplicationManager createReplicationManager() throws IOException {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/health/TestOpenContainerHandler.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport.HealthState;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerCheckRequest;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil;
@@ -36,6 +37,7 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
@@ -121,6 +123,7 @@ public class TestOpenContainerHandler {
     assertTrue(openContainerHandler.handle(readRequest));
     verify(replicationManager, times(1))
         .sendCloseContainerEvent(containerInfo.containerID());
+    assertEquals(1, request.getReport().getStat(HealthState.OPEN_UNHEALTHY));
   }
 
   @Test
@@ -148,6 +151,7 @@ public class TestOpenContainerHandler {
     assertTrue(openContainerHandler.handle(readRequest));
     verify(replicationManager, times(1))
         .sendCloseContainerEvent(containerInfo.containerID());
+    assertEquals(1, request.getReport().getStat(HealthState.OPEN_WITHOUT_PIPELINE));
   }
   @Test
   public void testClosedRatisContainerReturnsFalse() {
@@ -206,6 +210,7 @@ public class TestOpenContainerHandler {
     assertTrue(openContainerHandler.handle(request));
     assertTrue(openContainerHandler.handle(readRequest));
     verify(replicationManager, times(1)).sendCloseContainerEvent(any());
+    assertEquals(1, request.getReport().getStat(HealthState.OPEN_UNHEALTHY));
   }
 
   @Test
@@ -232,5 +237,6 @@ public class TestOpenContainerHandler {
     assertTrue(openContainerHandler.handle(request));
     assertTrue(openContainerHandler.handle(readRequest));
     verify(replicationManager, times(1)).sendCloseContainerEvent(any());
+    assertEquals(1, request.getReport().getStat(HealthState.OPEN_WITHOUT_PIPELINE));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
If there is an OPEN container without any pipeline, that container has to be moved to CLOSING state and CLOSE container command has to be sent to the datanodes.
Currently, this is done while SCM is initialized. Since Ratis is not set up completely (mostly no leader is elected at this point), the state update is done locally (not via Ratis).
Doing this on SCM start-up is error-prone.

The container state update has to be done only via Ratis. If not, there are chances of container state getting diverged between SCMs.

This PR changes the logic and moves it to ReplicationManager's `OpenContainerHandler`, where we check if the OPEN Container has a healthy Pipeline, if not the container is closed.



## What is the link to the Apache JIRA
HDDS-10231

## How was this patch tested?
Added new unit test to cover the scenario.
