### PR TITLE
HDDS-10252. [hsync] Revisit configuration keys for incremental chunk list after HDDS-9884

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -230,7 +230,7 @@ public class OzoneClientConfig {
           "list rather than full chunk list to optimize performance. " +
           "Critical to HBase.",
       tags = ConfigTag.CLIENT)
-  private boolean incrementalChunkList = false;
+  private boolean incrementalChunkList = true;
 
   @PostConstruct
   private void validate() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -146,7 +146,7 @@ public final class ScmConfigKeys {
       "32KB";
 
   public static final String OZONE_CHUNK_LIST_INCREMENTAL =
-      "ozone.chunk.list.incremental";
+      "ozone.incremental.chunk.list";
   public static final boolean OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT = true;
 
   public static final String OZONE_SCM_CONTAINER_LAYOUT_KEY =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -147,7 +147,7 @@ public final class ScmConfigKeys {
 
   public static final String OZONE_CHUNK_LIST_INCREMENTAL =
       "ozone.chunk.list.incremental";
-  public static final boolean OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT = false;
+  public static final boolean OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT = true;
 
   public static final String OZONE_SCM_CONTAINER_LAYOUT_KEY =
       "ozone.scm.container.layout";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -126,7 +126,7 @@ public final class OzoneConfigKeys {
   public static final String OZONE_FS_HSYNC_ENABLED
       = "ozone.fs.hsync.enabled";
   public static final boolean OZONE_FS_HSYNC_ENABLED_DEFAULT
-      = false;
+      = true;
 
   /**
    * hsync lease soft limit.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -856,7 +856,7 @@
     </description>
   </property>
   <property>
-    <name>ozone.chunk.list.incremental</name>
+    <name>ozone.incremental.chunk.list</name>
     <value>true</value>
     <tag>OZONE, CLIENT, DATANODE, PERFORMANCE</tag>
     <description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -857,7 +857,7 @@
   </property>
   <property>
     <name>ozone.chunk.list.incremental</name>
-    <value>false</value>
+    <value>true</value>
     <tag>OZONE, CLIENT, DATANODE, PERFORMANCE</tag>
     <description>
       By default, a writer client sends full chunk list of a block when it
@@ -4116,7 +4116,7 @@
 
   <property>
     <name>ozone.fs.hsync.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <tag>OZONE, CLIENT</tag>
     <description>
       Enable hsync/hflush. By default they are disabled.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -42,7 +42,6 @@ import com.google.common.base.Preconditions;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.BCSID_MISMATCH;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNKNOWN_BCSID;
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT;
 
@@ -103,13 +102,11 @@ public class BlockManagerImpl implements BlockManager {
       boolean endOfBlock) throws IOException {
     return persistPutBlock(
         (KeyValueContainer) container,
-        data,
-        config,
-        endOfBlock);
+        data, endOfBlock);
   }
 
   public long persistPutBlock(KeyValueContainer container,
-      BlockData data, ConfigurationSource config, boolean endOfBlock)
+      BlockData data, boolean endOfBlock)
       throws IOException {
     Preconditions.checkNotNull(data, "BlockData cannot be null for put " +
         "operation.");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -111,6 +111,7 @@ public class GeneratorDatanode extends BaseGenerator {
   private int overlap;
 
   private ChunkManager chunkManager;
+  private BlockManagerImpl blockManager;
 
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
 
@@ -136,6 +137,7 @@ public class GeneratorDatanode extends BaseGenerator {
     BlockManager blockManager = new BlockManagerImpl(config);
     chunkManager = ChunkManagerFactory
         .createChunkManager(config, blockManager, null);
+    blockManager = new BlockManagerImpl(config);
 
     final Collection<String> storageDirs =
         HddsServerUtil.getDatanodeStorageDirs(config);
@@ -286,7 +288,7 @@ public class GeneratorDatanode extends BaseGenerator {
           writtenBytes += currentChunkSize;
         }
 
-        BlockManagerImpl.persistPutBlock(container, blockData, config, true);
+        blockManager.persistPutBlock(container, blockData, config, true);
 
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -60,7 +60,6 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.impl.BlockManagerImpl;
 import org.apache.hadoop.ozone.container.keyvalue.impl.ChunkManagerFactory;
-import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
 
 import com.codahale.metrics.Timer;
@@ -134,10 +133,9 @@ public class GeneratorDatanode extends BaseGenerator {
 
     config = createOzoneConfiguration();
 
-    BlockManager blockManager = new BlockManagerImpl(config);
+    blockManager = new BlockManagerImpl(config);
     chunkManager = ChunkManagerFactory
         .createChunkManager(config, blockManager, null);
-    blockManager = new BlockManagerImpl(config);
 
     final Collection<String> storageDirs =
         HddsServerUtil.getDatanodeStorageDirs(config);
@@ -288,7 +286,7 @@ public class GeneratorDatanode extends BaseGenerator {
           writtenBytes += currentChunkSize;
         }
 
-        blockManager.persistPutBlock(container, blockData, config, true);
+        blockManager.persistPutBlock(container, blockData, true);
 
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enable ozone.fs.hsync.enabled, ozone.chunk.list.incremental, ozone.client.incremental.chunk.list by default.

Please describe your PR in detail:
* Let's enable these features in HDDS-7593 branch.
* If DataNode has not completed upgrade, fall back to full chunk list mode.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10252

## How was this patch tested?

Unit test