### PR TITLE
HDDS-10458. Mention datanode status decommission command in decommission feature docs

### DIFF
--- a/hadoop-hdds/docs/content/feature/Decommission.md
+++ b/hadoop-hdds/docs/content/feature/Decommission.md
@@ -54,8 +54,7 @@ You can enter multiple hosts to decommission multiple datanodes together.
 To view the status of a decommissioning datanode, you can execute the following command in cli,
 
 ```shell
-ozone admin datanode status decommission [-hV] [-id=<scmServiceId>]
-       [--scm=<scm>] [--id=<uuid>] [--ip=<ipAddress>]
+ozone admin datanode status decommission [-hV] [-id=<scmServiceId>] [--scm=<scm>] [--id=<uuid>] [--ip=<ipAddress>]
 ```
 You can pass the ipAddress or uuid of one datanode to view only the details related to that datanode.
 

--- a/hadoop-hdds/docs/content/feature/Decommission.md
+++ b/hadoop-hdds/docs/content/feature/Decommission.md
@@ -51,6 +51,15 @@ ozone admin datanode decommission [-hV] [-id=<scmServiceId>]
 ```
 You can enter multiple hosts to decommission multiple datanodes together.
 
+To view the status of a decommissioning datanode, you can execute the following command in cli,
+
+```shell
+ozone admin datanode status decommission [-hV] [-id=<scmServiceId>]
+       [--scm=<scm>] [--id=<uuid>] [--ip=<ipAddress>]
+```
+You can pass the ipAddress or uuid of one datanode to view only the details related to that datanode.
+
+
 **Note:** To recommission a datanode you may execute the below command in cli,
 ```shell
 ozone admin datanode recommission [-hV] [-id=<scmServiceId>]

--- a/hadoop-hdds/docs/content/feature/Decommission.md
+++ b/hadoop-hdds/docs/content/feature/Decommission.md
@@ -51,12 +51,12 @@ ozone admin datanode decommission [-hV] [-id=<scmServiceId>]
 ```
 You can enter multiple hosts to decommission multiple datanodes together.
 
-To view the status of a decommissioning datanode, you can execute the following command in cli,
+To view the status of a decommissioning datanode, you can execute the following command:
 
 ```shell
 ozone admin datanode status decommission [-hV] [-id=<scmServiceId>] [--scm=<scm>] [--id=<uuid>] [--ip=<ipAddress>]
 ```
-You can pass the ipAddress or uuid of one datanode to view only the details related to that datanode.
+You can pass the IP address or UUID of one datanode to view only the details related to that datanode.
 
 
 **Note:** To recommission a datanode you may execute the below command in cli,

--- a/hadoop-hdds/docs/content/feature/Decommission.zh.md
+++ b/hadoop-hdds/docs/content/feature/Decommission.zh.md
@@ -55,7 +55,7 @@ ozone admin datanode decommission [-hV] [-id=<scmServiceId>]
 ```shell
 ozone admin datanode status decommission [-hV] [-id=<scmServiceId>] [--scm=<scm>] [--id=<uuid>] [--ip=<ipAddress>]
 ```
-您可以传递一个 Datanode 的 ipAddress 或 uuid 以仅查看与该 Datanode 相关的详细信息。
+您可以指定一个 Datanode 的 IP address 或 UUID 以查看该 Datanode 相关的详细信息。
 
 
 **Note:** 要Recommission某台DataNode的时候，可在命令行执行以下命令,

--- a/hadoop-hdds/docs/content/feature/Decommission.zh.md
+++ b/hadoop-hdds/docs/content/feature/Decommission.zh.md
@@ -53,8 +53,7 @@ ozone admin datanode decommission [-hV] [-id=<scmServiceId>]
 查看 Decommission时datanode 的状态，可以执行下面的命令,
 
 ```shell
-ozone admin datanode status decommission [-hV] [-id=<scmServiceId>]
-       [--scm=<scm>] [--id=<uuid>] [--ip=<ipAddress>]
+ozone admin datanode status decommission [-hV] [-id=<scmServiceId>] [--scm=<scm>] [--id=<uuid>] [--ip=<ipAddress>]
 ```
 您可以传递一个 Datanode 的 ipAddress 或 uuid 以仅查看与该 Datanode 相关的详细信息。
 

--- a/hadoop-hdds/docs/content/feature/Decommission.zh.md
+++ b/hadoop-hdds/docs/content/feature/Decommission.zh.md
@@ -50,6 +50,15 @@ ozone admin datanode decommission [-hV] [-id=<scmServiceId>]
 ```
 您可以输入多个主机，以便一起Decommission多个DataNode。
 
+查看 Decommission时datanode 的状态，可以执行下面的命令,
+
+```shell
+ozone admin datanode status decommission [-hV] [-id=<scmServiceId>]
+       [--scm=<scm>] [--id=<uuid>] [--ip=<ipAddress>]
+```
+您可以传递一个 Datanode 的 ipAddress 或 uuid 以仅查看与该 Datanode 相关的详细信息。
+
+
 **Note:** 要Recommission某台DataNode的时候，可在命令行执行以下命令,
 ```shell
 ozone admin datanode recommission [-hV] [-id=<scmServiceId>]


### PR DESCRIPTION
## What changes were proposed in this pull request?

The command to view status of decommissioning datanodes: `ozone admin datanode status decommission` that was added recently as a part of HDDS-9324 should be mentioned in ozone documents so users are aware of it and can utilise it when necessary.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10458

## How was this patch tested?

Checked the rendering with `hugo serve` :

<img width="1117" alt="image" src="https://github.com/apache/ozone/assets/87555809/1fc1a29f-9b74-499e-9df9-b49ae6d2a036">

