### PR TITLE
HDDS-10279. Remove unused, dead code in hdds-config module.

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationTarget.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationTarget.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.conf;
 
-import java.time.temporal.TemporalUnit;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.conf.TimeDurationUtil.ParsedTimeDuration;
@@ -50,10 +49,6 @@ public interface ConfigurationTarget {
   }
 
   default void setTimeDuration(String name, long value, TimeUnit unit) {
-    set(name, value + ParsedTimeDuration.unitFor(unit).suffix());
-  }
-
-  default void setTimeDuration(String name, long value, TemporalUnit unit) {
     set(name, value + ParsedTimeDuration.unitFor(unit).suffix());
   }
 

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
@@ -207,14 +207,5 @@ public final class TimeDurationUtil {
       }
       return null;
     }
-
-    static ParsedTimeDuration unitFor(TemporalUnit unit) {
-      for (ParsedTimeDuration ptd : values()) {
-        if (ptd.temporalUnit() == unit) {
-          return ptd;
-        }
-      }
-      return null;
-    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removing dead code from hdds-config module. Dead code besides that it is not used can be harmful, if someone starts to use it, as it was not used it might not have been updated either along with similar functionality, so it is better to get rid of it.

Please describe your PR in detail:
The PR is, removing unused code from hdds-config module.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10248

## How was this patch tested?
Functionality should not be changing, if the code compiles, and existing tests are running fine, that pretty much proves that we did not needed these methods.
On the other hand, due to potential reflective access it is hard to prove that complete methods are not called, therefore I ran a search for the method name in the codebase and checked for that manually.