### PR TITLE
HDDS-10241. Improve the response for the Deleted Directories Insight Endpoint.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
@@ -222,8 +223,8 @@ public class OMDBInsightEndpoint {
             continue;
           }
           KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
-          keyEntityInfo.setKey(key);
-          keyEntityInfo.setPath(omKeyInfo.getKeyName());
+          keyEntityInfo.setKey(omKeyInfo.getFileName());
+          keyEntityInfo.setPath(createPath(omKeyInfo));
           keyEntityInfo.setInStateSince(omKeyInfo.getCreationTime());
           keyEntityInfo.setSize(omKeyInfo.getDataSize());
           keyEntityInfo.setReplicatedSize(omKeyInfo.getReplicatedSize());
@@ -536,8 +537,8 @@ public class OMDBInsightEndpoint {
           continue;
         }
         KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
-        keyEntityInfo.setKey(key);
-        keyEntityInfo.setPath(omKeyInfo.getKeyName());
+        keyEntityInfo.setKey(omKeyInfo.getFileName());
+        keyEntityInfo.setPath(createPath(omKeyInfo));
         keyEntityInfo.setInStateSince(omKeyInfo.getCreationTime());
         keyEntityInfo.setSize(
             fetchSizeForDeletedDirectory(omKeyInfo.getObjectID()));
@@ -663,6 +664,12 @@ public class OMDBInsightEndpoint {
               omKeyInfo.getReplicatedSize());
     });
   }
+
+  private String createPath(OmKeyInfo omKeyInfo) {
+    return omKeyInfo.getVolumeName() + OM_KEY_PREFIX +
+        omKeyInfo.getBucketName() + OM_KEY_PREFIX + omKeyInfo.getKeyName();
+  }
+
 
   @VisibleForTesting
   public GlobalStatsDao getDao() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -223,8 +223,8 @@ public class OMDBInsightEndpoint {
             continue;
           }
           KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
-          keyEntityInfo.setKey(omKeyInfo.getFileName());
-          keyEntityInfo.setPath(createPath(omKeyInfo));
+          keyEntityInfo.setKey(key);
+          keyEntityInfo.setPath(omKeyInfo.getKeyName());
           keyEntityInfo.setInStateSince(omKeyInfo.getCreationTime());
           keyEntityInfo.setSize(omKeyInfo.getDataSize());
           keyEntityInfo.setReplicatedSize(omKeyInfo.getReplicatedSize());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -664,7 +664,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     assertNotNull(keyInsightInfoResp);
     assertEquals(2,
         keyInsightInfoResp.getDeletedDirInfoList().size());
-    assertEquals("/sampleVol/bucketOne/dir_one",
+    assertEquals("dir_one",
         keyInsightInfoResp.getDeletedDirInfoList().get(0).getKey());
   }
 
@@ -696,7 +696,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     assertNotNull(keyInsightInfoResp);
     assertEquals(2,
         keyInsightInfoResp.getDeletedDirInfoList().size());
-    assertEquals("/sampleVol/bucketOne/dir_three",
+    assertEquals("dir_three",
         keyInsightInfoResp.getDeletedDirInfoList().get(0).getKey());
     assertEquals("/sampleVol/bucketOne/dir_two",
         keyInsightInfoResp.getLastKey());
@@ -729,7 +729,9 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     assertNotNull(keyInsightInfoResp);
     assertEquals(3,
         keyInsightInfoResp.getDeletedDirInfoList().size());
-    assertEquals("/sampleVol/bucketOne/dir_one",
+    assertEquals("sampleVol/bucketOne/dir_one", keyInsightInfoResp
+        .getDeletedDirInfoList().get(0).getPath());
+    assertEquals("dir_one",
         keyInsightInfoResp.getDeletedDirInfoList().get(0).getKey());
     assertEquals("/sampleVol/bucketOne/dir_two",
         keyInsightInfoResp.getLastKey());


### PR DESCRIPTION
## What changes were proposed in this pull request?
The current response of Deleted-Directories Insights has the following parameters :- 

```
"key":"/-9223372036854775552/-9223372036854775040/-9223372036854775040/dir1/-9223372036854774527",
"path": "dir1",
```
As we can see its confusing and not very intuitive for the user. 

We want the final response parameters to be like this :- 
```
"key": "dir1", 
"path": "volume/bucket1/dir1/dir2/dir3",
```
Here we will have to construct the path of the directory with their actual names rather than printing out the object ID's.
And we will also have to make a few changes to the frontend to accommodate this new info accordingly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10241

## How was this patch tested?

Manual Testing & Unit Testing

