### PR TITLE
HDDS-10370. Recon - Handle the pre-existing missing empty containers in clusters.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -397,6 +397,9 @@ public class ContainerEndpoint {
       summary = containerHealthSchemaManager.getUnhealthyContainersSummary();
       List<UnhealthyContainers> containers = containerHealthSchemaManager
           .getUnhealthyContainers(internalState, offset, limit);
+      containers.stream()
+          .filter(
+              container -> !container.getContainerState().equals(UnHealthyContainerStates.EMPTY_MISSING.toString()));
       for (UnhealthyContainers c : containers) {
         long containerID = c.getContainerId();
         ContainerInfo containerInfo =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -211,7 +211,7 @@ public class ContainerHealthTask extends ReconScmTask {
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.MISSING, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
-        EMPTY_MISSING, new HashMap<>());
+        UnHealthyContainerStates.EMPTY_MISSING, new HashMap<>());
     unhealthyContainerStateStatsMap.put(
         UnHealthyContainerStates.UNDER_REPLICATED, new HashMap<>());
     unhealthyContainerStateStatsMap.put(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -289,9 +289,6 @@ public class ContainerHealthTask extends ReconScmTask {
                 containerDeletedInSCM(currentContainer.getContainer())) {
               rec.delete();
             }
-            if (currentContainer.isEmpty()) {
-              rec.setContainerState(EMPTY_MISSING.toString());
-            }
             existingRecords.add(rec.getContainerState());
             if (rec.changed()) {
               rec.update();
@@ -400,7 +397,7 @@ public class ContainerHealthTask extends ReconScmTask {
       boolean returnValue = false;
       switch (UnHealthyContainerStates.valueOf(rec.getContainerState())) {
       case MISSING:
-        returnValue = container.isMissing();
+        returnValue = container.isMissing() && !container.isEmpty();
         break;
       case MIS_REPLICATED:
         returnValue = keepMisReplicatedRecord(container, rec);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -34,6 +34,9 @@ import org.jooq.Cursor;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.SelectQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 
 /**
@@ -41,6 +44,8 @@ import java.util.List;
  */
 @Singleton
 public class ContainerHealthSchemaManager {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ContainerHealthSchemaManager.class);
 
   private final UnhealthyContainersDao unhealthyContainersDao;
   private final ContainerSchemaDefinition containerSchemaDefinition;
@@ -113,6 +118,10 @@ public class ContainerHealthSchemaManager {
   }
 
   public void insertUnhealthyContainerRecords(List<UnhealthyContainers> recs) {
+    recs.forEach(rec -> {
+      LOG.debug("rec.getContainerId() : {}, rec.getContainerState(): {} ", rec.getContainerId(),
+          rec.getContainerState());
+    });
     unhealthyContainersDao.insert(recs);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -118,10 +118,12 @@ public class ContainerHealthSchemaManager {
   }
 
   public void insertUnhealthyContainerRecords(List<UnhealthyContainers> recs) {
-    recs.forEach(rec -> {
-      LOG.debug("rec.getContainerId() : {}, rec.getContainerState(): {} ", rec.getContainerId(),
-          rec.getContainerState());
-    });
+    if (LOG.isDebugEnabled()) {
+      recs.forEach(rec -> {
+        LOG.debug("rec.getContainerId() : {}, rec.getContainerState(): {} ", rec.getContainerId(),
+            rec.getContainerState());
+      });
+    }
     unhealthyContainersDao.insert(recs);
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.fsck;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_UNHEALTHY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -113,32 +114,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
           .thenReturn(new ContainerWithPipeline(c, null));
     }
 
-    ReplicatedReplicationConfig replicationConfig = new ReplicatedReplicationConfig() {
-      @Override
-      public HddsProtos.ReplicationFactor getReplicationFactor() {
-        return HddsProtos.ReplicationFactor.THREE;
-      }
-
-      @Override
-      public HddsProtos.ReplicationType getReplicationType() {
-        return HddsProtos.ReplicationType.RATIS;
-      }
-
-      @Override
-      public int getRequiredNodes() {
-        return 3;
-      }
-
-      @Override
-      public String getReplication() {
-        return null;
-      }
-
-      @Override
-      public String configFormat() {
-        return null;
-      }
-    };
+    ReplicatedReplicationConfig replicationConfig = RatisReplicationConfig.getInstance(THREE);
     // Under replicated
     ContainerInfo containerInfo1 =
         TestContainerInfo.newBuilderForTest().setContainerID(1).setReplicationConfig(replicationConfig).build();
@@ -429,9 +405,9 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
       when(c.getContainerID()).thenReturn((long)i);
       when(c.getReplicationConfig())
           .thenReturn(RatisReplicationConfig.getInstance(
-              HddsProtos.ReplicationFactor.THREE));
+              THREE));
       when(c.getReplicationFactor())
-          .thenReturn(HddsProtos.ReplicationFactor.THREE);
+          .thenReturn(THREE);
       when(c.getState()).thenReturn(HddsProtos.LifeCycleState.CLOSED);
       when(c.containerID()).thenReturn(ContainerID.valueOf(i));
       containers.add(c);
@@ -444,7 +420,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     when(c.getContainerID()).thenReturn((long)containerID);
     when(c.getReplicationConfig())
         .thenReturn(RatisReplicationConfig
-            .getInstance(HddsProtos.ReplicationFactor.THREE));
+            .getInstance(THREE));
     when(c.containerID()).thenReturn(ContainerID.valueOf(containerID));
     when(c.getState()).thenReturn(HddsProtos.LifeCycleState.DELETED);
     return c;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicatedReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -49,6 +50,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.TestContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager;
@@ -110,38 +112,86 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
       when(scmClientMock.getContainerWithPipeline(c.getContainerID()))
           .thenReturn(new ContainerWithPipeline(c, null));
     }
+
+    ReplicatedReplicationConfig replicationConfig = new ReplicatedReplicationConfig() {
+      @Override
+      public HddsProtos.ReplicationFactor getReplicationFactor() {
+        return HddsProtos.ReplicationFactor.THREE;
+      }
+
+      @Override
+      public HddsProtos.ReplicationType getReplicationType() {
+        return HddsProtos.ReplicationType.RATIS;
+      }
+
+      @Override
+      public int getRequiredNodes() {
+        return 3;
+      }
+
+      @Override
+      public String getReplication() {
+        return null;
+      }
+
+      @Override
+      public String configFormat() {
+        return null;
+      }
+    };
     // Under replicated
-    when(containerManagerMock.getContainerReplicas(ContainerID.valueOf(1L)))
+    ContainerInfo containerInfo1 =
+        TestContainerInfo.newBuilderForTest().setContainerID(1).setReplicationConfig(replicationConfig).build();
+    when(containerManagerMock.getContainer(ContainerID.valueOf(1L))).thenReturn(containerInfo1);
+    when(containerManagerMock.getContainerReplicas(containerInfo1.containerID()))
         .thenReturn(getMockReplicas(1L, State.CLOSED, State.UNHEALTHY));
 
     // return all UNHEALTHY replicas for container ID 2 -> UNDER_REPLICATED
-    when(containerManagerMock.getContainerReplicas(ContainerID.valueOf(2L)))
+    ContainerInfo containerInfo2 =
+        TestContainerInfo.newBuilderForTest().setContainerID(2).setReplicationConfig(replicationConfig).build();
+    when(containerManagerMock.getContainer(ContainerID.valueOf(2L))).thenReturn(containerInfo2);
+    when(containerManagerMock.getContainerReplicas(containerInfo2.containerID()))
         .thenReturn(getMockReplicas(2L, State.UNHEALTHY));
 
-    // return 0 replicas for container ID 3 -> Missing
-    when(containerManagerMock.getContainerReplicas(ContainerID.valueOf(3L)))
+    // return 0 replicas for container ID 3 -> Empty Missing
+    ContainerInfo containerInfo3 =
+        TestContainerInfo.newBuilderForTest().setContainerID(3).setReplicationConfig(replicationConfig).build();
+    when(containerManagerMock.getContainer(ContainerID.valueOf(3L))).thenReturn(containerInfo3);
+    when(containerManagerMock.getContainerReplicas(containerInfo3.containerID()))
         .thenReturn(Collections.emptySet());
 
     // Return 5 Healthy -> Over replicated
-    when(containerManagerMock.getContainerReplicas(ContainerID.valueOf(4L)))
+    ContainerInfo containerInfo4 =
+        TestContainerInfo.newBuilderForTest().setContainerID(4).setReplicationConfig(replicationConfig).build();
+    when(containerManagerMock.getContainer(ContainerID.valueOf(4L))).thenReturn(containerInfo4);
+    when(containerManagerMock.getContainerReplicas(containerInfo4.containerID()))
         .thenReturn(getMockReplicas(4L, State.CLOSED, State.CLOSED,
         State.CLOSED, State.CLOSED, State.CLOSED));
 
     // Mis-replicated
+    ContainerInfo containerInfo5 =
+        TestContainerInfo.newBuilderForTest().setContainerID(5).setReplicationConfig(replicationConfig).build();
+    when(containerManagerMock.getContainer(ContainerID.valueOf(5L))).thenReturn(containerInfo5);
     Set<ContainerReplica> misReplicas = getMockReplicas(5L,
         State.CLOSED, State.CLOSED, State.CLOSED);
     placementMock.setMisRepWhenDnPresent(
         misReplicas.iterator().next().getDatanodeDetails().getUuid());
-    when(containerManagerMock.getContainerReplicas(ContainerID.valueOf(5L)))
+    when(containerManagerMock.getContainerReplicas(containerInfo5.containerID()))
         .thenReturn(misReplicas);
 
     // Return 3 Healthy -> Healthy container
-    when(containerManagerMock.getContainerReplicas(ContainerID.valueOf(6L)))
+    ContainerInfo containerInfo6 =
+        TestContainerInfo.newBuilderForTest().setContainerID(6).setReplicationConfig(replicationConfig).build();
+    when(containerManagerMock.getContainer(ContainerID.valueOf(6L))).thenReturn(containerInfo6);
+    when(containerManagerMock.getContainerReplicas(containerInfo6.containerID()))
         .thenReturn(getMockReplicas(6L,
             State.CLOSED, State.CLOSED, State.CLOSED));
 
-    // return 0 replicas for container ID 7 -> EMPTY_MISSING
-    when(containerManagerMock.getContainerReplicas(ContainerID.valueOf(7L)))
+    // return 0 replicas for container ID 7 -> MISSING
+    ContainerInfo containerInfo7 =
+        TestContainerInfo.newBuilderForTest().setContainerID(7).setReplicationConfig(replicationConfig).build();
+    when(containerManagerMock.getContainer(ContainerID.valueOf(7L))).thenReturn(containerInfo7);
+    when(containerManagerMock.getContainerReplicas(containerInfo7.containerID()))
         .thenReturn(Collections.emptySet());
 
     List<UnhealthyContainers> all = unHealthyContainersTableHandle.findAll();
@@ -150,7 +200,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     long currentTime = System.currentTimeMillis();
     ReconTaskStatusDao reconTaskStatusDao = getDao(ReconTaskStatusDao.class);
     ReconTaskConfig reconTaskConfig = new ReconTaskConfig();
-    reconTaskConfig.setMissingContainerTaskInterval(Duration.ofSeconds(2));
+    reconTaskConfig.setMissingContainerTaskInterval(Duration.ofSeconds(5));
     when(reconContainerMetadataManager.getKeyCountForContainer(
         7L)).thenReturn(5L);
     ContainerHealthTask containerHealthTask =
@@ -215,7 +265,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
         .thenReturn(getMockReplicas(2L,
             State.CLOSED, State.CLOSED, State.CLOSED));
 
-    // return 0 replicas for container ID 3 -> Still Missing
+    // return 0 replicas for container ID 3 -> Still empty Missing
     when(containerManagerMock.getContainerReplicas(ContainerID.valueOf(3L)))
         .thenReturn(Collections.emptySet());
 
@@ -227,7 +277,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     // Was mis-replicated - make it healthy now
     placementMock.setMisRepWhenDnPresent(null);
 
-    LambdaTestUtils.await(6000, 1000, () ->
+    LambdaTestUtils.await(60000, 1000, () ->
         (unHealthyContainersTableHandle.count() == 4));
     rec = unHealthyContainersTableHandle.fetchByContainerId(1L).get(0);
     assertEquals("UNDER_REPLICATED", rec.getContainerState());
@@ -252,6 +302,21 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     // This container is now healthy, it should not be in the table any more
     assertEquals(0,
         unHealthyContainersTableHandle.fetchByContainerId(5L).size());
+
+    // Again make container Id 7 as empty which was missing as well, so in next
+    // container health task run, this container also should be deleted from
+    // UNHEALTHY_CONTAINERS table because we want to cleanup any existing
+    // EMPTY and MISSING containers from UNHEALTHY_CONTAINERS table.
+    when(reconContainerMetadataManager.getKeyCountForContainer(7L)).thenReturn(0L);
+    LambdaTestUtils.await(6000, 1000, () -> {
+      UnhealthyContainers emptyMissingContainer = unHealthyContainersTableHandle.fetchByContainerId(7L).get(0);
+      return ("EMPTY_MISSING".equals(emptyMissingContainer.getContainerState()));
+    });
+
+    // Just check once again that count doesn't change, only state of
+    // container 7 changes from MISSING to EMPTY_MISSING
+    LambdaTestUtils.await(60000, 1000, () ->
+        (unHealthyContainersTableHandle.count() == 4));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR addresses the corner case when a Recon has earlier identified some MISSING (UNHEALTHY) containers, but they all were EMPTY (No keys mapped), so Recon should filter out such existing MISSING (UNHEALTHY) containers.

In a running cluster, Recon may have identified some MISSING (UNHEALTHY) containers before the [HDDS-9695](https://issues.apache.org/jira/browse/HDDS-9695) was applied. After the fix is applied, in a running cluster, existing MISSING (UNHEALTHY) containers which were actually EMPTY were still shown as MISSING, so this PR change is to filter out such existing MISSING (UNHEALTHY) containers which were actually EMPTY.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10370

## How was this patch tested?
Existing Junit integration test `org.apache.hadoop.ozone.recon.TestReconTasks#testEmptyMissingContainerDownNode` was updated and tested.
