### PR TITLE
HDDS-10472. Audit log should include EC replication config

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -154,6 +154,14 @@ public class ECReplicationConfig implements ReplicationConfig {
         + chunkKB();
   }
 
+  /** Similar to {@link #getReplication()}, but applies to proto structure, without any validation. */
+  public static String toString(HddsProtos.ECReplicationConfig proto) {
+    return proto.getCodec() + EC_REPLICATION_PARAMS_DELIMITER
+        + proto.getData() + EC_REPLICATION_PARAMS_DELIMITER
+        + proto.getParity() + EC_REPLICATION_PARAMS_DELIMITER
+        + proto.getEcChunkSize();
+  }
+
   public HddsProtos.ECReplicationConfig toProto() {
     return HddsProtos.ECReplicationConfig.newBuilder()
         .setData(data)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditMessage;
@@ -68,10 +69,15 @@ public interface RequestAuditor {
       auditMap.put(OzoneConsts.KEY, keyArgs.getKeyName());
       auditMap.put(OzoneConsts.DATA_SIZE,
           String.valueOf(keyArgs.getDataSize()));
-      auditMap.put(OzoneConsts.REPLICATION_TYPE,
-          (keyArgs.getType() != null) ? keyArgs.getType().name() : null);
-      auditMap.put(OzoneConsts.REPLICATION_FACTOR,
-          (keyArgs.getFactor() != null) ? keyArgs.getFactor().name() : null);
+      if (keyArgs.hasType()) {
+        auditMap.put(OzoneConsts.REPLICATION_TYPE, keyArgs.getType().name());
+      }
+      if (keyArgs.hasFactor() && keyArgs.getFactor() != HddsProtos.ReplicationFactor.ZERO) {
+        auditMap.put(OzoneConsts.REPLICATION_FACTOR, keyArgs.getFactor().name());
+      }
+      if (keyArgs.hasEcReplicationConfig()) {
+        auditMap.put(OzoneConsts.REPLICATION_CONFIG, String.valueOf(keyArgs.getEcReplicationConfig()));
+      }
       return auditMap;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
@@ -76,7 +77,8 @@ public interface RequestAuditor {
         auditMap.put(OzoneConsts.REPLICATION_FACTOR, keyArgs.getFactor().name());
       }
       if (keyArgs.hasEcReplicationConfig()) {
-        auditMap.put(OzoneConsts.REPLICATION_CONFIG, String.valueOf(keyArgs.getEcReplicationConfig()));
+        auditMap.put(OzoneConsts.REPLICATION_CONFIG,
+            ECReplicationConfig.toString(keyArgs.getEcReplicationConfig()));
       }
       return auditMap;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Audit log for key creation is missing information about EC replication (see `replicationFactor=ZERO`).

```
2024-03-05 18:53:20,425 | INFO  | OMAudit | user=hadoop | ip=172.18.0.5 | op=COMMIT_KEY {volume=smxvvmay, bucket=cgszxdst, key=PUTFILE2.txt._COPYING_, dataSize=17289, replicationType=EC, replicationFactor=ZERO} | ret=SUCCESS |  
```

https://issues.apache.org/jira/browse/HDDS-10472

## How was this patch tested?

Verified OM audit log for EC key creation in acceptance tests:

```
2024-03-06 10:31:50,226 | INFO  | OMAudit | user=dlfknslnfslf | ip=172.18.0.2 | op=ALLOCATE_KEY {volume=s3v, bucket=erasure, key=testfile, dataSize=29, replicationType=EC, replicationConfig=rs-3-2-1048576} | ret=SUCCESS |  
2024-03-06 10:31:51,434 | INFO  | OMAudit | user=dlfknslnfslf | ip=172.18.0.2 | op=COMMIT_KEY {volume=s3v, bucket=erasure, key=testfile, dataSize=29, replicationType=EC, replicationConfig=rs-3-2-1048576} | ret=SUCCESS |  
```

Log for Ratis keys is unchanged:

```
2024-03-06 10:33:02,190 | INFO  | OMAudit | user=dlfknslnfslf | ip=172.18.0.2 | op=ALLOCATE_KEY {volume=s3v, bucket=destbucket-94098, key=ozone-test-5769387323/copyobject/key=value/f1, dataSize=29, replicationType=NONE} | ret=SUCCESS |  
2024-03-06 10:33:02,498 | INFO  | OMAudit | user=dlfknslnfslf | ip=172.18.0.2 | op=COMMIT_KEY {volume=s3v, bucket=destbucket-94098, key=ozone-test-5769387323/copyobject/key=value/f1, dataSize=29, replicationType=RATIS, replicationFactor=THREE} | ret=SUCCESS |  
```

https://github.com/adoroszlai/ozone/actions/runs/8170275505