### PR TITLE
HDDS-10468. CI: Make unit depend on build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
     needs:
       - build-info
       - basic
+      - build
     runs-on: ubuntu-20.04
     timeout-minutes: 150
     if: needs.build-info.outputs.needs-unit-check == 'true'


### PR DESCRIPTION
## What changes were proposed in this pull request?

To avoid unit from using old cached builds in PR CIs, hopefully.
At the cost of lengthening the CI by ~8 minutes.

For the background, see https://github.com/apache/ozone/pull/6286#issuecomment-1979440782

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10468

## How was this patch tested?

- CI dependency tree