### PR TITLE
HDDS-10432. Hadoop FS client write(byte[], int, int) is very slow in streaming

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ByteBufferOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ByteBufferOutputStream.java
@@ -40,6 +40,11 @@ public abstract class ByteBufferOutputStream extends OutputStream
   }
 
   @Override
+  public void write(@Nonnull byte[] byteArray, int off, int len) throws IOException {
+    write(ByteBuffer.wrap(byteArray), off, len);
+  }
+
+  @Override
   public void write(int b) throws IOException {
     write(new byte[]{(byte) b});
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

See [HDDS-10432](https://issues.apache.org/jira/browse/HDDS-10432).  Currently `write(byte[], int, int)` is inherited from OutputStream and thus write byte by byte.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10432

## How was this patch tested?

CI