### PR TITLE
HDDS-9844. [hsync] De-synchronize write APIs

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -376,17 +376,13 @@ public class BlockOutputStream extends OutputStream {
     waitForFlushAndCommit(true);
   }
 
-  void waitForFlushAndCommit(boolean bufferFull) throws IOException {
-    try {
-      checkOpen();
-      waitOnFlushFutures();
-    } catch (ExecutionException e) {
-      handleExecutionException(e);
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
-      handleInterruptedException(ex, true);
-    }
+  CompletableFuture<Void> waitForFlushAndCommit(boolean bufferFull) throws IOException {
+    checkOpen();
+    CompletableFuture<Void> future = waitOnFlushFutures();
+    // TODO: This call can be removed?
     watchForCommit(bufferFull);
+
+    return future;
   }
 
   void releaseBuffersOnException() {
@@ -605,7 +601,8 @@ public class BlockOutputStream extends OutputStream {
     }
   }
 
-  void waitOnFlushFutures() throws InterruptedException, ExecutionException {
+  CompletableFuture<Void> waitOnFlushFutures() {
+    return null;
   }
 
   void validateResponse(
@@ -752,6 +749,7 @@ public class BlockOutputStream extends OutputStream {
 
   /**
    * Handles InterruptedExecution.
+   * TODO: Move this to StreamUtil.
    *
    * @param ex
    * @param processExecutionException is optional, if passed as TRUE, then
@@ -771,6 +769,8 @@ public class BlockOutputStream extends OutputStream {
 
   /**
    * Handles ExecutionException by adjusting buffers.
+   * TODO: Move this to StreamUtil.
+   *
    * @param ex
    * @throws IOException
    */

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/NonBlockingSyncable.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/NonBlockingSyncable.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.storage;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * This is the interface for non-blocking flush/sync operations.
+ * Consult the Hadoop filesystem specification for the definition of the
+ * semantics of these operations.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface NonBlockingSyncable {
+
+  /** Flush out the data in client's user buffer. After the return of
+   * this call, new readers will see the data.
+   * @throws IOException if any error occurs
+   */
+  CompletableFuture<Void> hflush() throws IOException;
+
+  /** Similar to posix fsync, flush out the data in client's user buffer
+   * all the way to the disk device (but the disk may have it in its cache).
+   * @throws IOException if error occurs
+   */
+  CompletableFuture<Void> hsync() throws IOException;
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.hadoop.fs.Syncable;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -32,6 +33,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.scm.storage.BufferPool;
+import org.apache.hadoop.hdds.scm.storage.NonBlockingSyncable;
 import org.apache.hadoop.hdds.scm.storage.RatisBlockOutputStream;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
@@ -147,7 +149,7 @@ public class BlockOutputStreamEntry extends OutputStream {
     }
   }
 
-  void hsync() throws IOException {
+  CompletableFuture<Void> hsync() throws IOException {
     if (isInitialized()) {
       final OutputStream out = getOutputStream();
       if (!(out instanceof Syncable)) {
@@ -155,7 +157,9 @@ public class BlockOutputStreamEntry extends OutputStream {
             out.getClass() + " is not " + Syncable.class.getSimpleName());
       }
 
-      ((Syncable)out).hsync();
+      return ((NonBlockingSyncable) out).hsync();
+    } else {
+      return null;
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/StreamUtil.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/StreamUtil.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.client.io;
+
+/**
+ * Helper methods for stream operations.
+ */
+public final class StreamUtil {
+  public static final String EXCEPTION_MSG =
+      "Unexpected Storage Container Exception: ";
+
+  private StreamUtil() {
+  }
+}


### PR DESCRIPTION
Basing this on master branch since it is not confined to hsync change.

## What changes were proposed in this pull request?

`synchronized` keyword has been added to write/hsync methods in HDDS-7907 to ensure correctness. But it is deemed to reduce write/hsync throughput at this point.

This PR aims to reduce blocking by immediately returning the future rather than waiting on it to return to allow write/hsync to interleave while ensuring correctness. (Submit the request and return immediately.) This inevitably involves some refactoring.

- [ ] Finish error handling migration.
- [ ] Refactoring.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9844

## How was this patch tested?

- [ ] All existing tests involving key stream write/hsync/close shall pass.