### PR TITLE
HDDS-10404. Ozone admin reconfig command fails with security enabled

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -338,6 +338,9 @@ public final class HddsConfigKeys {
       HDDS_SECURITY_CLIENT_SCM_SECRET_KEY_DATANODE_PROTOCOL_ACL =
       "hdds.security.client.scm.secretkey.datanode.protocol.acl";
 
+  public static final String OZONE_SECURITY_RECONFIGURE_PROTOCOL_ACL =
+      "ozone.security.reconfigure.protocol.acl";
+
   // Determines if the Container Chunk Manager will write user data to disk
   // Set to false only for specific performance tests
   public static final String HDDS_CONTAINER_PERSISTDATA =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -20,9 +20,6 @@ package org.apache.hadoop.ozone;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.nio.file.Path;
@@ -32,7 +29,6 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -47,7 +43,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_DEF
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
-import org.apache.hadoop.security.KerberosInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,40 +140,5 @@ public final class OzoneSecurityUtil {
           cert, CertificateCodec::toIOException));
     }
     return x509Certificates;
-  }
-
-  public static void updateKerberosInfo(Class clz, String serverPrincipal) {
-    // new KerberosInfo
-    Annotation newValue = new KerberosInfo() {
-      @Override
-      public Class<? extends Annotation> annotationType() {
-        return KerberosInfo.class;
-      }
-      @Override
-      public String serverPrincipal() {
-        return serverPrincipal;
-      }
-      @Override
-      public String clientPrincipal() {
-        return null;
-      }
-    };
-
-    try {
-      Method method = clz.getClass().getDeclaredMethod("annotationData", null);
-      method.setAccessible(true);
-
-      Object annotationData = method.invoke(clz);
-      Field annotations = annotationData.getClass().getDeclaredField("annotations");
-      annotations.setAccessible(true);
-
-      Map<Class<? extends Annotation>, Annotation> map =
-          (Map<Class<? extends Annotation>, Annotation>) annotations.get(annotationData);
-      map.put(KerberosInfo.class, newValue);
-      LOG.debug("Class {} is updated with new server principal {}", clz, serverPrincipal);
-    } catch (Exception e) {
-      LOG.error("Failed to update Kerberos Info for new serverPrincipal {}. ", serverPrincipal, e);
-      throw new RuntimeException("Failed to update Kerberos Info for new serverPrincipal " + serverPrincipal);
-    }
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -148,15 +148,11 @@ public final class OzoneSecurityUtil {
   }
 
   public static void updateKerberosInfo(Class clz, String serverPrincipal) {
-    final String ANNOTATIONS = "annotations";
-    final String ANNOTATION_METHOD = "annotationData";
-    final Class<? extends Annotation> ANNOTATION_TO_ALTER = KerberosInfo.class;
-
     // new KerberosInfo
     Annotation newValue = new KerberosInfo() {
       @Override
       public Class<? extends Annotation> annotationType() {
-        return ANNOTATION_TO_ALTER;
+        return KerberosInfo.class;
       }
       @Override
       public String serverPrincipal() {
@@ -169,16 +165,16 @@ public final class OzoneSecurityUtil {
     };
 
     try {
-      Method method = clz.getClass().getDeclaredMethod(ANNOTATION_METHOD, null);
+      Method method = clz.getClass().getDeclaredMethod("annotationData", null);
       method.setAccessible(true);
 
       Object annotationData = method.invoke(clz);
-      Field annotations = annotationData.getClass().getDeclaredField(ANNOTATIONS);
+      Field annotations = annotationData.getClass().getDeclaredField("annotations");
       annotations.setAccessible(true);
 
       Map<Class<? extends Annotation>, Annotation> map =
           (Map<Class<? extends Annotation>, Annotation>) annotations.get(annotationData);
-      map.put(ANNOTATION_TO_ALTER, newValue);
+      map.put(KerberosInfo.class, newValue);
       LOG.debug("Class {} is updated with new server principal {}", clz, serverPrincipal);
     } catch (Exception e) {
       LOG.error("Failed to update Kerberos Info for new serverPrincipal {}. ", serverPrincipal, e);

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2782,6 +2782,14 @@
       manager admin protocol.
     </description>
   </property>
+  <property>
+    <name>ozone.security.reconfigure.protocol.acl</name>
+    <value>*</value>
+    <tag>SECURITY</tag>
+    <description>
+      Comma separated list of users and groups allowed to access reconfigure protocol.
+    </description>
+  </property>
 
   <property>
     <name>hdds.datanode.http.auth.kerberos.principal</name>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeClientProtocolServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeClientProtocolServer.java
@@ -21,13 +21,12 @@ package org.apache.hadoop.ozone;
 import com.google.protobuf.BlockingService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
-import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.ReconfigureProtocolProtos;
-import org.apache.hadoop.hdds.protocolPB.ReconfigureProtocolPB;
+import org.apache.hadoop.hdds.protocolPB.ReconfigureProtocolDatanodePB;
 import org.apache.hadoop.hdds.protocolPB.ReconfigureProtocolServerSideTranslatorPB;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.server.ServiceRuntimeInfoImpl;
@@ -103,20 +102,18 @@ public class HddsDatanodeClientProtocolServer extends ServiceRuntimeInfoImpl {
     InetSocketAddress rpcAddress = HddsUtils.getDatanodeRpcAddress(conf);
     // Add reconfigureProtocolService.
     RPC.setProtocolEngine(
-        configuration, ReconfigureProtocolPB.class, ProtobufRpcEngine.class);
+        configuration, ReconfigureProtocolDatanodePB.class, ProtobufRpcEngine.class);
 
     final int handlerCount = conf.getInt(HDDS_DATANODE_HANDLER_COUNT_KEY,
         HDDS_DATANODE_HANDLER_COUNT_DEFAULT);
     ReconfigureProtocolServerSideTranslatorPB reconfigureServerProtocol
         = new ReconfigureProtocolServerSideTranslatorPB(reconfigurationHandler);
-    OzoneSecurityUtil.updateKerberosInfo(ReconfigureProtocolPB.class,
-        DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_PRINCIPAL_KEY);
     BlockingService reconfigureService = ReconfigureProtocolProtos
         .ReconfigureProtocolService.newReflectiveBlockingService(
             reconfigureServerProtocol);
 
     return preserveThreadName(() -> startRpcServer(configuration, rpcAddress,
-        ReconfigureProtocolPB.class, reconfigureService, handlerCount));
+        ReconfigureProtocolDatanodePB.class, reconfigureService, handlerCount));
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeClientProtocolServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeClientProtocolServer.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone;
 
 import com.google.protobuf.BlockingService;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
@@ -66,6 +68,10 @@ public class HddsDatanodeClientProtocolServer extends ServiceRuntimeInfoImpl {
         HDDS_DATANODE_CLIENT_ADDRESS_KEY,
         HddsUtils.getDatanodeRpcAddress(conf), rpcServer);
     datanodeDetails.setPort(CLIENT_RPC, clientRpcAddress.getPort());
+    if (conf.getBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION,
+        false)) {
+      rpcServer.refreshServiceAcl(conf, HddsPolicyProvider.getInstance());
+    }
   }
 
   public void start() {
@@ -103,6 +109,8 @@ public class HddsDatanodeClientProtocolServer extends ServiceRuntimeInfoImpl {
         HDDS_DATANODE_HANDLER_COUNT_DEFAULT);
     ReconfigureProtocolServerSideTranslatorPB reconfigureServerProtocol
         = new ReconfigureProtocolServerSideTranslatorPB(reconfigurationHandler);
+    OzoneSecurityUtil.updateKerberosInfo(ReconfigureProtocolPB.class,
+        DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_PRINCIPAL_KEY);
     BlockingService reconfigureService = ReconfigureProtocolProtos
         .ReconfigureProtocolService.newReflectiveBlockingService(
             reconfigureServerProtocol);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsPolicyProvider.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsPolicyProvider.java
@@ -14,16 +14,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.hadoop.ozone.om;
+package org.apache.hadoop.ozone;
 
-import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+
 import org.apache.hadoop.hdds.annotation.InterfaceAudience.Private;
-import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.annotation.InterfaceStability.Unstable;
 import org.apache.hadoop.hdds.protocol.ReconfigureProtocol;
-import org.apache.hadoop.ozone.om.protocol.OMInterServiceProtocol;
-import org.apache.hadoop.ozone.om.protocol.OMAdminProtocol;
-import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.security.authorize.PolicyProvider;
 import org.apache.hadoop.security.authorize.Service;
 import org.apache.ratis.util.MemoizedSupplier;
@@ -33,44 +29,35 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_SECURITY_RECONFIGURE_PROTOCOL_ACL;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SECURITY_ADMIN_PROTOCOL_ACL;
-import static org.apache.hadoop.ozone.om.OMConfigKeys
-    .OZONE_OM_SECURITY_CLIENT_PROTOCOL_ACL;
 
 /**
- * {@link PolicyProvider} for OM protocols.
+ * {@link PolicyProvider} for Datanode protocols.
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
-public final class OMPolicyProvider extends PolicyProvider {
+@Private
+@Unstable
+public final class HddsPolicyProvider extends PolicyProvider {
 
-  private static final Supplier<OMPolicyProvider> SUPPLIER =
-      MemoizedSupplier.valueOf(OMPolicyProvider::new);
+  private static final Supplier<HddsPolicyProvider> SUPPLIER =
+      MemoizedSupplier.valueOf(HddsPolicyProvider::new);
 
-  private OMPolicyProvider() {
+  private HddsPolicyProvider() {
   }
 
   @Private
   @Unstable
-  public static OMPolicyProvider getInstance() {
+  public static HddsPolicyProvider getInstance() {
     return SUPPLIER.get();
   }
 
-  private static final List<Service> OM_SERVICES =
+  private static final List<Service> DN_SERVICES =
       Arrays.asList(
-          new Service(OZONE_OM_SECURITY_CLIENT_PROTOCOL_ACL,
-              OzoneManagerProtocol.class),
-          new Service(OZONE_OM_SECURITY_ADMIN_PROTOCOL_ACL,
-              OMInterServiceProtocol.class),
-          new Service(OZONE_OM_SECURITY_ADMIN_PROTOCOL_ACL,
-              OMAdminProtocol.class),
-          new Service(OZONE_SECURITY_RECONFIGURE_PROTOCOL_ACL,
+          new Service(
+              OZONE_SECURITY_RECONFIGURE_PROTOCOL_ACL,
               ReconfigureProtocol.class)
       );
 
   @Override
   public Service[] getServices() {
-    return OM_SERVICES.toArray(new Service[0]);
+    return DN_SERVICES.toArray(new Service[0]);
   }
-
 }

--- a/hadoop-hdds/docs/content/feature/Reconfigurability.md
+++ b/hadoop-hdds/docs/content/feature/Reconfigurability.md
@@ -28,10 +28,11 @@ If a property is reconfigurable, you can modify it in the configuration file (`o
 
 command:
 ```shell
-ozone admin reconfig --address=<ip:port> start|status|properties
+ozone admin reconfig --service=[OM|SCM|DATANODE] --address=<ip:port> start|status|properties
 ```
 
 The meaning of command options:
+- **--service**: The node type of the server specified with --address
 - **--address**: RPC address for one server
 - Three operations are provided:
     - **start**:      Execute the reconfig operation asynchronously
@@ -40,60 +41,60 @@ The meaning of command options:
 
 ## Retrieve the reconfigurable properties list
 To retrieve all the reconfigurable properties list for a specific component in Ozone,
-you can use the command: `ozone admin reconfig --address=<ip:port> properties`.
+you can use the command: `ozone admin reconfig --service=[OM|SCM|DATANODE] --address=<ip:port> properties`.
 This command will list all the properties that can be dynamically reconfigured at runtime for specific component.<br>
 
 > For example, get the Ozone OM reconfigurable properties list.
 >
->$ `ozone admin reconfig --address=hadoop1:9862 properties`<br>
+>$ `ozone admin reconfig --service=OM --address=hadoop1:9862 properties`<br>
 OM: Node [hadoop1:9862] Reconfigurable properties:<br>
 ozone.administrators
 
 ## OM Reconfigurability
 >For example, modify `ozone.administrators` in ozone-site.xml and execute:
 >
-> $ `ozone admin reconfig --address=hadoop1:9862 start`<br>
+> $ `ozone admin reconfig --service=OM --address=hadoop1:9862 start`<br>
 OM: Started OM reconfiguration task on node [hadoop1:9862].
 >
->$ `ozone admin reconfig --address=hadoop1:9862 status`<br>
+>$ `ozone admin reconfig --service=OM --address=hadoop1:9862 status`<br>
 OM: Reconfiguring status for node [hadoop1:9862]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
 SUCCESS: Changed property ozone.administrators<br>
 From: "hadoop"<br>
 To: "hadoop,bigdata"
 >
-> $ `ozone admin reconfig -address=hadoop1:9862 properties`<br>
+> $ `ozone admin reconfig --service=OM -address=hadoop1:9862 properties`<br>
 OM: Node [hadoop1:9862] Reconfigurable properties:<br>
 ozone.administrators
 
 ## SCM Reconfigurability
 >For example, modify `ozone.administrators` in ozone-site.xml and execute:
 >
-> $ `ozone admin reconfig --address=hadoop1:9860 start`<br>
+> $ `ozone admin reconfig --service=SCM --address=hadoop1:9860 start`<br>
 SCM: Started OM reconfiguration task on node [hadoop1:9860].
 >
->$ `ozone admin reconfig --address=hadoop1:9860 status`<br>
+>$ `ozone admin reconfig --service=SCM --address=hadoop1:9860 status`<br>
 SCM: Reconfiguring status for node [hadoop1:9860]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
 SUCCESS: Changed property ozone.administrators<br>
 From: "hadoop"<br>
 To: "hadoop,bigdata"
 >
-> $ `ozone admin reconfig -address=hadoop1:9860 properties`<br>
+> $ `ozone admin reconfig --service=SCM -address=hadoop1:9860 properties`<br>
 SCM: Node [hadoop1:9860] Reconfigurable properties:<br>
 ozone.administrators
 
 ## Datanode Reconfigurability
 >For example, modify `ozone.example.config` in ozone-site.xml and execute:
 >
-> $ `ozone admin reconfig --address=hadoop1:19864 start`<br>
+> $ `ozone admin reconfig --service=DATANODE --address=hadoop1:19864 start`<br>
 Datanode: Started reconfiguration task on node [hadoop1:19864].
 >
->$ `ozone admin reconfig --address=hadoop1:19864 status`<br>
+>$ `ozone admin reconfig --service=DATANODE --address=hadoop1:19864 status`<br>
 Datanode: Reconfiguring status for node [hadoop1:19864]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
 SUCCESS: Changed property ozone.example.config<br>
 From: "old"<br>
 To: "new"
 >
-> $ `ozone admin reconfig -address=hadoop1:19864 properties`<br>
+> $ `ozone admin reconfig --service=DATANODE -address=hadoop1:19864 properties`<br>
 Datanode: Node [hadoop1:19864] Reconfigurable properties:<br>
 ozone.example.config
 
@@ -104,7 +105,7 @@ Currently, only Datanode supports batch operations<br>
 
 
 >For example, to list the reconfigurable properties of all Datanodes:<br>
-> $ `ozone admin reconfig --in-service-datanodes properties`<br>
+> $ `ozone admin reconfig --service=DATANODE --in-service-datanodes properties`<br>
 Datanode: Node [hadoop1:19864] Reconfigurable properties:<br>
 ozone.example.config<br>
 Datanode: Node [hadoop2:19864] Reconfigurable properties:<br>

--- a/hadoop-hdds/docs/content/feature/Reconfigurability.zh.md
+++ b/hadoop-hdds/docs/content/feature/Reconfigurability.zh.md
@@ -27,10 +27,11 @@ Ozone支持在不重启服务的情况下动态加载某些配置。如果某个
 
 命令：
 ```shell
-ozone admin reconfig --address=<ip:port> start|status|properties
+ozone admin reconfig --service=[OM|SCM|DATANODE] --address=<ip:port> start|status|properties
 ```
 
 命令项的含义:
+- **--service**: --address 指定节点的Ozone服务类型
 - **--address**: 一台服务所在的主机与客户端通信的RPC地址
 - 提供3中操作:
     - **start**:      开始异步执行动态加载配置
@@ -38,44 +39,44 @@ ozone admin reconfig --address=<ip:port> start|status|properties
     - **properties**: 列出支持动态加载的配置项
 
 ## 获取可动态加载的属性列表
-要获取 Ozone 中指定组件的可动态加载属性列表, 可以使用命令 `ozone admin reconfig --address=<ip:port> properties`。
+要获取 Ozone 中指定组件的可动态加载属性列表, 可以使用命令 `ozone admin reconfig --service=[OM|SCM|DATANODE] --address=<ip:port> properties`。
 这个命令将会列出所有可以在运行时动态加载的属性。
 
 > 例如, 获取 Ozone OM 可动态加载属性列表
 >
->$ `ozone admin reconfig --address=hadoop1:9862 properties`<br>
+>$ `ozone admin reconfig --service=OM --address=hadoop1:9862 properties`<br>
 OM: Node [hadoop1:9862] Reconfigurable properties:<br>
 ozone.administrators
 
 ## OM动态配置
 >例如, 在`ozone-site.xml`文件中修改`ozone.administrators`的值并执行:
 >
-> $ `ozone admin reconfig --address=hadoop1:9862 start`<br>
+> $ `ozone admin reconfig --service=OM --address=hadoop1:9862 start`<br>
 OM: Started reconfiguration task on node [hadoop1:9862].
 >
->$ `ozone admin reconfig --address=hadoop1:9862 status`<br>
+>$ `ozone admin reconfig --service=OM --address=hadoop1:9862 status`<br>
 OM: Reconfiguring status for node [hadoop1:9862]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
 SUCCESS: Changed property ozone.administrators<br>
 From: "hadoop"<br>
 To: "hadoop,bigdata"
 >
-> $ `ozone admin reconfig --address=hadoop1:9862 properties`<br>
+> $ `ozone admin reconfig --service=OM --address=hadoop1:9862 properties`<br>
 OM: Node [hadoop1:9862] Reconfigurable properties:<br>
 ozone.administrators
 
 ## SCM动态配置
 >例如, 在`ozone-site.xml`文件中修改`ozone.administrators`的值并执行:
 >
-> $ `ozone admin reconfig --address=hadoop1:9860 start`<br>
+> $ `ozone admin reconfig --service=SCM --address=hadoop1:9860 start`<br>
 SCM: Started reconfiguration task on node [hadoop1:9860].
 >
->$ `ozone admin reconfig --address=hadoop1:9860 status`<br>
+>$ `ozone admin reconfig --service=SCM --address=hadoop1:9860 status`<br>
 SCM: Reconfiguring status for node [hadoop1:9860]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
 SUCCESS: Changed property ozone.administrators<br>
 From: "hadoop"<br>
 To: "hadoop,bigdata"
 >
-> $ `ozone admin reconfig --address=hadoop1:9860 properties`<br>
+> $ `ozone admin reconfig --service=SCM --address=hadoop1:9860 properties`<br>
 SCM: Node [hadoop1:9860] Reconfigurable properties:<br>
 ozone.administrators
 
@@ -83,16 +84,16 @@ ozone.administrators
 ## Datanode 动态配置
 >例如, 在`ozone-site.xml`文件中修改`ozone.example.config`的值并执行:
 >
-> $ `ozone admin reconfig --address=hadoop1:19864 start`<br>
+> $ `ozone admin reconfig --service=DATANODE --address=hadoop1:19864 start`<br>
 Datanode: Started reconfiguration task on node [hadoop1:19864].
 >
->$ `ozone admin reconfig --address=hadoop1:19864 status`<br>
+>$ `ozone admin reconfig --service=DATANODE --address=hadoop1:19864 status`<br>
 Datanode: Reconfiguring status for node [hadoop1:19864]: started at Wed Dec 28 19:04:44 CST 2022 and finished at Wed Dec 28 19:04:44 CST 2022.<br>
 SUCCESS: Changed property ozone.example.config<br>
 From: "old"<br>
 To: "new"
 >
-> $ `ozone admin reconfig --address=hadoop1:19864 properties`<br>
+> $ `ozone admin reconfig --service=DATANODE --address=hadoop1:19864 properties`<br>
 Datanode: Node [hadoop1:19864] Reconfigurable properties:<br>
 ozone.example.config
 
@@ -104,7 +105,7 @@ ozone.example.config
 
 
 >例如, 列出 Datanode 所有可配置的属性:<br>
-> $ `ozone admin reconfig --in-service-datanodes properties`<br>
+> $ `ozone admin reconfig --service=DATANODE --in-service-datanodes properties`<br>
 Datanode: Node [hadoop1:19864] Reconfigurable properties:<br>
 ozone.example.config<br>
 Datanode: Node [hadoop2:19864] Reconfigurable properties:<br>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolDatanodePB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolDatanodePB.java
@@ -17,20 +17,17 @@
  */
 package org.apache.hadoop.hdds.protocolPB;
 
-import org.apache.hadoop.hdds.protocol.proto.ReconfigureProtocolProtos.ReconfigureProtocolService;
-import org.apache.hadoop.hdds.scm.ScmConfig;
+import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.hadoop.security.KerberosInfo;
 
 /**
- * Protocol that clients use to communicate with the SCM to do
+ * Protocol that clients use to communicate with the DN to do
  * reconfiguration on the fly.
  */
 @ProtocolInfo(
     protocolName = "org.apache.hadoop.hdds.protocol.ReconfigureProtocol",
     protocolVersion = 1)
-@KerberosInfo(serverPrincipal = ScmConfig.ConfigStrings
-    .HDDS_SCM_KERBEROS_PRINCIPAL_KEY)
-public interface ReconfigureProtocolPB extends
-    ReconfigureProtocolService.BlockingInterface {
+@KerberosInfo(serverPrincipal = DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_PRINCIPAL_KEY)
+public interface ReconfigureProtocolDatanodePB extends ReconfigureProtocolPB {
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolOmPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolOmPB.java
@@ -17,20 +17,17 @@
  */
 package org.apache.hadoop.hdds.protocolPB;
 
-import org.apache.hadoop.hdds.protocol.proto.ReconfigureProtocolProtos.ReconfigureProtocolService;
-import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.hadoop.security.KerberosInfo;
 
 /**
- * Protocol that clients use to communicate with the SCM to do
+ * Protocol that clients use to communicate with the OM to do
  * reconfiguration on the fly.
  */
 @ProtocolInfo(
     protocolName = "org.apache.hadoop.hdds.protocol.ReconfigureProtocol",
     protocolVersion = 1)
-@KerberosInfo(serverPrincipal = ScmConfig.ConfigStrings
-    .HDDS_SCM_KERBEROS_PRINCIPAL_KEY)
-public interface ReconfigureProtocolPB extends
-    ReconfigureProtocolService.BlockingInterface {
+// TODO: move OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY to hdds-common.
+@KerberosInfo(serverPrincipal = "ozone.om.kerberos.principal")
+public interface ReconfigureProtocolOmPB extends ReconfigureProtocolPB {
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolPB.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.hadoop.security.KerberosInfo;
 
 /**
- * Protocol that clients use to communicate with the OM/SCM to do
+ * Protocol that clients use to communicate with the OM/SCM/DN to do
  * reconfiguration on the fly.
  */
 @ProtocolInfo(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/ReconfigureProtocolServerSideTranslatorPB.java
@@ -45,7 +45,7 @@ import java.util.Optional;
  * ReconfigureProtocol.
  */
 public class ReconfigureProtocolServerSideTranslatorPB implements
-    ReconfigureProtocolPB {
+    ReconfigureProtocolPB, ReconfigureProtocolOmPB, ReconfigureProtocolDatanodePB {
 
   private final ReconfigureProtocol impl;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMPolicyProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMPolicyProvider.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience.Private;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.annotation.InterfaceStability.Unstable;
+import org.apache.hadoop.hdds.protocol.ReconfigureProtocol;
 import org.apache.hadoop.hdds.protocol.SecretKeyProtocolDatanode;
 import org.apache.hadoop.hdds.protocol.SecretKeyProtocolOm;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
@@ -43,6 +44,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SECURITY_CLIENT_SCM_CON
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SECURITY_CLIENT_SCM_SECRET_KEY_DATANODE_PROTOCOL_ACL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SECURITY_CLIENT_SCM_SECRET_KEY_OM_PROTOCOL_ACL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SECURITY_CLIENT_SCM_SECRET_KEY_SCM_PROTOCOL_ACL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_SECURITY_RECONFIGURE_PROTOCOL_ACL;
 
 /**
  * {@link PolicyProvider} for SCM protocols.
@@ -85,7 +87,10 @@ public final class SCMPolicyProvider extends PolicyProvider {
               SecretKeyProtocolScm.class),
           new Service(
               HDDS_SECURITY_CLIENT_SCM_SECRET_KEY_DATANODE_PROTOCOL_ACL,
-              SecretKeyProtocolDatanode.class)
+              SecretKeyProtocolDatanode.class),
+          new Service(
+              OZONE_SECURITY_RECONFIGURE_PROTOCOL_ACL,
+              ReconfigureProtocol.class)
       );
 
   @Override

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -138,6 +138,7 @@ HADOOP-POLICY.XML_hdds.security.client.datanode.container.protocol.acl=*
 HADOOP-POLICY.XML_hdds.security.client.scm.container.protocol.acl=*
 HADOOP-POLICY.XML_hdds.security.client.scm.block.protocol.acl=*
 HADOOP-POLICY.XML_hdds.security.client.scm.certificate.protocol.acl=*
+HADOOP-POLICY.XML_ozone.security.reconfigure.protocol.acl=*
 
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-leadership.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test-leadership.sh
@@ -31,7 +31,7 @@ start_docker_env
 
 execute_robot_test s3g kinit.robot
 
-execute_robot_test s3g admincli
+execute_robot_test s3g admincli/scmrole.robot
 
 execute_robot_test s3g omha/om-fetch-key.robot
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -130,6 +130,7 @@ HADOOP-POLICY.XML_hdds.security.client.datanode.container.protocol.acl=*
 HADOOP-POLICY.XML_hdds.security.client.scm.container.protocol.acl=*
 HADOOP-POLICY.XML_hdds.security.client.scm.block.protocol.acl=*
 HADOOP-POLICY.XML_hdds.security.client.scm.certificate.protocol.acl=*
+HADOOP-POLICY.XML_ozone.security.reconfigure.protocol.acl=*
 
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/reconfigure.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/reconfigure.robot
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test ozone admin command
+Library             BuiltIn
+Resource            ../commonlib.robot
+Test Timeout        5 minutes
+
+*** Keywords ***
+Setup Test
+    Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
+
+*** Test Cases ***
+Reconfigure OM
+    Pass Execution If       '${SECURITY_ENABLED}' == 'false'    N/A
+        ${output} =             Execute          ozone admin reconfig --address=om:9862 --service=OM start
+        Should Contain          ${output}        Started reconfiguration task on node
+Reconfigure SCM
+    Pass Execution If       '${SECURITY_ENABLED}' == 'false'    N/A
+        ${output} =             Execute          ozone admin reconfig --address=scm:9860 --service=SCM start
+        Should Contain          ${output}        Started reconfiguration task on node
+Reconfigure DN
+    Pass Execution If       '${SECURITY_ENABLED}' == 'false'    N/A
+        ${output} =             Execute          ozone admin reconfig --address=datanode:19864 --service=DATANODE start
+        Should Contain          ${output}        Started reconfiguration task on node

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -213,6 +213,7 @@ function ozonecmd_case
     ;;
     admin)
       OZONE_CLASSNAME=org.apache.hadoop.hdds.cli.OzoneAdmin
+      OZONE_ADMIN_OPTS="${OZONE_ADMIN_OPTS} ${OZONE_MODULE_ACCESS_ARGS}"
       OZONE_RUN_ARTIFACT_NAME="ozone-tools"
     ;;
     debug)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
@@ -95,7 +95,7 @@ public class TestReconfigShell {
         HddsDatanodeClientProtocolServer server =
             datanodeService.getClientProtocolServer();
         InetSocketAddress socket = server.getClientRpcAddress();
-        executeAndAssertProperties(datanodeService.getReconfigurationHandler(),
+        executeAndAssertProperties(datanodeService.getReconfigurationHandler(), "--service=DATANODE",
             socket, capture);
       }
     }
@@ -105,7 +105,7 @@ public class TestReconfigShell {
   public void testOzoneManagerGetReconfigurationProperties() throws Exception {
     try (SystemOutCapturer capture = new SystemOutCapturer()) {
       InetSocketAddress socket = ozoneManager.getOmRpcServerAddr();
-      executeAndAssertProperties(ozoneManager.getReconfigurationHandler(),
+      executeAndAssertProperties(ozoneManager.getReconfigurationHandler(), "--service=OM",
           socket, capture);
     }
   }
@@ -116,17 +116,17 @@ public class TestReconfigShell {
     try (SystemOutCapturer capture = new SystemOutCapturer()) {
       InetSocketAddress socket = storageContainerManager.getClientRpcAddress();
       executeAndAssertProperties(
-          storageContainerManager.getReconfigurationHandler(), socket, capture);
+          storageContainerManager.getReconfigurationHandler(), "--service=SCM", socket, capture);
     }
   }
 
   private void executeAndAssertProperties(
-      ReconfigurableBase reconfigurableBase,
+      ReconfigurableBase reconfigurableBase, String service,
       InetSocketAddress socket, SystemOutCapturer capture)
       throws UnsupportedEncodingException {
     String address = socket.getHostString() + ":" + socket.getPort();
     ozoneAdmin.execute(
-        new String[] {"reconfig", "--address", address, "properties"});
+        new String[] {"reconfig", service, "--address", address, "properties"});
     assertReconfigurablePropertiesOutput(
         reconfigurableBase.getReconfigurableProperties(), capture.getOutput());
   }
@@ -171,7 +171,7 @@ public class TestReconfigShell {
       throws Exception {
     try (SystemOutCapturer capture = new SystemOutCapturer()) {
       ozoneAdmin.execute(new String[] {
-          "reconfig",  "--in-service-datanodes", "properties"});
+          "reconfig", "--service=DATANODE", "--in-service-datanodes", "properties"});
       String output = capture.getOutput();
 
       assertThat(capture.getOutput()).contains(String.format("successfully %d", except));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1239,6 +1239,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     ReconfigureProtocolServerSideTranslatorPB reconfigureServerProtocol
         = new ReconfigureProtocolServerSideTranslatorPB(reconfigurationHandler);
+    OzoneSecurityUtil.updateKerberosInfo(ReconfigureProtocolPB.class,
+        OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY);
     BlockingService reconfigureService =
         ReconfigureProtocolService.newReflectiveBlockingService(
             reconfigureServerProtocol);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -75,7 +75,7 @@ import org.apache.hadoop.hdds.conf.ReconfigurationHandler;
 import org.apache.hadoop.hdds.protocol.SecretKeyProtocol;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.ReconfigureProtocolProtos.ReconfigureProtocolService;
-import org.apache.hadoop.hdds.protocolPB.ReconfigureProtocolPB;
+import org.apache.hadoop.hdds.protocolPB.ReconfigureProtocolOmPB;
 import org.apache.hadoop.hdds.protocolPB.ReconfigureProtocolServerSideTranslatorPB;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
@@ -1239,8 +1239,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     ReconfigureProtocolServerSideTranslatorPB reconfigureServerProtocol
         = new ReconfigureProtocolServerSideTranslatorPB(reconfigurationHandler);
-    OzoneSecurityUtil.updateKerberosInfo(ReconfigureProtocolPB.class,
-        OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY);
     BlockingService reconfigureService =
         ReconfigureProtocolService.newReflectiveBlockingService(
             reconfigureServerProtocol);
@@ -1285,7 +1283,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         interOMProtocolService, rpcServer);
     HddsServerUtil.addPBProtocol(conf, OMAdminProtocolPB.class,
         omAdminProtocolService, rpcServer);
-    HddsServerUtil.addPBProtocol(conf, ReconfigureProtocolPB.class,
+    HddsServerUtil.addPBProtocol(conf, ReconfigureProtocolOmPB.class,
         reconfigureProtocolService, rpcServer);
 
     if (conf.getBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/AbstractReconfigureSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/AbstractReconfigureSubCommand.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.admin.reconfig;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import picocli.CommandLine;
 
 import java.util.List;
@@ -44,10 +45,10 @@ public abstract class AbstractReconfigureSubCommand implements Callable<Void> {
             " --in-service-datanodes is not given.");
         return null;
       }
-      executeCommand(parent.getAddress());
+      executeCommand(parent.getService(), parent.getAddress());
     }
     return null;
   }
 
-  protected abstract void executeCommand(String address);
+  protected abstract void executeCommand(HddsProtos.NodeType nodeType, String address);
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureCommands.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.kohsuke.MetaInfServices;
@@ -56,6 +57,11 @@ public class ReconfigureCommands implements Callable<Void>,
   @Spec
   private CommandSpec spec;
 
+  @CommandLine.Option(names = {"--service"},
+      description = "service: OM, SCM, DATANODE.",
+      required = true)
+  private String service;
+
   @CommandLine.Option(names = {"--address"},
       description = "node address: <ip:port> or <hostname:port>.",
       required = false)
@@ -75,6 +81,10 @@ public class ReconfigureCommands implements Callable<Void>,
 
   public String getAddress() {
     return address;
+  }
+
+  public HddsProtos.NodeType getService() {
+    return HddsProtos.NodeType.valueOf(service);
   }
 
   @Override

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigurePropertiesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigurePropertiesSubcommand.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.admin.reconfig;
 
 import org.apache.hadoop.hdds.protocol.ReconfigureProtocol;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
@@ -36,9 +37,9 @@ public class ReconfigurePropertiesSubcommand
     extends AbstractReconfigureSubCommand {
 
   @Override
-  protected void executeCommand(String address) {
+  protected void executeCommand(HddsProtos.NodeType nodeType, String address) {
     try (ReconfigureProtocol reconfigProxy = ReconfigureSubCommandUtil
-        .getSingleNodeReconfigureProxy(address)) {
+        .getSingleNodeReconfigureProxy(nodeType, address)) {
       String serverName = reconfigProxy.getServerName();
       List<String> properties = reconfigProxy.listReconfigureProperties();
       System.out.printf("%s: Node [%s] Reconfigurable properties:%n",

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureStartSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureStartSubcommand.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.admin.reconfig;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.ReconfigureProtocol;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
@@ -34,9 +35,9 @@ import java.io.IOException;
 public class ReconfigureStartSubcommand extends AbstractReconfigureSubCommand {
 
   @Override
-  protected void executeCommand(String address) {
+  protected void executeCommand(HddsProtos.NodeType nodeType, String address) {
     try (ReconfigureProtocol reconfigProxy = ReconfigureSubCommandUtil
-        .getSingleNodeReconfigureProxy(address)) {
+        .getSingleNodeReconfigureProxy(nodeType, address)) {
       String serverName = reconfigProxy.getServerName();
       reconfigProxy.startReconfigure();
       System.out.printf("%s: Started reconfiguration task on node [%s].%n",

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureStatusSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureStatusSubcommand.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.conf.ReconfigurationTaskStatus;
 import org.apache.hadoop.conf.ReconfigurationUtil;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.ReconfigureProtocol;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
@@ -40,9 +41,9 @@ public class ReconfigureStatusSubcommand
     extends AbstractReconfigureSubCommand {
 
   @Override
-  protected void executeCommand(String address) {
+  protected void executeCommand(HddsProtos.NodeType nodeType, String address) {
     try (ReconfigureProtocol reconfigProxy = ReconfigureSubCommandUtil
-        .getSingleNodeReconfigureProxy(address)) {
+        .getSingleNodeReconfigureProxy(nodeType, address)) {
       String serverName = reconfigProxy.getServerName();
       ReconfigurationTaskStatus status = reconfigProxy.getReconfigureStatus();
       System.out.printf("%s: Reconfiguring status for node [%s]: ",


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the issue that "ozone admin reconfig" CLI fails in a secure cluster.

Before the patch, reconfig will fail. Please go to the JIRA page to find the detail failure stack. 
After the patch,  rconfig will succeed. Here is the command output 

```
bash-4.2$ ozone admin reconfig --address=om:9862 --service=OM start
OM: Started reconfiguration task on node [om:9862].
bash-4.2$ ozone admin reconfig --address=scm:9860 --service=SCM start
SCM: Started reconfiguration task on node [scm:9860].
bash-4.2$ ozone admin reconfig --address=datanode:19864 --service=DATANODE start
DN: Started reconfiguration task on node [datanode:19864].
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10404

## How was this patch tested?

new robot test
