### PR TITLE
HDDS-10361. [hsync] Output stream should support direct byte buffer.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -855,7 +855,12 @@ public class BlockOutputStream extends OutputStream {
         try {
           LOG.debug("put into last chunk buffer start = {} len = {}",
               copyStart, copyLen);
-          lastChunkBuffer.put(bb.array(), copyStart, copyLen);
+          int origPos = bb.position();
+          int origLimit = bb.limit();
+          bb.position(copyStart).limit(copyStart + copyLen);
+          lastChunkBuffer.put(bb);
+          bb.position(origPos).limit(origLimit);
+          //lastChunkBuffer.put(bb.array(), copyStart, copyLen);
         } catch (BufferOverflowException e) {
           LOG.error("appending from " + copyStart + " for len=" + copyLen +
               ". lastChunkBuffer remaining=" + lastChunkBuffer.remaining() +

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -860,7 +860,6 @@ public class BlockOutputStream extends OutputStream {
           bb.position(copyStart).limit(copyStart + copyLen);
           lastChunkBuffer.put(bb);
           bb.position(origPos).limit(origLimit);
-          //lastChunkBuffer.put(bb.array(), copyStart, copyLen);
         } catch (BufferOverflowException e) {
           LOG.error("appending from " + copyStart + " for len=" + copyLen +
               ". lastChunkBuffer remaining=" + lastChunkBuffer.remaining() +


### PR DESCRIPTION
## What changes were proposed in this pull request?
A small update to HDDS-9752 such that it works for direct buffers too.

Please describe your PR in detail:
HDDS-9752 assumed the byte buffer is heap buffer which has a backing byte array. It's no longer the case after HDDS-9843 which uses direct buffer, so we need to adapt the code to support that.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10361

## How was this patch tested?

Unit tests