### PR TITLE
HDDS-10414. Some acceptance tests fail with Docker Compose V2

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
@@ -71,17 +71,17 @@ Check if Recon picks up OM data
 Check if Recon picks up DN heartbeats
     ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/datanodes
                         Should contain      ${result}       datanodes
-                        Should contain      ${result}       datanode_1
-                        Should contain      ${result}       datanode_2
-                        Should contain      ${result}       datanode_3
+                        Should contain      ${result}       datanode-1
+                        Should contain      ${result}       datanode-2
+                        Should contain      ${result}       datanode-3
 
     ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/pipelines
                         Should contain      ${result}       pipelines
                         Should contain      ${result}       RATIS
                         Should contain      ${result}       OPEN
-                        Should contain      ${result}       datanode_1
-                        Should contain      ${result}       datanode_2
-                        Should contain      ${result}       datanode_3
+                        Should contain      ${result}       datanode-1
+                        Should contain      ${result}       datanode-2
+                        Should contain      ${result}       datanode-3
 
     ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/clusterState
                         Should contain      ${result}       \"totalDatanodes\"

--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
@@ -71,17 +71,17 @@ Check if Recon picks up OM data
 Check if Recon picks up DN heartbeats
     ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/datanodes
                         Should contain      ${result}       datanodes
-                        Should contain      ${result}       datanode-1
-                        Should contain      ${result}       datanode-2
-                        Should contain      ${result}       datanode-3
+                        Should Match Regexp    ${result}    datanode[-_]1
+                        Should Match Regexp    ${result}    datanode[-_]2
+                        Should Match Regexp    ${result}    datanode[-_]3
 
     ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/pipelines
                         Should contain      ${result}       pipelines
                         Should contain      ${result}       RATIS
                         Should contain      ${result}       OPEN
-                        Should contain      ${result}       datanode-1
-                        Should contain      ${result}       datanode-2
-                        Should contain      ${result}       datanode-3
+                        Should Match Regexp    ${result}    datanode[-_]1
+                        Should Match Regexp    ${result}    datanode[-_]2
+                        Should Match Regexp    ${result}    datanode[-_]3
 
     ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/clusterState
                         Should contain      ${result}       \"totalDatanodes\"

--- a/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
@@ -22,18 +22,27 @@ Test Timeout        5 minutes
 
 *** Variables ***
 
-
 *** Test Cases ***
 Run printTopology
     ${output} =         Execute          ozone admin printTopology
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should Contain   ${output}         State = HEALTHY
+                        Should Contain          ${output}         IN_SERVICE
+                        Should Match Regexp     ${output}         .*datanode[-_]\\d+.*IN_SERVICE.*
+
 Run printTopology -o
     ${output} =         Execute          ozone admin printTopology -o
-                        Should contain   ${output}         Location: /rack2
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net) IN_SERVICE
+                        Should Contain   ${output}         State = HEALTHY
+                        Should Contain   ${output}         Location:
+                        Should Match Regexp   ${output}         .*ozone.*datanode[-_]\\d+.*IN_SERVICE.*
+
 Run printTopology --operational-state IN_SERVICE
     ${output} =         Execute          ozone admin printTopology --operational-state IN_SERVICE
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should Contain   ${output}         State = HEALTHY
+                        Should Contain   ${output}         IN_SERVICE
+                        Should Match Regexp   ${output}         .*ozone.*datanode[-_]\\d+.*IN_SERVICE.*
+
 Run printTopology --node-state HEALTHY
     ${output} =         Execute          ozone admin printTopology --node-state HEALTHY
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should Contain   ${output}         State = HEALTHY
+                        Should Contain   ${output}         IN_SERVICE
+                        Should Match Regexp   ${output}         .*ozone.*datanode[-_]\\d+.*IN_SERVICE.*rack.*

--- a/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
@@ -22,27 +22,30 @@ Test Timeout        5 minutes
 
 *** Variables ***
 
+*** Keywords ***
+Validate PrintTopology Output
+    [Arguments]           ${output}
+    Should Contain        ${output}         State = HEALTHY
+    Should Contain        ${output}         IN_SERVICE
+    Should Match Regexp   ${output}         .*ozone.*datanode[-_]\\d+.*IN_SERVICE.*rack.*
+
+
 *** Test Cases ***
 Run printTopology
     ${output} =         Execute          ozone admin printTopology
-                        Should Contain   ${output}         State = HEALTHY
-                        Should Contain          ${output}         IN_SERVICE
-                        Should Match Regexp     ${output}         .*datanode[-_]\\d+.*IN_SERVICE.*
+                        Validate PrintTopology Output    ${output}
 
 Run printTopology -o
     ${output} =         Execute          ozone admin printTopology -o
-                        Should Contain   ${output}         State = HEALTHY
-                        Should Contain   ${output}         Location:
+                        Should Contain        ${output}         State = HEALTHY
+                        Should Match Regexp   ${output}         Location: /.*rack.*
                         Should Match Regexp   ${output}         .*ozone.*datanode[-_]\\d+.*IN_SERVICE.*
 
 Run printTopology --operational-state IN_SERVICE
     ${output} =         Execute          ozone admin printTopology --operational-state IN_SERVICE
-                        Should Contain   ${output}         State = HEALTHY
-                        Should Contain   ${output}         IN_SERVICE
-                        Should Match Regexp   ${output}         .*ozone.*datanode[-_]\\d+.*IN_SERVICE.*
+                        Validate PrintTopology Output    ${output}
 
 Run printTopology --node-state HEALTHY
     ${output} =         Execute          ozone admin printTopology --node-state HEALTHY
-                        Should Contain   ${output}         State = HEALTHY
-                        Should Contain   ${output}         IN_SERVICE
-                        Should Match Regexp   ${output}         .*ozone.*datanode[-_]\\d+.*IN_SERVICE.*rack.*
+                        Validate PrintTopology Output    ${output}
+

--- a/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
@@ -26,14 +26,14 @@ Test Timeout        5 minutes
 *** Test Cases ***
 Run printTopology
     ${output} =         Execute          ozone admin printTopology
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should Match Regexp   ${output}         10.5.0.7(ozone-topology_datanode[-_]4_1.ozone-topology_net)    IN_SERVICE    /rack2
 Run printTopology -o
     ${output} =         Execute          ozone admin printTopology -o
                         Should contain   ${output}         Location: /rack2
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net) IN_SERVICE
+                        Should Match Regexp   ${output}         10.5.0.7(ozone-topology_datanode[-_]4_1.ozone-topology_net) IN_SERVICE
 Run printTopology --operational-state IN_SERVICE
     ${output} =         Execute          ozone admin printTopology --operational-state IN_SERVICE
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should Match Regexp   ${output}         10.5.0.7(ozone-topology_datanode[-_]4_1.ozone-topology_net)    IN_SERVICE    /rack2
 Run printTopology --node-state HEALTHY
     ${output} =         Execute          ozone admin printTopology --node-state HEALTHY
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should Match Regexp   ${output}         10.5.0.7(ozone-topology_datanode[-_]4_1.ozone-topology_net)    IN_SERVICE    /rack2

--- a/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
@@ -37,7 +37,6 @@ Run printTopology
 
 Run printTopology -o
     ${output} =         Execute          ozone admin printTopology -o
-                        Should Contain        ${output}         State = HEALTHY
                         Should Match Regexp   ${output}         Location: /.*rack.*
                         Should Match Regexp   ${output}         .*ozone.*datanode[-_]\\d+.*IN_SERVICE.*
 

--- a/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
@@ -1,9 +1,9 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
+# contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
-# the License. You may obtain a copy of the License at
+# the License.  You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -26,14 +26,14 @@ Test Timeout        5 minutes
 *** Test Cases ***
 Run printTopology
     ${output} =         Execute          ozone admin printTopology
-                        Should Match Regexp   ${output}         10.5.0.7(ozone-topology_datanode[-_]4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
 Run printTopology -o
     ${output} =         Execute          ozone admin printTopology -o
                         Should contain   ${output}         Location: /rack2
-                        Should Match Regexp   ${output}         10.5.0.7(ozone-topology_datanode[-_]4_1.ozone-topology_net) IN_SERVICE
+                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net) IN_SERVICE
 Run printTopology --operational-state IN_SERVICE
     ${output} =         Execute          ozone admin printTopology --operational-state IN_SERVICE
-                        Should Match Regexp   ${output}         10.5.0.7(ozone-topology_datanode[-_]4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
 Run printTopology --node-state HEALTHY
     ${output} =         Execute          ozone admin printTopology --node-state HEALTHY
-                        Should Match Regexp   ${output}         10.5.0.7(ozone-topology_datanode[-_]4_1.ozone-topology_net)    IN_SERVICE    /rack2
+                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2

--- a/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
@@ -1,9 +1,9 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
+# contributor license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+# the License. You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recon Acceptance test is failing for the robot test :-

```
hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
```
The discrepancy arises because, in local Docker setups, DataNodes are named using hyphens, such as `datanode-1`, whereas in the upstream (CI) environment, DataNodes utilize underscores, like `datanode_1`. This variation in naming conventions leads to inconsistencies across different environments.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10414
## How was this patch tested?

The acceptance test passed locally :- 
```
------------------------------------------------------------------------------
Check if Recon picks up DN heartbeats                                 | PASS |
------------------------------------------------------------------------------
Check if Recon Web UI is up                                           | PASS |
------------------------------------------------------------------------------
Check web UI access                                                   | PASS |
------------------------------------------------------------------------------
Check admin only api access                                           | PASS |
------------------------------------------------------------------------------
Check unhealthy, (admin) api access                                   | PASS |
------------------------------------------------------------------------------
Check normal api access                                               | PASS |
------------------------------------------------------------------------------
```

And in the forked CI :- https://github.com/ArafatKhan2198/ozone/actions/runs/8030499503
