### PR TITLE
HDDS-10246. Remove KeyValueHandler.checkContainerIsHealthy to improve read performance

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -749,14 +749,10 @@ public class KeyValueHandler extends Handler {
   @VisibleForTesting
   void checkContainerIsHealthy(KeyValueContainer kvContainer, BlockID blockID,
       Type cmd) {
-    kvContainer.readLock();
-    try {
-      if (kvContainer.getContainerData().getState() == State.UNHEALTHY) {
-        LOG.warn("{} request {} for UNHEALTHY container {} replica", cmd,
-            blockID, kvContainer.getContainerData().getContainerID());
-      }
-    } finally {
-      kvContainer.readUnlock();
+    // No kvContainer.readLock() for performance optimization
+    if (kvContainer.getContainerData().getState() == State.UNHEALTHY) {
+      LOG.warn("{} request {} for UNHEALTHY container {} replica", cmd,
+          blockID, kvContainer.getContainerData().getContainerID());
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -580,7 +580,6 @@ public class KeyValueHandler extends Handler {
     try {
       BlockID blockID = BlockID.getFromProtobuf(
           request.getGetBlock().getBlockID());
-      checkContainerIsHealthy(kvContainer, blockID, Type.GetBlock);
       responseData = blockManager.getBlock(kvContainer, blockID)
           .getProtoBufMessage();
       final long numBytes = responseData.getSerializedSize();
@@ -615,8 +614,6 @@ public class KeyValueHandler extends Handler {
     try {
       BlockID blockID = BlockID
           .getFromProtobuf(request.getGetCommittedBlockLength().getBlockID());
-      checkContainerIsHealthy(kvContainer, blockID,
-          Type.GetCommittedBlockLength);
       BlockUtils.verifyBCSId(kvContainer, blockID);
       blockLength = blockManager.getCommittedBlockLength(kvContainer, blockID);
     } catch (StorageContainerException ex) {
@@ -703,7 +700,6 @@ public class KeyValueHandler extends Handler {
           .getChunkData());
       Preconditions.checkNotNull(chunkInfo);
 
-      checkContainerIsHealthy(kvContainer, blockID, Type.ReadChunk);
       BlockUtils.verifyBCSId(kvContainer, blockID);
       if (dispatcherContext == null) {
         dispatcherContext = DispatcherContext.getHandleReadChunk();
@@ -739,21 +735,6 @@ public class KeyValueHandler extends Handler {
     Preconditions.checkNotNull(data, "Chunk data is null");
 
     return getReadChunkResponse(request, data, byteBufferToByteString);
-  }
-
-  /**
-   * Throw an exception if the container is unhealthy.
-   *
-   * @throws StorageContainerException if the container is unhealthy.
-   */
-  @VisibleForTesting
-  void checkContainerIsHealthy(KeyValueContainer kvContainer, BlockID blockID,
-      Type cmd) {
-    // No kvContainer.readLock() for performance optimization
-    if (kvContainer.getContainerData().getState() == State.UNHEALTHY) {
-      LOG.warn("{} request {} for UNHEALTHY container {} replica", cmd,
-          blockID, kvContainer.getContainerData().getContainerID());
-    }
   }
 
   /**
@@ -919,7 +900,6 @@ public class KeyValueHandler extends Handler {
     try {
       BlockID blockID = BlockID.getFromProtobuf(getSmallFileReq.getBlock()
           .getBlockID());
-      checkContainerIsHealthy(kvContainer, blockID, Type.GetSmallFile);
       BlockData responseData = blockManager.getBlock(kvContainer, blockID);
 
       ContainerProtos.ChunkInfo chunkInfoProto = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?
As described in HDDS-10146, all of the ChunkReader threads are blocked in the `KeyValueHandler#checkContainerIsHealthy` method, waiting for the `KeyValueContainer#readLock`. 

Remove readLock from KeyValueHandler.checkContainerIsHealthy to improve performance


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10246

## How was this patch tested?

- No new test and pass exist unit tests
- Works well in our cluster

