### PR TITLE
HDDS-10482. OMRequestTestUtils.createOmKeyInfo should set key modification time

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -698,6 +698,7 @@ public class TestOmMetadataManager {
               RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
           .setCreationTime(expiredOpenKeyCreationTime)
           .build();
+      assertTrue(keyInfo.getModificationTime() > 0L);
 
       final String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
       final OmMultipartKeyInfo multipartKeyInfo = OMRequestTestUtils.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -698,7 +698,7 @@ public class TestOmMetadataManager {
               RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
           .setCreationTime(expiredOpenKeyCreationTime)
           .build();
-      assertTrue(keyInfo.getModificationTime() > 0L);
+      assertThat(keyInfo.getModificationTime()).isPositive();
 
       final String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
       final OmMultipartKeyInfo multipartKeyInfo = OMRequestTestUtils.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -556,6 +556,7 @@ public final class OMRequestTestUtils {
         .setObjectID(0L)
         .setUpdateID(0L)
         .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
         .addOmKeyLocationInfoGroup(omKeyLocationInfoGroup)
         .setDataSize(1000L);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set mod time in `OMRequestTestUtils.createOmKeyInfo` to fix the regression in test util that caused test failure in a feature branch. See jira description for more backgrounds.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10482

## How was this patch tested?

- Added assertion to prevent such regression from happening on the master branch again.