### PR TITLE
HDDS-10286. Remove unused RatisTestSuite

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
@@ -18,86 +18,30 @@
 
 package org.apache.hadoop.ozone;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
-import org.apache.hadoop.ozone.client.rpc.RpcClient;
-
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.rpc.RpcType;
-import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.statemachine.StateMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 
 /**
  * Helpers for Ratis tests.
  */
 public interface RatisTestHelper {
   Logger LOG = LoggerFactory.getLogger(RatisTestHelper.class);
-
-  /** For testing Ozone with Ratis. */
-  class RatisTestSuite implements Closeable {
-    static final RpcType RPC = SupportedRpcType.GRPC;
-    static final int NUM_DATANODES = 3;
-
-    private final OzoneConfiguration conf;
-    private final MiniOzoneCluster cluster;
-
-    /**
-     * Create a {@link MiniOzoneCluster} for testing by setting.
-     *   OZONE_ENABLED = true
-     *   RATIS_ENABLED = true
-     */
-    public RatisTestSuite()
-        throws IOException, TimeoutException, InterruptedException {
-      conf = newOzoneConfiguration(RPC);
-
-      cluster = newMiniOzoneCluster(NUM_DATANODES, conf);
-    }
-
-    public OzoneConfiguration getConf() {
-      return conf;
-    }
-
-    public MiniOzoneCluster getCluster() {
-      return cluster;
-    }
-
-    public ClientProtocol newOzoneClient()
-        throws IOException {
-      return new RpcClient(conf, null);
-    }
-
-    @Override
-    public void close() {
-      cluster.shutdown();
-    }
-
-    public int getDatanodeOzoneRestPort() {
-      return cluster.getHddsDatanodes().get(0).getDatanodeDetails()
-          .getPort(DatanodeDetails.Port.Name.REST).getValue();
-    }
-  }
-
-  static OzoneConfiguration newOzoneConfiguration(RpcType rpc) {
-    final OzoneConfiguration conf = new OzoneConfiguration();
-    initRatisConf(rpc, conf);
-    return conf;
-  }
 
   static void initRatisConf(RpcType rpc, OzoneConfiguration conf) {
     conf.setBoolean(OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLED_KEY, true);
@@ -106,17 +50,6 @@ public interface RatisTestHelper {
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 30, TimeUnit.SECONDS);
     LOG.info("{} = {}", OzoneConfigKeys.DFS_CONTAINER_RATIS_RPC_TYPE_KEY,
             rpc.name());
-  }
-
-  static MiniOzoneCluster newMiniOzoneCluster(
-      int numDatanodes, OzoneConfiguration conf)
-      throws IOException, TimeoutException, InterruptedException {
-    final MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf)
-        .setHbInterval(1000)
-        .setHbProcessorInterval(1000)
-        .setNumDatanodes(numDatanodes).build();
-    cluster.waitForClusterToBeReady();
-    return cluster;
   }
 
   static void initXceiverServerRatis(


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RatisTestSuite` is unused, can be removed.

https://issues.apache.org/jira/browse/HDDS-10286

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7767145925