### PR TITLE
HDDS-9235. ReplicationManager metrics not collected after restart.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -294,6 +294,7 @@ public class ReplicationManager implements SCMService {
     if (!isRunning()) {
       LOG.info("Starting Replication Monitor Thread.");
       running = true;
+      metrics = ReplicationManagerMetrics.create(this);
       if (rmConf.isLegacyEnabled()) {
         legacyReplicationManager.setMetrics(metrics);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -235,10 +235,15 @@ public final class ReplicationManagerMetrics implements MetricsSource {
   }
 
   public static ReplicationManagerMetrics create(ReplicationManager manager) {
-    return DefaultMetricsSystem.instance().register(METRICS_SOURCE_NAME,
-        "SCM Replication manager (closed container replication) related "
-            + "metrics",
-        new ReplicationManagerMetrics(manager));
+    ReplicationManagerMetrics replicationManagerMetrics = (ReplicationManagerMetrics)
+        DefaultMetricsSystem.instance().getSource(METRICS_SOURCE_NAME);
+    if (replicationManagerMetrics == null) {
+      return DefaultMetricsSystem.instance().register(METRICS_SOURCE_NAME,
+          "SCM Replication manager (closed container replication) related "
+              + "metrics",
+          new ReplicationManagerMetrics(manager));
+    }
+    return replicationManagerMetrics;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
ReplicationManager can be stopped/restarted by admin from CLI. `stop() `unregisters the metrics source, and `start()` used to (re)create it. But now after #5126  it isn't re-created, so it won't work after restart. This patch fixes that by initiating  `ReplicationManagerMetrics` again during `start()` with the same instance. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9235

## How was this patch tested?

Existing Tests.
