### PR TITLE
HDDS-10320. Introduce factory to configure MiniOzoneCluster's datanodes

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -281,19 +281,6 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
           OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY, 100);
     }
 
-    /**
-     * Sets the number of data volumes per datanode.
-     *
-     * @param val number of volumes per datanode.
-     *
-     * @return MiniOzoneCluster.Builder
-     */
-    @Override
-    public Builder setNumDataVolumes(int val) {
-      numDataVolumes = val;
-      return this;
-    }
-
     @Override
     public MiniOzoneChaosCluster build() throws IOException {
       DefaultMetricsSystem.setMiniClusterMode(true);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -130,7 +130,9 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
         .setOMServiceID(omServiceId)
         .setNumStorageContainerManagers(numStorageContainerManagerss)
         .setSCMServiceID(scmServiceId)
-        .setNumDataVolumes(numDataVolumes);
+        .setDatanodeFactory(UniformDatanodesFactory.newBuilder()
+            .setNumDataVolumes(numDataVolumes)
+            .build());
     failureClasses.forEach(chaosBuilder::addFailures);
 
     cluster = chaosBuilder.build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -76,6 +76,7 @@ import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneClusterProvider;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.UniformDatanodesFactory;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -170,7 +171,9 @@ public class TestHDDSUpgrade {
         .setNumDatanodes(NUM_DATA_NODES)
         .setNumOfStorageContainerManagers(NUM_SCMS)
         .setSCMConfigurator(scmConfigurator)
-        .setDnLayoutVersion(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion());
+        .setDatanodeFactory(UniformDatanodesFactory.newBuilder()
+            .setLayoutVersion(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion())
+            .build());
 
     // Setting the provider to a max of 100 clusters. Some of the tests here
     // use multiple clusters, so its hard to know exactly how many will be

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestScmHAFinalization.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.server.upgrade.FinalizationStateManagerImpl;
 import org.apache.hadoop.hdds.scm.server.upgrade.SCMUpgradeFinalizationContext;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.UniformDatanodesFactory;
 import org.apache.hadoop.ozone.upgrade.DefaultUpgradeFinalizationExecutor;
 import org.apache.hadoop.ozone.upgrade.InjectedUpgradeFinalizationExecutor.UpgradeTestInjectionPoints;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizationExecutor;
@@ -98,7 +99,9 @@ public class TestScmHAFinalization {
         .setSCMConfigurator(configurator)
         .setNumOfOzoneManagers(1)
         .setNumDatanodes(NUM_DATANODES)
-        .setDnLayoutVersion(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion());
+        .setDatanodeFactory(UniformDatanodesFactory.newBuilder()
+            .setLayoutVersion(HDDSLayoutFeature.INITIAL_VERSION.layoutVersion())
+            .build());
     this.cluster = (MiniOzoneHAClusterImpl) clusterBuilder.build();
 
     scmClient = cluster.getStorageContainerLocationClient();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
@@ -38,6 +37,7 @@ import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.util.ExitUtils;
+import org.apache.ratis.util.function.CheckedFunction;
 
 /**
  * Interface used for MiniOzoneClusters.
@@ -287,16 +287,13 @@ public interface MiniOzoneCluster extends AutoCloseable {
     protected String scmId = UUID.randomUUID().toString();
     protected String omId = UUID.randomUUID().toString();
     
-    protected Optional<String> datanodeReservedSpace = Optional.empty();
     protected boolean includeRecon = false;
 
-    protected Optional<Integer> dnLayoutVersion = Optional.empty();
-
     protected int numOfDatanodes = 3;
-    protected int numDataVolumes = 1;
     protected boolean  startDataNodes = true;
     protected CertificateClient certClient;
     protected SecretKeyClient secretKeyClient;
+    protected DatanodeFactory dnFactory = UniformDatanodesFactory.newBuilder().build();
 
     protected Builder(OzoneConfiguration conf) {
       this.conf = conf;
@@ -366,33 +363,8 @@ public interface MiniOzoneCluster extends AutoCloseable {
       return this;
     }
 
-    /**
-     * Sets the number of data volumes per datanode.
-     *
-     * @param val number of volumes per datanode.
-     *
-     * @return MiniOzoneCluster.Builder
-     */
-    public Builder setNumDataVolumes(int val) {
-      numDataVolumes = val;
-      return this;
-    }
-
-    /**
-     * Sets the reserved space
-     * {@link org.apache.hadoop.hdds.scm.ScmConfigKeys}
-     * HDDS_DATANODE_DIR_DU_RESERVED
-     * for each volume in each datanode.
-     * @param reservedSpace String that contains the numeric size value and
-     *                      ends with a
-     *                      {@link org.apache.hadoop.hdds.conf.StorageUnit}
-     *                      suffix. For example, "50GB".
-     * @see org.apache.hadoop.ozone.container.common.volume.VolumeInfo
-     *
-     * @return {@link MiniOzoneCluster} Builder
-     */
-    public Builder setDatanodeReservedSpace(String reservedSpace) {
-      datanodeReservedSpace = Optional.of(reservedSpace);
+    public Builder setDatanodeFactory(DatanodeFactory factory) {
+      this.dnFactory = factory;
       return this;
     }
 
@@ -431,16 +403,18 @@ public interface MiniOzoneCluster extends AutoCloseable {
       return this;
     }
 
-    public Builder setDnLayoutVersion(int layoutVersion) {
-      dnLayoutVersion = Optional.of(layoutVersion);
-      return this;
-    }
-
     /**
      * Constructs and returns MiniOzoneCluster.
      *
      * @return {@link MiniOzoneCluster}
      */
     public abstract MiniOzoneCluster build() throws IOException;
+  }
+
+  /**
+   * Factory to customize configuration of each datanode.
+   */
+  interface DatanodeFactory extends CheckedFunction<OzoneConfiguration, OzoneConfiguration, IOException> {
+    // marker
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -258,8 +258,10 @@ public class TestMiniOzoneCluster {
     String reservedSpace = "1B";
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(1)
-        .setNumDataVolumes(3)
-        .setDatanodeReservedSpace(reservedSpace)
+        .setDatanodeFactory(UniformDatanodesFactory.newBuilder()
+            .setNumDataVolumes(3)
+            .setReservedSpace(reservedSpace)
+            .build())
         .build();
     cluster.waitForClusterToBeReady();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/UniformDatanodesFactory.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/UniformDatanodesFactory.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone;
+
+import org.apache.hadoop.hdds.conf.ConfigurationTarget;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
+import org.apache.hadoop.ozone.container.replication.ReplicationServer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.hadoop.hdds.DFSConfigKeysLegacy.DFS_DATANODE_DATA_DIR_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_REST_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_IPC_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ADMIN_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_IPC_PORT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_SERVER_PORT;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.anyHostWithFreePort;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
+
+/**
+ * Creates datanodes with similar configuration (same number of volumes, same layout version, etc.).
+ */
+public class UniformDatanodesFactory implements MiniOzoneCluster.DatanodeFactory {
+
+  private final AtomicInteger nodesCreated = new AtomicInteger();
+
+  private final int numDataVolumes;
+  private final String reservedSpace;
+  private final Integer layoutVersion;
+
+  protected UniformDatanodesFactory(Builder builder) {
+    numDataVolumes = builder.numDataVolumes;
+    layoutVersion = builder.layoutVersion;
+    reservedSpace = builder.reservedSpace;
+  }
+
+  @Override
+  public OzoneConfiguration apply(OzoneConfiguration conf) throws IOException {
+    final int i = nodesCreated.incrementAndGet();
+    final OzoneConfiguration dnConf = new OzoneConfiguration(conf);
+
+    configureDatanodePorts(dnConf);
+
+    Path baseDir = Paths.get(Objects.requireNonNull(conf.get(OZONE_METADATA_DIRS)), "datanode-" + i);
+
+    Path metaDir = baseDir.resolve("meta");
+    Files.createDirectories(metaDir);
+    dnConf.set(OZONE_METADATA_DIRS, metaDir.toString());
+
+    List<String> dataDirs = new ArrayList<>();
+    List<String> reservedSpaceList = new ArrayList<>();
+    for (int j = 0; j < numDataVolumes; j++) {
+      Path dir = baseDir.resolve("data-" + j);
+      Files.createDirectories(dir);
+      dataDirs.add(dir.toString());
+      if (reservedSpace != null) {
+        reservedSpaceList.add(dir + ":" + reservedSpace);
+      }
+    }
+    String reservedSpaceString = String.join(",", reservedSpaceList);
+    String listOfDirs = String.join(",", dataDirs);
+    dnConf.set(DFS_DATANODE_DATA_DIR_KEY, listOfDirs);
+    dnConf.set(HDDS_DATANODE_DIR_KEY, listOfDirs);
+    dnConf.set(HDDS_DATANODE_DIR_DU_RESERVED, reservedSpaceString);
+
+    Path ratisDir = baseDir.resolve("ratis");
+    Files.createDirectories(ratisDir);
+    dnConf.set(DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR, ratisDir.toString());
+
+    if (layoutVersion != null) {
+      DatanodeLayoutStorage layoutStorage = new DatanodeLayoutStorage(
+          dnConf, UUID.randomUUID().toString(), layoutVersion);
+      layoutStorage.initialize();
+    }
+
+    return dnConf;
+  }
+
+  private void configureDatanodePorts(ConfigurationTarget conf) {
+    conf.set(HDDS_REST_HTTP_ADDRESS_KEY, anyHostWithFreePort());
+    conf.set(HDDS_DATANODE_HTTP_ADDRESS_KEY, anyHostWithFreePort());
+    conf.set(HDDS_DATANODE_CLIENT_ADDRESS_KEY, anyHostWithFreePort());
+    conf.setInt(DFS_CONTAINER_IPC_PORT, getFreePort());
+    conf.setInt(DFS_CONTAINER_RATIS_IPC_PORT, getFreePort());
+    conf.setInt(DFS_CONTAINER_RATIS_ADMIN_PORT, getFreePort());
+    conf.setInt(DFS_CONTAINER_RATIS_SERVER_PORT, getFreePort());
+    conf.setInt(DFS_CONTAINER_RATIS_DATASTREAM_PORT, getFreePort());
+    conf.setFromObject(new ReplicationServer.ReplicationConfig().setPort(getFreePort()));
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for UniformDatanodesFactory.
+   */
+  public static class Builder {
+
+    private int numDataVolumes = 1;
+    private String reservedSpace;
+    private Integer layoutVersion;
+
+    /**
+     * Sets the number of data volumes per datanode.
+     */
+    public Builder setNumDataVolumes(int n) {
+      numDataVolumes = n;
+      return this;
+    }
+
+    /**
+     * Sets the reserved space
+     * {@link org.apache.hadoop.hdds.scm.ScmConfigKeys#HDDS_DATANODE_DIR_DU_RESERVED}
+     * for each volume in each datanode.
+     * @param reservedSpace String that contains the numeric size value and ends with a
+     *   {@link org.apache.hadoop.hdds.conf.StorageUnit} suffix. For example, "50GB".
+     * @see org.apache.hadoop.ozone.container.common.volume.VolumeInfo
+     */
+    public Builder setReservedSpace(String reservedSpace) {
+      this.reservedSpace = reservedSpace;
+      return this;
+    }
+
+    public Builder setLayoutVersion(int layoutVersion) {
+      this.layoutVersion = layoutVersion;
+      return this;
+    }
+
+    public UniformDatanodesFactory build() {
+      return new UniformDatanodesFactory(this);
+    }
+
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -274,7 +274,6 @@ class TestDatanodeHddsVolumeFailureDetection {
     ozoneConfig.setFromObject(dnConf);
     MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(ozoneConfig)
         .setNumDatanodes(1)
-        .setNumDataVolumes(1)
         .build();
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(ReplicationFactor.ONE, 30000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.UniformDatanodesFactory;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -90,7 +91,9 @@ public class TestDatanodeHddsVolumeFailureToleration {
     ozoneConfig.setFromObject(dnConf);
     cluster = MiniOzoneCluster.newBuilder(ozoneConfig)
         .setNumDatanodes(1)
-        .setNumDataVolumes(3)
+        .setDatanodeFactory(UniformDatanodesFactory.newBuilder()
+            .setNumDataVolumes(3)
+            .build())
         .build();
     cluster.waitForClusterToBeReady();
     datanodes = cluster.getHddsDatanodes();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently MiniOzoneCluster creates almost identical datanodes, based on global config and few datanode-specific properties:

* `numDataVolumes`
* `datanodeReservedSpace`
* `dnLayoutVersion`

This change introduces a factory to create datanodes for `MiniOzoneCluster`, further cleaning up the global `MiniOzoneCluster.Builder` interface.

Other implementations can be added in the future to customize each datanode (e.g. different number of volumes, different amount of reserved space, etc.).

https://issues.apache.org/jira/browse/HDDS-10320

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/7979189177