### PR TITLE
HDDS-10285. Remove unnecessary sleep in TestMiniOzoneCluster

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -233,7 +233,6 @@ public class TestMiniOzoneCluster {
             EndpointStateMachine.EndPointStates.GETVERSION,
             endpoint.getState());
       }
-      Thread.sleep(1000);
     }
 
     // DN should successfully register with the SCM after SCM is restarted.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove unnecessary sleep in `TestMiniOzoneCluster`. Saves 20s in the split.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10285

## How was this patch tested?

- [x] Test should pass without flakiness.