### PR TITLE
HDDS-10293. IllegalArgumentException: containerSize Negative

### DIFF
--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -51,8 +51,9 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     UNDER_REPLICATED,
     OVER_REPLICATED,
     MIS_REPLICATED,
-    ALL_REPLICAS_UNHEALTHY
-  }
+    ALL_REPLICAS_UNHEALTHY,
+    NEGATIVE_SIZE // Added new state to track containers with negative sizes
+    }
 
   private static final String CONTAINER_ID = "container_id";
   private static final String CONTAINER_STATE = "container_state";

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -53,7 +53,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     MIS_REPLICATED,
     ALL_REPLICAS_UNHEALTHY,
     NEGATIVE_SIZE // Added new state to track containers with negative sizes
-    }
+  }
 
   private static final String CONTAINER_ID = "container_id";
   private static final String CONTAINER_STATE = "container_state";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
@@ -51,6 +51,12 @@ public class UnhealthyContainersResponse {
   private long misReplicatedCount = 0;
 
   /**
+   * Total count of containers with negative size.
+   */
+  @JsonProperty("negativeSizeCount")
+  private long negativeSizeCount = 0;
+
+  /**
    * A collection of unhealthy containers.
    */
   @JsonProperty("containers")
@@ -77,6 +83,9 @@ public class UnhealthyContainersResponse {
     } else if (state.equals(
         UnHealthyContainerStates.MIS_REPLICATED.toString())) {
       this.misReplicatedCount = count;
+    } else if (state.equals(
+        UnHealthyContainerStates.NEGATIVE_SIZE.toString())) {
+      this.negativeSizeCount = count;
     }
   }
 
@@ -94,6 +103,10 @@ public class UnhealthyContainersResponse {
 
   public long getMisReplicatedCount() {
     return misReplicatedCount;
+  }
+
+  public long getNegativeSizeCount() {
+    return negativeSizeCount;
   }
 
   public Collection<UnhealthyContainerMetadata> getContainers() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -217,6 +217,8 @@ public class ContainerHealthTask extends ReconScmTask {
         UnHealthyContainerStates.OVER_REPLICATED, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.MIS_REPLICATED, new HashMap<>());
+    unhealthyContainerStateStatsMap.put(
+        UnHealthyContainerStates.NEGATIVE_SIZE, new HashMap<>());
   }
 
   private ContainerHealthStatus setCurrentContainer(long recordId)
@@ -496,6 +498,19 @@ public class ContainerHealthTask extends ReconScmTask {
             container, UnHealthyContainerStates.MIS_REPLICATED, time));
         populateContainerStats(container,
             UnHealthyContainerStates.MIS_REPLICATED,
+            unhealthyContainerStateStatsMap);
+      }
+
+      ContainerInfo containerInfo = container.getContainer();
+      if (containerInfo.getUsedBytes() < 0) {
+        LOG.error("Container {} has negative size. Please visit Recon's " +
+            "missing container page for a list of keys (and their metadata) " +
+            "mapped to this container.", containerInfo.getContainerID());
+        records.add(
+            recordForState(container, UnHealthyContainerStates.NEGATIVE_SIZE,
+                time));
+        populateContainerStats(container,
+            UnHealthyContainerStates.NEGATIVE_SIZE,
             unhealthyContainerStateStatsMap);
       }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -338,19 +338,26 @@ public class ContainerSizeCountTask extends ReconScmTask {
   }
 
   /**
-   *
    * The purpose of this function is to categorize containers into different
    * size ranges, or "bins," based on their size.
    * The ContainerSizeCountKey object is used to store the upper bound value
    * for each size range, and is later used to lookup the count of containers
    * in that size range within a Map.
    *
-   * Used by decrementContainerSizeCount() and incrementContainerSizeCount()
+   * If the container size is 0, the method sets the size of
+   * ContainerSizeCountKey as zero without calculating the upper bound. Used by
+   * decrementContainerSizeCount() and incrementContainerSizeCount()
    *
    * @param containerSize to calculate the upperSizeBound
    */
   private static ContainerSizeCountKey getContainerSizeCountKey(
       long containerSize) {
+    // If containerSize is 0, return a ContainerSizeCountKey with size 0
+    if (containerSize == 0) {
+      return new ContainerSizeCountKey(0L);
+    }
+
+    // Otherwise, calculate the upperSizeBound
     return new ContainerSizeCountKey(
         ReconUtils.getContainerSizeUpperBound(containerSize));
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.scm.ReconScmTask;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
+import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition;
 import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.daos.ContainerCountBySizeDao;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
@@ -34,10 +35,7 @@ import org.jooq.Record1;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -61,6 +59,8 @@ public class ContainerSizeCountTask extends ReconScmTask {
   private ContainerCountBySizeDao containerCountBySizeDao;
   private DSLContext dslContext;
   private HashMap<ContainerID, Long> processedContainers = new HashMap<>();
+  private Map<ContainerSchemaDefinition.UnHealthyContainerStates, Map<String, Long>>
+      unhealthyContainerStateStatsMap;
   private ReadWriteLock lock = new ReentrantReadWriteLock(true);
 
   public ContainerSizeCountTask(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -256,10 +256,10 @@ public class ContainerSizeCountTask extends ReconScmTask {
 
   /**
    *
-   * The handleContainerDeleteOperations() function loops through the entries
-   * in the deletedContainers map and calls the handleDeleteKeyEvent() function
-   * for each one. This will decrement the size counts of those containers by
-   * one which are no longer present in the cluster
+   * Handles the deletion of containers by updating the tracking of processed containers
+   * and adjusting the count of containers based on their sizes. When a container is deleted,
+   * it is removed from the tracking of processed containers, and the count of containers
+   * corresponding to its size is decremented in the container size count map.
    *
    * Used by process()
    *
@@ -325,7 +325,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
       Map<ContainerSizeCountKey, Long> containerSizeCountMap) {
     ContainerSizeCountKey key = getContainerSizeCountKey(containerSize);
     containerSizeCountMap.compute(key,
-        (k, previous) -> previous != null ? previous + delta : delta);
+        (k, previous) -> previous != null ? previous + delta : 0);
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -35,7 +35,10 @@ import org.jooq.Record1;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -19,8 +19,6 @@
 package org.apache.hadoop.ozone.recon.tasks;
 
 
-import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -125,12 +125,17 @@ public class ContainerSizeCountTask extends ReconScmTask {
   private void process(ContainerInfo container,
       Map<ContainerSizeCountKey, Long> map) {
     final ContainerID id = container.containerID();
-    final long currentSize = container.getUsedBytes();
-    if (currentSize < 0) {
-      LOG.error("Negative container size: {} for container: {}", currentSize,
-          id);
-      return;
+    final long usedBytes = container.getUsedBytes();
+    final long currentSize;
+
+    if (usedBytes < 0) {
+      LOG.warn("Negative usedBytes ({}) for container {}, treating it as 0",
+          usedBytes, id);
+      currentSize = 0;
+    } else {
+      currentSize = usedBytes;
     }
+
     final Long previousSize = processedContainers.put(id, currentSize);
     if (previousSize != null) {
       decrementContainerSizeCount(previousSize, map);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -168,8 +168,9 @@ public class ContainerSizeCountTask extends ReconScmTask {
     try {
       final Map<ContainerSizeCountKey, Long> containerSizeCountMap
           = new HashMap<>();
-      final Map<ContainerID, Long> deletedContainers =
-          new HashMap<>(processedContainers);
+      final Map<ContainerID, Long> deletedContainers
+          = new HashMap<>(processedContainers);
+
       // Loop to handle container create and size-update operations
       for (ContainerInfo container : containers) {
         if (container.getState().equals(DELETED)) {
@@ -328,7 +329,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
       Map<ContainerSizeCountKey, Long> containerSizeCountMap) {
     ContainerSizeCountKey key = getContainerSizeCountKey(containerSize);
     containerSizeCountMap.compute(key,
-        (k, previous) -> previous != null ? previous + delta : 0);
+        (k, previous) -> previous != null ? previous + delta : delta);
   }
 
   /**

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -866,10 +866,12 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     ContainerInfo omContainerInfo1 = mock(ContainerInfo.class);
     given(omContainerInfo1.containerID()).willReturn(new ContainerID(1));
     given(omContainerInfo1.getUsedBytes()).willReturn(1500000000L); // 1.5GB
+    given(omContainerInfo1.getState()).willReturn(LifeCycleState.OPEN);
 
     ContainerInfo omContainerInfo2 = mock(ContainerInfo.class);
     given(omContainerInfo2.containerID()).willReturn(new ContainerID(2));
     given(omContainerInfo2.getUsedBytes()).willReturn(2500000000L); // 2.5GB
+    given(omContainerInfo2.getState()).willReturn(LifeCycleState.OPEN);
 
     // Create a list of container info objects
     List<ContainerInfo> containers = new ArrayList<>();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
@@ -113,8 +113,8 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
 
     task.process(containers);
 
-    // Verify 2 containers are in correct bins.
-    assertEquals(2, containerCountBySizeDao.count());
+    // Verify 3 containers are in correct bins.
+    assertEquals(3, containerCountBySizeDao.count());
 
     // container size upper bound for
     // 1500000000L (1.5GB) is 2147483648L = 2^31 = 2GB (next highest power of 2)
@@ -146,7 +146,7 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
     task.process(containers);
 
     // Total size groups added to the database
-    assertEquals(4, containerCountBySizeDao.count());
+    assertEquals(5, containerCountBySizeDao.count());
 
     // Check whether container size upper bound for
     // 50000L is 536870912L = 2^29 = 512MB (next highest power of 2)
@@ -206,7 +206,7 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
     given(negativeSizeDeletedContainer.getUsedBytes()).willReturn(-1L);
     given(negativeSizeDeletedContainer.getState()).willReturn(DELETED);
 
-    // Create a container with valid size
+    // Create a mock container with id 1 and updated size of 1GB from 1.5GB
     final ContainerInfo validSizeContainer = mock(ContainerInfo.class);
     given(validSizeContainer.containerID()).willReturn(new ContainerID(1));
     given(validSizeContainer.getUsedBytes()).willReturn(1000000000L); // 1GB
@@ -225,7 +225,7 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
     task.process(containers);
 
     // Verify that only the valid containers are counted
-    assertEquals(2, containerCountBySizeDao.count());
+    assertEquals(3, containerCountBySizeDao.count());
   }
 
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.*;
 import static org.hadoop.ozone.recon.schema.tables.ContainerCountBySizeTable.CONTAINER_COUNT_BY_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
@@ -84,18 +85,21 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
   @Test
   public void testProcess() {
     // mock a container with invalid used bytes
-    final ContainerInfo omContainerInfo0 = mock(ContainerInfo.class);
+    ContainerInfo omContainerInfo0 = mock(ContainerInfo.class);
     given(omContainerInfo0.containerID()).willReturn(new ContainerID(0));
     given(omContainerInfo0.getUsedBytes()).willReturn(-1L);
+    given(omContainerInfo0.getState()).willReturn(OPEN);
 
     // Write 2 keys
     ContainerInfo omContainerInfo1 = mock(ContainerInfo.class);
     given(omContainerInfo1.containerID()).willReturn(new ContainerID(1));
     given(omContainerInfo1.getUsedBytes()).willReturn(1500000000L); // 1.5GB
+    given(omContainerInfo1.getState()).willReturn(CLOSED);
 
     ContainerInfo omContainerInfo2 = mock(ContainerInfo.class);
     given(omContainerInfo2.containerID()).willReturn(new ContainerID(2));
     given(omContainerInfo2.getUsedBytes()).willReturn(2500000000L); // 2.5GB
+    given(omContainerInfo2.getState()).willReturn(CLOSING);
 
     // mock getContainers method to return a list of containers
     List<ContainerInfo> containers = new ArrayList<>();
@@ -124,10 +128,11 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
         containerCountBySizeDao.findById(recordToFind.value1()).getCount()
             .longValue());
 
-    // Add a new key
+    // Add a new container
     ContainerInfo omContainerInfo3 = mock(ContainerInfo.class);
     given(omContainerInfo3.containerID()).willReturn(new ContainerID(3));
     given(omContainerInfo3.getUsedBytes()).willReturn(1000000000L); // 1GB
+    given(omContainerInfo3.getState()).willReturn(QUASI_CLOSED);
     containers.add(omContainerInfo3);
 
     // Update existing key.
@@ -164,4 +169,74 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
         .getCount()
         .longValue());
   }
+
+  @Test
+  public void testProcessDeletedContainers() {
+    // Create a list of containers, including one that is deleted
+    ContainerInfo omContainerInfo1 = mock(ContainerInfo.class);
+    given(omContainerInfo1.containerID()).willReturn(new ContainerID(1));
+    given(omContainerInfo1.getUsedBytes()).willReturn(1500000000L); // 1.5GB
+    given(omContainerInfo1.getState()).willReturn(OPEN);
+
+    ContainerInfo omContainerInfo2 = mock(ContainerInfo.class);
+    given(omContainerInfo2.containerID()).willReturn(new ContainerID(2));
+    given(omContainerInfo2.getUsedBytes()).willReturn(2500000000L); // 2.5GB
+    given(omContainerInfo2.getState()).willReturn(CLOSED);
+
+    ContainerInfo omContainerInfoDeleted = mock(ContainerInfo.class);
+    given(omContainerInfoDeleted.containerID()).willReturn(new ContainerID(3));
+    given(omContainerInfoDeleted.getUsedBytes()).willReturn(1000000000L);
+    given(omContainerInfoDeleted.getState()).willReturn(DELETED); // 1GB
+
+    List<ContainerInfo> containers = new ArrayList<>();
+    containers.add(omContainerInfo1);
+    containers.add(omContainerInfo2);
+    containers.add(omContainerInfoDeleted);
+
+    task.process(containers);
+
+    // Verify that the deleted container is not counted
+    assertEquals(2, containerCountBySizeDao.count());
+  }
+
+  @Test
+  public void testProcessWithNegativeSizeContainers() {
+    // Create a mock container with negative size
+    final ContainerInfo negativeSizeContainer = mock(ContainerInfo.class);
+    given(negativeSizeContainer.containerID()).willReturn(new ContainerID(0));
+    given(negativeSizeContainer.getUsedBytes()).willReturn(-1L);
+    given(negativeSizeContainer.getState()).willReturn(OPEN);
+
+    // Create a mock container with negative size and DELETE state
+    final ContainerInfo negativeSizeDeletedContainer =
+        mock(ContainerInfo.class);
+    given(negativeSizeDeletedContainer.containerID()).willReturn(
+        new ContainerID(0));
+    given(negativeSizeDeletedContainer.getUsedBytes()).willReturn(-1L);
+    given(negativeSizeDeletedContainer.getState()).willReturn(DELETED);
+
+    // Create a container with valid size
+    final ContainerInfo validSizeContainer = mock(ContainerInfo.class);
+    given(validSizeContainer.containerID()).willReturn(new ContainerID(1));
+    given(validSizeContainer.getUsedBytes()).willReturn(1000000000L); // 1GB
+    given(validSizeContainer.getState()).willReturn(CLOSED);
+
+    // Mock getContainers method to return a list of containers including
+    // the one with negative size
+    List<ContainerInfo> containers = new ArrayList<>();
+    containers.add(negativeSizeContainer);
+    containers.add(validSizeContainer);
+
+    task.process(containers);
+
+    // Verify that only the container with valid size has been processed
+    assertEquals(1, containerCountBySizeDao.count());
+
+    // Check whether container size upper bound for 1000000000L is correctly added
+    Record1<Long> recordToFind = dslContext.newRecord(
+        CONTAINER_COUNT_BY_SIZE.CONTAINER_SIZE).value1(1073741824L); // 1GB
+    assertEquals(1L, containerCountBySizeDao.findById(recordToFind.value1())
+        .getCount().longValue());
+  }
+
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
@@ -18,7 +18,11 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.*;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.DELETED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QUASI_CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
 import static org.hadoop.ozone.recon.schema.tables.ContainerCountBySizeTable.CONTAINER_COUNT_BY_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Encounterd an error in recon log `IllegalArgumentExpection`: containerSize Negative" :-

```
2024-02-01 19:50:21,727 ERROR [ContainerSizeCountTask]-org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask: FIXME: Failed to process ContainerInfo{id=#3979, state=DELETED, stateEnterTime=2024-02-01T02:45:43.506025Z, pipelineID=PipelineID=0ea98cdd-adf9-4ffa-b7f8-15a3052b155a, owner=om1546336125}
java.lang.IllegalArgumentException: containerSize = -63 < 0
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:204)
    at org.apache.hadoop.ozone.recon.ReconUtils.getContainerSizeBinIndex(ReconUtils.java:329)
    at org.apache.hadoop.ozone.recon.ReconUtils.getContainerSizeUpperBound(ReconUtils.java:309)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.getContainerSizeCountKey(ContainerSizeCountTask.java:333)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.updateContainerSizeCount(ContainerSizeCountTask.java:313)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.decrementContainerSizeCount(ContainerSizeCountTask.java:308)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.process(ContainerSizeCountTask.java:127)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.process(ContainerSizeCountTask.java:168)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.run(ContainerSizeCountTask.java:106)
    at java.base/java.lang.Thread.run(Thread.java:834)
2024-02-01 19:50:21,728 ERROR [ContainerSizeCountTask]-org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask: FIXME: Failed to process ContainerInfo{id=#3985, state=DELETED, stateEnterTime=2024-02-01T02:45:43.509864Z, pipelineID=PipelineID=4c92a12e-7c4d-457a-ab61-0bddd1a23711, owner=om1546336125}
java.lang.IllegalArgumentException: containerSize = -63 < 0
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:204)
    at org.apache.hadoop.ozone.recon.ReconUtils.getContainerSizeBinIndex(ReconUtils.java:329)
    at org.apache.hadoop.ozone.recon.ReconUtils.getContainerSizeUpperBound(ReconUtils.java:309)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.getContainerSizeCountKey(ContainerSizeCountTask.java:333)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.updateContainerSizeCount(ContainerSizeCountTask.java:313)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.decrementContainerSizeCount(ContainerSizeCountTask.java:308)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.process(ContainerSizeCountTask.java:127)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.process(ContainerSizeCountTask.java:168)
    at org.apache.hadoop.ozone.recon.tasks.ContainerSizeCountTask.run(ContainerSizeCountTask.java:106)
    at java.base/java.lang.Thread.run(Thread.java:834)  
```

The changes proposed in the PR :- 
1. Skip the containers having negative size for some reasaon.
2. Skip the containers which has gone into the DELETED state.
3. Track containers with negative sizes in the `UnhealthyContainersTable` under a new unhealthy state termed `NEGATIVE_SIZE`.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10293
## How was this patch tested?
Conducted unit and manual testing for scenarios where containers reporting negative sizes are skipped in the containerSizeCountTask and tracked in the unhealthyContainerTable.

`http://localhost:9888/api/v1/containers/unhealthy` :- 

<img width="690" alt="image" src="https://github.com/apache/ozone/assets/98023601/991b32a4-5e57-42a5-874d-b92ef57fdf9b">


