### PR TITLE
HDDS-10265. Use SnapshotId in BackgroundServices.

### DIFF
--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1315,8 +1315,9 @@ message DeletedKeys {
 message PurgeKeysRequest {
     repeated DeletedKeys deletedKeys = 1;
     // if set, will purge keys in a snapshot DB instead of active DB
-    optional string snapshotTableKey = 2;
+    optional string snapshotTableKey = 2 [deprecated = true];
     repeated SnapshotMoveKeyInfos keysToUpdate = 3;
+    optional hadoop.hdds.UUID snapshotId = 4;
 }
 
 message PurgeKeysResponse {
@@ -1338,7 +1339,8 @@ message PurgePathsResponse {
 
 message PurgeDirectoriesRequest {
   repeated PurgePathRequest deletedPath = 1;
-  optional string snapshotTableKey = 2;
+  optional string snapshotTableKey = 2 [deprecated = true];
+  optional hadoop.hdds.UUID snapshotId = 3;
 }
 
 message PurgeDirectoriesResponse {
@@ -1893,11 +1895,12 @@ message PrintCompactionLogDagRequest {
 }
 
 message SnapshotMoveDeletedKeysRequest {
-  optional SnapshotInfo fromSnapshot = 1;
+  optional SnapshotInfo fromSnapshot = 1 [deprecated = true];
   repeated SnapshotMoveKeyInfos nextDBKeys = 2;
   repeated SnapshotMoveKeyInfos reclaimKeys = 3;
   repeated hadoop.hdds.KeyValue renamedKeys = 4;
   repeated string deletedDirsToMove = 5;
+  optional hadoop.hdds.UUID snapshotId = 6;
 }
 
 message SnapshotMoveKeyInfos {
@@ -1906,16 +1909,18 @@ message SnapshotMoveKeyInfos {
 }
 
 message SnapshotPurgeRequest {
-  repeated string snapshotDBKeys = 1;
+  repeated string snapshotDBKeys = 1 [deprecated = true];
   repeated string updatedSnapshotDBKey = 2 [deprecated = true];
+  repeated hadoop.hdds.UUID snapshotIds = 3;
 }
 
 message SetSnapshotPropertyRequest {
   optional SnapshotProperty snapshotProperty = 1 [deprecated = true];
-  optional string snapshotKey = 2;
+  optional string snapshotKey = 2 [deprecated = true];
   optional SnapshotSize snapshotSize = 3;
   optional bool deepCleanedDeletedDir = 4;
   optional bool deepCleanedDeletedKey = 5;
+  optional hadoop.hdds.UUID snapshotId = 6;
 }
 
 // SnapshotProperty in entirely deprecated, Keeping it here for proto.lock compatibility

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -75,6 +75,11 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
 
     OMMetrics omMetrics = ozoneManager.getMetrics();
     try {
+      if (purgeDirsRequest.hasSnapshotTableKey()) {
+        throw new OMException("The field snapshotTableKey from PurgeDirectoriesRequest is deprecated." +
+            " The request will be retried in the next try", OMException.ResultCodes.INTERNAL_ERROR);
+      }
+
       if (fromSnapshotId != null) {
         String snapTableKey = metadataManager.getSnapshotChainManager()
             .getTableKey(fromSnapshotId);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
@@ -79,6 +79,11 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
     }
 
     try {
+      if (purgeKeysRequest.hasSnapshotTableKey()) {
+        throw new OMException("The field snapshotTableKey from PurgeKeysRequest is deprecated." +
+            " The request will be retried in the next try", OMException.ResultCodes.INTERNAL_ERROR);
+      }
+
       SnapshotInfo fromSnapshotInfo = null;
       if (fromSnapshotId != null) {
         String snapTableKey = metadataManager.getSnapshotChainManager()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.ozone.om.request.snapshot;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
@@ -79,6 +80,11 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
     OzoneManagerProtocolProtos.OMResponse.Builder omResponse =
         OmResponseUtil.getOMResponseBuilder(getOmRequest());
     try {
+      if (moveDeletedKeysRequest.hasFromSnapshot()) {
+        throw new OMException("The field fromSnapshot from SnapshotMoveDeletedKeysRequest is deprecated." +
+            " The request will be retried in the next try", OMException.ResultCodes.INTERNAL_ERROR);
+      }
+
       String fromSnapshotKey = snapshotChainManager.getTableKey(fromSnapshotId);
       SnapshotInfo fromSnapshot = omMetadataManager.getSnapshotInfoTable().get(fromSnapshotKey);
       nextSnapshot = SnapshotUtils.getNextActiveSnapshot(fromSnapshot,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
@@ -41,7 +41,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
+import static org.apache.hadoop.hdds.HddsUtils.fromProtobuf;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.FILESYSTEM_SNAPSHOT;
 
 /**
@@ -68,8 +70,7 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
 
     SnapshotMoveDeletedKeysRequest moveDeletedKeysRequest =
         getOmRequest().getSnapshotMoveDeletedKeysRequest();
-    SnapshotInfo fromSnapshot = SnapshotInfo.getFromProtobuf(
-        moveDeletedKeysRequest.getFromSnapshot());
+    UUID fromSnapshotId = fromProtobuf(moveDeletedKeysRequest.getSnapshotId());
 
     // If there is no Non-Deleted Snapshot move the
     // keys to Active Object Store.
@@ -78,6 +79,8 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
     OzoneManagerProtocolProtos.OMResponse.Builder omResponse =
         OmResponseUtil.getOMResponseBuilder(getOmRequest());
     try {
+      String fromSnapshotKey = snapshotChainManager.getTableKey(fromSnapshotId);
+      SnapshotInfo fromSnapshot = omMetadataManager.getSnapshotInfoTable().get(fromSnapshotKey);
       nextSnapshot = SnapshotUtils.getNextActiveSnapshot(fromSnapshot,
           snapshotChainManager, omSnapshotManager);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.ozone.om.request.snapshot;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -78,6 +79,11 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
         .getSnapshotPurgeRequest();
 
     try {
+      if (!snapshotPurgeRequest.getSnapshotDBKeysList().isEmpty()) {
+        throw new OMException("The field snapshotDBKeys from SnapshotPurgeRequest is deprecated." +
+            " The request will be retried in the next try", OMException.ResultCodes.INTERNAL_ERROR);
+      }
+
       List<HddsProtos.UUID> snapshotIds = snapshotPurgeRequest
           .getSnapshotIdsList();
       List<String> snapshotDbKeys = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotSetPropertyRequest.java
@@ -65,6 +65,11 @@ public class OMSnapshotSetPropertyRequest extends OMClientRequest {
     SnapshotInfo updatedSnapInfo = null;
 
     try {
+      if (setSnapshotPropertyRequest.hasSnapshotKey()) {
+        throw new OMException("The field snapshotKey from SetSnapshotPropertyRequest is deprecated." +
+            " The request will be retried in the next try", OMException.ResultCodes.INTERNAL_ERROR);
+      }
+
       UUID snapshotId = fromProtobuf(setSnapshotPropertyRequest.getSnapshotId());
       String snapshotKey = metadataManager.getSnapshotChainManager().getTableKey(snapshotId);
       updatedSnapInfo = metadataManager.getSnapshotInfoTable().get(snapshotKey);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
+import static org.apache.hadoop.hdds.HddsUtils.toProtobuf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -93,8 +94,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
    * Create OMRequest which encapsulates DeleteKeyRequest.
    * @return OMRequest
    */
-  private OMRequest createPurgeKeysRequest(List<String> deletedKeys,
-       String snapshotDbKey) {
+  private OMRequest createPurgeKeysRequest(List<String> deletedKeys, UUID snapshotId) {
     DeletedKeys deletedKeysInBucket = DeletedKeys.newBuilder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -103,8 +103,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     PurgeKeysRequest.Builder purgeKeysRequest = PurgeKeysRequest.newBuilder()
         .addDeletedKeys(deletedKeysInBucket);
 
-    if (snapshotDbKey != null) {
-      purgeKeysRequest.setSnapshotTableKey(snapshotDbKey);
+    if (snapshotId != null) {
+      purgeKeysRequest.setSnapshotId(toProtobuf(snapshotId));
     }
     purgeKeysRequest.build();
 
@@ -231,7 +231,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
     // Create PurgeKeysRequest to purge the deleted keys
     OMRequest omRequest = createPurgeKeysRequest(deletedKeyNames,
-        snapInfo.getTableKey());
+        snapInfo.getSnapshotId());
 
     OMRequest preExecutedRequest = preExecute(omRequest);
     OMKeyPurgeRequest omKeyPurgeRequest =


### PR DESCRIPTION
## What changes were proposed in this pull request?

With #6006, We support snapshot rename operation. Many of the background services sends `OMRequest` with respect to `snapshotTableKey`. If there is a rename operation that happens in-between the request, It will fail and the system may be in an undesirable state. In this PR, Instead of using `snapshotTableKey`  we are changing the background services to use `snapshotId` which remains constant throughout a snapshot's lifetime.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10265

## How was this patch tested?

Existing Tests.
