### PR TITLE
HDDS-10251. Intermittent failure in TestKeyDeletingService

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -164,7 +164,7 @@ public class TestKeyDeletingService {
     GenericTestUtils.waitFor(
         () -> keyDeletingService.getDeletedKeyCount().get() >= keyCount,
         1000, 10000);
-    assertThat(keyDeletingService.getRunCount().get()).isGreaterThan(1);
+    assertThat(keyDeletingService.getRunCount().get()).isGreaterThanOrEqualTo(1);
     assertEquals(0, keyManager.getPendingDeletionKeys(
         Integer.MAX_VALUE).getKeyBlocksList().size());
   }
@@ -366,7 +366,7 @@ public class TestKeyDeletingService {
     GenericTestUtils.waitFor(
         () -> keyDeletingService.getDeletedKeyCount().get() >= 1,
         1000, 10000);
-    assertThat(keyDeletingService.getRunCount().get()).isGreaterThan(1);
+    assertThat(keyDeletingService.getRunCount().get()).isGreaterThanOrEqualTo(1);
     assertEquals(0, keyManager.getPendingDeletionKeys(
         Integer.MAX_VALUE).getKeyBlocksList().size());
 
@@ -444,7 +444,7 @@ public class TestKeyDeletingService {
     GenericTestUtils.waitFor(
         () -> keyDeletingService.getDeletedKeyCount().get() >= 1,
         1000, 10000);
-    assertThat(keyDeletingService.getRunCount().get()).isGreaterThan(1);
+    assertThat(keyDeletingService.getRunCount().get()).isGreaterThanOrEqualTo(1);
     assertEquals(0, keyManager
         .getPendingDeletionKeys(Integer.MAX_VALUE).getKeyBlocksList().size());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in `TestKeyDeletingService`.  `KeyDeletingService` may complete deleting all keys in 1 run.

https://issues.apache.org/jira/browse/HDDS-10251

## How was this patch tested?

Tested with 100x repeated CI runs.

Before HDDS-10215: 100/100 pass
https://github.com/adoroszlai/ozone/actions/runs/7716648128

HDDS-10215 seems to have introduced the flakiness: 100/100 failed (although the same test passed in the PR and in fork run)
https://github.com/adoroszlai/ozone/actions/runs/7716644638

With this fix: 100/100 pass
https://github.com/adoroszlai/ozone/actions/runs/7716856421

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/7716815030