### PR TITLE
HDDS-10365. Fix description for `ozone getconf ozonemanagers`

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
@@ -33,8 +33,7 @@ import static org.apache.hadoop.ozone.OmUtils.getOmHAAddressesById;
  */
 @Command(name = "ozonemanagers",
     aliases = {"-ozonemanagers"},
-    description = "gets list of ozone storage container "
-        + "manager nodes in the cluster",
+    description = "gets list of Ozone ozone-manager nodes in the cluster",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class OzoneManagersCommandHandler implements Callable<Void> {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
@@ -33,7 +33,7 @@ import static org.apache.hadoop.ozone.OmUtils.getOmHAAddressesById;
  */
 @Command(name = "ozonemanagers",
     aliases = {"-ozonemanagers"},
-    description = "gets list of Ozone ozone-manager nodes in the cluster",
+    description = "gets list of Ozone Manager nodes in the cluster",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class OzoneManagersCommandHandler implements Callable<Void> {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changed the description for `ozone getconf -ozonemanagers` from "gets list of ozone storage container manager nodes in the cluster" to "gets list of Ozone ozone-manager nodes in the cluster" in "OzoneManagersCommandHandler.class"

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10365