### PR TITLE
HDDS-10218. Speed up TestSstFilteringService

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
@@ -18,86 +18,30 @@
 
 package org.apache.hadoop.ozone;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
-import org.apache.hadoop.ozone.client.rpc.RpcClient;
-
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.rpc.RpcType;
-import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.statemachine.StateMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 
 /**
  * Helpers for Ratis tests.
  */
 public interface RatisTestHelper {
   Logger LOG = LoggerFactory.getLogger(RatisTestHelper.class);
-
-  /** For testing Ozone with Ratis. */
-  class RatisTestSuite implements Closeable {
-    static final RpcType RPC = SupportedRpcType.GRPC;
-    static final int NUM_DATANODES = 3;
-
-    private final OzoneConfiguration conf;
-    private final MiniOzoneCluster cluster;
-
-    /**
-     * Create a {@link MiniOzoneCluster} for testing by setting.
-     *   OZONE_ENABLED = true
-     *   RATIS_ENABLED = true
-     */
-    public RatisTestSuite()
-        throws IOException, TimeoutException, InterruptedException {
-      conf = newOzoneConfiguration(RPC);
-
-      cluster = newMiniOzoneCluster(NUM_DATANODES, conf);
-    }
-
-    public OzoneConfiguration getConf() {
-      return conf;
-    }
-
-    public MiniOzoneCluster getCluster() {
-      return cluster;
-    }
-
-    public ClientProtocol newOzoneClient()
-        throws IOException {
-      return new RpcClient(conf, null);
-    }
-
-    @Override
-    public void close() {
-      cluster.shutdown();
-    }
-
-    public int getDatanodeOzoneRestPort() {
-      return cluster.getHddsDatanodes().get(0).getDatanodeDetails()
-          .getPort(DatanodeDetails.Port.Name.REST).getValue();
-    }
-  }
-
-  static OzoneConfiguration newOzoneConfiguration(RpcType rpc) {
-    final OzoneConfiguration conf = new OzoneConfiguration();
-    initRatisConf(rpc, conf);
-    return conf;
-  }
 
   static void initRatisConf(RpcType rpc, OzoneConfiguration conf) {
     conf.setBoolean(OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLED_KEY, true);
@@ -106,17 +50,6 @@ public interface RatisTestHelper {
     conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 30, TimeUnit.SECONDS);
     LOG.info("{} = {}", OzoneConfigKeys.DFS_CONTAINER_RATIS_RPC_TYPE_KEY,
             rpc.name());
-  }
-
-  static MiniOzoneCluster newMiniOzoneCluster(
-      int numDatanodes, OzoneConfiguration conf)
-      throws IOException, TimeoutException, InterruptedException {
-    final MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf)
-        .setHbInterval(1000)
-        .setHbProcessorInterval(1000)
-        .setNumDatanodes(numDatanodes).build();
-    cluster.waitForClusterToBeReady();
-    return cluster;
   }
 
   static void initXceiverServerRatis(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -36,10 +36,10 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotCache;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ratis.util.ExitUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.LiveFileMetaData;
@@ -81,12 +81,8 @@ public class TestSstFilteringService {
   private KeyManager keyManager;
 
   @BeforeAll
-  public static void setup() {
+  void setup() throws AuthenticationException, IOException, InterruptedException, TimeoutException {
     ExitUtils.disableSystemExit();
-  }
-
-  @BeforeEach
-  void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(OZONE_METADATA_DIRS, folder.getAbsolutePath());
     conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,
@@ -102,7 +98,7 @@ public class TestSstFilteringService {
     om = omTestManagers.getOzoneManager();
   }
 
-  @AfterEach
+  @AfterAll
   public void cleanup() throws Exception {
     if (keyManager != null) {
       keyManager.stop();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -78,7 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(OrderAnnotation.class)
 public class TestSstFilteringService {
-  private static final String SST_FILE_EXTENSION = ".sst";;
+  private static final String SST_FILE_EXTENSION = ".sst";
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
   private OzoneConfiguration conf;
@@ -189,8 +189,7 @@ public class TestSstFilteringService {
     activeDbStore.getDb().flush(OmMetadataManagerImpl.KEY_TABLE);
     List<LiveFileMetaData> allFiles = activeDbStore.getDb().getSstFileList();
     String snapshotName1 = "snapshot1";
-    writeClient.createSnapshot(volumeName, bucketName2, snapshotName1);
-    countTotalSnapshots++;
+    createSnapshot(volumeName, bucketName2, snapshotName1);
     SnapshotInfo snapshotInfo = om.getMetadataManager().getSnapshotInfoTable()
         .get(SnapshotInfo.getTableKey(volumeName, bucketName2, snapshotName1));
     assertFalse(snapshotInfo.isSstFiltered());
@@ -227,8 +226,7 @@ public class TestSstFilteringService {
     try (BootstrapStateHandler.Lock lock =
              filteringService.getBootstrapStateLock().lock()) {
       count = filteringService.getSnapshotFilteredCount().get();
-      writeClient.createSnapshot(volumeName, bucketName2, snapshotName2);
-      countTotalSnapshots++;
+      createSnapshot(volumeName, bucketName2, snapshotName2);
 
       assertThrows(TimeoutException.class,
           () -> waitForSnapshotsAtLeast(filteringService, count + 1));
@@ -272,10 +270,8 @@ public class TestSstFilteringService {
         keyManager.getSnapshotSstFilteringService();
     sstFilteringService.pause();
 
-    writeClient.createSnapshot(volumeName, bucketNames.get(0), "snap1");
-    countTotalSnapshots++;
-    writeClient.createSnapshot(volumeName, bucketNames.get(0), "snap2");
-    countTotalSnapshots++;
+    createSnapshot(volumeName, bucketNames.get(0), "snap1");
+    createSnapshot(volumeName, bucketNames.get(0), "snap2");
 
     SnapshotInfo snapshot1Info = om.getMetadataManager().getSnapshotInfoTable()
         .get(SnapshotInfo.getTableKey(volumeName, bucketNames.get(0), "snap1"));
@@ -422,8 +418,7 @@ public class TestSstFilteringService {
     List<String> snapshotNames = Arrays.asList("snap", "snap-1", "snap-2");
 
     for (int i = 0; i < 3; i++) {
-      writeClient.createSnapshot(volumeName, bucketNames.get(i), snapshotNames.get(i));
-      countTotalSnapshots++;
+      createSnapshot(volumeName, bucketNames.get(i), snapshotNames.get(i));
     }
 
     SstFilteringService sstFilteringService =
@@ -483,5 +478,10 @@ public class TestSstFilteringService {
       OmSnapshot omSnapshot = (OmSnapshot) snapshotMetadataReader.get();
       return getKeysFromDb(omSnapshot.getMetadataManager(), volume, bucket);
     }
+  }
+
+  private void createSnapshot(String volumeName, String bucketName, String snapshotName) throws IOException {
+    writeClient.createSnapshot(volumeName, bucketName, snapshotName);
+    countTotalSnapshots++;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -78,7 +78,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(OrderAnnotation.class)
 public class TestSstFilteringService {
-  public static final String SST_FILE_EXTENSION = ".sst";;
+  private static final String SST_FILE_EXTENSION = ".sst";;
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
   private OzoneConfiguration conf;
@@ -313,7 +313,7 @@ public class TestSstFilteringService {
     assertEquals(snap1SstFileCountBeforeFilter, snap1SstFileCountAfterFilter);
     // If method with order 1 is run .sst file from /vol1/buck1 and /vol1/buck2 will be deleted.
     // As part of this method .sst file from /volume1/bucket2/ will be deleted.
-    // sstFiltering won't run on deleted snapshots /volume1/bucket1.
+    // sstFiltering won't run on deleted snapshots in /volume1/bucket1.
     assertThat(snap2SstFileCountBeforeFilter).isGreaterThan(snap2SstFileCountAfterFilter);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSstFilteringService.java
@@ -41,6 +41,7 @@ import org.apache.ratis.util.ExitUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.LiveFileMetaData;
 
@@ -71,17 +72,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test SST Filtering Service.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestSstFilteringService {
-  public static final String SST_FILE_EXTENSION = ".sst";
-  @TempDir
-  private File folder;
+  public static final String SST_FILE_EXTENSION = ".sst";;
   private OzoneManagerProtocol writeClient;
   private OzoneManager om;
   private OzoneConfiguration conf;
   private KeyManager keyManager;
 
   @BeforeAll
-  void setup() throws AuthenticationException, IOException, InterruptedException, TimeoutException {
+  void setup(@TempDir File folder) throws AuthenticationException, IOException, InterruptedException, TimeoutException {
     ExitUtils.disableSystemExit();
     conf = new OzoneConfiguration();
     conf.set(OZONE_METADATA_DIRS, folder.getAbsolutePath());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changes are done to improve the test run speed to 33.23 s as compare to 59.43 s earlier.
- The setup method modified to be initialize one time for all methods.
- Introduced the method orderer
- Declared one counter to track the number of snapshots been generated in all the methods to assert the count according.
- Separated the methods for creation of volume and bucket which was combine and there were repeated calls to it.
- Changed one assert statement to assert that because the .sst file from the bucket created in first method was not consistent to available in second method.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10218

## How was this patch tested?
Tested on local system and in CI-CD integration.
