### PR TITLE
HDDS-10470. Populate Maven dependency cache in separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Cache for maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
@@ -164,7 +164,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
@@ -202,7 +202,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
@@ -246,7 +246,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
@@ -314,7 +314,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
@@ -449,7 +449,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
@@ -509,7 +509,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -75,10 +75,10 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v4
       - name: Cache for maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
@@ -115,7 +115,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.m2/repository
+            ~/.m2/repository/*/*/*
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
           restore-keys: |

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -56,6 +56,10 @@ jobs:
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: mvn --batch-mode --fail-never --no-transfer-progress --show-version dependency:go-offline
 
+      - name: Delete Ozone jars from repo
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: rm -frv ~/.m2/repository/org/apache/ozone
+
       - name: List repo contents
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: find ~/.m2/repository -type f | sort | xargs ls -lh

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow creates cache with Maven dependencies for Ozone build.
+
+name: populate-cache
+
+on:
+  push:
+    branches:
+      - master
+      - ozone-1.4
+    paths:
+      - 'pom.xml'
+      - '**/pom.xml'
+      - '.github/workflows/populate-cache.yml'
+  schedule:
+    - cron: '20 3 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Restore cache for Maven dependencies
+        id: restore-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ozone
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+
+      - name: Setup Java
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 8
+
+      - name: Fetch dependencies
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: mvn --batch-mode --fail-never --no-transfer-progress --show-version dependency:go-offline
+
+      - name: List repo contents
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: find ~/.m2/repository -type f | sort | xargs ls -lh
+
+      - name: Save cache for Maven dependencies
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ozone
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Delete Ozone jars from repo
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: rm -frv ~/.m2/repository/org/apache/ozone
+        run: rm -fr ~/.m2/repository/org/apache/ozone
 
       - name: List repo contents
         if: steps.restore-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/repeat-acceptance.yml
+++ b/.github/workflows/repeat-acceptance.yml
@@ -91,9 +91,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Cache for maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
-          path: ~/.m2/repository
+          path: |
+            ~/.m2/repository/*/*/*
+            !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ env.JAVA_VERSION }}
           restore-keys: |
             maven-repo-${{ hashFiles('**/pom.xml') }}
@@ -115,12 +117,6 @@ jobs:
             hadoop-ozone/dist/target/ozone-*.tar.gz
             !hadoop-ozone/dist/target/ozone-*-src.tar.gz
           retention-days: 1
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
   acceptance:
     needs:
       - prepare-job


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create a separate CI workflow to populate the cache for Maven dependencies from scratch.  This prevents cache inflation that can happen if existing cache is updated with new dependencies: obsolete dependencies are never removed.

The workflow runs on `master` and `ozone-1.4` branches whenever `pom.xml` files are changed.  It also runs on a schedule to avoid cache miss due to expiry.

Existing workflows are updated to only restore the cache, do not create/update it.

https://issues.apache.org/jira/browse/HDDS-10470

## How was this patch tested?

Tested in fork:

- initial commit: https://github.com/adoroszlai/ozone/actions/runs/8170279080/job/22336101638
- no pom change: https://github.com/adoroszlai/ozone/actions/runs/8170585645/job/22337004185
- pom change: https://github.com/adoroszlai/ozone/actions/runs/8170893673/job/22337974520