### PR TITLE
HDDS-10424. Add more info regarding trailing slash during prefix crea…

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -641,7 +641,7 @@ public class TestKeyManagerImpl {
     // add acl with invalid prefix name
     Exception ex = assertThrows(OMException.class,
         () -> writeClient.addAcl(ozInvalidPrefix, ozAcl1));
-    assertTrue(ex.getMessage().startsWith("Invalid prefix name"));
+    assertTrue(ex.getMessage().startsWith("Missing trailing slash"));
 
     OzoneObj ozPrefix1 = new OzoneObjInfo.Builder()
         .setVolumeName(volumeName)
@@ -659,7 +659,7 @@ public class TestKeyManagerImpl {
     // get acl with invalid prefix name
     ex = assertThrows(OMException.class,
         () -> writeClient.getAcl(ozInvalidPrefix));
-    assertTrue(ex.getMessage().startsWith("Invalid prefix name"));
+    assertTrue(ex.getMessage().startsWith("Missing trailing slash"));
 
     // set acl with invalid prefix name
     List<OzoneAcl> ozoneAcls = new ArrayList<OzoneAcl>();
@@ -667,12 +667,12 @@ public class TestKeyManagerImpl {
 
     ex = assertThrows(OMException.class,
         () -> writeClient.setAcl(ozInvalidPrefix, ozoneAcls));
-    assertTrue(ex.getMessage().startsWith("Invalid prefix name"));
+    assertTrue(ex.getMessage().startsWith("Missing trailing slash"));
 
     // remove acl with invalid prefix name
     ex = assertThrows(OMException.class,
         () -> writeClient.removeAcl(ozInvalidPrefix, ozAcl1));
-    assertTrue(ex.getMessage().startsWith("Invalid prefix name"));
+    assertTrue(ex.getMessage().startsWith("Missing trailing slash"));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
@@ -218,7 +218,7 @@ public class PrefixManagerImpl implements PrefixManager {
       throw new OMException("Prefix name is required.", PREFIX_NOT_FOUND);
     }
     if (!prefixName.endsWith("/")) {
-      throw new OMException("Invalid prefix name: " + prefixName,
+      throw new OMException("Missing trailing slash '/' in prefix name: " + prefixName,
           PREFIX_NOT_FOUND);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PREFIX_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_PATH_IN_ACL_REQUEST;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.PREFIX_LOCK;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.PREFIX;
 
@@ -219,7 +220,7 @@ public class PrefixManagerImpl implements PrefixManager {
     }
     if (!prefixName.endsWith("/")) {
       throw new OMException("Missing trailing slash '/' in prefix name: " + prefixName,
-          PREFIX_NOT_FOUND);
+          INVALID_PATH_IN_ACL_REQUEST);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Some Ozone users often forget to add the trailing slash in prefix ACL operations (i.e. ozone sh prefix setacl, ...), causing confusing PREFIX_NOT_FOUND error. 
This patch should add more info about trailing slash in exception message.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10424