### PR TITLE
HDDS-10367. Fix possible NullPointerException in listKeysLight method

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -254,7 +254,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   private OmTransport transport;
   private ThreadLocal<S3Auth> threadLocalS3Auth
       = new ThreadLocal<>();
-    
+
   private boolean s3AuthCheck;
 
   public static final int BLOCK_ALLOCATION_RETRY_COUNT = 5;
@@ -1033,7 +1033,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     reqBuilder.setBucketName(bucketName);
     reqBuilder.setCount(maxKeys);
 
-    if (StringUtils.isNotEmpty(startKey)) {
+    if (startKey != null) {
       reqBuilder.setStartKey(startKey);
     }
 
@@ -2261,8 +2261,11 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         ListStatusRequest.newBuilder()
             .setKeyArgs(keyArgs)
             .setRecursive(recursive)
-            .setStartKey(startKey)
             .setNumEntries(numEntries);
+
+    if (startKey != null) {
+      listStatusRequestBuilder.setStartKey(startKey);
+    }
 
     if (allowPartialPrefixes) {
       listStatusRequestBuilder.setAllowPartialPrefix(allowPartialPrefixes);
@@ -2297,8 +2300,11 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         ListStatusRequest.newBuilder()
             .setKeyArgs(keyArgs)
             .setRecursive(recursive)
-            .setStartKey(startKey)
             .setNumEntries(numEntries);
+
+    if (startKey != null) {
+      listStatusRequestBuilder.setStartKey(startKey);
+    }
 
     if (allowPartialPrefixes) {
       listStatusRequestBuilder.setAllowPartialPrefix(allowPartialPrefixes);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -254,7 +254,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   private OmTransport transport;
   private ThreadLocal<S3Auth> threadLocalS3Auth
       = new ThreadLocal<>();
-
   private boolean s3AuthCheck;
 
   public static final int BLOCK_ALLOCATION_RETRY_COUNT = 5;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2256,21 +2256,9 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setSortDatanodes(args.getSortDatanodes())
         .setLatestVersionLocation(args.getLatestVersionLocation())
         .build();
-    ListStatusRequest.Builder listStatusRequestBuilder =
-        ListStatusRequest.newBuilder()
-            .setKeyArgs(keyArgs)
-            .setRecursive(recursive)
-            .setNumEntries(numEntries);
 
-    if (startKey != null) {
-      listStatusRequestBuilder.setStartKey(startKey);
-    } else {
-      listStatusRequestBuilder.setStartKey("");
-    }
-
-    if (allowPartialPrefixes) {
-      listStatusRequestBuilder.setAllowPartialPrefix(allowPartialPrefixes);
-    }
+    ListStatusRequest.Builder listStatusRequestBuilder = createListStatusRequestBuilder(keyArgs, recursive, startKey,
+        numEntries, allowPartialPrefixes);
 
     OMRequest omRequest = createOMRequest(Type.ListStatus)
         .setListStatusRequest(listStatusRequestBuilder.build())
@@ -2297,19 +2285,9 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setSortDatanodes(false)
         .setLatestVersionLocation(true)
         .build();
-    ListStatusRequest.Builder listStatusRequestBuilder =
-        ListStatusRequest.newBuilder()
-            .setKeyArgs(keyArgs)
-            .setRecursive(recursive)
-            .setNumEntries(numEntries);
 
-    if (startKey != null) {
-      listStatusRequestBuilder.setStartKey(startKey);
-    }
-
-    if (allowPartialPrefixes) {
-      listStatusRequestBuilder.setAllowPartialPrefix(allowPartialPrefixes);
-    }
+    ListStatusRequest.Builder listStatusRequestBuilder = createListStatusRequestBuilder(keyArgs, recursive, startKey,
+        numEntries, allowPartialPrefixes);
 
     OMRequest omRequest = createOMRequest(Type.ListStatusLight)
         .setListStatusRequest(listStatusRequestBuilder.build())
@@ -2324,6 +2302,26 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       statusList.add(OzoneFileStatusLight.getFromProtobuf(fileStatus));
     }
     return statusList;
+  }
+
+  private ListStatusRequest.Builder createListStatusRequestBuilder(KeyArgs keyArgs, boolean recursive, String startKey,
+      long numEntries, boolean allowPartialPrefixes) {
+    ListStatusRequest.Builder listStatusRequestBuilder =
+        ListStatusRequest.newBuilder()
+            .setKeyArgs(keyArgs)
+            .setRecursive(recursive)
+            .setNumEntries(numEntries);
+
+    if (startKey != null) {
+      listStatusRequestBuilder.setStartKey(startKey);
+    } else {
+      listStatusRequestBuilder.setStartKey("");
+    }
+
+    if (allowPartialPrefixes) {
+      listStatusRequestBuilder.setAllowPartialPrefix(allowPartialPrefixes);
+    }
+    return listStatusRequestBuilder;
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2264,6 +2264,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     if (startKey != null) {
       listStatusRequestBuilder.setStartKey(startKey);
+    } else {
+      listStatusRequestBuilder.setStartKey("");
     }
 
     if (allowPartialPrefixes) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestListKeysWithFSO.java
@@ -21,8 +21,6 @@ import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestListKeysWithFSO.java
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.hadoop.ozone.om;
+package org.apache.hadoop.ozone;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,6 +64,8 @@ public class TestListKeysWithFSO {
   private static OzoneBucket fsoOzoneBucket;
   private static OzoneBucket legacyOzoneBucket2;
   private static OzoneBucket fsoOzoneBucket2;
+  private static OzoneBucket emptyLegacyOzoneBucket;
+  private static OzoneBucket emptyFsoOzoneBucket;
   private static OzoneClient client;
 
   /**
@@ -105,6 +108,10 @@ public class TestListKeysWithFSO {
     ozoneVolume.createBucket(fsoBucketName, omBucketArgs);
     fsoOzoneBucket2 = ozoneVolume.getBucket(fsoBucketName);
 
+    fsoBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    ozoneVolume.createBucket(fsoBucketName, omBucketArgs);
+    emptyFsoOzoneBucket = ozoneVolume.getBucket(fsoBucketName);
+
     builder = BucketArgs.newBuilder();
     builder.setStorageType(StorageType.DISK);
     builder.setBucketLayout(BucketLayout.LEGACY);
@@ -112,6 +119,10 @@ public class TestListKeysWithFSO {
     String legacyBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
     ozoneVolume.createBucket(legacyBucketName, omBucketArgs);
     legacyOzoneBucket2 = ozoneVolume.getBucket(legacyBucketName);
+
+    legacyBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    ozoneVolume.createBucket(legacyBucketName, omBucketArgs);
+    emptyLegacyOzoneBucket = ozoneVolume.getBucket(legacyBucketName);
 
     initFSNameSpace();
   }
@@ -473,6 +484,24 @@ public class TestListKeysWithFSO {
 
     // case-6: keyPrefix corresponds to multiple existing keys and
     // startKey reaches last key
+    keyPrefix = "a1/b1/c12";
+    startKey = "a1/b1/c12/c3.tx";
+    // a1/b1/c1222.tx
+    expectedKeys =
+        getExpectedKeyShallowList(keyPrefix, startKey, legacyOzoneBucket);
+    checkKeyShallowList(keyPrefix, startKey, expectedKeys, fsoOzoneBucket);
+
+    // case-7: keyPrefix corresponds to multiple existing keys and
+    // startKey is null in empty bucket
+    keyPrefix = "a1/b1/c12";
+    startKey = null;
+    // a1/b1/c1222.tx
+    expectedKeys =
+        getExpectedKeyShallowList(keyPrefix, startKey, emptyLegacyOzoneBucket);
+    checkKeyShallowList(keyPrefix, startKey, expectedKeys, emptyFsoOzoneBucket);
+
+    // case-8: keyPrefix corresponds to multiple existing keys and
+    // startKey is null
     keyPrefix = "a1/b1/c12";
     startKey = "a1/b1/c12/c3.tx";
     // a1/b1/c1222.tx

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -14,13 +14,15 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.hadoop.ozone;
+package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListKeysWithFSO.java
@@ -503,7 +503,6 @@ public class TestListKeysWithFSO {
     // case-8: keyPrefix corresponds to multiple existing keys and
     // startKey is null
     keyPrefix = "a1/b1/c12";
-    startKey = "a1/b1/c12/c3.tx";
     // a1/b1/c1222.tx
     expectedKeys =
         getExpectedKeyShallowList(keyPrefix, startKey, legacyOzoneBucket);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -16,10 +16,10 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -29,24 +29,30 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.
-    OZONE_FS_ITERATE_BATCH_SIZE;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * A simple test that asserts that list status output is sorted.
  */
 @Timeout(1200)
 public class TestListStatus {
+  private static final Logger LOG = LoggerFactory.getLogger(TestListStatus.class);
 
   private static MiniOzoneCluster cluster = null;
-  private static OzoneConfiguration conf;
   private static OzoneBucket fsoOzoneBucket;
   private static OzoneClient client;
 
@@ -54,11 +60,11 @@ public class TestListStatus {
    * Create a MiniDFSCluster for testing.
    * <p>
    *
-   * @throws IOException
+   * @throws IOException in case of I/O error
    */
   @BeforeAll
   public static void init() throws Exception {
-    conf = new OzoneConfiguration();
+    OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
         true);
     cluster = MiniOzoneCluster.newBuilder(conf).build();
@@ -69,7 +75,7 @@ public class TestListStatus {
     fsoOzoneBucket = TestDataUtil
         .createVolumeAndBucket(client, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
-    // Set the number of keys to be processed during batch operate.
+    // Set the number of keys to be processed during batch operated.
     conf.setInt(OZONE_FS_ITERATE_BATCH_SIZE, 5);
 
     buildNameSpaceTree(fsoOzoneBucket);
@@ -83,44 +89,43 @@ public class TestListStatus {
     }
   }
 
-  @Test
-  public void testSortedListStatus() throws Exception {
-    // a) test if output is sorted
-    checkKeyList("", "", 1000, 10, false);
+  @MethodSource("sortedListStatusParametersSource")
+  @ParameterizedTest
+  public void testSortedListStatus(String keyPrefix, String startKey, int numEntries, int expectedNumKeys,
+                                   boolean isPartialPrefix) throws Exception {
+    checkKeyList(keyPrefix, startKey, numEntries, expectedNumKeys, isPartialPrefix);
+  }
 
-    // b) number of keys returns is expected
-    checkKeyList("", "", 2, 2, false);
-
-    // c) check if full prefix works
-    checkKeyList("a1", "", 100, 3, false);
-
-    //  d) check if full prefix with numEntries work
-    checkKeyList("a1", "", 2, 2, false);
-
-    // e) check if existing start key >>>
-    checkKeyList("a1", "a1/a12", 100, 2, false);
-
-    // f) check with non-existing start key
-    checkKeyList("", "a7", 100, 6, false);
-
-    // g) check if half prefix works
-    checkKeyList("b", "", 100, 4, true);
-
-    // h) check half prefix with non-existing start key
-    checkKeyList("b", "b5", 100, 2, true);
-
-    // i) check half prefix with non-existing parent in start key
-    checkKeyList("b", "c", 100, 0, true);
-
-    // i) check half prefix with non-existing parent in start key
-    checkKeyList("b", "b/g5", 100, 4, true);
-
-    // i) check half prefix with non-existing parent in start key
-    checkKeyList("b", "c/g5", 100, 0, true);
-
-    // j) check prefix with non-existing prefix key
-    //    and non-existing parent in start key
-    checkKeyList("a1/a111", "a1/a111/a100", 100, 0, true);
+  private static Stream<Arguments> sortedListStatusParametersSource() {
+    return Stream.of(
+        // 1) test if output is sorted
+        arguments("", "", 1000, 10, false),
+        // 2) number of keys returns is expected
+        arguments("", "", 2, 2, false),
+        // 3) check if the full prefix works
+        arguments("a1", "", 100, 3, false),
+        // 4) check if full prefix with numEntries work
+        arguments("a1", "", 2, 2, false),
+        // 5) check if existing start key >>>
+        arguments("a1", "a1/a12", 100, 2, false),
+        // 6) check with a non-existing start key
+        arguments("", "a7", 100, 6, false),
+        // 7) check if half-prefix works
+        arguments("b", "", 100, 4, true),
+        // 8) check half prefix with non-existing start key
+        arguments("b", "b5", 100, 2, true),
+        // 9) check half prefix with non-existing parent in a start key
+        arguments("b", "c", 100, 0, true),
+        // 10) check half prefix with non-existing parent in a start key
+        arguments("b", "b/g5", 100, 4, true),
+        // 11) check half prefix with non-existing parent in a start key
+        arguments("b", "c/g5", 100, 0, true),
+        // 12) check prefix with a non-existing prefix key
+        //    and non-existing parent in a start key
+        arguments("a1/a111", "a1/a111/a100", 100, 0, true),
+        // 13) check start key is null
+        arguments("a1/a111", null, 100, 0, true)
+    );
   }
 
   private static void createFile(OzoneBucket bucket, String keyName)
@@ -131,6 +136,7 @@ public class TestListStatus {
       oos.flush();
     }
   }
+
   private static void buildNameSpaceTree(OzoneBucket ozoneBucket)
       throws Exception {
     /*
@@ -172,33 +178,29 @@ public class TestListStatus {
     createFile(ozoneBucket, "/b8");
   }
 
-  private void checkKeyList(String keyPrefix, String startKey,
-                            long numEntries, int expectedNumKeys,
-                            boolean isPartialPrefix)
-      throws Exception {
+  private void checkKeyList(String keyPrefix, String startKey, long numEntries, int expectedNumKeys,
+                            boolean isPartialPrefix) throws Exception {
 
     List<OzoneFileStatus> statuses =
         fsoOzoneBucket.listStatus(keyPrefix, false, startKey,
             numEntries, isPartialPrefix);
     assertEquals(expectedNumKeys, statuses.size());
 
-    System.out.println("BEGIN:::keyPrefix---> " + keyPrefix + ":::---> " +
-        startKey);
+    LOG.info("BEGIN:::keyPrefix---> {} :::---> {}", keyPrefix, startKey);
 
     for (int i = 0; i < statuses.size() - 1; i++) {
       OzoneFileStatus stCurr = statuses.get(i);
       OzoneFileStatus stNext = statuses.get(i + 1);
 
-      System.out.println("status:"  + stCurr);
+      LOG.info("status: {}", stCurr);
       assertThat(stCurr.getPath().compareTo(stNext.getPath())).isLessThan(0);
     }
 
     if (!statuses.isEmpty()) {
       OzoneFileStatus stNext = statuses.get(statuses.size() - 1);
-      System.out.println("status:" + stNext);
+      LOG.info("status: {}", stNext);
     }
 
-    System.out.println("END:::keyPrefix---> " + keyPrefix + ":::---> " +
-        startKey);
+    LOG.info("END:::keyPrefix---> {}:::---> {}", keyPrefix, startKey);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -90,41 +90,28 @@ public class TestListStatus {
   }
 
   @MethodSource("sortedListStatusParametersSource")
-  @ParameterizedTest
+  @ParameterizedTest(name = "{index} {5}")
   public void testSortedListStatus(String keyPrefix, String startKey, int numEntries, int expectedNumKeys,
-                                   boolean isPartialPrefix) throws Exception {
+                                   boolean isPartialPrefix, String testName) throws Exception {
     checkKeyList(keyPrefix, startKey, numEntries, expectedNumKeys, isPartialPrefix);
   }
 
   private static Stream<Arguments> sortedListStatusParametersSource() {
     return Stream.of(
-        // 1) test if output is sorted
-        arguments("", "", 1000, 10, false),
-        // 2) number of keys returns is expected
-        arguments("", "", 2, 2, false),
-        // 3) check if the full prefix works
-        arguments("a1", "", 100, 3, false),
-        // 4) check if full prefix with numEntries work
-        arguments("a1", "", 2, 2, false),
-        // 5) check if existing start key >>>
-        arguments("a1", "a1/a12", 100, 2, false),
-        // 6) check with a non-existing start key
-        arguments("", "a7", 100, 6, false),
-        // 7) check if half-prefix works
-        arguments("b", "", 100, 4, true),
-        // 8) check half prefix with non-existing start key
-        arguments("b", "b5", 100, 2, true),
-        // 9) check half prefix with non-existing parent in a start key
-        arguments("b", "c", 100, 0, true),
-        // 10) check half prefix with non-existing parent in a start key
-        arguments("b", "b/g5", 100, 4, true),
-        // 11) check half prefix with non-existing parent in a start key
-        arguments("b", "c/g5", 100, 0, true),
-        // 12) check prefix with a non-existing prefix key
-        //    and non-existing parent in a start key
-        arguments("a1/a111", "a1/a111/a100", 100, 0, true),
-        // 13) check start key is null
-        arguments("a1/a111", null, 100, 0, true)
+        arguments("", "", 1000, 10, false, "Test if output is sorted"),
+        arguments("", "", 2, 2, false, "Number of keys returns is expected"),
+        arguments("a1", "", 100, 3, false, "Check if the full prefix works"),
+        arguments("a1", "", 2, 2, false, "Check if full prefix with numEntries work"),
+        arguments("a1", "a1/a12", 100, 2, false, "Check if existing start key >>>"),
+        arguments("", "a7", 100, 6, false, "Check with a non-existing start key"),
+        arguments("b", "", 100, 4, true, "Check if half-prefix works"),
+        arguments("b", "b5", 100, 2, true, "Check half prefix with non-existing start key"),
+        arguments("b", "c", 100, 0, true, "Check half prefix with non-existing parent in a start key"),
+        arguments("b", "b/g5", 100, 4, true, "Check half prefix with non-existing parent in a start key"),
+        arguments("b", "c/g5", 100, 0, true, "Check half prefix with non-existing parent in a start key"),
+        arguments("a1/a111", "a1/a111/a100", 100, 0, true, "Check prefix with a non-existing prefix key\n" +
+            " and non-existing parent in a start key"),
+        arguments("a1/a111", null, 100, 0, true, "Check start key is null")
     );
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix possible NullPointerException which can occur in some cases while invoking listKeysLight from OzoneManagerProtocolClientSideTranslatorPB. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10367

## How was this patch tested?

This patch is test manually. 
Separate epic created to cover testing of hdfs client with S3A protocol: https://issues.apache.org/jira/browse/HDDS-10381