### PR TITLE
HDDS-10396. Encapsulate fields in WithMetadata and subclasses

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -154,7 +154,7 @@ public class OzoneBucket extends WithMetadata {
   private String owner;
 
   protected OzoneBucket(Builder builder) {
-    this.metadata = builder.metadata;
+    setMetadata(builder.metadata);
     this.proxy = builder.proxy;
     this.volumeName = builder.volumeName;
     this.name = builder.name;  // bucket name

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -106,7 +106,7 @@ public class OzoneVolume extends WithMetadata {
   private long refCount;
 
   protected OzoneVolume(Builder builder) {
-    this.metadata = builder.metadata;
+    setMetadata(builder.metadata);
     this.proxy = builder.proxy;
     this.name = builder.name;
     this.admin = builder.admin;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -80,7 +80,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     this.bucketName = bucketName;
     this.isVersionEnabled = isVersionEnabled;
     this.storageType = storageType;
-    this.metadata = metadata;
+    setMetadata(metadata);
     this.ownerName = ownerName;
   }
 
@@ -206,7 +206,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     auditMap.put(OzoneConsts.VOLUME, this.volumeName);
     auditMap.put(OzoneConsts.BUCKET, this.bucketName);
     auditMap.put(OzoneConsts.GDPR_FLAG,
-        this.metadata.get(OzoneConsts.GDPR_FLAG));
+        getMetadata().get(OzoneConsts.GDPR_FLAG));
     auditMap.put(OzoneConsts.IS_VERSION_ENABLED,
                 String.valueOf(this.isVersionEnabled));
     if (this.storageType != null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -158,9 +158,9 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     this.storageType = storageType;
     this.creationTime = creationTime;
     this.modificationTime = modificationTime;
-    this.objectID = objectID;
-    this.updateID = updateID;
-    this.metadata = metadata;
+    setObjectID(objectID);
+    setUpdateID(updateID);
+    setMetadata(metadata);
     this.bekInfo = bekInfo;
     this.sourceVolume = sourceVolume;
     this.sourceBucket = sourceBucket;
@@ -351,7 +351,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     auditMap.put(OzoneConsts.BUCKET, this.bucketName);
     auditMap.put(OzoneConsts.BUCKET_LAYOUT, String.valueOf(this.bucketLayout));
     auditMap.put(OzoneConsts.GDPR_FLAG,
-        this.metadata.get(OzoneConsts.GDPR_FLAG));
+        getMetadata().get(OzoneConsts.GDPR_FLAG));
     auditMap.put(OzoneConsts.ACLS,
         (this.acls != null) ? this.acls.toString() : null);
     auditMap.put(OzoneConsts.IS_VERSION_ENABLED,
@@ -403,13 +403,13 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
         .setIsVersionEnabled(isVersionEnabled)
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
-        .setObjectID(objectID)
-        .setUpdateID(updateID)
+        .setObjectID(getObjectID())
+        .setUpdateID(getUpdateID())
         .setBucketEncryptionKey(bekInfo)
         .setSourceVolume(sourceVolume)
         .setSourceBucket(sourceBucket)
         .setAcls(acls)
-        .addAllMetadata(metadata)
+        .addAllMetadata(getMetadata())
         .setUsedBytes(usedBytes)
         .setUsedNamespace(usedNamespace)
         .setQuotaInBytes(quotaInBytes)
@@ -607,11 +607,11 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
         .setStorageType(storageType.toProto())
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
-        .setObjectID(objectID)
-        .setUpdateID(updateID)
+        .setObjectID(getObjectID())
+        .setUpdateID(getUpdateID())
         .setUsedBytes(usedBytes)
         .setUsedNamespace(usedNamespace)
-        .addAllMetadata(KeyValueUtil.toProtobuf(metadata))
+        .addAllMetadata(KeyValueUtil.toProtobuf(getMetadata()))
         .setQuotaInBytes(quotaInBytes)
         .setQuotaInNamespace(quotaInNamespace);
     if (bucketLayout != null) {
@@ -739,13 +739,13 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
         Objects.equals(acls, that.acls) &&
         Objects.equals(isVersionEnabled, that.isVersionEnabled) &&
         storageType == that.storageType &&
-        objectID == that.objectID &&
-        updateID == that.updateID &&
+        getObjectID() == that.getObjectID() &&
+        getUpdateID() == that.getUpdateID() &&
         usedBytes == that.usedBytes &&
         usedNamespace == that.usedNamespace &&
         Objects.equals(sourceVolume, that.sourceVolume) &&
         Objects.equals(sourceBucket, that.sourceBucket) &&
-        Objects.equals(metadata, that.metadata) &&
+        Objects.equals(getMetadata(), that.getMetadata()) &&
         Objects.equals(bekInfo, that.bekInfo) &&
         Objects.equals(owner, that.owner) &&
         Objects.equals(defaultReplicationConfig, that.defaultReplicationConfig);
@@ -768,9 +768,9 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
         ", bekInfo=" + bekInfo +
         ", sourceVolume='" + sourceVolume + "'" +
         ", sourceBucket='" + sourceBucket + "'" +
-        ", objectID=" + objectID +
-        ", updateID=" + updateID +
-        ", metadata=" + metadata +
+        ", objectID=" + getObjectID() +
+        ", updateID=" + getUpdateID() +
+        ", metadata=" + getMetadata() +
         ", usedBytes=" + usedBytes +
         ", usedNamespace=" + usedNamespace +
         ", quotaInBytes=" + quotaInBytes +

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -58,10 +58,10 @@ public class OmDirectoryInfo extends WithParentObjectId
   public OmDirectoryInfo(Builder builder) {
     this.name = builder.name;
     this.acls = builder.acls;
-    this.metadata = builder.metadata;
-    this.objectID = builder.objectID;
-    this.updateID = builder.updateID;
-    this.parentObjectID = builder.parentObjectID;
+    setMetadata(builder.metadata);
+    setObjectID(builder.objectID);
+    setUpdateID(builder.updateID);
+    setParentObjectID(builder.parentObjectID);
     this.creationTime = builder.creationTime;
     this.modificationTime = builder.modificationTime;
   }
@@ -164,10 +164,6 @@ public class OmDirectoryInfo extends WithParentObjectId
     return getPath() + ":" + getObjectID();
   }
 
-  public long getParentObjectID() {
-    return parentObjectID;
-  }
-
   public String getPath() {
     return getParentObjectID() + OzoneConsts.OM_KEY_PREFIX + getName();
   }
@@ -196,10 +192,10 @@ public class OmDirectoryInfo extends WithParentObjectId
             DirectoryInfo.newBuilder().setName(name)
                     .setCreationTime(creationTime)
                     .setModificationTime(modificationTime)
-                    .addAllMetadata(KeyValueUtil.toProtobuf(metadata))
-                    .setObjectID(objectID)
-                    .setUpdateID(updateID)
-                    .setParentID(parentObjectID);
+                    .addAllMetadata(KeyValueUtil.toProtobuf(getMetadata()))
+                    .setObjectID(getObjectID())
+                    .setUpdateID(getUpdateID())
+                    .setParentID(getParentObjectID());
     if (acls != null) {
       pib.addAllAcls(OzoneAclUtil.toProtobuf(acls));
     }
@@ -245,16 +241,16 @@ public class OmDirectoryInfo extends WithParentObjectId
     return creationTime == omDirInfo.creationTime &&
             modificationTime == omDirInfo.modificationTime &&
             name.equals(omDirInfo.name) &&
-            Objects.equals(metadata, omDirInfo.metadata) &&
+            Objects.equals(getMetadata(), omDirInfo.getMetadata()) &&
             Objects.equals(acls, omDirInfo.acls) &&
-            objectID == omDirInfo.objectID &&
-            updateID == omDirInfo.updateID &&
-            parentObjectID == omDirInfo.parentObjectID;
+            getObjectID() == omDirInfo.getObjectID() &&
+            getUpdateID() == omDirInfo.getUpdateID() &&
+            getParentObjectID() == omDirInfo.getParentObjectID();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(objectID, parentObjectID, name);
+    return Objects.hash(getObjectID(), getParentObjectID(), name);
   }
 
   /**
@@ -266,16 +262,16 @@ public class OmDirectoryInfo extends WithParentObjectId
             .setName(name)
             .setCreationTime(creationTime)
             .setModificationTime(modificationTime)
-            .setParentObjectID(parentObjectID)
-            .setObjectID(objectID)
-            .setUpdateID(updateID);
+            .setParentObjectID(getParentObjectID())
+            .setObjectID(getObjectID())
+            .setUpdateID(getUpdateID());
 
     acls.forEach(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
             acl.getName(), (BitSet) acl.getAclBitSet().clone(),
             acl.getAclScope())));
 
-    if (metadata != null) {
-      builder.addAllMetadata(metadata);
+    if (getMetadata() != null) {
+      builder.addAllMetadata(getMetadata());
     }
 
     return builder.build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -116,11 +116,11 @@ public final class OmKeyInfo extends WithParentObjectId
     this.creationTime = creationTime;
     this.modificationTime = modificationTime;
     this.replicationConfig = replicationConfig;
-    this.metadata = metadata;
+    setMetadata(metadata);
     this.encInfo = encInfo;
     this.acls = acls;
-    this.objectID = objectID;
-    this.updateID = updateID;
+    setObjectID(objectID);
+    setUpdateID(updateID);
     this.fileChecksum = fileChecksum;
   }
 
@@ -137,7 +137,7 @@ public final class OmKeyInfo extends WithParentObjectId
             creationTime, modificationTime, replicationConfig, metadata,
             encInfo, acls, objectID, updateID, fileChecksum);
     this.fileName = fileName;
-    this.parentObjectID = parentObjectID;
+    setParentObjectID(parentObjectID);
     this.isFile = isFile;
   }
 
@@ -181,11 +181,6 @@ public final class OmKeyInfo extends WithParentObjectId
     return fileName;
   }
 
-  public long getParentObjectID() {
-    return parentObjectID;
-  }
-
-
   public synchronized OmKeyLocationInfoGroup getLatestVersionLocations() {
     return keyLocationVersions.size() == 0 ? null :
         keyLocationVersions.get(keyLocationVersions.size() - 1);
@@ -213,7 +208,7 @@ public final class OmKeyInfo extends WithParentObjectId
   }
 
   public boolean isHsync() {
-    return metadata.containsKey(OzoneConsts.HSYNC_CLIENT_ID);
+    return getMetadata().containsKey(OzoneConsts.HSYNC_CLIENT_ID);
   }
 
   /**
@@ -411,10 +406,6 @@ public final class OmKeyInfo extends WithParentObjectId
 
   public boolean setAcls(List<OzoneAcl> newAcls) {
     return OzoneAclUtil.setAcl(acls, newAcls);
-  }
-
-  public void setParentObjectID(long parentObjectID) {
-    this.parentObjectID = parentObjectID;
   }
 
   public void setReplicationConfig(ReplicationConfig repConfig) {
@@ -674,11 +665,11 @@ public final class OmKeyInfo extends WithParentObjectId
         .addAllKeyLocationList(keyLocations)
         .setCreationTime(creationTime)
         .setModificationTime(modificationTime)
-        .addAllMetadata(KeyValueUtil.toProtobuf(metadata))
+        .addAllMetadata(KeyValueUtil.toProtobuf(getMetadata()))
         .addAllAcls(OzoneAclUtil.toProtobuf(acls))
-        .setObjectID(objectID)
-        .setUpdateID(updateID)
-        .setParentID(parentObjectID);
+        .setObjectID(getObjectID())
+        .setUpdateID(getUpdateID())
+        .setParentID(getParentObjectID());
 
     FileChecksumProto fileChecksumProto = OMPBHelper.convert(fileChecksum);
     if (fileChecksumProto != null) {
@@ -753,8 +744,8 @@ public final class OmKeyInfo extends WithParentObjectId
         ", key='" + keyName + '\'' +
         ", dataSize='" + dataSize + '\'' +
         ", creationTime='" + creationTime + '\'' +
-        ", objectID='" + objectID + '\'' +
-        ", parentID='" + parentObjectID + '\'' +
+        ", objectID='" + getObjectID() + '\'' +
+        ", parentID='" + getParentObjectID() + '\'' +
         ", replication='" + replicationConfig + '\'' +
         ", fileChecksum='" + fileChecksum +
         '}';
@@ -770,12 +761,12 @@ public final class OmKeyInfo extends WithParentObjectId
         volumeName.equals(omKeyInfo.volumeName) &&
         bucketName.equals(omKeyInfo.bucketName) &&
         replicationConfig.equals(omKeyInfo.replicationConfig) &&
-        Objects.equals(metadata, omKeyInfo.metadata) &&
+        Objects.equals(getMetadata(), omKeyInfo.getMetadata()) &&
         Objects.equals(acls, omKeyInfo.acls) &&
-        objectID == omKeyInfo.objectID;
+        getObjectID() == omKeyInfo.getObjectID();
 
     if (isEqual && checkUpdateID) {
-      isEqual = updateID == omKeyInfo.updateID;
+      isEqual = getUpdateID() == omKeyInfo.getUpdateID();
     }
 
     if (isEqual && checkModificationTime) {
@@ -783,7 +774,7 @@ public final class OmKeyInfo extends WithParentObjectId
     }
 
     if (isEqual && checkPath) {
-      isEqual = parentObjectID == omKeyInfo.parentObjectID &&
+      isEqual = getParentObjectID() == omKeyInfo.getParentObjectID() &&
           keyName.equals(omKeyInfo.keyName);
     }
 
@@ -808,7 +799,7 @@ public final class OmKeyInfo extends WithParentObjectId
 
   @Override
   public int hashCode() {
-    return Objects.hash(volumeName, bucketName, keyName, parentObjectID);
+    return Objects.hash(volumeName, bucketName, keyName, getParentObjectID());
   }
 
   /**
@@ -825,9 +816,9 @@ public final class OmKeyInfo extends WithParentObjectId
         .setDataSize(dataSize)
         .setReplicationConfig(replicationConfig)
         .setFileEncryptionInfo(encInfo)
-        .setObjectID(objectID)
-        .setUpdateID(updateID)
-        .setParentObjectID(parentObjectID)
+        .setObjectID(getObjectID())
+        .setUpdateID(getUpdateID())
+        .setParentObjectID(getParentObjectID())
         .setFileName(fileName)
         .setFile(isFile);
 
@@ -841,8 +832,8 @@ public final class OmKeyInfo extends WithParentObjectId
             acl.getName(), (BitSet) acl.getAclBitSet().clone(),
         acl.getAclScope())));
 
-    if (metadata != null) {
-      metadata.forEach((k, v) -> builder.addMetadata(k, v));
+    if (getMetadata() != null) {
+      getMetadata().forEach((k, v) -> builder.addMetadata(k, v));
     }
 
     if (fileChecksum != null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
@@ -170,8 +170,8 @@ public final class OmMultipartKeyInfo extends WithObjectID {
     this.creationTime = creationTime;
     this.replicationConfig = replicationConfig;
     this.partKeyInfoMap = sortedMap;
-    this.objectID = objectID;
-    this.updateID = updateID;
+    setObjectID(objectID);
+    setUpdateID(updateID);
     this.parentID = parentObjId;
   }
 
@@ -323,8 +323,8 @@ public final class OmMultipartKeyInfo extends WithObjectID {
         .setUploadID(uploadID)
         .setCreationTime(creationTime)
         .setType(replicationConfig.getReplicationType())
-        .setObjectID(objectID)
-        .setUpdateID(updateID)
+        .setObjectID(getObjectID())
+        .setUpdateID(getUpdateID())
         .setParentID(parentID);
 
     if (replicationConfig instanceof ECReplicationConfig) {
@@ -362,7 +362,7 @@ public final class OmMultipartKeyInfo extends WithObjectID {
     // is added, it returns a new shallow copy of the PartKeyInfoMap Object
     // so here we can directly pass in partKeyInfoMap
     return new OmMultipartKeyInfo(uploadID, creationTime, replicationConfig,
-        partKeyInfoMap, objectID, updateID, parentID);
+        partKeyInfoMap, getObjectID(), getUpdateID(), parentID);
   }
 
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
@@ -102,12 +102,12 @@ public final class OmVolumeArgs extends WithObjectID
     this.quotaInBytes = quotaInBytes;
     this.quotaInNamespace = quotaInNamespace;
     this.usedNamespace = usedNamespace;
-    this.metadata = metadata;
+    setMetadata(metadata);
     this.acls = acls;
     this.creationTime = creationTime;
     this.modificationTime = modificationTime;
-    this.objectID = objectID;
-    this.updateID = updateID;
+    setObjectID(objectID);
+    setUpdateID(updateID);
     this.refCount = refCount;
   }
 
@@ -286,12 +286,12 @@ public final class OmVolumeArgs extends WithObjectID
       return false;
     }
     OmVolumeArgs that = (OmVolumeArgs) o;
-    return Objects.equals(this.objectID, that.objectID);
+    return Objects.equals(this.getObjectID(), that.getObjectID());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.objectID);
+    return Objects.hash(getObjectID());
   }
 
   /**
@@ -430,13 +430,13 @@ public final class OmVolumeArgs extends WithObjectID
         .setQuotaInBytes(quotaInBytes)
         .setQuotaInNamespace(quotaInNamespace)
         .setUsedNamespace(usedNamespace)
-        .addAllMetadata(KeyValueUtil.toProtobuf(metadata))
+        .addAllMetadata(KeyValueUtil.toProtobuf(getMetadata()))
         .addAllVolumeAcls(aclList)
         .setCreationTime(
             creationTime == 0 ? System.currentTimeMillis() : creationTime)
         .setModificationTime(modificationTime)
-        .setObjectID(objectID)
-        .setUpdateID(updateID)
+        .setObjectID(getObjectID())
+        .setUpdateID(getUpdateID())
         .setRefCount(refCount)
         .build();
   }
@@ -476,8 +476,8 @@ public final class OmVolumeArgs extends WithObjectID
   @Override
   public OmVolumeArgs copyObject() {
     Map<String, String> cloneMetadata = new HashMap<>();
-    if (metadata != null) {
-      metadata.forEach((k, v) -> cloneMetadata.put(k, v));
+    if (getMetadata() != null) {
+      getMetadata().forEach((k, v) -> cloneMetadata.put(k, v));
     }
 
     List<OzoneAcl> cloneAcls = new ArrayList(acls.size());
@@ -488,6 +488,6 @@ public final class OmVolumeArgs extends WithObjectID
 
     return new OmVolumeArgs(adminName, ownerName, volume, quotaInBytes,
         quotaInNamespace, usedNamespace, cloneMetadata, cloneAcls,
-        creationTime, modificationTime, objectID, updateID, refCount);
+        creationTime, modificationTime, getObjectID(), getUpdateID(), refCount);
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithMetadata.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithMetadata.java
@@ -23,22 +23,21 @@ import java.util.Map;
 /**
  * Mixin class to handle custom metadata.
  */
-public class WithMetadata {
+public abstract class WithMetadata {
 
-  @SuppressWarnings("visibilitymodifier")
-  protected Map<String, String> metadata = new HashMap<>();
+  private Map<String, String> metadata = new HashMap<>();
 
   /**
    * Custom key value metadata.
    */
-  public Map<String, String> getMetadata() {
+  public final Map<String, String> getMetadata() {
     return metadata;
   }
 
   /**
    * Set custom key value metadata.
    */
-  public void setMetadata(Map<String, String> metadata) {
+  public final void setMetadata(Map<String, String> metadata) {
     this.metadata = metadata;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithParentObjectId.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithParentObjectId.java
@@ -22,6 +22,8 @@ package org.apache.hadoop.ozone.om.helpers;
  * Object ID with additional parent ID field.
  */
 public class WithParentObjectId extends WithObjectID {
+  private long parentObjectID;
+
   /**
    * Object ID with additional parent ID field.
    *
@@ -45,11 +47,11 @@ public class WithParentObjectId extends WithObjectID {
    *     key1      |     1026     |     1025   |
    * ------------------------------------------|
    */
-  @SuppressWarnings("visibilitymodifier")
-  protected long parentObjectID;
-
-  public long getParentObjectID() {
+  public final long getParentObjectID() {
     return parentObjectID;
   }
 
+  public final void setParentObjectID(long parentObjectID) {
+    this.parentObjectID = parentObjectID;
+  }
 }

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -55,9 +55,9 @@ public final class OmPrefixInfo extends WithObjectID {
       Map<String, String> metadata, long objectId, long updateId) {
     this.name = name;
     this.acls = acls;
-    this.metadata = metadata;
-    this.objectID = objectId;
-    this.updateID = updateId;
+    setMetadata(metadata);
+    setObjectID(objectId);
+    setUpdateID(updateId);
   }
 
   /**
@@ -164,9 +164,9 @@ public final class OmPrefixInfo extends WithObjectID {
   public PersistedPrefixInfo getProtobuf() {
     PersistedPrefixInfo.Builder pib =
         PersistedPrefixInfo.newBuilder().setName(name)
-        .addAllMetadata(KeyValueUtil.toProtobuf(metadata))
-        .setObjectID(objectID)
-        .setUpdateID(updateID);
+        .addAllMetadata(KeyValueUtil.toProtobuf(getMetadata()))
+        .setObjectID(getObjectID())
+        .setUpdateID(getUpdateID());
     if (acls != null) {
       pib.addAllAcls(OzoneAclStorageUtil.toProtobuf(acls));
     }
@@ -210,14 +210,14 @@ public final class OmPrefixInfo extends WithObjectID {
     OmPrefixInfo that = (OmPrefixInfo) o;
     return name.equals(that.name) &&
         Objects.equals(acls, that.acls) &&
-        Objects.equals(metadata, that.metadata) &&
-        objectID == that.objectID &&
-        updateID == that.updateID;
+        Objects.equals(getMetadata(), that.getMetadata()) &&
+        getObjectID() == that.getObjectID() &&
+        getUpdateID() == that.getUpdateID();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, acls, metadata, objectID, updateID);
+    return Objects.hash(name, acls, getMetadata(), getObjectID(), getUpdateID());
   }
 
   @Override
@@ -225,9 +225,9 @@ public final class OmPrefixInfo extends WithObjectID {
     return "OmPrefixInfo{" +
         "name='" + name + '\'' +
         ", acls=" + acls +
-        ", metadata=" + metadata +
-        ", objectID=" + objectID +
-        ", updateID=" + updateID +
+        ", metadata=" + getMetadata() +
+        ", objectID=" + getObjectID() +
+        ", updateID=" + getUpdateID() +
         '}';
   }
 
@@ -241,10 +241,10 @@ public final class OmPrefixInfo extends WithObjectID {
         .collect(Collectors.toList());
 
     Map<String, String> metadataList = new HashMap<>();
-    if (metadata != null) {
-      metadata.forEach((k, v) -> metadataList.put(k, v));
+    if (getMetadata() != null) {
+      getMetadata().forEach((k, v) -> metadataList.put(k, v));
     }
-    return new OmPrefixInfo(name, aclList, metadataList, objectID, updateID);
+    return new OmPrefixInfo(name, aclList, metadataList, getObjectID(), getUpdateID());
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Eliminate `@SuppressWarnings("visibilitymodifier")` in `WithMetadata` and similar subclasses.

https://issues.apache.org/jira/browse/HDDS-10396

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7972059774