### PR TITLE
HDDS-9039. Added a test to verify that no compaction log entry is added to compactionLogTable and DAG when tarball creation is in progress.

### DIFF
--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -587,7 +587,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
    * Check if there is any in_progress tarball creation request and wait till
    * all tarball creation finish, and it gets notified.
    */
-  private void waitForTarballCreation() {
+  private synchronized void waitForTarballCreation() {
     while (tarballRequestCount.get() != 0) {
       try {
         wait(Integer.MAX_VALUE);


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are two major changes in this PR.
1. Added a new test to validate that no new compaction log entry is added to `compactionLogTable` and DAG while tarball creation is in progress.
2. Made `waitForTarballCreation` synchronized function so that wait and notify threads are on a same object's monitor.

## What is the link to the Apache JIRA
HDDS-9039

## How was this patch tested?
Ran newly added test locally and fork branch.