### PR TITLE
HDDS-10460. Refine audit logging for bucket property updation operations

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -294,6 +294,7 @@ public final class OzoneConsts {
   public static final String USED_NAMESPACE = "usedNamespace";
   public static final String QUOTA_IN_BYTES = "quotaInBytes";
   public static final String QUOTA_IN_NAMESPACE = "quotaInNamespace";
+  public static final String BUCKET_ENCRYPTION_KEY_NAME = "bekName";
   public static final String OBJECT_ID = "objectID";
   public static final String UPDATE_ID = "updateID";
   public static final String CLIENT_ID = "clientID";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -294,7 +294,7 @@ public final class OzoneConsts {
   public static final String USED_NAMESPACE = "usedNamespace";
   public static final String QUOTA_IN_BYTES = "quotaInBytes";
   public static final String QUOTA_IN_NAMESPACE = "quotaInNamespace";
-  public static final String BUCKET_ENCRYPTION_KEY_NAME = "bekName";
+  public static final String BUCKET_ENCRYPTION_KEY_NAME = "bucketEncryptionKey";
   public static final String OBJECT_ID = "objectID";
   public static final String UPDATE_ID = "updateID";
   public static final String CLIENT_ID = "clientID";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -294,7 +294,6 @@ public final class OzoneConsts {
   public static final String USED_NAMESPACE = "usedNamespace";
   public static final String QUOTA_IN_BYTES = "quotaInBytes";
   public static final String QUOTA_IN_NAMESPACE = "quotaInNamespace";
-  public static final String BUCKET_ENCRYPTION_KEY_NAME = "bucketEncryptionKey";
   public static final String OBJECT_ID = "objectID";
   public static final String UPDATE_ID = "updateID";
   public static final String CLIENT_ID = "clientID";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -187,6 +187,27 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     if (this.ownerName != null) {
       auditMap.put(OzoneConsts.OWNER, this.ownerName);
     }
+    if (this.quotaInBytesSet && quotaInBytes > 0 ||
+        !(this.quotaInBytes == OzoneConsts.QUOTA_RESET)) {
+      auditMap.put(OzoneConsts.QUOTA_IN_BYTES,
+          String.valueOf(this.quotaInBytes));
+    }
+    if (this.quotaInNamespaceSet && quotaInNamespace > 0 ||
+        !(this.quotaInNamespace == OzoneConsts.QUOTA_RESET)) {
+      auditMap.put(OzoneConsts.QUOTA_IN_NAMESPACE,
+          String.valueOf(this.quotaInNamespace));
+    }
+    if (this.bekInfo != null) {
+      auditMap.put(OzoneConsts.BUCKET_ENCRYPTION_KEY_NAME,
+          this.bekInfo.getKeyName());
+    }
+    if (this.defaultReplicationConfig != null) {
+      auditMap.put(OzoneConsts.REPLICATION_TYPE, String.valueOf(
+          this.defaultReplicationConfig.getType()));
+      auditMap.put(OzoneConsts.REPLICATION_FACTOR,
+          this.defaultReplicationConfig.getReplicationConfig()
+              .getReplication());
+    }
     return auditMap;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -204,7 +204,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     if (this.defaultReplicationConfig != null) {
       auditMap.put(OzoneConsts.REPLICATION_TYPE, String.valueOf(
           this.defaultReplicationConfig.getType()));
-      auditMap.put(OzoneConsts.REPLICATION_FACTOR,
+      auditMap.put(OzoneConsts.REPLICATION_CONFIG,
           this.defaultReplicationConfig.getReplicationConfig()
               .getReplication());
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -198,7 +198,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
           String.valueOf(this.quotaInNamespace));
     }
     if (this.bekInfo != null) {
-      auditMap.put(OzoneConsts.BUCKET_ENCRYPTION_KEY_NAME,
+      auditMap.put(OzoneConsts.BUCKET_ENCRYPTION_KEY,
           this.bekInfo.getKeyName());
     }
     if (this.defaultReplicationConfig != null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -188,7 +188,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
       auditMap.put(OzoneConsts.OWNER, this.ownerName);
     }
     if (this.quotaInBytesSet && quotaInBytes > 0 ||
-        !(this.quotaInBytes == OzoneConsts.QUOTA_RESET)) {
+        (this.quotaInBytes != OzoneConsts.QUOTA_RESET)) {
       auditMap.put(OzoneConsts.QUOTA_IN_BYTES,
           String.valueOf(this.quotaInBytes));
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -193,7 +193,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
           String.valueOf(this.quotaInBytes));
     }
     if (this.quotaInNamespaceSet && quotaInNamespace > 0 ||
-        !(this.quotaInNamespace == OzoneConsts.QUOTA_RESET)) {
+        (this.quotaInNamespace != OzoneConsts.QUOTA_RESET)) {
       auditMap.put(OzoneConsts.QUOTA_IN_NAMESPACE,
           String.valueOf(this.quotaInNamespace));
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should refine audit logging for operations modifying bucket properties.

**How can this be useful?**

- Critical for consumers on earlier versions of Ozone who could potentially run into known bugs: [HDDS-7449](https://issues.apache.org/jira/browse/HDDS-7449) and [HDDS-7526](https://issues.apache.org/jira/browse/HDDS-7526).
- Losing bucket replication properties/bucket encryption properties when one (re)sets quota/bucket replication configurations poses significant risks.
- It is difficult for diagnosing the root cause when one runs into such issues just by looking at the audit logs.
- Currently, the audit logs do not provide much insight into what properties have been modified while performing bucket config re(set) operations.

As of today, we are only capturing basic information such as volume, bucket, gdprEnabled, isVersionEnabled, storageType and owner properties for any given bucket.

We should also be capturing bucket quota, encryption and replication-related properties.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10460

## How was this patch tested?

- Green Git CI: https://github.com/tanvipenumudy/ozone/actions/runs/8152588034/
- The patch has been tested manually on a docker-compose cluster.

Create a bucket with replication-type: `RATIS`, replication-factor: `THREE`:
```
ozone sh bucket create voltest/bucktest --type=RATIS --replication=THREE
```
Set `quotaInBytes`, `quotaInNamespace` for the created bucket:
```
ozone sh bucket setquota --quota=1GB --namespace-quota=5 voltest/bucktest
```
`om-audit.log`:
```
2024-03-05 12:35:15,917 | INFO  | OMAudit | user=hadoop | ip=172.19.0.9 | op=UPDATE_BUCKET {volume=voltest, bucket=bucktest, gdprEnabled=null, isVersionEnabled=null, quotaInBytes=1073741824, quotaInNamespace=5} | ret=SUCCESS |
```
Set replication-config from replication-factor: `THREE` to replication-factor: `ONE`:
```
ozone sh bucket set-replication-config --type=RATIS --replication=ONE voltest/bucktest
```
`om-audit.log`:
```
2024-03-05 12:35:59,013 | INFO  | OMAudit | user=hadoop | ip=172.19.0.9 | op=UPDATE_BUCKET {volume=voltest, bucket=bucktest, gdprEnabled=null, isVersionEnabled=null, replicationType=RATIS, replicationFactor=ONE} | ret=SUCCESS |
```