### PR TITLE
HDDS-10332. [Diskbalancer] Include Disk Balancer Report in the heartbeat message

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.ozone.container.common.statemachine
 import org.apache.hadoop.ozone.container.common.statemachine
     .EndpointStateMachine.EndPointStates;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.container.diskbalancer.DiskBalancerInfo;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.ClosePipelineCommand;
 import org.apache.hadoop.ozone.protocol.commands.CreatePipelineCommand;
@@ -178,6 +179,7 @@ public class HeartbeatEndpointTask
       addContainerActions(requestBuilder);
       addPipelineActions(requestBuilder);
       addQueuedCommandCounts(requestBuilder);
+      addDiskBalancerReport(requestBuilder);
       SCMHeartbeatRequestProto request = requestBuilder.build();
       LOG.debug("Sending heartbeat message : {}", request);
       SCMHeartbeatResponseProto response = rpcEndpoint.getEndPoint()
@@ -286,6 +288,11 @@ public class HeartbeatEndpointTask
           .addCount(entry.getValue());
     }
     requestBuilder.setCommandQueueReport(reportProto.build());
+  }
+
+  private void addDiskBalancerReport(SCMHeartbeatRequestProto.Builder requestBuilder) {
+    DiskBalancerInfo info = context.getParent().getContainer().getDiskBalancerInfo();
+    requestBuilder.setDiskBalancerReport(info.toDiskBalancerReportProto());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/diskbalancer/DiskBalancerInfo.java
@@ -16,9 +16,12 @@
  */
 package org.apache.hadoop.ozone.container.diskbalancer;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.storage.DiskBalancerConfiguration;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * DiskBalancer's information to persist.
@@ -64,6 +67,18 @@ public class DiskBalancerInfo {
     if (parallelThread != diskBalancerConf.getParallelThread()) {
       setParallelThread(diskBalancerConf.getParallelThread());
     }
+  }
+
+  public StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto toDiskBalancerReportProto() {
+    DiskBalancerConfiguration conf = new DiskBalancerConfiguration(Optional.of(threshold),
+        Optional.of(bandwidthInMB), Optional.of(parallelThread));
+    HddsProtos.DiskBalancerConfigurationProto confProto = conf.toProtobufBuilder().build();
+
+    StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto.Builder builder =
+        StorageContainerDatanodeProtocolProtos.DiskBalancerReportProto.newBuilder();
+    builder.setIsRunning(shouldRun);
+    builder.setDiskBalancerConf(confProto);
+    return builder.build();
   }
 
   public boolean isShouldRun() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

All the pieces are in place to allow the DNs to relay their disk balancer status to SCM, but the disk balancer report is not yet added to the heartbeat message in HeartbeatEndpointTask. This results in the SCM details never getting updated and the status command always shows UNKNOWN as the status.

This change simply adds the report into the heartbeat message.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10332

## How was this patch tested?

Manually tested via docker proving the current status is update in SCM after a DN heartbeat.