### PR TITLE
HDDS-10412. Prefix ACL check needs to resolve the bucket link

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneObjInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneObjInfo.java
@@ -186,6 +186,16 @@ public final class OzoneObjInfo extends OzoneObj {
           .setResType(ResourceType.KEY);
     }
 
+    public static Builder fromOzoneObj(OzoneObj obj) {
+      return new Builder()
+          .setVolumeName(obj.getVolumeName())
+          .setBucketName(obj.getBucketName())
+          .setKeyName(obj.getKeyName())
+          .setResType(obj.getResourceType())
+          .setStoreType(obj.getStoreType())
+          .setOzonePrefixPath(obj.getOzonePrefixPathViewer());
+    }
+
     public Builder setResType(OzoneObj.ResourceType res) {
       this.resType = res;
       return this;

--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -171,6 +171,21 @@ Source and target key have same ACLs
     Verify ACL          key    ${target}/link1/key1     GROUP   group2    READ
     Verify ACL          key    ${source}/bucket1/key1   GROUP   group2    READ
 
+Source and target prefix have same ACLs
+    Execute             ozone sh prefix addacl --acl user:user1:rwxy ${source}/bucket1/prefix1/
+    Verify ACL          prefix       ${target}/link1/prefix1/     USER    user1    READ WRITE READ_ACL WRITE_ACL
+    Verify ACL          prefix       ${source}/bucket1/prefix1/   USER    user1    READ WRITE READ_ACL WRITE_ACL
+    Execute             ozone sh prefix removeacl --acl user:user1:y ${target}/link1/prefix1/
+    Verify ACL          prefix       ${target}/link1/prefix1/     USER    user1    READ WRITE READ_ACL
+    Verify ACL          prefix       ${source}/bucket1/prefix1/   USER    user1    READ WRITE READ_ACL
+    Execute             ozone sh prefix setacl --acl user:user1:rw ${source}/bucket1/prefix1/
+    Verify ACL          prefix       ${target}/link1/prefix1/     USER    user1    READ WRITE
+    Verify ACL          prefix       ${source}/bucket1/prefix1/   USER    user1    READ WRITE
+
+    Execute             ozone sh prefix addacl --acl group:group2:r ${source}/bucket1/prefix1/
+    Verify ACL          prefix       ${target}/link1/prefix1/     GROUP   group2    READ
+    Verify ACL          prefix       ${source}/bucket1/prefix1/   GROUP   group2    READ
+
 Buckets and links share namespace
                         Execute                     ozone sh bucket link ${source}/bucket2 ${target}/link2
     ${result} =         Execute And Ignore Error    ozone sh bucket create ${target}/link2

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.ha.HadoopRpcOMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Timeout;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.HashMap;
@@ -61,6 +63,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVI
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -215,6 +218,14 @@ public abstract class TestOzoneManagerHA {
         ReplicationFactor.ONE, new HashMap<>());
     ozoneOutputStream.write(data.getBytes(UTF_8), 0, data.length());
     ozoneOutputStream.close();
+  }
+
+  public static String createPrefixName() {
+    return "prefix" + RandomStringUtils.randomNumeric(5) + OZONE_URI_DELIMITER;
+  }
+
+  public static void createPrefix(OzoneObj prefixObj) throws IOException {
+    assertTrue(objectStore.setAcl(prefixObj, Collections.emptyList()));
   }
 
   protected OzoneBucket setupBucket() throws Exception {

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -122,7 +122,6 @@ public interface OMMetadataManager extends DBStoreHAManager {
    * @param key    - key name
    * @return DB key as String.
    */
-
   String getOzoneKey(String volume, String bucket, String key);
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
@@ -154,7 +154,8 @@ public class BucketManagerImpl implements BucketManager {
             && context.getAclRights() != ACLType.READ);
 
     if (bucketNeedResolved ||
-        ozObject.getResourceType() == OzoneObj.ResourceType.KEY) {
+        ozObject.getResourceType() == OzoneObj.ResourceType.KEY ||
+        ozObject.getResourceType() == OzoneObj.ResourceType.PREFIX) {
       try {
         ResolvedBucket resolvedBucket =
             ozoneManager.resolveBucketLink(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -923,12 +923,6 @@ public class KeyManagerImpl implements KeyManager {
     return partName;
   }
 
-  /**
-   * Returns list of ACLs for given Ozone object.
-   *
-   * @param obj Ozone object.
-   * @throws IOException if there is error.
-   */
   @Override
   public List<OzoneAcl> getAcl(OzoneObj obj) throws IOException {
     validateOzoneObj(obj);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -387,7 +387,7 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
     String volumeName = obj.getVolumeName();
     String bucketName = obj.getBucketName();
     String keyName = obj.getKeyName();
-    if (obj.getResourceType() == ResourceType.KEY) {
+    if (obj.getResourceType() == ResourceType.KEY || obj.getResourceType() == ResourceType.PREFIX) {
       ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
           Pair.of(volumeName, bucketName));
       volumeName = resolvedBucket.realVolume();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -372,7 +372,7 @@ public final class OmSnapshotManager implements AutoCloseable {
         try {
           // create the other manager instances based on snapshot
           // metadataManager
-          PrefixManagerImpl pm = new PrefixManagerImpl(snapshotMetadataManager,
+          PrefixManagerImpl pm = new PrefixManagerImpl(ozoneManager, snapshotMetadataManager,
               false);
           KeyManagerImpl km = new KeyManagerImpl(ozoneManager,
               ozoneManager.getScmClient(), snapshotMetadataManager, conf,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -839,7 +839,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       delegationTokenMgr = createDelegationTokenSecretManager(configuration);
     }
 
-    prefixManager = new PrefixManagerImpl(metadataManager, isRatisEnabled);
+    prefixManager = new PrefixManagerImpl(this, metadataManager, isRatisEnabled);
     keyManager = new KeyManagerImpl(this, scmClient, configuration,
         perfMetrics);
     accessAuthorizer = OzoneAuthorizerFactory.forOM(this);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
@@ -18,6 +18,8 @@ package org.apache.hadoop.ozone.om;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -25,6 +27,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
 import org.apache.hadoop.ozone.util.RadixNode;
 import org.apache.hadoop.ozone.util.RadixTree;
@@ -40,6 +43,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PREFIX_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.PREFIX_LOCK;
@@ -53,6 +57,7 @@ public class PrefixManagerImpl implements PrefixManager {
       LoggerFactory.getLogger(PrefixManagerImpl.class);
 
   private static final List<OzoneAcl> EMPTY_ACL_LIST = new ArrayList<>();
+  private final OzoneManager ozoneManager;
   private final OMMetadataManager metadataManager;
 
   // In-memory prefix tree to optimize ACL evaluation
@@ -62,9 +67,10 @@ public class PrefixManagerImpl implements PrefixManager {
   //  where we integrate both HA and Non-HA code.
   private boolean isRatisEnabled;
 
-  public PrefixManagerImpl(OMMetadataManager metadataManager,
+  public PrefixManagerImpl(OzoneManager ozoneManager, OMMetadataManager metadataManager,
       boolean isRatisEnabled) {
     this.isRatisEnabled = isRatisEnabled;
+    this.ozoneManager = ozoneManager;
     this.metadataManager = metadataManager;
     loadPrefixTree();
   }
@@ -90,16 +96,11 @@ public class PrefixManagerImpl implements PrefixManager {
     return metadataManager;
   }
 
-  /**
-   * Returns list of ACLs for given Ozone object.
-   *
-   * @param obj Ozone object.
-   * @throws IOException if there is error.
-   */
   @Override
   public List<OzoneAcl> getAcl(OzoneObj obj) throws IOException {
     validateOzoneObj(obj);
-    String prefixPath = obj.getPath();
+    OzoneObj resolvedObj = getResolvedPrefixObj(obj);
+    String prefixPath = resolvedObj.getPath();
     metadataManager.getLock().acquireReadLock(PREFIX_LOCK, prefixPath);
     try {
       String longestPrefix = prefixTree.getLongestPrefix(prefixPath);
@@ -149,7 +150,14 @@ public class PrefixManagerImpl implements PrefixManager {
     Objects.requireNonNull(ozObject);
     Objects.requireNonNull(context);
 
-    String prefixPath = ozObject.getPath();
+    OzoneObj resolvedObj;
+    try {
+      resolvedObj = getResolvedPrefixObj(ozObject);
+    } catch (IOException e) {
+      throw new OMException("Failed to resolveBucketLink:", e, INTERNAL_ERROR);
+    }
+
+    String prefixPath = resolvedObj.getPath();
     metadataManager.getLock().acquireReadLock(PREFIX_LOCK, prefixPath);
     try {
       String longestPrefix = prefixTree.getLongestPrefix(prefixPath);
@@ -312,6 +320,7 @@ public class PrefixManagerImpl implements PrefixManager {
 
   public OMPrefixAclOpResult setAcl(OzoneObj ozoneObj, List<OzoneAcl> ozoneAcls,
       OmPrefixInfo prefixInfo, long transactionLogIndex) throws IOException {
+    boolean newPrefix = false;
     if (prefixInfo == null) {
       OmPrefixInfo.Builder prefixInfoBuilder =
           new OmPrefixInfo.Builder()
@@ -322,10 +331,13 @@ public class PrefixManagerImpl implements PrefixManager {
         prefixInfoBuilder.setUpdateID(transactionLogIndex);
       }
       prefixInfo = prefixInfoBuilder.build();
+      newPrefix = true;
     }
 
     boolean changed = prefixInfo.setAcls(ozoneAcls);
-    inheritParentAcl(ozoneObj, prefixInfo);
+    if (newPrefix) {
+      inheritParentAcl(ozoneObj, prefixInfo);
+    }
     prefixTree.insert(ozoneObj.getPath(), prefixInfo);
     if (!isRatisEnabled) {
       metadataManager.getPrefixTable().put(ozoneObj.getPath(), prefixInfo);
@@ -334,11 +346,38 @@ public class PrefixManagerImpl implements PrefixManager {
   }
 
   /**
+   * Get the resolved prefix object to handle prefix that is under a link bucket.
+   * @param obj prefix object
+   * @return the resolved prefix object if the object belongs under a link bucket.
+   * Otherwise, return the same prefix object.
+   * @throws IOException Exception thrown when resolving the bucket link.
+   */
+  private OzoneObj getResolvedPrefixObj(OzoneObj obj) throws IOException {
+    if (StringUtils.isEmpty(obj.getVolumeName()) || StringUtils.isEmpty(obj.getBucketName())) {
+      return obj;
+    }
+
+    ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
+        Pair.of(obj.getVolumeName(), obj.getBucketName()));
+    String realVolume = resolvedBucket.realVolume();
+    String realBucket = resolvedBucket.realBucket();
+    // If the bucket is not a link bucket, just return the Ozone object
+    if (realVolume.equals(obj.getVolumeName()) && realBucket.equals(obj.getBucketName())) {
+      return obj;
+    }
+    // If the bucket is a link bucket, return a new OzoneObj with resolved volume and bucket name
+    return OzoneObjInfo.Builder.fromOzoneObj(obj)
+        .setVolumeName(realVolume).setBucketName(realBucket).build();
+  }
+
+  /**
    * Result of the prefix acl operation.
    */
   public static class OMPrefixAclOpResult {
-    private OmPrefixInfo omPrefixInfo;
-    private boolean operationsResult;
+    /** The updated prefix info after applying the prefix acl operation. */
+    private final OmPrefixInfo omPrefixInfo;
+    /** Operation result, success if the underlying ACL is changed, false otherwise. */
+    private final boolean operationsResult;
 
     public OMPrefixAclOpResult(OmPrefixInfo omPrefixInfo,
         boolean operationsResult) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
-import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
 import org.apache.hadoop.ozone.util.RadixNode;
 import org.apache.hadoop.ozone.util.RadixTree;
@@ -352,22 +351,14 @@ public class PrefixManagerImpl implements PrefixManager {
    * Otherwise, return the same prefix object.
    * @throws IOException Exception thrown when resolving the bucket link.
    */
-  private OzoneObj getResolvedPrefixObj(OzoneObj obj) throws IOException {
+  public OzoneObj getResolvedPrefixObj(OzoneObj obj) throws IOException {
     if (StringUtils.isEmpty(obj.getVolumeName()) || StringUtils.isEmpty(obj.getBucketName())) {
       return obj;
     }
 
     ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
         Pair.of(obj.getVolumeName(), obj.getBucketName()));
-    String realVolume = resolvedBucket.realVolume();
-    String realBucket = resolvedBucket.realBucket();
-    // If the bucket is not a link bucket, just return the Ozone object
-    if (realVolume.equals(obj.getVolumeName()) && realBucket.equals(obj.getBucketName())) {
-      return obj;
-    }
-    // If the bucket is a link bucket, return a new OzoneObj with resolved volume and bucket name
-    return OzoneObjInfo.Builder.fromOzoneObj(obj)
-        .setVolumeName(realVolume).setBucketName(realBucket).build();
+    return resolvedBucket.update(obj);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -118,6 +120,15 @@ public class ResolvedBucket {
             .setBucketName(realBucket())
             .build()
         : args;
+  }
+
+  public OzoneObj update(OzoneObj ozoneObjInfo) {
+    return isLink()
+        ? OzoneObjInfo.Builder.fromOzoneObj(ozoneObjInfo)
+            .setVolumeName(realVolume())
+            .setBucketName(realBucket())
+            .build()
+        : ozoneObjInfo;
   }
 
   public boolean isLink() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java
@@ -122,13 +122,13 @@ public class ResolvedBucket {
         : args;
   }
 
-  public OzoneObj update(OzoneObj ozoneObjInfo) {
+  public OzoneObj update(OzoneObj ozoneObj) {
     return isLink()
-        ? OzoneObjInfo.Builder.fromOzoneObj(ozoneObjInfo)
+        ? OzoneObjInfo.Builder.fromOzoneObj(ozoneObj)
             .setVolumeName(realVolume())
             .setBucketName(realBucket())
             .build()
-        : ozoneObjInfo;
+        : ozoneObj;
   }
 
   public boolean isLink() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -85,7 +85,8 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
       if (ozoneManager.getAclsEnabled()) {
         checkAcls(ozoneManager, OzoneObj.ResourceType.PREFIX,
             OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
-            volume, bucket, prefix);
+            resolvedPrefixObj.getVolumeName(), resolvedPrefixObj.getBucketName(),
+            resolvedPrefixObj.getPrefixName());
       }
 
       mergeOmLockDetails(omMetadataManager.getLock()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -64,9 +64,6 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
 
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
     boolean lockAcquired = false;
-    String volume = null;
-    String bucket = null;
-    String prefix = null;
     String prefixPath = null;
     OzoneObj resolvedPrefixObj = null;
     OMPrefixAclOpResult operationResult = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -22,10 +22,7 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.Map;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
-import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -79,16 +76,7 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
     PrefixManagerImpl prefixManager =
         (PrefixManagerImpl) ozoneManager.getPrefixManager();
     try {
-      ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
-          Pair.of(getOzoneObj().getVolumeName(), getOzoneObj().getBucketName()));
-      volume = resolvedBucket.realVolume();
-      bucket = resolvedBucket.realBucket();
-      prefix = getOzoneObj().getPrefixName();
-      resolvedPrefixObj = OzoneObjInfo.Builder
-          .fromOzoneObj(getOzoneObj())
-          .setVolumeName(volume)
-          .setBucketName(bucket)
-          .build();
+      resolvedPrefixObj = prefixManager.getResolvedPrefixObj(getOzoneObj());
       prefixManager.validateOzoneObj(getOzoneObj());
       validatePrefixPath(resolvedPrefixObj.getPath());
       prefixPath = resolvedPrefixObj.getPath();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -22,7 +22,10 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -33,9 +36,7 @@ import org.apache.hadoop.ozone.om.PrefixManagerImpl.OMPrefixAclOpResult;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
-import org.apache.hadoop.ozone.om.request.util.ObjectParser;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -68,7 +69,9 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
     boolean lockAcquired = false;
     String volume = null;
     String bucket = null;
-    String key = null;
+    String prefix = null;
+    String prefixPath = null;
+    OzoneObj resolvedPrefixObj = null;
     OMPrefixAclOpResult operationResult = null;
     boolean opResult = false;
     Result result = null;
@@ -76,20 +79,25 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
     PrefixManagerImpl prefixManager =
         (PrefixManagerImpl) ozoneManager.getPrefixManager();
     try {
+      ResolvedBucket resolvedBucket = ozoneManager.resolveBucketLink(
+          Pair.of(getOzoneObj().getVolumeName(), getOzoneObj().getBucketName()));
+      volume = resolvedBucket.realVolume();
+      bucket = resolvedBucket.realBucket();
+      prefix = getOzoneObj().getPrefixName();
+      resolvedPrefixObj = OzoneObjInfo.Builder
+          .fromOzoneObj(getOzoneObj())
+          .setVolumeName(volume)
+          .setBucketName(bucket)
+          .build();
       prefixManager.validateOzoneObj(getOzoneObj());
-      String prefixPath = getOzoneObj().getPath();
-      validatePrefixPath(prefixPath);
-      ObjectParser objectParser = new ObjectParser(prefixPath,
-          OzoneManagerProtocolProtos.OzoneObj.ObjectType.PREFIX);
-      volume = objectParser.getVolume();
-      bucket = objectParser.getBucket();
-      key = objectParser.getKey();
+      validatePrefixPath(resolvedPrefixObj.getPath());
+      prefixPath = resolvedPrefixObj.getPath();
 
       // check Acl
       if (ozoneManager.getAclsEnabled()) {
         checkAcls(ozoneManager, OzoneObj.ResourceType.PREFIX,
             OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
-            volume, bucket, key);
+            volume, bucket, prefix);
       }
 
       mergeOmLockDetails(omMetadataManager.getLock()
@@ -102,7 +110,7 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
       }
 
       try {
-        operationResult = apply(prefixManager, omPrefixInfo, trxnLogIndex);
+        operationResult = apply(resolvedPrefixObj, prefixManager, omPrefixInfo, trxnLogIndex);
       } catch (IOException ex) {
         // In HA case this will never happen.
         // As in add/remove/setAcl method we have logic to update database,
@@ -145,16 +153,21 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
     } finally {
       if (lockAcquired) {
         mergeOmLockDetails(omMetadataManager.getLock()
-            .releaseWriteLock(PREFIX_LOCK, getOzoneObj().getPath()));
+            .releaseWriteLock(PREFIX_LOCK, prefixPath));
       }
       if (omClientResponse != null) {
         omClientResponse.setOmLockDetails(getOmLockDetails());
       }
     }
 
-    OzoneObj obj = getOzoneObj();
+    OzoneObj obj = resolvedPrefixObj;
+    if (obj == null) {
+      // Fall back to the prefix under link bucket
+      obj = getOzoneObj();
+    }
+
     Map<String, String> auditMap = obj.toAuditMap();
-    onComplete(opResult, exception, ozoneManager.getMetrics(), result,
+    onComplete(obj, opResult, exception, ozoneManager.getMetrics(), result,
         trxnLogIndex, ozoneManager.getAuditLogger(), auditMap);
 
     return omClientResponse;
@@ -168,24 +181,26 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
   }
 
   /**
-   * Get the path name from the request.
-   * @return path name
+   * Get the prefix ozone object passed in the request.
+   * Note: The ozone object might still refer to a prefix under a link bucket which
+   *       might require to be resolved.
+   * @return Prefix ozone object.
    */
   abstract OzoneObj getOzoneObj();
 
   // TODO: Finer grain metrics can be moved to these callbacks. They can also
   // be abstracted into separate interfaces in future.
   /**
-   * Get the initial om response builder with lock.
-   * @return om response builder.
+   * Get the initial OM response builder with lock.
+   * @return OM response builder.
    */
   abstract OMResponse.Builder onInit();
 
   /**
-   * Get the om client response on success case with lock.
-   * @param omResponse
-   * @param omPrefixInfo
-   * @param operationResult
+   * Get the OM client response on success case with lock.
+   * @param omResponse OM response builder.
+   * @param omPrefixInfo The updated prefix info.
+   * @param operationResult The operation result. See {@link OMPrefixAclOpResult}.
    * @return OMClientResponse
    */
   abstract OMClientResponse onSuccess(
@@ -194,8 +209,8 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
 
   /**
    * Get the om client response on failure case with lock.
-   * @param omResponse
-   * @param exception
+   * @param omResponse OM response builder.
+   * @param exception Exception thrown while processing the request.
    * @return OMClientResponse
    */
   abstract OMClientResponse onFailure(OMResponse.Builder omResponse,
@@ -204,23 +219,28 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
   /**
    * Completion hook for final processing before return without lock.
    * Usually used for logging without lock and metric update.
-   * @param operationResult
-   * @param exception
-   * @param omMetrics
+   * @param resolvedOzoneObj Resolved prefix object in case the prefix is under a link bucket.
+   *                         The original ozone object if the prefix is not under a link bucket.
+   * @param operationResult The operation result. See {@link OMPrefixAclOpResult}.
+   * @param exception Exception thrown while processing the request.
+   * @param omMetrics OM metrics used to update the relevant metrics.
    */
-  abstract void onComplete(boolean operationResult, Exception exception,
-      OMMetrics omMetrics, Result result, long trxnLogIndex,
-      AuditLogger auditLogger, Map<String, String> auditMap);
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  abstract void onComplete(OzoneObj resolvedOzoneObj, boolean operationResult,
+                           Exception exception, OMMetrics omMetrics, Result result, long trxnLogIndex,
+                           AuditLogger auditLogger, Map<String, String> auditMap);
 
   /**
-   * Apply the acl operation, if successfully completed returns true,
-   * else false.
-   * @param prefixManager
-   * @param omPrefixInfo
-   * @param trxnLogIndex
-   * @throws IOException
+   * Apply the acl operation to underlying storage (prefix tree and table cache).
+   * @param resolvedOzoneObj Resolved prefix object in case the prefix is under a link bucket.
+   *                         The original ozone object if the prefix is not under a link bucket.
+   * @param prefixManager Prefix manager used to update the underlying prefix storage.
+   * @param omPrefixInfo Previous prefix info, null if there is no existing prefix info.
+   * @param trxnLogIndex Transaction log index.
+   * @return result of the prefix operation, see {@link OMPrefixAclOpResult}.
+   * @throws IOException Exception thrown when updating the underlying prefix storage.
    */
-  abstract OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
+  abstract OMPrefixAclOpResult apply(OzoneObj resolvedOzoneObj, PrefixManagerImpl prefixManager,
       OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException;
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixRemoveAclRequest.java
@@ -45,15 +45,15 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclResponse;
 
 /**
- * Handle add Acl request for prefix.
+ * Handle remove Acl request for prefix.
  */
 public class OMPrefixRemoveAclRequest extends OMPrefixAclRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMPrefixRemoveAclRequest.class);
 
-  private OzoneObj ozoneObj;
-  private List<OzoneAcl> ozoneAcls;
+  private final OzoneObj ozoneObj;
+  private final List<OzoneAcl> ozoneAcls;
 
   public OMPrefixRemoveAclRequest(OMRequest omRequest) {
     super(omRequest);
@@ -93,25 +93,24 @@ public class OMPrefixRemoveAclRequest extends OMPrefixAclRequest {
   }
 
   @Override
-  void onComplete(boolean operationResult, Exception exception,
-      OMMetrics omMetrics, Result result, long trxnLogIndex,
+  void onComplete(OzoneObj resolvedOzoneObj, boolean operationResult,
+      Exception exception, OMMetrics omMetrics, Result result, long trxnLogIndex,
       AuditLogger auditLogger, Map<String, String> auditMap) {
     switch (result) {
     case SUCCESS:
       if (LOG.isDebugEnabled()) {
         if (operationResult) {
           LOG.debug("Remove acl: {} to path: {} success!", ozoneAcls,
-              ozoneObj.getPath());
+              resolvedOzoneObj.getPath());
         } else {
           LOG.debug("Acl {} not removed from path {} as it does not exist",
-              ozoneAcls, ozoneObj.getPath());
+              ozoneAcls, resolvedOzoneObj.getPath());
         }
       }
       break;
     case FAILURE:
-      omMetrics.incNumBucketUpdateFails();
       LOG.error("Remove acl {} to path {} failed!", ozoneAcls,
-          ozoneObj.getPath(), exception);
+          resolvedOzoneObj.getPath(), exception);
       break;
     default:
       LOG.error("Unrecognized Result for OMPrefixRemoveAclRequest: {}",
@@ -126,9 +125,9 @@ public class OMPrefixRemoveAclRequest extends OMPrefixAclRequest {
   }
 
   @Override
-  OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
+  OMPrefixAclOpResult apply(OzoneObj resolvedOzoneObj, PrefixManagerImpl prefixManager,
       OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException {
-    return prefixManager.removeAcl(ozoneObj, ozoneAcls.get(0), omPrefixInfo);
+    return prefixManager.removeAcl(resolvedOzoneObj, ozoneAcls.get(0), omPrefixInfo);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
@@ -45,15 +45,15 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetAclResponse;
 
 /**
- * Handle add Acl request for prefix.
+ * Handle set Acl request for prefix.
  */
 public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMPrefixSetAclRequest.class);
 
-  private OzoneObj ozoneObj;
-  private List<OzoneAcl> ozoneAcls;
+  private final OzoneObj ozoneObj;
+  private final List<OzoneAcl> ozoneAcls;
 
   public OMPrefixSetAclRequest(OMRequest omRequest) {
     super(omRequest);
@@ -94,20 +94,19 @@ public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
   }
 
   @Override
-  void onComplete(boolean operationResult, Exception exception,
-      OMMetrics omMetrics, Result result, long trxnLogIndex,
-      AuditLogger auditLogger, Map<String, String> auditMap) {
+  void onComplete(OzoneObj resolvedOzoneObj, boolean operationResult,
+      Exception exception, OMMetrics omMetrics, Result result,
+      long trxnLogIndex, AuditLogger auditLogger, Map<String, String> auditMap) {
     switch (result) {
     case SUCCESS:
       if (LOG.isDebugEnabled()) {
         LOG.debug("Set acl: {} to path: {} success!", ozoneAcls,
-            ozoneObj.getPath());
+            resolvedOzoneObj.getPath());
       }
       break;
     case FAILURE:
-      omMetrics.incNumBucketUpdateFails();
       LOG.error("Set acl {} to path {} failed!", ozoneAcls,
-          ozoneObj.getPath(), exception);
+          resolvedOzoneObj.getPath(), exception);
       break;
     default:
       LOG.error("Unrecognized Result for OMPrefixSetAclRequest: {}",
@@ -122,9 +121,9 @@ public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
   }
 
   @Override
-  OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
+  OMPrefixAclOpResult apply(OzoneObj resolvedOzoneObj, PrefixManagerImpl prefixManager,
       OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException {
-    return prefixManager.setAcl(ozoneObj, ozoneAcls, omPrefixInfo,
+    return prefixManager.setAcl(resolvedOzoneObj, ozoneAcls, omPrefixInfo,
         trxnLogIndex);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -422,7 +422,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @MethodSource("data")
   public void testValidateAndUpdateCacheWithInvalidPath(
       boolean setKeyPathLock, boolean setFileSystemPaths) throws Exception {
-    PrefixManager prefixManager = new PrefixManagerImpl(
+    PrefixManager prefixManager = new PrefixManagerImpl(ozoneManager,
         ozoneManager.getMetadataManager(), true);
     when(ozoneManager.getPrefixManager()).thenReturn(prefixManager);
     when(ozoneManager.getOzoneLockProvider()).thenReturn(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMPrefixAclRequest.java
@@ -50,7 +50,7 @@ public class TestOMPrefixAclRequest extends TestOMKeyRequest {
 
   @Test
   public void testAddAclRequest() throws Exception {
-    PrefixManagerImpl prefixManager = new PrefixManagerImpl(
+    PrefixManagerImpl prefixManager = new PrefixManagerImpl(ozoneManager,
         ozoneManager.getMetadataManager(), true);
     when(ozoneManager.getPrefixManager()).thenReturn(prefixManager);
     String prefixName = UUID.randomUUID() + OZONE_URI_DELIMITER;
@@ -116,7 +116,7 @@ public class TestOMPrefixAclRequest extends TestOMKeyRequest {
 
   @Test
   public void testValidationFailure() {
-    PrefixManagerImpl prefixManager = new PrefixManagerImpl(
+    PrefixManagerImpl prefixManager = new PrefixManagerImpl(ozoneManager,
         ozoneManager.getMetadataManager(), true);
     when(ozoneManager.getPrefixManager()).thenReturn(prefixManager);
 
@@ -143,7 +143,7 @@ public class TestOMPrefixAclRequest extends TestOMKeyRequest {
 
   @Test
   public void testRemoveAclRequest() throws Exception {
-    PrefixManagerImpl prefixManager = new PrefixManagerImpl(
+    PrefixManagerImpl prefixManager = new PrefixManagerImpl(ozoneManager,
         ozoneManager.getMetadataManager(), true);
     when(ozoneManager.getPrefixManager()).thenReturn(prefixManager);
     String prefixName = UUID.randomUUID() + OZONE_URI_DELIMITER;
@@ -223,7 +223,7 @@ public class TestOMPrefixAclRequest extends TestOMKeyRequest {
 
   @Test
   public void testSetAclRequest() throws Exception {
-    PrefixManagerImpl prefixManager = new PrefixManagerImpl(
+    PrefixManagerImpl prefixManager = new PrefixManagerImpl(ozoneManager,
         ozoneManager.getMetadataManager(), true);
     when(ozoneManager.getPrefixManager()).thenReturn(prefixManager);
     String prefixName = UUID.randomUUID() + OZONE_URI_DELIMITER;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Following up on [HDDS-4715](https://issues.apache.org/jira/browse/HDDS-4715), we also need to resolve the bucket link for prefix ACL.

Here are the changes included in this patch:
-  Include prefix resource type to be `BucketManagerImpl`  so that prefix access under a bucket link will be resolved to the source bucket
- Prefix ACL read: `PrefixManagerImpl#getAcl` will resolve the bucket to get the ACL
- Prefix ACL write: `OMPrefixAclRequest#validateAndUpdateCache` will resolve the bucket before writing the ACL
   - This requires passing the resolved prefix `OzoneObj` to the request hooks (`onComplete`, `apply`) so that the request implementation can use the resolved object and not the link object
- Fixed `PrefixManagerImpl#setAcl` so that default ACL is inherited only when the prefix does not exist
   - This was found in the integration test
- Some comments and cosmetics improvements

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10412

## How was this patch tested?

Acceptance and integration tests.

Clean CI run: https://github.com/ivandika3/ozone/actions/runs/8029229022