### PR TITLE
HDDS-10330. Rename additional Ozone/HDDS config keys prefixed with 'dfs'

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -51,7 +51,7 @@ public final class ScmConfigKeys {
       = "GRPC";
   public static final String
       DFS_CONTAINER_RATIS_NUM_WRITE_CHUNK_THREADS_PER_VOLUME
-      = "dfs.container.ratis.num.write.chunk.threads.per.volume";
+      = "ozone.container.ratis.num.write.chunk.threads.per.volume";
   public static final int
       DFS_CONTAINER_RATIS_NUM_WRITE_CHUNK_THREADS_PER_VOLUME_DEFAULT
       = 10;
@@ -79,44 +79,44 @@ public final class ScmConfigKeys {
       TimeDuration.valueOf(10, TimeUnit.SECONDS);
   public static final String
       DFS_CONTAINER_RATIS_STATEMACHINEDATA_SYNC_RETRIES =
-      "dfs.container.ratis.statemachinedata.sync.retries";
+      "ozone.container.ratis.statemachinedata.sync.retries";
   public static final String
       DFS_CONTAINER_RATIS_STATEMACHINE_MAX_PENDING_APPLY_TXNS =
-      "dfs.container.ratis.statemachine.max.pending.apply-transactions";
+      "ozone.container.ratis.statemachine.max.pending.apply-transactions";
   // The default value of maximum number of pending state machine apply
   // transactions is kept same as default snapshot threshold.
   public static final int
       DFS_CONTAINER_RATIS_STATEMACHINE_MAX_PENDING_APPLY_TXNS_DEFAULT =
       100000;
   public static final String DFS_CONTAINER_RATIS_LOG_QUEUE_NUM_ELEMENTS =
-      "dfs.container.ratis.log.queue.num-elements";
+      "ozone.container.ratis.log.queue.num-elements";
   public static final int DFS_CONTAINER_RATIS_LOG_QUEUE_NUM_ELEMENTS_DEFAULT =
       1024;
   public static final String DFS_CONTAINER_RATIS_LOG_QUEUE_BYTE_LIMIT =
-      "dfs.container.ratis.log.queue.byte-limit";
+      "ozone.container.ratis.log.queue.byte-limit";
   public static final String DFS_CONTAINER_RATIS_LOG_QUEUE_BYTE_LIMIT_DEFAULT =
       "4GB";
   public static final String
       DFS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS =
-      "dfs.container.ratis.log.appender.queue.num-elements";
+      "ozone.container.ratis.log.appender.queue.num-elements";
   public static final int
       DFS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS_DEFAULT = 1;
   public static final String DFS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT =
-      "dfs.container.ratis.log.appender.queue.byte-limit";
+      "ozone.container.ratis.log.appender.queue.byte-limit";
   public static final String
       DFS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT = "32MB";
   public static final String DFS_CONTAINER_RATIS_LOG_PURGE_GAP =
-      "dfs.container.ratis.log.purge.gap";
+      "ozone.container.ratis.log.purge.gap";
   // TODO: Set to 1024 once RATIS issue around purge is fixed.
   public static final int DFS_CONTAINER_RATIS_LOG_PURGE_GAP_DEFAULT =
       1000000;
   public static final String DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT =
-      "dfs.container.ratis.leader.pending.bytes.limit";
+      "ozone.container.ratis.leader.pending.bytes.limit";
   public static final String
       DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT = "1GB";
 
   public static final String DFS_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DURATION_KEY =
-      "dfs.ratis.server.retry-cache.timeout.duration";
+      "ozone.ratis.server.retry-cache.timeout.duration";
   public static final TimeDuration
       DFS_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DURATION_DEFAULT =
       TimeDuration.valueOf(600000, TimeUnit.MILLISECONDS);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -65,13 +65,13 @@ public final class OzoneConfigKeys {
       false;
 
   public static final String DFS_CONTAINER_RATIS_DATASTREAM_RANDOM_PORT =
-      "dfs.container.ratis.datastream.random.port";
+      "ozone.container.ratis.datastream.random.port";
   public static final boolean
       DFS_CONTAINER_RATIS_DATASTREAM_RANDOM_PORT_DEFAULT =
       false;
 
   public static final String DFS_CONTAINER_CHUNK_WRITE_SYNC_KEY =
-      "dfs.container.chunk.write.sync";
+      "ozone.container.chunk.write.sync";
   public static final boolean DFS_CONTAINER_CHUNK_WRITE_SYNC_DEFAULT = false;
   /**
    * Ratis Port where containers listen to.
@@ -83,24 +83,24 @@ public final class OzoneConfigKeys {
    * Ratis Port where containers listen to admin requests.
    */
   public static final String DFS_CONTAINER_RATIS_ADMIN_PORT =
-      "dfs.container.ratis.admin.port";
+      "ozone.container.ratis.admin.port";
   public static final int DFS_CONTAINER_RATIS_ADMIN_PORT_DEFAULT = 9857;
   /**
    * Ratis Port where containers listen to server-to-server requests.
    */
   public static final String DFS_CONTAINER_RATIS_SERVER_PORT =
-      "dfs.container.ratis.server.port";
+      "ozone.container.ratis.server.port";
   public static final int DFS_CONTAINER_RATIS_SERVER_PORT_DEFAULT = 9856;
 
   /**
    * Ratis Port where containers listen to datastream requests.
    */
   public static final String DFS_CONTAINER_RATIS_DATASTREAM_ENABLED
-      = "dfs.container.ratis.datastream.enabled";
+      = "ozone.container.ratis.datastream.enabled";
   public static final boolean DFS_CONTAINER_RATIS_DATASTREAM_ENABLED_DEFAULT
       = false;
   public static final String DFS_CONTAINER_RATIS_DATASTREAM_PORT
-      = "dfs.container.ratis.datastream.port";
+      = "ozone.container.ratis.datastream.port";
   public static final int DFS_CONTAINER_RATIS_DATASTREAM_PORT_DEFAULT
       = 9855;
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -53,19 +53,19 @@
   </property>
 
   <property>
-    <name>dfs.container.ratis.datastream.enabled</name>
+    <name>ozone.container.ratis.datastream.enabled</name>
     <value>false</value>
     <tag>OZONE, CONTAINER, RATIS, DATASTREAM</tag>
     <description>It specifies whether to enable data stream of container.</description>
   </property>
   <property>
-    <name>dfs.container.ratis.datastream.port</name>
+    <name>ozone.container.ratis.datastream.port</name>
     <value>9855</value>
     <tag>OZONE, CONTAINER, RATIS, DATASTREAM</tag>
     <description>The datastream port number of container.</description>
   </property>
   <property>
-    <name>dfs.container.ratis.datastream.random.port</name>
+    <name>ozone.container.ratis.datastream.random.port</name>
     <value>false</value>
     <tag>OZONE, CONTAINER, RATIS, DATASTREAM</tag>
     <description>Allocates a random free port for ozone container datastream.
@@ -82,7 +82,7 @@
     </description>
   </property>
   <property>
-    <name>dfs.container.chunk.write.sync</name>
+    <name>ozone.container.chunk.write.sync</name>
     <value>false</value>
     <tag>OZONE, CONTAINER, MANAGEMENT</tag>
     <description>Determines whether the chunk writes in the container happen as
@@ -97,7 +97,7 @@
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.statemachinedata.sync.retries</name>
+    <name>ozone.container.ratis.statemachinedata.sync.retries</name>
     <value/>
     <tag>OZONE, DEBUG, CONTAINER, RATIS</tag>
     <description>Number of times the WriteStateMachineData op will be tried
@@ -112,21 +112,21 @@
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.log.queue.num-elements</name>
+    <name>ozone.container.ratis.log.queue.num-elements</name>
     <value>1024</value>
     <tag>OZONE, DEBUG, CONTAINER, RATIS</tag>
     <description>Limit for the number of operations in Ratis Log Worker.
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.log.queue.byte-limit</name>
+    <name>ozone.container.ratis.log.queue.byte-limit</name>
     <value>4GB</value>
     <tag>OZONE, DEBUG, CONTAINER, RATIS</tag>
     <description>Byte limit for Ratis Log Worker queue.
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.log.appender.queue.num-elements</name>
+    <name>ozone.container.ratis.log.appender.queue.num-elements</name>
     <value>1</value>
     <tag>OZONE, DEBUG, CONTAINER, RATIS</tag>
     <description>Limit for number of append entries in ratis leader's
@@ -134,14 +134,14 @@
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.log.appender.queue.byte-limit</name>
+    <name>ozone.container.ratis.log.appender.queue.byte-limit</name>
     <value>32MB</value>
     <tag>OZONE, DEBUG, CONTAINER, RATIS</tag>
     <description>Byte limit for ratis leader's log appender queue.
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.log.purge.gap</name>
+    <name>ozone.container.ratis.log.purge.gap</name>
     <value>1000000</value>
     <tag>OZONE, DEBUG, CONTAINER, RATIS</tag>
     <description>Purge gap between the last purged commit index
@@ -238,13 +238,13 @@
     <description>The ipc port number of container for clients.</description>
   </property>
   <property>
-    <name>dfs.container.ratis.admin.port</name>
+    <name>ozone.container.ratis.admin.port</name>
     <value>9857</value>
     <tag>OZONE, CONTAINER, PIPELINE, RATIS, MANAGEMENT</tag>
     <description>The ipc port number of container for admin requests.</description>
   </property>
   <property>
-    <name>dfs.container.ratis.server.port</name>
+    <name>ozone.container.ratis.server.port</name>
     <value>9856</value>
     <tag>OZONE, CONTAINER, PIPELINE, RATIS, MANAGEMENT</tag>
     <description>The ipc port number of container for server-server communication.</description>
@@ -276,7 +276,7 @@
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.statemachine.max.pending.apply-transactions</name>
+    <name>ozone.container.ratis.statemachine.max.pending.apply-transactions</name>
     <value>10000</value>
     <tag>OZONE, RATIS</tag>
     <description>Maximum number of pending apply transactions in a data
@@ -285,7 +285,7 @@
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.num.write.chunk.threads.per.volume</name>
+    <name>ozone.container.ratis.num.write.chunk.threads.per.volume</name>
     <value>10</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>
     <description>Maximum number of threads in the thread pool that Datanode
@@ -295,7 +295,7 @@
     </description>
   </property>
   <property>
-    <name>dfs.container.ratis.leader.pending.bytes.limit</name>
+    <name>ozone.container.ratis.leader.pending.bytes.limit</name>
     <value>1GB</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>
     <description>Limit on the total bytes of pending requests after which
@@ -336,7 +336,7 @@
     </description>
   </property>
   <property>
-    <name>dfs.ratis.server.retry-cache.timeout.duration</name>
+    <name>ozone.ratis.server.retry-cache.timeout.duration</name>
     <value>600000ms</value>
     <tag>OZONE, RATIS, MANAGEMENT</tag>
     <description>Retry Cache entry timeout for ratis server.</description>

--- a/hadoop-hdds/docs/content/feature/Streaming-Write-Pipeline.md
+++ b/hadoop-hdds/docs/content/feature/Streaming-Write-Pipeline.md
@@ -43,7 +43,7 @@ Set the following properties to the Ozone configuration file `ozone-site.xml`.
 - To enable the Streaming Write Pipeline feature, set the following property to true.
 ```XML
   <property>
-    <name>dfs.container.ratis.datastream.enabled</name>
+    <name>ozone.container.ratis.datastream.enabled</name>
     <value>false</value>
     <tag>OZONE, CONTAINER, RATIS, DATASTREAM</tag>
     <description>It specifies whether to enable data stream of container.</description>
@@ -52,7 +52,7 @@ Set the following properties to the Ozone configuration file `ozone-site.xml`.
 - Datanodes listen to the following port for the streaming traffic.
 ```XML
   <property>
-    <name>dfs.container.ratis.datastream.port</name>
+    <name>ozone.container.ratis.datastream.port</name>
     <value>9855</value>
     <tag>OZONE, CONTAINER, RATIS, DATASTREAM</tag>
     <description>The datastream port number of container.</description>

--- a/hadoop-ozone/dev-support/intellij/runConfigurations/Datanode2-ha.xml
+++ b/hadoop-ozone/dev-support/intellij/runConfigurations/Datanode2-ha.xml
@@ -18,7 +18,7 @@
   <configuration default="false" name="Datanode2-ha" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
-    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/datanode2 --set hdds.datanode.dir=/tmp/datanode2/storage --set hdds.datanode.http-address=127.0.0.1:10021 --set dfs.container.ratis.ipc=10022 --set dfs.container.ipc=10023 --set dfs.container.ratis.server.port=10024 --set dfs.container.ratis.admin.port=10025 --set hdds.datanode.replication.port=10026 --set dfs.container.ratis.datastream.port=10027 --set hdds.datanode.client.port=10028" />
+    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/datanode2 --set hdds.datanode.dir=/tmp/datanode2/storage --set hdds.datanode.http-address=127.0.0.1:10021 --set dfs.container.ratis.ipc=10022 --set dfs.container.ipc=10023 --set ozone.container.ratis.server.port=10024 --set ozone.container.ratis.admin.port=10025 --set hdds.datanode.replication.port=10026 --set ozone.container.ratis.datastream.port=10027 --set hdds.datanode.client.port=10028" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">
       <pattern>

--- a/hadoop-ozone/dev-support/intellij/runConfigurations/Datanode2.xml
+++ b/hadoop-ozone/dev-support/intellij/runConfigurations/Datanode2.xml
@@ -18,7 +18,7 @@
   <configuration default="false" name="Datanode2" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
-    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --set ozone.metadata.dirs=/tmp/datanode2 --set hdds.datanode.dir=/tmp/datanode2/storage --set hdds.datanode.http-address=127.0.0.1:10021 --set dfs.container.ratis.ipc=10022 --set dfs.container.ipc=10023 --set dfs.container.ratis.server.port=10024 --set dfs.container.ratis.admin.port=10025 --set hdds.datanode.replication.port=10026 --set dfs.container.ratis.datastream.port=10027 --set hdds.datanode.client.port=10028" />
+    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --set ozone.metadata.dirs=/tmp/datanode2 --set hdds.datanode.dir=/tmp/datanode2/storage --set hdds.datanode.http-address=127.0.0.1:10021 --set dfs.container.ratis.ipc=10022 --set dfs.container.ipc=10023 --set ozone.container.ratis.server.port=10024 --set ozone.container.ratis.admin.port=10025 --set hdds.datanode.replication.port=10026 --set ozone.container.ratis.datastream.port=10027 --set hdds.datanode.client.port=10028" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">
       <pattern>

--- a/hadoop-ozone/dev-support/intellij/runConfigurations/Datanode3-ha.xml
+++ b/hadoop-ozone/dev-support/intellij/runConfigurations/Datanode3-ha.xml
@@ -18,7 +18,7 @@
   <configuration default="false" name="Datanode3-ha" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
-    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/datanode3 --set hdds.datanode.dir=/tmp/datanode3/storage --set hdds.datanode.http-address=127.0.0.1:10031 --set dfs.container.ratis.ipc=10032 --set dfs.container.ipc=10033 --set dfs.container.ratis.server.port=10034 --set dfs.container.ratis.admin.port=10035 --set hdds.datanode.replication.port=10036 --set dfs.container.ratis.datastream.port=10037 --set hdds.datanode.client.port=10038" />
+    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site-ha.xml --set ozone.metadata.dirs=/tmp/datanode3 --set hdds.datanode.dir=/tmp/datanode3/storage --set hdds.datanode.http-address=127.0.0.1:10031 --set dfs.container.ratis.ipc=10032 --set dfs.container.ipc=10033 --set ozone.container.ratis.server.port=10034 --set ozone.container.ratis.admin.port=10035 --set hdds.datanode.replication.port=10036 --set ozone.container.ratis.datastream.port=10037 --set hdds.datanode.client.port=10038" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">
       <pattern>

--- a/hadoop-ozone/dev-support/intellij/runConfigurations/Datanode3.xml
+++ b/hadoop-ozone/dev-support/intellij/runConfigurations/Datanode3.xml
@@ -18,7 +18,7 @@
   <configuration default="false" name="Datanode3" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.hadoop.ozone.HddsDatanodeService" />
     <module name="ozone-datanode" />
-    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --set ozone.metadata.dirs=/tmp/datanode3 --set hdds.datanode.dir=/tmp/datanode3/storage --set hdds.datanode.http-address=127.0.0.1:10031 --set dfs.container.ratis.ipc=10032 --set dfs.container.ipc=10033 --set dfs.container.ratis.server.port=10034 --set dfs.container.ratis.admin.port=10035 --set hdds.datanode.replication.port=10036 --set dfs.container.ratis.datastream.port=10037 --set hdds.datanode.client.port=10038" />
+    <option name="PROGRAM_PARAMETERS" value="-conf=hadoop-ozone/dev-support/intellij/ozone-site.xml --set ozone.metadata.dirs=/tmp/datanode3 --set hdds.datanode.dir=/tmp/datanode3/storage --set hdds.datanode.http-address=127.0.0.1:10031 --set dfs.container.ratis.ipc=10032 --set dfs.container.ipc=10033 --set ozone.container.ratis.server.port=10034 --set ozone.container.ratis.admin.port=10035 --set hdds.datanode.replication.port=10036 --set ozone.container.ratis.datastream.port=10037 --set hdds.datanode.client.port=10038" />
     <option name="VM_PARAMETERS" value="-Dlog4j.configuration=file:hadoop-ozone/dev-support/intellij/log4j.properties" />
     <extension name="coverage">
       <pattern>

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
@@ -49,7 +49,7 @@ OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.address=recon:9891
 OZONE-SITE.XML_ozone.recon.http-address=0.0.0.0:9888
 OZONE-SITE.XML_ozone.recon.https-address=0.0.0.0:9889
-OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
+OZONE-SITE.XML_ozone.container.ratis.datastream.enabled=true
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -52,7 +52,7 @@ OZONE-SITE.XML_hdds.scm.replication.under.replicated.interval=5s
 OZONE-SITE.XML_hdds.scm.replication.over.replicated.interval=5s
 OZONE-SITE.XML_hdds.scm.wait.time.after.safemode.exit=30s
 
-OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
+OZONE-SITE.XML_ozone.container.ratis.datastream.enabled=true
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -57,7 +57,7 @@ OZONE-SITE.XML_hdds.grpc.tls.enabled=true
 OZONE-SITE.XML_ozone.server.default.replication=3
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_hdds.container.report.interval=60s
-OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
+OZONE-SITE.XML_ozone.container.ratis.datastream.enabled=true
 
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -84,7 +84,7 @@ OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.container.report.interval=60s
 OZONE-SITE.XML_ozone.scm.close.container.wait.duration=5s
 
-OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
+OZONE-SITE.XML_ozone.container.ratis.datastream.enabled=true
 
 HDFS-SITE.XML_dfs.datanode.kerberos.principal=dn/dn@EXAMPLE.COM
 HDFS-SITE.XML_dfs.datanode.kerberos.keytab.file=/etc/security/keytabs/dn.keytab

--- a/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
+++ b/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
@@ -37,7 +37,7 @@
   </property>
 
   <property>
-    <name>dfs.container.ratis.num.write.chunk.threads.per.volume</name>
+    <name>ozone.container.ratis.num.write.chunk.threads.per.volume</name>
     <value>4</value>
   </property>
 
@@ -52,7 +52,7 @@
   </property>
 
   <property>
-    <name>dfs.container.ratis.datastream.enabled</name>
+    <name>ozone.container.ratis.datastream.enabled</name>
     <value>true</value>
   </property>
 
@@ -67,7 +67,7 @@
   </property>
 
   <property>
-    <name>dfs.container.ratis.log.appender.queue.byte-limit</name>
+    <name>ozone.container.ratis.log.appender.queue.byte-limit</name>
     <value>8MB</value>
   </property>
   <property>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Renaming additional config keys prefixed with 'dfs' to 'ozone'.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10330

## How was this patch tested?
Successfully passed all the CI jobs