### PR TITLE
HDDS-10384. RPC client Reusing thread resources.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
@@ -73,7 +73,7 @@ abstract class AbstractCommitWatcher<BUFFER> {
     return commitIndexMap;
   }
 
-  void updateCommitInfoMap(long index, List<BUFFER> buffers) {
+  synchronized void updateCommitInfoMap(long index, List<BUFFER> buffers) {
     commitIndexMap.computeIfAbsent(index, k -> new LinkedList<>())
         .addAll(buffers);
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -25,7 +25,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -182,8 +181,7 @@ public class BlockOutputStream extends OutputStream {
             (long) flushPeriod * streamBufferArgs.getStreamBufferSize() == streamBufferArgs
                 .getStreamBufferFlushSize());
 
-    // A single thread executor handle the responses of async requests
-    responseExecutor = Executors.newSingleThreadExecutor();
+    this.responseExecutor = blockOutputStreamResourceProvider.get();
     bufferList = null;
     totalDataFlushedLength = 0;
     writtenDataLength = 0;
@@ -657,7 +655,6 @@ public class BlockOutputStream extends OutputStream {
       bufferList.clear();
     }
     bufferList = null;
-    responseExecutor.shutdown();
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
@@ -29,8 +29,6 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerC
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
@@ -113,16 +113,13 @@ public class RatisBlockOutputStream extends BlockOutputStream
   }
 
   @Override
-  void putFlushFuture(long flushPos,
-      CompletableFuture<ContainerCommandResponseProto> flushFuture) {
-    commitWatcher.getFutureMap().put(flushPos, flushFuture);
+  void putFlushFuture(long flushPos, CompletableFuture<ContainerCommandResponseProto> flushFuture) {
+    commitWatcher.putFlushFuture(flushPos, flushFuture);
   }
 
   @Override
   void waitOnFlushFutures() throws InterruptedException, ExecutionException {
-    // wait for all the transactions to complete
-    CompletableFuture.allOf(commitWatcher.getFutureMap().values().toArray(
-        new CompletableFuture[0])).get();
+    commitWatcher.waitOnFlushFutures();
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -101,8 +101,7 @@ public class ECReconstructionCoordinator implements Closeable {
 
   private static final int EC_RECONSTRUCT_STRIPE_READ_POOL_MIN_SIZE = 3;
 
-  // TODO: Adjusts to the appropriate value when the ec-reconstruct-writer thread pool is used.
-  private static final int EC_RECONSTRUCT_STRIPE_WRITE_POOL_MIN_SIZE = 0;
+  private static final int EC_RECONSTRUCT_STRIPE_WRITE_POOL_MIN_SIZE = 5;
 
   private final ECContainerOperationClient containerOperationClient;
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -196,8 +196,7 @@ public class RpcClient implements ClientProtocol {
   // for reconstruction.
   private static final int EC_RECONSTRUCT_STRIPE_READ_POOL_MIN_SIZE = 3;
 
-  // TODO: Adjusts to the appropriate value when the writeThreadPool is used.
-  private static final int WRITE_POOL_MIN_SIZE = 0;
+  private static final int WRITE_POOL_MIN_SIZE = 1;
 
   private final ConfigurationSource conf;
   private final OzoneManagerClientProtocol ozoneManagerClient;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestCommitWatcher.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.storage;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -209,7 +210,7 @@ public class TestCommitWatcher {
                 return v;
               });
           futures.add(future);
-          watcher.getFutureMap().put(length, future);
+          watcher.putFlushFuture(length, future);
           replies.add(reply);
         }
 
@@ -220,10 +221,10 @@ public class TestCommitWatcher {
         CompletableFuture<ContainerCommandResponseProto> future2 =
             futures.get(1);
         future1.get();
-        assertEquals(future1, watcher.getFutureMap().get((long) chunkSize));
+        assertEquals(Collections.singletonList(future1), watcher.getFutureMap().get((long) chunkSize));
         // wait on 2nd putBlock to complete
         future2.get();
-        assertEquals(future2, watcher.getFutureMap().get((long) 2 * chunkSize));
+        assertEquals(Collections.singletonList(future2), watcher.getFutureMap().get((long) 2 * chunkSize));
         assertEquals(2, watcher.
             getCommitIndexMap().size());
         watcher.watchOnFirstIndex();
@@ -282,7 +283,7 @@ public class TestCommitWatcher {
                 return v;
               });
           futures.add(future);
-          watcher.getFutureMap().put(length, future);
+          watcher.putFlushFuture(length, future);
           replies.add(reply);
         }
 
@@ -293,10 +294,10 @@ public class TestCommitWatcher {
         CompletableFuture<ContainerCommandResponseProto> future2 =
             futures.get(1);
         future1.get();
-        assertEquals(future1, watcher.getFutureMap().get((long) chunkSize));
+        assertEquals(Collections.singletonList(future1), watcher.getFutureMap().get((long) chunkSize));
         // wait on 2nd putBlock to complete
         future2.get();
-        assertEquals(future2, watcher.getFutureMap().get((long) 2 * chunkSize));
+        assertEquals(Collections.singletonList(future2), watcher.getFutureMap().get((long) 2 * chunkSize));
         assertEquals(2, watcher.getCommitIndexMap().size());
         watcher.watchOnFirstIndex();
         assertThat(watcher.getCommitIndexMap()).doesNotContainKey(replies.get(0).getLogIndex());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestCommitWatcher.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.storage;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -221,10 +220,10 @@ public class TestCommitWatcher {
         CompletableFuture<ContainerCommandResponseProto> future2 =
             futures.get(1);
         future1.get();
-        assertEquals(Collections.singletonList(future1), watcher.getFutureMap().get((long) chunkSize));
+        assertEquals(future1, watcher.getFutureMap().get((long) chunkSize));
         // wait on 2nd putBlock to complete
         future2.get();
-        assertEquals(Collections.singletonList(future2), watcher.getFutureMap().get((long) 2 * chunkSize));
+        assertEquals(future2, watcher.getFutureMap().get((long) 2 * chunkSize));
         assertEquals(2, watcher.
             getCommitIndexMap().size());
         watcher.watchOnFirstIndex();
@@ -294,10 +293,10 @@ public class TestCommitWatcher {
         CompletableFuture<ContainerCommandResponseProto> future2 =
             futures.get(1);
         future1.get();
-        assertEquals(Collections.singletonList(future1), watcher.getFutureMap().get((long) chunkSize));
+        assertEquals(future1, watcher.getFutureMap().get((long) chunkSize));
         // wait on 2nd putBlock to complete
         future2.get();
-        assertEquals(Collections.singletonList(future2), watcher.getFutureMap().get((long) 2 * chunkSize));
+        assertEquals(future2, watcher.getFutureMap().get((long) 2 * chunkSize));
         assertEquals(2, watcher.getCommitIndexMap().size());
         watcher.watchOnFirstIndex();
         assertThat(watcher.getCommitIndexMap()).doesNotContainKey(replies.get(0).getLogIndex());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -213,6 +213,14 @@ class TestOzoneAtRestEncryption {
     }
   }
 
+  static void reInitClient() throws IOException {
+    ozClient = OzoneClientFactory.getRpcClient(conf);
+    store = ozClient.getObjectStore();
+    TestOzoneRpcClient.setOzClient(ozClient);
+    TestOzoneRpcClient.setStore(store);
+  }
+
+
   @ParameterizedTest
   @EnumSource
   void testPutKeyWithEncryption(BucketLayout bucketLayout) throws Exception {
@@ -770,9 +778,7 @@ class TestOzoneAtRestEncryption {
 
     KeyProvider kp3 = ozClient.getObjectStore().getKeyProvider();
     assertNotEquals(kp3, kpSpy);
-    // Restore ozClient and store
-    TestOzoneRpcClient.setOzClient(OzoneClientFactory.getRpcClient(conf));
-    TestOzoneRpcClient.setStore(ozClient.getObjectStore());
+    reInitClient();
   }
 
   private static RepeatedOmKeyInfo getMatchedKeyInfo(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1651,6 +1651,7 @@ public abstract class TestOzoneRpcClientAbstract {
         }
         latch.countDown();
       } catch (IOException ex) {
+        LOG.error("Execution failed: ", ex);
         latch.countDown();
         failCount.incrementAndGet();
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -322,9 +322,8 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
         new OMRequestHandlerPauseInjector();
     omSM.getHandler().setInjector(injector);
     thread1.start();
-    Thread.sleep(1000);
     thread2.start();
-    Thread.sleep(10000);
+    Thread.sleep(2000);
     injector.resume();
 
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -322,8 +322,9 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
         new OMRequestHandlerPauseInjector();
     omSM.getHandler().setInjector(injector);
     thread1.start();
+    Thread.sleep(1000);
     thread2.start();
-    Thread.sleep(2000);
+    Thread.sleep(10000);
     injector.resume();
 
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The old PR https://github.com/apache/ozone/pull/6270 has been reverted due to a bug. This PR fixed the bug and recreated the PR.
###  root cause 
The root cause of the bug in the old PR is that the future put into the `executePutBlock` of `CommitWatcher#futureMap` may be overwritten by the last closed `executePutBlock`. Therefore, the buffer cannot be released correctly.

### Fix
  Change the `CommitWatcher#futureMap` from `ConcurrentMap<Long, CompletableFuture<xxx>>
     ` to `ConcurrentMap<Long, List<CompletableFuture<xxx>>>`  Records and releases all futures with the same key, so all the future can be released.

### A detail log about this bug：
```bash
2024-03-03 18:49:16,741 [Thread-955] ERROR storage.BlockOutputStream (BlockOutputStream.java:executePutBlock(512)) - executePutBlock putFlushFuture flushPos 4194304, flushFuture java.util.concurrent.CompletableFuture@8bc6bca[Not completed], close false, force false
2024-03-03 18:49:16,741 [Thread-955] ERROR storage.BlockOutputStream (RatisBlockOutputStream.java:putFlushFuture(120)) - putFlushFuture flushPos 4194304 flushFuture java.util.concurrent.CompletableFuture@8bc6bca[Not completed]
```
In the next log， we can see the entry **{4194304, CompletableFuture@8bc6bca}** has been overwritten by the **{4194304, CompletableFuture@4230f10c}**
```bash

2024-03-03 18:49:16,741 [Thread-955] ERROR storage.BlockOutputStream (BlockOutputStream.java:executePutBlock(512)) - executePutBlock putFlushFuture flushPos 4194304, flushFuture java.util.concurrent.CompletableFuture@4230f10c[Not completed], close true, force true
2024-03-03 18:49:16,741 [Thread-955] ERROR storage.BlockOutputStream (RatisBlockOutputStream.java:putFlushFuture(120)) - putFlushFuture flushPos 4194304 flushFuture java.util.concurrent.CompletableFuture@4230f10c[Not completed]
2024-03-03 18:49:16,741 [Thread-955] ERROR storage.BlockOutputStream (RatisBlockOutputStream.java:waitOnFlushFutures(127)) - waitOnFlushFutures getFutureMap keySet [4194304] keySet Value [java.util.concurrent.CompletableFuture@4230f10c[Not completed]]
```




## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10384






## How was this patch tested?
Twice 10x10  tests for TestSecureOzoneRpcClient,TestFreonWithPipelineDestroy,TestOzoneRpcClientWithRatis#ALL all passed. （In order to make all tests pass, this test code includes a fix for the unstable test `testParallelDeleteBucketAndCreateKey` [HDDS-10143](https://issues.apache.org/jira/browse/HDDS-10143)）

https://github.com/xichen01/ozone/actions/runs/8138828724/attempts/1
https://github.com/xichen01/ozone/actions/runs/8138828724


