### PR TITLE
HDDS-10477. Make Rocksdb tools native lib compatible with all chipset with the same arch

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -235,6 +235,7 @@
                       <arg line="${project.build.directory}/rocksdb/rocksdb-${rocksdb.version}"/>
                     </exec>
                     <exec executable="make" dir="${project.build.directory}/rocksdb/rocksdb-${rocksdb.version}" failonerror="true">
+                      <arg line="PORTABLE=1"/>
                       <arg line="DEBUG_LEVEL=0"/>
                       <arg line="EXTRA_CXXFLAGS='-fPIC -D_GLIBCXX_USE_CXX11_ABI=0'"/>
                       <arg line="-j${system.numCores}"/>

--- a/hadoop-hdds/rocks-native/src/CMakeLists.txt
+++ b/hadoop-hdds/rocks-native/src/CMakeLists.txt
@@ -22,8 +22,8 @@
 
 cmake_minimum_required(VERSION 2.8)
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -O0")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -O0")
 project(ozone_native)
 set(CMAKE_BUILD_TYPE Release)
 find_package(JNI REQUIRED)

--- a/hadoop-hdds/rocks-native/src/CMakeLists.txt
+++ b/hadoop-hdds/rocks-native/src/CMakeLists.txt
@@ -22,8 +22,8 @@
 
 cmake_minimum_required(VERSION 2.8)
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -O0")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -O0")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 project(ozone_native)
 set(CMAKE_BUILD_TYPE Release)
 find_package(JNI REQUIRED)


### PR DESCRIPTION
## What changes were proposed in this pull request?
While building rocksdb tools lib, makefile of rocksdb adds native optmization gcc flags when compiling rocksdb code. This makes the built code incompatible with other chipsets, where it fails with illegal instruction when loading the native lib on ozone manager jvm.

Setting PORTABLE=1 while building rocksdb tools will fix this particular issue, and also adding -O0 flag while compiling jni on ozone will prevent the same on ozone jnilib side.
https://github.com/facebook/rocksdb/blob/v7.7.3/INSTALL.md#:~:text=By%20default%20the,make%20static_lib.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10477

## How was this patch tested?
Successful build and checking the native lib manually on various instance
