### PR TITLE
HDDS-10304. [DiskBalancer] Start command - Fix nodes not being processed and incorrect config values

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DiskBalancerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/DiskBalancerCommand.java
@@ -76,4 +76,9 @@ public class DiskBalancerCommand extends SCMCommand<DiskBalancerCommandProto> {
   public DiskBalancerConfiguration getDiskBalancerConfiguration() {
     return diskBalancerConfiguration;
   }
+
+  @Override
+  public String toString() {
+    return getType() + ": opType=" + opType + ", configuration=" + diskBalancerConfiguration;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DiskBalancerManager.java
@@ -156,7 +156,7 @@ public class DiskBalancerManager {
     List<DatanodeAdminError> errors = new ArrayList<>();
     for (DatanodeDetails dn : dns) {
       try {
-        if (nodeManager.getNodeStatus(dn).isHealthy()) {
+        if (!nodeManager.getNodeStatus(dn).isHealthy()) {
           errors.add(new DatanodeAdminError(dn.getHostName(),
               "Datanode not in healthy state"));
           continue;
@@ -169,6 +169,7 @@ public class DiskBalancerManager {
             HddsProtos.DiskBalancerOpType.START, updateConf);
         sendCommand(dn, command);
       } catch (Exception e) {
+        LOG.info("Caught an error for {}", dn);
         errors.add(new DatanodeAdminError(dn.getHostName(), e.getMessage()));
       }
     }
@@ -355,6 +356,7 @@ public class DiskBalancerManager {
           " since not leader SCM.", dn.getUuidString());
       return;
     }
+    LOG.info("Sending {} to Datanode {}", command, dn);
     scmNodeEventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
         new CommandForDatanode<>(dn.getUuid(), command));
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -1336,23 +1336,26 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
           DatanodeDiskBalancerOpRequestProto request)
       throws IOException {
     List<DatanodeAdminError> errors;
+    HddsProtos.DiskBalancerConfigurationProto conf = request.getConf();
     switch (request.getOpType()) {
     case START:
       errors = impl.startDiskBalancer(
-          Optional.of(request.getConf().getThreshold()),
-          Optional.of(request.getConf().getDiskBandwidthInMB()),
-          Optional.of(request.getConf().getParallelThread()),
-          Optional.of(request.getHostsList()));
+          conf.hasThreshold() ? Optional.of(conf.getThreshold()) : Optional.empty(),
+          conf.hasDiskBandwidthInMB() ? Optional.of(conf.getDiskBandwidthInMB()) : Optional.empty(),
+          conf.hasParallelThread() ? Optional.of(conf.getParallelThread()) : Optional.empty(),
+          request.getHostsList().isEmpty() ? Optional.empty() : Optional.of(request.getHostsList()));
       break;
     case UPDATE:
+
       errors = impl.updateDiskBalancerConfiguration(
-          Optional.of(request.getConf().getThreshold()),
-          Optional.of(request.getConf().getDiskBandwidthInMB()),
-          Optional.of(request.getConf().getParallelThread()),
-          Optional.of(request.getHostsList()));
+          conf.hasThreshold() ? Optional.of(conf.getThreshold()) : Optional.empty(),
+          conf.hasDiskBandwidthInMB() ? Optional.of(conf.getDiskBandwidthInMB()) : Optional.empty(),
+          conf.hasParallelThread() ? Optional.of(conf.getParallelThread()) : Optional.empty(),
+          request.getHostsList().isEmpty() ? Optional.empty() : Optional.of(request.getHostsList()));
       break;
     case STOP:
-      errors = impl.stopDiskBalancer(Optional.of(request.getHostsList()));
+      errors = impl.stopDiskBalancer(
+          request.getHostsList().isEmpty() ? Optional.empty() : Optional.of(request.getHostsList()));
       break;
     default:
       errors = new ArrayList<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix various problems with the disk balancer start command:

1. When using -a for all datanodes, the hosts appear as an empty list due to the way the protobuf is deserialized, resulting in no hosts getting processed.

2. All the config values appear at zero, as if the proto value is not set for a double, it returns 0.0, so we need to check for has<field> and set an optional or empty

3. The isHealthy check needed negated, as it was excluding healthy nodes rather than unhealthy ones resulting in no nodes getting processed.

I also added a log message or two so we can have a record in the SCM log of the command being sent.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10304

## How was this patch tested?

Manually using docker compose. Prior to these changes the command would fail silently, but now SCM sends the command to the datanode.