### PR TITLE
HDDS-10457. Remove dependency commons-pool2

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -136,10 +136,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-pool2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -360,7 +360,6 @@ Apache License 2.0
    org.apache.commons:commons-compress
    org.apache.commons:commons-configuration2
    org.apache.commons:commons-lang3
-   org.apache.commons:commons-pool2
    org.apache.commons:commons-text
    org.apache.curator:curator-client
    org.apache.curator:curator-framework

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -28,7 +28,6 @@ share/ozone/lib/commons-lang3.jar
 share/ozone/lib/commons-lang.jar
 share/ozone/lib/commons-logging.jar
 share/ozone/lib/commons-net.jar
-share/ozone/lib/commons-pool2.jar
 share/ozone/lib/commons-text.jar
 share/ozone/lib/commons-validator.jar
 share/ozone/lib/commons-fileupload.jar

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -128,7 +128,6 @@
                     <include>org.apache.commons.digester.**.*</include>
                     <include>org.apache.commons.io.**.*</include>
                     <include>org.apache.commons.logging.**.*</include>
-                    <include>org.apache.commons.pool2.**.*</include>
                     <include>org.apache.commons.validator.**.*</include>
                     <include>org.apache.commons.lang3.**.*</include>
                     <include>org.sqlite.**.*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <commons-logging-api.version>1.1</commons-logging-api.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-net.version>3.10.0</commons-net.version>
-    <commons-pool2.version>2.6.0</commons-pool2.version>
     <commons-text.version>1.11.0</commons-text.version>
     <commons-validator.version>1.6</commons-validator.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
@@ -789,11 +788,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
         <version>${commons-net.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-pool2</artifactId>
-        <version>${commons-pool2.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-validator</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove dependency `commons-pool2`, which seems to be unused.

https://issues.apache.org/jira/browse/HDDS-10457

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8124160811