### PR TITLE
HDDS-10425. Increase OM transaction index for non-Ratis based on existing Ratis transactionInfoTable

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2153,15 +2153,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   long getLastTrxnIndexForNonRatis() throws IOException {
     TransactionInfo transactionInfo =
         TransactionInfo.readTransactionInfo(metadataManager);
-    // If the OMTransactionInfo does not exist in DB or if the term is not -1
-    // (corresponding to non-Ratis cluster), return 0 so that new incoming
+    // If the OMTransactionInfo does not exist in DB, return 0 so that new incoming
     // requests can have transaction index starting from 1.
-    if (transactionInfo == null || transactionInfo.getTerm() != -1) {
+    if (transactionInfo == null) {
       return 0;
     }
-    // If there exists a last transaction index in DB, the new incoming
-    // requests in non-Ratis cluster must have transaction index
-    // incrementally increasing from the stored transaction index onwards.
+    // If there exists a last transaction index in DB, including two cases:
+    // 1. the term is -1 corresponds to an existing non-Ratis cluster
+    // 2. or the term is not -1 indicates that the DB may be migrated from Ratis cluster
+    // For both cases above, the new incoming requests in non-Ratis cluster must have
+    // transaction index incrementally increasing from the stored transaction index onwards.
     return transactionInfo.getTransactionIndex();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2159,8 +2159,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return 0;
     }
     // If there exists a last transaction index in DB, including two cases:
-    // 1. the term is -1 corresponds to an existing non-Ratis cluster
-    // 2. or the term is not -1 indicates that the DB may be migrated from Ratis cluster
+    // 1. transactionInfo.getTerm() == -1 corresponds to a non-Ratis cluster
+    // 2. transactionInfo.getTerm() != -1 indicates that the DB may be migrated from Ratis cluster
     // For both cases above, the new incoming requests in non-Ratis cluster must have
     // transaction index incrementally increasing from the stored transaction index onwards.
     return transactionInfo.getTransactionIndex();


### PR DESCRIPTION
## What changes were proposed in this pull request?
ObjectIDs duplicate when non-Ratis OM start from an existing Ratis transactionInfoTable.
Transaction index should increase incrementally based on the existing transactionInfoTable for non-Ratis rather than from 0.
This approach will facilitate the migration from Ratis to non-Ratis scenarios seamlessly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10425

## How was this patch tested?

**manual tests.**
For origin ratis transactionInfoTable
```bash
bin/ozone debug ldb --db=/home/hadoop/cluster-data/ozonedata/om/db/om.db scan --cf=transactionInfoTable

{ "#TRANSACTIONINFO": {
"term" : 1,
"transactionIndex" : 9
}
```
**(1) without pr**
migrate to non-ratis
```bash
bin/ozone debug ldb --db=/home/hadoop/cluster-data/ozonedata/om/db/om.db scan --cf=transactionInfoTable

{ "#TRANSACTIONINFO": {
  "term" : -1,
  "transactionIndex" : 3
}
```
**(2) with pr**
migrate to non-ratis
```bash
bin/ozone debug ldb --db=/home/hadoop/cluster-data/ozonedata/om/db/om.db scan --cf=transactionInfoTable
{ "#TRANSACTIONINFO": {
  "term" : -1,
  "transactionIndex" : 11
}
```
TransactionIndex 11 increases  from 9 is what we expect.
