### PR TITLE
HDDS-10271. Fixing SCM start-up logs.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -245,8 +245,11 @@ public abstract class DefaultCertificateClient implements CertificateClient {
       updateCachedData(fileName, CAType.SUBORDINATE, this::updateCachedSubCAId);
       updateCachedData(fileName, CAType.ROOT, this::updateCachedRootCAId);
 
-      getLogger().info("Added certificate {} from file: {}.", cert,
+      getLogger().info("Added certificate {} from file: {}.", readCertSerialId,
           filePath.toAbsolutePath());
+      if (getLogger().isDebugEnabled()) {
+        getLogger().debug("Certificate: {}", cert);
+      }
     } catch (java.security.cert.CertificateException
              | IOException | IndexOutOfBoundsException e) {
       getLogger().error("Error reading certificate from file: {}.",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -255,8 +255,8 @@ public final class ContainerStateManagerImpl
             // CLOSING state by ReplicationManager's OpenContainerHandler
             // For more info: HDDS-10231
             LOG.warn("Found container {} which is in OPEN state with " +
-                "pipeline {} that does not exist. Marking container for " +
-                "closing.", container, container.getPipelineID());
+                "pipeline {} that does not exist.",
+                container, container.getPipelineID());
           }
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -450,7 +450,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     moveManager = new MoveManager(replicationManager, containerManager);
     containerReplicaPendingOps.registerSubscriber(moveManager);
     containerBalancer = new ContainerBalancer(this);
-    LOG.info(containerBalancer.toString());
 
     // Emit initial safe mode status, as now handlers are registered.
     scmSafeModeManager.emitSafeModeStatus();


### PR DESCRIPTION
## What changes were proposed in this pull request?
- We are already logging all the config properties during start-up, in addition to that the container balancer config is also logged. We can avoid logging container balancer config during startup.
- We don't have to print the complete certificate information at the info level. Printing SerialId should be enough.
- Fix incorrect log message in ContainerStateManager#initialize


## What is the link to the Apache JIRA
HDDS-10271

## How was this patch tested?
NA
