### PR TITLE
HDDS-10143. Fix intermittent failure in testParallelDeleteBucketAndCreateKey

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -323,7 +323,8 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     omSM.getHandler().setInjector(injector);
     thread1.start();
     thread2.start();
-    Thread.sleep(2000);
+    // Wait long enough for createKey's preExecute to finish executing
+    Thread.sleep(10000);
     injector.resume();
 
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -324,7 +325,10 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     thread1.start();
     thread2.start();
     // Wait long enough for createKey's preExecute to finish executing
-    Thread.sleep(10000);
+    GenericTestUtils.waitFor(() -> {
+      return getCluster().getOzoneManager().getOmServerProtocol().getLastRequestToSubmit().getCmdType().equals(
+          Type.CreateKey);
+    }, 100, 10000);
     injector.resume();
 
     try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -86,6 +86,9 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
   // always true, only used in tests
   private boolean shouldFlushCache = true;
 
+  private OMRequest lastRequestToSubmit;
+
+
   /**
    * Constructs an instance of the server handler.
    *
@@ -210,6 +213,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
         assert (omClientRequest != null);
         OMClientRequest finalOmClientRequest = omClientRequest;
         requestToSubmit = preExecute(finalOmClientRequest);
+        this.lastRequestToSubmit = requestToSubmit;
       } catch (IOException ex) {
         if (omClientRequest != null) {
           omClientRequest.handleRequestFailure(ozoneManager);
@@ -231,6 +235,11 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
       throws IOException {
     return captureLatencyNs(perfMetrics.getPreExecuteLatencyNs(),
         () -> finalOmClientRequest.preExecute(ozoneManager));
+  }
+
+  @VisibleForTesting
+  public OMRequest getLastRequestToSubmit() {
+    return lastRequestToSubmit;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix testParallelDeleteBucketAndCreateKey

The root cause is the `preExecute#resolveBucketAndCheckKeyAcls` of `CreateKey` may execute after `deleteBucket`, then the `CreateKey#preExecute` will throw an exception, so the test will fail.  For fix this, we just need to add the waiting time.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10143


## How was this patch tested?
Before, lots of failures.
https://github.com/xichen01/ozone/actions/runs/8158284595
After, All successful
https://github.com/xichen01/ozone/actions/runs/8158363756