### PR TITLE
HDDS-10242. [hsync] Handle penultimate block finalization.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/LeaseKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/LeaseKeyInfo.java
@@ -18,12 +18,14 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 /**
- * This class represents LeaseKeyInfo
- * isKeyInfo represents whether key is from openKeyTable or keyTable
- * true corresponds to keyInfo is from keyTable.
+ * This class represents LeaseKeyInfo.
  */
 public class LeaseKeyInfo {
   private final OmKeyInfo keyInfo;
+  /**
+   * isKeyInfo = true indicates keyInfo is from keyTable.
+   * isKeyInfo = false indicates keyInfo is from openKeyTable.
+   */
   private boolean isKeyInfo;
 
   public LeaseKeyInfo(OmKeyInfo info, boolean isKeyInfo) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/LeaseKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/LeaseKeyInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+/**
+ * This class represents LeaseKeyInfo
+ * isKeyInfo represents whether key is from openKeyTable or keyTable
+ * true corresponds to keyInfo is from keyTable.
+ */
+public class LeaseKeyInfo {
+  private final OmKeyInfo keyInfo;
+  private boolean isKeyInfo;
+
+  public LeaseKeyInfo(OmKeyInfo info, boolean isKeyInfo) {
+    this.keyInfo = info;
+    this.isKeyInfo = isKeyInfo;
+  }
+
+  public boolean getIsKeyInfo() {
+    return this.isKeyInfo;
+  }
+
+  public OmKeyInfo getKeyInfo() {
+    return keyInfo;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -1112,10 +1113,10 @@ public interface OzoneManagerProtocol
    * @param bucketName - The bucket name.
    * @param keyName - The key user want to recover.
    * @param force - force recover the file.
-   * @return OmKeyInfo KeyInfo of file under recovery
+   * @return LeaseKeyInfo KeyInfo of file under recovery
    * @throws IOException if an error occurs
    */
-  OmKeyInfo recoverLease(String volumeName, String bucketName, String keyName, boolean force) throws IOException;
+  LeaseKeyInfo recoverLease(String volumeName, String bucketName, String keyName, boolean force) throws IOException;
 
   /**
    * Update modification time and access time of a file.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.KeyInfoWithVolumeContext;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -2476,7 +2477,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public OmKeyInfo recoverLease(String volumeName, String bucketName, String keyName, boolean force)
+  public LeaseKeyInfo recoverLease(String volumeName, String bucketName, String keyName, boolean force)
       throws IOException {
     RecoverLeaseRequest recoverLeaseRequest =
         RecoverLeaseRequest.newBuilder()
@@ -2492,7 +2493,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     RecoverLeaseResponse recoverLeaseResponse =
         handleError(submitRequest(omRequest)).getRecoverLeaseResponse();
 
-    return OmKeyInfo.getFromProtobuf(recoverLeaseResponse.getKeyInfo());
+    return new LeaseKeyInfo(OmKeyInfo.getFromProtobuf(recoverLeaseResponse.getKeyInfo()),
+        recoverLeaseResponse.getIsKeyInfo());
   }
 
   @Override

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -2117,6 +2117,7 @@ message RecoverLeaseRequest {
 message RecoverLeaseResponse {
   optional bool response = 1 [deprecated=true];
   optional KeyInfo keyInfo = 2;
+  optional bool isKeyInfo = 3 [default = true];
 }
 
 message SetTimesRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -89,6 +89,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.SnapshotDiffJob;
 import org.apache.hadoop.ozone.om.lock.OMLockDetails;
@@ -4683,7 +4684,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-  public OmKeyInfo recoverLease(String volumeName, String bucketName, String keyName, boolean force) {
+  public LeaseKeyInfo recoverLease(String volumeName, String bucketName, String keyName, boolean force) {
     return null;
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -691,7 +692,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   }
 
   @Override
-  public OmKeyInfo recoverFilePrepare(final String pathStr, boolean force) throws IOException {
+  public LeaseKeyInfo recoverFilePrepare(final String pathStr, boolean force) throws IOException {
     incrementCounter(Statistic.INVOCATION_RECOVER_FILE_PREPARE, 1);
 
     return ozoneClient.getProxy().getOzoneManagerClient().recoverLease(

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -79,6 +79,7 @@ import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -1364,7 +1365,7 @@ public class BasicRootedOzoneClientAdapterImpl
   }
 
   @Override
-  public OmKeyInfo recoverFilePrepare(final String pathStr, boolean force) throws IOException {
+  public LeaseKeyInfo recoverFilePrepare(final String pathStr, boolean force) throws IOException {
     incrementCounter(Statistic.INVOCATION_RECOVER_FILE_PREPARE, 1);
     OFSPath ofsPath = new OFSPath(pathStr, config);
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.SafeModeAction;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
@@ -98,7 +98,7 @@ public interface OzoneClientAdapter {
       String fromSnapshot, String toSnapshot)
       throws IOException, InterruptedException;
 
-  OmKeyInfo recoverFilePrepare(String pathStr, boolean force) throws IOException;
+  LeaseKeyInfo recoverFilePrepare(String pathStr, boolean force) throws IOException;
 
   void recoverFile(OmKeyArgs keyArgs) throws IOException;
 

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -35,12 +35,15 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
 /**
@@ -142,9 +145,9 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
 
     Path qualifiedPath = makeQualified(f);
     String key = pathToKey(qualifiedPath);
-    OmKeyInfo keyInfo = null;
+    LeaseKeyInfo leaseKeyInfo;
     try {
-      keyInfo = getAdapter().recoverFilePrepare(key, forceRecovery);
+      leaseKeyInfo = getAdapter().recoverFilePrepare(key, forceRecovery);
     } catch (OMException e) {
       if (e.getResult() == OMException.ResultCodes.KEY_ALREADY_CLOSED) {
         // key is already closed, let's just return success
@@ -154,25 +157,41 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
     }
 
     // finalize the final block and get block length
-    List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
+    List<OmKeyLocationInfo> locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList();
     if (!locationInfoList.isEmpty()) {
       OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
       try {
         block.setLength(getAdapter().finalizeBlock(block));
       } catch (Throwable e) {
-        if (!forceRecovery) {
+        if (e instanceof StorageContainerException && (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
+            || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
+            && !leaseKeyInfo.getIsKeyInfo() && locationInfoList.size() > 1) {
+          locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList().subList(0,
+              locationInfoList.size() - 1);
+          block = locationInfoList.get(locationInfoList.size() - 1);
+          try {
+            block.setLength(getAdapter().finalizeBlock(block));
+          } catch (Throwable exp) {
+            if (!forceRecovery) {
+              throw exp;
+            }
+            LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+                FORCE_LEASE_RECOVERY_ENV, exp);
+          }
+        } else if (!forceRecovery) {
           throw e;
+        } else {
+          LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+              FORCE_LEASE_RECOVERY_ENV, e);
         }
-        LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-            FORCE_LEASE_RECOVERY_ENV, e);
       }
     }
 
     // recover and commit file
     long keyLength = locationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
-    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(keyInfo.getVolumeName())
-        .setBucketName(keyInfo.getBucketName()).setKeyName(keyInfo.getKeyName())
-        .setReplicationConfig(keyInfo.getReplicationConfig()).setDataSize(keyLength)
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(leaseKeyInfo.getKeyInfo().getVolumeName())
+        .setBucketName(leaseKeyInfo.getKeyInfo().getBucketName()).setKeyName(leaseKeyInfo.getKeyInfo().getKeyName())
+        .setReplicationConfig(leaseKeyInfo.getKeyInfo().getReplicationConfig()).setDataSize(keyLength)
         .setLocationInfoList(locationInfoList)
         .build();
     getAdapter().recoverFile(keyArgs);

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -30,9 +30,10 @@ import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
@@ -41,6 +42,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
 /**
@@ -146,9 +149,9 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     LOG.trace("recoverLease() path:{}", f);
     Path qualifiedPath = makeQualified(f);
     String key = pathToKey(qualifiedPath);
-    OmKeyInfo keyInfo = null;
+    LeaseKeyInfo leaseKeyInfo;
     try {
-      keyInfo = getAdapter().recoverFilePrepare(key, forceRecovery);
+      leaseKeyInfo = getAdapter().recoverFilePrepare(key, forceRecovery);
     } catch (OMException e) {
       if (e.getResult() == OMException.ResultCodes.KEY_ALREADY_CLOSED) {
         // key is already closed, let's just return success
@@ -158,25 +161,41 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     }
 
     // finalize the final block and get block length
-    List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
+    List<OmKeyLocationInfo> locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList();
     if (!locationInfoList.isEmpty()) {
       OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
       try {
         block.setLength(getAdapter().finalizeBlock(block));
       } catch (Throwable e) {
-        if (!forceRecovery) {
+        if (e instanceof StorageContainerException && (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
+            || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
+            && !leaseKeyInfo.getIsKeyInfo() && locationInfoList.size() > 1) {
+          locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList().subList(0,
+              locationInfoList.size() - 1);
+          block = locationInfoList.get(locationInfoList.size() - 1);
+          try {
+            block.setLength(getAdapter().finalizeBlock(block));
+          } catch (Throwable exp) {
+            if (!forceRecovery) {
+              throw exp;
+            }
+            LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+                FORCE_LEASE_RECOVERY_ENV, exp);
+          }
+        } else if (!forceRecovery) {
           throw e;
+        } else {
+          LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+              FORCE_LEASE_RECOVERY_ENV, e);
         }
-        LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-            FORCE_LEASE_RECOVERY_ENV, e);
       }
     }
 
     // recover and commit file
     long keyLength = locationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
-    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(keyInfo.getVolumeName())
-        .setBucketName(keyInfo.getBucketName()).setKeyName(keyInfo.getKeyName())
-        .setReplicationConfig(keyInfo.getReplicationConfig()).setDataSize(keyLength)
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(leaseKeyInfo.getKeyInfo().getVolumeName())
+        .setBucketName(leaseKeyInfo.getKeyInfo().getBucketName()).setKeyName(leaseKeyInfo.getKeyInfo().getKeyName())
+        .setReplicationConfig(leaseKeyInfo.getKeyInfo().getReplicationConfig()).setDataSize(keyLength)
         .setLocationInfoList(locationInfoList)
         .build();
     getAdapter().recoverFile(keyArgs);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -35,12 +35,15 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
 /**
@@ -142,9 +145,9 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
 
     Path qualifiedPath = makeQualified(f);
     String key = pathToKey(qualifiedPath);
-    OmKeyInfo keyInfo = null;
+    LeaseKeyInfo leaseKeyInfo;
     try {
-      keyInfo = getAdapter().recoverFilePrepare(key, forceRecovery);
+      leaseKeyInfo = getAdapter().recoverFilePrepare(key, forceRecovery);
     } catch (OMException e) {
       if (e.getResult() == OMException.ResultCodes.KEY_ALREADY_CLOSED) {
         // key is already closed, let's just return success
@@ -154,25 +157,41 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
     }
 
     // finalize the final block and get block length
-    List<OmKeyLocationInfo> locationInfoList = keyInfo.getLatestVersionLocations().getLocationList();
+    List<OmKeyLocationInfo> locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList();
     if (!locationInfoList.isEmpty()) {
       OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
       try {
         block.setLength(getAdapter().finalizeBlock(block));
       } catch (Throwable e) {
-        if (!forceRecovery) {
+        if (e instanceof StorageContainerException && (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
+            || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
+            && !leaseKeyInfo.getIsKeyInfo() && locationInfoList.size() > 1) {
+          locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList().subList(0,
+              locationInfoList.size() - 1);
+          block = locationInfoList.get(locationInfoList.size() - 1);
+          try {
+            block.setLength(getAdapter().finalizeBlock(block));
+          } catch (Throwable exp) {
+            if (!forceRecovery) {
+              throw exp;
+            }
+            LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+                FORCE_LEASE_RECOVERY_ENV, exp);
+          }
+        } else if (!forceRecovery) {
           throw e;
+        } else {
+          LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+              FORCE_LEASE_RECOVERY_ENV, e);
         }
-        LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-            FORCE_LEASE_RECOVERY_ENV, e);
       }
     }
 
     // recover and commit file
     long keyLength = locationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
-    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(keyInfo.getVolumeName())
-        .setBucketName(keyInfo.getBucketName()).setKeyName(keyInfo.getKeyName())
-        .setReplicationConfig(keyInfo.getReplicationConfig()).setDataSize(keyLength)
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(leaseKeyInfo.getKeyInfo().getVolumeName())
+        .setBucketName(leaseKeyInfo.getKeyInfo().getBucketName()).setKeyName(leaseKeyInfo.getKeyInfo().getKeyName())
+        .setReplicationConfig(leaseKeyInfo.getKeyInfo().getReplicationConfig()).setDataSize(keyLength)
         .setLocationInfoList(locationInfoList)
         .build();
     getAdapter().recoverFile(keyArgs);


### PR DESCRIPTION
## What changes were proposed in this pull request?

During leaseRecovery if final block doesn't exist in datanode(when data still not yet flushed to datanode for the last block) but exist in openFileTable. In this case recovery client should finalize the penultimate block and the lease recovery should succeed with the penultimate block length.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10242

## How was this patch tested?

New integration test.
