### PR TITLE
HDDS-10385. Memory leak for thread local usages in OMClientRequest

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotDeletingService.java
@@ -484,8 +484,9 @@ public class TestSnapshotDeletingService {
     client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_ONE,
         "bucket1key0", false);
     assertTableRowCount(keyTable, 0);
-    // bucket1key0 should also be reclaimed as it not same
-    assertTableRowCount(deletedTable, 1);
+    // one copy of bucket1key0 should also be reclaimed as it not same
+    // but original deleted key created during overwrite should not be deleted
+    assertTableRowCount(deletedTable, 2);
 
     // Create Snapshot 2.
     client.getProxy().createSnapshot(VOLUME_NAME, BUCKET_NAME_ONE,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -79,8 +79,7 @@ public abstract class OMClientRequest implements RequestAuditor {
 
   private UserGroupInformation userGroupInformation;
   private InetAddress inetAddress;
-  private final ThreadLocal<OMLockDetails> omLockDetails =
-      ThreadLocal.withInitial(OMLockDetails::new);
+  private final OMLockDetails omLockDetails = new OMLockDetails();
 
   /**
    * Stores the result of request execution in
@@ -95,7 +94,7 @@ public abstract class OMClientRequest implements RequestAuditor {
   public OMClientRequest(OMRequest omRequest) {
     Preconditions.checkNotNull(omRequest);
     this.omRequest = omRequest;
-    this.omLockDetails.get().clear();
+    this.omLockDetails.clear();
   }
   /**
    * Perform pre-execute steps on a OMRequest.
@@ -576,10 +575,10 @@ public abstract class OMClientRequest implements RequestAuditor {
   }
 
   public OMLockDetails getOmLockDetails() {
-    return omLockDetails.get();
+    return omLockDetails;
   }
 
   public void mergeOmLockDetails(OMLockDetails details) {
-    omLockDetails.get().merge(details);
+    omLockDetails.merge(details);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -270,8 +270,10 @@ public class OMKeyCommitRequest extends OMKeyRequest {
             keyToDelete, trxnLogIndex, ozoneManager.isRatisEnabled());
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
+        // using pseutoObjId as objectId can be same in case of overwrite key
+        long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(
-            keyToDelete.getObjectID(), dbOzoneKey);
+            pseudoObjId, dbOzoneKey);
         if (null == oldKeyVersionsToDeleteMap) {
           oldKeyVersionsToDeleteMap = new HashMap<>();
         }
@@ -303,8 +305,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         if (null == oldKeyVersionsToDeleteMap) {
           oldKeyVersionsToDeleteMap = new HashMap<>();
         }
-        oldKeyVersionsToDeleteMap.put(delKeyName,
-            new RepeatedOmKeyInfo(pseudoKeyInfo));
+        oldKeyVersionsToDeleteMap.computeIfAbsent(delKeyName,
+            key -> new RepeatedOmKeyInfo()).addOmKeyInfo(pseudoKeyInfo);
       }
 
       // Add to cache of open key table and key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -270,7 +270,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
             keyToDelete, trxnLogIndex, ozoneManager.isRatisEnabled());
         checkBucketQuotaInBytes(omMetadataManager, omBucketInfo,
             correctedSpace);
-        // using pseutoObjId as objectId can be same in case of overwrite key
+        // using pseudoObjId as objectId can be same in case of overwrite key
         long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(
             pseudoObjId, dbOzoneKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -203,8 +203,10 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
             correctedSpace);
         String delKeyName = omMetadataManager
             .getOzoneKey(volumeName, bucketName, fileName);
+        // using pseutoObjId as objectId can be same in case of overwrite key
+        long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         delKeyName = omMetadataManager.getOzoneDeletePathKey(
-            keyToDelete.getObjectID(), delKeyName);
+            pseudoObjId, delKeyName);
         if (null == oldKeyVersionsToDeleteMap) {
           oldKeyVersionsToDeleteMap = new HashMap<>();
         }
@@ -238,8 +240,8 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         if (null == oldKeyVersionsToDeleteMap) {
           oldKeyVersionsToDeleteMap = new HashMap<>();
         }
-        oldKeyVersionsToDeleteMap.put(delKeyName,
-            new RepeatedOmKeyInfo(pseudoKeyInfo));
+        oldKeyVersionsToDeleteMap.computeIfAbsent(delKeyName,
+            key -> new RepeatedOmKeyInfo()).addOmKeyInfo(pseudoKeyInfo);
       }
 
       // Add to cache of open key table and key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -203,7 +203,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
             correctedSpace);
         String delKeyName = omMetadataManager
             .getOzoneKey(volumeName, bucketName, fileName);
-        // using pseutoObjId as objectId can be same in case of overwrite key
+        // using pseudoObjId as objectId can be same in case of overwrite key
         long pseudoObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         delKeyName = omMetadataManager.getOzoneDeletePathKey(
             pseudoObjId, delKeyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -27,6 +27,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -60,6 +63,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 
 /**
  * Class tests OMKeyCommitRequest class.
@@ -555,16 +560,17 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
   @Test
   public void testValidateAndUpdateCacheOnOverwrite() throws Exception {
+    when(ozoneManager.getObjectIdFromTxId(anyLong())).thenAnswer(tx ->
+        OmUtils.getObjectIdFromTxId(2, tx.getArgument(0)));
     testValidateAndUpdateCache();
 
     // Become a new client and set next version number
     clientID = Time.now();
     version += 1;
 
-    OMRequest modifiedOmRequest = doPreExecute(createCommitKeyRequest());
+    OMRequest modifiedOmRequest = doPreExecute(createCommitKeyRequest(getKeyLocation(10).subList(4, 10), false));
 
-    OMKeyCommitRequest omKeyCommitRequest =
-            getOmKeyCommitRequest(modifiedOmRequest);
+    OMKeyCommitRequest omKeyCommitRequest = getOmKeyCommitRequest(modifiedOmRequest);
 
     KeyArgs keyArgs = modifiedOmRequest.getCommitKeyRequest().getKeyArgs();
 
@@ -576,49 +582,54 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     assertNotNull(omKeyInfo);
     // Previously committed version
-    assertEquals(0L,
-            omKeyInfo.getLatestVersionLocations().getVersion());
+    assertEquals(0L, omKeyInfo.getLatestVersionLocations().getVersion());
 
     // Append new blocks
     List<OmKeyLocationInfo> allocatedLocationList =
-            keyArgs.getKeyLocationsList().stream()
-                    .map(OmKeyLocationInfo::getFromProtobuf)
-                    .collect(Collectors.toList());
+        keyArgs.getKeyLocationsList().stream()
+            .map(OmKeyLocationInfo::getFromProtobuf)
+            .collect(Collectors.toList());
     addKeyToOpenKeyTable(allocatedLocationList);
 
     OMClientResponse omClientResponse =
         omKeyCommitRequest.validateAndUpdateCache(ozoneManager, 102L);
 
-    assertEquals(OzoneManagerProtocolProtos.Status.OK,
-            omClientResponse.getOMResponse().getStatus());
+    assertEquals(OzoneManagerProtocolProtos.Status.OK, omClientResponse.getOMResponse().getStatus());
 
     // New entry should be created in key Table.
-    omKeyInfo =
-        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
-            .get(ozoneKey);
+    omKeyInfo = omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout()).get(ozoneKey);
 
     assertNotNull(omKeyInfo);
-    assertEquals(version,
-            omKeyInfo.getLatestVersionLocations().getVersion());
+    assertEquals(version, omKeyInfo.getLatestVersionLocations().getVersion());
     // DB keyInfo format
     verifyKeyName(omKeyInfo);
 
     // Check modification time
     CommitKeyRequest commitKeyRequest = modifiedOmRequest.getCommitKeyRequest();
-    assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(),
-            omKeyInfo.getModificationTime());
+    assertEquals(commitKeyRequest.getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
 
     // Check block location.
     List<OmKeyLocationInfo> locationInfoListFromCommitKeyRequest =
-        commitKeyRequest.getKeyArgs()
-        .getKeyLocationsList().stream().map(OmKeyLocationInfo::getFromProtobuf)
-        .collect(Collectors.toList());
+        commitKeyRequest.getKeyArgs().getKeyLocationsList().stream().map(OmKeyLocationInfo::getFromProtobuf)
+            .collect(Collectors.toList());
 
-    assertEquals(locationInfoListFromCommitKeyRequest,
-            omKeyInfo.getLatestVersionLocations().getLocationList());
-    assertEquals(allocatedLocationList,
-            omKeyInfo.getLatestVersionLocations().getLocationList());
+    assertEquals(locationInfoListFromCommitKeyRequest, omKeyInfo.getLatestVersionLocations().getLocationList());
+    assertEquals(allocatedLocationList, omKeyInfo.getLatestVersionLocations().getLocationList());
     assertEquals(1, omKeyInfo.getKeyLocationVersions().size());
+
+    // flush response content to db
+    BatchOperation batchOperation = omMetadataManager.getStore().initBatchOperation();
+    ((OMKeyCommitResponse) omClientResponse).addToDBBatch(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    // verify deleted key is unique generated
+    String deletedKey = omMetadataManager.getOzoneKey(volumeName, omKeyInfo.getBucketName(), keyName);
+    List<? extends Table.KeyValue<String, RepeatedOmKeyInfo>> rangeKVs
+        = omMetadataManager.getDeletedTable().getRangeKVs(null, 100, deletedKey);
+    assertThat(rangeKVs.size()).isGreaterThan(0);
+    assertEquals(1, rangeKVs.get(0).getValue().getOmKeyInfoList().size());
+    assertTrue(!rangeKVs.get(0).getKey().endsWith(rangeKVs.get(0).getValue().getOmKeyInfoList().get(0).getObjectID()
+        + ""));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -628,7 +629,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         = omMetadataManager.getDeletedTable().getRangeKVs(null, 100, deletedKey);
     assertThat(rangeKVs.size()).isGreaterThan(0);
     assertEquals(1, rangeKVs.get(0).getValue().getOmKeyInfoList().size());
-    assertTrue(!rangeKVs.get(0).getKey().endsWith(rangeKVs.get(0).getValue().getOmKeyInfoList().get(0).getObjectID()
+    assertFalse(rangeKVs.get(0).getKey().endsWith(rangeKVs.get(0).getValue().getOmKeyInfoList().get(0).getObjectID()
         + ""));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instance object is having thread local object, which can have memory leak as thread local is not explicitly released. Further there do not seems any usecase having thread local definition for OmLockDetails.
So removed thread local definition.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10385

## How was this patch tested?

- Existing test case to cover impact
