### PR TITLE
HDDS-10272. Container Report admin command displays incorrect value immediately after SCM restart

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReportSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReportSubcommand.java
@@ -54,7 +54,7 @@ public class ReportSubcommand extends ScmSubcommand {
     ReplicationManagerReport report = scmClient.getReplicationManagerReport();
     if (report.getReportTimeStamp() == 0) {
       System.err.println("The Container Report is not available until Replication Manager completes" +
-          " its first run after startup or failover. All values will be zero until that time.\n");
+          " its first run after startup or fail over. All values will be zero until that time.\n");
     }
 
     if (json) {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReportSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReportSubcommand.java
@@ -52,6 +52,10 @@ public class ReportSubcommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     ReplicationManagerReport report = scmClient.getReplicationManagerReport();
+    if (report.getReportTimeStamp() == 0) {
+      System.err.println("The Container Report is not available until Replication Manager completes" +
+          " its first run after startup or failover. All values will be zero until that time.\n");
+    }
 
     if (json) {
       output(JsonUtils.toJsonStringWithDefaultPrettyPrinter(report));

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReportSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ReportSubcommand.java
@@ -72,9 +72,11 @@ public class ReportSubcommand extends ScmSubcommand {
   }
 
   private void outputHeader(long epochMs) {
+    if (epochMs == 0) {
+      epochMs = Instant.now().toEpochMilli();
+    }
     Instant reportTime = Instant.ofEpochSecond(epochMs / 1000);
     outputHeading("Container Summary Report generated at " + reportTime);
-
   }
 
   private void outputContainerStats(ReplicationManagerReport report) {

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReportSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReportSubCommand.java
@@ -74,18 +74,20 @@ public class TestReportSubCommand {
 
     cmd.execute(scmClient);
 
+    Pattern p = Pattern.compile("^The Container Report is not available until Replication Manager completes.*");
+    Matcher m = p.matcher(errContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
     for (HddsProtos.LifeCycleState state : HddsProtos.LifeCycleState.values()) {
-      Pattern p = Pattern.compile(
-          "^" + state.toString() + ": 0$", Pattern.MULTILINE);
-      Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+      p = Pattern.compile("^" + state.toString() + ": 0$", Pattern.MULTILINE);
+      m = p.matcher(outContent.toString(DEFAULT_ENCODING));
       assertTrue(m.find());
     }
 
     for (ReplicationManagerReport.HealthState state :
         ReplicationManagerReport.HealthState.values()) {
-      Pattern p = Pattern.compile(
-          "^" + state.toString() + ": 0$", Pattern.MULTILINE);
-      Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+      p = Pattern.compile("^" + state.toString() + ": 0$", Pattern.MULTILINE);
+      m = p.matcher(outContent.toString(DEFAULT_ENCODING));
       assertTrue(m.find());
     }
   }
@@ -100,6 +102,10 @@ public class TestReportSubCommand {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("--json");
     cmd.execute(scmClient);
+
+    Pattern p = Pattern.compile("^The Container Report is not available until Replication Manager completes.*");
+    Matcher m = p.matcher(errContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
 
     ObjectMapper mapper = new ObjectMapper();
     JsonNode json = mapper.readTree(outContent.toString("UTF-8"));


### PR DESCRIPTION
## What changes were proposed in this pull request?
After SCM is started or after a failover, all the numbers in the replication manager report will be zero, which can lead to confusion.

While it may be an idea to throw an error if the report isn't ready yet, that could be an incompatible change, as some monitoring tools to QA scripts could depend on the output to some extent.

Therefore it makes sense to print a warning to stderr indicating the report has zero values until replication manager runs for the first time. Same output after this PR:

```
bash-4.2$ ozone admin container report
The Container Report is not available until Replication Manager completes its first run after startup or fail over. All values will be zero until that time.

Container Summary Report generated at 1970-01-01T00:00:00Z
==========================================================

Container State Summary
=======================
OPEN: 0
CLOSING: 0
QUASI_CLOSED: 0
CLOSED: 0
DELETING: 0
DELETED: 0
RECOVERING: 0

Container Health Summary
========================
UNDER_REPLICATED: 0
MIS_REPLICATED: 0
OVER_REPLICATED: 0
MISSING: 0
UNHEALTHY: 0
EMPTY: 0
OPEN_UNHEALTHY: 0
QUASI_CLOSED_STUCK: 0
OPEN_WITHOUT_PIPELINE: 0
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10272

## How was this patch tested?

Unit tests adjusted and checked the output in docker compose.