### PR TITLE
HDDS-10493. Fix parameter number warning in DatanodeDetails and ContainerInfo

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -132,6 +132,7 @@ public class DatanodeDetails extends NodeImpl implements
     this.ipAddress = datanodeDetails.ipAddress;
     this.hostName = datanodeDetails.hostName;
     this.ports = datanodeDetails.ports;
+    this.certSerialId = datanodeDetails.certSerialId;
     this.setNetworkName(datanodeDetails.getNetworkName());
     this.setParent(datanodeDetails.getParent());
     this.version = datanodeDetails.version;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -97,46 +97,29 @@ public class DatanodeDetails extends NodeImpl implements
   private int initialVersion;
   private int currentVersion;
 
-  /**
-   * Constructs DatanodeDetails instance. DatanodeDetails.Builder is used
-   * for instantiating DatanodeDetails.
-   * @param uuid DataNode's UUID
-   * @param ipAddress IP Address of this DataNode
-   * @param hostName DataNode's hostname
-   * @param networkLocation DataNode's network location path
-   * @param ports Ports used by the DataNode
-   * @param certSerialId serial id from SCM issued certificate.
-   * @param version DataNode's version
-   * @param setupTime the setup time of DataNode
-   * @param revision DataNodes's revision
-   * @param buildDate DataNodes's build timestamp
-   * @param persistedOpState Operational State stored on DN.
-   * @param persistedOpStateExpiryEpochSec Seconds after the epoch the stored
-   *                                       state should expire.
-   */
-  @SuppressWarnings("parameternumber")
-  private DatanodeDetails(UUID uuid, String ipAddress, String hostName,
-      String networkLocation, List<Port> ports, String certSerialId,
-      String version, long setupTime, String revision, String buildDate,
-      HddsProtos.NodeOperationalState persistedOpState,
-      long persistedOpStateExpiryEpochSec,
-      int initialVersion, int currentVersion) {
-    super(hostName, networkLocation, NetConstants.NODE_COST_DEFAULT);
-    this.uuid = uuid;
-    this.uuidString = uuid.toString();
+  private DatanodeDetails(Builder b) {
+    super(b.hostName, b.networkLocation, NetConstants.NODE_COST_DEFAULT);
+    uuid = b.id;
+    uuidString = uuid.toString();
     threadNamePrefix = HddsUtils.threadNamePrefix(uuidString);
-    this.ipAddress = ipAddress;
-    this.hostName = hostName;
-    this.ports = ports;
-    this.certSerialId = certSerialId;
-    this.version = version;
-    this.setupTime = setupTime;
-    this.revision = revision;
-    this.buildDate = buildDate;
-    this.persistedOpState = persistedOpState;
-    this.persistedOpStateExpiryEpochSec = persistedOpStateExpiryEpochSec;
-    this.initialVersion = initialVersion;
-    this.currentVersion = currentVersion;
+    ipAddress = b.ipAddress;
+    hostName = b.hostName;
+    ports = b.ports;
+    certSerialId = b.certSerialId;
+    version = b.version;
+    setupTime = b.setupTime;
+    revision = b.revision;
+    buildDate = b.buildDate;
+    persistedOpState = b.persistedOpState;
+    persistedOpStateExpiryEpochSec = b.persistedOpStateExpiryEpochSec;
+    initialVersion = b.initialVersion;
+    currentVersion = b.currentVersion;
+    if (b.networkName != null) {
+      setNetworkName(b.networkName);
+    }
+    if (b.level > 0) {
+      setLevel(b.level);
+    }
   }
 
   public DatanodeDetails(DatanodeDetails datanodeDetails) {
@@ -813,17 +796,7 @@ public class DatanodeDetails extends NodeImpl implements
       if (networkLocation == null) {
         networkLocation = NetConstants.DEFAULT_RACK;
       }
-      DatanodeDetails dn = new DatanodeDetails(id, ipAddress, hostName,
-          networkLocation, ports, certSerialId, version, setupTime, revision,
-          buildDate, persistedOpState, persistedOpStateExpiryEpochSec,
-          initialVersion, currentVersion);
-      if (networkName != null) {
-        dn.setNetworkName(networkName);
-      }
-      if (level > 0) {
-        dn.setLevel(level);
-      }
-      return dn;
+      return new DatanodeDetails(this);
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -86,14 +86,14 @@ public class DatanodeDetails extends NodeImpl implements
 
   private String ipAddress;
   private String hostName;
-  private List<Port> ports;
+  private final List<Port> ports;
   private String certSerialId;
   private String version;
   private long setupTime;
   private String revision;
   private String buildDate;
   private volatile HddsProtos.NodeOperationalState persistedOpState;
-  private volatile long persistedOpStateExpiryEpochSec = 0;
+  private volatile long persistedOpStateExpiryEpochSec;
   private int initialVersion;
   private int currentVersion;
 
@@ -843,9 +843,6 @@ public class DatanodeDetails extends NodeImpl implements
     /**
      * Private constructor for constructing Port object. Use
      * DatanodeDetails#newPort to create a new Port object.
-     *
-     * @param name
-     * @param value
      */
     private Port(Name name, Integer value) {
       this.name = name;
@@ -1004,9 +1001,8 @@ public class DatanodeDetails extends NodeImpl implements
   @Override
   public HddsProtos.NetworkNode toProtobuf(
       int clientVersion) {
-    HddsProtos.NetworkNode networkNode =
-        HddsProtos.NetworkNode.newBuilder()
-            .setDatanodeDetails(toProtoBuilder(clientVersion).build()).build();
-    return networkNode;
+    return HddsProtos.NetworkNode.newBuilder()
+        .setDatanodeDetails(toProtoBuilder(clientVersion).build())
+        .build();
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -90,31 +90,19 @@ public final class ContainerInfo implements Comparable<ContainerInfo> {
   // container replica should have the same sequenceId.
   private long sequenceId;
 
-  @SuppressWarnings("parameternumber")
-  private ContainerInfo(
-      long containerID,
-      HddsProtos.LifeCycleState state,
-      PipelineID pipelineID,
-      long usedBytes,
-      long numberOfKeys,
-      long stateEnterTime,
-      String owner,
-      long deleteTransactionId,
-      long sequenceId,
-      ReplicationConfig repConfig,
-      Clock clock) {
-    this.containerID = ContainerID.valueOf(containerID);
-    this.pipelineID = pipelineID;
-    this.usedBytes = usedBytes;
-    this.numberOfKeys = numberOfKeys;
-    this.lastUsed = clock.instant();
-    this.state = state;
-    this.stateEnterTime = Instant.ofEpochMilli(stateEnterTime);
-    this.owner = owner;
-    this.deleteTransactionId = deleteTransactionId;
-    this.sequenceId = sequenceId;
-    this.replicationConfig = repConfig;
-    this.clock = clock;
+  private ContainerInfo(Builder b) {
+    containerID = ContainerID.valueOf(b.containerID);
+    pipelineID = b.pipelineID;
+    usedBytes = b.used;
+    numberOfKeys = b.keys;
+    lastUsed = b.clock.instant();
+    state = b.state;
+    stateEnterTime = Instant.ofEpochMilli(b.stateEnterTime);
+    owner = b.owner;
+    deleteTransactionId = b.deleteTransactionId;
+    sequenceId = b.sequenceId;
+    replicationConfig = b.replicationConfig;
+    clock = b.clock;
   }
 
   public static ContainerInfo fromProtobuf(HddsProtos.ContainerInfoProto info) {
@@ -445,9 +433,7 @@ public final class ContainerInfo implements Comparable<ContainerInfo> {
     }
 
     public ContainerInfo build() {
-      return new ContainerInfo(containerID, state, pipelineID,
-          used, keys, stateEnterTime, owner, deleteTransactionId,
-          sequenceId, replicationConfig, clock);
+      return new ContainerInfo(this);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Avoid the need for `@SuppressWarnings` by converting private constructors in `DatanodeDetails` and `ContainerInfo` to accept the builder instead of individual properties.
- Set `certSerialId` in copy constructor, was missing.

https://issues.apache.org/jira/browse/HDDS-10493

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8199986611