### PR TITLE
HDDS-10268. [hsync] Add OpenTracing traces to client side read path

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -229,7 +229,7 @@ public final class ContainerProtocolCalls  {
     final ContainerCommandRequestProto request = builder
         .setDatanodeUuid(datanode.getUuidString()).build();
     ContainerCommandResponseProto response =
-        xceiverClient.sendCommand(builder.build(), validators);
+        xceiverClient.sendCommand(request, validators);
     return response.getGetBlock();
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -151,18 +151,20 @@ public final class ContainerProtocolCalls  {
     for (; ;) {
       final DatanodeDetails d = pipeline.getClosestNode(excluded);
 
-      try (AutoCloseable scope = TracingUtil
-          .createActivatedSpan(d.toString())){
+      try {
         return op.apply(d);
       } catch (IOException e) {
+        Span span = GlobalTracer.get().activeSpan();
         if (e instanceof StorageContainerException) {
           StorageContainerException sce = (StorageContainerException)e;
           // Block token expired. There's no point retrying other DN.
           // Throw the exception to request a new block token right away.
           if (sce.getResult() == BLOCK_TOKEN_VERIFICATION_FAILED) {
+            span.log("block token verification failed at DN " + d);
             throw e;
           }
         }
+        span.log("failed to connect to DN " + d);
         excluded.add(d);
         if (excluded.size() < pipeline.size()) {
           LOG.warn(toErrorMessage.apply(d)
@@ -170,8 +172,6 @@ public final class ContainerProtocolCalls  {
         } else {
           throw e;
         }
-      } catch (Exception e) {
-        LOG.warn("Unable to close trace span");
       }
     }
   }
@@ -341,10 +341,15 @@ public final class ContainerProtocolCalls  {
     Span span = GlobalTracer.get()
         .buildSpan("readChunk").start();
     try (Scope ignored = GlobalTracer.get().activateSpan(span)) {
+      span.setTag("offset", chunk.getOffset())
+          .setTag("length", chunk.getLen())
+          .setTag("block", blockID.toString());
       return tryEachDatanode(xceiverClient.getPipeline(),
           d -> readChunk(xceiverClient, chunk, blockID,
               validators, builder, d),
           d -> toErrorMessage(chunk, blockID, d));
+    } finally {
+      span.finish();
     }
   }
 
@@ -355,7 +360,8 @@ public final class ContainerProtocolCalls  {
       DatanodeDetails d) throws IOException {
     ContainerCommandRequestProto.Builder requestBuilder = builder
         .setDatanodeUuid(d.getUuidString());
-    String traceId = TracingUtil.exportCurrentSpan();
+    Span span = GlobalTracer.get().activeSpan();
+    String traceId = TracingUtil.exportSpan(span);
     if (traceId != null) {
       requestBuilder = requestBuilder.setTraceID(traceId);
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -166,6 +166,16 @@ public final class TracingUtil {
   }
 
   /**
+   * Execute {@code supplier} inside an activated new span.
+   */
+  public static <E extends Exception> void executeInNewSpan(String spanName,
+      CheckedRunnable<E> runnable) throws E {
+    Span span = GlobalTracer.get()
+        .buildSpan(spanName).start();
+    executeInSpan(span, runnable);
+  }
+
+  /**
    * Execute {@code runnable} in the given {@code span}.
    */
   private static <E extends Exception> void executeInSpan(Span span,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -142,6 +142,16 @@ public final class TracingUtil {
   /**
    * Execute {@code supplier} inside an activated new span.
    */
+  public static <E extends Exception> void executeInNewSpan(String spanName,
+      CheckedRunnable<E> runnable) throws E {
+    Span span = GlobalTracer.get()
+        .buildSpan(spanName).start();
+    executeInSpan(span, runnable);
+  }
+
+  /**
+   * Execute {@code supplier} inside an activated new span.
+   */
   public static <R, E extends Exception> R executeInNewSpan(String spanName,
       CheckedSupplier<R, E> supplier) throws E {
     Span span = GlobalTracer.get()

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -166,16 +166,6 @@ public final class TracingUtil {
   }
 
   /**
-   * Execute {@code supplier} inside an activated new span.
-   */
-  public static <E extends Exception> void executeInNewSpan(String spanName,
-      CheckedRunnable<E> runnable) throws E {
-    Span span = GlobalTracer.get()
-        .buildSpan(spanName).start();
-    executeInSpan(span, runnable);
-  }
-
-  /**
    * Execute {@code runnable} in the given {@code span}.
    */
   private static <E extends Exception> void executeInSpan(Span span,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -140,7 +140,7 @@ public final class TracingUtil {
   }
 
   /**
-   * Execute {@code supplier} inside an activated new span.
+   * Execute {@code runnable} inside an activated new span.
    */
   public static <E extends Exception> void executeInNewSpan(String spanName,
       CheckedRunnable<E> runnable) throws E {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -322,6 +322,8 @@ public class RpcClient implements ClientProtocol {
     this.blockInputStreamFactory = BlockInputStreamFactoryImpl
         .getInstance(byteBufferPool, ecReconstructExecutor);
     this.clientMetrics = ContainerClientMetrics.acquire();
+
+    TracingUtil.initTracing("client", conf);
   }
 
   public XceiverClientFactory getXceiverClientManager() {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -264,9 +264,9 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public FSDataOutputStream create(Path f, FsPermission permission,
-                                   boolean overwrite, int bufferSize,
-                                   short replication, long blockSize,
-                                   Progressable progress) throws IOException {
+      boolean overwrite, int bufferSize,
+      short replication, long blockSize,
+      Progressable progress) throws IOException {
     LOG.trace("create() path:{}", f);
     incrementCounter(Statistic.INVOCATION_CREATE, 1);
     statistics.incrementWriteOps(1);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.fs.ozone;
 
 import com.google.common.base.Preconditions;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.CreateFlag;
@@ -41,6 +43,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.ozone.OFSPath;
@@ -239,7 +242,12 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     statistics.incrementReadOps(1);
     LOG.trace("open() path: {}", path);
     final String key = pathToKey(path);
-    return new FSDataInputStream(createFSInputStream(adapter.readFile(key)));
+    return TracingUtil.executeInNewSpan("ofs open",
+        () -> {
+          Span span = GlobalTracer.get().activeSpan();
+          span.setTag("path", key);
+          return new FSDataInputStream(createFSInputStream(adapter.readFile(key)));
+        });
   }
 
   protected InputStream createFSInputStream(InputStream inputStream) {
@@ -256,14 +264,15 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public FSDataOutputStream create(Path f, FsPermission permission,
-      boolean overwrite, int bufferSize,
-      short replication, long blockSize,
-      Progressable progress) throws IOException {
+                                   boolean overwrite, int bufferSize,
+                                   short replication, long blockSize,
+                                   Progressable progress) throws IOException {
     LOG.trace("create() path:{}", f);
     incrementCounter(Statistic.INVOCATION_CREATE, 1);
     statistics.incrementWriteOps(1);
     final String key = pathToKey(f);
-    return createOutputStream(key, replication, overwrite, true);
+    return TracingUtil.executeInNewSpan("ofs create",
+        () -> createOutputStream(key, replication, overwrite, true));
   }
 
   @Override
@@ -277,8 +286,10 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_CREATE_NON_RECURSIVE, 1);
     statistics.incrementWriteOps(1);
     final String key = pathToKey(path);
-    return createOutputStream(key,
-        replication, flags.contains(CreateFlag.OVERWRITE), false);
+    return TracingUtil.executeInNewSpan("ofs createNonRecursive",
+        () ->
+            createOutputStream(key,
+                replication, flags.contains(CreateFlag.OVERWRITE), false));
   }
 
   private OutputStream selectOutputStream(String key, short replication,
@@ -374,6 +385,14 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
    */
   @Override
   public boolean rename(Path src, Path dst) throws IOException {
+    return TracingUtil.executeInNewSpan("ofs rename",
+        () -> renameInSpan(src, dst));
+  }
+
+  private boolean renameInSpan(Path src, Path dst) throws IOException {
+    Span span = GlobalTracer.get().activeSpan();
+    span.setTag("src", src.toString())
+        .setTag("dst", dst.toString());
     incrementCounter(Statistic.INVOCATION_RENAME, 1);
     statistics.incrementWriteOps(1);
     if (src.equals(dst)) {
@@ -526,8 +545,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public Path createSnapshot(Path path, String snapshotName)
           throws IOException {
-    String snapshot = getAdapter()
-        .createSnapshot(pathToKey(path), snapshotName);
+    String snapshot = TracingUtil.executeInNewSpan("ofs createSnapshot",
+        () -> getAdapter().createSnapshot(pathToKey(path), snapshotName));
     return new Path(OzoneFSUtils.trimPathToDepth(path, PATH_DEPTH_TO_BUCKET),
         OM_SNAPSHOT_INDICATOR + OZONE_URI_DELIMITER + snapshot);
   }
@@ -541,7 +560,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public void deleteSnapshot(Path path, String snapshotName)
       throws IOException {
-    adapter.deleteSnapshot(pathToKey(path), snapshotName);
+    TracingUtil.executeInNewSpan("ofs deleteSnapshot",
+        () -> adapter.deleteSnapshot(pathToKey(path), snapshotName));
   }
 
   private class DeleteIterator extends OzoneListingIterator {
@@ -672,6 +692,11 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
    */
   @Override
   public boolean delete(Path f, boolean recursive) throws IOException {
+    return TracingUtil.executeInNewSpan("ofs delete",
+        () -> deleteInSpan(f, recursive));
+  }
+
+  private boolean deleteInSpan(Path f, boolean recursive) throws IOException {
     incrementCounter(Statistic.INVOCATION_DELETE, 1);
     statistics.incrementWriteOps(1);
     LOG.debug("Delete path {} - recursive {}", f, recursive);
@@ -889,7 +914,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public FileStatus[] listStatus(Path f) throws IOException {
-    return convertFileStatusArr(listStatusAdapter(f));
+    return TracingUtil.executeInNewSpan("ofs listStatus",
+        () -> convertFileStatusArr(listStatusAdapter(f)));
   }
 
   private FileStatus[] convertFileStatusArr(
@@ -946,7 +972,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public Token<?> getDelegationToken(String renewer) throws IOException {
-    return adapter.getDelegationToken(renewer);
+    return TracingUtil.executeInNewSpan("ofs getDelegationToken",
+        () -> adapter.getDelegationToken(renewer));
   }
 
   /**
@@ -1014,7 +1041,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     if (isEmpty(key)) {
       return false;
     }
-    return mkdir(f);
+    return TracingUtil.executeInNewSpan("ofs mkdirs",
+        () -> mkdir(f));
   }
 
   @Override
@@ -1025,7 +1053,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public FileStatus getFileStatus(Path f) throws IOException {    
-    return convertFileStatus(getFileStatusAdapter(f));
+    return TracingUtil.executeInNewSpan("ofs getFileStatus",
+        () -> convertFileStatus(getFileStatusAdapter(f)));
   }
 
   public FileStatusAdapter getFileStatusAdapter(Path f) throws IOException {
@@ -1096,7 +1125,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   public FileChecksum getFileChecksum(Path f, long length) throws IOException {
     incrementCounter(Statistic.INVOCATION_GET_FILE_CHECKSUM);
     String key = pathToKey(f);
-    return adapter.getFileChecksum(key, length);
+    return TracingUtil.executeInNewSpan("ofs getFileChecksum",
+        () -> adapter.getFileChecksum(key, length));
   }
 
   @Override
@@ -1508,6 +1538,11 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public ContentSummary getContentSummary(Path f) throws IOException {
+    return TracingUtil.executeInNewSpan("ofs getContentSummary",
+        () -> getContentSummaryInSpan(f));
+  }
+
+  private ContentSummary getContentSummaryInSpan(Path f) throws IOException {
     FileStatusAdapter status = getFileStatusAdapter(f);
 
     if (status.isFile()) {
@@ -1583,7 +1618,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     if (key.equals("NONE")) {
       throw new FileNotFoundException("File not found. path /NONE.");
     }
-    adapter.setTimes(key, mtime, atime);
+    TracingUtil.executeInNewSpan("ofs setTimes",
+        () -> adapter.setTimes(key, mtime, atime));
   }
 
   protected boolean setSafeModeUtil(SafeModeAction action,
@@ -1595,6 +1631,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       statistics.incrementWriteOps(1);
     }
     LOG.trace("setSafeMode() action:{}", action);
-    return getAdapter().setSafeMode(action, isChecked);
+    return TracingUtil.executeInNewSpan("ofs setSafeMode",
+        () -> getAdapter().setSafeMode(action, isChecked));
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
@@ -23,6 +23,9 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
 import org.apache.hadoop.fs.CanUnbuffer;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
@@ -30,6 +33,7 @@ import org.apache.hadoop.fs.ByteBufferReadable;
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.Seekable;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 
 /**
  * The input stream for Ozone file system.
@@ -52,25 +56,40 @@ public class OzoneFSInputStream extends FSInputStream
 
   @Override
   public int read() throws IOException {
-    int byteRead = inputStream.read();
-    if (statistics != null && byteRead >= 0) {
-      statistics.incrementBytesRead(1);
+    Span span = GlobalTracer.get()
+        .buildSpan("OzoneFSInputStream.read").start();
+    try (Scope scope = GlobalTracer.get().activateSpan(span)) {
+      int byteRead = inputStream.read();
+      if (statistics != null && byteRead >= 0) {
+        statistics.incrementBytesRead(1);
+      }
+      return byteRead;
+    } finally {
+      span.finish();
     }
-    return byteRead;
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
-    int bytesRead = inputStream.read(b, off, len);
-    if (statistics != null && bytesRead >= 0) {
-      statistics.incrementBytesRead(bytesRead);
+    Span span = GlobalTracer.get()
+        .buildSpan("OzoneFSInputStream.read").start();
+    try (Scope scope = GlobalTracer.get().activateSpan(span)) {
+      span.setTag("offset", off)
+          .setTag("length", len);
+      int bytesRead = inputStream.read(b, off, len);
+      if (statistics != null && bytesRead >= 0) {
+        statistics.incrementBytesRead(bytesRead);
+      }
+      return bytesRead;
+    } finally {
+      span.finish();
     }
-    return bytesRead;
   }
 
   @Override
   public synchronized void close() throws IOException {
-    inputStream.close();
+    TracingUtil.executeInNewSpan("OzoneFSInputStream.close",
+        inputStream::close);
   }
 
   @Override
@@ -101,6 +120,11 @@ public class OzoneFSInputStream extends FSInputStream
    */
   @Override
   public int read(ByteBuffer buf) throws IOException {
+    return TracingUtil.executeInNewSpan("OzoneFSInputStream.read(ByteBuffer)",
+        () -> readInTrace(buf));
+  }
+
+  private int readInTrace(ByteBuffer buf) throws IOException {
     if (buf.isReadOnly()) {
       throw new ReadOnlyBufferException();
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import io.opentracing.util.GlobalTracer;
 import org.apache.hadoop.fs.LeaseRecoverable;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.SafeMode;
@@ -29,6 +30,7 @@ import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
 import java.io.IOException;
@@ -124,6 +126,11 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
   @Override
   public boolean recoverLease(final Path f) throws IOException {
+    return TracingUtil.executeInNewSpan("ofs recoverLease",
+        () -> recoverLeaseTraced(f));
+  }
+  private boolean recoverLeaseTraced(final Path f) throws IOException {
+    GlobalTracer.get().activeSpan().setTag("path", f.toString());
     statistics.incrementWriteOps(1);
     LOG.trace("recoverLease() path:{}", f);
     Path qualifiedPath = makeQualified(f);
@@ -133,6 +140,11 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
   @Override
   public boolean isFileClosed(Path f) throws IOException {
+    return TracingUtil.executeInNewSpan("ofs isFileClosed",
+        () -> isFileClosedTraced(f));
+  }
+  private boolean isFileClosedTraced(Path f) throws IOException {
+    GlobalTracer.get().activeSpan().setTag("path", f.toString());
     statistics.incrementWriteOps(1);
     LOG.trace("isFileClosed() path:{}", f);
     Path qualifiedPath = makeQualified(f);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -143,6 +143,7 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     return TracingUtil.executeInNewSpan("ofs isFileClosed",
         () -> isFileClosedTraced(f));
   }
+
   private boolean isFileClosedTraced(Path f) throws IOException {
     GlobalTracer.get().activeSpan().setTag("path", f.toString());
     statistics.incrementWriteOps(1);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add client side trace spans to ofs file system APIs and input/output stream APIs.

Select screenshots:

input stream read()
<img width="1721" alt="Screenshot 2024-02-23 at 10 31 43 AM" src="https://github.com/apache/ozone/assets/2691807/e0a4913d-b392-431c-87a5-b5f458506670">

outputstream hsyc
<img width="1715" alt="Screenshot 2024-02-23 at 5 03 42 PM" src="https://github.com/apache/ozone/assets/2691807/34d417ca-b253-4fb2-8d70-c1b01aa96441">

file system contentSummary API
<img width="1723" alt="Screenshot 2024-02-23 at 10 43 46 AM" src="https://github.com/apache/ozone/assets/2691807/e9727805-37f4-4f6b-801c-6f5c5551bf50">

file system create file API
<img width="1718" alt="Screenshot 2024-02-23 at 5 06 45 PM" src="https://github.com/apache/ozone/assets/2691807/0bea880b-1e49-4df0-b30e-c5bca0f66b7e">


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10268

## How was this patch tested?

Tested in a dev cluster.