### PR TITLE
HDDS-10440. Set new cluster ID and config instance in `MiniOzoneCluster#build()`

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -309,6 +309,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
       if (startDataNodes) {
         cluster.startHddsDatanodes();
       }
+      prepareForNextBuild();
       return cluster;
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestSafeMode.java
@@ -62,7 +62,7 @@ class TestSafeMode {
   static void setup() {
     OzoneConfiguration conf = new OzoneConfiguration();
     clusterProvider = new MiniOzoneClusterProvider(
-        conf, MiniOzoneCluster.newBuilder(conf), 2);
+        MiniOzoneCluster.newBuilder(conf), 2);
   }
 
   @BeforeEach

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
@@ -152,7 +152,7 @@ public class TestDecommissionAndMaintenance {
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(DATANODE_COUNT);
 
-    clusterProvider = new MiniOzoneClusterProvider(conf, builder, 7);
+    clusterProvider = new MiniOzoneClusterProvider(builder, 7);
   }
 
   @AfterAll

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -178,7 +178,7 @@ public class TestHDDSUpgrade {
     // use multiple clusters, so its hard to know exactly how many will be
     // needed. This means the provider will create 1 extra cluster than needed
     // but that will not greatly affect runtimes.
-    clusterProvider = new MiniOzoneClusterProvider(conf, builder, 100);
+    clusterProvider = new MiniOzoneClusterProvider(builder, 100);
   }
 
   @AfterAll

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -281,15 +281,17 @@ public interface MiniOzoneCluster extends AutoCloseable {
 
     protected Builder(OzoneConfiguration conf) {
       this.conf = conf;
-      setClusterId(UUID.randomUUID().toString());
+      setClusterId();
       // Use default SCM configurations if no override is provided.
       setSCMConfigurator(new SCMConfigurator());
       ExitUtils.disableSystemExit();
     }
 
-    public Builder setConf(OzoneConfiguration config) {
-      this.conf = config;
-      return this;
+    /** Prepare the builder for another call to {@link #build()}, avoiding conflict
+     * between the clusters created. */
+    protected void prepareForNextBuild() {
+      conf = new OzoneConfiguration(conf);
+      setClusterId();
     }
 
     public Builder setSCMConfigurator(SCMConfigurator configurator) {
@@ -297,13 +299,8 @@ public interface MiniOzoneCluster extends AutoCloseable {
       return this;
     }
 
-    /**
-     * Sets the cluster Id.
-     *
-     * @param id cluster Id
-     */
-    void setClusterId(String id) {
-      clusterId = id;
+    private void setClusterId() {
+      clusterId = UUID.randomUUID().toString();
       path = GenericTestUtils.getTempPath(
           MiniOzoneClusterImpl.class.getSimpleName() + "-" + clusterId);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -545,6 +545,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
         if (startDataNodes) {
           cluster.startHddsDatanodes();
         }
+
+        prepareForNextBuild();
         return cluster;
       } catch (Exception ex) {
         stopOM(om);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +116,6 @@ public class MiniOzoneClusterProvider {
   private final int clusterLimit;
   private int consumedClusterCount = 0;
 
-  private final OzoneConfiguration conf;
   private final MiniOzoneCluster.Builder builder;
   private final Thread createThread;
   private final Thread reapThread;
@@ -129,16 +127,13 @@ public class MiniOzoneClusterProvider {
       = new ArrayBlockingQueue<>(EXPIRED_LIMIT);
 
   /**
-   *
-   * @param conf The configuration to use when creating the cluster
    * @param builder A builder object with all cluster options set
    * @param clusterLimit The total number of clusters this provider should
    *                     create. If another is requested after this limit has
    *                     been reached, an exception will be thrown.
    */
-  public MiniOzoneClusterProvider(OzoneConfiguration conf,
+  public MiniOzoneClusterProvider(
       MiniOzoneCluster.Builder builder, int clusterLimit) {
-    this.conf = conf;
     this.builder = builder;
     this.clusterLimit = clusterLimit;
     createThread = createClusters();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
@@ -47,10 +47,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * however shutting down the cluster in the background while the new cluster is
  * getting created will likely save about 10 seconds per test.
  *
- * To use this class, setup the Cluster Provider in a static method annotated
- * with @BeforeClass, eg:
- *
- *   @BeforeClass
+ * To use this class, set up the Cluster Provider in a static method annotated
+ * with {@code @BeforeAll}, eg:
+ * <pre>
+ *   &#64;BeforeAll
  *   public static void init() {
  *     OzoneConfiguration conf = new OzoneConfiguration();
  *     final int interval = 100;
@@ -69,29 +69,34 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  *
  *     clusterProvider = new MiniOzoneClusterProvider(conf, builder, 5);
  *   }
+ * </pre>
  *
- * Ensure you shutdown the provider in a @AfterClass annotated method:
+ * Ensure you shut down the provider in an {@code @AfterAll} annotated method:
  *
- *   @AfterClass
+ * <pre>
+ *   &#64;AfterAll
  *   public static void shutdown() throws InterruptedException {
  *     if (clusterProvider != null) {
  *       clusterProvider.shutdown();
  *     }
  *   }
+ * </pre>
  *
- * Then in the @Before method, or in the test itself, obtain a cluster:
+ * Then in the {@code @BeforeEach} method, or in the test itself, obtain a cluster:
  *
- *   @Before
+ * <pre>
+ *   &#64;BeforeEach
  *   public void setUp() throws Exception {
  *     cluster = clusterProvider.provide();
  *   }
  *
- *   @After
+ *   &#64;AfterEach
  *   public void tearDown() throws InterruptedException, IOException {
  *     if (cluster != null) {
  *       clusterProvider.destroy(cluster);
  *     }
  *   }
+ * </pre>
  *
  *  This only works if the same config / builder object can be passed to each
  *  cluster in the test suite.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -214,9 +213,6 @@ public class MiniOzoneClusterProvider {
       while (!Thread.interrupted() && createdCount < clusterLimit) {
         MiniOzoneCluster cluster = null;
         try {
-          builder.setClusterId(UUID.randomUUID().toString());
-          builder.setConf(new OzoneConfiguration(conf));
-
           cluster = builder.build();
           cluster.waitForClusterToBeReady();
           createdCount++;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -437,6 +437,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       if (startDataNodes) {
         cluster.startHddsDatanodes();
       }
+      prepareForNextBuild();
       return cluster;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MiniOzoneCluster.Builder` allows creating multiple cluster instances from the same builder.  To avoid conflict, users (currently only `MiniOzoneClusterProvider`) need to set new cluster ID and a copy of the configuration.  The goal of this change is to automatically set the cluster ID and config whenever `build()` is called.

https://issues.apache.org/jira/browse/HDDS-10440

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8139597150