### PR TITLE
HDDS-10345. Sorting isn't needed when excluding Datanodes during Ratis Pipeline Creation

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -244,7 +244,6 @@ public class RatisPipelineProvider
                     getPipelineStateManager(), d)))
         .filter(d ->
             (d.getPipelines() >= getNodeManager().pipelineLimit(d.getDn())))
-        .sorted(Comparator.comparingInt(DnWithPipelines::getPipelines))
         .map(d -> d.getDn())
         .collect(Collectors.toList());
     return excluded;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## What changes were proposed in this pull request?
`RatisPipelineProvider` is used to create a new Ratis pipeline when SCM is asked to provide one and existing pipelines can't be used. Both `WritableRatisContainerProvider` and `BackgroundPipelineCreator` create pipelines this way, dynamically and in the background, respectively.

As part of new pipeline creation, Datanodes are excluded if they're already engaged in "ozone.scm.datanode.pipeline.limit" number of pipelines:

```
  private List<DatanodeDetails> filterPipelineEngagement() {
    List<DatanodeDetails> healthyNodes =
        getNodeManager().getNodes(NodeStatus.inServiceHealthy());
    List<DatanodeDetails> excluded = healthyNodes.stream()
        .map(d ->
            new DnWithPipelines(d,
                PipelinePlacementPolicy
                    .currentRatisThreePipelineCount(getNodeManager(),
                    getPipelineStateManager(), d)))
        .filter(d ->
            (d.getPipelines() >= getNodeManager().pipelineLimit(d.getDn())))
        .sorted(Comparator.comparingInt(DnWithPipelines::getPipelines))
        .map(d -> d.getDn())
        .collect(Collectors.toList());
    return excluded;
  }
```

As you can see, this list is sorted before returning. I don't think sorting here is required since those Datanodes will just get excluded and we don't really need ordering.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10345

## How was this patch tested?

Existing tests.

Successful CI in my fork: https://github.com/siddhantsangwan/ozone/actions/runs/7916689597
