### PR TITLE
HDDS-10413. Recon - UnsupportedOperationException while merging Incremental Container Reports.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -213,7 +213,7 @@ public final class SCMDatanodeHeartbeatDispatcher {
 
     private final DatanodeDetails datanodeDetails;
 
-    private final T report;
+    private T report;
 
     public ReportFromDatanode(DatanodeDetails datanodeDetails, T report) {
       this.datanodeDetails = datanodeDetails;
@@ -226,6 +226,10 @@ public final class SCMDatanodeHeartbeatDispatcher {
 
     public T getReport() {
       return report;
+    }
+
+    public void setReport(T report) {
+      this.report = report;
     }
   }
 
@@ -381,9 +385,11 @@ public final class SCMDatanodeHeartbeatDispatcher {
     @Override
     public void mergeReport(ContainerReport nextReport) {
       if (nextReport.getType() == ContainerReportType.ICR) {
-        getReport().getReportList().addAll(
-            ((ReportFromDatanode<IncrementalContainerReportProto>) nextReport)
-                .getReport().getReportList());
+        // To update existing report list , need to create a builder and then
+        // merge new reports to existing report list.
+        IncrementalContainerReportProto reportProto = getReport().toBuilder().addAllReport(
+            ((ReportFromDatanode<IncrementalContainerReportProto>) nextReport).getReport().getReportList()).build();
+        setReport(reportProto);
       }
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -45,7 +45,11 @@ import java.net.URL;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -53,6 +57,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Test Recon Utility methods.
  */
 public class TestReconUtils {
+  private static PipelineID randomPipelineID = PipelineID.randomId();
 
   @TempDir
   private Path temporaryFolder;
@@ -233,5 +238,25 @@ public class TestReconUtils {
       index += 1;
     }
     return index;
+  }
+
+  private static ContainerInfo.Builder getDefaultContainerInfoBuilder(
+      final HddsProtos.LifeCycleState state) {
+    return new ContainerInfo.Builder()
+        .setContainerID(RandomUtils.nextLong())
+        .setReplicationConfig(
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
+        .setState(state)
+        .setSequenceId(10000L)
+        .setOwner("TEST");
+  }
+
+
+  public static ContainerInfo getContainer(
+      final HddsProtos.LifeCycleState state) {
+    return getDefaultContainerInfoBuilder(state)
+        .setPipelineID(randomPipelineID)
+        .build();
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.IncrementalContainerReportProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
@@ -55,6 +56,7 @@ import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.ozone.recon.TestReconUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -163,6 +165,31 @@ public class TestReconIncrementalContainerReportHandler
           String.format("Expecting %s in container state for replica state %s",
               expectedState, state));
     }
+  }
+
+  @Test
+  public void testMergeMultipleICRs() {
+    final ContainerInfo container = TestReconUtils.getContainer(LifeCycleState.OPEN);
+    final DatanodeDetails datanodeOne = randomDatanodeDetails();
+    final IncrementalContainerReportProto containerReport =
+        getIncrementalContainerReportProto(container.containerID(),
+            ContainerReplicaProto.State.CLOSED,
+            datanodeOne.getUuidString());
+    final IncrementalContainerReportFromDatanode icrFromDatanode1 =
+        new IncrementalContainerReportFromDatanode(
+            datanodeOne, containerReport);
+    final IncrementalContainerReportFromDatanode icrFromDatanode2 =
+        new IncrementalContainerReportFromDatanode(
+            datanodeOne, containerReport);
+    assertEquals(1, icrFromDatanode1.getReport().getReportList().size());
+    icrFromDatanode1.mergeReport(icrFromDatanode2);
+    assertEquals(2, icrFromDatanode1.getReport().getReportList().size());
+
+    final IncrementalContainerReportFromDatanode icrFromDatanode3 =
+        new IncrementalContainerReportFromDatanode(
+            datanodeOne, containerReport);
+    icrFromDatanode1.mergeReport(icrFromDatanode3);
+    assertEquals(3, icrFromDatanode1.getReport().getReportList().size());
   }
 
   private LifeCycleState getContainerStateFromReplicaState(


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes the UnsupportedOperationException while merging Incremental Container Reports.

Recon processes the Incremental Container Reports (ICRs) being sent from datanodes and to improve performance and process multiple ICRs in a heartbeat,  [HDDS-9883](https://issues.apache.org/jira/browse/HDDS-9883) merged multiple ICRs from datanodes into a single report before sending to Recon ICR handler (`ReconIncrementalContainerReportHandler`) where it handles such merged container reports , but merge operation was throwing `UnsupportedOperationException` while merging ICRs. This PR fixes the issue and handles the merge operation correctly.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10413

## How was this patch tested?
This patch was tested manually by adding new `org.apache.hadoop.ozone.recon.scm.TestReconIncrementalContainerReportHandler#testMergeMultipleICRs`.
