### PR TITLE
HDDS-10325. Make BucketArgs immutable

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/BucketArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/BucketArgs.java
@@ -18,12 +18,15 @@
 
 package org.apache.hadoop.ozone.client;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,80 +40,60 @@ public final class BucketArgs {
   /**
    * ACL Information.
    */
-  private List<OzoneAcl> acls;
+  private final ImmutableList<OzoneAcl> acls;
   /**
    * Bucket Version flag.
    */
-  private Boolean versioning;
+  private final boolean versioning;
   /**
    * Type of storage to be used for this bucket.
    * [RAM_DISK, SSD, DISK, ARCHIVE]
    */
-  private StorageType storageType;
+  private final StorageType storageType;
 
   /**
    * Custom key/value metadata.
    */
-  private Map<String, String> metadata;
+  private final Map<String, String> metadata;
 
   /**
    * Bucket encryption key name.
    */
-  private String bucketEncryptionKey;
-  private DefaultReplicationConfig defaultReplicationConfig;
+  private final String bucketEncryptionKey;
+  private final DefaultReplicationConfig defaultReplicationConfig;
   private final String sourceVolume;
   private final String sourceBucket;
 
-  private long quotaInBytes;
-  private long quotaInNamespace;
+  private final long quotaInBytes;
+  private final long quotaInNamespace;
 
-  private String owner;
+  private final String owner;
 
   /**
    * Bucket Layout.
    */
-  private BucketLayout bucketLayout = BucketLayout.DEFAULT;
+  private final BucketLayout bucketLayout;
 
-  /**
-   * Private constructor, constructed via builder.
-   * @param versioning Bucket version flag.
-   * @param storageType Storage type to be used.
-   * @param acls list of ACLs.
-   * @param metadata map of bucket metadata
-   * @param bucketEncryptionKey bucket encryption key name
-   * @param sourceVolume
-   * @param sourceBucket
-   * @param quotaInBytes Bucket quota in bytes.
-   * @param quotaInNamespace Bucket quota in counts.
-   * @param bucketLayout bucket layout.
-   * @param owner owner of the bucket.
-   * @param defaultReplicationConfig default replication config.
-   */
-  @SuppressWarnings("parameternumber")
-  private BucketArgs(Boolean versioning, StorageType storageType,
-      List<OzoneAcl> acls, Map<String, String> metadata,
-      String bucketEncryptionKey, String sourceVolume, String sourceBucket,
-      long quotaInBytes, long quotaInNamespace, BucketLayout bucketLayout,
-      String owner, DefaultReplicationConfig defaultReplicationConfig) {
-    this.acls = acls;
-    this.versioning = versioning;
-    this.storageType = storageType;
-    this.metadata = metadata;
-    this.bucketEncryptionKey = bucketEncryptionKey;
-    this.sourceVolume = sourceVolume;
-    this.sourceBucket = sourceBucket;
-    this.quotaInBytes = quotaInBytes;
-    this.quotaInNamespace = quotaInNamespace;
-    this.bucketLayout = bucketLayout;
-    this.owner = owner;
-    this.defaultReplicationConfig = defaultReplicationConfig;
+  private BucketArgs(Builder b) {
+    acls = b.acls == null ? ImmutableList.of() : ImmutableList.copyOf(b.acls);
+    versioning = b.versioning;
+    storageType = b.storageType;
+    metadata = b.metadata == null ? ImmutableMap.of() : ImmutableMap.copyOf(b.metadata);
+    bucketEncryptionKey = b.bucketEncryptionKey;
+    sourceVolume = b.sourceVolume;
+    sourceBucket = b.sourceBucket;
+    quotaInBytes = b.quotaInBytes;
+    quotaInNamespace = b.quotaInNamespace;
+    bucketLayout = b.bucketLayout;
+    owner = b.owner;
+    defaultReplicationConfig = b.defaultReplicationConfig;
   }
 
   /**
    * Returns true if bucket version is enabled, else false.
    * @return isVersionEnabled
    */
-  public Boolean getVersioning() {
+  public boolean getVersioning() {
     return versioning;
   }
 
@@ -206,7 +189,7 @@ public final class BucketArgs {
    * Builder for OmBucketInfo.
    */
   public static class Builder {
-    private Boolean versioning;
+    private boolean versioning;
     private StorageType storageType;
     private List<OzoneAcl> acls;
     private Map<String, String> metadata;
@@ -220,12 +203,11 @@ public final class BucketArgs {
     private DefaultReplicationConfig defaultReplicationConfig;
 
     public Builder() {
-      metadata = new HashMap<>();
       quotaInBytes = OzoneConsts.QUOTA_RESET;
       quotaInNamespace = OzoneConsts.QUOTA_RESET;
     }
 
-    public BucketArgs.Builder setVersioning(Boolean versionFlag) {
+    public BucketArgs.Builder setVersioning(boolean versionFlag) {
       this.versioning = versionFlag;
       return this;
     }
@@ -235,13 +217,19 @@ public final class BucketArgs {
       return this;
     }
 
-    public BucketArgs.Builder setAcls(List<OzoneAcl> listOfAcls) {
-      this.acls = listOfAcls;
+    public BucketArgs.Builder addAcl(OzoneAcl acl) {
+      if (acls == null) {
+        acls = new ArrayList<>();
+      }
+      acls.add(acl);
       return this;
     }
 
     public BucketArgs.Builder addMetadata(String key, String value) {
-      this.metadata.put(key, value);
+      if (metadata == null) {
+        metadata = new HashMap<>();
+      }
+      metadata.put(key, value);
       return this;
     }
 
@@ -291,9 +279,7 @@ public final class BucketArgs {
      * @return instance of BucketArgs.
      */
     public BucketArgs build() {
-      return new BucketArgs(versioning, storageType, acls, metadata,
-          bucketEncryptionKey, sourceVolume, sourceBucket, quotaInBytes,
-          quotaInNamespace, bucketLayout, owner, defaultReplicationConfig);
+      return new BucketArgs(this);
     }
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -627,8 +627,7 @@ public class RpcClient implements ClientProtocol {
           ugi.getShortUserName() : bucketArgs.getOwner();
     }
 
-    Boolean isVersionEnabled = bucketArgs.getVersioning() == null ?
-        Boolean.FALSE : bucketArgs.getVersioning();
+    boolean isVersionEnabled = bucketArgs.getVersioning();
     StorageType storageType = bucketArgs.getStorageType() == null ?
         StorageType.DEFAULT : bucketArgs.getStorageType();
     BucketLayout bucketLayout = bucketArgs.getBucketLayout();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
@@ -97,9 +97,23 @@ public class OzoneAcl {
    *
    * @param type   - Type
    * @param name   - Name of user
-   * @param acls   - Rights
    * @param scope  - AclScope
+   * @param acls   - Rights
    */
+  public OzoneAcl(ACLIdentityType type, String name, AclScope scope, ACLType... acls) {
+    this(type, name, bitSetOf(acls), scope);
+  }
+
+  private static BitSet bitSetOf(ACLType... acls) {
+    BitSet bits = new BitSet();
+    if (acls != null && acls.length > 0) {
+      for (ACLType acl : acls) {
+        bits.set(acl.ordinal());
+      }
+    }
+    return bits;
+  }
+
   public OzoneAcl(ACLIdentityType type, String name, BitSet acls,
       AclScope scope) {
     Objects.requireNonNull(type);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -90,7 +90,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -122,7 +121,6 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PERM
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE;
-import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.DELETE;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.LIST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -1223,20 +1221,11 @@ abstract class AbstractRootedOzoneFileSystemTest {
     }
 
     // set acls for shared tmp mount under the tmp volume
-    List<OzoneAcl> objectAcls = new ArrayList<>();
-    objectAcls.add(new OzoneAcl(ACLIdentityType.USER, "admin", userRights,
-        ACCESS));
-    aclRights.clear(DELETE.ordinal());
-    aclRights.set(LIST.ordinal());
-    objectAcls.add(new OzoneAcl(ACLIdentityType.WORLD, "",
-        aclRights, ACCESS));
-    objectAcls.add(new OzoneAcl(ACLIdentityType.USER, "admin", userRights,
-        ACCESS));
     // bucket acls have all access to admin and read+write+list access to world
-
     BucketArgs bucketArgs = new BucketArgs.Builder()
         .setOwner("admin")
-        .setAcls(Collections.unmodifiableList(objectAcls))
+        .addAcl(new OzoneAcl(ACLIdentityType.WORLD, "", ACCESS, READ, WRITE, LIST))
+        .addAcl(new OzoneAcl(ACLIdentityType.USER, "admin", userRights, ACCESS))
         .setQuotaInNamespace(1000)
         .setQuotaInBytes(Long.MAX_VALUE).build();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix findbugs warnings by making `BucketArgs` immutable.  See #6193 for similar change in `VolumeArgs`.

```
M V EI: org.apache.hadoop.ozone.client.BucketArgs.getAcls() may expose internal representation by returning BucketArgs.acls  At BucketArgs.java:[line 130]
M V EI: org.apache.hadoop.ozone.client.BucketArgs.getMetadata() may expose internal representation by returning BucketArgs.metadata  At BucketArgs.java:[line 139]
M V EI2: org.apache.hadoop.ozone.client.BucketArgs$Builder.setAcls(List) may expose internal representation by storing an externally mutable object into BucketArgs$Builder.acls  At BucketArgs.java:[line 239]
```

Also eliminate `@SuppressWarnings("parameternumber")` by passing the builder to the constructor, instead of individual properties.

Create new constructor in `OzoneAcl` to simplify instantiation with multiple `ACLType` (avoid the need to mess with `BitSet`).

https://issues.apache.org/jira/browse/HDDS-10325

## How was this patch tested?

```
$ hadoop-ozone/dev-support/checks/findbugs.sh -Dspotbugs.version=4.8.3.0
$ grep -c 'client.BucketArgs' target/findbugs/summary.txt
0
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/7843743627