### PR TITLE
HDDS-10410. Avoid creating ChunkInfo.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerLayoutVersion.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerLayoutVersion.java
@@ -25,12 +25,9 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Defines layout versions for the Chunks.
@@ -39,21 +36,16 @@ public enum ContainerLayoutVersion {
 
   FILE_PER_CHUNK(1, "One file per chunk") {
     @Override
-    public File getChunkFile(File chunkDir, BlockID blockID,
-        ChunkInfo info) {
-      return new File(chunkDir, info.getChunkName());
+    public File getChunkFile(File chunkDir, BlockID blockID, String chunkName) {
+      return new File(chunkDir, chunkName);
     }
   },
   FILE_PER_BLOCK(2, "One file per block") {
     @Override
-    public File getChunkFile(File chunkDir, BlockID blockID,
-        ChunkInfo info) {
+    public File getChunkFile(File chunkDir, BlockID blockID, String chunkName) {
       return new File(chunkDir, blockID.getLocalID() + ".block");
     }
   };
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(ContainerLayoutVersion.class);
 
   private static final ContainerLayoutVersion
       DEFAULT_LAYOUT = ContainerLayoutVersion.FILE_PER_BLOCK;
@@ -118,12 +110,12 @@ public enum ContainerLayoutVersion {
   }
 
   public abstract File getChunkFile(File chunkDir,
-      BlockID blockID, ChunkInfo info);
+      BlockID blockID, String chunkName);
 
   public File getChunkFile(ContainerData containerData, BlockID blockID,
-      ChunkInfo info) throws StorageContainerException {
+      String chunkName) throws StorageContainerException {
     File chunkDir = ContainerUtils.getChunkDir(containerData);
-    return getChunkFile(chunkDir, blockID, info);
+    return getChunkFile(chunkDir, blockID, chunkName);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -345,7 +345,7 @@ public class KeyValueContainerCheck {
       File chunkFile;
       try {
         chunkFile = layout.getChunkFile(onDiskContainerData,
-            block.getBlockID(), ChunkInfo.getFromProtoBuf(chunk));
+            block.getBlockID(), chunk.getChunkName());
       } catch (IOException ex) {
         return ScanResult.unhealthy(
             ScanResult.FailureType.MISSING_CHUNK_FILE,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -23,7 +23,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 
@@ -32,7 +31,6 @@ import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
@@ -64,12 +62,6 @@ public final class KeyValueContainerUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(
       KeyValueContainerUtil.class);
-
-  /**
-   *
-   * @param containerMetaDataPath
-   * @throws IOException
-   */
 
   /**
    * creates metadata path, chunks path and metadata DB for the specified
@@ -411,46 +403,9 @@ public final class KeyValueContainerUtil {
   }
 
   public static long getBlockLength(BlockData block) throws IOException {
-    long blockLen = 0;
-    List<ContainerProtos.ChunkInfo> chunkInfoList = block.getChunks();
-
-    for (ContainerProtos.ChunkInfo chunk : chunkInfoList) {
-      ChunkInfo info = ChunkInfo.getFromProtoBuf(chunk);
-      blockLen += info.getLen();
-    }
-
-    return blockLen;
-  }
-
-  /**
-   * Returns the path where data or chunks live for a given container.
-   *
-   * @param kvContainerData - KeyValueContainerData
-   * @return - Path to the chunks directory
-   */
-  public static Path getDataDirectory(KeyValueContainerData kvContainerData) {
-
-    String chunksPath = kvContainerData.getChunksPath();
-    Preconditions.checkNotNull(chunksPath);
-
-    return Paths.get(chunksPath);
-  }
-
-  /**
-   * Container metadata directory -- here is where the RocksDB and
-   * .container file lives.
-   *
-   * @param kvContainerData - KeyValueContainerData
-   * @return Path to the metadata directory
-   */
-  public static Path getMetadataDirectory(
-      KeyValueContainerData kvContainerData) {
-
-    String metadataPath = kvContainerData.getMetadataPath();
-    Preconditions.checkNotNull(metadataPath);
-
-    return Paths.get(metadataPath);
-
+    return block.getChunks().stream()
+        .mapToLong(ContainerProtos.ChunkInfo::getLen)
+        .sum();
   }
 
   public static boolean isSameSchemaVersion(String schema, String other) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -96,7 +96,7 @@ public class FilePerBlockStrategy implements ChunkManager {
   public String streamInit(Container container, BlockID blockID)
       throws StorageContainerException {
     checkLayoutVersion(container);
-    File chunkFile = getChunkFile(container, blockID, null);
+    final File chunkFile = getChunkFile(container, blockID);
     return chunkFile.getAbsolutePath();
   }
 
@@ -105,7 +105,7 @@ public class FilePerBlockStrategy implements ChunkManager {
           Container container, BlockID blockID, ContainerMetrics metrics)
           throws StorageContainerException {
     checkLayoutVersion(container);
-    File chunkFile = getChunkFile(container, blockID, null);
+    final File chunkFile = getChunkFile(container, blockID);
     return new KeyValueStreamDataChannel(chunkFile,
         container.getContainerData(), metrics);
   }
@@ -137,7 +137,7 @@ public class FilePerBlockStrategy implements ChunkManager {
     KeyValueContainerData containerData = (KeyValueContainerData) container
         .getContainerData();
 
-    File chunkFile = getChunkFile(container, blockID, info);
+    final File chunkFile = getChunkFile(container, blockID);
     long len = info.getLen();
     long offset = info.getOffset();
 
@@ -188,7 +188,7 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     HddsVolume volume = containerData.getVolume();
 
-    File chunkFile = getChunkFile(container, blockID, info);
+    final File chunkFile = getChunkFile(container, blockID);
 
     final long len = info.getLen();
     long offset = info.getOffset();
@@ -213,7 +213,7 @@ public class FilePerBlockStrategy implements ChunkManager {
   @Override
   public void finishWriteChunks(KeyValueContainer container,
       BlockData blockData) throws IOException {
-    File chunkFile = getChunkFile(container, blockData.getBlockID(), null);
+    final File chunkFile = getChunkFile(container, blockData.getBlockID());
     try {
       files.close(chunkFile);
       verifyChunkFileExists(chunkFile);
@@ -230,7 +230,7 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     Preconditions.checkNotNull(blockID, "Block ID cannot be null.");
 
-    File file = getChunkFile(container, blockID, info);
+    final File file = getChunkFile(container, blockID);
 
     // if the chunk file does not exist, it might have already been deleted.
     // The call might be because of reapply of transactions on datanode
@@ -250,10 +250,8 @@ public class FilePerBlockStrategy implements ChunkManager {
     LOG.info("Deleted block file: {}", file);
   }
 
-  private File getChunkFile(Container container, BlockID blockID,
-      ChunkInfo info) throws StorageContainerException {
-    return FILE_PER_BLOCK.getChunkFile(container.getContainerData(), blockID,
-        info);
+  private static File getChunkFile(Container container, BlockID blockID) throws StorageContainerException {
+    return FILE_PER_BLOCK.getChunkFile(container.getContainerData(), blockID, null);
   }
 
   private static void checkFullDelete(ChunkInfo info, File chunkFile)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -342,8 +342,7 @@ public class FilePerChunkStrategy implements ChunkManager {
 
   private static File getChunkFile(KeyValueContainer container, BlockID blockID,
       ChunkInfo info) throws StorageContainerException {
-    return FILE_PER_CHUNK.getChunkFile(container.getContainerData(), blockID,
-        info);
+    return FILE_PER_CHUNK.getChunkFile(container.getContainerData(), blockID, info.getChunkName());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdfs.util.Canceler;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
@@ -123,9 +122,7 @@ public class TestKeyValueContainerCheck
       assertFalse(block.getChunks().isEmpty());
       ContainerProtos.ChunkInfo c = block.getChunks().get(0);
       BlockID blockID = block.getBlockID();
-      ChunkInfo chunkInfo = ChunkInfo.getFromProtoBuf(c);
-      File chunkFile = getChunkLayout()
-          .getChunkFile(containerData, blockID, chunkInfo);
+      File chunkFile = getChunkLayout().getChunkFile(containerData, blockID, c.getChunkName());
       long length = chunkFile.length();
       assertThat(length).isGreaterThan(0);
       // forcefully truncate the file to induce failure.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -76,7 +76,7 @@ public abstract class CommonChunkManagerTestCases extends AbstractTestChunkManag
 
     // write chunk bypassing size limit
     File chunkFile = getStrategy().getLayout()
-        .getChunkFile(getKeyValueContainerData(), blockID, chunkInfo);
+        .getChunkFile(getKeyValueContainerData(), blockID, chunkInfo.getChunkName());
     FileUtils.writeByteArrayToFile(chunkFile, array);
 
     // WHEN+THEN

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerChunkStrategy.java
@@ -67,7 +67,7 @@ public class TestFilePerChunkStrategy extends CommonChunkManagerTestCases {
     long term = 0;
     long index = 0;
     File chunkFile = ContainerLayoutVersion.FILE_PER_CHUNK
-        .getChunkFile(container.getContainerData(), blockID, chunkInfo);
+        .getChunkFile(container.getContainerData(), blockID, chunkInfo.getChunkName());
     File tempChunkFile = new File(chunkFile.getParent(),
         chunkFile.getName() + OzoneConsts.CONTAINER_CHUNK_NAME_DELIMITER
             + OzoneConsts.CONTAINER_TEMPORARY_CHUNK_PREFIX
@@ -109,7 +109,7 @@ public class TestFilePerChunkStrategy extends CommonChunkManagerTestCases {
     ChunkInfo oldDatanodeChunkInfo = new ChunkInfo(chunkInfo.getChunkName(),
         offset, chunkInfo.getLen());
     File file = ContainerLayoutVersion.FILE_PER_CHUNK.getChunkFile(
-        container.getContainerData(), blockID, chunkInfo);
+        container.getContainerData(), blockID, chunkInfo.getChunkName());
     ChunkUtils.writeData(file,
         ChunkBuffer.wrap(getData()), offset, chunkInfo.getLen(),
         null, true);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -158,7 +158,7 @@ public class ChunkKeyHandler extends KeyHandler implements
               String fileName = containerLayoutVersion.getChunkFile(new File(
                       getChunkLocationPath(containerData.getContainerPath())),
                   keyLocation.getBlockID(),
-                  ChunkInfo.getFromProtoBuf(chunkInfo)).toString();
+                  chunkInfo.getChunkName()).toString();
               chunkPaths.add(fileName);
               ChunkDetails chunkDetails = new ChunkDetails();
               chunkDetails.setChunkName(fileName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the container-service code, it often creates a `ChunkInfo` object from a proto in order to get length/name. It should get length/name directly from the proto.
 
## What is the link to the Apache JIRA

HDDS-10410

## How was this patch tested?

By existing tests.