### PR TITLE
HDDS-10329. [snapshot] Add unit-test for recreating snapshots with deleted snapshot names

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -25,11 +25,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -66,12 +69,13 @@ class TestOzoneFsSnapshot {
   private static final String OM_SERVICE_ID = "om-service-test1";
   private static OzoneManager ozoneManager;
   private static OzoneFsShell shell;
+  private static final AtomicInteger counter = new AtomicInteger();
   private static final String VOLUME =
-      "vol-" + RandomStringUtils.randomNumeric(5);
+      "vol-" + counter.incrementAndGet();
   private static final String BUCKET =
-      "buck-" + RandomStringUtils.randomNumeric(5);
+      "buck-" + counter.incrementAndGet();
   private static final String KEY =
-      "key-" + RandomStringUtils.randomNumeric(5);
+      "key-" + counter.incrementAndGet();
   private static final String BUCKET_PATH =
       OM_KEY_PREFIX + VOLUME + OM_KEY_PREFIX + BUCKET;
   private static final String BUCKET_WITH_SNAPSHOT_INDICATOR_PATH =
@@ -128,7 +132,7 @@ class TestOzoneFsSnapshot {
 
   @Test
   void testCreateSnapshotDuplicateName() throws Exception {
-    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String snapshotName = "snap-" + counter.incrementAndGet();
 
     int res = ToolRunner.run(shell,
         new String[]{"-createSnapshot", BUCKET_PATH, snapshotName});
@@ -152,7 +156,7 @@ class TestOzoneFsSnapshot {
     // rather than:
     // Created snapshot ofs://om/vol1/buck2/dir3/.snapshot/snap1
 
-    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String snapshotName = "snap-" + counter.incrementAndGet();
 
     String dirPath = BUCKET_PATH + "/dir1/";
 
@@ -257,7 +261,7 @@ class TestOzoneFsSnapshot {
    */
   @Test
   void testFsLsSnapshot(@TempDir Path tempDir) throws Exception {
-    String key1 = "key-" + RandomStringUtils.randomNumeric(5);
+    String key1 = "key-" + counter.incrementAndGet();
     String newKeyPath = BUCKET_PATH + OM_KEY_PREFIX + key1;
     // Pause SnapshotDeletingService so that Snapshot marked deleted is not reclaimed.
     ozoneManager.getKeyManager().getSnapshotDeletingService().suspend();
@@ -274,7 +278,7 @@ class TestOzoneFsSnapshot {
       String snapshotPath1 = BUCKET_WITH_SNAPSHOT_INDICATOR_PATH +
           OM_KEY_PREFIX + snapshotName1;
 
-      String key2 = "key-" + RandomStringUtils.randomNumeric(5);
+      String key2 = "key-" + counter.incrementAndGet();
       String newKeyPath2 = BUCKET_PATH + OM_KEY_PREFIX + key2;
       execShellCommandAndGetOutput(0,
           new String[]{"-put", tempFile.toString(), newKeyPath2});
@@ -413,6 +417,67 @@ class TestOzoneFsSnapshot {
     assertThat(errorMessage).contains(expectedMessage);
   }
 
+  @Test
+  public void testSnapshotReuseSnapName() throws Exception {
+    String key1 = "key-" + counter.incrementAndGet();
+    int res = ToolRunner.run(shell, new String[]{"-touch",
+        BUCKET_PATH + OM_KEY_PREFIX + key1});
+    assertEquals(0, res);
+
+    String snap1 = "snap" + counter.incrementAndGet();
+    res = ToolRunner.run(shell,
+        new String[]{"-createSnapshot", BUCKET_PATH, snap1});
+    // Asserts that create request succeeded
+    assertEquals(0, res);
+
+    String listSnapOut = execShellCommandAndGetOutput(0,
+        new String[]{"-ls", BUCKET_WITH_SNAPSHOT_INDICATOR_PATH + OM_KEY_PREFIX + snap1});
+    assertThat(listSnapOut).contains(key1);
+
+    res = ToolRunner.run(shell,
+        new String[]{"-deleteSnapshot", BUCKET_PATH, snap1});
+    // Asserts that delete request succeeded
+    assertEquals(0, res);
+
+    // Wait for the snapshot to be marked deleted.
+    GenericTestUtils.waitFor(() -> {
+      try {
+        SnapshotInfo snapshotInfo = ozoneManager.getMetadataManager()
+            .getSnapshotInfoTable()
+            .get(SnapshotInfo.getTableKey(VOLUME, BUCKET, snap1));
+        return snapshotInfo.getSnapshotStatus() == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 200, 10000);
+
+    String key2 = "key-" + counter.incrementAndGet();
+    res = ToolRunner.run(shell, new String[]{"-touch",
+        BUCKET_PATH + OM_KEY_PREFIX + key2});
+    assertEquals(0, res);
+    String snap2 = "snap" + counter.incrementAndGet();
+    res = ToolRunner.run(shell,
+        new String[]{"-createSnapshot", BUCKET_PATH, snap2});
+    // Asserts that create request succeeded
+    assertEquals(0, res);
+
+    String key3 = "key-" + counter.incrementAndGet();
+    res = ToolRunner.run(shell, new String[]{"-touch",
+        BUCKET_PATH + OM_KEY_PREFIX + key3});
+    assertEquals(0, res);
+
+    res = ToolRunner.run(shell,
+        new String[]{"-createSnapshot", BUCKET_PATH, snap1});
+    // Asserts that create request succeeded
+    assertEquals(0, res);
+
+    listSnapOut = execShellCommandAndGetOutput(0,
+        new String[]{"-ls", BUCKET_WITH_SNAPSHOT_INDICATOR_PATH + OM_KEY_PREFIX + snap1});
+    assertThat(listSnapOut).contains(key1);
+    assertThat(listSnapOut).contains(key2);
+    assertThat(listSnapOut).contains(key3);
+  }
+
   /**
    * Execute a shell command with provided arguments
    * and return a string of the output.
@@ -453,7 +518,7 @@ class TestOzoneFsSnapshot {
   }
 
   private String createSnapshot() throws Exception {
-    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(5);
+    String snapshotName = "snap-" + counter.incrementAndGet();
 
     // Create snapshot
     int res = ToolRunner.run(shell,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsSnapshot.java
@@ -29,11 +29,8 @@ import java.util.stream.Stream;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.client.OzoneBucket;
-import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -73,7 +70,7 @@ class TestOzoneFsSnapshot {
   private static final String OM_SERVICE_ID = "om-service-test1";
   private static OzoneManager ozoneManager;
   private static OzoneFsShell shell;
-  private static final AtomicInteger counter = new AtomicInteger();
+  private static AtomicInteger counter = new AtomicInteger();
   private static final String VOLUME =
       "vol-" + counter.incrementAndGet();
   private static final String BUCKET =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -116,7 +116,11 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SE
 import static org.apache.hadoop.ozone.admin.scm.FinalizeUpgradeCommandUtil.isDone;
 import static org.apache.hadoop.ozone.admin.scm.FinalizeUpgradeCommandUtil.isStarting;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.*;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DISABLE_NATIVE_LIBS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_FORCE_FULL_DIFF;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_SST_FILTERING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OmSnapshotManager.DELIMITER;
 import static org.apache.hadoop.ozone.om.OmUpgradeConfig.ConfigStrings.OZONE_OM_INIT_DEFAULT_LAYOUT_VERSION;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -75,7 +75,6 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.service.SnapshotDiffCleanupService;
-import org.apache.hadoop.ozone.om.service.SnapshotDeletingService;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding unit-test for recreating snapshots with deleted snapshot names - `TestOmSnapshot#testSnapshotReuseSnapName`, 
`TestOzoneFsSnapshot#testSnapshotReuseSnapName`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10329

## How was this patch tested?
Tested using mvn for **TestOzoneFsSnapshot** and **TestOmSnapshot** inherited files - **TestOmSnapshotLegacy, TestOmSnapshotFsoWithNativeLib, TestOmSnapshotFsoWithoutNativeLib, TestOmSnapshotObjectStore**
