### PR TITLE
HDDS-10385. Memory leak for thread local usages in OMClientRequest

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -78,8 +78,7 @@ public abstract class OMClientRequest implements RequestAuditor {
 
   private UserGroupInformation userGroupInformation;
   private InetAddress inetAddress;
-  private final ThreadLocal<OMLockDetails> omLockDetails =
-      ThreadLocal.withInitial(OMLockDetails::new);
+  private final OMLockDetails omLockDetails = new OMLockDetails();
 
   /**
    * Stores the result of request execution in
@@ -94,7 +93,7 @@ public abstract class OMClientRequest implements RequestAuditor {
   public OMClientRequest(OMRequest omRequest) {
     Preconditions.checkNotNull(omRequest);
     this.omRequest = omRequest;
-    this.omLockDetails.get().clear();
+    this.omLockDetails.clear();
   }
   /**
    * Perform pre-execute steps on a OMRequest.
@@ -575,10 +574,10 @@ public abstract class OMClientRequest implements RequestAuditor {
   }
 
   public OMLockDetails getOmLockDetails() {
-    return omLockDetails.get();
+    return omLockDetails;
   }
 
   public void mergeOmLockDetails(OMLockDetails details) {
-    omLockDetails.get().merge(details);
+    omLockDetails.merge(details);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Instance object is having thread local object, which can have memory leak as thread local is not explicitly released. Further there do not seems any usecase having thread local definition for OmLockDetails.
So removed thread local definition.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10385

## How was this patch tested?

Existing test case to cover impact
