### PR TITLE
HDDS-10487. Intermittent crash in TestSnapshotDiffManager

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -390,6 +390,7 @@ public class TestSnapshotDiffManager {
 
   @AfterEach
   public void tearDown() {
+    IOUtils.closeQuietly(snapshotDiffManager);
     if (columnFamilyHandles != null) {
       columnFamilyHandles.forEach(IOUtils::closeQuietly);
     }
@@ -397,7 +398,6 @@ public class TestSnapshotDiffManager {
     IOUtils.closeQuietly(db);
     IOUtils.closeQuietly(dbOptions);
     IOUtils.closeQuietly(columnFamilyOptions);
-    IOUtils.closeQuietly(snapshotDiffManager);
   }
 
   private OmSnapshot getMockedOmSnapshot(UUID snapshotId) {
@@ -674,8 +674,6 @@ public class TestSnapshotDiffManager {
       Table<String, ? extends WithParentObjectId> fromSnapshotTable =
           getMockedTable(fromSnapshotTableMap, snapshotTableName);
 
-      snapshotDiffManager = new SnapshotDiffManager(db, differ, ozoneManager,
-          snapDiffJobTable, snapDiffReportTable, columnFamilyOptions, codecRegistry);
       SnapshotDiffManager spy = spy(snapshotDiffManager);
 
       doAnswer(invocation -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent crash in `TestSnapshotDiffManager`:

- Avoid recreating `SnapshotDiffManager` without closing the previous instance.  Actually the new one seems to be unnecessary, as original one is created `@BeforeEach`.
- Close `SnapshotDiffManager` before closing RocksDB objects.

https://issues.apache.org/jira/browse/HDDS-10487

## How was this patch tested?

No crash in 500 runs (but had 5 failures due to NPE, reported in HDDS-10490):
https://github.com/adoroszlai/ozone/actions/runs/8191095498

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/8191527914