### PR TITLE
HDDS-10369. Set Times API doesn't work with linked buckets.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -2485,4 +2485,39 @@ abstract class AbstractRootedOzoneFileSystemTest {
     assertEquals(mtime, fileStatus.getModificationTime());
   }
 
+  @Test
+  public void testSetTimesForLinkedBucketPath() throws Exception {
+    // Create a file
+    OzoneBucket sourceBucket =
+        TestDataUtil.createVolumeAndBucket(client, bucketLayout);
+    Path volumePath1 =
+        new Path(OZONE_URI_DELIMITER, sourceBucket.getVolumeName());
+    Path sourceBucketPath = new Path(volumePath1, sourceBucket.getName());
+    Path path = new Path(sourceBucketPath, "key1");
+    try (FSDataOutputStream stream = fs.create(path)) {
+      stream.write(1);
+    }
+    OzoneVolume sourceVol = client.getObjectStore().getVolume(sourceBucket.getVolumeName());
+    String linkBucketName = UUID.randomUUID().toString();
+    createLinkBucket(sourceVol.getName(), linkBucketName,
+        sourceVol.getName(), sourceBucket.getName());
+
+    Path linkedBucketPath = new Path(volumePath1, linkBucketName);
+    Path keyInLinkedBucket = new Path(linkedBucketPath, "key1");
+
+    // test setTimes in linked bucket path
+    long mtime = 1000;
+    fs.setTimes(keyInLinkedBucket, mtime, 2000);
+
+    FileStatus fileStatus = fs.getFileStatus(path);
+    // verify that mtime is updated as expected.
+    assertEquals(mtime, fileStatus.getModificationTime());
+
+    long mtimeDontUpdate = -1;
+    fs.setTimes(keyInLinkedBucket, mtimeDontUpdate, 2000);
+
+    fileStatus = fs.getFileStatus(keyInLinkedBucket);
+    // verify that mtime is NOT updated as expected.
+    assertEquals(mtime, fileStatus.getModificationTime());
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
@@ -23,7 +23,6 @@ import java.nio.file.InvalidPathException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
@@ -64,10 +64,9 @@ public class OMKeySetTimesRequest extends OMKeyRequest {
     OMRequest request = super.preExecute(ozoneManager);
     SetTimesRequest setTimesRequest = request.getSetTimesRequest();
     String keyPath = setTimesRequest.getKeyArgs().getKeyName();
-    OmBucketInfo bucketInfo = ozoneManager.getBucketInfo(volumeName, bucketName);
     String normalizedKeyPath =
         validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
-            keyPath, bucketInfo.getBucketLayout());
+            keyPath, getBucketLayout());
 
     OzoneManagerProtocolProtos.KeyArgs keyArgs =
         OzoneManagerProtocolProtos.KeyArgs.newBuilder()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Set Times API doesn't work with linked buckets, This PR fixes it by adding resolution for the linked bucket.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10369

## How was this patch tested?
Unit test