### PR TITLE
HDDS-10428. OzoneClientConfig#validate doesn't get called

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -231,7 +231,7 @@ public class OzoneClientConfig {
   private String fsDefaultBucketLayout = "FILE_SYSTEM_OPTIMIZED";
 
   @PostConstruct
-  private void validate() {
+  public void validate() {
     Preconditions.checkState(streamBufferSize > 0);
     Preconditions.checkState(streamBufferFlushSize > 0);
     Preconditions.checkState(streamBufferMaxSize > 0);

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestOzoneClientConfig.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/TestOzoneClientConfig.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_BYTES_PER_CHECKSUM_MIN_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestOzoneClientConfig {
@@ -33,6 +34,6 @@ class TestOzoneClientConfig {
 
     OzoneClientConfig subject = conf.getObject(OzoneClientConfig.class);
 
-    assertEquals(bytes, subject.getBytesPerChecksum());
+    assertEquals(OZONE_CLIENT_BYTES_PER_CHECKSUM_MIN_SIZE, subject.getBytesPerChecksum());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix the issue that OzoneClientConfig#validate doesn't get called. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10428

## How was this patch tested?

improved unit test
