### PR TITLE
HDDS-10366. Add new testPrepare() in TestOzoneManagerPrepare

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -84,7 +84,7 @@ public abstract class TestOzoneManagerHA {
   /* Reduce max number of retries to speed up unit test. */
   private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
-  private static final long SNAPSHOT_THRESHOLD = 50;
+  private static final long SNAPSHOT_THRESHOLD = 1;
   private static final Duration RETRY_CACHE_DURATION = Duration.ofSeconds(30);
   private static OzoneClient client;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -84,7 +84,7 @@ public abstract class TestOzoneManagerHA {
   /* Reduce max number of retries to speed up unit test. */
   private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
-  private static final long SNAPSHOT_THRESHOLD = 1;
+  private static final long SNAPSHOT_THRESHOLD = 50;
   private static final Duration RETRY_CACHE_DURATION = Duration.ofSeconds(30);
   private static OzoneClient client;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -88,7 +88,6 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
   private static final long SNAPSHOT_THRESHOLD = 1;
 
   private MiniOzoneHAClusterImpl cluster;
-  private static MiniOzoneCluster.Builder clusterBuilder = null;
   private ClientProtocol clientProtocol;
   private ObjectStore store;
 
@@ -97,7 +96,6 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
 
   private void initInstanceVariables() {
     cluster = getCluster();
-    clusterBuilder = getClusterBuilder();
     store = getObjectStore();
     clientProtocol = store.getClientProxy();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -363,10 +363,10 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
     conf.setLong(
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
         SNAPSHOT_THRESHOLD);
-    clusterBuilder = MiniOzoneCluster.newOMHABuilder(conf)
-        .setOMServiceId(getOmServiceId())
-        .setNumOfOzoneManagers(getNumOfOMs());
-    cluster = (MiniOzoneHAClusterImpl) clusterBuilder.build();
+    MiniOzoneHAClusterImpl.Builder clusterBuilder =
+        MiniOzoneCluster.newHABuilder(conf).setOMServiceId(getOmServiceId())
+            .setNumOfOzoneManagers(getNumOfOMs());
+    cluster = clusterBuilder.build();
     cluster.waitForClusterToBeReady();
 
     long prepareIndex = submitPrepareRequest();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -212,12 +212,6 @@ public class OMPrepareRequest extends OMClientRequest {
               "OM database flushed index %d which is less than the minimum " +
               "required index %d.",
           flushTimeout.getSeconds(), lastOMDBFlushIndex, minOMDBFlushIndex));
-    } else if (!ratisStateMachineApplied) {
-      throw new IOException(String.format("After waiting for %d seconds, " +
-              "Ratis state machine applied index %d which is less than" +
-              " the minimum required index %d.",
-          flushTimeout.getSeconds(), lastRatisCommitIndex,
-          minRatisStateMachineIndex));
     }
     return lastRatisCommitIndex;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding new testPrepare() in TestOzoneManagerPrepare which has snapshot interval set to 1, when upgrade prepare request comes, triggers force snapshot from ratis and waits for complete, once force snapshot is completed, then submit the upgrade prepare for the remaining task to mark the upgrade prepare complete. We then verify that prepare index should always be less than the current transaction index.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10366

## How was this patch tested?

Tested Manually.
