### PR TITLE
HDDS-10301. Recon - Fold the pipeline info for a DN on Datanode page.

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -44,6 +44,42 @@
             "replicationType": "RATIS",
             "replicationFactor": 1,
             "leaderNode": "localhost1.storage.enterprise.com"
+          },
+          {
+            "pipelineID": "02e3d908-ff01-4ce6-ad75-f3ec79bcc710",
+            "replicationType": "RATIS",
+            "replicationFactor": 3,
+            "leaderNode": "localhost1.storage.enterprise.com"
+          },
+          {
+            "pipelineID": "09d3a478-ff01-4ce6-ad75-f3ec79bcc711",
+            "replicationType": "RATIS",
+            "replicationFactor": 1,
+            "leaderNode": "localhost1.storage.enterprise.com"
+          },
+          {
+            "pipelineID": "02e3d908-ff01-4ce6-ad75-f3ec79bcc712",
+            "replicationType": "RATIS",
+            "replicationFactor": 3,
+            "leaderNode": "localhost1.storage.enterprise.com"
+          },
+          {
+            "pipelineID": "09d3a478-ff01-4ce6-ad75-f3ec79bcc713",
+            "replicationType": "RATIS",
+            "replicationFactor": 1,
+            "leaderNode": "localhost1.storage.enterprise.com"
+          },
+          {
+            "pipelineID": "02e3d908-ff01-4ce6-ad75-f3ec79bcc714",
+            "replicationType": "RATIS",
+            "replicationFactor": 3,
+            "leaderNode": "localhost1.storage.enterprise.com"
+          },
+          {
+            "pipelineID": "09d3a478-ff01-4ce6-ad75-f3ec79bcc715",
+            "replicationType": "RATIS",
+            "replicationFactor": 1,
+            "leaderNode": "localhost1.storage.enterprise.com"
           }
         ],
         "containers": 80,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -217,7 +217,7 @@ const COLUMNS = [
           }
           {
             remainingPipelinesIDs.length > 1 &&
-            <Popover content={<RenderPipelineIds pipelinesIds={remainingPipelinesIDs} />} title="Remaining Pieplines" placement="rightTop" trigger="hover">
+            <Popover content={<RenderPipelineIds pipelinesIds={remainingPipelinesIDs} />} title="Remaining pipelines" placement="rightTop" trigger="hover">
               {`... and ${remainingPipelinesIDs.length} more pipelines`}
             </Popover>
           }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import {Table, Icon, Tooltip} from 'antd';
+import {Table, Icon, Tooltip, Popover} from 'antd';
 import {PaginationConfig} from 'antd/lib/pagination';
 import moment from 'moment';
 import {ReplicationIcon} from 'utils/themeIcons';
@@ -192,21 +192,36 @@ const COLUMNS = [
     key: 'pipelines',
     isVisible: true,
     render: (pipelines: IPipeline[], record: IDatanode) => {
+      let firstThreePipeLineIDs = [];
+      let remainingPipelinesIDs: any[] = [];
+      firstThreePipeLineIDs = pipelines && pipelines.filter((element, index) => index < 3);
+      remainingPipelinesIDs = pipelines && pipelines.slice(3, pipelines.length);
+
+      const RenderPipelineIds = ({ pipeLinesIds }) => {
+        return pipeLinesIds && pipeLinesIds.map((pipeline: any, index: any) => (
+          <div key={index} className='pipeline-container'>
+            <ReplicationIcon
+              replicationFactor={pipeline.replicationFactor}
+              replicationType={pipeline.replicationType}
+              leaderNode={pipeline.leaderNode}
+              isLeader={pipeline.leaderNode === record.hostname} />
+            {pipeline.pipelineID}
+          </div >
+        ))
+      }
+
       return (
-        <div>
+        <>
           {
-            pipelines && pipelines.map((pipeline, index) => (
-              <div key={index} className='pipeline-container'>
-                <ReplicationIcon
-                  replicationFactor={pipeline.replicationFactor}
-                  replicationType={pipeline.replicationType}
-                  leaderNode={pipeline.leaderNode}
-                  isLeader={pipeline.leaderNode === record.hostname}/>
-                {pipeline.pipelineID}
-              </div>
-            ))
+            <RenderPipelineIds pipeLinesIds={firstThreePipeLineIDs} />
           }
-        </div>
+          {
+            remainingPipelinesIDs.length > 1 &&
+            <Popover content={<RenderPipelineIds pipeLinesIds={remainingPipelinesIDs} />} title="Remaining Pieplines" placement="rightTop" trigger="hover">
+              {`... and ${remainingPipelinesIDs.length} more pipelines`}
+            </Popover>
+          }
+        </>
       );
     }
   },

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -216,7 +216,7 @@ const COLUMNS = [
             <RenderPipelineIds pipelinesIds={firstThreePipelinesIDs} />
           }
           {
-            remainingPipelinesIDs.length > 1 &&
+            remainingPipelinesIDs.length > 0 &&
             <Popover content={<RenderPipelineIds pipelinesIds={remainingPipelinesIDs} />} title="Remaining pipelines" placement="rightTop" trigger="hover">
               {`... and ${remainingPipelinesIDs.length} more pipelines`}
             </Popover>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -192,13 +192,13 @@ const COLUMNS = [
     key: 'pipelines',
     isVisible: true,
     render: (pipelines: IPipeline[], record: IDatanode) => {
-      let firstThreePipeLineIDs = [];
+      let firstThreePipelinesIDs = [];
       let remainingPipelinesIDs: any[] = [];
-      firstThreePipeLineIDs = pipelines && pipelines.filter((element, index) => index < 3);
+      firstThreePipelinesIDs = pipelines && pipelines.filter((element, index) => index < 3);
       remainingPipelinesIDs = pipelines && pipelines.slice(3, pipelines.length);
 
-      const RenderPipelineIds = ({ pipeLinesIds }) => {
-        return pipeLinesIds && pipeLinesIds.map((pipeline: any, index: any) => (
+      const RenderPipelineIds = ({ pipelinesIds }) => {
+        return pipelinesIds && pipelinesIds.map((pipeline: any, index: any) => (
           <div key={index} className='pipeline-container'>
             <ReplicationIcon
               replicationFactor={pipeline.replicationFactor}
@@ -213,11 +213,11 @@ const COLUMNS = [
       return (
         <>
           {
-            <RenderPipelineIds pipeLinesIds={firstThreePipeLineIDs} />
+            <RenderPipelineIds pipelinesIds={firstThreePipelinesIDs} />
           }
           {
             remainingPipelinesIDs.length > 1 &&
-            <Popover content={<RenderPipelineIds pipeLinesIds={remainingPipelinesIDs} />} title="Remaining Pieplines" placement="rightTop" trigger="hover">
+            <Popover content={<RenderPipelineIds pipelinesIds={remainingPipelinesIDs} />} title="Remaining Pieplines" placement="rightTop" trigger="hover">
               {`... and ${remainingPipelinesIDs.length} more pipelines`}
             </Popover>
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?
We are displaying only first 3 PipelinesID's and remaining pipelinesId's we displaying in popup after over on text
... and N more pipelines

###Please describe your PR in detail:
As discussed in APAC community sync:
Suggested one improvement on Recon UI, fold the pipeline info for a DN  on Datanode page. When a Datanode has more than 10 pipelines, it will  display all the pipelines by default, which is not necessary most of the  time. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10301

## How was this patch tested?
Manually
Before this PR
![image](https://github.com/apache/ozone/assets/112169209/d4cddffa-4086-445d-9643-48c882bc268a)


With this PR
![image](https://github.com/apache/ozone/assets/112169209/16ba7b94-f33c-4f8f-b905-2e1481b7573c)




