### PR TITLE
HDDS-10439. Remove setConf from MiniOzoneCluster public interface

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -74,11 +74,6 @@ public interface MiniOzoneCluster extends AutoCloseable {
   OzoneConfiguration getConf();
 
   /**
-   * Set the configuration for the MiniOzoneCluster.
-   */
-  void setConf(OzoneConfiguration newConf);
-
-  /**
    * Waits for the cluster to be ready, this call blocks till all the
    * configured {@link HddsDatanodeService} registers with
    * {@link StorageContainerManager}.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -164,8 +164,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
     return conf;
   }
 
-  @Override
-  public void setConf(OzoneConfiguration newConf) {
+  protected void setConf(OzoneConfiguration newConf) {
     this.conf = newConf;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1333,7 +1333,6 @@ public abstract class TestOzoneRpcClientAbstract {
     if (layout.equals(BucketLayout.LEGACY)) {
       OzoneConfiguration conf = cluster.getConf();
       conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
-      cluster.setConf(conf);
     }
 
     // the directory "/dir1", ""/dir1/dir2/", "/dir1/dir2/dir3/"

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -303,7 +303,6 @@ public class TestAddRemoveOzoneManager {
     config.setInt(OMConfigKeys.OZONE_OM_ADMIN_PROTOCOL_MAX_RETRIES_KEY, 2);
     config.setInt(
         OMConfigKeys.OZONE_OM_ADMIN_PROTOCOL_WAIT_BETWEEN_RETRIES_KEY, 100);
-    cluster.setConf(config);
 
     GenericTestUtils.LogCapturer omLog =
         GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabled.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabled.java
@@ -64,9 +64,6 @@ public class TestOmSnapshotDisabled {
     cluster.waitForClusterToBeReady();
     client = cluster.newClient();
 
-    OzoneManager leaderOzoneManager = cluster.getOMLeader();
-    OzoneConfiguration leaderConfig = leaderOzoneManager.getConfiguration();
-    cluster.setConf(leaderConfig);
     store = client.getObjectStore();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabledRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmSnapshotDisabledRestart.java
@@ -61,9 +61,6 @@ public class TestOmSnapshotDisabledRestart {
     cluster.waitForClusterToBeReady();
     client = cluster.newClient();
 
-    OzoneManager leaderOzoneManager = cluster.getOMLeader();
-    OzoneConfiguration leaderConfig = leaderOzoneManager.getConfiguration();
-    cluster.setConf(leaderConfig);
     store = client.getObjectStore();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotAcl.java
@@ -116,10 +116,6 @@ public class TestOzoneManagerSnapshotAcl {
         .build();
     cluster.waitForClusterToBeReady();
 
-    ozoneManager = cluster.getOzoneManager();
-    final OzoneConfiguration ozoneManagerConf = ozoneManager.getConfiguration();
-    cluster.setConf(ozoneManagerConf);
-
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
     final OzoneConfiguration clientConf =
         new OzoneConfiguration(cluster.getConf());
@@ -128,12 +124,13 @@ public class TestOzoneManagerSnapshotAcl {
     client = cluster.newClient();
     objectStore = client.getObjectStore();
 
+    ozoneManager = cluster.getOzoneManager();
     final KeyManagerImpl keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "keyManager");
 
     // stop the deletion services so that keys can still be read
     keyManager.stop();
-    OMStorage.getOmDbDir(ozoneManagerConf);
+    OMStorage.getOmDbDir(cluster.getConf());
   }
 
   @AfterAll

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneSnapshotRestore.java
@@ -113,10 +113,9 @@ public class TestOzoneSnapshotRestore {
 
     leaderOzoneManager = cluster.getOMLeader();
     OzoneConfiguration leaderConfig = leaderOzoneManager.getConfiguration();
-    cluster.setConf(leaderConfig);
 
     String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + serviceID;
-    clientConf = new OzoneConfiguration(cluster.getConf());
+    clientConf = new OzoneConfiguration(leaderConfig);
     clientConf.set(FS_DEFAULT_NAME_KEY, hostPrefix);
 
     client = cluster.newClient();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not expose method to set config on `MiniOzoneCluster` after it is already created.

https://issues.apache.org/jira/browse/HDDS-10439

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8132769261