### PR TITLE
HDDS-10322. Make VolumeArgs immutable

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/VolumeArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/VolumeArgs.java
@@ -18,10 +18,13 @@
 
 package org.apache.hadoop.ozone.client;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,8 +39,8 @@ public final class VolumeArgs {
   private final String owner;
   private final long quotaInBytes;
   private final long quotaInNamespace;
-  private final List<OzoneAcl> acls;
-  private Map<String, String> metadata;
+  private final ImmutableList<OzoneAcl> acls;
+  private final ImmutableMap<String, String> metadata;
 
   /**
    * Private constructor, constructed via builder.
@@ -58,8 +61,8 @@ public final class VolumeArgs {
     this.owner = owner;
     this.quotaInBytes = quotaInBytes;
     this.quotaInNamespace = quotaInNamespace;
-    this.acls = acls;
-    this.metadata = metadata;
+    this.acls = acls == null ? ImmutableList.of() : ImmutableList.copyOf(acls);
+    this.metadata = metadata == null ? ImmutableMap.of() : ImmutableMap.copyOf(metadata);
   }
 
   /**
@@ -107,34 +110,20 @@ public final class VolumeArgs {
     return acls;
   }
 
-  /**
-   * Returns new builder class that builds a OmVolumeArgs.
-   *
-   * @return Builder
-   */
   public static VolumeArgs.Builder newBuilder() {
     return new VolumeArgs.Builder();
   }
 
   /**
-   * Builder for OmVolumeArgs.
+   * Builder for VolumeArgs.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static class Builder {
     private String adminName;
     private String ownerName;
-    private long quotaInBytes;
-    private long quotaInNamespace;
-    private List<OzoneAcl> listOfAcls;
-    private Map<String, String> metadata = new HashMap<>();
-
-    /**
-     * Constructs a builder.
-     */
-    public Builder() {
-      quotaInBytes = OzoneConsts.QUOTA_RESET;
-      quotaInNamespace = OzoneConsts.QUOTA_RESET;
-    }
+    private long quotaInBytes = OzoneConsts.QUOTA_RESET;
+    private long quotaInNamespace = OzoneConsts.QUOTA_RESET;
+    private List<OzoneAcl> acls;
+    private Map<String, String> metadata;
 
     public VolumeArgs.Builder setAdmin(String admin) {
       this.adminName = admin;
@@ -157,12 +146,18 @@ public final class VolumeArgs {
     }
 
     public VolumeArgs.Builder addMetadata(String key, String value) {
+      if (metadata == null) {
+        metadata = new HashMap<>();
+      }
       metadata.put(key, value);
       return this;
     }
-    public VolumeArgs.Builder setAcls(List<OzoneAcl> acls)
+    public VolumeArgs.Builder addAcl(OzoneAcl acl)
         throws IOException {
-      this.listOfAcls = acls;
+      if (acls == null) {
+        acls = new ArrayList<>();
+      }
+      acls.add(acl);
       return this;
     }
 
@@ -172,7 +167,7 @@ public final class VolumeArgs {
      */
     public VolumeArgs build() {
       return new VolumeArgs(adminName, ownerName, quotaInBytes,
-          quotaInNamespace, listOfAcls, metadata);
+          quotaInNamespace, acls, metadata);
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -430,8 +430,9 @@ public class RpcClient implements ClientProtocol {
     userGroups.stream().forEach((group) -> listOfAcls.add(
         new OzoneAcl(ACLIdentityType.GROUP, group, groupRights, ACCESS)));
     //ACLs from VolumeArgs
-    if (volArgs.getAcls() != null) {
-      listOfAcls.addAll(volArgs.getAcls());
+    List<OzoneAcl> volumeAcls = volArgs.getAcls();
+    if (volumeAcls != null) {
+      listOfAcls.addAll(volumeAcls);
     }
 
     OmVolumeArgs.Builder builder = OmVolumeArgs.newBuilder();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1185,18 +1185,14 @@ abstract class AbstractRootedOzoneFileSystemTest {
     BitSet aclRights = new BitSet();
     aclRights.set(READ.ordinal());
     aclRights.set(WRITE.ordinal());
-    List<OzoneAcl> objectAcls = new ArrayList<>();
-    objectAcls.add(new OzoneAcl(ACLIdentityType.WORLD, "",
-        aclRights, ACCESS));
-    objectAcls.add(new OzoneAcl(ACLIdentityType.USER, "admin", userRights,
-        ACCESS));
     // volume acls have all access to admin and read+write access to world
 
     // Construct VolumeArgs
-    VolumeArgs volumeArgs = new VolumeArgs.Builder()
+    VolumeArgs volumeArgs = VolumeArgs.newBuilder()
         .setAdmin("admin")
         .setOwner("admin")
-        .setAcls(Collections.unmodifiableList(objectAcls))
+        .addAcl(new OzoneAcl(ACLIdentityType.WORLD, "", aclRights, ACCESS))
+        .addAcl(new OzoneAcl(ACLIdentityType.USER, "admin", userRights, ACCESS))
         .setQuotaInNamespace(1000)
         .setQuotaInBytes(Long.MAX_VALUE).build();
     // Sanity check
@@ -1227,7 +1223,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     }
 
     // set acls for shared tmp mount under the tmp volume
-    objectAcls.clear();
+    List<OzoneAcl> objectAcls = new ArrayList<>();
     objectAcls.add(new OzoneAcl(ACLIdentityType.USER, "admin", userRights,
         ACCESS));
     aclRights.clear(DELETE.ordinal());
@@ -1302,8 +1298,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
     OzoneAcl aclWorldAccess = new OzoneAcl(ACLIdentityType.WORLD, "",
         userRights, ACCESS);
     // Construct VolumeArgs
-    VolumeArgs volumeArgs = new VolumeArgs.Builder()
-        .setAcls(Collections.singletonList(aclWorldAccess))
+    VolumeArgs volumeArgs = VolumeArgs.newBuilder()
+        .addAcl(aclWorldAccess)
         .setQuotaInNamespace(1000).build();
     // Sanity check
     assertNull(volumeArgs.getOwner());
@@ -2303,8 +2299,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
     OzoneAcl aclWorldAccess = new OzoneAcl(ACLIdentityType.WORLD, "",
         userRights, ACCESS);
     // Construct VolumeArgs, set ACL to world access
-    VolumeArgs volumeArgs = new VolumeArgs.Builder()
-        .setAcls(Collections.singletonList(aclWorldAccess))
+    VolumeArgs volumeArgs = VolumeArgs.newBuilder()
+        .addAcl(aclWorldAccess)
         .build();
     proxy.createVolume(volume, volumeArgs);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -630,7 +630,7 @@ public class TestOzoneManagerSnapshotAcl {
   private void createVolume() throws IOException {
     final String volumePrefix = "volume-";
     volumeName = volumePrefix + RandomStringUtils.randomNumeric(32);
-    final VolumeArgs volumeArgs = new VolumeArgs.Builder()
+    final VolumeArgs volumeArgs = VolumeArgs.newBuilder()
         .setAdmin(ADMIN)
         .setOwner(ADMIN)
         .build();

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
@@ -20,7 +20,6 @@
 package org.apache.hadoop.ozone.client;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -62,7 +61,7 @@ public class ObjectStoreStub extends ObjectStore {
             .setAdmin("root")
             .setOwner("root")
             .setQuotaInBytes(Integer.MAX_VALUE)
-            .setAcls(new ArrayList<>()).build());
+            .build());
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix findbugs warnings by making `VolumeArgs` immutable.

```
M V EI: org.apache.hadoop.ozone.client.VolumeArgs.getAcls() may expose internal representation by returning VolumeArgs.acls  At VolumeArgs.java:[line 107]
M V EI: org.apache.hadoop.ozone.client.VolumeArgs.getMetadata() may expose internal representation by returning VolumeArgs.metadata  At VolumeArgs.java:[line 103]
M V EI2: org.apache.hadoop.ozone.client.VolumeArgs$Builder.setAcls(List) may expose internal representation by storing an externally mutable object into VolumeArgs$Builder.listOfAcls  At VolumeArgs.java:[line 165]
```

Findbugs complains about `get...` method even if the corresponding field is initialized using `Collections.unmodifiable...`.  Two possible ways to solve the problem:
1. wrap in `unmodifiable...` in `get...` method
2. use `Immutable...` collection (from Guava) and declare the field as such

This patch uses the second approach.

https://issues.apache.org/jira/browse/HDDS-10322

## How was this patch tested?

```
$ hadoop-ozone/dev-support/checks/findbugs.sh -Dspotbugs.version=4.8.3.0
$ grep -c 'client.VolumeArgs' target/findbugs/summary.txt
0
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7820568596