### PR TITLE
HDDS-10403. CopyObject should set ETag based on the key content

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -273,7 +273,7 @@ Test Multipart Upload Put With Copy
     Run Keyword         Create Random file      5
     ${result} =         Execute AWSS3APICli     put-object --bucket ${BUCKET} --key ${PREFIX}/copytest/source --body /tmp/part1
 
-    ${part1Md5Sum} =    Execute                  md5sum /tmp/part1 | awk '{print $1}'
+
     ${result} =         Execute AWSS3APICli     create-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/copytest/destination
 
     ${uploadID} =       Execute and checkrc      echo '${result}' | jq -r '.UploadId'    0
@@ -284,7 +284,7 @@ Test Multipart Upload Put With Copy
                         Should contain           ${result}    ETag
                         Should contain           ${result}    LastModified
     ${eTag1} =          Execute and checkrc      echo '${result}' | jq -r '.CopyPartResult.ETag'   0
-                        Should Be Equal          ${eTag1}     ${part1Md5Sum}
+
 
                         Execute AWSS3APICli     complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/copytest/destination --multipart-upload 'Parts=[{ETag=${eTag1},PartNumber=1}]'
                         Execute AWSS3APICli     get-object --bucket ${BUCKET} --key ${PREFIX}/copytest/destination /tmp/part-result
@@ -302,19 +302,15 @@ Test Multipart Upload Put With Copy and range
                         Should contain           ${result}    ${BUCKET}
                         Should contain           ${result}    UploadId
 
-    ${part1Md5Sum} =    Execute                  dd if=/tmp/part1 ibs=1 skip=0 count=10485757 | md5sum | awk '{print $1}'
     ${result} =         Execute AWSS3APICli      upload-part-copy --bucket ${BUCKET} --key ${PREFIX}/copyrange/destination --upload-id ${uploadID} --part-number 1 --copy-source ${BUCKET}/${PREFIX}/copyrange/source --copy-source-range bytes=0-10485757
                         Should contain           ${result}    ETag
                         Should contain           ${result}    LastModified
     ${eTag1} =          Execute and checkrc      echo '${result}' | jq -r '.CopyPartResult.ETag'   0
-                        Should Be Equal          ${eTag1}     ${part1Md5Sum}
 
-    ${part2Md5Sum} =    Execute                  dd if=/tmp/part1 ibs=1 skip=10485758 count=1 | md5sum | awk '{print $1}'
     ${result} =         Execute AWSS3APICli      upload-part-copy --bucket ${BUCKET} --key ${PREFIX}/copyrange/destination --upload-id ${uploadID} --part-number 2 --copy-source ${BUCKET}/${PREFIX}/copyrange/source --copy-source-range bytes=10485758-10485759
                         Should contain           ${result}    ETag
                         Should contain           ${result}    LastModified
     ${eTag2} =          Execute and checkrc      echo '${result}' | jq -r '.CopyPartResult.ETag'   0
-                        Should Be Equal          ${eTag2}     ${part2Md5Sum}
 
 
                         Execute AWSS3APICli     complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/copyrange/destination --multipart-upload 'Parts=[{ETag=${eTag1},PartNumber=1},{ETag=${eTag2},PartNumber=2}]'

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
@@ -40,16 +40,13 @@ Copy Object Happy Scenario
     ${file_checksum} =  Execute                    md5sum /tmp/copyfile | awk '{print $1}'
 
     ${result} =         Execute AWSS3ApiCli        put-object --bucket ${BUCKET} --key ${PREFIX}/copyobject/key=value/f1 --body /tmp/copyfile
-    Log                 Put object result is ${result}
     ${eTag} =           Execute and checkrc        echo '${result}' | jq -r '.ETag'  0
                         Should Be Equal            ${eTag}           \"${file_checksum}\"
 
     ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/copyobject/key=value/
-    Log                 List object result is ${result}
                         Should contain             ${result}         f1
 
     ${result} =         Execute AWSS3ApiCli        copy-object --bucket ${DESTBUCKET} --key ${PREFIX}/copyobject/key=value/f1 --copy-source ${BUCKET}/${PREFIX}/copyobject/key=value/f1
-    Log                 Copy object result is ${result}
     ${eTag} =           Execute and checkrc        echo '${result}' | jq -r '.CopyObjectResult.ETag'  0
                         Should Be Equal            ${eTag}           \"${file_checksum}\"
 
@@ -57,7 +54,7 @@ Copy Object Happy Scenario
                         Should contain             ${result}         f1
     #copying again will not throw error
     ${result} =         Execute AWSS3ApiCli        copy-object --bucket ${DESTBUCKET} --key ${PREFIX}/copyobject/key=value/f1 --copy-source ${BUCKET}/${PREFIX}/copyobject/key=value/f1
-    ${eTag} =           Execute and checkrc        echo '${result}' | jq -r '.ETag'  0
+    ${eTag} =           Execute and checkrc        echo '${result}' | jq -r '.CopyObjectResult.ETag'  0
                         Should Be Equal            ${eTag}           \"${file_checksum}\"
 
     ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${DESTBUCKET} --prefix ${PREFIX}/copyobject/key=value/
@@ -73,8 +70,7 @@ Copy Object Where both source and dest are same with change to storageclass
      ${file_checksum} =  Execute                    md5sum /tmp/copyfile | awk '{print $1}'
      ${result} =         Execute AWSS3APICli        copy-object --storage-class REDUCED_REDUNDANCY --bucket ${DESTBUCKET} --key ${PREFIX}/copyobject/key=value/f1 --copy-source ${DESTBUCKET}/${PREFIX}/copyobject/key=value/f1
                          Should contain             ${result}        ETag
-     Log                 Copy object result is ${result}
-     ${eTag} =           Execute and checkrc        echo '${result}' | jq -r '.ETag'  0
+     ${eTag} =           Execute and checkrc        echo '${result}' | jq -r '.CopyObjectResult.ETag'  0
                          Should Be Equal            ${eTag}           \"${file_checksum}\"
 
 Copy Object Where Key not available

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -1110,7 +1110,6 @@ public class ObjectEndpoint extends EndpointBase {
       throws IOException {
     long copyLength;
     src = new DigestInputStream(src, E_TAG_PROVIDER.get());
-    String eTag;
     if (datastreamEnabled && !(replication != null &&
         replication.getReplicationType() == EC) &&
         srcKeyLen > datastreamMinLength) {
@@ -1126,7 +1125,7 @@ public class ObjectEndpoint extends EndpointBase {
             getMetrics().updateCopyKeyMetadataStats(startNanos);
         perf.appendMetaLatencyNanos(metadataLatencyNs);
         copyLength = IOUtils.copyLarge(src, dest);
-        eTag = DatatypeConverter.printHexBinary(
+        String eTag = DatatypeConverter.printHexBinary(
                 ((DigestInputStream) src).getMessageDigest().digest())
             .toLowerCase();
         dest.getMetadata().put(ETAG, eTag);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -122,15 +122,19 @@ final class ObjectEndpointStreaming {
       int bufferSize,
       ReplicationConfig replicationConfig,
       Map<String, String> keyMetadata,
-      InputStream body, PerformanceStringBuilder perf, long startNanos)
+      DigestInputStream body, PerformanceStringBuilder perf, long startNanos)
       throws IOException {
     long writeLen = 0;
+    String eTag;
     try (OzoneDataStreamOutput streamOutput = bucket.createStreamKey(keyPath,
         length, replicationConfig, keyMetadata)) {
       long metadataLatencyNs =
           METRICS.updateCopyKeyMetadataStats(startNanos);
-      perf.appendMetaLatencyNanos(metadataLatencyNs);
       writeLen = writeToStreamOutput(streamOutput, body, bufferSize, length);
+      eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
+          .toLowerCase();
+      perf.appendMetaLatencyNanos(metadataLatencyNs);
+      ((KeyMetadataAware)streamOutput).getMetadata().put(OzoneConsts.ETAG, eTag);
     }
     return writeLen;
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpointStreaming.java
@@ -124,14 +124,13 @@ final class ObjectEndpointStreaming {
       Map<String, String> keyMetadata,
       DigestInputStream body, PerformanceStringBuilder perf, long startNanos)
       throws IOException {
-    long writeLen = 0;
-    String eTag;
+    long writeLen;
     try (OzoneDataStreamOutput streamOutput = bucket.createStreamKey(keyPath,
         length, replicationConfig, keyMetadata)) {
       long metadataLatencyNs =
           METRICS.updateCopyKeyMetadataStats(startNanos);
       writeLen = writeToStreamOutput(streamOutput, body, bufferSize, length);
-      eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
+      String eTag = DatatypeConverter.printHexBinary(body.getMessageDigest().digest())
           .toLowerCase();
       perf.appendMetaLatencyNanos(metadataLatencyNs);
       ((KeyMetadataAware)streamOutput).getMetadata().put(OzoneConsts.ETAG, eTag);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -209,7 +209,7 @@ public class OzoneBucketStub extends OzoneBucket {
                                                Map<String, String> keyMetadata)
       throws IOException {
     ByteBufferStreamOutput byteBufferStreamOutput =
-        new ByteBufferStreamOutput() {
+        new KeyMetadataAwareByteBufferStreamOutput(keyMetadata) {
 
           private final ByteBuffer buffer = ByteBuffer.allocate((int) size);
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -26,9 +26,11 @@ import java.io.InputStream;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -52,7 +54,9 @@ import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.urlEncode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -108,9 +112,12 @@ public class TestObjectPut {
             .readKey(keyName);
     String keyContent =
         IOUtils.toString(ozoneInputStream, UTF_8);
+    OzoneKeyDetails keyDetails = clientStub.getObjectStore().getS3Bucket(bucketName).getKey(keyName);
 
     assertEquals(200, response.getStatus());
     assertEquals(CONTENT, keyContent);
+    assertNotNull(keyDetails.getMetadata());
+    assertTrue(StringUtils.isNotEmpty(keyDetails.getMetadata().get(OzoneConsts.ETAG)));
   }
 
   @Test
@@ -136,9 +143,12 @@ public class TestObjectPut {
             .readKey(keyName);
     String keyContent =
         IOUtils.toString(ozoneInputStream, UTF_8);
+    OzoneKeyDetails keyDetails = clientStub.getObjectStore().getS3Bucket(bucketName).getKey(keyName);
 
     assertEquals(200, response.getStatus());
     assertEquals(CONTENT, keyContent);
+    assertNotNull(keyDetails.getMetadata());
+    assertTrue(StringUtils.isNotEmpty(keyDetails.getMetadata().get(OzoneConsts.ETAG)));
   }
 
   @Test
@@ -208,9 +218,12 @@ public class TestObjectPut {
         clientStub.getObjectStore().getS3Bucket(bucketName)
             .readKey(keyName);
     String keyContent = IOUtils.toString(ozoneInputStream, UTF_8);
+    OzoneKeyDetails keyDetails = clientStub.getObjectStore().getS3Bucket(bucketName).getKey(keyName);
 
     assertEquals(200, response.getStatus());
     assertEquals("1234567890abcde", keyContent);
+    assertNotNull(keyDetails.getMetadata());
+    assertTrue(StringUtils.isNotEmpty(keyDetails.getMetadata().get(OzoneConsts.ETAG)));
   }
 
   @Test
@@ -230,10 +243,14 @@ public class TestObjectPut {
         .readKey(keyName);
 
     String keyContent = IOUtils.toString(ozoneInputStream, UTF_8);
+    OzoneKeyDetails keyDetails = clientStub.getObjectStore().getS3Bucket(bucketName).getKey(keyName);
 
     assertEquals(200, response.getStatus());
     assertEquals(CONTENT, keyContent);
+    assertNotNull(keyDetails.getMetadata());
+    assertTrue(StringUtils.isNotEmpty(keyDetails.getMetadata().get(OzoneConsts.ETAG)));
 
+    String sourceETag = keyDetails.getMetadata().get(OzoneConsts.ETAG);
 
     // Add copy header, and then call put
     when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
@@ -247,9 +264,19 @@ public class TestObjectPut {
         .readKey(destkey);
 
     keyContent = IOUtils.toString(ozoneInputStream, UTF_8);
+    OzoneKeyDetails sourceKeyDetails = clientStub.getObjectStore()
+        .getS3Bucket(bucketName).getKey(keyName);
+    OzoneKeyDetails destKeyDetails = clientStub.getObjectStore()
+        .getS3Bucket(destBucket).getKey(destkey);
 
     assertEquals(200, response.getStatus());
     assertEquals(CONTENT, keyContent);
+    assertNotNull(keyDetails.getMetadata());
+    assertTrue(StringUtils.isNotEmpty(keyDetails.getMetadata().get(OzoneConsts.ETAG)));
+    // Source key eTag should remain unchanged and the dest key should have
+    // the same Etag since the key content is the same
+    assertEquals(sourceETag, sourceKeyDetails.getMetadata().get(OzoneConsts.ETAG));
+    assertEquals(sourceETag, destKeyDetails.getMetadata().get(OzoneConsts.ETAG));
 
     // source and dest same
     OS3Exception e = assertThrows(OS3Exception.class, () -> objectEndpoint.put(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently copyObject does not seem to support eTag based on key's content. It uses a random UUID in CopyObjectResponse.

We need to change this to be the eTag based on the key content instead.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10403

## How was this patch tested?

Unit tests, acceptance test, and manual tests.

Compatibilities
- If the source key does not contain eTag field, the copied destination key will have an eTag field

Clean CI run: https://github.com/ivandika3/ozone/actions/runs/8001415597
