### PR TITLE
HDDS-10450. Add GitHub actions labeler for the reconciliation feature branch.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for .github/workflows/label-pr.yml
+# This workflow and its configuration can be deleted once the container reconciliation feature branch is merged.
+container-reconciliation:
+  - base-branch: HDDS-10239-container-reconciliation

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,8 @@
 # limitations under the License.
 
 # Configuration for .github/workflows/label-pr.yml
-# This workflow and its configuration can be deleted once the container reconciliation feature branch is merged.
+
+# This rule can be deleted once the container reconciliation feature branch is merged.
 container-reconciliation:
 - base-branch: HDDS-10239-container-reconciliation
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,4 +16,5 @@
 # Configuration for .github/workflows/label-pr.yml
 # This workflow and its configuration can be deleted once the container reconciliation feature branch is merged.
 container-reconciliation:
-  - base-branch: HDDS-10239-container-reconciliation
+- base-branch: HDDS-10239-container-reconciliation
+

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # This workflow reads its configuration from the .github/labeler.yml file.
-# This workflow and its configuration can be deleted once the website's feature branch is merged.
+# This workflow and its configuration can be deleted once the container reconciliation feature branch is merged.
 name: pull-request-labeler
 on:
 - pull_request_target

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -27,3 +27,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v5
+

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 # This workflow reads its configuration from the .github/labeler.yml file.
-# This workflow and its configuration can be deleted once the container reconciliation feature branch is merged.
 name: pull-request-labeler
 on:
 - pull_request_target

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -15,7 +15,7 @@
 
 # This workflow reads its configuration from the .github/labeler.yml file.
 # This workflow and its configuration can be deleted once the website's feature branch is merged.
-name: "Pull Request Labeler"
+name: pull-request-labeler
 on:
 - pull_request_target
 

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow reads its configuration from the .github/labeler.yml file.
+# This workflow and its configuration can be deleted once the website's feature branch is merged.
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
## What changes were proposed in this pull request?

Automatically label PRs targeting the container reconciliation feature branch.

## What is the link to the Apache JIRA

HDDS-10450

## How was this patch tested?

The workflow will not run until merged. There is a similar workflow running successfully for the ozone-site repo . See the [config](https://github.com/apache/ozone-site/blob/HDDS-9225-website-v2/.github/labeler.yml) and [workflow](https://github.com/apache/ozone-site/blob/HDDS-9225-website-v2/.github/workflows/label-pr.yml) there for reference.