### PR TITLE
HDDS-10328. Support cross realm Kerberos out of box.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2227,6 +2227,14 @@
     <description>The OzoneManager service principal. Ex om/_HOST@REALM.COM</description>
   </property>
   <property>
+    <name>ozone.om.kerberos.principal.pattern</name>
+    <value>*</value>
+    <description>
+      A client-side RegEx that can be configured to control
+      allowed realms to authenticate with (useful in cross-realm env.)
+    </description>
+  </property>
+  <property>
     <name>ozone.om.http.auth.kerberos.principal</name>
     <value>HTTP/_HOST@REALM</value>
     <tag>OZONE, SECURITY, KERBEROS</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -289,6 +289,8 @@ public final class OMConfigKeys {
       + "kerberos.keytab.file";
   public static final String OZONE_OM_KERBEROS_PRINCIPAL_KEY = "ozone.om"
       + ".kerberos.principal";
+  public static final String OZONE_OM_KERBEROS_PRINCIPAL_PATTERN_KEY =
+      "ozone.om.kerberos.principal.pattern";
   public static final String OZONE_OM_HTTP_KERBEROS_KEYTAB_FILE =
       "ozone.om.http.auth.kerberos.keytab";
   public static final String OZONE_OM_HTTP_KERBEROS_PRINCIPAL_KEY


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a default value "*" for the configuration property ozone.om.kerberos.principal.pattern to support accessing Ozone cluster in other Kerberos realms.

Please describe your PR in detail:
* Follow what was done in HDFS-7546.
* Currently we simply workaround the issue by adding the property to the command line. Adding it to the default makes Ozone more user friendly. E.g. 
`hdfs dfs -Dozone.om.kerberos.principal.pattern=* -ls ofs://ozone1707264383/vol1/bucket1/`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10328

## How was this patch tested?

