### PR TITLE
HDDS-10269. Remove duplicate addCacheEntry in OMDirectoryCreateRequest#getAllParentInfo

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -297,10 +297,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       objectCount++;
 
       missingParentInfos.add(parentKeyInfo);
-      omMetadataManager.getKeyTable(BucketLayout.DEFAULT).addCacheEntry(
-          omMetadataManager.getOzoneKey(
-              volumeName, bucketName, parentKeyInfo.getKeyName()),
-          parentKeyInfo, trxnLogIndex);
     }
 
     return missingParentInfos;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -264,7 +264,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       KeyArgs keyArgs, List<String> missingParents, OmBucketInfo bucketInfo,
       OMFileRequest.OMPathInfo omPathInfo, long trxnLogIndex)
       throws IOException {
-    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
     List<OmKeyInfo> missingParentInfos = new ArrayList<>();
 
     // The base id is left shifted by 8 bits for creating space to


### PR DESCRIPTION
## What changes were proposed in this pull request?

In OMDirectoryCreateRequest#getAllParentInfo, there is an unnecessary call to add cache entry for the missing parent directory info.

```java
omMetadataManager.getKeyTable(BucketLayout.DEFAULT).addCacheEntry(
    omMetadataManager.getOzoneKey(
        volumeName, bucketName, parentKeyInfo.getKeyName()),
    parentKeyInfo, trxnLogIndex); 
```
Although it is already added later in OMFileRequest#addKeyToTableCacheEntries

As the method name suggest, getAllParentInfo should just return the missing parent info without doing any table operation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10269

## How was this patch tested?

Existing tests.

Clean CI: https://github.com/ivandika3/ozone/actions/runs/7737930007