### PR TITLE
HDDS-10297. [Disk Balancer] Report command should default to 25 nodes

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerReportSubcommand.java
@@ -39,8 +39,8 @@ import java.util.List;
 public class DiskBalancerReportSubcommand extends ScmSubcommand {
   @Option(names = {"-c", "--count"},
       description = "Result count to return. Sort by Volume Density " +
-          "in descending order.")
-  private int count;
+          "in descending order. Defaults to 25")
+  private int count = 25;
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the disk balancer status command requires passing -c / --count to list any nodes as the default value of "count" is zero. If you omit the -c no results are returned.

The default should allow the report to be produced. I propose setting the default to 25.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10297

## How was this patch tested?
Manually via docker-compose. After this change the output looks like:

```
bash-4.2$ ozone admin datanode diskbalancer report
Report result:
Datanode                                           VolumeDensity
ozone_datanode_1.ozone_default                     0.0
```

Before, no results would have been returned unless a positive value was passed for -c
