### PR TITLE
HDDS-10344. Schedule dependabot for weekend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,5 +38,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "saturday"
+      time: "07:00" # UTC
     pull-request-branch-name:
       separator: "-"


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default Dependabot performs its duties (check for updates and open pull requests) on Monday.  We could better distribute CI workflow runs by shifting Dependabot schedule to the weekend, when fewer PRs are created by developers.

https://issues.apache.org/jira/browse/HDDS-10344

## How was this patch tested?

Not tested.

Reference:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday