### PR TITLE
HDDS-10423. Datanode fails to start with checksum size setting without suffix

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestOzoneClientConfig.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestOzoneClientConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestOzoneClientConfig {
+
+  @Test
+  void missingSizeSuffix() {
+    final int bytes = 1024;
+
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setInt("ozone.client.bytes.per.checksum", bytes);
+
+    OzoneClientConfig subject = conf.getObject(OzoneClientConfig.class);
+
+    assertEquals(bytes, subject.getBytesPerChecksum());
+  }
+}

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigType.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigType.java
@@ -118,7 +118,7 @@ public enum ConfigType {
   SIZE {
     @Override
     Object parse(String value, Config config, Class<?> type, String key) {
-      StorageSize measure = StorageSize.parse(value);
+      StorageSize measure = StorageSize.parse(value, config.sizeUnit());
       long val = Math.round(measure.getUnit().toBytes(measure.getValue()));
       if (type == int.class) {
         return (int) val;
@@ -130,9 +130,9 @@ public enum ConfigType {
     void set(ConfigurationTarget target, String key, Object value,
         Config config) {
       if (value instanceof Long) {
-        target.setStorageSize(key, (long) value, StorageUnit.BYTES);
+        target.setStorageSize(key, (long) value, config.sizeUnit());
       } else if (value instanceof Integer) {
-        target.setStorageSize(key, (int) value, StorageUnit.BYTES);
+        target.setStorageSize(key, (int) value, config.sizeUnit());
       } else {
         throw new ConfigurationException("Unsupported type " + value.getClass()
             + " for " + key);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Missing size suffix in some config properties can prevent Datanode from starting up:

```
[main] ERROR ozone.HddsDatanodeService: Exception in HddsDatanodeService.
org.apache.hadoop.hdds.conf.ConfigurationException: Failed to inject configuration to OzoneClientConfig.bytesPerChecksum
	at org.apache.hadoop.hdds.conf.ConfigurationReflectionUtil.setField(ConfigurationReflectionUtil.java:146)
	at org.apache.hadoop.hdds.conf.ConfigurationReflectionUtil.injectConfigurationToObject(ConfigurationReflectionUtil.java:103)
	at org.apache.hadoop.hdds.conf.ConfigurationReflectionUtil.injectConfiguration(ConfigurationReflectionUtil.java:73)
	at org.apache.hadoop.hdds.conf.ConfigurationSource.getObject(ConfigurationSource.java:177)
	at org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator.<init>(ECReconstructionCoordinator.java:128)
	at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.<init>(DatanodeStateMachine.java:223)
	at org.apache.hadoop.ozone.HddsDatanodeService.start(HddsDatanodeService.java:299)
	...
	at org.apache.hadoop.ozone.HddsDatanodeService.main(HddsDatanodeService.java:163)
Caused by: java.lang.IllegalArgumentException: 1024 is not in expected format.Expected format is <number><unit>. e.g. 1000MB
	at org.apache.hadoop.hdds.conf.StorageSize.parse(StorageSize.java:61)
	at org.apache.hadoop.hdds.conf.ConfigType$7.parse(ConfigType.java:121)
	at org.apache.hadoop.hdds.conf.ConfigurationReflectionUtil.setField(ConfigurationReflectionUtil.java:142)
	... 20 more
```

If suffix is not given, use the unit given for the config property (defaults to bytes).

https://issues.apache.org/jira/browse/HDDS-10423

## How was this patch tested?

Added unit test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/8051537545