### PR TITLE
HDDS-8683. Container balancer thread interrupt may not work

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -342,10 +342,13 @@ public class ContainerBalancer extends StatefulService {
     // NOTE: join should be called outside the lock in hierarchy
     // to avoid locking others waiting
     // wait for balancingThread to die with interrupt
-    balancingThread.interrupt();
     LOG.info("Container Balancer waiting for {} to stop", balancingThread);
     try {
-      balancingThread.join();
+      while (balancingThread.isAlive()) {
+        // retry interrupt every 5ms to avoid waiting when thread is sleeping
+        balancingThread.interrupt();
+        balancingThread.join(5);
+      }
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -342,7 +342,6 @@ public class ContainerBalancer extends StatefulService {
     // NOTE: join should be called outside the lock in hierarchy
     // to avoid locking others waiting
     // wait for balancingThread to die with interrupt
-    balancingThread.interrupt();
     LOG.info("Container Balancer waiting for {} to stop", balancingThread);
     try {
       while (balancingThread.isAlive()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -342,13 +342,10 @@ public class ContainerBalancer extends StatefulService {
     // NOTE: join should be called outside the lock in hierarchy
     // to avoid locking others waiting
     // wait for balancingThread to die with interrupt
+    balancingThread.interrupt();
     LOG.info("Container Balancer waiting for {} to stop", balancingThread);
     try {
-      while (balancingThread.isAlive()) {
-        // retry interrupt every 5ms to avoid waiting when thread is sleeping
-        balancingThread.interrupt();
-        balancingThread.join(5);
-      }
+      balancingThread.join();
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -345,7 +345,11 @@ public class ContainerBalancer extends StatefulService {
     balancingThread.interrupt();
     LOG.info("Container Balancer waiting for {} to stop", balancingThread);
     try {
-      balancingThread.join();
+      while (balancingThread.isAlive()) {
+        // retry interrupt every 5ms to avoid waiting when thread is sleeping
+        balancingThread.interrupt();
+        balancingThread.join(5);
+      }
     } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -173,9 +173,7 @@ public class ContainerBalancerTask implements Runnable {
             TimeUnit.SECONDS);
         LOG.info("ContainerBalancer will sleep for {} seconds before starting" +
             " balancing.", delayDuration);
-        if (isBalancerRunning()) {
-          Thread.sleep(Duration.ofSeconds(delayDuration).toMillis());
-        }
+        Thread.sleep(Duration.ofSeconds(delayDuration).toMillis());
       }
       balance();
     } catch (Exception e) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -173,7 +173,9 @@ public class ContainerBalancerTask implements Runnable {
             TimeUnit.SECONDS);
         LOG.info("ContainerBalancer will sleep for {} seconds before starting" +
             " balancing.", delayDuration);
-        Thread.sleep(Duration.ofSeconds(delayDuration).toMillis());
+        if (isBalancerRunning()) {
+          Thread.sleep(Duration.ofSeconds(delayDuration).toMillis());
+        }
       }
       balance();
     } catch (Exception e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Container balancer tries to interrupt current balancing thread upon being stopped. This may fail when the interrupt is before the thread even starts i.e., it hasn't been picked up by the scheduler. As a result, the balancer stop is delayed by the interval for which the thread goes to sleep next, which may be 5m by default for delayStart.
In this PR, a check is added in run() to check whether the containerBalancer is running on the scm. If it is running, only then it goes to sleep for delayStart. Otherwise the sleep is skipped.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8683

## How was this patch tested?

Existing tests. No regression is caused by the refactoring in this PR. 
Successful CI run on my fork: https://github.com/Tejaskriya/ozone/actions/runs/7796903702
