### PR TITLE
HDDS-10445. OM admin CLI to enable force fetching network topology tree from SCM

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmTopologyClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/client/ScmTopologyClient.java
@@ -66,6 +66,12 @@ public class ScmTopologyClient {
         "ScmBlockLocationClient must have been initialized already.");
   }
 
+  public boolean refetchClusterTree(ConfigurationSource conf) {
+    // this would perform a force refresh of the network topology tree
+    // information from SCM.
+    return checkAndRefresh(conf);
+  }
+
   public void start(ConfigurationSource conf) throws IOException {
     final InnerNode initialTopology =
         scmBlockLocationProtocol.getNetworkTopology();
@@ -118,7 +124,7 @@ public class ScmTopologyClient {
     return Duration.ofMillis(refreshDurationInMs);
   }
 
-  private synchronized void checkAndRefresh(ConfigurationSource conf) {
+  private synchronized boolean checkAndRefresh(ConfigurationSource conf) {
     InnerNode current = (InnerNode) cache.get().getNode(ROOT);
     try {
       InnerNode newTopology = scmBlockLocationProtocol.getNetworkTopology();
@@ -128,10 +134,12 @@ public class ScmTopologyClient {
             ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_DEFAULT),
             newTopology));
         LOG.info("Updated network topology fetched from SCM: {}.", newTopology);
+        return true;
       }
     } catch (IOException e) {
       throw new UncheckedIOException(
           "Error fetching updated network topology from SCM", e);
     }
+    return false;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -273,6 +273,7 @@ public final class OmUtils {
     case SetSafeMode:
     case PrintCompactionLogDag:
     case GetSnapshotInfo:
+    case RefetchNetworkTopologyTree:
       return true;
     case CreateVolume:
     case SetVolumeProperty:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -1134,4 +1134,6 @@ public interface OzoneManagerProtocol
    */
   boolean setSafeMode(SafeModeAction action, boolean isChecked)
       throws IOException;
+
+  boolean refetchNetworkTopologyTree() throws IOException;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -1135,5 +1135,11 @@ public interface OzoneManagerProtocol
   boolean setSafeMode(SafeModeAction action, boolean isChecked)
       throws IOException;
 
+  /**
+   * API for OM to force fetch the network topology tree information from SCM
+   * without having to rely on ozone.om.network.topology.refresh.duration.
+   * @return status of the refetch operation (success/failure).
+   * @throws IOException
+   */
   boolean refetchNetworkTopologyTree() throws IOException;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -178,6 +178,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Recover
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverTrashResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchSecretKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchSecretKeyResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchNetworkTopologyTreeRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchNetworkTopologyTreeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeyRequest;
@@ -2561,6 +2563,19 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     SetSafeModeResponse setSafeModeResponse =
         handleError(submitRequest(omRequest)).getSetSafeModeResponse();
     return setSafeModeResponse.getResponse();
+  }
+
+  @Override
+  public boolean refetchNetworkTopologyTree() throws IOException {
+    final RefetchNetworkTopologyTreeRequest.Builder requestBuilder =
+        RefetchNetworkTopologyTreeRequest.newBuilder();
+    final OMRequest omRequest = createOMRequest(Type.RefetchNetworkTopologyTree)
+        .setRefetchNetworkTopologyTreeRequest(requestBuilder)
+        .build();
+    final OMResponse omResponse = submitRequest(omRequest);
+    final RefetchNetworkTopologyTreeResponse resp =
+        handleError(omResponse).getRefetchNetworkTopologyTreeResponse();
+    return resp.getStatus();
   }
 
   private SafeMode toProtoBuf(SafeModeAction action) {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -147,6 +147,7 @@ enum Type {
   ListStatusLight = 129;
   GetSnapshotInfo = 130;
   RenameSnapshot = 131;
+  RefetchNetworkTopologyTree = 132;
 }
 
 enum SafeMode {
@@ -283,6 +284,7 @@ message OMRequest {
   optional SetSnapshotPropertyRequest       SetSnapshotPropertyRequest     = 127;
   optional SnapshotInfoRequest              SnapshotInfoRequest            = 128;
   optional RenameSnapshotRequest            RenameSnapshotRequest          = 129;
+  optional RefetchNetworkTopologyTreeRequest RefetchNetworkTopologyTreeRequest = 130;
 }
 
 message OMResponse {
@@ -406,6 +408,7 @@ message OMResponse {
   optional SnapshotInfoResponse              SnapshotInfoResponse          = 130;
   optional OMLockDetailsProto                omLockDetails                 = 131;
   optional RenameSnapshotResponse            RenameSnapshotResponse        = 132;
+  optional RefetchNetworkTopologyTreeResponse RefetchNetworkTopologyTreeResponse = 133;
 }
 
 enum Status {
@@ -2127,6 +2130,13 @@ message OMLockDetailsProto {
   optional uint64 waitLockNanos    = 2;
   optional uint64 readLockNanos    = 3;
   optional uint64 writeLockNanos   = 4;
+}
+
+message RefetchNetworkTopologyTreeRequest {
+}
+
+message RefetchNetworkTopologyTreeResponse {
+    optional bool status = 1;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1094,9 +1094,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
   }
 
+  @Override
   public UUID refetchSecretKey() {
     secretKeyClient.refetchSecretKey();
     return secretKeyClient.getCurrentSecretKey().getId();
+  }
+
+  @Override
+  public boolean refetchNetworkTopologyTree() {
+    return scmTopologyClient.refetchClusterTree(configuration);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -95,6 +95,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetKeyI
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrintCompactionLogDagRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrintCompactionLogDagResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchSecretKeyResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RefetchNetworkTopologyTreeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoBucketRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoBucketResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoVolumeRequest;
@@ -370,6 +371,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         OzoneManagerProtocolProtos.SnapshotInfoResponse snapshotInfoResponse =
             getSnapshotInfo(request.getSnapshotInfoRequest());
         responseBuilder.setSnapshotInfoResponse(snapshotInfoResponse);
+        break;
+      case RefetchNetworkTopologyTree:
+        responseBuilder.setRefetchNetworkTopologyTreeResponse(
+            refetchNetworkTopologyTree());
         break;
       default:
         responseBuilder.setSuccess(false);
@@ -1475,6 +1480,15 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     return SetSafeModeResponse.newBuilder()
         .setResponse(response)
         .build();
+  }
+
+  private RefetchNetworkTopologyTreeResponse refetchNetworkTopologyTree() {
+    boolean status = impl.refetchNetworkTopologyTree();
+    RefetchNetworkTopologyTreeResponse response =
+        RefetchNetworkTopologyTreeResponse.newBuilder()
+            .setStatus(status)
+            .build();
+    return response;
   }
 
   private SafeModeAction toSafeModeAction(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/FetchNetworkTopologyTreeSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/FetchNetworkTopologyTreeSubCommand.java
@@ -38,7 +38,7 @@ public class FetchNetworkTopologyTreeSubCommand implements Callable<Void> {
   private OMAdmin parent;
 
   @CommandLine.Option(
-      names = {"-id", "--service-id"},
+      names = {"--service-id"},
       description = "Ozone Manager Service ID",
       required = false
   )

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/FetchNetworkTopologyTreeSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/FetchNetworkTopologyTreeSubCommand.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.admin.om;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import picocli.CommandLine;
+
+/**
+ * Handler of ozone admin om fetch-topology-tree command.
+ */
+@CommandLine.Command(
+    name = "fetch-topology-tree",
+    description = "CLI command for OM to force fetch the latest network " +
+        "topology tree information from SCM.",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+public class FetchNetworkTopologyTreeSubCommand implements Callable<Void> {
+  @CommandLine.ParentCommand
+  private OMAdmin parent;
+
+  @CommandLine.Option(
+      names = {"-id", "--service-id"},
+      description = "Ozone Manager Service ID",
+      required = false
+  )
+  private String omServiceId;
+
+  @Override
+  public Void call() throws Exception {
+    try (OzoneManagerProtocol client = parent.createOmClient(omServiceId)) {
+      boolean status = false;
+      try {
+        status = client.refetchNetworkTopologyTree();
+      } catch (IOException e) {
+        System.err.println("Force fetching network topology tree information " +
+            "has failed: " + e.getMessage());
+      }
+      if (status) {
+        System.out.println(
+            "Force fetching network topology tree information " +
+                "is complete.");
+      }
+    }
+    return null;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -60,7 +60,8 @@ import java.util.Collection;
         DecommissionOMSubcommand.class,
         UpdateRangerSubcommand.class,
         TransferOmLeaderSubCommand.class,
-        FetchKeySubCommand.class
+        FetchKeySubCommand.class,
+        FetchNetworkTopologyTreeSubCommand.class
     })
 @MetaInfServices(SubcommandWithParent.class)
 public class OMAdmin extends GenericCli implements SubcommandWithParent {


### PR DESCRIPTION
## What changes were proposed in this pull request?

OM has a background thread running that periodically refetches the updated network topology layout information from SCM for the refresh duration frequency of every one hour (default).

This change introduces an OM admin CLI for force fetching the network topology tree information from SCM (on demand) without having to rely on the configuration: `ozone.om.network.topology.refresh.duration`.

CLI usage:
```
ozone admin om fetch-topology-tree -id=omServiceId
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10445

## How was this patch tested?

- Added integration test.
- Green Git CI: https://github.com/tanvipenumudy/ozone/actions/runs/8108558196
