### PR TITLE
HDDS-10494. Recon datanode page to support sort by other storage metrics

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/storageBar/storageBar.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/storageBar/storageBar.less
@@ -50,3 +50,7 @@
 .committed-bg {
   color: @progress-dark-grey;
 }
+
+.percentage-bg {
+  color: linear-gradient(to right, @progress-green 50%, @progress-blue 50%);
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/storageBar/storageBar.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/storageBar/storageBar.tsx
@@ -51,12 +51,14 @@ class StorageBar extends React.Component<IStorageBarProps> {
     const {total, used, remaining, committed, showMeta} = this.props;
     const nonOzoneUsed = total - remaining - used;
     const totalUsed = total - remaining;
+    const percentageUsed = getCapacityPercent(totalUsed, total)
     const tooltip = (
       <div>
+        <div> Total storage utilization ({percentageUsed}%)</div>
         <div><Icon component={FilledIcon} className='ozone-used-bg'/> Ozone Used ({size(used)})</div>
         <div><Icon component={FilledIcon} className='non-ozone-used-bg'/> Non Ozone Used ({size(nonOzoneUsed)})</div>
         <div><Icon component={FilledIcon} className='remaining-bg'/> Remaining ({size(remaining)})</div>
-        <div><Icon component={FilledIcon} className='committed-bg'/> Container Pre-allocated ({size(committed)})</div>
+        <div><Icon component={FilledIcon} className='committed-bg'/> Committed ({size(committed)})</div>
       </div>
     );
     const metaElement = showMeta ? <div>{size(used)} + {size(nonOzoneUsed)} / {size(total)}</div> : null;
@@ -66,7 +68,7 @@ class StorageBar extends React.Component<IStorageBarProps> {
           {metaElement}
           <Progress
             strokeLinecap='square'
-            percent={getCapacityPercent(totalUsed, total)}
+            percent={percentageUsed}
             successPercent={getCapacityPercent(used, total)}
             className='capacity-bar' strokeWidth={3}/>
         </Tooltip>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/storageBar/storageBar.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/storageBar/storageBar.tsx
@@ -22,7 +22,7 @@ import {withRouter} from 'react-router-dom';
 import {RouteComponentProps} from 'react-router';
 import {FilledIcon} from 'utils/themeIcons';
 import Tooltip from 'antd/lib/tooltip';
-import {getCapacityPercent} from 'utils/common';
+import {getCapacityPercent, getNonOzoneUsed, getTotalUsed} from 'utils/common';
 import filesize from 'filesize';
 import './storageBar.less';
 
@@ -49,16 +49,16 @@ class StorageBar extends React.Component<IStorageBarProps> {
 
   render() {
     const {total, used, remaining, committed, showMeta} = this.props;
-    const nonOzoneUsed = total - remaining - used;
-    const totalUsed = total - remaining;
+    const nonOzoneUsed = getNonOzoneUsed(total, remaining, used);
+    const totalUsed = getTotalUsed(total, remaining);
     const percentageUsed = getCapacityPercent(totalUsed, total)
     const tooltip = (
       <div>
         <div> Total storage utilization ({percentageUsed}%)</div>
         <div><Icon component={FilledIcon} className='ozone-used-bg'/> Ozone Used ({size(used)})</div>
         <div><Icon component={FilledIcon} className='non-ozone-used-bg'/> Non Ozone Used ({size(nonOzoneUsed)})</div>
+        <div><Icon component={FilledIcon} className='committed-bg'/> Pre-allocated ({size(committed)})</div>
         <div><Icon component={FilledIcon} className='remaining-bg'/> Remaining ({size(remaining)})</div>
-        <div><Icon component={FilledIcon} className='committed-bg'/> Committed ({size(committed)})</div>
       </div>
     );
     const metaElement = showMeta ? <div>{size(used)} + {size(nonOzoneUsed)} / {size(total)}</div> : null;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/common.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/common.tsx
@@ -21,6 +21,9 @@ import {notification} from 'antd';
 
 export const getCapacityPercent = (used: number, total: number) => Math.round((used / total) * 100);
 
+export const getNonOzoneUsed = (total: number, remaining: number, ozoneUsed: number) => getTotalUsed(total, remaining) - ozoneUsed;
+export const getTotalUsed = (total: number, remaining: number) => total - remaining;
+
 export const timeFormat = (time: number) => time > 0 ?
   moment(time).format('lll') : 'NA';
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -34,7 +34,7 @@ import {AutoReloadHelper} from 'utils/autoReloadHelper';
 import AutoReloadPanel from 'components/autoReloadPanel/autoReloadPanel';
 import {IOption, MultiSelect} from 'components/multiSelect/multiSelect';
 import {ActionMeta, ValueType} from 'react-select';
-import {showDataFetchError} from 'utils/common';
+import {getCapacityPercent, showDataFetchError} from 'utils/common';
 import {ColumnSearch} from 'utils/columnSearch';
 import {AxiosGetHelper} from 'utils/axiosRequestHelper';
 import {ColumnProps} from "antd/es/table";
@@ -223,7 +223,10 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
             text: 'Storage Total',
             value: 'storageTotal',
           },
-
+          {
+            text: 'Storage Utilization',
+            value: 'storageUtilization',
+          }
         ],
         filterIcon: () => (
           <Icon type={'sort-ascending'} />
@@ -249,6 +252,10 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
             return a.storageCommitted - b.storageCommitted;
           } else if (sortBy === "storageTotal") {
             return a.storageTotal- b.storageTotal;
+          } else if (sortBy === 'storageUtilization') {
+            // See totalUsed calculation in storageBar.tsx
+            return getCapacityPercent(a.storageTotal - a.storageRemaining, a.storageRemaining) -
+                getCapacityPercent(b.storageTotal - b.storageRemaining, b.storageRemaining)
           } else {
             return a.storageRemaining - b.storageRemaining
           }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -34,7 +34,7 @@ import {AutoReloadHelper} from 'utils/autoReloadHelper';
 import AutoReloadPanel from 'components/autoReloadPanel/autoReloadPanel';
 import {MultiSelect, IOption} from 'components/multiSelect/multiSelect';
 import {ActionMeta, ValueType} from 'react-select';
-import {getCapacityPercent, showDataFetchError} from 'utils/common';
+import {getCapacityPercent, getNonOzoneUsed, getTotalUsed, showDataFetchError} from 'utils/common';
 import {ColumnSearch} from 'utils/columnSearch';
 import { AxiosGetHelper } from 'utils/axiosRequestHelper';
 import {ColumnProps} from "antd/es/table";
@@ -212,21 +212,29 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
             value: 'storageRemaining',
           },
           {
-            text: 'Storage Used',
-            value: 'storageUsed',
+            text: 'Storage Used - Ozone',
+            value: 'storageUsedOzone',
           },
           {
-            text: 'Storage Committed',
+            text: 'Storage Used - Non-Ozone',
+            value: 'storageUsedNonOzone',
+          },
+          {
+            text: 'Storage Total Used',
+            value: 'storageUsedTotal',
+          },
+          {
+            text: 'Storage Total Used (%)',
+            value: 'storageUsedTotalUtilization',
+          },
+          {
+            text: 'Storage Pre-allocated',
             value: 'storageCommitted'
           },
           {
             text: 'Storage Total',
             value: 'storageTotal',
           },
-          {
-            text: 'Total Storage Utilization %',
-            value: 'storageUtilization',
-          }
         ],
         filterIcon: () => (
           <Icon type={'sort-ascending'} />
@@ -246,16 +254,20 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
             return a.storageRemaining - b.storageRemaining
           }
 
-          if (sortBy === "storageUsed") {
+          if (sortBy === "storageUsedOzone") {
             return a.storageUsed - b.storageUsed;
+          } else if (sortBy === "storageUsedNonOzone") {
+            return getNonOzoneUsed(a.storageTotal, a.storageRemaining, a.storageUsed) -
+                getNonOzoneUsed(b.storageTotal, b.storageRemaining, a.storageUsed);
+          } else if (sortBy === "storageUsedTotal") {
+            return getTotalUsed(a.storageTotal, a.storageRemaining) - getTotalUsed(a.storageTotal, a.storageRemaining)
+          } else if (sortBy === 'storageUsedTotalUtilization') {
+            return getCapacityPercent(a.storageTotal - a.storageRemaining, a.storageTotal) -
+                getCapacityPercent(b.storageTotal - b.storageRemaining, b.storageTotal)
           } else if (sortBy === "storageCommitted") {
             return a.storageCommitted - b.storageCommitted;
           } else if (sortBy === "storageTotal") {
             return a.storageTotal- b.storageTotal;
-          } else if (sortBy === 'storageUtilization') {
-            // See totalUsed calculation in storageBar.tsx
-            return getCapacityPercent(a.storageTotal - a.storageRemaining, a.storageTotal) -
-                getCapacityPercent(b.storageTotal - b.storageRemaining, b.storageTotal)
           } else {
             return a.storageRemaining - b.storageRemaining
           }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -224,7 +224,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
             value: 'storageTotal',
           },
           {
-            text: 'Storage Utilization',
+            text: 'Total Storage Utilization %',
             value: 'storageUtilization',
           }
         ],

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -254,8 +254,8 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
             return a.storageTotal- b.storageTotal;
           } else if (sortBy === 'storageUtilization') {
             // See totalUsed calculation in storageBar.tsx
-            return getCapacityPercent(a.storageTotal - a.storageRemaining, a.storageRemaining) -
-                getCapacityPercent(b.storageTotal - b.storageRemaining, b.storageRemaining)
+            return getCapacityPercent(a.storageTotal - a.storageRemaining, a.storageTotal) -
+                getCapacityPercent(b.storageTotal - b.storageRemaining, b.storageTotal)
           } else {
             return a.storageRemaining - b.storageRemaining
           }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -17,26 +17,26 @@
  */
 
 import React from 'react';
-import {Icon, Popover, Table, Tooltip} from 'antd';
+import {Table, Icon, Tooltip, Popover} from 'antd';
 import {PaginationConfig} from 'antd/lib/pagination';
 import moment from 'moment';
 import {ReplicationIcon} from 'utils/themeIcons';
 import StorageBar from 'components/storageBar/storageBar';
 import {
-  DatanodeOpState,
-  DatanodeOpStateList,
   DatanodeState,
   DatanodeStateList,
+  DatanodeOpState,
+  DatanodeOpStateList,
   IStorageReport
 } from 'types/datanode.types';
 import './datanodes.less';
 import {AutoReloadHelper} from 'utils/autoReloadHelper';
 import AutoReloadPanel from 'components/autoReloadPanel/autoReloadPanel';
-import {IOption, MultiSelect} from 'components/multiSelect/multiSelect';
+import {MultiSelect, IOption} from 'components/multiSelect/multiSelect';
 import {ActionMeta, ValueType} from 'react-select';
 import {getCapacityPercent, showDataFetchError} from 'utils/common';
 import {ColumnSearch} from 'utils/columnSearch';
-import {AxiosGetHelper} from 'utils/axiosRequestHelper';
+import { AxiosGetHelper } from 'utils/axiosRequestHelper';
 import {ColumnProps} from "antd/es/table";
 
 interface IDatanodeResponse {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -17,26 +17,27 @@
  */
 
 import React from 'react';
-import {Table, Icon, Tooltip, Popover} from 'antd';
+import {Icon, Popover, Table, Tooltip} from 'antd';
 import {PaginationConfig} from 'antd/lib/pagination';
 import moment from 'moment';
 import {ReplicationIcon} from 'utils/themeIcons';
 import StorageBar from 'components/storageBar/storageBar';
 import {
-  DatanodeState,
-  DatanodeStateList,
   DatanodeOpState,
   DatanodeOpStateList,
+  DatanodeState,
+  DatanodeStateList,
   IStorageReport
 } from 'types/datanode.types';
 import './datanodes.less';
 import {AutoReloadHelper} from 'utils/autoReloadHelper';
 import AutoReloadPanel from 'components/autoReloadPanel/autoReloadPanel';
-import {MultiSelect, IOption} from 'components/multiSelect/multiSelect';
+import {IOption, MultiSelect} from 'components/multiSelect/multiSelect';
 import {ActionMeta, ValueType} from 'react-select';
 import {showDataFetchError} from 'utils/common';
 import {ColumnSearch} from 'utils/columnSearch';
-import { AxiosGetHelper } from 'utils/axiosRequestHelper';
+import {AxiosGetHelper} from 'utils/axiosRequestHelper';
+import {ColumnProps} from "antd/es/table";
 
 interface IDatanodeResponse {
   hostname: string;
@@ -96,6 +97,7 @@ interface IDatanodesState {
   lastUpdated: number;
   selectedColumns: IOption[];
   columnOptions: IOption[];
+  filteredInfo: Partial<Record<string, string[]>>;
 }
 
 const renderDatanodeState = (state: DatanodeState) => {
@@ -120,204 +122,11 @@ const renderDatanodeOpState = (opState: DatanodeOpState) => {
   return <span>{icon} {opState}</span>;
 };
 
-const COLUMNS = [
-  {
-    title: 'Hostname',
-    dataIndex: 'hostname',
-    key: 'hostname',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.hostname.localeCompare(b.hostname, undefined, {numeric: true}),
-    defaultSortOrder: 'ascend' as const,
-    fixed: 'left'
-  },
-  {
-    title: 'State',
-    dataIndex: 'state',
-    key: 'state',
-    isVisible: true,
-    isSearchable: true,
-    filterMultiple: true,
-    filters: DatanodeStateList && DatanodeStateList.map(state => ({text: state, value: state})),
-    onFilter: (value: DatanodeState, record: IDatanode) => record.state === value,
-    render: (text: DatanodeState) => renderDatanodeState(text),
-    sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state)
-  },
-  {
-    title: 'Operational State',
-    dataIndex: 'opState',
-    key: 'opState',
-    isVisible: true,
-    isSearchable: true,
-    filterMultiple: true,
-    filters: DatanodeOpStateList && DatanodeOpStateList.map(state => ({text: state, value: state})),
-    onFilter: (value: DatanodeOpState, record: IDatanode) => record.opState === value,
-    render: (text: DatanodeOpState) => renderDatanodeOpState(text),
-    sorter: (a: IDatanode, b: IDatanode) => a.opState.localeCompare(b.opState)
-  },
- 
-  {
-    title: 'Uuid',
-    dataIndex: 'uuid',
-    key: 'uuid',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.uuid.localeCompare(b.uuid),
-    defaultSortOrder: 'ascend' as const
-  },
-  {
-    title: 'Storage Capacity',
-    dataIndex: 'storageUsed',
-    key: 'storageUsed',
-    isVisible: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.storageRemaining - b.storageRemaining,
-    render: (text: string, record: IDatanode) => (
-      <StorageBar
-        total={record.storageTotal} used={record.storageUsed}
-        remaining={record.storageRemaining} committed={record.storageCommitted}/>
-    )},
-  {
-    title: 'Last Heartbeat',
-    dataIndex: 'lastHeartbeat',
-    key: 'lastHeartbeat',
-    isVisible: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.lastHeartbeat - b.lastHeartbeat,
-    render: (heartbeat: number) => {
-      return heartbeat > 0 ? getTimeDiffFromTimestamp(heartbeat) : 'NA';
-    }
-  },
-  {
-    title: 'Pipeline ID(s)',
-    dataIndex: 'pipelines',
-    key: 'pipelines',
-    isVisible: true,
-    render: (pipelines: IPipeline[], record: IDatanode) => {
-      let firstThreePipelinesIDs = [];
-      let remainingPipelinesIDs: any[] = [];
-      firstThreePipelinesIDs = pipelines && pipelines.filter((element, index) => index < 3);
-      remainingPipelinesIDs = pipelines && pipelines.slice(3, pipelines.length);
-
-      const RenderPipelineIds = ({ pipelinesIds }) => {
-        return pipelinesIds && pipelinesIds.map((pipeline: any, index: any) => (
-          <div key={index} className='pipeline-container'>
-            <ReplicationIcon
-              replicationFactor={pipeline.replicationFactor}
-              replicationType={pipeline.replicationType}
-              leaderNode={pipeline.leaderNode}
-              isLeader={pipeline.leaderNode === record.hostname} />
-            {pipeline.pipelineID}
-          </div >
-        ))
-      }
-
-      return (
-        <>
-          {
-            <RenderPipelineIds pipelinesIds={firstThreePipelinesIDs} />
-          }
-          {
-            remainingPipelinesIDs.length > 0 &&
-            <Popover content={<RenderPipelineIds pipelinesIds={remainingPipelinesIDs} />} title="Remaining pipelines" placement="rightTop" trigger="hover">
-              {`... and ${remainingPipelinesIDs.length} more pipelines`}
-            </Popover>
-          }
-        </>
-      );
-    }
-  },
-  {
-    title:
-  <span>
-    Leader Count&nbsp;
-    <Tooltip title='The number of Ratis Pipelines in which the given datanode is elected as a leader.'>
-      <Icon type='info-circle'/>
-    </Tooltip>
-  </span>,
-    dataIndex: 'leaderCount',
-    key: 'leaderCount',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.leaderCount - b.leaderCount
-  },
-  {
-    title: 'Containers',
-    dataIndex: 'containers',
-    key: 'containers',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.containers - b.containers
-  },
-  {
-    title:
-    <span>
-    Open Containers&nbsp;
-    <Tooltip title='The number of open containers per pipeline.'>
-      <Icon type='info-circle'/>
-    </Tooltip>
-  </span>,
-    dataIndex: 'openContainers',
-    key: 'openContainers',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.openContainers - b.openContainers
-  },
-  {
-    title: 'Version',
-    dataIndex: 'version',
-    key: 'version',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.version.localeCompare(b.version),
-    defaultSortOrder: 'ascend' as const
-  },
-  {
-    title: 'Setup Time',
-    dataIndex: 'setupTime',
-    key: 'setupTime',
-    isVisible: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.setupTime - b.setupTime,
-    render: (uptime: number) => {
-      return uptime > 0 ? moment(uptime).format('ll LTS') : 'NA';
-    }
-  },
-  {
-    title: 'Revision',
-    dataIndex: 'revision',
-    key: 'revision',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.revision.localeCompare(b.revision),
-    defaultSortOrder: 'ascend' as const
-  },
-  {
-    title: 'Build Date',
-    dataIndex: 'buildDate',
-    key: 'buildDate',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.buildDate.localeCompare(b.buildDate),
-    defaultSortOrder: 'ascend' as const
-  },
-  {
-    title: 'Network Location',
-    dataIndex: 'networkLocation',
-    key: 'networkLocation',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.networkLocation.localeCompare(b.networkLocation),
-    defaultSortOrder: 'ascend' as const
-  }
-];
-
 const allColumnsOption: IOption = {
   label: 'Select all',
   value: '*'
 };
 
-const defaultColumns: IOption[] = COLUMNS.map(column => ({
-  label: column.key,
-  value: column.key
-}));
 
 const getTimeDiffFromTimestamp = (timestamp: number): string => {
   const timestampDate = new Date(timestamp);
@@ -343,21 +152,272 @@ let cancelSignal: AbortController;
 
 export class Datanodes extends React.Component<Record<string, object>, IDatanodesState> {
   autoReload: AutoReloadHelper;
+  columns: ColumnProps<IDatanode>[];
+  defaultColumns: IOption[];
 
   constructor(props = {}) {
     super(props);
+    this.columns = [
+      {
+        title: 'Hostname',
+        dataIndex: 'hostname',
+        key: 'hostname',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.hostname.localeCompare(b.hostname, undefined, {numeric: true}),
+        defaultSortOrder: 'ascend' as const,
+        fixed: 'left'
+      },
+      {
+        title: 'State',
+        dataIndex: 'state',
+        key: 'state',
+        isVisible: true,
+        isSearchable: true,
+        filterMultiple: true,
+        filters: DatanodeStateList && DatanodeStateList.map(state => ({text: state, value: state})),
+        onFilter: (value: DatanodeState, record: IDatanode) => record.state === value,
+        render: (text: DatanodeState) => renderDatanodeState(text),
+        sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state)
+      },
+      {
+        title: 'Operational State',
+        dataIndex: 'opState',
+        key: 'opState',
+        isVisible: true,
+        isSearchable: true,
+        filterMultiple: true,
+        filters: DatanodeOpStateList && DatanodeOpStateList.map(state => ({text: state, value: state})),
+        onFilter: (value: DatanodeOpState, record: IDatanode) => record.opState === value,
+        render: (text: DatanodeOpState) => renderDatanodeOpState(text),
+        sorter: (a: IDatanode, b: IDatanode) => a.opState.localeCompare(b.opState)
+      },
+      {
+        title: 'Uuid',
+        dataIndex: 'uuid',
+        key: 'uuid',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.uuid.localeCompare(b.uuid),
+        defaultSortOrder: 'ascend' as const
+      },
+      {
+        title: 'Storage Capacity',
+        dataIndex: 'storageCapacity',
+        key: 'storageCapacity',
+        isVisible: true,
+        filters: [
+          {
+            text: 'Storage Remaining (default)',
+            value: 'storageRemaining',
+          },
+          {
+            text: 'Storage Used',
+            value: 'storageUsed',
+          },
+          {
+            text: 'Storage Committed',
+            value: 'storageCommitted'
+          },
+          {
+            text: 'Storage Total',
+            value: 'storageTotal',
+          },
+
+        ],
+        filterIcon: () => (
+          <Icon type={'sort-ascending'} />
+        ),
+        filterMultiple: false,
+        onFilter: () => {
+          // This filter is only used for placeholder, so return true regardless of the filter
+          return true;
+        },
+        sorter: (a: IDatanode, b: IDatanode) => {
+          let sortBy = "storageRemaining"
+          if (this.state.filteredInfo.storageCapacity &&
+              this.state.filteredInfo.storageCapacity.length > 0) {
+            sortBy = this.state.filteredInfo.storageCapacity[0]
+          }
+          if (!sortBy) {
+            return a.storageRemaining - b.storageRemaining
+          }
+
+          if (sortBy === "storageUsed") {
+            return a.storageUsed - b.storageUsed;
+          } else if (sortBy === "storageCommitted") {
+            return a.storageCommitted - b.storageCommitted;
+          } else if (sortBy === "storageTotal") {
+            return a.storageTotal- b.storageTotal;
+          } else {
+            return a.storageRemaining - b.storageRemaining
+          }
+        },
+        render: (text: string, record: IDatanode) => (
+            <StorageBar
+                total={record.storageTotal} used={record.storageUsed}
+                remaining={record.storageRemaining} committed={record.storageCommitted}/>
+        )},
+      {
+        title: 'Last Heartbeat',
+        dataIndex: 'lastHeartbeat',
+        key: 'lastHeartbeat',
+        isVisible: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.lastHeartbeat - b.lastHeartbeat,
+        render: (heartbeat: number) => {
+          return heartbeat > 0 ? getTimeDiffFromTimestamp(heartbeat) : 'NA';
+        }
+      },
+      {
+        title: 'Pipeline ID(s)',
+        dataIndex: 'pipelines',
+        key: 'pipelines',
+        isVisible: true,
+        render: (pipelines: IPipeline[], record: IDatanode) => {
+          let firstThreePipelinesIDs = [];
+          let remainingPipelinesIDs: any[] = [];
+          firstThreePipelinesIDs = pipelines && pipelines.filter((element, index) => index < 3);
+          remainingPipelinesIDs = pipelines && pipelines.slice(3, pipelines.length);
+
+          const RenderPipelineIds = ({ pipelinesIds }) => {
+            return pipelinesIds && pipelinesIds.map((pipeline: any, index: any) => (
+                <div key={index} className='pipeline-container'>
+                  <ReplicationIcon
+                      replicationFactor={pipeline.replicationFactor}
+                      replicationType={pipeline.replicationType}
+                      leaderNode={pipeline.leaderNode}
+                      isLeader={pipeline.leaderNode === record.hostname} />
+                  {pipeline.pipelineID}
+                </div >
+            ))
+          }
+
+          return (
+              <>
+                {
+                  <RenderPipelineIds pipelinesIds={firstThreePipelinesIDs} />
+                }
+                {
+                    remainingPipelinesIDs.length > 0 &&
+                    <Popover content={<RenderPipelineIds pipelinesIds={remainingPipelinesIDs} />} title="Remaining pipelines" placement="rightTop" trigger="hover">
+                      {`... and ${remainingPipelinesIDs.length} more pipelines`}
+                    </Popover>
+                }
+              </>
+          );
+        }
+      },
+      {
+        title:
+            <span>
+    Leader Count&nbsp;
+              <Tooltip title='The number of Ratis Pipelines in which the given datanode is elected as a leader.'>
+      <Icon type='info-circle'/>
+    </Tooltip>
+  </span>,
+        dataIndex: 'leaderCount',
+        key: 'leaderCount',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.leaderCount - b.leaderCount
+      },
+      {
+        title: 'Containers',
+        dataIndex: 'containers',
+        key: 'containers',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.containers - b.containers
+      },
+      {
+        title:
+            <span>
+    Open Containers&nbsp;
+              <Tooltip title='The number of open containers per pipeline.'>
+      <Icon type='info-circle'/>
+    </Tooltip>
+  </span>,
+        dataIndex: 'openContainers',
+        key: 'openContainers',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.openContainers - b.openContainers
+      },
+      {
+        title: 'Version',
+        dataIndex: 'version',
+        key: 'version',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.version.localeCompare(b.version),
+        defaultSortOrder: 'ascend' as const
+      },
+      {
+        title: 'Setup Time',
+        dataIndex: 'setupTime',
+        key: 'setupTime',
+        isVisible: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.setupTime - b.setupTime,
+        render: (uptime: number) => {
+          return uptime > 0 ? moment(uptime).format('ll LTS') : 'NA';
+        }
+      },
+      {
+        title: 'Revision',
+        dataIndex: 'revision',
+        key: 'revision',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.revision.localeCompare(b.revision),
+        defaultSortOrder: 'ascend' as const
+      },
+      {
+        title: 'Build Date',
+        dataIndex: 'buildDate',
+        key: 'buildDate',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.buildDate.localeCompare(b.buildDate),
+        defaultSortOrder: 'ascend' as const
+      },
+      {
+        title: 'Network Location',
+        dataIndex: 'networkLocation',
+        key: 'networkLocation',
+        isVisible: true,
+        isSearchable: true,
+        sorter: (a: IDatanode, b: IDatanode) => a.networkLocation.localeCompare(b.networkLocation),
+        defaultSortOrder: 'ascend' as const
+      }
+    ];
+
+    this.defaultColumns = this.columns.map(column => ({
+      label: column.key,
+      value: column.key
+    }));
+
     this.state = {
       loading: false,
       dataSource: [],
       totalCount: 0,
       lastUpdated: 0,
       selectedColumns: [],
-      columnOptions: defaultColumns
+      columnOptions: this.defaultColumns,
+      filteredInfo: {},
     };
+
+
     this.autoReload = new AutoReloadHelper(this._loadData);
   }
 
-  _handleColumnChange = (selected: ValueType<IOption>, _action: ActionMeta<IOption>) => {
+  _handleChange = (pagination: PaginationConfig,
+                   filters: Partial<Record<keyof IDatanode, string[]>>) => {
+    this.setState({
+      filteredInfo: filters,
+    });
+  }
+
+  _handleColumnChange = (selected: ValueType<IOption, any>, _action: ActionMeta<IOption>) => {
     const selectedColumns = (selected == null ? [] : selected as IOption[]);
     this.setState({
       selectedColumns
@@ -365,11 +425,10 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
   };
 
   _getSelectedColumns = (selected: IOption[]) => {
-    const selectedColumns = selected.length > 0 ? selected : COLUMNS.filter(column => column.isVisible).map(column => ({
+    return selected.length > 0 ? selected : this.columns.filter(column => column.isVisible).map(column => ({
       label: column.key,
       value: column.key
     }));
-    return selectedColumns;
   };
 
   _loadData = () => {
@@ -377,7 +436,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
       loading: true,
       selectedColumns: this._getSelectedColumns(prevState.selectedColumns)
     }));
-    
+
     const { request, controller } = AxiosGetHelper('/api/v1/datanodes', cancelSignal);
     cancelSignal = controller;
     request.then(response => {
@@ -443,6 +502,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
       showSizeChanger: true,
       onShowSizeChange: this.onShowSizeChange
     };
+
     return (
       <div className='datanodes-container'>
         <div className='page-header'>
@@ -472,7 +532,8 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
         <div className='content-div'>
           <Table
             dataSource={dataSource}
-            columns={COLUMNS.reduce<any[]>((filtered, column) => {
+            onChange={this._handleChange}
+            columns={this.columns.reduce<any[]>((filtered, column) => {
               if (selectedColumns.some(e => e.value === column.key)) {
                 if (column.isSearchable) {
                   const newColumn = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently in the Datanode page the "Storage Capacity" columns only supports sorting by "storageRemaining". Add a filter option for user to be able to pick other storage metrics.

The options are:

- Storage Remaining (default)
- Storage Used
- Storage Committed
- Storage Total
- Storage Utilization (include both Ozone and non-ozone usage): The one shown in the percentage of the storage bar

This patch will reuse the Antd table filter and uses the filter info state to set which storage metric the column will be sorted by (i.e. the filter will not be used for filtering data, but will be used as a placeholder to manage the sort state). You can refer to https://3x.ant.design/components/table/#components-table-demo-reset-filter for some of the implementation (See `filteredInfo` and `onChange`).

This requires some React state management which requires moving the columns definition into the React class, but the main change is only on the `storageCapacity` column.

Note: I tried setting `defaultFilteredValue = ['storageRemaining']` and `filteredValue = ['storageRemaining']`  for the filter to pick the Storage Remaining by default, but `defaultFilteredValue` does not seem to work and `filteredValue` causes the filtered value to randomly get reset back to 'storageRemaining' although other filters are chosen. So currently I used the "(default)" in the filter label to pick which metric is default. Any suggestion is appreciated.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10494

## How was this patch tested?

Manual test using `pnpm run dev`.

Screenshot:

<img width="189" alt="image" src="https://github.com/apache/ozone/assets/36403683/9fe15dd5-0c69-476c-8e95-d313650fa935">


