### PR TITLE
HDDS-10437. Rename method to getContainersPendingReplication

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitor.java
@@ -35,6 +35,6 @@ public interface DatanodeAdminMonitor extends Runnable {
   void stopMonitoring(DatanodeDetails dn);
   Set<DatanodeAdminMonitorImpl.TrackedNode> getTrackedNodes();
   void setMetrics(NodeDecommissionMetrics metrics);
-  Map<String, List<ContainerID>> getContainersReplicatedOnNode(DatanodeDetails dn)
+  Map<String, List<ContainerID>> getContainersPendingReplication(DatanodeDetails dn)
       throws NodeNotFoundException;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -494,7 +494,8 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
     return underReplicated == 0 && unclosed == 0;
   }
 
-  public Map<String, List<ContainerID>> getContainersReplicatedOnNode(DatanodeDetails dn) {
+  @Override
+  public Map<String, List<ContainerID>> getContainersPendingReplication(DatanodeDetails dn) {
     Iterator<TrackedNode> iterator = trackedNodes.iterator();
     while (iterator.hasNext()) {
       TrackedNode trackedNode = iterator.next();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -294,9 +294,9 @@ public class NodeDecommissionManager {
         TimeUnit.SECONDS);
   }
 
-  public Map<String, List<ContainerID>> getContainersReplicatedOnNode(DatanodeDetails dn)
+  public Map<String, List<ContainerID>> getContainersPendingReplication(DatanodeDetails dn)
       throws NodeNotFoundException {
-    return getMonitor().getContainersReplicatedOnNode(dn);
+    return getMonitor().getContainersPendingReplication(dn);
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -592,7 +592,7 @@ public class SCMClientProtocolServer implements
   @Override
   public Map<String, List<ContainerID>> getContainersOnDecomNode(DatanodeDetails dn) throws IOException {
     try {
-      return scm.getScmDecommissionManager().getContainersReplicatedOnNode(dn);
+      return scm.getScmDecommissionManager().getContainersPendingReplication(dn);
     } catch (NodeNotFoundException e) {
       throw new IOException("Failed to get containers list. Unable to find required node", e);
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -864,8 +864,8 @@ public class TestDatanodeAdminMonitor {
     assertEquals(1, monitor.getTrackedNodeCount());
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
         nodeManager.getNodeStatus(dn1).getOperationalState());
-    assertEquals(monitor.getContainersReplicatedOnNode(dn1).get("UnderReplicated").size(), 2);
-    assertEquals(monitor.getContainersReplicatedOnNode(dn1).get("UnClosed").size(), 0);
+    assertEquals(monitor.getContainersPendingReplication(dn1).get("UnderReplicated").size(), 2);
+    assertEquals(monitor.getContainersPendingReplication(dn1).get("UnClosed").size(), 0);
 
     DatanodeAdminMonitorTestUtil
         .mockGetContainerReplicaCount(repManager,
@@ -877,8 +877,8 @@ public class TestDatanodeAdminMonitor {
     assertEquals(1, monitor.getTrackedNodeCount());
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
         nodeManager.getNodeStatus(dn1).getOperationalState());
-    assertEquals(monitor.getContainersReplicatedOnNode(dn1).get("UnderReplicated").size(), 0);
-    assertEquals(monitor.getContainersReplicatedOnNode(dn1).get("UnClosed").size(), 2);
+    assertEquals(monitor.getContainersPendingReplication(dn1).get("UnderReplicated").size(), 0);
+    assertEquals(monitor.getContainersPendingReplication(dn1).get("UnClosed").size(), 2);
   }
 
   /**

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -124,12 +124,12 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           double underReplicated = Double.parseDouble(counts.get("UnderReplicatedDN." + i).toString());
           double unclosed = Double.parseDouble(counts.get("UnclosedContainersDN." + i).toString());
           long startTime = Long.parseLong(counts.get("StartTimeDN." + i).toString());
-          System.out.print("Decommission started at : ");
+          System.out.print("Decommission Started At : ");
           Date date = new Date(startTime);
           DateFormat formatter = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss z");
           System.out.println(formatter.format(date));
-          System.out.println("No. of Pipelines: " + pipelines);
-          System.out.println("No. of UnderReplicated containers: " + underReplicated);
+          System.out.println("No. of Unclosed Pipelines: " + pipelines);
+          System.out.println("No. of UnderReplicated Containers: " + underReplicated);
           System.out.println("No. of Unclosed Containers: " + unclosed);
           return;
         }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionStatusSubCommand.java
@@ -96,7 +96,7 @@ public class TestDecommissionStatusSubCommand {
     p = Pattern.compile("Datanode:\\s.*host1\\)");
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
     assertTrue(m.find());
-    p = Pattern.compile("No\\. of Pipelines:");
+    p = Pattern.compile("No\\. of Unclosed Pipelines:");
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
     assertTrue(m.find());
     assertTrue(m.find()); // metrics for both are shown


### PR DESCRIPTION
## What changes were proposed in this pull request?

DatanodeAdminMonitor#getContainersReplicatedOnNode() is renamed to something more appropriate i.e., getContainersPendingReplication() as the method only returns a list of under-replicated and unclosed containers, and not all containers like the current name would suggest. Some other minor improvements are also done for the output of `ozone admin datanode status decommission` command to make output match up with the design doc attached the the parent Jira HDDS-9324

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10437

## How was this patch tested?

As it is minor code refactoring, existing tests cover the cases.
