### PR TITLE
HDDS-10397. Restrict legacy bucket directory deletion through sh command.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -2012,11 +2012,6 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
 
     // Check number of keys
-    args = new String[] {"key", "list", "o3://" + omServiceId + OZONE_URI_DELIMITER +
-          volumeName + OZONE_URI_DELIMITER + bucketName};
-    out.reset();
-    execute(ozoneShell, args);
-
     OzoneVolume volume = client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     List<OzoneFileStatus> files = bucket.listStatus("", true, "", 5);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.ToolRunner;
@@ -182,6 +183,7 @@ public class TestOzoneShellHA {
     final int numDNs = 5;
     conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_KEY_PROVIDER_PATH,
         getKeyProviderURI(miniKMS));
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
     cluster = MiniOzoneCluster.newOMHABuilder(conf)
         .setOMServiceId(omServiceId)
         .setNumOfOzoneManagers(numOfOMs)
@@ -1982,6 +1984,48 @@ public class TestOzoneShellHA {
     execute(ozoneShell,
         new String[]{"volume", "delete", "/volume1"});
     out.reset();
+  }
+
+  @Test
+  public void testKeyDeleteLegacyWithEnableFileSystemPath() throws IOException {
+    String volumeName = "vol5";
+    String bucketName = "legacybucket";
+    String[] args = new String[] {"volume", "create", "o3://" + omServiceId + OZONE_URI_DELIMITER + volumeName};
+    execute(ozoneShell, args);
+
+    args = new String[] {"bucket", "create", "o3://" + omServiceId + OZONE_URI_DELIMITER +
+          volumeName + OZONE_URI_DELIMITER + bucketName, "--layout", BucketLayout.LEGACY.toString()};
+    execute(ozoneShell, args);
+
+    String dirPath = OZONE_URI_DELIMITER + volumeName + OZONE_URI_DELIMITER +
+        bucketName + OZONE_URI_DELIMITER + "dir/";
+    String keyPath = dirPath + "key1";
+
+    // Create key, it will generate two keys, one with dirPath other with keyPath
+    args = new String[] {"key", "put", "o3://" + omServiceId + keyPath, testFile.getPath()};
+    execute(ozoneShell, args);
+
+    // Enable fileSystem path for client config
+    String fileSystemEnable = generateSetConfString(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, "true");
+    // Delete dirPath key, it should fail
+    args = new String[] {fileSystemEnable, "key", "delete", dirPath};
+    execute(ozoneShell, args);
+
+    // Check number of keys
+    args = new String[] {"key", "list", "o3://" + omServiceId + OZONE_URI_DELIMITER +
+          volumeName + OZONE_URI_DELIMITER + bucketName};
+    out.reset();
+    execute(ozoneShell, args);
+
+    OzoneVolume volume = client.getObjectStore().getVolume(volumeName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    List<OzoneFileStatus> files = bucket.listStatus("", true, "", 5);
+    // Two keys should still exist, dirPath and keyPath
+    assertEquals(2, files.size());
+
+    // cleanup
+    args = new String[] {"volume", "delete", volumeName, "-r", "--yes"};
+    execute(ozoneShell, args);
   }
 
   private static String getKeyProviderURI(MiniKMS kms) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/DeleteKeyHandler.java
@@ -41,6 +41,8 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERV
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT;
 
 /**
  * Executes Delete Key.
@@ -65,6 +67,12 @@ public class DeleteKeyHandler extends KeyHandler {
       OmUtils.verifyKeyNameWithSnapshotReservedWordForDeletion(keyName);
     } catch (OMException omException) {
       out().printf("Operation not permitted: %s %n", omException.getMessage());
+      return;
+    }
+
+    if (bucket.getBucketLayout().isLegacy() && keyName.endsWith(OZONE_URI_DELIMITER)
+        && (getConf().getBoolean(OZONE_OM_ENABLE_FILESYSTEM_PATHS, OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT))) {
+      out().printf("Use FS(ofs/o3fs) interface to delete legacy bucket directory %n");
       return;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
When enableFileSystemPath is true and bucket layout is legacy, during key delete operation in normalizekey(prexecute) it removes trailing slash, but in DB key is present with trailing slash. And because of this KEY_NOT_FOUND error comes.
But fixing legacy bucket directory deletion using sh can lead to other issues. In this PR we are restricting legacy bucket directory deletion using sh command.
More discussion in [PR](https://github.com/apache/ozone/pull/6218).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10397

## How was this patch tested?

New Integration test.