### PR TITLE
HDDS-10041. Do not start the daemon inside the OzoneManagerDoubleBuffer constructor.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -211,11 +211,15 @@ public final class OzoneManagerDoubleBuffer {
 
     this.isTracingEnabled = b.isTracingEnabled;
 
-    isRunning.set(true);
     // Daemon thread which runs in background and flushes transactions to DB.
     daemon = new Daemon(this::flushTransactions);
     daemon.setName(b.threadPrefix + "OMDoubleBufferFlushThread");
+  }
+
+  public OzoneManagerDoubleBuffer start() {
     daemon.start();
+    isRunning.set(true);
+    return this;
   }
 
   private boolean isRatisEnabled() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -67,7 +68,6 @@ import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
-import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -159,7 +159,6 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.util.MetricUtil.captureLatencyNs;
 
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
-import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.ProtobufUtils;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.slf4j.Logger;
@@ -173,13 +172,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   static final Logger LOG =
       LoggerFactory.getLogger(OzoneManagerRequestHandler.class);
   private final OzoneManager impl;
-  private OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer;
   private FaultInjector injector;
 
-  public OzoneManagerRequestHandler(OzoneManager om,
-      OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer) {
+  public OzoneManagerRequestHandler(OzoneManager om) {
     this.impl = om;
-    this.ozoneManagerDoubleBuffer = ozoneManagerDoubleBuffer;
   }
 
   //TODO simplify it to make it shorter
@@ -392,27 +388,14 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @Override
-  public OMClientResponse handleWriteRequest(OMRequest omRequest, TermIndex termIndex) throws IOException {
+  public OMClientResponse handleWriteRequestImpl(OMRequest omRequest, TermIndex termIndex) throws IOException {
     injectPause();
     OMClientRequest omClientRequest =
         OzoneManagerRatisUtils.createClientRequest(omRequest, impl);
     return captureLatencyNs(
         impl.getPerfMetrics().getValidateAndUpdateCacheLatencyNs(),
-        () -> {
-          OMClientResponse omClientResponse =
-              omClientRequest.validateAndUpdateCache(getOzoneManager(), termIndex);
-          Preconditions.checkNotNull(omClientResponse,
-              "omClientResponse returned by validateAndUpdateCache cannot be null");
-          if (omRequest.getCmdType() != Type.Prepare) {
-            ozoneManagerDoubleBuffer.add(omClientResponse, termIndex);
-          }
-          return omClientResponse;
-        });
-  }
-
-  @Override
-  public void updateDoubleBuffer(OzoneManagerDoubleBuffer omDoubleBuffer) {
-    this.ozoneManagerDoubleBuffer = omDoubleBuffer;
+        () -> Objects.requireNonNull(omClientRequest.validateAndUpdateCache(getOzoneManager(), termIndex),
+            "omClientResponse returned by validateAndUpdateCache cannot be null"));
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/RequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/RequestHandler.java
@@ -20,10 +20,9 @@ package org.apache.hadoop.ozone.protocolPB;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
-    OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
-    OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.ratis.server.protocol.TermIndex;
 
 import java.io.IOException;
@@ -50,22 +49,30 @@ public interface RequestHandler {
   void validateRequest(OMRequest omRequest) throws OMException;
 
   /**
-   * Handle write requests. In HA this will be called from
-   * OzoneManagerStateMachine applyTransaction method. In non-HA this will be
-   * called from {@link OzoneManagerProtocolServerSideTranslatorPB} for write
-   * requests.
+   * Handle write requests.
+   * In HA this will be called from OzoneManagerStateMachine applyTransaction method.
+   * In non-HA this will be called from {@link OzoneManagerProtocolServerSideTranslatorPB}.
    *
-   * @param omRequest
-   * @param termIndex - ratis transaction log (term, index)
+   * @param omRequest the write request
+   * @param termIndex - ratis transaction term and index
+   * @param ozoneManagerDoubleBuffer for adding response
    * @return OMClientResponse
    */
-  OMClientResponse handleWriteRequest(OMRequest omRequest, TermIndex termIndex) throws IOException;
+  default OMClientResponse handleWriteRequest(OMRequest omRequest, TermIndex termIndex,
+      OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer) throws IOException {
+    final OMClientResponse response = handleWriteRequestImpl(omRequest, termIndex);
+    if (omRequest.getCmdType() != Type.Prepare) {
+      ozoneManagerDoubleBuffer.add(response, termIndex);
+    }
+    return response;
+  }
 
   /**
-   * Update the OzoneManagerDoubleBuffer. This will be called when
-   * stateMachine is unpaused and set with new doublebuffer object.
-   * @param ozoneManagerDoubleBuffer
+   * Implementation of {@link #handleWriteRequest(OMRequest, TermIndex, OzoneManagerDoubleBuffer)}.
+   *
+   * @param omRequest the write request
+   * @param termIndex - ratis transaction term and index
+   * @return OMClientResponse
    */
-  void updateDoubleBuffer(OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer);
-
+  OMClientResponse handleWriteRequestImpl(OMRequest omRequest, TermIndex termIndex) throws IOException;
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManager.java
@@ -156,7 +156,7 @@ public class TestOMMultiTenantManager {
 
     // Check that Multi-Tenancy read requests are blocked when not enabled
     final OzoneManagerRequestHandler ozoneManagerRequestHandler =
-        new OzoneManagerRequestHandler(ozoneManager, null);
+        new OzoneManagerRequestHandler(ozoneManager);
 
     expectReadRequestToFail(ozoneManagerRequestHandler,
         OMRequestTestUtils.listUsersInTenantRequest(tenantId));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBuffer.java
@@ -137,7 +137,8 @@ class TestOzoneManagerDoubleBuffer {
         .setMaxUnFlushedTransactionCount(1000)
         .enableRatis(true)
         .setFlushNotifier(spyFlushNotifier)
-        .build();
+        .build()
+        .start();
 
     doNothing().when(omKeyCreateResponse).checkAndUpdateDB(any(), any());
     doNothing().when(omBucketCreateResponse).checkAndUpdateDB(any(), any());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -79,7 +79,8 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
         .setOmMetadataManager(omMetadataManager)
         .setMaxUnFlushedTransactionCount(10000)
         .enableRatis(true)
-        .build();
+        .build()
+        .start();
   }
 
   @AfterEach

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -112,7 +112,8 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
         .setOmMetadataManager(omMetadataManager)
         .setMaxUnFlushedTransactionCount(100000)
         .enableRatis(true)
-        .build();
+        .build()
+        .start();
   }
 
   @AfterEach


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is generally a bad practice to start a thread inside a constructor; see https://stackoverflow.com/questions/11834173/why-shouldnt-i-use-thread-start-in-the-constructor-of-my-class

Also, quite a few tests (such as `TestOzoneManagerDoubleBuffer`) has to stop the daemon in order to eliminate the race condition in the very beginning.

## What is the link to the Apache JIRA

HDDS-10041

## How was this patch tested?

Updating existing tests.