### PR TITLE
HDDS-10299. [DiskBalancer] Status command should output all statuses by default

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -1318,7 +1318,9 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
     case status:
       infoProtoList = impl.getDiskBalancerStatus(
           Optional.of(request.getHostsList()),
-          Optional.of(request.getStatus()),
+          // If an optional proto enum field is not set, it will return the first
+          // enum value. So, we need to check if the field is set.
+          request.hasStatus() ? Optional.of(request.getStatus()) : Optional.empty(),
           clientVersion);
       break;
     default:

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DiskBalancerStatusSubcommand.java
@@ -27,12 +27,8 @@ import picocli.CommandLine.Option;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Handler to get disk balancer status.
@@ -44,12 +40,9 @@ import java.util.Set;
     versionProvider = HddsVersionProvider.class)
 public class DiskBalancerStatusSubcommand extends ScmSubcommand {
 
-  private final Set<String> stateSet =
-      new HashSet<>(Arrays.asList("RUNNING", "STOPPED", "UNKNOWN"));
-
   @Option(names = {"-s", "--state"},
-      description = "RUNNING, STOPPED, UNKNOWN. Default state is RUNNING.")
-  private String state = "RUNNING";
+      description = "Display only datanodes with the given status: RUNNING, STOPPED, UNKNOWN.")
+  private HddsProtos.DiskBalancerRunningStatus state = null;
 
   @CommandLine.Option(names = {"-d", "--datanodes"},
       description = "Get diskBalancer status on specific datanodes.")
@@ -57,17 +50,10 @@ public class DiskBalancerStatusSubcommand extends ScmSubcommand {
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    if (state != null && !stateSet.contains(state.toUpperCase(Locale.ROOT))) {
-      System.err.println("Unsupported state: " + state);
-    }
-
-    assert state != null;
     List<HddsProtos.DatanodeDiskBalancerInfoProto> resultProto =
         scmClient.getDiskBalancerStatus(
-            hosts.size() == 0 ? Optional.empty() : Optional.of(hosts),
-            Optional.of(HddsProtos.DiskBalancerRunningStatus.valueOf(
-                state.toUpperCase(Locale.ROOT)))
-            );
+            hosts.isEmpty() ? Optional.empty() : Optional.of(hosts),
+            state == null ? Optional.empty() : Optional.of(state));
 
     System.out.println(generateStatus(resultProto));
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current status command only shows nodes where the disk balancer is RUNNING. The different states can be filtered via the -s switch (RUNNING, STOPPED, UNKNOWN). The current CLI gives no way to list "all nodes".

It would be better to just output all the states by default and then allow them to be filtered with the -s switch. That way, we can list all nodes, or filter down by a specific status.

This change also simplifies the code in the CLI command a little by using an enum for the status state value, rather than a string, which can result in better errors if a wrong value is given.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10299

## How was this patch tested?

Manually via docker compose. Now the output by default looks like:

```
sodonnell@sodonnell-MBP16 ozone % docker exec -it ozone_scm_1 /bin/bash
bash-4.2$ ozone admin datanode diskbalancer status
Status result:
Datanode                                           VolumeDensity Status Threshold BandwidthInMB ParallelThread
ozone_datanode_1.ozone_default                     0.0 UNKNOWN 0.0 0 0
```

If you give an incorrect status, you get a reasonable error:

```
bash-4.2$ ozone admin datanode diskbalancer status --state RUNNI
Invalid value for option '--state': expected one of [RUNNING, STOPPED, UNKNOWN] (case-sensitive) but was 'RUNNI'
Usage: ozone admin datanode diskbalancer status [-hV] [-id=<scmServiceId>]
       [-s=<state>] [--scm=<scm>] [-d=<hosts>]...
Get Datanode DiskBalancer Status
  -d, --datanodes=<hosts>   Get diskBalancer status on specific datanodes.
  -h, --help                Show this help message and exit.
      -id, --service-id=<scmServiceId>
                            ServiceId of SCM HA Cluster
  -s, --state=<state>       Display only datanodes with the given status:
                              RUNNING, STOPPED, UNKNOWN.
      --scm=<scm>           The destination scm (host:port)
  -V, --version             Print version information and exit.
```