### PR TITLE
HDDS-10300. InstallSnapshot may fail if OM metadata dir and OM DB dir are in different local storage partitions.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -248,7 +248,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       differ.incrementTarballRequestCount();
       FileUtils.copyDirectory(compactionLogDir.getOriginalDir(),
           compactionLogDir.getTmpDir());
-      OmSnapshotUtils.linkFiles(sstBackupDir.getOriginalDir(),
+      OmSnapshotUtils.linkFilesOrCopy(sstBackupDir.getOriginalDir(),
           sstBackupDir.getTmpDir());
       checkpoint = getDbStore().getCheckpoint(flush);
     } finally {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3711,7 +3711,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     TermIndex termIndex = null;
     try {
       // Install hard links.
-      OmSnapshotUtils.createHardLinks(omDBCheckpoint.getCheckpointLocation());
+      OmSnapshotUtils.createHardLinksOrCopyFromHardlinkFile(omDBCheckpoint.getCheckpointLocation());
       termIndex = installCheckpoint(leaderId, omDBCheckpoint);
     } catch (Exception ex) {
       LOG.error("Failed to install snapshot from Leader OM.", ex);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3946,7 +3946,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       // Link each of the candidate DB files to real DB directory.  This
       // preserves the links that already exist between files in the
       // candidate db.
-      OmSnapshotUtils.linkFiles(checkpointPath.toFile(),
+      OmSnapshotUtils.linkFilesOrCopy(checkpointPath.toFile(),
           oldDB);
       moveOmSnapshotData(oldDB.toPath(), dbSnapshotsDir.toPath());
       Files.deleteIfExists(markerFile);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
@@ -32,7 +32,6 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
@@ -141,6 +141,8 @@ public final class OmSnapshotUtils {
   }
 
   private static void createHardLinksOrCopy(Path fullFromPath, Path fullToPath) throws IOException {
+    Objects.requireNonNull(fullFromPath, "From path is null");
+    Objects.requireNonNull(fullToPath, "To path is null");
     if (isSamePartition(fullFromPath.getParent(), fullToPath.getParent())) {
       Files.createLink(fullToPath, fullFromPath);
     } else {
@@ -149,8 +151,8 @@ public final class OmSnapshotUtils {
   }
 
   private static boolean isSamePartition(Path fromPathParent, Path toPathParent) throws IOException {
-    Objects.requireNonNull(fromPathParent, "From path is null");
-    Objects.requireNonNull(toPathParent, "To path is null");
+    Objects.requireNonNull(fromPathParent, "From parent path is null");
+    Objects.requireNonNull(toPathParent, "To parent path is null");
     FileStore fromPathStore = Files.getFileStore(fromPathParent);
     FileStore toPathStore = Files.getFileStore(toPathParent);
     return fromPathStore.equals(toPathStore);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
@@ -141,8 +141,6 @@ public final class OmSnapshotUtils {
   }
 
   private static void createHardLinksOrCopy(Path fullFromPath, Path fullToPath) throws IOException {
-    Objects.requireNonNull(fullFromPath, "From path is null");
-    Objects.requireNonNull(fullToPath, "To path is null");
     if (isSamePartition(fullFromPath.getParent(), fullToPath.getParent())) {
       Files.createLink(fullToPath, fullFromPath);
     } else {
@@ -151,8 +149,9 @@ public final class OmSnapshotUtils {
   }
 
   private static boolean isSamePartition(Path fromPathParent, Path toPathParent) throws IOException {
-    Objects.requireNonNull(fromPathParent, "From parent path is null");
-    Objects.requireNonNull(toPathParent, "To parent path is null");
+    if (fromPathParent == null || toPathParent == null) {
+      throw new IOException("From path: " + fromPathParent + " or To path: " + toPathParent + " is null");
+    }
     FileStore fromPathStore = Files.getFileStore(fromPathParent);
     FileStore toPathStore = Files.getFileStore(toPathParent);
     return fromPathStore.equals(toPathStore);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OmSnapshotUtils.java
@@ -131,10 +131,10 @@ public final class OmSnapshotUtils {
             }
           }
 
-          if (isSamePartition(fullFromPath, fullToPath)) {
+          if (isSamePartition(fullFromPath.getParent(), fullToPath.getParent())) {
             Files.createLink(fullToPath, fullFromPath);
           } else {
-            Files.move(fullFromPath, fullToPath, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(fullFromPath, fullToPath, StandardCopyOption.REPLACE_EXISTING);
           }
         }
         if (!hardLinkFile.delete()) {
@@ -144,13 +144,17 @@ public final class OmSnapshotUtils {
     }
   }
 
-  private static boolean isSamePartition(Path fromPath, Path toPath) throws IOException {
+  private static boolean isSamePartition(Path fromPathParent, Path toPathParent) throws IOException {
     try {
-      FileStore fromPathStore = Files.getFileStore(fromPath.getParent());
-      FileStore toPathStore = Files.getFileStore(toPath.getParent());
+      if (fromPathParent == null || toPathParent == null) {
+        throw new IOException("From path: " + fromPathParent + " or To path: " + toPathParent + " is null");
+      }
+
+      FileStore fromPathStore = Files.getFileStore(fromPathParent);
+      FileStore toPathStore = Files.getFileStore(toPathParent);
       return fromPathStore.equals(toPathStore);
     } catch (IOException ex) {
-      throw new IOException("Failed to get the stores, fromPath: " + fromPath + " toPath: " + toPath, ex);
+      throw new IOException("Failed to get the stores, fromPath: " + fromPathParent + " toPath: " + toPathParent, ex);
     }
   }
 
@@ -186,10 +190,10 @@ public final class OmSnapshotUtils {
         if (!newFile.mkdirs()) {
           throw new IOException("Directory create fails: " + newFile);
         }
-      } else if (isSamePartition(newFile.toPath(), oldFile.toPath())) {
+      } else if (isSamePartition(newFile.toPath().getParent(), oldFile.toPath().getParent())) {
         Files.createLink(newFile.toPath(), oldFile.toPath());
       } else {
-        Files.move(oldFile.toPath(), newFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(oldFile.toPath(), newFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
       }
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotManager.java
@@ -297,7 +297,7 @@ class TestOmSnapshotManager {
     File s1FileLink = new File(followerSnapDir2, "s1.sst");
 
     // Create links on the follower from list.
-    OmSnapshotUtils.createHardLinks(candidateDir.toPath());
+    OmSnapshotUtils.createHardLinksOrCopyFromHardlinkFile(candidateDir.toPath());
 
     // Confirm expected follower links.
     assertTrue(s1FileLink.exists());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
@@ -66,7 +66,7 @@ public class TestOmSnapshotUtils {
     assertFalse(tree2.exists());
     assertFalse(f1Link.exists());
 
-    OmSnapshotUtils.linkFiles(tree1, tree2);
+    OmSnapshotUtils.linkFilesOrCopy(tree1, tree2);
 
     // Expected files/links should exist now.
     assertTrue(tree2.exists());


### PR DESCRIPTION
## What changes were proposed in this pull request?
When we hard link files between different disk/partition we face this `Invalid cross-device link` error. Because we can't create hard links between different disks. In this patch,  Instead of creating a hard link we move the file to the target directory.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10300

## How was this patch tested?

Existing Tests
