### PR TITLE
HDDS-10447. Extract helper methods from Ozone native ACL unit tests

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAclTestUtil.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAclTestUtil.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.security.acl;
+
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Helper for ACL tests. */
+final class OzoneNativeAclTestUtil {
+
+  public static void addVolumeAcl(
+      OMMetadataManager metadataManager,
+      String volume,
+      OzoneAcl ozoneAcl
+  ) throws IOException {
+    final String volumeKey = metadataManager.getVolumeKey(volume);
+    final Table<String, OmVolumeArgs> volumeTable = metadataManager.getVolumeTable();
+    final OmVolumeArgs omVolumeArgs = volumeTable.get(volumeKey);
+
+    omVolumeArgs.addAcl(ozoneAcl);
+
+    volumeTable.addCacheEntry(
+        new CacheKey<>(volumeKey),
+        CacheValue.get(1L, omVolumeArgs));
+  }
+
+  public static void addBucketAcl(
+      OMMetadataManager metadataManager,
+      String volume,
+      String bucket,
+      OzoneAcl ozoneAcl) throws IOException {
+    final String bucketKey = metadataManager.getBucketKey(volume, bucket);
+    final Table<String, OmBucketInfo> bucketTable = metadataManager.getBucketTable();
+    final OmBucketInfo omBucketInfo = bucketTable.get(bucketKey);
+
+    omBucketInfo.addAcl(ozoneAcl);
+
+    bucketTable.addCacheEntry(
+        new CacheKey<>(bucketKey),
+        CacheValue.get(1L, omBucketInfo));
+  }
+
+  public static void addKeyAcl(
+      OMMetadataManager metadataManager,
+      String volume,
+      String bucket,
+      BucketLayout bucketLayout,
+      String key,
+      OzoneAcl ozoneAcl
+  ) throws IOException {
+    final String objKey = metadataManager.getOzoneKey(volume, bucket, key);
+    final Table<String, OmKeyInfo> keyTable = metadataManager.getKeyTable(bucketLayout);
+    final OmKeyInfo omKeyInfo = keyTable.get(objKey);
+
+    omKeyInfo.addAcl(ozoneAcl);
+
+    keyTable.addCacheEntry(
+        new CacheKey<>(objKey),
+        CacheValue.get(1L, omKeyInfo));
+  }
+
+  public static void setVolumeAcl(
+      OMMetadataManager metadataManager,
+      String volume,
+      List<OzoneAcl> ozoneAcls) throws IOException {
+    final String volumeKey = metadataManager.getVolumeKey(volume);
+    final Table<String, OmVolumeArgs> volumeTable = metadataManager.getVolumeTable();
+    final OmVolumeArgs omVolumeArgs = volumeTable.get(volumeKey);
+
+    omVolumeArgs.setAcls(ozoneAcls);
+
+    volumeTable.addCacheEntry(
+        new CacheKey<>(volumeKey),
+        CacheValue.get(1L, omVolumeArgs));
+  }
+
+  public static void setBucketAcl(
+      OMMetadataManager metadataManager,
+      String volume,
+      String bucket,
+      List<OzoneAcl> ozoneAcls) throws IOException {
+    final String bucketKey = metadataManager.getBucketKey(volume, bucket);
+    final Table<String, OmBucketInfo> bucketTable = metadataManager.getBucketTable();
+    final OmBucketInfo omBucketInfo = bucketTable.get(bucketKey);
+
+    omBucketInfo.setAcls(ozoneAcls);
+
+    bucketTable.addCacheEntry(
+        new CacheKey<>(bucketKey),
+        CacheValue.get(1L, omBucketInfo));
+  }
+
+  public static void setKeyAcl(
+      OMMetadataManager metadataManager,
+      String volume,
+      String bucket,
+      BucketLayout bucketLayout,
+      String key,
+      List<OzoneAcl> ozoneAcls) throws IOException {
+    final String objKey = metadataManager.getOzoneKey(volume, bucket, key);
+    final Table<String, OmKeyInfo> keyTable = metadataManager.getKeyTable(bucketLayout);
+    final OmKeyInfo omKeyInfo = keyTable.get(objKey);
+
+    omKeyInfo.setAcls(ozoneAcls);
+
+    keyTable.addCacheEntry(
+        new CacheKey<>(objKey),
+        CacheValue.get(1L, omKeyInfo));
+  }
+
+  public static List<OzoneAcl> getVolumeAcls(
+      OMMetadataManager metadataManager,
+      String volume
+  ) throws IOException {
+    return metadataManager.getVolumeTable()
+        .get(metadataManager.getVolumeKey(volume))
+        .getAcls();
+  }
+
+  public static List<OzoneAcl> getBucketAcls(
+      OMMetadataManager metadataManager,
+      String volume,
+      String bucket
+  ) throws IOException {
+    return metadataManager.getBucketTable()
+        .get(metadataManager.getBucketKey(volume, bucket))
+        .getAcls();
+  }
+
+  public static List<OzoneAcl> getKeyAcls(
+      OMMetadataManager metadataManager,
+      String volume,
+      String bucket,
+      BucketLayout bucketLayout,
+      String key
+  ) throws IOException {
+    return metadataManager.getKeyTable(bucketLayout)
+        .get(metadataManager.getOzoneKey(volume, bucket, key))
+        .getAcls();
+  }
+
+  private OzoneNativeAclTestUtil() {
+    // utilities
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -21,8 +21,6 @@ import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.server.OzoneAdmins;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.BucketManager;
 import org.apache.hadoop.ozone.om.KeyManager;
@@ -314,45 +312,19 @@ public class TestOzoneNativeAuthorizer {
 
 
   private void setVolumeAcl(List<OzoneAcl> ozoneAcls) throws IOException {
-    String volumeKey = metadataManager.getVolumeKey(volObj.getVolumeName());
-    OmVolumeArgs omVolumeArgs =
-        metadataManager.getVolumeTable().get(volumeKey);
-
-    omVolumeArgs.setAcls(ozoneAcls);
-
-    metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-        CacheValue.get(1L, omVolumeArgs));
+    OzoneNativeAclTestUtil.setVolumeAcl(metadataManager, vol, ozoneAcls);
   }
 
   private void setBucketAcl(List<OzoneAcl> ozoneAcls) throws IOException {
-    String bucketKey = metadataManager.getBucketKey(vol, buck);
-    OmBucketInfo omBucketInfo = metadataManager.getBucketTable().get(bucketKey);
-
-    omBucketInfo.setAcls(ozoneAcls);
-
-    metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        CacheValue.get(1L, omBucketInfo));
+    OzoneNativeAclTestUtil.setBucketAcl(metadataManager, vol, buck, ozoneAcls);
   }
 
   private void addVolumeAcl(OzoneAcl ozoneAcl) throws IOException {
-    String volumeKey = metadataManager.getVolumeKey(volObj.getVolumeName());
-    OmVolumeArgs omVolumeArgs =
-        metadataManager.getVolumeTable().get(volumeKey);
-
-    omVolumeArgs.addAcl(ozoneAcl);
-
-    metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-        CacheValue.get(1L, omVolumeArgs));
+    OzoneNativeAclTestUtil.addVolumeAcl(metadataManager, vol, ozoneAcl);
   }
 
   private void addBucketAcl(OzoneAcl ozoneAcl) throws IOException {
-    String bucketKey = metadataManager.getBucketKey(vol, buck);
-    OmBucketInfo omBucketInfo = metadataManager.getBucketTable().get(bucketKey);
-
-    omBucketInfo.addAcl(ozoneAcl);
-
-    metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        CacheValue.get(1L, omBucketInfo));
+    OzoneNativeAclTestUtil.addBucketAcl(metadataManager, vol, buck, ozoneAcl);
   }
 
   private void resetAclsAndValidateAccess(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -23,8 +23,6 @@ import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.server.OzoneAdmins;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.BucketManager;
 import org.apache.hadoop.ozone.om.KeyManager;
@@ -34,7 +32,6 @@ import org.apache.hadoop.ozone.om.PrefixManager;
 import org.apache.hadoop.ozone.om.VolumeManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
@@ -265,88 +262,46 @@ public class TestParentAcl {
   }
 
   private void addVolumeAcl(String vol, OzoneAcl ozoneAcl) throws IOException {
-    String volumeKey = metadataManager.getVolumeKey(vol);
-    OmVolumeArgs omVolumeArgs =
-        metadataManager.getVolumeTable().get(volumeKey);
-
-    omVolumeArgs.addAcl(ozoneAcl);
-
-    metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-        CacheValue.get(1L, omVolumeArgs));
+    OzoneNativeAclTestUtil.addVolumeAcl(metadataManager, vol, ozoneAcl);
   }
 
   private List<OzoneAcl> getVolumeAcls(String vol) throws IOException {
-    String volumeKey = metadataManager.getVolumeKey(vol);
-    OmVolumeArgs omVolumeArgs =
-        metadataManager.getVolumeTable().get(volumeKey);
-
-    return omVolumeArgs.getAcls();
+    return OzoneNativeAclTestUtil.getVolumeAcls(metadataManager, vol);
   }
 
   private void setVolumeAcl(String vol, List<OzoneAcl> ozoneAcls)
       throws IOException {
-    String volumeKey = metadataManager.getVolumeKey(vol);
-    OmVolumeArgs omVolumeArgs = metadataManager.getVolumeTable().get(volumeKey);
-
-    omVolumeArgs.setAcls(ozoneAcls);
-
-    metadataManager.getVolumeTable().addCacheEntry(new CacheKey<>(volumeKey),
-        CacheValue.get(1L, omVolumeArgs));
+    OzoneNativeAclTestUtil.setVolumeAcl(metadataManager, vol, ozoneAcls);
   }
 
   private void addKeyAcl(String vol, String buck, String key,
       OzoneAcl ozoneAcl) throws IOException {
-    String objKey = metadataManager.getOzoneKey(vol, buck, key);
-    OmKeyInfo omKeyInfo =
-        metadataManager.getKeyTable(getBucketLayout()).get(objKey);
-
-    omKeyInfo.addAcl(ozoneAcl);
-
-    metadataManager.getKeyTable(getBucketLayout())
-        .addCacheEntry(new CacheKey<>(objKey),
-            CacheValue.get(1L, omKeyInfo));
+    OzoneNativeAclTestUtil.addKeyAcl(metadataManager, vol, buck, getBucketLayout(), key, ozoneAcl);
   }
 
   private void setKeyAcl(String vol, String buck, String key,
                          List<OzoneAcl> ozoneAcls) throws IOException {
-    String objKey = metadataManager.getOzoneKey(vol, buck, key);
-    OmKeyInfo omKeyInfo =
-        metadataManager.getKeyTable(getBucketLayout()).get(objKey);
-    omKeyInfo.setAcls(ozoneAcls);
-
-    metadataManager.getKeyTable(getBucketLayout())
-        .addCacheEntry(new CacheKey<>(objKey),
-            CacheValue.get(1L, omKeyInfo));
+    OzoneNativeAclTestUtil.setKeyAcl(metadataManager, vol, buck, getBucketLayout(), key, ozoneAcls);
   }
 
   private void addBucketAcl(String vol, String buck, OzoneAcl ozoneAcl)
       throws IOException {
-    String bucketKey = metadataManager.getBucketKey(vol, buck);
-    OmBucketInfo omBucketInfo = metadataManager.getBucketTable().get(bucketKey);
-
-    omBucketInfo.addAcl(ozoneAcl);
-
-    metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        CacheValue.get(1L, omBucketInfo));
+    OzoneNativeAclTestUtil.addBucketAcl(metadataManager, vol, buck, ozoneAcl);
   }
 
   private List<OzoneAcl> getBucketAcls(String vol, String buck)
       throws IOException {
-    String bucketKey = metadataManager.getBucketKey(vol, buck);
-    OmBucketInfo omBucketInfo = metadataManager.getBucketTable().get(bucketKey);
+    return OzoneNativeAclTestUtil.getBucketAcls(metadataManager, vol, buck);
+  }
 
-    return omBucketInfo.getAcls();
+  private List<OzoneAcl> getKeyAcls(String vol, String buck, String key)
+      throws IOException {
+    return OzoneNativeAclTestUtil.getKeyAcls(metadataManager, vol, buck, getBucketLayout(), key);
   }
 
   private void setBucketAcl(String vol, String buck,
       List<OzoneAcl> ozoneAcls) throws IOException {
-    String bucketKey = metadataManager.getBucketKey(vol, buck);
-    OmBucketInfo omBucketInfo = metadataManager.getBucketTable().get(bucketKey);
-
-    omBucketInfo.setAcls(ozoneAcls);
-
-    metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
-        CacheValue.get(1L, omBucketInfo));
+    OzoneNativeAclTestUtil.setBucketAcl(metadataManager, vol, buck, ozoneAcls);
   }
 
   private static OzoneObjInfo createVolume(String volumeName)


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestOzoneNativeAuthorizer` and `TestParentAcl` has some duplicated code that can be extracted into a helper class.

https://issues.apache.org/jira/browse/HDDS-10447

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8109661988