### PR TITLE
HDDS-10398. Remove deleted_blocks table in container schema V2 and V3 definition

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 
 import java.io.File;
 
@@ -70,7 +69,4 @@ public abstract class AbstractDatanodeDBDefinition implements DBDefinition {
 
   public abstract DBColumnFamilyDefinition<String, Long>
       getMetadataColumnFamily();
-
-  public abstract DBColumnFamilyDefinition<String, ChunkInfoList>
-      getDeletedBlocksColumnFamily();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -60,8 +60,6 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
   private Table<String, BlockData> blockDataTableWithIterator;
 
-  private Table<String, ChunkInfoList> deletedBlocksTable;
-
   static final Logger LOG =
       LoggerFactory.getLogger(AbstractDatanodeStore.class);
   private volatile DBStore store;
@@ -154,10 +152,6 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
       blockDataTable = new DatanodeTable<>(blockDataTableWithIterator);
       checkTableStatus(blockDataTable, blockDataTable.getName());
-
-      deletedBlocksTable = new DatanodeTable<>(
-              dbDef.getDeletedBlocksColumnFamily().getTable(this.store));
-      checkTableStatus(deletedBlocksTable, deletedBlocksTable.getName());
     }
   }
 
@@ -191,7 +185,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
   @Override
   public Table<String, ChunkInfoList> getDeletedBlocksTable() {
-    return deletedBlocksTable;
+    throw new UnsupportedOperationException("DeletedBlocksTable is only supported in Container Schema One");
   }
 
   @Override
@@ -250,7 +244,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
     return this.blockDataTableWithIterator;
   }
 
-  private static void checkTableStatus(Table<?, ?> table, String name)
+  protected static void checkTableStatus(Table<?, ?> table, String name)
           throws IOException {
     String logMessage = "Unable to get a reference to %s table. Cannot " +
             "continue.";

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -96,7 +96,6 @@ public class DatanodeSchemaOneDBDefinition
     return METADATA;
   }
 
-  @Override
   public DBColumnFamilyDefinition<String, ChunkInfoList>
       getDeletedBlocksColumnFamily() {
     return DELETED_BLOCKS;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.utils.db.FixedLengthStringCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.utils.db.DatanodeDBProfile;
 
@@ -74,15 +73,6 @@ public class DatanodeSchemaThreeDBDefinition
           Long.class,
           LongCodec.get());
 
-  public static final DBColumnFamilyDefinition<String, ChunkInfoList>
-      DELETED_BLOCKS =
-      new DBColumnFamilyDefinition<>(
-          "deleted_blocks",
-          String.class,
-          FixedLengthStringCodec.get(),
-          ChunkInfoList.class,
-          ChunkInfoList.getCodec());
-
   public static final DBColumnFamilyDefinition<String, DeletedBlocksTransaction>
       DELETE_TRANSACTION =
       new DBColumnFamilyDefinition<>(
@@ -98,7 +88,6 @@ public class DatanodeSchemaThreeDBDefinition
       COLUMN_FAMILIES = DBColumnFamilyDefinition.newUnmodifiableMap(
          BLOCK_DATA,
          METADATA,
-         DELETED_BLOCKS,
          DELETE_TRANSACTION);
 
   public DatanodeSchemaThreeDBDefinition(String dbPath,
@@ -120,7 +109,6 @@ public class DatanodeSchemaThreeDBDefinition
 
     BLOCK_DATA.setCfOptions(cfOptions);
     METADATA.setCfOptions(cfOptions);
-    DELETED_BLOCKS.setCfOptions(cfOptions);
     DELETE_TRANSACTION.setCfOptions(cfOptions);
   }
 
@@ -138,12 +126,6 @@ public class DatanodeSchemaThreeDBDefinition
   @Override
   public DBColumnFamilyDefinition<String, Long> getMetadataColumnFamily() {
     return METADATA;
-  }
-
-  @Override
-  public DBColumnFamilyDefinition<String, ChunkInfoList>
-      getDeletedBlocksColumnFamily() {
-    return DELETED_BLOCKS;
   }
 
   public DBColumnFamilyDefinition<String, DeletedBlocksTransaction>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 
@@ -58,15 +57,6 @@ public class DatanodeSchemaTwoDBDefinition
           Long.class,
           LongCodec.get());
 
-  public static final DBColumnFamilyDefinition<String, ChunkInfoList>
-          DELETED_BLOCKS =
-          new DBColumnFamilyDefinition<>(
-                  "deleted_blocks",
-                  String.class,
-                  StringCodec.get(),
-                  ChunkInfoList.class,
-                  ChunkInfoList.getCodec());
-
   public static final DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
       DELETE_TRANSACTION =
       new DBColumnFamilyDefinition<>(
@@ -85,7 +75,6 @@ public class DatanodeSchemaTwoDBDefinition
       COLUMN_FAMILIES = DBColumnFamilyDefinition.newUnmodifiableMap(
           BLOCK_DATA,
           METADATA,
-          DELETED_BLOCKS,
           DELETE_TRANSACTION);
 
   @Override
@@ -102,12 +91,6 @@ public class DatanodeSchemaTwoDBDefinition
   @Override
   public DBColumnFamilyDefinition<String, Long> getMetadataColumnFamily() {
     return METADATA;
-  }
-
-  @Override
-  public DBColumnFamilyDefinition<String, ChunkInfoList>
-      getDeletedBlocksColumnFamily() {
-    return DELETED_BLOCKS;
   }
 
   public DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaOneImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaOneImpl.java
@@ -28,6 +28,9 @@ import java.io.IOException;
  * places all data in the default column family.
  */
 public class DatanodeStoreSchemaOneImpl extends AbstractDatanodeStore {
+
+  private Table<String, ChunkInfoList> deletedBlocksTable;
+
   /**
    * Constructs the metadata store and starts the DB Services.
    *
@@ -38,12 +41,15 @@ public class DatanodeStoreSchemaOneImpl extends AbstractDatanodeStore {
       boolean openReadOnly) throws IOException {
     super(config, new DatanodeSchemaOneDBDefinition(dbPath, config),
         openReadOnly);
+    deletedBlocksTable = new DatanodeTable<>(
+        ((DatanodeSchemaOneDBDefinition) getDbDef()).getDeletedBlocksColumnFamily().getTable(getStore()));
+    checkTableStatus(deletedBlocksTable, deletedBlocksTable.getName());
   }
 
   @Override
   public Table<String, ChunkInfoList> getDeletedBlocksTable() {
     // Return a wrapper around the deleted blocks table to handle prefixes
     // when all data is stored in a single table.
-    return new SchemaOneDeletedBlocksTable(super.getDeletedBlocksTable());
+    return new SchemaOneDeletedBlocksTable(deletedBlocksTable);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
@@ -99,7 +99,6 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
     try (BatchOperation batch = getBatchHandler().initBatchOperation()) {
       getMetadataTable().deleteBatchWithPrefix(batch, prefix);
       getBlockDataTable().deleteBatchWithPrefix(batch, prefix);
-      getDeletedBlocksTable().deleteBatchWithPrefix(batch, prefix);
       getDeleteTransactionTable().deleteBatchWithPrefix(batch, prefix);
       getBatchHandler().commitBatchOperation(batch);
     }
@@ -112,8 +111,6 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
         getTableDumpFile(getMetadataTable(), dumpDir), prefix);
     getBlockDataTable().dumpToFileWithPrefix(
         getTableDumpFile(getBlockDataTable(), dumpDir), prefix);
-    getDeletedBlocksTable().dumpToFileWithPrefix(
-        getTableDumpFile(getDeletedBlocksTable(), dumpDir), prefix);
     getDeleteTransactionTable().dumpToFileWithPrefix(
         getTableDumpFile(getDeleteTransactionTable(), dumpDir),
         prefix);
@@ -125,8 +122,6 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
         getTableDumpFile(getMetadataTable(), dumpDir));
     getBlockDataTable().loadFromFile(
         getTableDumpFile(getBlockDataTable(), dumpDir));
-    getDeletedBlocksTable().loadFromFile(
-        getTableDumpFile(getDeletedBlocksTable(), dumpDir));
     getDeleteTransactionTable().loadFromFile(
         getTableDumpFile(getDeleteTransactionTable(), dumpDir));
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

deleted_blocks table is only used in container schema V1. It's replaced with delete_txns table in schema V2 and V3. But currently deleted_blocks table is still defined and kept in DatanodeSchemaThreeDBDefinition and DatanodeSchemaTwoDBDefinition, which will confuse the code readers who don't know this background.

This task removes the deleted_blocks table definition and reference in schema V2 and V3.
 
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10398

## How was this patch tested?

Existing unit tests
