### PR TITLE
HDDS-10394. Fix parameter number warning in om.helpers

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
@@ -28,29 +28,37 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListKey
 /**
  * Lightweight OmKeyInfo class.
  */
-public class BasicOmKeyInfo {
+public final class BasicOmKeyInfo {
 
-  private String volumeName;
-  private String bucketName;
-  private String keyName;
-  private long dataSize;
-  private long creationTime;
-  private long modificationTime;
-  private ReplicationConfig replicationConfig;
-  private boolean isFile;
+  private final String volumeName;
+  private final String bucketName;
+  private final String keyName;
+  private final long dataSize;
+  private final long creationTime;
+  private final long modificationTime;
+  private final ReplicationConfig replicationConfig;
+  private final boolean isFile;
 
-  @SuppressWarnings("parameternumber")
-  public BasicOmKeyInfo(String volumeName, String bucketName, String keyName,
-                        long dataSize, long creationTime, long modificationTime,
-                        ReplicationConfig replicationConfig, boolean isFile) {
-    this.volumeName = volumeName;
-    this.bucketName = bucketName;
-    this.keyName = keyName;
-    this.dataSize = dataSize;
-    this.creationTime = creationTime;
-    this.modificationTime = modificationTime;
-    this.replicationConfig = replicationConfig;
-    this.isFile = isFile;
+  private BasicOmKeyInfo(Builder b) {
+    this.volumeName = b.volumeName;
+    this.bucketName = b.bucketName;
+    this.keyName = b.keyName;
+    this.dataSize = b.dataSize;
+    this.creationTime = b.creationTime;
+    this.modificationTime = b.modificationTime;
+    this.replicationConfig = b.replicationConfig;
+    this.isFile = b.isFile;
+  }
+
+  private BasicOmKeyInfo(OmKeyInfo b) {
+    this.volumeName = b.getVolumeName();
+    this.bucketName = b.getBucketName();
+    this.keyName = b.getKeyName();
+    this.dataSize = b.getDataSize();
+    this.creationTime = b.getCreationTime();
+    this.modificationTime = b.getModificationTime();
+    this.replicationConfig = b.getReplicationConfig();
+    this.isFile = b.isFile();
   }
 
   public String getVolumeName() {
@@ -139,8 +147,7 @@ public class BasicOmKeyInfo {
     }
 
     public BasicOmKeyInfo build() {
-      return new BasicOmKeyInfo(volumeName, bucketName, keyName, dataSize,
-          creationTime, modificationTime, replicationConfig, isFile);
+      return new BasicOmKeyInfo(this);
     }
   }
 
@@ -233,14 +240,6 @@ public class BasicOmKeyInfo {
   }
 
   public static BasicOmKeyInfo fromOmKeyInfo(OmKeyInfo omKeyInfo) {
-    return new BasicOmKeyInfo(
-        omKeyInfo.getVolumeName(),
-        omKeyInfo.getBucketName(),
-        omKeyInfo.getKeyName(),
-        omKeyInfo.getDataSize(),
-        omKeyInfo.getCreationTime(),
-        omKeyInfo.getModificationTime(),
-        omKeyInfo.getReplicationConfig(),
-        omKeyInfo.isFile());
+    return new BasicOmKeyInfo(omKeyInfo);
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -197,7 +198,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     private String bucketName;
     private Boolean isVersionEnabled;
     private StorageType storageType;
-    private Map<String, String> metadata;
+    private final Map<String, String> metadata = new HashMap<>();
     private boolean quotaInBytesSet = false;
     private long quotaInBytes;
     private boolean quotaInNamespaceSet = false;
@@ -233,11 +234,6 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
       if (info == null || info.getKeyName() != null) {
         this.bekInfo = info;
       }
-      return this;
-    }
-
-    public Builder addMetadata(Map<String, String> metadataMap) {
-      this.metadata = metadataMap;
       return this;
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -44,44 +44,40 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
   /**
    * Bucket Version flag.
    */
-  private Boolean isVersionEnabled;
+  private final Boolean isVersionEnabled;
   /**
    * Type of storage to be used for this bucket.
    * [RAM_DISK, SSD, DISK, ARCHIVE]
    */
-  private StorageType storageType;
+  private final StorageType storageType;
 
   /**
    * Bucket encryption key info if encryption is enabled.
    */
-  private BucketEncryptionKeyInfo bekInfo;
-  private long quotaInBytes = OzoneConsts.QUOTA_RESET;
-  private long quotaInNamespace = OzoneConsts.QUOTA_RESET;
-  private boolean quotaInBytesSet = false;
-  private boolean quotaInNamespaceSet = false;
-  private DefaultReplicationConfig defaultReplicationConfig = null;
+  private final BucketEncryptionKeyInfo bekInfo;
+  private final long quotaInBytes;
+  private final long quotaInNamespace;
+  private final boolean quotaInBytesSet;
+  private final boolean quotaInNamespaceSet;
+  private final DefaultReplicationConfig defaultReplicationConfig;
   /**
    * Bucket Owner Name.
    */
-  private String ownerName;
+  private final String ownerName;
 
-  /**
-   * Private constructor, constructed via builder.
-   * @param volumeName - Volume name.
-   * @param bucketName - Bucket name.
-   * @param isVersionEnabled - Bucket version flag.
-   * @param storageType - Storage type to be used.
-   */
-  @SuppressWarnings("checkstyle:ParameterNumber")
-  private OmBucketArgs(String volumeName, String bucketName,
-      Boolean isVersionEnabled, StorageType storageType,
-      Map<String, String> metadata, String ownerName) {
-    this.volumeName = volumeName;
-    this.bucketName = bucketName;
-    this.isVersionEnabled = isVersionEnabled;
-    this.storageType = storageType;
-    setMetadata(metadata);
-    this.ownerName = ownerName;
+  private OmBucketArgs(Builder b) {
+    setMetadata(b.metadata);
+    this.volumeName = b.volumeName;
+    this.bucketName = b.bucketName;
+    this.isVersionEnabled = b.isVersionEnabled;
+    this.storageType = b.storageType;
+    this.ownerName = b.ownerName;
+    this.defaultReplicationConfig = b.defaultReplicationConfig;
+    this.quotaInBytesSet = b.quotaInBytesSet;
+    this.quotaInBytes = quotaInBytesSet ? b.quotaInBytes : OzoneConsts.QUOTA_RESET;
+    this.quotaInNamespaceSet = b.quotaInNamespaceSet;
+    this.quotaInNamespace = quotaInNamespaceSet ? b.quotaInNamespace : OzoneConsts.QUOTA_RESET;
+    this.bekInfo = b.bekInfo;
   }
 
   /**
@@ -149,7 +145,6 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
 
   /**
    * Returns Bucket default replication config.
-   * @return
    */
   public DefaultReplicationConfig getDefaultReplicationConfig() {
     return defaultReplicationConfig;
@@ -157,30 +152,6 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
 
   public BucketEncryptionKeyInfo getBucketEncryptionKeyInfo() {
     return bekInfo;
-  }
-
-  /**
-   * Sets the Bucket default replication config.
-   */
-  private void setDefaultReplicationConfig(
-      DefaultReplicationConfig defaultReplicationConfig) {
-    this.defaultReplicationConfig = defaultReplicationConfig;
-  }
-
-  private void setQuotaInBytes(long quotaInBytes) {
-    this.quotaInBytesSet = true;
-    this.quotaInBytes = quotaInBytes;
-  }
-
-  private void setQuotaInNamespace(long quotaInNamespace) {
-    this.quotaInNamespaceSet = true;
-    this.quotaInNamespace = quotaInNamespace;
-  }
-
-  @Deprecated
-  private void setBucketEncryptionKey(
-      BucketEncryptionKeyInfo bucketEncryptionKey) {
-    this.bekInfo = bucketEncryptionKey;
   }
 
   /**
@@ -259,12 +230,19 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
 
     @Deprecated
     public Builder setBucketEncryptionKey(BucketEncryptionKeyInfo info) {
-      this.bekInfo = info;
+      if (info == null || info.getKeyName() != null) {
+        this.bekInfo = info;
+      }
       return this;
     }
 
     public Builder addMetadata(Map<String, String> metadataMap) {
       this.metadata = metadataMap;
+      return this;
+    }
+
+    public Builder addAllMetadata(Map<String, String> map) {
+      metadata.putAll(map);
       return this;
     }
 
@@ -303,20 +281,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     public OmBucketArgs build() {
       Preconditions.checkNotNull(volumeName);
       Preconditions.checkNotNull(bucketName);
-      OmBucketArgs omBucketArgs =
-          new OmBucketArgs(volumeName, bucketName, isVersionEnabled,
-              storageType, metadata, ownerName);
-      omBucketArgs.setDefaultReplicationConfig(defaultReplicationConfig);
-      if (quotaInBytesSet) {
-        omBucketArgs.setQuotaInBytes(quotaInBytes);
-      }
-      if (quotaInNamespaceSet) {
-        omBucketArgs.setQuotaInNamespace(quotaInNamespace);
-      }
-      if (bekInfo != null && bekInfo.getKeyName() != null) {
-        omBucketArgs.setBucketEncryptionKey(bekInfo);
-      }
-      return omBucketArgs;
+      return new OmBucketArgs(this);
     }
   }
 
@@ -348,7 +313,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
       builder.setOwnerName(ownerName);
     }
 
-    if (bekInfo != null && bekInfo.getKeyName() != null) {
+    if (bekInfo != null) {
       builder.setBekInfo(OMPBHelper.convert(bekInfo));
     }
 
@@ -357,39 +322,42 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
 
   /**
    * Parses BucketInfo protobuf and creates OmBucketArgs.
-   * @param bucketArgs
    * @return instance of OmBucketArgs
    */
   public static OmBucketArgs getFromProtobuf(BucketArgs bucketArgs) {
-    OmBucketArgs omBucketArgs =
-        new OmBucketArgs(bucketArgs.getVolumeName(),
-            bucketArgs.getBucketName(),
-            bucketArgs.hasIsVersionEnabled() ?
-                bucketArgs.getIsVersionEnabled() : null,
-            bucketArgs.hasStorageType() ? StorageType.valueOf(
-                bucketArgs.getStorageType()) : null,
-            KeyValueUtil.getFromProtobuf(bucketArgs.getMetadataList()),
-            bucketArgs.hasOwnerName() ?
-                bucketArgs.getOwnerName() : null);
-    // OmBucketArgs ctor already has more arguments, so setting the default
-    // replication config separately.
+    final OmBucketArgs.Builder builder = newBuilder()
+        .setVolumeName(bucketArgs.getVolumeName())
+        .setBucketName(bucketArgs.getBucketName())
+        .addAllMetadata(KeyValueUtil.getFromProtobuf(bucketArgs.getMetadataList()));
+
+    if (bucketArgs.hasIsVersionEnabled()) {
+      builder.setIsVersionEnabled(bucketArgs.getIsVersionEnabled());
+    }
+    if (bucketArgs.hasStorageType()) {
+      builder.setStorageType(StorageType.valueOf(bucketArgs.getStorageType()));
+    }
+    if (bucketArgs.hasOwnerName()) {
+      builder.setOwnerName(bucketArgs.getOwnerName());
+    }
+
     if (bucketArgs.hasDefaultReplicationConfig()) {
-      omBucketArgs.setDefaultReplicationConfig(
+      builder.setDefaultReplicationConfig(
           DefaultReplicationConfig.fromProto(
               bucketArgs.getDefaultReplicationConfig()));
     }
 
     if (bucketArgs.hasQuotaInBytes()) {
-      omBucketArgs.setQuotaInBytes(bucketArgs.getQuotaInBytes());
+      builder.setQuotaInBytes(bucketArgs.getQuotaInBytes());
     }
     if (bucketArgs.hasQuotaInNamespace()) {
-      omBucketArgs.setQuotaInNamespace(bucketArgs.getQuotaInNamespace());
+      builder.setQuotaInNamespace(bucketArgs.getQuotaInNamespace());
     }
 
     if (bucketArgs.hasBekInfo()) {
-      omBucketArgs.setBucketEncryptionKey(
+      builder.setBucketEncryptionKey(
           OMPBHelper.convert(bucketArgs.getBekInfo()));
     }
-    return omBucketArgs;
+
+    return builder.build();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -109,68 +109,27 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
 
   private String owner;
 
-  /**
-   * Private constructor, constructed via builder.
-   * @param volumeName - Volume name.
-   * @param bucketName - Bucket name.
-   * @param acls - list of ACLs.
-   * @param isVersionEnabled - Bucket version flag.
-   * @param storageType - Storage type to be used.
-   * @param creationTime - Bucket creation time.
-   * @param modificationTime - Bucket modification time.
-   * @param metadata - metadata.
-   * @param bekInfo - bucket encryption key info.
-   * @param sourceVolume - source volume for bucket links, null otherwise
-   * @param sourceBucket - source bucket for bucket links, null otherwise
-   * @param usedBytes - Bucket Quota Usage in bytes.
-   * @param quotaInBytes Bucket quota in bytes.
-   * @param quotaInNamespace Bucket quota in counts.
-   * @param bucketLayout bucket layout.
-   * @param owner owner of the bucket.
-   * @param defaultReplicationConfig default replication config.
-   * @param bucketLayout Bucket Layout.
-   */
-  @SuppressWarnings("checkstyle:ParameterNumber")
-  private OmBucketInfo(String volumeName,
-      String bucketName,
-      List<OzoneAcl> acls,
-      boolean isVersionEnabled,
-      StorageType storageType,
-      long creationTime,
-      long modificationTime,
-      long objectID,
-      long updateID,
-      Map<String, String> metadata,
-      BucketEncryptionKeyInfo bekInfo,
-      String sourceVolume,
-      String sourceBucket,
-      long usedBytes,
-      long usedNamespace,
-      long quotaInBytes,
-      long quotaInNamespace,
-      BucketLayout bucketLayout,
-      String owner,
-      DefaultReplicationConfig defaultReplicationConfig) {
-    this.volumeName = volumeName;
-    this.bucketName = bucketName;
-    this.acls = acls;
-    this.isVersionEnabled = isVersionEnabled;
-    this.storageType = storageType;
-    this.creationTime = creationTime;
-    this.modificationTime = modificationTime;
-    setObjectID(objectID);
-    setUpdateID(updateID);
-    setMetadata(metadata);
-    this.bekInfo = bekInfo;
-    this.sourceVolume = sourceVolume;
-    this.sourceBucket = sourceBucket;
-    this.usedBytes = usedBytes;
-    this.usedNamespace = usedNamespace;
-    this.quotaInBytes = quotaInBytes;
-    this.quotaInNamespace = quotaInNamespace;
-    this.bucketLayout = bucketLayout;
-    this.owner = owner;
-    this.defaultReplicationConfig = defaultReplicationConfig;
+  private OmBucketInfo(Builder b) {
+    setMetadata(b.metadata);
+    setObjectID(b.objectID);
+    setUpdateID(b.updateID);
+    this.volumeName = b.volumeName;
+    this.bucketName = b.bucketName;
+    this.acls = b.acls;
+    this.isVersionEnabled = b.isVersionEnabled;
+    this.storageType = b.storageType;
+    this.creationTime = b.creationTime;
+    this.modificationTime = b.modificationTime;
+    this.bekInfo = b.bekInfo;
+    this.sourceVolume = b.sourceVolume;
+    this.sourceBucket = b.sourceBucket;
+    this.usedBytes = b.usedBytes;
+    this.usedNamespace = b.usedNamespace;
+    this.quotaInBytes = b.quotaInBytes;
+    this.quotaInNamespace = b.quotaInNamespace;
+    this.bucketLayout = b.bucketLayout;
+    this.owner = b.owner;
+    this.defaultReplicationConfig = b.defaultReplicationConfig;
   }
 
   /**
@@ -531,31 +490,37 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
       return this;
     }
 
+    /** @param volume - source volume for bucket links, null otherwise */
     public Builder setSourceVolume(String volume) {
       this.sourceVolume = volume;
       return this;
     }
 
+    /** @param bucket - source bucket for bucket links, null otherwise */
     public Builder setSourceBucket(String bucket) {
       this.sourceBucket = bucket;
       return this;
     }
 
+    /** @param quotaUsage - Bucket Quota Usage in bytes. */
     public Builder setUsedBytes(long quotaUsage) {
       this.usedBytes = quotaUsage;
       return this;
     }
 
+    /** @param quotaUsage - Bucket Quota Usage in counts. */
     public Builder setUsedNamespace(long quotaUsage) {
       this.usedNamespace = quotaUsage;
       return this;
     }
 
+    /** @param quota Bucket quota in bytes. */
     public Builder setQuotaInBytes(long quota) {
       this.quotaInBytes = quota;
       return this;
     }
 
+    /** @param quota Bucket quota in counts. */
     public Builder setQuotaInNamespace(long quota) {
       this.quotaInNamespace = quota;
       return this;
@@ -587,11 +552,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
       Preconditions.checkNotNull(acls);
       Preconditions.checkNotNull(isVersionEnabled);
       Preconditions.checkNotNull(storageType);
-      return new OmBucketInfo(volumeName, bucketName, acls, isVersionEnabled,
-          storageType, creationTime, modificationTime, objectID, updateID,
-          metadata, bekInfo, sourceVolume, sourceBucket, usedBytes,
-          usedNamespace, quotaInBytes, quotaInNamespace, bucketLayout, owner,
-          defaultReplicationConfig);
+      return new OmBucketInfo(this);
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -45,39 +45,31 @@ public final class OmKeyArgs implements Auditable {
   private final boolean isMultipartKey;
   private final String multipartUploadID;
   private final int multipartUploadPartNumber;
-  private Map<String, String> metadata;
-  private boolean sortDatanodesInPipeline;
-  private List<OzoneAcl> acls;
-  private boolean latestVersionLocation;
-  private boolean recursive;
-  private boolean headOp;
-  private boolean forceUpdateContainerCacheFromSCM;
+  private final Map<String, String> metadata;
+  private final boolean sortDatanodesInPipeline;
+  private final List<OzoneAcl> acls;
+  private final boolean latestVersionLocation;
+  private final boolean recursive;
+  private final boolean headOp;
+  private final boolean forceUpdateContainerCacheFromSCM;
 
-  @SuppressWarnings("parameternumber")
-  private OmKeyArgs(String volumeName, String bucketName, String keyName,
-      long dataSize, ReplicationConfig replicationConfig,
-      List<OmKeyLocationInfo> locationInfoList, boolean isMultipart,
-      String uploadID, int partNumber,
-      Map<String, String> metadataMap,
-      List<OzoneAcl> acls, boolean sortDatanode,
-      boolean latestVersionLocation, boolean recursive, boolean headOp,
-      boolean forceUpdateContainerCacheFromSCM) {
-    this.volumeName = volumeName;
-    this.bucketName = bucketName;
-    this.keyName = keyName;
-    this.dataSize = dataSize;
-    this.replicationConfig = replicationConfig;
-    this.locationInfoList = locationInfoList;
-    this.isMultipartKey = isMultipart;
-    this.multipartUploadID = uploadID;
-    this.multipartUploadPartNumber = partNumber;
-    this.metadata = metadataMap;
-    this.acls = acls;
-    this.sortDatanodesInPipeline = sortDatanode;
-    this.latestVersionLocation = latestVersionLocation;
-    this.recursive = recursive;
-    this.headOp = headOp;
-    this.forceUpdateContainerCacheFromSCM = forceUpdateContainerCacheFromSCM;
+  private OmKeyArgs(Builder b) {
+    this.volumeName = b.volumeName;
+    this.bucketName = b.bucketName;
+    this.keyName = b.keyName;
+    this.dataSize = b.dataSize;
+    this.replicationConfig = b.replicationConfig;
+    this.locationInfoList = b.locationInfoList;
+    this.isMultipartKey = b.isMultipartKey;
+    this.multipartUploadID = b.multipartUploadID;
+    this.multipartUploadPartNumber = b.multipartUploadPartNumber;
+    this.metadata = b.metadata;
+    this.acls = b.acls;
+    this.sortDatanodesInPipeline = b.sortDatanodesInPipeline;
+    this.latestVersionLocation = b.latestVersionLocation;
+    this.recursive = b.recursive;
+    this.headOp = b.headOp;
+    this.forceUpdateContainerCacheFromSCM = b.forceUpdateContainerCacheFromSCM;
   }
 
   public boolean getIsMultipartKey() {
@@ -122,10 +114,6 @@ public final class OmKeyArgs implements Auditable {
 
   public Map<String, String> getMetadata() {
     return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
   }
 
   public void setLocationInfoList(List<OmKeyLocationInfo> locationInfoList) {
@@ -224,7 +212,7 @@ public final class OmKeyArgs implements Auditable {
     private boolean isMultipartKey;
     private String multipartUploadID;
     private int multipartUploadPartNumber;
-    private Map<String, String> metadata = new HashMap<>();
+    private final Map<String, String> metadata = new HashMap<>();
     private boolean sortDatanodesInPipeline;
     private boolean latestVersionLocation;
     private List<OzoneAcl> acls;
@@ -326,12 +314,7 @@ public final class OmKeyArgs implements Auditable {
     }
 
     public OmKeyArgs build() {
-      return new OmKeyArgs(volumeName, bucketName, keyName, dataSize,
-          replicationConfig, locationInfoList, isMultipartKey,
-          multipartUploadID,
-          multipartUploadPartNumber, metadata, acls,
-          sortDatanodesInPipeline, latestVersionLocation, recursive, headOp,
-          forceUpdateContainerCacheFromSCM);
+      return new OmKeyArgs(this);
     }
 
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -98,47 +98,26 @@ public final class OmKeyInfo extends WithParentObjectId
   /**
    * ACL Information.
    */
-  private List<OzoneAcl> acls;
+  private final List<OzoneAcl> acls;
 
-  @SuppressWarnings("parameternumber")
-  OmKeyInfo(String volumeName, String bucketName, String keyName,
-      List<OmKeyLocationInfoGroup> versions, long dataSize,
-      long creationTime, long modificationTime,
-      ReplicationConfig replicationConfig,
-      Map<String, String> metadata,
-      FileEncryptionInfo encInfo, List<OzoneAcl> acls,
-      long objectID, long updateID, FileChecksum fileChecksum) {
-    this.volumeName = volumeName;
-    this.bucketName = bucketName;
-    this.keyName = keyName;
-    this.dataSize = dataSize;
-    this.keyLocationVersions = versions;
-    this.creationTime = creationTime;
-    this.modificationTime = modificationTime;
-    this.replicationConfig = replicationConfig;
-    setMetadata(metadata);
-    this.encInfo = encInfo;
-    this.acls = acls;
-    setObjectID(objectID);
-    setUpdateID(updateID);
-    this.fileChecksum = fileChecksum;
-  }
-
-  @SuppressWarnings("parameternumber")
-  OmKeyInfo(String volumeName, String bucketName, String keyName,
-            String fileName, List<OmKeyLocationInfoGroup> versions,
-            long dataSize, long creationTime, long modificationTime,
-            ReplicationConfig replicationConfig,
-            Map<String, String> metadata,
-            FileEncryptionInfo encInfo, List<OzoneAcl> acls,
-            long parentObjectID, long objectID, long updateID,
-            FileChecksum fileChecksum, boolean isFile) {
-    this(volumeName, bucketName, keyName, versions, dataSize,
-            creationTime, modificationTime, replicationConfig, metadata,
-            encInfo, acls, objectID, updateID, fileChecksum);
-    this.fileName = fileName;
-    setParentObjectID(parentObjectID);
-    this.isFile = isFile;
+  private OmKeyInfo(Builder b) {
+    setMetadata(b.metadata);
+    setObjectID(b.objectID);
+    setUpdateID(b.updateID);
+    setParentObjectID(b.parentObjectID);
+    this.volumeName = b.volumeName;
+    this.bucketName = b.bucketName;
+    this.keyName = b.keyName;
+    this.dataSize = b.dataSize;
+    this.keyLocationVersions = b.omKeyLocationInfoGroups;
+    this.creationTime = b.creationTime;
+    this.modificationTime = b.modificationTime;
+    this.replicationConfig = b.replicationConfig;
+    this.encInfo = b.encInfo;
+    this.acls = b.acls;
+    this.fileChecksum = b.fileChecksum;
+    this.fileName = b.fileName;
+    this.isFile = b.isFile;
   }
 
   public String getVolumeName() {
@@ -193,10 +172,6 @@ public final class OmKeyInfo extends WithParentObjectId
   public void setKeyLocationVersions(
       List<OmKeyLocationInfoGroup> keyLocationVersions) {
     this.keyLocationVersions = keyLocationVersions;
-  }
-
-  public void updateModifcationTime() {
-    this.modificationTime = Time.monotonicNow();
   }
 
   public void setFile(boolean file) {
@@ -443,14 +418,14 @@ public final class OmKeyInfo extends WithParentObjectId
     private String bucketName;
     private String keyName;
     private long dataSize;
-    private List<OmKeyLocationInfoGroup> omKeyLocationInfoGroups =
+    private final List<OmKeyLocationInfoGroup> omKeyLocationInfoGroups =
         new ArrayList<>();
     private long creationTime;
     private long modificationTime;
     private ReplicationConfig replicationConfig;
-    private Map<String, String> metadata;
+    private final Map<String, String> metadata;
     private FileEncryptionInfo encInfo;
-    private List<OzoneAcl> acls;
+    private final List<OzoneAcl> acls;
     private long objectID;
     private long updateID;
     // not persisted to DB. FileName will be the last element in path keyName.
@@ -462,7 +437,6 @@ public final class OmKeyInfo extends WithParentObjectId
 
     public Builder() {
       this.metadata = new HashMap<>();
-      omKeyLocationInfoGroups = new ArrayList<>();
       acls = new ArrayList<>();
     }
 
@@ -577,11 +551,7 @@ public final class OmKeyInfo extends WithParentObjectId
     }
 
     public OmKeyInfo build() {
-      return new OmKeyInfo(
-              volumeName, bucketName, keyName, fileName,
-              omKeyLocationInfoGroups, dataSize, creationTime,
-              modificationTime, replicationConfig, metadata, encInfo, acls,
-              parentObjectID, objectID, updateID, fileChecksum, isFile);
+      return new OmKeyInfo(this);
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
@@ -155,37 +155,34 @@ public final class OmMultipartKeyInfo extends WithObjectID {
    *   multiKey1   |     1026     |     1025   |
    * ------------------------------------------|
    */
-  private long parentID;
+  private final long parentID;
 
   /**
    * Construct OmMultipartKeyInfo object which holds multipart upload
    * information for a key.
    */
-  @SuppressWarnings("parameternumber")
-  private OmMultipartKeyInfo(String id, long creationTime,
-      ReplicationConfig replicationConfig,
-      PartKeyInfoMap sortedMap, long objectID, long updateID,
-      long parentObjId) {
-    this.uploadID = id;
-    this.creationTime = creationTime;
-    this.replicationConfig = replicationConfig;
-    this.partKeyInfoMap = sortedMap;
-    setObjectID(objectID);
-    setUpdateID(updateID);
-    this.parentID = parentObjId;
+  private OmMultipartKeyInfo(Builder b) {
+    this.uploadID = b.uploadID;
+    this.creationTime = b.creationTime;
+    this.replicationConfig = b.replicationConfig;
+    this.partKeyInfoMap = new PartKeyInfoMap(b.partKeyInfoList);
+    setObjectID(b.objectID);
+    setUpdateID(b.updateID);
+    this.parentID = b.parentID;
   }
 
-  /**
-   * Construct OmMultipartKeyInfo object which holds multipart upload
-   * information for a key.
-   */
-  @SuppressWarnings("parameternumber")
-  private OmMultipartKeyInfo(String id, long creationTime,
-      ReplicationConfig replicationConfig,
-      SortedMap<Integer, PartKeyInfo> list, long objectID, long updateID,
-      long parentObjId) {
-    this(id, creationTime, replicationConfig, new PartKeyInfoMap(list),
-        objectID, updateID, parentObjId);
+  /** Copy constructor. */
+  private OmMultipartKeyInfo(OmMultipartKeyInfo b) {
+    this.uploadID = b.uploadID;
+    this.creationTime = b.creationTime;
+    this.replicationConfig = b.replicationConfig;
+    // PartKeyInfoMap is an immutable data structure. Whenever a PartKeyInfo
+    // is added, it returns a new shallow copy of the PartKeyInfoMap Object
+    // so here we can directly pass in partKeyInfoMap
+    this.partKeyInfoMap = b.partKeyInfoMap;
+    setObjectID(b.getObjectID());
+    setUpdateID(b.getUpdateID());
+    this.parentID = b.parentID;
   }
 
   /**
@@ -232,7 +229,7 @@ public final class OmMultipartKeyInfo extends WithObjectID {
     private String uploadID;
     private long creationTime;
     private ReplicationConfig replicationConfig;
-    private TreeMap<Integer, PartKeyInfo> partKeyInfoList;
+    private final TreeMap<Integer, PartKeyInfo> partKeyInfoList;
     private long objectID;
     private long updateID;
     private long parentID;
@@ -286,8 +283,7 @@ public final class OmMultipartKeyInfo extends WithObjectID {
     }
 
     public OmMultipartKeyInfo build() {
-      return new OmMultipartKeyInfo(uploadID, creationTime, replicationConfig,
-              partKeyInfoList, objectID, updateID, parentID);
+      return new OmMultipartKeyInfo(this);
     }
   }
 
@@ -308,10 +304,15 @@ public final class OmMultipartKeyInfo extends WithObjectID {
         multipartKeyInfo.getEcReplicationConfig()
     );
 
-    return new OmMultipartKeyInfo(multipartKeyInfo.getUploadID(),
-        multipartKeyInfo.getCreationTime(), replicationConfig,
-        list, multipartKeyInfo.getObjectID(),
-        multipartKeyInfo.getUpdateID(), multipartKeyInfo.getParentID());
+    return new Builder()
+        .setUploadID(multipartKeyInfo.getUploadID())
+        .setCreationTime(multipartKeyInfo.getCreationTime())
+        .setReplicationConfig(replicationConfig)
+        .setPartKeyInfoList(list)
+        .setObjectID(multipartKeyInfo.getObjectID())
+        .setUpdateID(multipartKeyInfo.getUpdateID())
+        .setParentID(multipartKeyInfo.getParentID())
+        .build();
   }
 
   /**
@@ -358,11 +359,7 @@ public final class OmMultipartKeyInfo extends WithObjectID {
   }
 
   public OmMultipartKeyInfo copyObject() {
-    // PartKeyInfoMap is an immutable data structure. Whenever a PartKeyInfo
-    // is added, it returns a new shallow copy of the PartKeyInfoMap Object
-    // so here we can directly pass in partKeyInfoMap
-    return new OmMultipartKeyInfo(uploadID, creationTime, replicationConfig,
-        partKeyInfoMap, getObjectID(), getUpdateID(), parentID);
+    return new OmMultipartKeyInfo(this);
   }
 
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -125,65 +125,26 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
   private long exclusiveReplicatedSize;
   private boolean deepCleanedDeletedDir;
 
-  /**
-   * Private constructor, constructed via builder.
-   * @param snapshotId - Snapshot UUID.
-   * @param name - snapshot name.
-   * @param volumeName - volume name.
-   * @param bucketName - bucket name.
-   * @param snapshotStatus - status: SNAPSHOT_ACTIVE, SNAPSHOT_DELETED
-   * @param creationTime - Snapshot creation time.
-   * @param deletionTime - Snapshot deletion time.
-   * @param pathPreviousSnapshotId - Snapshot path previous snapshot id.
-   * @param globalPreviousSnapshotId - Snapshot global previous snapshot id.
-   * @param snapshotPath - Snapshot path, bucket .snapshot path.
-   * @param checkpointDir - Snapshot checkpoint directory.
-   * @param dbTxSequenceNumber - RDB latest transaction sequence number.
-   * @param deepCleaned - To be deep cleaned status for snapshot.
-   * @param referencedSize - Snapshot referenced size.
-   * @param referencedReplicatedSize - Snapshot referenced size w/ replication.
-   * @param exclusiveSize - Snapshot exclusive size.
-   * @param exclusiveReplicatedSize - Snapshot exclusive size w/ replication.
-   */
-  @SuppressWarnings("checkstyle:ParameterNumber")
-  private SnapshotInfo(UUID snapshotId,
-                       String name,
-                       String volumeName,
-                       String bucketName,
-                       SnapshotStatus snapshotStatus,
-                       long creationTime,
-                       long deletionTime,
-                       UUID pathPreviousSnapshotId,
-                       UUID globalPreviousSnapshotId,
-                       String snapshotPath,
-                       String checkpointDir,
-                       long dbTxSequenceNumber,
-                       boolean deepCleaned,
-                       boolean sstFiltered,
-                       long referencedSize,
-                       long referencedReplicatedSize,
-                       long exclusiveSize,
-                       long exclusiveReplicatedSize,
-                       boolean deepCleanedDeletedDir) {
-    this.snapshotId = snapshotId;
-    this.name = name;
-    this.volumeName = volumeName;
-    this.bucketName = bucketName;
-    this.snapshotStatus = snapshotStatus;
-    this.creationTime = creationTime;
-    this.deletionTime = deletionTime;
-    this.pathPreviousSnapshotId = pathPreviousSnapshotId;
-    this.globalPreviousSnapshotId = globalPreviousSnapshotId;
-    this.snapshotPath = snapshotPath;
-    this.checkpointDir = checkpointDir;
-    this.dbTxSequenceNumber = dbTxSequenceNumber;
-    this.deepClean = deepCleaned;
-    this.sstFiltered = sstFiltered;
-    this.referencedSize = referencedSize;
-    this.referencedReplicatedSize = referencedReplicatedSize;
-    this.exclusiveSize = exclusiveSize;
-    this.exclusiveReplicatedSize = exclusiveReplicatedSize;
-    this.deepCleanedDeletedDir = deepCleanedDeletedDir;
+  private SnapshotInfo(Builder b) {
+    this.snapshotId = b.snapshotId;
+    this.name = b.name;
+    this.volumeName = b.volumeName;
+    this.bucketName = b.bucketName;
+    this.snapshotStatus = b.snapshotStatus;
+    this.creationTime = b.creationTime;
+    this.deletionTime = b.deletionTime;
+    this.pathPreviousSnapshotId = b.pathPreviousSnapshotId;
+    this.globalPreviousSnapshotId = b.globalPreviousSnapshotId;
+    this.snapshotPath = b.snapshotPath;
+    this.checkpointDir = b.checkpointDir;
+    this.dbTxSequenceNumber = b.dbTxSequenceNumber;
+    this.deepClean = b.deepClean;
+    this.sstFiltered = b.sstFiltered;
+    this.referencedSize = b.referencedSize;
+    this.referencedReplicatedSize = b.referencedReplicatedSize;
+    this.exclusiveSize = b.exclusiveSize;
+    this.exclusiveReplicatedSize = b.exclusiveReplicatedSize;
+    this.deepCleanedDeletedDir = b.deepCleanedDeletedDir;
   }
 
   public void setName(String name) {
@@ -338,66 +299,79 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
       this.snapshotStatus = SnapshotStatus.DEFAULT;
     }
 
+    /** @param snapshotId - Snapshot UUID. */
     public Builder setSnapshotId(UUID snapshotId) {
       this.snapshotId = snapshotId;
       return this;
     }
 
+    /** @param name - snapshot name. */
     public Builder setName(String name) {
       this.name = name;
       return this;
     }
 
+    /** @param volumeName - volume name. */
     public Builder setVolumeName(String volumeName) {
       this.volumeName = volumeName;
       return this;
     }
 
+    /** @param bucketName - bucket name. */
     public Builder setBucketName(String bucketName) {
       this.bucketName = bucketName;
       return this;
     }
 
+    /** @param snapshotStatus - status: SNAPSHOT_ACTIVE, SNAPSHOT_DELETED */
     public Builder setSnapshotStatus(SnapshotStatus snapshotStatus) {
       this.snapshotStatus = snapshotStatus;
       return this;
     }
 
+    /** @param crTime - Snapshot creation time. */
     public Builder setCreationTime(long crTime) {
       this.creationTime = crTime;
       return this;
     }
 
+    /** @param delTime - Snapshot deletion time. */
     public Builder setDeletionTime(long delTime) {
       this.deletionTime = delTime;
       return this;
     }
 
+    /** @param pathPreviousSnapshotId - Snapshot path previous snapshot id. */
     public Builder setPathPreviousSnapshotId(UUID pathPreviousSnapshotId) {
       this.pathPreviousSnapshotId = pathPreviousSnapshotId;
       return this;
     }
 
+    /** @param globalPreviousSnapshotId - Snapshot global previous snapshot id. */
     public Builder setGlobalPreviousSnapshotId(UUID globalPreviousSnapshotId) {
       this.globalPreviousSnapshotId = globalPreviousSnapshotId;
       return this;
     }
 
+    /** @param snapshotPath - Snapshot path, bucket .snapshot path. */
     public Builder setSnapshotPath(String snapshotPath) {
       this.snapshotPath = snapshotPath;
       return this;
     }
 
+    /** @param checkpointDir - Snapshot checkpoint directory. */
     public Builder setCheckpointDir(String checkpointDir) {
       this.checkpointDir = checkpointDir;
       return this;
     }
 
+    /** @param dbTxSequenceNumber - RDB latest transaction sequence number. */
     public Builder setDbTxSequenceNumber(long dbTxSequenceNumber) {
       this.dbTxSequenceNumber = dbTxSequenceNumber;
       return this;
     }
 
+    /** @param deepClean - To be deep cleaned status for snapshot. */
     public Builder setDeepClean(boolean deepClean) {
       this.deepClean = deepClean;
       return this;
@@ -408,21 +382,25 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
       return this;
     }
 
+    /** @param referencedSize - Snapshot referenced size. */
     public Builder setReferencedSize(long referencedSize) {
       this.referencedSize = referencedSize;
       return this;
     }
 
+    /** @param referencedReplicatedSize - Snapshot referenced size w/ replication. */
     public Builder setReferencedReplicatedSize(long referencedReplicatedSize) {
       this.referencedReplicatedSize = referencedReplicatedSize;
       return this;
     }
 
+    /** @param exclusiveSize - Snapshot exclusive size. */
     public Builder setExclusiveSize(long exclusiveSize) {
       this.exclusiveSize = exclusiveSize;
       return this;
     }
 
+    /** @param exclusiveReplicatedSize - Snapshot exclusive size w/ replication. */
     public Builder setExclusiveReplicatedSize(long exclusiveReplicatedSize) {
       this.exclusiveReplicatedSize = exclusiveReplicatedSize;
       return this;
@@ -435,27 +413,7 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
 
     public SnapshotInfo build() {
       Preconditions.checkNotNull(name);
-      return new SnapshotInfo(
-          snapshotId,
-          name,
-          volumeName,
-          bucketName,
-          snapshotStatus,
-          creationTime,
-          deletionTime,
-          pathPreviousSnapshotId,
-          globalPreviousSnapshotId,
-          snapshotPath,
-          checkpointDir,
-          dbTxSequenceNumber,
-          deepClean,
-          sstFiltered,
-          referencedSize,
-          referencedReplicatedSize,
-          exclusiveSize,
-          exclusiveReplicatedSize,
-          deepCleanedDeletedDir
-      );
+      return new SnapshotInfo(this);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor some constructors in `package org.apache.hadoop.ozone.om.helpers` to eliminate `@SuppressWarnings("parameternumber")`.

(`OmVolumeArgs` and `SnapshotDiffJob` still have suppression, those require more change, should be done separately.)

https://issues.apache.org/jira/browse/HDDS-10394

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8033013820