### PR TITLE
HDDS-10340. Skip ci on dashboard updates

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -57,6 +57,18 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=false
 }
 
+@test "dashboard only" {
+  run dev-support/ci/selective_ci_checks.sh 039dea9
+
+  assert_output -p 'basic-checks=["rat"]'
+  assert_output -p needs-build=false
+  assert_output -p needs-compile=false
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-dependency-check=false
+  assert_output -p needs-integration-tests=false
+  assert_output -p needs-kubernetes-tests=false
+}
+
 @test "compose and robot" {
   run dev-support/ci/selective_ci_checks.sh b83039eef
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -233,6 +233,7 @@ function get_count_compose_files() {
     local ignore_array=(
         "^hadoop-ozone/dist/src/main/k8s"
         "^hadoop-ozone/dist/src/main/license"
+        "^hadoop-ozone/dist/src/main/compose/common/grafana/dashboards"
         "\.md$"
     )
     filter_changed_files true
@@ -494,6 +495,7 @@ function get_count_misc_files() {
         "\.md$"
         "findbugsExcludeFile.xml"
         "/NOTICE$"
+        "^hadoop-ozone/dist/src/main/compose/common/grafana/dashboards"
     )
     local ignore_array=(
         "^.github/workflows/post-commit.yml"


### PR DESCRIPTION

## What changes were proposed in this pull request?

Currently there are no test for dashboard changes but the PRs still run the entire CI workflow.
Skip the CI if only the dashboards have been updated.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10340

## How was this patch tested?

Pushed this change and a dashboard change to https://github.com/kerneltime/ozone/commits/HDDS-10339-skip-ci/
