### PR TITLE
HDDS-10226. Refactor OMRequestTestUtils.createOmKeyInfo

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -297,7 +297,7 @@ public class TestLDBCli {
       for (int i = 1; i <= 5; i++) {
         String key = "key" + i;
         OmKeyInfo value = OMRequestTestUtils.createOmKeyInfo("vol1", "buck1",
-            key, ReplicationConfig.fromProtoTypeAndFactor(STAND_ALONE, HddsProtos.ReplicationFactor.ONE));
+            key, ReplicationConfig.fromProtoTypeAndFactor(STAND_ALONE, HddsProtos.ReplicationFactor.ONE)).build();
         keyTable.put(key.getBytes(UTF_8),
             value.getProtobuf(ClientVersion.CURRENT_VERSION).toByteArray());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.DBStore;
@@ -61,6 +62,7 @@ import java.util.TreeMap;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.STAND_ALONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -295,8 +297,7 @@ public class TestLDBCli {
       for (int i = 1; i <= 5; i++) {
         String key = "key" + i;
         OmKeyInfo value = OMRequestTestUtils.createOmKeyInfo("vol1", "buck1",
-            key, HddsProtos.ReplicationType.STAND_ALONE,
-            HddsProtos.ReplicationFactor.ONE);
+            key, ReplicationConfig.fromProtoTypeAndFactor(STAND_ALONE, HddsProtos.ReplicationFactor.ONE));
         keyTable.put(key.getBytes(UTF_8),
             value.getProtobuf(ClientVersion.CURRENT_VERSION).toByteArray());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1454,7 +1454,7 @@ public class TestKeyManagerImpl {
     when(scmClientMock.getContainerClient()).thenReturn(sclProtocolMock);
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo("v1",
-        "b1", "k1", RatisReplicationConfig.getInstance(THREE));
+        "b1", "k1", RatisReplicationConfig.getInstance(THREE)).build();
 
     // Add block to key.
     List<OmKeyLocationInfo> omKeyLocationInfoList = new ArrayList<>();
@@ -1508,7 +1508,7 @@ public class TestKeyManagerImpl {
     OMPerformanceMetrics metrics = mock(OMPerformanceMetrics.class);
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo("v1",
-        "b1", "k1", RatisReplicationConfig.getInstance(THREE));
+        "b1", "k1", RatisReplicationConfig.getInstance(THREE)).build();
 
     // Add block to key.
     List<OmKeyLocationInfo> omKeyLocationInfoList = new ArrayList<>();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -44,9 +44,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -989,12 +987,11 @@ public class TestKeyManagerImpl {
       if (i % 2 == 0) {  // Add to DB
         OMRequestTestUtils.addKeyToTable(false,
             VOLUME_NAME, BUCKET_NAME, prefixKeyInDB + i,
-            1000L, HddsProtos.ReplicationType.RATIS,
-            ONE, metadataManager);
+            1000L, RatisReplicationConfig.getInstance(ONE), metadataManager);
       } else {  // Add to TableCache
         OMRequestTestUtils.addKeyToTableCache(
             VOLUME_NAME, BUCKET_NAME, prefixKeyInCache + i,
-            HddsProtos.ReplicationType.RATIS, ONE,
+            RatisReplicationConfig.getInstance(ONE),
             metadataManager);
       }
     }
@@ -1061,13 +1058,12 @@ public class TestKeyManagerImpl {
         OMRequestTestUtils.addKeyToTable(false,
             VOLUME_NAME, BUCKET_NAME,
             keyNameDir1Subdir1 + OZONE_URI_DELIMITER + prefixKeyInDB + i,
-            1000L, HddsProtos.ReplicationType.RATIS,
-            ONE, metadataManager);
+            1000L, RatisReplicationConfig.getInstance(ONE), metadataManager);
       } else {  // Add to TableCache
         OMRequestTestUtils.addKeyToTableCache(
             VOLUME_NAME, BUCKET_NAME,
             keyNameDir1Subdir1 + OZONE_URI_DELIMITER + prefixKeyInCache + i,
-            HddsProtos.ReplicationType.RATIS, ONE,
+            RatisReplicationConfig.getInstance(ONE),
             metadataManager);
       }
     }
@@ -1105,13 +1101,12 @@ public class TestKeyManagerImpl {
       if (i % 2 == 0) {
         OMRequestTestUtils.addKeyToTable(false,
             VOLUME_NAME, BUCKET_NAME, prefixKey + i,
-            1000L, HddsProtos.ReplicationType.RATIS,
-            ONE, metadataManager);
+            1000L, RatisReplicationConfig.getInstance(ONE), metadataManager);
         existKeySet.add(prefixKey + i);
       } else {
         OMRequestTestUtils.addKeyToTableCache(
             VOLUME_NAME, BUCKET_NAME, prefixKey + i,
-            HddsProtos.ReplicationType.RATIS, ONE,
+            RatisReplicationConfig.getInstance(ONE),
             metadataManager);
 
         String key = metadataManager.getOzoneKey(
@@ -1459,8 +1454,7 @@ public class TestKeyManagerImpl {
     when(scmClientMock.getContainerClient()).thenReturn(sclProtocolMock);
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo("v1",
-        "b1", "k1", ReplicationType.RATIS,
-        ReplicationFactor.THREE);
+        "b1", "k1", RatisReplicationConfig.getInstance(THREE));
 
     // Add block to key.
     List<OmKeyLocationInfo> omKeyLocationInfoList = new ArrayList<>();
@@ -1514,8 +1508,7 @@ public class TestKeyManagerImpl {
     OMPerformanceMetrics metrics = mock(OMPerformanceMetrics.class);
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo("v1",
-        "b1", "k1", ReplicationType.RATIS,
-        ReplicationFactor.THREE);
+        "b1", "k1", RatisReplicationConfig.getInstance(THREE));
 
     // Add block to key.
     List<OmKeyLocationInfo> omKeyLocationInfoList = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
@@ -50,6 +51,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -621,8 +623,10 @@ public class TestOmMetadataManager {
     for (int i = 0; i < numExpiredOpenKeys + numUnexpiredOpenKeys; i++) {
       final long creationTime = i < numExpiredOpenKeys ?
           expiredOpenKeyCreationTime : Time.now();
-      final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-          bucketName, "expired" + i, RatisReplicationConfig.getInstance(ONE), 0L, creationTime);
+      final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(
+              volumeName, bucketName, "expired" + i, RatisReplicationConfig.getInstance(ONE))
+          .setCreationTime(creationTime)
+          .build();
 
       final String dbOpenKeyName;
       if (bucketLayout.isFileSystemOptimized()) {
@@ -690,10 +694,10 @@ public class TestOmMetadataManager {
     // Ensure that "expired" MPU-related open keys are not fetched.
     // MPU-related open keys, identified by isMultipartKey = false
     for (int i = 0; i < numExpiredMPUOpenKeys; i++) {
-      final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-          bucketName, "expired" + i,
-          RatisReplicationConfig.getInstance(ONE),
-          0L, expiredOpenKeyCreationTime, true);
+      final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, "expired" + i,
+              RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+          .setCreationTime(expiredOpenKeyCreationTime)
+          .build();
 
       final String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
       final OmMultipartKeyInfo multipartKeyInfo = OMRequestTestUtils.
@@ -723,10 +727,10 @@ public class TestOmMetadataManager {
     // HDDS-9017. Although these open keys are MPU-related,
     // the isMultipartKey flags are set to false
     for (int i = numExpiredMPUOpenKeys; i < 2 * numExpiredMPUOpenKeys; i++) {
-      final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-          bucketName, "expired" + i,
-          RatisReplicationConfig.getInstance(ONE),
-          0L, expiredOpenKeyCreationTime, false);
+      final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(
+              volumeName, bucketName, "expired" + i, RatisReplicationConfig.getInstance(ONE))
+          .setCreationTime(expiredOpenKeyCreationTime)
+          .build();
 
       final String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
       final OmMultipartKeyInfo multipartKeyInfo = OMRequestTestUtils.
@@ -789,7 +793,9 @@ public class TestOmMetadataManager {
       String keyName = "expired" + i;
       // Key info to construct the MPU DB key
       final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-          bucketName, keyName, RatisReplicationConfig.getInstance(ONE), 0L, creationTime);
+              bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+          .setCreationTime(creationTime)
+          .build();
 
 
       for (int j = 1; j <= numPartsPerMPU; j++) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -16,6 +16,7 @@
  */
 
 package org.apache.hadoop.ozone.om;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -61,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD;
@@ -620,8 +622,7 @@ public class TestOmMetadataManager {
       final long creationTime = i < numExpiredOpenKeys ?
           expiredOpenKeyCreationTime : Time.now();
       final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-          bucketName, "expired" + i, HddsProtos.ReplicationType.RATIS,
-          HddsProtos.ReplicationFactor.ONE, 0L, creationTime);
+          bucketName, "expired" + i, RatisReplicationConfig.getInstance(ONE), 0L, creationTime);
 
       final String dbOpenKeyName;
       if (bucketLayout.isFileSystemOptimized()) {
@@ -691,7 +692,7 @@ public class TestOmMetadataManager {
     for (int i = 0; i < numExpiredMPUOpenKeys; i++) {
       final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
           bucketName, "expired" + i,
-          HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+          RatisReplicationConfig.getInstance(ONE),
           0L, expiredOpenKeyCreationTime, true);
 
       final String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
@@ -724,7 +725,7 @@ public class TestOmMetadataManager {
     for (int i = numExpiredMPUOpenKeys; i < 2 * numExpiredMPUOpenKeys; i++) {
       final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
           bucketName, "expired" + i,
-          HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+          RatisReplicationConfig.getInstance(ONE),
           0L, expiredOpenKeyCreationTime, false);
 
       final String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
@@ -788,8 +789,7 @@ public class TestOmMetadataManager {
       String keyName = "expired" + i;
       // Key info to construct the MPU DB key
       final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-          bucketName, keyName, HddsProtos.ReplicationType.RATIS,
-          HddsProtos.ReplicationFactor.ONE, 0L, creationTime);
+          bucketName, keyName, RatisReplicationConfig.getInstance(ONE), 0L, creationTime);
 
 
       for (int j = 1; j <= numPartsPerMPU; j++) {
@@ -861,11 +861,10 @@ public class TestOmMetadataManager {
 
     if (i % 2 == 0) {
       OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
-          1000L, HddsProtos.ReplicationType.RATIS,
-          HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+          1000L, RatisReplicationConfig.getInstance(ONE), omMetadataManager);
     } else {
       OMRequestTestUtils.addKeyToTableCache(volumeName, bucketName, keyName,
-          HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+          RatisReplicationConfig.getInstance(ONE),
           omMetadataManager);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -267,8 +267,8 @@ public final class OMRequestTestUtils {
       ReplicationConfig replicationConfig, long trxnLogIndex,
       OMMetadataManager omMetadataManager) throws Exception {
 
-    OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationConfig, trxnLogIndex);
+    OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig)
+        .setObjectID(trxnLogIndex).build();
 
     addKeyToTable(openKeyTable, addToCache, omKeyInfo, clientID, trxnLogIndex,
         omMetadataManager);
@@ -437,7 +437,7 @@ public final class OMRequestTestUtils {
       OMMetadataManager omMetadataManager) {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationConfig);
+        replicationConfig).build();
 
     omMetadataManager.getKeyTable(getDefaultBucketLayout()).addCacheEntry(
         new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
@@ -534,33 +534,41 @@ public final class OMRequestTestUtils {
   /**
    * Create OmKeyInfo.
    */
-  public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
+  public static OmKeyInfo.Builder createOmKeyInfo(String volumeName, String bucketName,
+      String keyName, ReplicationConfig replicationConfig, OmKeyLocationInfoGroup omKeyLocationInfoGroup) {
+    return new OmKeyInfo.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setFileName(OzoneFSUtils.getFileName(keyName))
+        .setReplicationConfig(replicationConfig)
+        .setObjectID(0L)
+        .setUpdateID(0L)
+        .setCreationTime(Time.now())
+        .addOmKeyLocationInfoGroup(omKeyLocationInfoGroup)
+        .setDataSize(1000L);
+  }
+
+  public static OmKeyInfo.Builder createOmKeyInfo(String volumeName, String bucketName,
       String keyName, ReplicationConfig replicationConfig) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, 0L);
+    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig,
+        new OmKeyLocationInfoGroup(0L, new ArrayList<>(), false));
   }
 
   /**
    * Create OmDirectoryInfo.
    */
   public static OmDirectoryInfo createOmDirectoryInfo(String keyName,
-                                                      long objectID,
-                                                      long parentObjID) {
+      long objectID,
+      long parentObjID) {
     return new OmDirectoryInfo.Builder()
-            .setName(keyName)
-            .setCreationTime(Time.now())
-            .setModificationTime(Time.now())
-            .setObjectID(objectID)
-            .setParentObjectID(parentObjID)
-            .setUpdateID(50)
-            .build();
-  }
-
-  /**
-   * Create OmKeyInfo.
-   */
-  public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, ReplicationConfig replicationConfig, long objectID) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, objectID, Time.now());
+        .setName(keyName)
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setObjectID(objectID)
+        .setParentObjectID(parentObjID)
+        .setUpdateID(50)
+        .build();
   }
 
   /**
@@ -611,8 +619,8 @@ public final class OMRequestTestUtils {
    * Create OmMultipartKeyInfo for OBS/LEGACY bucket.
    */
   public static OmMultipartKeyInfo createOmMultipartKeyInfo(String uploadId,
-        long creationTime, HddsProtos.ReplicationType replicationType,
-        HddsProtos.ReplicationFactor replicationFactor, long objectID) {
+      long creationTime, HddsProtos.ReplicationType replicationType,
+      HddsProtos.ReplicationFactor replicationFactor, long objectID) {
     return new OmMultipartKeyInfo.Builder()
         .setUploadID(uploadId)
         .setCreationTime(creationTime)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -248,12 +248,14 @@ public final class OMRequestTestUtils {
       List<OmKeyLocationInfo> locationList, long version) throws Exception {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationConfig, trxnLogIndex, Time.now(), version,
-        false);
+        replicationConfig, new OmKeyLocationInfoGroup(version, new ArrayList<>(), false))
+        .setObjectID(trxnLogIndex)
+        .build();
+
     omKeyInfo.appendNewBlocks(locationList, false);
 
     addKeyToTable(openKeyTable, addToCache, omKeyInfo, clientID, trxnLogIndex,
-            omMetadataManager);
+        omMetadataManager);
   }
 
   /**
@@ -286,8 +288,9 @@ public final class OMRequestTestUtils {
       OMMetadataManager omMetadataManager) throws Exception {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationConfig, trxnLogIndex, Time.now(), 0L,
-        isMultipartKey);
+        replicationConfig, new OmKeyLocationInfoGroup(0, new ArrayList<>(), isMultipartKey))
+        .setObjectID(trxnLogIndex)
+        .build();
 
     addKeyToTable(openKeyTable, addToCache, omKeyInfo, clientID, trxnLogIndex,
         omMetadataManager);
@@ -533,6 +536,7 @@ public final class OMRequestTestUtils {
 
   /**
    * Create OmKeyInfo.
+   * Initializes most values to a sensible default.
    */
   public static OmKeyInfo.Builder createOmKeyInfo(String volumeName, String bucketName,
       String keyName, ReplicationConfig replicationConfig, OmKeyLocationInfoGroup omKeyLocationInfoGroup) {
@@ -568,30 +572,6 @@ public final class OMRequestTestUtils {
         .setObjectID(objectID)
         .setParentObjectID(parentObjID)
         .setUpdateID(50)
-        .build();
-  }
-
-  /**
-   * Create OmKeyInfo for LEGACY/OBS bucket.
-   */
-  @SuppressWarnings("parameterNumber")
-  private static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, ReplicationConfig replicationConfig, long objectID,
-      long creationTime, long version, boolean isMultipartKey) {
-    return new OmKeyInfo.Builder()
-        .setVolumeName(volumeName)
-        .setBucketName(bucketName)
-        .setKeyName(keyName)
-        .setFileName(OzoneFSUtils.getFileName(keyName))
-        .setOmKeyLocationInfos(Collections.singletonList(
-            new OmKeyLocationInfoGroup(version, new ArrayList<>(),
-                isMultipartKey)))
-        .setCreationTime(creationTime)
-        .setModificationTime(Time.now())
-        .setDataSize(1000L)
-        .setReplicationConfig(replicationConfig)
-        .setObjectID(objectID)
-        .setUpdateID(objectID)
         .build();
   }
 
@@ -1375,46 +1355,6 @@ public final class OMRequestTestUtils {
         new CacheKey<>(dbVolumeKey),
         CacheValue.get(1L, omVolumeArgs));
   }
-
-  /**
-   * Create OmKeyInfo.
-   */
-  @SuppressWarnings("parameterNumber")
-  public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, ReplicationConfig replicationConfig, long objectID,
-      long parentID, long trxnLogIndex, long creationTime, long version) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, objectID, parentID, trxnLogIndex,
-        creationTime,
-        version, false);
-  }
-
-  /**
-   * Create OmKeyInfo for FSO bucket.
-   */
-  @SuppressWarnings("parameterNumber")
-  private static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, ReplicationConfig replicationConfig, long objectID,
-      long parentID, long trxnLogIndex, long creationTime, long version,
-      boolean isMultipartKey) {
-    String fileName = OzoneFSUtils.getFileName(keyName);
-    return new OmKeyInfo.Builder()
-        .setVolumeName(volumeName)
-        .setBucketName(bucketName)
-        .setKeyName(keyName)
-        .setOmKeyLocationInfos(Collections.singletonList(
-            new OmKeyLocationInfoGroup(version, new ArrayList<>(),
-                isMultipartKey)))
-        .setCreationTime(creationTime)
-        .setModificationTime(Time.now())
-        .setDataSize(1000L)
-        .setReplicationConfig(replicationConfig)
-        .setObjectID(objectID)
-        .setUpdateID(trxnLogIndex)
-        .setParentObjectID(parentID)
-        .setFileName(fileName)
-        .build();
-  }
-
 
   /**
    * Add key entry to KeyTable. if openKeyTable flag is true, add's entries

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -157,23 +157,22 @@ public final class OMRequestTestUtils {
 
   @SuppressWarnings("parameterNumber")
   public static void addKeyToTableAndCache(String volumeName, String bucketName,
-      String keyName, long clientID, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
+      String keyName, long clientID, ReplicationConfig replicationConfig, long trxnLogIndex,
       OMMetadataManager omMetadataManager) throws Exception {
     addKeyToTable(false, true, volumeName, bucketName, keyName, clientID,
-        replicationType, replicationFactor, trxnLogIndex, omMetadataManager);
+        replicationConfig, trxnLogIndex, omMetadataManager);
   }
 
   /**
    * Add key entry to KeyTable. if openKeyTable flag is true, add's entries
    * to openKeyTable, else add's it to keyTable.
+   *
    * @param openKeyTable
    * @param volumeName
    * @param bucketName
    * @param keyName
    * @param clientID
-   * @param replicationType
-   * @param replicationFactor
+   * @param replicationConfig
    * @param omMetadataManager
    * @param locationList
    * @throws Exception
@@ -181,12 +180,11 @@ public final class OMRequestTestUtils {
   @SuppressWarnings("parameterNumber")
   public static void addKeyToTable(boolean openKeyTable, String volumeName,
       String bucketName, String keyName, long clientID,
-      HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor,
+      ReplicationConfig replicationConfig,
       OMMetadataManager omMetadataManager,
       List<OmKeyLocationInfo> locationList, long version) throws Exception {
     addKeyToTable(openKeyTable, false, volumeName, bucketName, keyName,
-        clientID, replicationType, replicationFactor, 0L, omMetadataManager,
+        clientID, replicationConfig, 0L, omMetadataManager,
         locationList, version);
   }
 
@@ -194,24 +192,23 @@ public final class OMRequestTestUtils {
   /**
    * Add key entry to KeyTable. if openKeyTable flag is true, add's entries
    * to openKeyTable, else add's it to keyTable.
+   *
    * @param openKeyTable
    * @param volumeName
    * @param bucketName
    * @param keyName
    * @param clientID
-   * @param replicationType
-   * @param replicationFactor
+   * @param replicationConfig
    * @param omMetadataManager
    * @throws Exception
    */
   @SuppressWarnings("parameterNumber")
   public static void addKeyToTable(boolean openKeyTable, String volumeName,
       String bucketName, String keyName, long clientID,
-      HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor,
+      ReplicationConfig replicationConfig,
       OMMetadataManager omMetadataManager) throws Exception {
     addKeyToTable(openKeyTable, false, volumeName, bucketName, keyName,
-        clientID, replicationType, replicationFactor, 0L, omMetadataManager);
+        clientID, replicationConfig, 0L, omMetadataManager);
   }
 
   /**
@@ -225,20 +222,17 @@ public final class OMRequestTestUtils {
    * @param bucketName
    * @param keyName
    * @param clientID
-   * @param replicationType
-   * @param replicationFactor
+   * @param replicationConfig
    * @param omMetadataManager
    * @throws Exception
    */
   @SuppressWarnings("parameterNumber")
   public static void addKeyToTable(boolean openKeyTable, boolean isMultipartKey,
       String volumeName, String bucketName, String keyName, long clientID,
-      HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor,
+      ReplicationConfig replicationConfig,
       OMMetadataManager omMetadataManager) throws Exception {
     addKeyToTable(openKeyTable, isMultipartKey, false,
-        volumeName, bucketName, keyName, clientID, replicationType,
-        replicationFactor, 0L, omMetadataManager);
+        volumeName, bucketName, keyName, clientID, replicationConfig, 0L, omMetadataManager);
   }
 
   /**
@@ -248,14 +242,13 @@ public final class OMRequestTestUtils {
    */
   @SuppressWarnings("parameternumber")
   public static void addKeyToTable(boolean openKeyTable, boolean addToCache,
-      String volumeName, String bucketName, String keyName, long clientID,
-      HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
+      String volumeName, String bucketName, String keyName, long clientID, ReplicationConfig replicationConfig,
+      long trxnLogIndex,
       OMMetadataManager omMetadataManager,
       List<OmKeyLocationInfo> locationList, long version) throws Exception {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationType, replicationFactor, trxnLogIndex, Time.now(), version,
+        replicationConfig, trxnLogIndex, Time.now(), version,
         false);
     omKeyInfo.appendNewBlocks(locationList, false);
 
@@ -271,12 +264,11 @@ public final class OMRequestTestUtils {
   @SuppressWarnings("parameternumber")
   public static void addKeyToTable(boolean openKeyTable, boolean addToCache,
       String volumeName, String bucketName, String keyName, long clientID,
-      HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
+      ReplicationConfig replicationConfig, long trxnLogIndex,
       OMMetadataManager omMetadataManager) throws Exception {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationType, replicationFactor, trxnLogIndex);
+        replicationConfig, trxnLogIndex);
 
     addKeyToTable(openKeyTable, addToCache, omKeyInfo, clientID, trxnLogIndex,
         omMetadataManager);
@@ -290,12 +282,11 @@ public final class OMRequestTestUtils {
   @SuppressWarnings("parameternumber")
   public static void addKeyToTable(boolean openKeyTable, boolean isMultipartKey,
       boolean addToCache, String volumeName, String bucketName, String keyName,
-      long clientID, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
+      long clientID, ReplicationConfig replicationConfig, long trxnLogIndex,
       OMMetadataManager omMetadataManager) throws Exception {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationType, replicationFactor, trxnLogIndex, Time.now(), 0L,
+        replicationConfig, trxnLogIndex, Time.now(), 0L,
         isMultipartKey);
 
     addKeyToTable(openKeyTable, addToCache, omKeyInfo, clientID, trxnLogIndex,
@@ -431,23 +422,22 @@ public final class OMRequestTestUtils {
 
   /**
    * Add key entry to key table cache.
+   *
    * @param volumeName
    * @param bucketName
    * @param keyName
-   * @param replicationType
-   * @param replicationFactor
+   * @param replicationConfig
    * @param omMetadataManager
    */
   @SuppressWarnings("parameterNumber")
   public static void addKeyToTableCache(String volumeName,
       String bucketName,
       String keyName,
-      HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor,
+      ReplicationConfig replicationConfig,
       OMMetadataManager omMetadataManager) {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationType, replicationFactor);
+        replicationConfig);
 
     omMetadataManager.getKeyTable(getDefaultBucketLayout()).addCacheEntry(
         new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
@@ -545,10 +535,8 @@ public final class OMRequestTestUtils {
    * Create OmKeyInfo.
    */
   public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationType,
-        replicationFactor, 0L);
+      String keyName, ReplicationConfig replicationConfig) {
+    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, 0L);
   }
 
   /**
@@ -571,21 +559,17 @@ public final class OMRequestTestUtils {
    * Create OmKeyInfo.
    */
   public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long objectID) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationType,
-            replicationFactor, objectID, Time.now());
+      String keyName, ReplicationConfig replicationConfig, long objectID) {
+    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, objectID, Time.now());
   }
 
   /**
    * Create OmKeyInfo.
    */
   public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long objectID,
+      String keyName, ReplicationConfig replicationConfig, long objectID,
       long creationTime) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationType,
-            replicationFactor, objectID, creationTime, 0L, false);
+    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, objectID, creationTime, 0L, false);
   }
 
   /**
@@ -593,11 +577,10 @@ public final class OMRequestTestUtils {
    */
   @SuppressWarnings("parameterNumber")
   public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long objectID,
+      String keyName, ReplicationConfig replicationConfig, long objectID,
       long creationTime, boolean isMultipartKey) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationType,
-        replicationFactor, objectID, creationTime, 0L, isMultipartKey);
+    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, objectID, creationTime, 0L,
+        isMultipartKey);
   }
 
   /**
@@ -605,8 +588,7 @@ public final class OMRequestTestUtils {
    */
   @SuppressWarnings("parameterNumber")
   private static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long objectID,
+      String keyName, ReplicationConfig replicationConfig, long objectID,
       long creationTime, long version, boolean isMultipartKey) {
     return new OmKeyInfo.Builder()
         .setVolumeName(volumeName)
@@ -619,9 +601,7 @@ public final class OMRequestTestUtils {
         .setCreationTime(creationTime)
         .setModificationTime(Time.now())
         .setDataSize(1000L)
-        .setReplicationConfig(
-            ReplicationConfig
-                .fromProtoTypeAndFactor(replicationType, replicationFactor))
+        .setReplicationConfig(replicationConfig)
         .setObjectID(objectID)
         .setUpdateID(objectID)
         .build();
@@ -1413,12 +1393,11 @@ public final class OMRequestTestUtils {
    */
   @SuppressWarnings("parameterNumber")
   public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long objectID,
+      String keyName, ReplicationConfig replicationConfig, long objectID,
       long parentID, long trxnLogIndex, long creationTime) {
     return createOmKeyInfo(volumeName, bucketName, keyName,
-      replicationType, replicationFactor, objectID,
-      parentID, trxnLogIndex, creationTime, 0L, false);
+        replicationConfig, objectID,
+        parentID, trxnLogIndex, creationTime, 0L, false);
   }
 
   /**
@@ -1426,12 +1405,11 @@ public final class OMRequestTestUtils {
    */
   @SuppressWarnings("parameterNumber")
   public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long objectID,
+      String keyName, ReplicationConfig replicationConfig, long objectID,
       long parentID, long trxnLogIndex, long creationTime,
       boolean isMultipartKey) {
     return createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationType, replicationFactor, objectID,
+        replicationConfig, objectID,
         parentID, trxnLogIndex, creationTime, 0L, isMultipartKey);
   }
 
@@ -1440,11 +1418,10 @@ public final class OMRequestTestUtils {
    */
   @SuppressWarnings("parameterNumber")
   public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long objectID,
+      String keyName, ReplicationConfig replicationConfig, long objectID,
       long parentID, long trxnLogIndex, long creationTime, long version) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationType,
-        replicationFactor, objectID, parentID, trxnLogIndex, creationTime,
+    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, objectID, parentID, trxnLogIndex,
+        creationTime,
         version, false);
   }
 
@@ -1453,28 +1430,26 @@ public final class OMRequestTestUtils {
    */
   @SuppressWarnings("parameterNumber")
   private static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long objectID,
+      String keyName, ReplicationConfig replicationConfig, long objectID,
       long parentID, long trxnLogIndex, long creationTime, long version,
       boolean isMultipartKey) {
     String fileName = OzoneFSUtils.getFileName(keyName);
     return new OmKeyInfo.Builder()
-            .setVolumeName(volumeName)
-            .setBucketName(bucketName)
-            .setKeyName(keyName)
-            .setOmKeyLocationInfos(Collections.singletonList(
-                    new OmKeyLocationInfoGroup(version, new ArrayList<>(),
-                        isMultipartKey)))
-            .setCreationTime(creationTime)
-            .setModificationTime(Time.now())
-            .setDataSize(1000L)
-            .setReplicationConfig(ReplicationConfig
-                    .fromProtoTypeAndFactor(replicationType, replicationFactor))
-            .setObjectID(objectID)
-            .setUpdateID(trxnLogIndex)
-            .setParentObjectID(parentID)
-            .setFileName(fileName)
-            .build();
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(version, new ArrayList<>(),
+                isMultipartKey)))
+        .setCreationTime(creationTime)
+        .setModificationTime(Time.now())
+        .setDataSize(1000L)
+        .setReplicationConfig(replicationConfig)
+        .setObjectID(objectID)
+        .setUpdateID(trxnLogIndex)
+        .setParentObjectID(parentID)
+        .setFileName(fileName)
+        .build();
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -572,26 +572,6 @@ public final class OMRequestTestUtils {
   }
 
   /**
-   * Create OmKeyInfo.
-   */
-  public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, ReplicationConfig replicationConfig, long objectID,
-      long creationTime) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, objectID, creationTime, 0L, false);
-  }
-
-  /**
-   * Create OmKeyInfo.
-   */
-  @SuppressWarnings("parameterNumber")
-  public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, ReplicationConfig replicationConfig, long objectID,
-      long creationTime, boolean isMultipartKey) {
-    return createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, objectID, creationTime, 0L,
-        isMultipartKey);
-  }
-
-  /**
    * Create OmKeyInfo for LEGACY/OBS bucket.
    */
   @SuppressWarnings("parameterNumber")
@@ -1394,31 +1374,6 @@ public final class OMRequestTestUtils {
     omMetadataManager.getVolumeTable().addCacheEntry(
         new CacheKey<>(dbVolumeKey),
         CacheValue.get(1L, omVolumeArgs));
-  }
-
-  /**
-   * Create OmKeyInfo.
-   */
-  @SuppressWarnings("parameterNumber")
-  public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, ReplicationConfig replicationConfig, long objectID,
-      long parentID, long trxnLogIndex, long creationTime) {
-    return createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationConfig, objectID,
-        parentID, trxnLogIndex, creationTime, 0L, false);
-  }
-
-  /**
-   * Create OmKeyInfo with isMultipartKey flag.
-   */
-  @SuppressWarnings("parameterNumber")
-  public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
-      String keyName, ReplicationConfig replicationConfig, long objectID,
-      long parentID, long trxnLogIndex, long creationTime,
-      boolean isMultipartKey) {
-    return createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationConfig, objectID,
-        parentID, trxnLogIndex, creationTime, 0L, isMultipartKey);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
@@ -19,12 +19,14 @@
 
 package org.apache.hadoop.ozone.om.request.bucket;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -123,7 +125,7 @@ public class TestOMBucketDeleteRequest extends TestBucketRequest {
     String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
     final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
         bucketName, UUID.randomUUID().toString(),
-        HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+        RatisReplicationConfig.getInstance(ONE),
         0L, creationTime, true);
     final OmMultipartKeyInfo multipartKeyInfo = OMRequestTestUtils.
         createOmMultipartKeyInfo(uploadId, Time.now(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -31,6 +33,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.junit.jupiter.api.Test;
@@ -121,12 +124,10 @@ public class TestOMBucketDeleteRequest extends TestBucketRequest {
         new OMBucketDeleteRequest(omRequest);
 
     // Create a MPU key in the MPU table to simulate incomplete MPU
-    long creationTime = Time.now();
     String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
-    final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, UUID.randomUUID().toString(),
-        RatisReplicationConfig.getInstance(ONE),
-        0L, creationTime, true);
+    final OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, UUID.randomUUID().toString(),
+            RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+        .build();
     final OmMultipartKeyInfo multipartKeyInfo = OMRequestTestUtils.
         createOmMultipartKeyInfo(uploadId, Time.now(),
             HddsProtos.ReplicationType.RATIS,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -60,6 +60,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateD
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -297,8 +298,7 @@ public class TestOMDirectoryCreateRequest {
         omMetadataManager);
 
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        keyName.substring(0, 12), 1L, HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        keyName.substring(0, 12), 1L, RatisReplicationConfig.getInstance(ONE), omMetadataManager);
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
@@ -340,7 +340,7 @@ public class TestOMDirectoryCreateRequest {
 
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
         OzoneFSUtils.addTrailingSlashIfNeeded(keyName), 1L,
-        HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+        RatisReplicationConfig.getInstance(ONE),
         omMetadataManager);
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
@@ -383,8 +383,7 @@ public class TestOMDirectoryCreateRequest {
         omMetadataManager);
     // Add a key with first two levels.
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        keyName.substring(0, 11), 1L, HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        keyName.substring(0, 11), 1L, RatisReplicationConfig.getInstance(ONE), omMetadataManager);
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.file;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -60,6 +59,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -423,7 +423,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     // Add a file into the FileTable, this is to simulate "file exists" check.
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), objID++);
+        bucketName, keyName, RatisReplicationConfig.getInstance(THREE)).setObjectID(objID++).build();
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omBucketInfo.getObjectID();
 
@@ -492,20 +492,22 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     // for index=0, parentID is bucketID
     OmDirectoryInfo omDirInfo = OMRequestTestUtils.createOmDirectoryInfo(
-            dirs.get(0), objID++, parentID);
+        dirs.get(0), objID++, parentID);
     OMRequestTestUtils.addDirKeyToDirTable(true, omDirInfo,
-            volumeName, bucketName, txnID, omMetadataManager);
+        volumeName, bucketName, txnID, omMetadataManager);
     parentID = omDirInfo.getObjectID();
 
     // Add a key in second level.
-    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), objID);
+    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+            RatisReplicationConfig.getInstance(THREE))
+        .setObjectID(objID)
+        .build();
 
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omBucketInfo.getObjectID();
 
     final String ozoneKey = omMetadataManager.getOzonePathKey(
-            volumeId, bucketId, parentID, dirs.get(1));
+        volumeId, bucketId, parentID, dirs.get(1));
     ++txnID;
     omMetadataManager.getKeyTable(getBucketLayout())
         .addCacheEntry(new CacheKey<>(ozoneKey),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.request.file;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -422,8 +423,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     // Add a file into the FileTable, this is to simulate "file exists" check.
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-            bucketName, keyName, HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, objID++);
+        bucketName, keyName, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), objID++);
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omBucketInfo.getObjectID();
 
@@ -499,8 +499,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     // Add a key in second level.
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-            bucketName, keyName, HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, objID);
+        bucketName, keyName, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), objID);
 
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omBucketInfo.getObjectID();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -190,7 +191,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
             .setBucketName(bucketName)
             .setBucketLayout(getBucketLayout())
             .setQuotaInNamespace(1));
-    
+
     OMFileCreateRequest omFileCreateRequest = getOMFileCreateRequest(omRequest);
     OMRequest modifiedOmRequest = omFileCreateRequest.preExecute(ozoneManager);
 
@@ -243,19 +244,17 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     testNonRecursivePath(UUID.randomUUID().toString(), false, false, false);
     testNonRecursivePath("a/b", false, false, true);
 
+    ReplicationConfig replicationConfig = ReplicationConfig.fromProtoTypeAndFactor(HddsProtos.ReplicationType.RATIS,
+        HddsProtos.ReplicationFactor.ONE);
     // Create some child keys for the path
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "a/b/c/d", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "a/b/c/d", 0L, replicationConfig, omMetadataManager);
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "a/b/c/", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "a/b/c/", 0L, replicationConfig, omMetadataManager);
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "a/b/", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "a/b/", 0L, replicationConfig, omMetadataManager);
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "a/", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "a/", 0L, replicationConfig, omMetadataManager);
 
     // cannot create file if directory of same name exists
     testNonRecursivePath("a/b/c", false, false, true);
@@ -275,14 +274,14 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     // Should be able to create file even if parent directories does not
     // exist and key already exist, as this is with overwrite enabled.
     testNonRecursivePath(UUID.randomUUID().toString(), false, false, false);
+    ReplicationConfig replicationConfig = ReplicationConfig.fromProtoTypeAndFactor(HddsProtos.ReplicationType.RATIS,
+        HddsProtos.ReplicationFactor.ONE);
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "c/d/e/f", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "c/d/e/f", 0L, replicationConfig, omMetadataManager);
     testNonRecursivePath("c/d/e/f", true, true, false);
     // Create some child keys for the path
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "a/b/c/d", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "a/b/c/d", 0L, replicationConfig, omMetadataManager);
     testNonRecursivePath("a/b/c", false, true, false);
   }
 
@@ -293,16 +292,17 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     String key = "c/d/e/f";
     // Should be able to create file even if parent directories does not exist
     testNonRecursivePath(key, false, true, false);
-    
+
     // 3 parent directory created c/d/e
     assertEquals(omMetadataManager.getBucketTable().get(
             omMetadataManager.getBucketKey(volumeName, bucketName))
         .getUsedNamespace(), 3);
-    
+
     // Add the key to key table
+    ReplicationConfig replicationConfig = ReplicationConfig.fromProtoTypeAndFactor(HddsProtos.ReplicationType.RATIS,
+        HddsProtos.ReplicationFactor.ONE);
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        key, 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        key, 0L, replicationConfig, omMetadataManager);
 
     // Even if key exists, should be able to create file as overwrite is set
     // to true
@@ -315,23 +315,21 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
       throws Exception {
 
     String key = "c/d/e/f";
+    ReplicationConfig replicationConfig = ReplicationConfig.fromProtoTypeAndFactor(HddsProtos.ReplicationType.RATIS,
+        HddsProtos.ReplicationFactor.ONE);
     // Need to add the path which starts with "c/d/e" to keyTable as this is
     // non-recursive parent should exist.
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "c/", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "c/", 0L, replicationConfig, omMetadataManager);
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "c/d/", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "c/d/", 0L, replicationConfig, omMetadataManager);
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        "c/d/e/", 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "c/d/e/", 0L, replicationConfig, omMetadataManager);
     testNonRecursivePath(key, false, false, false);
 
     // Add the key to key table
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        key, 0L,  HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        key, 0L, replicationConfig, omMetadataManager);
 
     // Even if key exists, should be able to create file as overwrite is set
     // to true

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.StringUtils;
-import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -115,10 +114,11 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
     // Add the key to key table
     OmDirectoryInfo omDirInfo = getDirInfo("c/d/e");
     OmKeyInfo omKeyInfo =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
-                RatisReplicationConfig.getInstance(ONE),
-                omDirInfo.getObjectID() + 10,
-                omDirInfo.getObjectID(), 100, Time.now());
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key, RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(omDirInfo.getObjectID() + 10)
+            .setParentObjectID(omDirInfo.getObjectID())
+            .setUpdateID(100)
+            .build();
     OMRequestTestUtils.addFileToKeyTable(false, false,
             "f", omKeyInfo, -1,
             omDirInfo.getObjectID() + 10, omMetadataManager);
@@ -136,22 +136,22 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
     String fileName = "f";
     String key = parentDir + "/" + fileName;
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-            omMetadataManager, getBucketLayout());
+        omMetadataManager, getBucketLayout());
     // Create parent dirs for the path
     long parentId = OMRequestTestUtils.addParentsToDirTable(volumeName,
-            bucketName, parentDir, omMetadataManager);
+        bucketName, parentDir, omMetadataManager);
 
     // Need to add the path which starts with "c/d/e" to OpenKeyTable as this is
     // non-recursive parent should exist.
     testNonRecursivePath(key, false, false, false);
 
     OmKeyInfo omKeyInfo =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
-                RatisReplicationConfig.getInstance(ONE),
-                parentId + 1,
-                parentId, 100, Time.now());
-    OMRequestTestUtils.addFileToKeyTable(false, false,
-            fileName, omKeyInfo, -1, 50, omMetadataManager);
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key, RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(parentId + 1L)
+            .setParentObjectID(parentId)
+            .setUpdateID(100L)
+            .build();
+    OMRequestTestUtils.addFileToKeyTable(false, false, fileName, omKeyInfo, -1, 50, omMetadataManager);
 
     // Even if key exists in KeyTable, should be able to create file as
     // overwrite is set to true

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.request.file;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -55,8 +57,7 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
             "a/b/c", omMetadataManager);
     String fileNameD = "d";
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-            "a/b/c/" + fileNameD, 0L, HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        "a/b/c/" + fileNameD, 0L, RatisReplicationConfig.getInstance(ONE), omMetadataManager);
 
     // cannot create file if directory of same name exists
     testNonRecursivePath("a/b/c", false, false, true);
@@ -80,7 +81,7 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
   public void testValidateAndUpdateCacheWithNamespaceQuotaExceeded()
       throws Exception {
     OMRequest omRequest = createFileRequest(volumeName, bucketName,
-        "/test/a1/a2", HddsProtos.ReplicationFactor.ONE,
+        "/test/a1/a2", ONE,
         HddsProtos.ReplicationType.RATIS, false, true);
 
     // create bucket with quota limit 1
@@ -115,10 +116,9 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
     OmDirectoryInfo omDirInfo = getDirInfo("c/d/e");
     OmKeyInfo omKeyInfo =
             OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE,
-                    omDirInfo.getObjectID() + 10,
-                    omDirInfo.getObjectID(), 100, Time.now());
+                RatisReplicationConfig.getInstance(ONE),
+                omDirInfo.getObjectID() + 10,
+                omDirInfo.getObjectID(), 100, Time.now());
     OMRequestTestUtils.addFileToKeyTable(false, false,
             "f", omKeyInfo, -1,
             omDirInfo.getObjectID() + 10, omMetadataManager);
@@ -147,10 +147,9 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
 
     OmKeyInfo omKeyInfo =
             OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE,
-                    parentId + 1,
-                    parentId, 100, Time.now());
+                RatisReplicationConfig.getInstance(ONE),
+                parentId + 1,
+                parentId, 100, Time.now());
     OMRequestTestUtils.addFileToKeyTable(false, false,
             fileName, omKeyInfo, -1, 50, omMetadataManager);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -272,7 +272,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
   String addToOpenFileTable(List<OmKeyLocationInfo> locationList)
       throws Exception {
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, replicationType, replicationFactor, 0, parentId,
+        bucketName, keyName, replicationConfig, 0, parentId,
         0, Time.now(), version);
     omKeyInfo.appendNewBlocks(locationList, false);
     omKeyInfo.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID,
@@ -294,7 +294,7 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
   String addToFileTable(List<OmKeyLocationInfo> locationList)
       throws Exception {
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, replicationType, replicationFactor, 0, parentId,
+        bucketName, keyName, replicationConfig, 0, parentId,
         0, Time.now(), version);
     omKeyInfo.appendNewBlocks(locationList, false);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMRecoverLeaseRequest.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
@@ -35,7 +36,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .RecoverLeaseRequest;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
-import org.apache.hadoop.util.Time;
 import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
@@ -272,8 +272,9 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
   String addToOpenFileTable(List<OmKeyLocationInfo> locationList)
       throws Exception {
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, replicationConfig, 0, parentId,
-        0, Time.now(), version);
+            bucketName, keyName, replicationConfig, new OmKeyLocationInfoGroup(version, new ArrayList<>(), false))
+        .setParentObjectID(parentId)
+        .build();
     omKeyInfo.appendNewBlocks(locationList, false);
     omKeyInfo.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID,
         String.valueOf(clientID));
@@ -294,8 +295,9 @@ public class TestOMRecoverLeaseRequest extends TestOMKeyRequest {
   String addToFileTable(List<OmKeyLocationInfo> locationList)
       throws Exception {
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, replicationConfig, 0, parentId,
-        0, Time.now(), version);
+            bucketName, keyName, replicationConfig, new OmKeyLocationInfoGroup(version, new ArrayList<>(), false))
+        .setParentObjectID(parentId)
+        .build();
     omKeyInfo.appendNewBlocks(locationList, false);
 
     OMRequestTestUtils.addFileToKeyTable(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -236,7 +237,8 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
     KeyArgs keyArgs = KeyArgs.newBuilder()
         .setVolumeName(volumeName).setBucketName(bucketName)
         .setKeyName(keyName)
-        .setFactor(replicationFactor).setType(replicationType)
+        .setFactor(((RatisReplicationConfig) replicationConfig).getReplicationFactor())
+        .setType(replicationConfig.getReplicationType())
         .build();
 
     AllocateBlockRequest allocateBlockRequest =
@@ -253,8 +255,8 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
   protected String addKeyToOpenKeyTable(String volumeName, String bucketName)
           throws Exception {
     OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName,
-            keyName, clientID, replicationType, replicationFactor,
-            omMetadataManager);
+        keyName, clientID, replicationConfig,
+        omMetadataManager);
     return "";
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequestWithFSO.java
@@ -20,10 +20,12 @@
 package org.apache.hadoop.ozone.om.request.key;
 
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
@@ -66,9 +68,8 @@ public class TestOMAllocateBlockRequestWithFSO
 
     OmKeyInfo omKeyInfoFSO =
             OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE, objectId, parentID, txnId,
-                    Time.now());
+                RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
+                Time.now());
 
     // add key to openFileTable
     OMRequestTestUtils.addFileToKeyTable(true, false,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequestWithFSO.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.StringUtils;
-import org.apache.hadoop.util.Time;
 import jakarta.annotation.Nonnull;
 
 /**
@@ -67,9 +66,11 @@ public class TestOMAllocateBlockRequestWithFSO
     long objectId = parentID + 1;
 
     OmKeyInfo omKeyInfoFSO =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
-                Time.now());
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(objectId)
+            .setParentObjectID(parentID)
+            .setUpdateID(txnId)
+            .build();
 
     // add key to openFileTable
     OMRequestTestUtils.addFileToKeyTable(true, false,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -68,7 +68,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     for (int i = 1; i <= numKeys; i++) {
       String key = keyName + "-" + i;
       OMRequestTestUtils.addKeyToTable(false, false, volumeName, bucket,
-          key, clientID, replicationType, replicationFactor, trxnIndex++,
+          key, clientID, replicationConfig, trxnIndex++,
           omMetadataManager);
       String ozoneKey = omMetadataManager.getOzoneKey(
           volumeName, bucket, key);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
@@ -20,8 +20,12 @@ package org.apache.hadoop.ozone.om.request.key;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.List;
 import java.util.UUID;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -247,7 +251,7 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
 
   protected String addKeyToTable() throws Exception {
     OMRequestTestUtils.addKeyToTable(false, false, volumeName, bucketName,
-        keyName, clientID, replicationType, replicationFactor, 1L,
+        keyName, clientID, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE), 1L,
         omMetadataManager);
 
     return omMetadataManager.getOzoneKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.om.request.key.acl.OMKeyAddAclRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeyRemoveAclRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeySetAclRequestWithFSO;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 
@@ -46,20 +45,22 @@ public class TestOMKeyAclRequestWithFSO extends TestOMKeyAclRequest {
         .addParentsToDirTable(volumeName, bucketName, parentDir,
             omMetadataManager);
 
-    OmKeyInfo omKeyInfo = OMRequestTestUtils
-        .createOmKeyInfo(volumeName, bucketName, key,
-            RatisReplicationConfig.getInstance(ONE),
-            parentId + 1, parentId, 100, Time.now());
+    OmKeyInfo omKeyInfo =
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key, RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(parentId + 1L)
+            .setParentObjectID(parentId)
+            .setUpdateID(100L)
+            .build();
     OMRequestTestUtils
         .addFileToKeyTable(false, false, fileName, omKeyInfo, -1, 50,
             omMetadataManager);
     final long volumeId = omMetadataManager.getVolumeId(
-            omKeyInfo.getVolumeName());
+        omKeyInfo.getVolumeName());
     final long bucketId = omMetadataManager.getBucketId(
-            omKeyInfo.getVolumeName(), omKeyInfo.getBucketName());
+        omKeyInfo.getVolumeName(), omKeyInfo.getBucketName());
     return omMetadataManager.getOzonePathKey(
-            volumeId, bucketId, omKeyInfo.getParentObjectID(),
-            fileName);
+        volumeId, bucketId, omKeyInfo.getParentObjectID(),
+        fileName);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ozone.om.request.key;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -27,6 +27,8 @@ import org.apache.hadoop.ozone.om.request.key.acl.OMKeyRemoveAclRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeySetAclRequestWithFSO;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.Time;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 
 /**
  * Test Key ACL requests for prefix layout.
@@ -46,7 +48,7 @@ public class TestOMKeyAclRequestWithFSO extends TestOMKeyAclRequest {
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils
         .createOmKeyInfo(volumeName, bucketName, key,
-            HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+            RatisReplicationConfig.getInstance(ONE),
             parentId + 1, parentId, 100, Time.now());
     OMRequestTestUtils
         .addFileToKeyTable(false, false, fileName, omKeyInfo, -1, 50,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -686,7 +687,8 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     KeyArgs keyArgs =
         KeyArgs.newBuilder().setDataSize(dataSize).setVolumeName(volumeName)
             .setKeyName(keyName).setBucketName(bucketName)
-            .setType(replicationType).setFactor(replicationFactor)
+            .setType(replicationConfig.getReplicationType())
+            .setFactor(((RatisReplicationConfig) replicationConfig).getReplicationFactor())
             .addAllKeyLocations(keyLocations).build();
 
     CommitKeyRequest commitKeyRequest =
@@ -731,7 +733,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
   protected String addKeyToOpenKeyTable(List<OmKeyLocationInfo> locationList)
       throws Exception {
     OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
-        clientID, replicationType, replicationFactor, omMetadataManager,
+        clientID, replicationConfig, omMetadataManager,
         locationList, version);
 
     return omMetadataManager.getOpenKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
@@ -19,8 +19,10 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -78,10 +80,9 @@ public class TestOMKeyCommitRequestWithFSO extends TestOMKeyCommitRequest {
     long objectId = 100;
 
     OmKeyInfo omKeyInfoFSO =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE, objectId, parentID, 100,
-                    Time.now(), version);
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+            RatisReplicationConfig.getInstance(ONE), objectId, parentID, 100,
+            Time.now(), version);
     omKeyInfoFSO.appendNewBlocks(locationList, false);
 
     String fileName = OzoneFSUtils.getFileName(keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
@@ -27,13 +27,14 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.util.Time;
 import jakarta.annotation.Nonnull;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -81,8 +82,11 @@ public class TestOMKeyCommitRequestWithFSO extends TestOMKeyCommitRequest {
 
     OmKeyInfo omKeyInfoFSO =
         OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            RatisReplicationConfig.getInstance(ONE), objectId, parentID, 100,
-            Time.now(), version);
+                RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(version, new ArrayList<>(), false))
+            .setObjectID(objectId)
+            .setParentObjectID(parentID)
+            .setUpdateID(100L)
+            .build();
     omKeyInfoFSO.appendNewBlocks(locationList, false);
 
     String fileName = OzoneFSUtils.getFileName(keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -548,7 +549,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     KeyArgs.Builder keyArgs = KeyArgs.newBuilder()
         .setVolumeName(volumeName).setBucketName(bucketName)
         .setKeyName(keyName).setIsMultipartKey(isMultipartKey)
-        .setFactor(replicationFactor).setType(replicationType)
+        .setFactor(((RatisReplicationConfig) replicationConfig).getReplicationFactor())
+        .setType(replicationConfig.getReplicationType())
         .setLatestVersionLocation(true);
 
     if (isMultipartKey) {
@@ -795,7 +797,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
   protected void addToKeyTable(String keyName) throws Exception {
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
-        keyName.substring(1), 0L, RATIS, THREE, omMetadataManager);
+        keyName.substring(1), 0L, RatisReplicationConfig.getInstance(THREE), omMetadataManager);
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.om.lock.OzoneLockProvider;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.util.Time;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -108,11 +107,13 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     Path keyPath = Paths.get(keyName);
     long parentId = checkIntermediatePaths(keyPath);
     String fileName = OzoneFSUtils.getFileName(keyName);
-    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, fileName, RatisReplicationConfig.getInstance(ONE), parentId + 1, parentId, 100,
-        Time.now());
-    OMRequestTestUtils.addFileToKeyTable(false, false,
-            fileName, omKeyInfo, -1, 50, omMetadataManager);
+    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, fileName,
+            RatisReplicationConfig.getInstance(ONE))
+        .setObjectID(parentId + 1L)
+        .setParentObjectID(parentId)
+        .setUpdateID(100L)
+        .build();
+    OMRequestTestUtils.addFileToKeyTable(false, false, fileName, omKeyInfo, -1, 50, omMetadataManager);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -108,8 +109,7 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     long parentId = checkIntermediatePaths(keyPath);
     String fileName = OzoneFSUtils.getFileName(keyName);
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, fileName, HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE,  parentId + 1, parentId, 100,
+        bucketName, fileName, RatisReplicationConfig.getInstance(ONE), parentId + 1, parentId, 100,
         Time.now());
     OMRequestTestUtils.addFileToKeyTable(false, false,
             fileName, omKeyInfo, -1, 50, omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
@@ -192,8 +192,8 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
 
   protected String addKeyToTable(String key) throws Exception {
     OMRequestTestUtils.addKeyToTable(false, volumeName,
-            bucketName, key, clientID, replicationType, replicationFactor,
-            omMetadataManager);
+        bucketName, key, clientID, replicationConfig,
+        omMetadataManager);
 
     return omMetadataManager.getOzoneKey(volumeName, bucketName, key);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -72,11 +73,10 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
             bucketName, PARENT_DIR, omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_KEY,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE,
-                    parentId + 1,
-                    parentId, 100, Time.now());
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_KEY,
+            RatisReplicationConfig.getInstance(ONE),
+            parentId + 1,
+            parentId, 100, Time.now());
     omKeyInfo.setKeyName(FILE_NAME);
     OMRequestTestUtils.addFileToKeyTable(false, false,
         FILE_NAME, omKeyInfo, -1, 50, omMetadataManager);
@@ -97,8 +97,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     OmKeyInfo omKeyInfo =
         OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
-            HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE,
+            RatisReplicationConfig.getInstance(ONE),
             parentId + 1,
             parentId, 100, Time.now());
     omKeyInfo.setKeyName(key);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.security.acl.OzonePrefixPath;
-import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -73,10 +72,11 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
             bucketName, PARENT_DIR, omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_KEY,
-            RatisReplicationConfig.getInstance(ONE),
-            parentId + 1,
-            parentId, 100, Time.now());
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_KEY, RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(parentId + 1L)
+            .setParentObjectID(parentId)
+            .setUpdateID(100L)
+            .build();
     omKeyInfo.setKeyName(FILE_NAME);
     OMRequestTestUtils.addFileToKeyTable(false, false,
         FILE_NAME, omKeyInfo, -1, 50, omMetadataManager);
@@ -96,10 +96,11 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
         bucketName, key, omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
-            RatisReplicationConfig.getInstance(ONE),
-            parentId + 1,
-            parentId, 100, Time.now());
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key, RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(parentId + 1L)
+            .setParentObjectID(parentId)
+            .setUpdateID(100L)
+            .build();
     omKeyInfo.setKeyName(key);
     return omKeyInfo.getPath();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -76,7 +76,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     for (int i = 1; i <= numKeys; i++) {
       String key = keyName + "-" + i;
       OMRequestTestUtils.addKeyToTable(false, false, volumeName, bucket,
-          key, clientID, replicationType, replicationFactor, trxnIndex++,
+          key, clientID, replicationConfig, trxnIndex++,
           omMetadataManager);
       ozoneKeyNames.add(omMetadataManager.getOzoneKey(
           volumeName, bucket, key));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
@@ -240,7 +240,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
   protected OmKeyInfo getOmKeyInfo(String keyName) {
     return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationConfig, 0L);
+        replicationConfig).build();
   }
 
   protected String addKeyToTable(OmKeyInfo keyInfo) throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
@@ -240,7 +240,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
   protected OmKeyInfo getOmKeyInfo(String keyName) {
     return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationType, replicationFactor, 0L);
+        replicationConfig, 0L);
   }
 
   protected String addKeyToTable(OmKeyInfo keyInfo) throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
@@ -18,12 +18,14 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -181,7 +183,7 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
     long bucketId = random.nextLong();
     return OMRequestTestUtils.createOmKeyInfo(
         volumeName, bucketName, keyName,
-        HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+        RatisReplicationConfig.getInstance(ONE),
         bucketId + 100L, bucketId + 101L, 0L, Time.now());
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeyRequest;
-import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -181,10 +180,10 @@ public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRenameRequest {
   @Override
   protected OmKeyInfo getOmKeyInfo(String keyName) {
     long bucketId = random.nextLong();
-    return OMRequestTestUtils.createOmKeyInfo(
-        volumeName, bucketName, keyName,
-        RatisReplicationConfig.getInstance(ONE),
-        bucketId + 100L, bucketId + 101L, 0L, Time.now());
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+        .setObjectID(bucketId + 100L)
+        .setParentObjectID(bucketId + 101L)
+        .build();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import java.util.UUID;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -55,7 +56,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -110,8 +110,7 @@ public class TestOMKeyRequest {
   protected String volumeName;
   protected String bucketName;
   protected String keyName;
-  protected HddsProtos.ReplicationType replicationType;
-  protected HddsProtos.ReplicationFactor replicationFactor;
+  protected ReplicationConfig replicationConfig;
   protected long clientID;
   protected long scmBlockSize = 1000L;
   protected long dataSize;
@@ -209,8 +208,7 @@ public class TestOMKeyRequest {
     volumeName = UUID.randomUUID().toString();
     bucketName = UUID.randomUUID().toString();
     keyName = UUID.randomUUID().toString();
-    replicationFactor = HddsProtos.ReplicationFactor.ONE;
-    replicationType = HddsProtos.ReplicationType.RATIS;
+    replicationConfig = RatisReplicationConfig.getInstance(ReplicationFactor.ONE);
     clientID = Time.now();
     dataSize = 1000L;
     random = new Random();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.PARTIAL_DELETE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -145,8 +146,7 @@ public class TestOMKeysDeleteRequest extends TestOMKeyRequest {
     for (int i = 0; i < count; i++) {
       key = parentDir.concat("/key" + i);
       OMRequestTestUtils.addKeyToTableCache(volumeName, bucketName,
-          parentDir.concat("/key" + i), HddsProtos.ReplicationType.RATIS,
-          HddsProtos.ReplicationFactor.THREE, omMetadataManager);
+          parentDir.concat("/key" + i), RatisReplicationConfig.getInstance(THREE), omMetadataManager);
       deleteKeyArgs.addKeys(key);
       deleteKeyList.add(key);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequestWithFSO.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -84,10 +83,13 @@ public class TestOMKeysDeleteRequestWithFSO extends TestOMKeysDeleteRequest {
       long parentId = OMRequestTestUtils
           .addParentsToDirTable(volumeName, bucketName, dir, omMetadataManager);
 
-      OmKeyInfo omKeyInfo = OMRequestTestUtils
-          .createOmKeyInfo(volumeName, bucketName, dir + "/" + file,
-              RatisReplicationConfig.getInstance(ONE), parentId + 1, parentId, 100,
-              Time.now());
+      OmKeyInfo omKeyInfo =
+          OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, dir + "/" + file,
+                  RatisReplicationConfig.getInstance(ONE))
+              .setObjectID(parentId + 1L)
+              .setParentObjectID(parentId)
+              .setUpdateID(100L)
+              .build();
       omKeyInfo.setKeyName(file);
       OMRequestTestUtils
           .addFileToKeyTable(false, false, file, omKeyInfo, -1, 50,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequestWithFSO.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ozone.om.request.key;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.UUID;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
 
 /**
@@ -85,8 +86,7 @@ public class TestOMKeysDeleteRequestWithFSO extends TestOMKeysDeleteRequest {
 
       OmKeyInfo omKeyInfo = OMRequestTestUtils
           .createOmKeyInfo(volumeName, bucketName, dir + "/" + file,
-              HddsProtos.ReplicationType.RATIS,
-              HddsProtos.ReplicationFactor.ONE, parentId + 1, parentId, 100,
+              RatisReplicationConfig.getInstance(ONE), parentId + 1, parentId, 100,
               Time.now());
       omKeyInfo.setKeyName(file);
       OMRequestTestUtils

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysRenameRequest.java
@@ -18,12 +18,14 @@
 
 package org.apache.hadoop.ozone.om.request.key;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -127,8 +129,7 @@ public class TestOMKeysRenameRequest extends TestOMKeyRequest {
       String key = parentDir.concat("/key" + i);
       String toKey = parentDir.concat("/newKey" + i);
       OMRequestTestUtils.addKeyToTableCache(volumeName, bucketName,
-          parentDir.concat("/key" + i), HddsProtos.ReplicationType.RATIS,
-          HddsProtos.ReplicationFactor.THREE, omMetadataManager);
+          parentDir.concat("/key" + i), RatisReplicationConfig.getInstance(THREE), omMetadataManager);
 
       RenameKeysMap.Builder renameKey = RenameKeysMap.newBuilder()
           .setFromKeyName(key)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequest.java
@@ -100,7 +100,7 @@ public class TestOMSetTimesRequest extends TestOMKeyRequest {
 
   protected String addKeyToTable() throws Exception {
     OMRequestTestUtils.addKeyToTable(false, false, volumeName, bucketName,
-        keyName, clientID, replicationType, replicationFactor, 1L,
+        keyName, clientID, replicationConfig, 1L,
         omMetadataManager);
 
     return omMetadataManager.getOzoneKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequestWithFSO.java
@@ -20,15 +20,14 @@ package org.apache.hadoop.ozone.om.request.key;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.junit.jupiter.api.Test;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.util.Time;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -116,10 +115,13 @@ public class TestOMSetTimesRequestWithFSO extends TestOMSetTimesRequest {
         .addParentsToDirTable(volumeName, bucketName, PARENT_DIR,
             omMetadataManager);
 
-    OmKeyInfo omKeyInfo = OMRequestTestUtils
-        .createOmKeyInfo(volumeName, bucketName, FILE_NAME,
-            RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
-            parentId + 1, parentId, 100, Time.now());
+    OmKeyInfo omKeyInfo =
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_NAME,
+                RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(parentId + 1L)
+            .setParentObjectID(parentId)
+            .setUpdateID(100L)
+            .build();
     OMRequestTestUtils
         .addFileToKeyTable(false, false, FILE_NAME, omKeyInfo, -1, 50,
             omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMSetTimesRequestWithFSO.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.om.request.key;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -117,7 +118,7 @@ public class TestOMSetTimesRequestWithFSO extends TestOMSetTimesRequest {
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils
         .createOmKeyInfo(volumeName, bucketName, FILE_NAME,
-            HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+            RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
             parentId + 1, parentId, 100, Time.now());
     OMRequestTestUtils
         .addFileToKeyTable(false, false, FILE_NAME, omKeyInfo, -1, 50,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -27,10 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.UniqueId;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -481,8 +482,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
 
         // Add key to open key table to be used in MPU commit processing
         OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volume,
-            bucket, keyName, HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, parentID + j, parentID,
+            bucket, keyName, RatisReplicationConfig.getInstance(ONE), parentID + j, parentID,
             trxnLogIndex, Time.now(), true);
         String fileName = OzoneFSUtils.getFileName(keyName);
         OMRequestTestUtils.addFileToKeyTable(true, false,
@@ -563,8 +563,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
         // Add key to open key table to be used in MPU commit processing
         OMRequestTestUtils.addKeyToTable(
             true, true,
-            volume, bucket, keyName, clientID, HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+            volume, bucket, keyName, clientID, RatisReplicationConfig.getInstance(ONE), omMetadataManager);
 
         OMClientResponse commitResponse =
             s3MultipartUploadCommitPartRequest.validateAndUpdateCache(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.utils.UniqueId;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -52,7 +53,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Expired
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExpiredMultipartUploadsBucket;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartUploadsExpiredAbortRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.util.Time;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -481,9 +481,13 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
                 commitMultipartRequest, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
         // Add key to open key table to be used in MPU commit processing
-        OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volume,
-            bucket, keyName, RatisReplicationConfig.getInstance(ONE), parentID + j, parentID,
-            trxnLogIndex, Time.now(), true);
+        OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volume, bucket, keyName,
+                RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+            .setObjectID(parentID + j)
+            .setParentObjectID(parentID)
+            .setUpdateID(trxnLogIndex)
+            .build();
+
         String fileName = OzoneFSUtils.getFileName(keyName);
         OMRequestTestUtils.addFileToKeyTable(true, false,
             fileName, omKeyInfo, clientID, trxnLogIndex, omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -224,9 +226,8 @@ public class TestS3MultipartUploadCommitPartRequest
 
   protected void addKeyToOpenKeyTable(String volumeName, String bucketName,
       String keyName, long clientID) throws Exception {
-    OMRequestTestUtils.addKeyToTable(true, true,  volumeName, bucketName,
-            keyName, clientID, HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+    OMRequestTestUtils.addKeyToTable(true, true, volumeName, bucketName,
+        keyName, clientID, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE), omMetadataManager);
   }
 
   protected String getKeyName() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -69,9 +70,9 @@ public class TestS3MultipartUploadCommitPartRequestWithFSO
       String keyName, long clientID) throws Exception {
     long txnLogId = 0L;
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-            bucketName, keyName, HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, parentID + 1, parentID,
-            txnLogId, Time.now(), true);
+        bucketName, keyName, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
+        parentID + 1, parentID,
+        txnLogId, Time.now(), true);
     String fileName = OzoneFSUtils.getFileName(keyName);
     OMRequestTestUtils.addFileToKeyTable(true, false,
             fileName, omKeyInfo, clientID, txnLogId, omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
@@ -28,12 +28,13 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.util.Time;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.UUID;
 
 /**
@@ -69,13 +70,16 @@ public class TestS3MultipartUploadCommitPartRequestWithFSO
   protected void addKeyToOpenKeyTable(String volumeName, String bucketName,
       String keyName, long clientID) throws Exception {
     long txnLogId = 0L;
-    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
-        parentID + 1, parentID,
-        txnLogId, Time.now(), true);
+    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+            RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
+            new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+        .setObjectID(parentID + 1)
+        .setParentObjectID(parentID)
+        .setUpdateID(txnLogId)
+        .build();
     String fileName = OzoneFSUtils.getFileName(keyName);
     OMRequestTestUtils.addFileToKeyTable(true, false,
-            fileName, omKeyInfo, clientID, txnLogId, omMetadataManager);
+        fileName, omKeyInfo, clientID, txnLogId, omMetadataManager);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -37,7 +39,6 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.junit.jupiter.api.Test;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -315,8 +316,7 @@ public class TestS3MultipartUploadCompleteRequest
   protected void addKeyToTable(String volumeName, String bucketName,
                              String keyName, long clientID) throws Exception {
     OMRequestTestUtils.addKeyToTable(true, true, volumeName, bucketName,
-            keyName, clientID, HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+        keyName, clientID, RatisReplicationConfig.getInstance(ONE), omMetadataManager);
   }
 
   protected String getMultipartKey(String volumeName, String bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
@@ -25,13 +25,14 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.util.Time;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.UUID;
 
 /**
@@ -74,9 +75,12 @@ public class TestS3MultipartUploadCompleteRequestWithFSO
     long objectId = parentID + 1;
 
     OmKeyInfo omKeyInfoFSO =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
-                Time.now(), true);
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+                RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+            .setObjectID(objectId)
+            .setParentObjectID(parentID)
+            .setUpdateID(txnId)
+            .build();
 
     // add key to openFileTable
     String fileName = OzoneFSUtils.getFileName(keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
@@ -18,8 +18,10 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -73,9 +75,8 @@ public class TestS3MultipartUploadCompleteRequestWithFSO
 
     OmKeyInfo omKeyInfoFSO =
             OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE, objectId, parentID, txnId,
-                    Time.now(), true);
+                RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
+                Time.now(), true);
 
     // add key to openFileTable
     String fileName = OzoneFSUtils.getFileName(keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.getFromProtobuf;
 import static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.getTableKey;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.createSnapshotRequest;
@@ -321,8 +322,7 @@ public class TestOMSnapshotCreateRequest {
       throws Exception {
     String fromKeyParentName = UUID.randomUUID().toString();
     OmKeyInfo fromKeyParent = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, fromKeyParentName, HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.THREE, 100L);
+        bucketName, fromKeyParentName, RatisReplicationConfig.getInstance(THREE), 100L);
 
     OmKeyInfo toKeyInfo = addKey(toKey, offset + 4L);
     OmKeyInfo fromKeyInfo = addKey(fromKey, offset + 5L);
@@ -381,7 +381,7 @@ public class TestOMSnapshotCreateRequest {
 
   private OmKeyInfo addKey(String keyName, long objectId) {
     return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-        HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.THREE,
+        RatisReplicationConfig.getInstance(THREE),
         objectId);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -322,7 +322,9 @@ public class TestOMSnapshotCreateRequest {
       throws Exception {
     String fromKeyParentName = UUID.randomUUID().toString();
     OmKeyInfo fromKeyParent = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, fromKeyParentName, RatisReplicationConfig.getInstance(THREE), 100L);
+            bucketName, fromKeyParentName, RatisReplicationConfig.getInstance(THREE))
+        .setObjectID(100L)
+        .build();
 
     OmKeyInfo toKeyInfo = addKey(toKey, offset + 4L);
     OmKeyInfo fromKeyInfo = addKey(fromKey, offset + 5L);
@@ -381,8 +383,8 @@ public class TestOMSnapshotCreateRequest {
 
   private OmKeyInfo addKey(String keyName, long objectId) {
     return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-        RatisReplicationConfig.getInstance(THREE),
-        objectId);
+            RatisReplicationConfig.getInstance(THREE)).setObjectID(objectId)
+        .build();
   }
 
   protected String addKeyToTable(OmKeyInfo keyInfo) throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -84,7 +84,7 @@ public class TestOMDirectoryCreateResponse {
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
         bucketName, OzoneFSUtils.addTrailingSlashIfNeeded(keyName),
-        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE)).build();
 
     ThreadLocalRandom random = ThreadLocalRandom.current();
     long usedNamespace = Math.abs(random.nextLong(Long.MAX_VALUE));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.om.response.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -82,7 +84,7 @@ public class TestOMDirectoryCreateResponse {
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
         bucketName, OzoneFSUtils.addTrailingSlashIfNeeded(keyName),
-        HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE);
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
 
     ThreadLocalRandom random = ThreadLocalRandom.current();
     long usedNamespace = Math.abs(random.nextLong(Long.MAX_VALUE));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
 import org.apache.hadoop.ozone.om.response.key.TestOMKeyCreateResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.apache.hadoop.util.Time;
 import jakarta.annotation.Nonnull;
 
 import java.io.IOException;
@@ -41,10 +40,11 @@ public class TestOMFileCreateResponseWithFSO extends TestOMKeyCreateResponse {
   @Override
   protected OmKeyInfo getOmKeyInfo() {
     assertNotNull(omBucketInfo);
-    return OMRequestTestUtils.createOmKeyInfo(volumeName,
-        omBucketInfo.getBucketName(), keyName, replicationConfig,
-        omBucketInfo.getObjectID() + 1,
-        omBucketInfo.getObjectID(), 100, Time.now());
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, omBucketInfo.getBucketName(), keyName, replicationConfig)
+        .setObjectID(omBucketInfo.getObjectID() + 1)
+        .setParentObjectID(omBucketInfo.getObjectID())
+        .setUpdateID(100L)
+        .build();
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
@@ -42,10 +42,9 @@ public class TestOMFileCreateResponseWithFSO extends TestOMKeyCreateResponse {
   protected OmKeyInfo getOmKeyInfo() {
     assertNotNull(omBucketInfo);
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
-            omBucketInfo.getBucketName(), keyName, replicationType,
-            replicationFactor,
-            omBucketInfo.getObjectID() + 1,
-            omBucketInfo.getObjectID(), 100, Time.now());
+        omBucketInfo.getBucketName(), keyName, replicationConfig,
+        omBucketInfo.getObjectID() + 1,
+        omBucketInfo.getObjectID(), 100, Time.now());
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -92,7 +92,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
 
   protected OmKeyInfo createOmKeyInfo() throws Exception {
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, replicationConfig);
+        bucketName, keyName, replicationConfig).build();
   }
 
   protected String getOpenKey() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -92,7 +92,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
 
   protected OmKeyInfo createOmKeyInfo() throws Exception {
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
-            bucketName, keyName, replicationType, replicationFactor);
+        bucketName, keyName, replicationConfig);
   }
 
   protected String getOpenKey() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponseWithFSO.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.apache.hadoop.util.Time;
 import jakarta.annotation.Nonnull;
 
 import java.io.IOException;
@@ -51,11 +50,11 @@ public class TestOMAllocateBlockResponseWithFSO
     long txnId = 50;
     long objectId = parentID + 1;
 
-    OmKeyInfo omKeyInfoFSO =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
-                Time.now());
-    return omKeyInfoFSO;
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+        .setObjectID(objectId)
+        .setParentObjectID(parentID)
+        .setUpdateID(txnId)
+        .build();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponseWithFSO.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -29,6 +29,8 @@ import org.apache.hadoop.util.Time;
 import jakarta.annotation.Nonnull;
 
 import java.io.IOException;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 
 /**
  * Tests OMAllocateBlockResponse - prefix layout.
@@ -51,9 +53,8 @@ public class TestOMAllocateBlockResponseWithFSO
 
     OmKeyInfo omKeyInfoFSO =
             OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE, objectId, parentID, txnId,
-                    Time.now());
+                RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
+                Time.now());
     return omKeyInfoFSO;
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -81,7 +81,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
   public void testAddToDBBatchNoOp() throws Exception {
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, replicationConfig);
+        bucketName, keyName, replicationConfig).build();
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setCommitKeyResponse(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -81,7 +81,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
   public void testAddToDBBatchNoOp() throws Exception {
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName, replicationType, replicationFactor);
+        bucketName, keyName, replicationConfig);
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setCommitKeyResponse(
@@ -135,7 +135,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
   @Nonnull
   protected void addKeyToOpenKeyTable() throws Exception {
     OMRequestTestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
-            clientID, replicationType, replicationFactor, omMetadataManager);
+        clientID, replicationConfig, omMetadataManager);
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.util.Time;
 import jakarta.annotation.Nonnull;
 
 import java.io.IOException;
@@ -65,10 +64,11 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   @Override
   protected OmKeyInfo getOmKeyInfo() {
     assertNotNull(omBucketInfo);
-    return OMRequestTestUtils.createOmKeyInfo(volumeName,
-        omBucketInfo.getBucketName(), keyName, replicationConfig,
-        omBucketInfo.getObjectID() + 1,
-        omBucketInfo.getObjectID(), 100, Time.now());
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, omBucketInfo.getBucketName(), keyName, replicationConfig)
+        .setObjectID(omBucketInfo.getObjectID() + 1)
+        .setParentObjectID(omBucketInfo.getObjectID())
+        .setUpdateID(100L)
+        .build();
   }
 
   @Nonnull
@@ -79,10 +79,11 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
     long objectId = parentID + 10;
 
     OmKeyInfo omKeyInfoFSO =
-        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            RatisReplicationConfig.getInstance(ONE), objectId, parentID, 100,
-            Time.now());
-
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(objectId)
+            .setParentObjectID(parentID)
+            .setUpdateID(100L)
+            .build();
     String fileName = OzoneFSUtils.getFileName(keyName);
     OMRequestTestUtils.addFileToKeyTable(true, false,
             fileName, omKeyInfoFSO, clientID, txnLogId, omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -18,10 +18,13 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
@@ -63,10 +66,9 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   protected OmKeyInfo getOmKeyInfo() {
     assertNotNull(omBucketInfo);
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
-            omBucketInfo.getBucketName(), keyName, replicationType,
-            replicationFactor,
-            omBucketInfo.getObjectID() + 1,
-            omBucketInfo.getObjectID(), 100, Time.now());
+        omBucketInfo.getBucketName(), keyName, replicationConfig,
+        omBucketInfo.getObjectID() + 1,
+        omBucketInfo.getObjectID(), 100, Time.now());
   }
 
   @Nonnull
@@ -77,10 +79,9 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
     long objectId = parentID + 10;
 
     OmKeyInfo omKeyInfoFSO =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE, objectId, parentID, 100,
-                    Time.now());
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+            RatisReplicationConfig.getInstance(ONE), objectId, parentID, 100,
+            Time.now());
 
     String fileName = OzoneFSUtils.getFileName(keyName);
     OMRequestTestUtils.addFileToKeyTable(true, false,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
@@ -18,13 +18,15 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.apache.hadoop.util.Time;
 import jakarta.annotation.Nonnull;
 
 import java.io.IOException;
@@ -50,10 +52,12 @@ public class TestOMKeyCreateResponseWithFSO extends TestOMKeyCreateResponse {
   @Override
   protected OmKeyInfo getOmKeyInfo() {
     assertNotNull(omBucketInfo);
-    return OMRequestTestUtils.createOmKeyInfo(volumeName,
-        omBucketInfo.getBucketName(), keyName, replicationConfig,
-        omBucketInfo.getObjectID() + 1,
-        omBucketInfo.getObjectID(), 100, Time.now());
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, omBucketInfo.getBucketName(), keyName,
+            RatisReplicationConfig.getInstance(ONE))
+        .setObjectID(omBucketInfo.getObjectID() + 1)
+        .setParentObjectID(omBucketInfo.getObjectID())
+        .setUpdateID(100L)
+        .build();
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
@@ -51,10 +51,9 @@ public class TestOMKeyCreateResponseWithFSO extends TestOMKeyCreateResponse {
   protected OmKeyInfo getOmKeyInfo() {
     assertNotNull(omBucketInfo);
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
-            omBucketInfo.getBucketName(), keyName, replicationType,
-            replicationFactor,
-            omBucketInfo.getObjectID() + 1,
-            omBucketInfo.getObjectID(), 100, Time.now());
+        omBucketInfo.getBucketName(), keyName, replicationConfig,
+        omBucketInfo.getObjectID() + 1,
+        omBucketInfo.getObjectID(), 100, Time.now());
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.hadoop.hdds.client.BlockID;
-import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -89,8 +88,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
     Pipeline pipeline = Pipeline.newBuilder()
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
-        .setReplicationConfig(RatisReplicationConfig
-            .getInstance(replicationFactor))
+        .setReplicationConfig(replicationConfig)
         .setNodes(new ArrayList<>())
         .build();
 
@@ -167,7 +165,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             keyName);
 
     OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
-            clientID, replicationType, replicationFactor, omMetadataManager);
+        clientID, replicationConfig, omMetadataManager);
     return ozoneKey;
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.util.Time;
 
 /**
  * Tests OMKeyDeleteResponse - prefix layout.
@@ -52,10 +51,11 @@ public class TestOMKeyDeleteResponseWithFSO extends TestOMKeyDeleteResponse {
             bucketName, "", omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            RatisReplicationConfig.getInstance(ONE),
-            parentId + 1,
-            parentId, 100, Time.now());
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+            .setObjectID(parentId + 1)
+            .setParentObjectID(parentId)
+            .setUpdateID(100L)
+            .build();
     OMRequestTestUtils.addFileToKeyTable(false, false,
             keyName, omKeyInfo, -1, 50, omMetadataManager);
     return omMetadataManager.getOzonePathKey(
@@ -67,10 +67,12 @@ public class TestOMKeyDeleteResponseWithFSO extends TestOMKeyDeleteResponse {
   @Override
   protected OmKeyInfo getOmKeyInfo() {
     assertNotNull(getOmBucketInfo());
-    return OMRequestTestUtils.createOmKeyInfo(volumeName,
-        getOmBucketInfo().getBucketName(), keyName, replicationConfig,
-        getOmBucketInfo().getObjectID() + 1,
-        getOmBucketInfo().getObjectID(), 100, Time.now());
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, omBucketInfo.getBucketName(), keyName,
+            replicationConfig)
+        .setObjectID(getOmBucketInfo().getObjectID() + 1)
+        .setParentObjectID(getOmBucketInfo().getObjectID())
+        .setUpdateID(100L)
+        .build();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
@@ -18,8 +18,10 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -50,11 +52,10 @@ public class TestOMKeyDeleteResponseWithFSO extends TestOMKeyDeleteResponse {
             bucketName, "", omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE,
-                    parentId + 1,
-                    parentId, 100, Time.now());
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+            RatisReplicationConfig.getInstance(ONE),
+            parentId + 1,
+            parentId, 100, Time.now());
     OMRequestTestUtils.addFileToKeyTable(false, false,
             keyName, omKeyInfo, -1, 50, omMetadataManager);
     return omMetadataManager.getOzonePathKey(
@@ -67,10 +68,9 @@ public class TestOMKeyDeleteResponseWithFSO extends TestOMKeyDeleteResponse {
   protected OmKeyInfo getOmKeyInfo() {
     assertNotNull(getOmBucketInfo());
     return OMRequestTestUtils.createOmKeyInfo(volumeName,
-            getOmBucketInfo().getBucketName(), keyName, replicationType,
-            replicationFactor,
-            getOmBucketInfo().getObjectID() + 1,
-            getOmBucketInfo().getObjectID(), 100, Time.now());
+        getOmBucketInfo().getBucketName(), keyName, replicationConfig,
+        getOmBucketInfo().getObjectID() + 1,
+        getOmBucketInfo().getObjectID(), 100, Time.now());
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
@@ -154,7 +154,7 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
   }
 
   protected OmKeyInfo getOmKeyInfo(String keyName) {
-    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, 0L);
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig).build();
   }
 
   protected OmKeyInfo getOmKeyInfo(OmKeyInfo toKeyInfo, String keyName) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
@@ -154,12 +154,10 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
   }
 
   protected OmKeyInfo getOmKeyInfo(String keyName) {
-    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationType, replicationFactor, 0L);
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig, 0L);
   }
 
-  protected OmKeyInfo getOmKeyInfo(OmKeyInfo toKeyInfo,
-                                   String keyName) {
+  protected OmKeyInfo getOmKeyInfo(OmKeyInfo toKeyInfo, String keyName) {
     return getOmKeyInfo(keyName);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponseWithFSO.java
@@ -18,16 +18,17 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.TestOMResponseUtils;
-import org.apache.hadoop.util.Time;
 
 import java.io.IOException;
 import java.util.UUID;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
 /**
@@ -37,17 +38,21 @@ public class TestOMKeyRenameResponseWithFSO extends TestOMKeyRenameResponse {
   @Override
   protected OmKeyInfo getOmKeyInfo(String keyName) {
     long bucketId = random.nextLong();
-    return OMRequestTestUtils.createOmKeyInfo(
-        volumeName, bucketName, keyName, replicationConfig,
-        bucketId + 100L, bucketId + 101L, 0L, Time.now());
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+        .setObjectID(bucketId + 100)
+        .setParentObjectID(bucketId + 101)
+        .build();
   }
 
   @Override
   protected OmKeyInfo getOmKeyInfo(OmKeyInfo toKeyInfo,
                                    String keyName) {
-    return OMRequestTestUtils.createOmKeyInfo(toKeyInfo.getVolumeName(),
-        toKeyInfo.getBucketName(), keyName, replicationConfig, toKeyInfo.getObjectID(),
-        toKeyInfo.getParentObjectID(), 0L, toKeyInfo.getCreationTime());
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+        .setObjectID(toKeyInfo.getObjectID())
+        .setParentObjectID(toKeyInfo.getParentObjectID())
+        .setUpdateID(0L)
+        .setCreationTime(toKeyInfo.getCreationTime())
+        .build();
   }
 
   @Override
@@ -77,12 +82,12 @@ public class TestOMKeyRenameResponseWithFSO extends TestOMKeyRenameResponse {
     long bucketId = random.nextLong();
     String fromKeyParentName = UUID.randomUUID().toString();
     String toKeyParentName = UUID.randomUUID().toString();
-    fromKeyParent = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, fromKeyParentName, replicationConfig,
-        bucketId + 100L);
-    toKeyParent = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, toKeyParentName, replicationConfig,
-        bucketId + 101L);
+    fromKeyParent = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, fromKeyParentName, replicationConfig)
+        .setObjectID(bucketId + 100L)
+        .build();
+    toKeyParent = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, toKeyParentName, replicationConfig)
+        .setObjectID(bucketId + 101L)
+        .build();
     fromKeyParent.setParentObjectID(bucketId);
     toKeyParent.setParentObjectID(bucketId);
     fromKeyParent.setFileName(OzoneFSUtils.getFileName(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponseWithFSO.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
@@ -39,8 +38,7 @@ public class TestOMKeyRenameResponseWithFSO extends TestOMKeyRenameResponse {
   protected OmKeyInfo getOmKeyInfo(String keyName) {
     long bucketId = random.nextLong();
     return OMRequestTestUtils.createOmKeyInfo(
-        volumeName, bucketName, keyName,
-        HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+        volumeName, bucketName, keyName, replicationConfig,
         bucketId + 100L, bucketId + 101L, 0L, Time.now());
   }
 
@@ -48,8 +46,7 @@ public class TestOMKeyRenameResponseWithFSO extends TestOMKeyRenameResponse {
   protected OmKeyInfo getOmKeyInfo(OmKeyInfo toKeyInfo,
                                    String keyName) {
     return OMRequestTestUtils.createOmKeyInfo(toKeyInfo.getVolumeName(),
-        toKeyInfo.getBucketName(), keyName, replicationType,
-        replicationFactor, toKeyInfo.getObjectID(),
+        toKeyInfo.getBucketName(), keyName, replicationConfig, toKeyInfo.getObjectID(),
         toKeyInfo.getParentObjectID(), 0L, toKeyInfo.getCreationTime());
   }
 
@@ -81,10 +78,10 @@ public class TestOMKeyRenameResponseWithFSO extends TestOMKeyRenameResponse {
     String fromKeyParentName = UUID.randomUUID().toString();
     String toKeyParentName = UUID.randomUUID().toString();
     fromKeyParent = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, fromKeyParentName, replicationType, replicationFactor,
+        bucketName, fromKeyParentName, replicationConfig,
         bucketId + 100L);
     toKeyParent = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, toKeyParentName, replicationType, replicationFactor,
+        bucketName, toKeyParentName, replicationConfig,
         bucketId + 101L);
     fromKeyParent.setParentObjectID(bucketId);
     toKeyParent.setParentObjectID(bucketId);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyResponse.java
@@ -117,7 +117,7 @@ public class TestOMKeyResponse {
 
   @Nonnull
   protected OmKeyInfo getOmKeyInfo() {
-    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig);
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig).build();
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyResponse.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Random;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -59,8 +60,7 @@ public class TestOMKeyResponse {
   protected String volumeName;
   protected String bucketName;
   protected String keyName;
-  protected HddsProtos.ReplicationFactor replicationFactor;
-  protected HddsProtos.ReplicationType replicationType;
+  protected ReplicationConfig replicationConfig;
   protected OmBucketInfo omBucketInfo;
   protected long clientID;
   protected Random random;
@@ -78,18 +78,18 @@ public class TestOMKeyResponse {
     volumeName = UUID.randomUUID().toString();
     bucketName = UUID.randomUUID().toString();
     keyName = UUID.randomUUID().toString();
-    replicationFactor = HddsProtos.ReplicationFactor.ONE;
-    replicationType = HddsProtos.ReplicationType.RATIS;
+    replicationConfig = ReplicationConfig.fromProtoTypeAndFactor(
+        HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE);
     clientID = 1000L;
     random = new Random();
     keysToDelete = null;
 
     final OmVolumeArgs volumeArgs = OmVolumeArgs.newBuilder()
-            .setVolume(volumeName)
-            .setAdminName("admin")
-            .setOwnerName("owner")
-            .setObjectID(System.currentTimeMillis())
-            .build();
+        .setVolume(volumeName)
+        .setAdminName("admin")
+        .setOwnerName("owner")
+        .setObjectID(System.currentTimeMillis())
+        .build();
 
     omMetadataManager.getVolumeTable().addCacheEntry(
             new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
@@ -117,8 +117,7 @@ public class TestOMKeyResponse {
 
   @Nonnull
   protected OmKeyInfo getOmKeyInfo() {
-    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            replicationType, replicationFactor);
+    return OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, replicationConfig);
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -31,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
@@ -63,7 +63,7 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
     for (int i = 0; i < 10; i++) {
       keyName = parent.concat(key + i);
       OMRequestTestUtils.addKeyToTable(false, volumeName,
-          bucketName, keyName, 0L, RATIS, THREE, omMetadataManager);
+          bucketName, keyName, 0L, RatisReplicationConfig.getInstance(THREE), omMetadataManager);
       ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
       omKeyInfoList
           .add(omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.om.response.bucket.OMBucketDeleteResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -94,9 +93,11 @@ public class TestOMKeysDeleteResponseWithFSO
       keyName = keyPrefix + i;
 
       OmKeyInfo omKeyInfo =
-          OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-              RatisReplicationConfig.getInstance(ONE), dirId + 1, buckId,
-              dirId + 1, Time.now());
+          OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+              .setObjectID(dirId + 1)
+              .setParentObjectID(buckId)
+              .setUpdateID(dirId + 1)
+              .build();
       ozoneDBKey = OMRequestTestUtils.addFileToKeyTable(false, false,
           keyName, omKeyInfo, -1, 50, omMetadataManager);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -94,8 +95,7 @@ public class TestOMKeysDeleteResponseWithFSO
 
       OmKeyInfo omKeyInfo =
           OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-              HddsProtos.ReplicationType.RATIS,
-              HddsProtos.ReplicationFactor.ONE, dirId + 1, buckId,
+              RatisReplicationConfig.getInstance(ONE), dirId + 1, buckId,
               dirId + 1, Time.now());
       ozoneDBKey = OMRequestTestUtils.addFileToKeyTable(false, false,
           keyName, omKeyInfo, -1, 50, omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysRenameResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.OmRenameKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -32,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -117,7 +117,8 @@ public class TestOMKeysRenameResponse extends TestOMKeyResponse {
       String key = parentDir.concat("/key" + i);
       String toKey = parentDir.concat("/newKey" + i);
       OMRequestTestUtils.addKeyToTable(false, volumeName,
-          bucketName, parentDir.concat("/key" + i), 0L, RATIS, THREE,
+          bucketName, parentDir.concat("/key" + i), 0L,
+          RatisReplicationConfig.getInstance(THREE),
           omMetadataManager);
 
       OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
@@ -208,7 +208,7 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
       long parentID = random.nextLong();
 
       OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volume,
-          bucket, key, replicationType, replicationFactor);
+          bucket, key, replicationConfig);
 
       if (keyLength > 0) {
         OMRequestTestUtils.addKeyLocationInfo(omKeyInfo, 0, keyLength);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMOpenKeysDeleteResponse.java
@@ -208,7 +208,7 @@ public class TestOMOpenKeysDeleteResponse extends TestOMKeyResponse {
       long parentID = random.nextLong();
 
       OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volume,
-          bucket, key, replicationConfig);
+          bucket, key, replicationConfig).build();
 
       if (keyLength > 0) {
         OMRequestTestUtils.addKeyLocationInfo(omKeyInfo, 0, keyLength);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3ExpiredMultipartUploadsAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3ExpiredMultipartUploadsAbortResponse.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.utils.UniqueId;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartAbortInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
@@ -282,7 +283,8 @@ public class TestS3ExpiredMultipartUploadsAbortResponse
 
       ReplicationConfig replicationConfig = RatisReplicationConfig.getInstance(ONE);
       final OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volume, bucket, keyName, replicationConfig,
-          0L, Time.now(), true);
+              new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+          .build();
 
       if (getBucketLayout().equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
         omKeyInfo.setParentObjectID(omBucketInfo.getObjectID());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3ExpiredMultipartUploadsAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3ExpiredMultipartUploadsAbortResponse.java
@@ -19,9 +19,12 @@
 
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.utils.UniqueId;
@@ -277,9 +280,8 @@ public class TestS3ExpiredMultipartUploadsAbortResponse
       OmBucketInfo omBucketInfo = OMRequestTestUtils.addBucketToDB(volume,
           bucket, omMetadataManager, getBucketLayout());
 
-      final OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volume,
-          bucket, keyName,
-          HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
+      ReplicationConfig replicationConfig = RatisReplicationConfig.getInstance(ONE);
+      final OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volume, bucket, keyName, replicationConfig,
           0L, Time.now(), true);
 
       if (getBucketLayout().equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -92,8 +93,11 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
         parentID, fileName);
     OmKeyInfo omKeyInfoFSO =
         OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
-            Time.now(), true);
+                RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+            .setObjectID(objectId)
+            .setParentObjectID(parentID)
+            .setUpdateID(txnId)
+            .build();
 
     // add key to openFileTable
     omKeyInfoFSO.setKeyName(fileName);
@@ -176,8 +180,11 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
         parentID, fileName);
     OmKeyInfo omKeyInfoFSO =
         OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
-            Time.now(), true);
+                RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+            .setObjectID(objectId)
+            .setParentObjectID(parentID)
+            .setUpdateID(txnId)
+            .build();
 
     // add key to openFileTable
     omKeyInfoFSO.setKeyName(fileName);
@@ -244,19 +251,20 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     String keyName = getKeyName();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-            omMetadataManager);
+        omMetadataManager);
     createParentPath(volumeName, bucketName);
 
     // Put an entry to delete table with the same key prior to multipart commit
-    OmKeyInfo prevKey = OMRequestTestUtils.createOmKeyInfo(volumeName,
-        bucketName, keyName,
-        RatisReplicationConfig.getInstance(ONE),
-        parentID + 8,
-        parentID, 8, Time.now(), true);
+    OmKeyInfo prevKey = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+            RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+        .setObjectID(parentID + 8)
+        .setParentObjectID(parentID)
+        .setUpdateID(8)
+        .build();
     RepeatedOmKeyInfo prevKeys = new RepeatedOmKeyInfo(prevKey);
     String ozoneKey = omMetadataManager
-            .getOzoneKey(prevKey.getVolumeName(),
-                    prevKey.getBucketName(), prevKey.getFileName());
+        .getOzoneKey(prevKey.getVolumeName(),
+            prevKey.getBucketName(), prevKey.getFileName());
     omMetadataManager.getDeletedTable().put(ozoneKey, prevKeys);
 
     long oId = runAddDBToBatchWithParts(volumeName, bucketName, keyName, 1);
@@ -312,9 +320,11 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
 
     OmKeyInfo omKeyInfo =
         OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            RatisReplicationConfig.getInstance(ONE),
-            parentID + 9,
-            parentID, 100, Time.now(), true);
+                RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
+            .setObjectID(parentID + 9)
+            .setParentObjectID(parentID)
+            .setUpdateID(100)
+            .build();
     List<OmKeyInfo> unUsedParts = new ArrayList<>();
     unUsedParts.add(omKeyInfo);
     S3MultipartUploadCompleteResponse s3MultipartUploadCompleteResponse =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
@@ -18,11 +18,13 @@
 
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -85,14 +87,13 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     String dbOpenKey = omMetadataManager.getOpenFileName(volumeId, bucketId,
-            parentID, fileName, clientId);
+        parentID, fileName, clientId);
     String dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
-            parentID, fileName);
+        parentID, fileName);
     OmKeyInfo omKeyInfoFSO =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE, objectId, parentID, txnId,
-                    Time.now(), true);
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+            RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
+            Time.now(), true);
 
     // add key to openFileTable
     omKeyInfoFSO.setKeyName(fileName);
@@ -175,8 +176,7 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
         parentID, fileName);
     OmKeyInfo omKeyInfoFSO =
         OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, objectId, parentID, txnId,
+            RatisReplicationConfig.getInstance(ONE), objectId, parentID, txnId,
             Time.now(), true);
 
     // add key to openFileTable
@@ -249,11 +249,10 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
 
     // Put an entry to delete table with the same key prior to multipart commit
     OmKeyInfo prevKey = OMRequestTestUtils.createOmKeyInfo(volumeName,
-            bucketName, keyName,
-            HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE,
-            parentID + 8,
-            parentID, 8, Time.now(), true);
+        bucketName, keyName,
+        RatisReplicationConfig.getInstance(ONE),
+        parentID + 8,
+        parentID, 8, Time.now(), true);
     RepeatedOmKeyInfo prevKeys = new RepeatedOmKeyInfo(prevKey);
     String ozoneKey = omMetadataManager
             .getOzoneKey(prevKey.getVolumeName(),
@@ -312,11 +311,10 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
             omMetadataManager.getBucketTable().get(bucketKey);
 
     OmKeyInfo omKeyInfo =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-                    HddsProtos.ReplicationType.RATIS,
-                    HddsProtos.ReplicationFactor.ONE,
-                    parentID + 9,
-                    parentID, 100, Time.now(), true);
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+            RatisReplicationConfig.getInstance(ONE),
+            parentID + 9,
+            parentID, 100, Time.now(), true);
     List<OmKeyInfo> unUsedParts = new ArrayList<>();
     unUsedParts.add(omKeyInfo);
     S3MultipartUploadCompleteResponse s3MultipartUploadCompleteResponse =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -131,9 +131,11 @@ public class TestDirectoryDeletingService {
     for (int i = 0; i < 2000; ++i) {
       String keyName = "key" + longName + i;
       OmKeyInfo omKeyInfo =
-          OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName,
-              keyName, RatisReplicationConfig.getInstance(ONE), dir1.getObjectID() + 1 + i,
-              dir1.getObjectID(), 100, Time.now());
+          OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+              .setObjectID(dir1.getObjectID() + 1 + i)
+              .setParentObjectID(dir1.getObjectID())
+              .setUpdateID(100L)
+              .build();
       OMRequestTestUtils.addFileToKeyTable(false, true, keyName,
           omKeyInfo, 1234L, i + 1, om.getMetadataManager());
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestDirectoryDeletingService.java
@@ -23,9 +23,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.utils.db.DBConfigFromFile;
 import org.apache.hadoop.ozone.om.KeyManager;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -130,8 +132,7 @@ public class TestDirectoryDeletingService {
       String keyName = "key" + longName + i;
       OmKeyInfo omKeyInfo =
           OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName,
-              keyName, HddsProtos.ReplicationType.RATIS,
-              HddsProtos.ReplicationFactor.ONE, dir1.getObjectID() + 1 + i,
+              keyName, RatisReplicationConfig.getInstance(ONE), dir1.getObjectID() + 1 + i,
               dir1.getObjectID(), 100, Time.now());
       OMRequestTestUtils.addFileToKeyTable(false, true, keyName,
           omKeyInfo, 1234L, i + 1, om.getMetadataManager());
@@ -143,7 +144,7 @@ public class TestDirectoryDeletingService {
         .setBucketName(bucketName)
         .setKeyName("dir" + longName)
         .setReplicationConfig(StandaloneReplicationConfig.getInstance(
-            HddsProtos.ReplicationFactor.ONE))
+            ONE))
         .setDataSize(0).setRecursive(true)
         .build();
     writeClient.deleteKey(delArgs);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
@@ -19,8 +19,11 @@
 
 package org.apache.hadoop.ozone.om.service;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -48,8 +51,7 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     String parentDir = "/user";
     for (int i = 0; i < count; i++) {
       OMRequestTestUtils.addKeyToTableAndCache(volumeName, bucketName,
-          parentDir.concat("/key" + i), -1, HddsProtos.ReplicationType.RATIS,
-          HddsProtos.ReplicationFactor.THREE, 150 + i, omMetadataManager);
+          parentDir.concat("/key" + i), -1, RatisReplicationConfig.getInstance(THREE), 150 + i, omMetadataManager);
     }
 
     String fsoBucketName = "fso" + bucketName;
@@ -61,8 +63,7 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
       String fileName = "file1" + i;
       OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(
           volumeName, fsoBucketName, fileName,
-          HddsProtos.ReplicationType.RATIS,
-          HddsProtos.ReplicationFactor.ONE,
+          RatisReplicationConfig.getInstance(ONE),
           parentId + 1 + i,
           parentId, 100 + i, Time.now());
       omKeyInfo.setKeyName(fileName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
@@ -61,11 +61,13 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
         fsoBucketName, "c/d/e", omMetadataManager);
     for (int i = 0; i < count; i++) {
       String fileName = "file1" + i;
-      OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(
-          volumeName, fsoBucketName, fileName,
-          RatisReplicationConfig.getInstance(ONE),
-          parentId + 1 + i,
-          parentId, 100 + i, Time.now());
+      OmKeyInfo omKeyInfo =
+          OMRequestTestUtils.createOmKeyInfo(volumeName, fsoBucketName, fileName,
+                  RatisReplicationConfig.getInstance(ONE))
+              .setObjectID(parentId + 1 + i)
+              .setParentObjectID(parentId)
+              .setUpdateID(100L)
+              .build();
       omKeyInfo.setKeyName(fileName);
       OMRequestTestUtils.addFileToKeyTable(false, false,
           fileName, omKeyInfo, -1, 50 + i, omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
@@ -66,7 +66,7 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
                   RatisReplicationConfig.getInstance(ONE))
               .setObjectID(parentId + 1 + i)
               .setParentObjectID(parentId)
-              .setUpdateID(100L)
+              .setUpdateID(100L + i)
               .build();
       omKeyInfo.setKeyName(fileName);
       OMRequestTestUtils.addFileToKeyTable(false, false,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In OMRequestTestUtils the createOmKeyInfo was repeated a lot of times with minor changes instead of using a builder pattern. Here those usages are eliminated and only 2 of them remains.

The two methods only differ in 1 parameter because the setter `setOmKeyLocationInfos` is actually an addAll method that doesn't overwrite the previous values and there could be unforeseen bugs storing multiple OmKeyLocationInfos with the same version number.

Another small refactor is that instead of using replication type and factor together they are combined into replicationconfig now.

[HDDS-10266](https://issues.apache.org/jira/browse/HDDS-10226)

## How was this patch tested?

No functional change was created for production code, all tests have passed in ci run:
https://github.com/Galsza/ozone/actions/runs/7800629334/job/21280738076
