### PR TITLE
HDDS-10471. [hsync] MockDatanodeStorage.writeChunk should make a copy of byte string.

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
@@ -162,10 +162,10 @@ public class MockDatanodeStorage {
     if (data.containsKey(blockKey)) {
       block = data.get(blockKey);
       assert block.size() == chunkInfo.getOffset();
-      data.put(blockKey, block.concat(bytes));
+      data.put(blockKey, block.concat(ByteString.copyFrom(bytes.asReadOnlyByteBuffer())));
     } else {
       assert chunkInfo.getOffset() == 0;
-      data.put(blockKey, bytes);
+      data.put(blockKey, ByteString.copyFrom(bytes.asReadOnlyByteBuffer()));
     }
 
     fullBlockData


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix a memory corruption in test utility caused by (potentially unsafe) memory manipulation.

Please describe your PR in detail:
Found in  HDDS-10431 (#6286). For some reason it only fails for Linux not Mac.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10471

## How was this patch tested?

Unit test.