### PR TITLE
HDDS-10430. Race condition around Pipeline#nodesInOrder

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/AllocatedBlock.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/AllocatedBlock.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
  * contains a Pipeline and the key.
  */
 public final class AllocatedBlock {
-  private Pipeline pipeline;
-  private ContainerBlockID containerBlockID;
+  private final Pipeline pipeline;
+  private final ContainerBlockID containerBlockID;
 
   /**
    * Builder for AllocatedBlock.
@@ -62,5 +62,15 @@ public final class AllocatedBlock {
 
   public ContainerBlockID getBlockID() {
     return containerBlockID;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder()
+        .setContainerBlockID(containerBlockID)
+        .setPipeline(pipeline);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -203,15 +203,20 @@ public class SCMBlockProtocolServer implements
         AllocatedBlock block = scm.getScmBlockManager()
             .allocateBlock(size, replicationConfig, owner, excludeList);
         if (block != null) {
-          blocks.add(block);
           // Sort the datanodes if client machine is specified
           final Node client = getClientNode(clientMachine);
           if (client != null) {
             final List<DatanodeDetails> nodes = block.getPipeline().getNodes();
             final List<DatanodeDetails> sorted = scm.getClusterMap()
                 .sortByDistanceCost(client, nodes, nodes.size());
-            block.getPipeline().setNodesInOrder(sorted);
+            block = block.toBuilder()
+                .setPipeline(block.getPipeline()
+                    .toBuilder()
+                    .setNodesInOrder(sorted)
+                    .build())
+                .build();
           }
+          blocks.add(block);
         }
       }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -209,12 +210,11 @@ public class SCMBlockProtocolServer implements
             final List<DatanodeDetails> nodes = block.getPipeline().getNodes();
             final List<DatanodeDetails> sorted = scm.getClusterMap()
                 .sortByDistanceCost(client, nodes, nodes.size());
-            block = block.toBuilder()
-                .setPipeline(block.getPipeline()
-                    .toBuilder()
-                    .setNodesInOrder(sorted)
-                    .build())
-                .build();
+            if (!Objects.equals(sorted, block.getPipeline().getNodesInOrder())) {
+              block = block.toBuilder()
+                  .setPipeline(block.getPipeline().copyWithNodesInOrder(sorted))
+                  .build();
+            }
           }
           blocks.add(block);
         }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -71,8 +71,8 @@ public class TestXceiverClientGrpc {
             RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setState(Pipeline.PipelineState.CLOSED)
         .setNodes(dns)
+        .setNodesInOrder(dnsInOrder)
         .build();
-    pipeline.setNodesInOrder(dnsInOrder);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1880,7 +1880,7 @@ public class KeyManagerImpl implements KeyManager {
             LOG.debug("Found sorted datanodes for pipeline {} and client {} "
                 + "in cache", pipeline.getId(), clientMachine);
           }
-          pipeline.setNodesInOrder(sortedNodes);
+          k.setPipeline(pipeline.toBuilder().setNodesInOrder(sortedNodes).build());
         }
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1880,7 +1880,9 @@ public class KeyManagerImpl implements KeyManager {
             LOG.debug("Found sorted datanodes for pipeline {} and client {} "
                 + "in cache", pipeline.getId(), clientMachine);
           }
-          k.setPipeline(pipeline.toBuilder().setNodesInOrder(sortedNodes).build());
+          if (!Objects.equals(pipeline.getNodesInOrder(), sortedNodes)) {
+            k.setPipeline(pipeline.copyWithNodesInOrder(sortedNodes));
+          }
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `Pipeline#nodesInOrder` immutable to avoid race condition.

https://issues.apache.org/jira/browse/HDDS-10430

## How was this patch tested?

Existing tests.

https://github.com/adoroszlai/ozone/actions/runs/8121255974