### PR TITLE
HDDS-10498. Improved configuration for license compliance

### DIFF
--- a/dev-support/rat/rat-exclusions.txt
+++ b/dev-support/rat/rat-exclusions.txt
@@ -15,41 +15,60 @@
 ###### specific language governing permissions and limitations
 ###### under the License.
 
+.gitattributes
 .github/*
 CONTRIBUTING.md
 README.md
 SECURITY.md
-.gitattributes
+dev-support/ci/bats-assert/**
+dev-support/ci/bats-support/**
+
+# hadoop-hdds/interface-client
 src/main/resources/proto.lock
-**/output.xml
-**/log.html
-**/report.html
-**/.ssh/id_rsa*
-src/test/resources/*.log
-src/test/resources/ssl/*
-**/dependency-reduced-pom.xml
-**/pnpm-lock.yaml
-src/test/resources/prometheus-test-response.txt
-src/main/license/**
-src/main/resources/proto.lock
-src/test/resources/test.db.ini
+
+# tools/fault-injection-service
 tools/fault-injection-service/README.md
+
+# hadoop-hdds/framework
+**/webapps/static/angular-1.8.0.min.js
 **/webapps/static/angular-nvd3-1.0.9.min.js
 **/webapps/static/angular-route-1.8.0.min.js
 **/webapps/static/bootstrap-3.4.1/**
 **/webapps/static/d3-3.5.17.min.js
 **/webapps/static/jquery-3.5.1.min.js
-**/webapps/static/nvd3-1.8.5.min.css.map
 **/webapps/static/nvd3-1.8.5.min.css
-**/webapps/static/nvd3-1.8.5.min.js.map
+**/webapps/static/nvd3-1.8.5.min.css.map
 **/webapps/static/nvd3-1.8.5.min.js
-**/webapps/static/angular-1.8.0.min.js
+**/webapps/static/nvd3-1.8.5.min.js.map
+
+# hadoop-hdds/container-service
+src/test/resources/123-dn-container.db/**
+src/test/resources/123.container
 src/test/resources/additionalfields.container
 src/test/resources/incorrect.checksum.container
 src/test/resources/incorrect.container
 src/test/resources/test.db.ini
-src/test/resources/123-dn-container.db/**
-src/test/resources/123.container
-static/slides/*
+
+# hadoop-hdds/docs
 **/themes/ozonedoc/**
-**/*.json
+static/slides/*
+
+# hadoop-ozone/dist
+**/.ssh/id_rsa*
+**/log.html
+**/output.xml
+**/report.html
+src/main/license/**
+
+# hadoop-ozone/integration-test
+src/test/resources/ssl/*
+
+# hadoop-ozone/recon
+**/pnpm-lock.yaml
+src/test/resources/prometheus-test-response.txt
+
+# hadoop-ozone/shaded
+**/dependency-reduced-pom.xml
+
+# hadoop-ozone/tools
+src/test/resources/*.log

--- a/dev-support/rat/rat-exclusions.txt
+++ b/dev-support/rat/rat-exclusions.txt
@@ -15,6 +15,7 @@
 ###### specific language governing permissions and limitations
 ###### under the License.
 
+**/*.json
 .gitattributes
 .github/*
 CONTRIBUTING.md

--- a/dev-support/rat/rat-exclusions.txt
+++ b/dev-support/rat/rat-exclusions.txt
@@ -1,0 +1,55 @@
+###### Licensed to the Apache Software Foundation (ASF) under one
+###### or more contributor license agreements.  See the NOTICE file
+###### distributed with this work for additional information
+###### regarding copyright ownership.  The ASF licenses this file
+###### to you under the Apache License, Version 2.0 (the
+###### "License"); you may not use this file except in compliance
+###### with the License.  You may obtain a copy of the License at
+######
+######   http://www.apache.org/licenses/LICENSE-2.0
+######
+###### Unless required by applicable law or agreed to in writing,
+###### software distributed under the License is distributed on an
+###### "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+###### KIND, either express or implied.  See the License for the
+###### specific language governing permissions and limitations
+###### under the License.
+
+.github/*
+CONTRIBUTING.md
+README.md
+SECURITY.md
+.gitattributes
+src/main/resources/proto.lock
+**/output.xml
+**/log.html
+**/report.html
+**/.ssh/id_rsa*
+src/test/resources/*.log
+src/test/resources/ssl/*
+**/dependency-reduced-pom.xml
+**/pnpm-lock.yaml
+src/test/resources/prometheus-test-response.txt
+src/main/license/**
+src/main/resources/proto.lock
+src/test/resources/test.db.ini
+tools/fault-injection-service/README.md
+**/webapps/static/angular-nvd3-1.0.9.min.js
+**/webapps/static/angular-route-1.8.0.min.js
+**/webapps/static/bootstrap-3.4.1/**
+**/webapps/static/d3-3.5.17.min.js
+**/webapps/static/jquery-3.5.1.min.js
+**/webapps/static/nvd3-1.8.5.min.css.map
+**/webapps/static/nvd3-1.8.5.min.css
+**/webapps/static/nvd3-1.8.5.min.js.map
+**/webapps/static/nvd3-1.8.5.min.js
+**/webapps/static/angular-1.8.0.min.js
+src/test/resources/additionalfields.container
+src/test/resources/incorrect.checksum.container
+src/test/resources/incorrect.container
+src/test/resources/test.db.ini
+src/test/resources/123-dn-container.db/**
+src/test/resources/123.container
+static/slides/*
+**/themes/ozonedoc/**
+**/*.json

--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -51,30 +51,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-            <excludes>
-            <exclude>static/slides/*</exclude>
-            <exclude>themes/ozonedoc/static/js/bootstrap.min.js</exclude>
-            <exclude>themes/ozonedoc/static/js/jquery-3.5.1.min.js</exclude>
-            <exclude>themes/ozonedoc/static/js/swagger-ui-bundle.js</exclude>
-            <exclude>themes/ozonedoc/static/css/bootstrap-theme.min.css
-            </exclude>
-            <exclude>themes/ozonedoc/static/css/bootstrap.min.css.map</exclude>
-            <exclude>themes/ozonedoc/static/css/bootstrap.min.css</exclude>
-            <exclude>themes/ozonedoc/static/css/bootstrap-theme.min.css.map
-            </exclude>
-            <exclude>themes/ozonedoc/static/css/swagger-ui.css</exclude>
-            <exclude>
-              themes/ozonedoc/static/fonts/glyphicons-halflings-regular.svg
-            </exclude>
-            <exclude>themes/ozonedoc/layouts/index.html</exclude>
-            <exclude>themes/ozonedoc/theme.toml</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -235,45 +235,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
-
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>**/*.json</exclude>
-            <exclude>**/hs_err*.log</exclude>
-            <exclude>**/.attach_*</exclude>
-            <exclude>**/**.rej</exclude>
-            <exclude>**/.factorypath</exclude>
-            <exclude>public</exclude>
-            <exclude>**/*.iml</exclude>
-            <exclude>**/target/**</exclude>
-            <exclude>**/output.xml</exclude>
-            <exclude>**/log.html</exclude>
-            <exclude>**/report.html</exclude>
-            <exclude>.gitattributes</exclude>
-            <exclude>.idea/**</exclude>
-            <exclude>src/main/resources/webapps/static/angular-1.8.0.min.js</exclude>
-            <exclude>src/main/resources/webapps/static/angular-nvd3-1.0.9.min.js</exclude>
-            <exclude>src/main/resources/webapps/static/angular-route-1.8.0.min.js</exclude>
-            <exclude>src/main/resources/webapps/static/d3-3.5.17.min.js</exclude>
-            <exclude>src/main/resources/webapps/static/nvd3-1.8.5.min.css.map</exclude>
-            <exclude>src/main/resources/webapps/static/nvd3-1.8.5.min.css</exclude>
-            <exclude>src/main/resources/webapps/static/nvd3-1.8.5.min.js.map</exclude>
-            <exclude>src/main/resources/webapps/static/nvd3-1.8.5.min.js</exclude>
-            <exclude>src/main/resources/webapps/static/jquery-3.5.1.min.js</exclude>
-            <exclude>src/main/resources/webapps/static/bootstrap-3.4.1/**</exclude>
-            <exclude>src/test/resources/additionalfields.container</exclude>
-            <exclude>src/test/resources/incorrect.checksum.container</exclude>
-            <exclude>src/test/resources/incorrect.container</exclude>
-            <exclude>src/test/resources/test.db.ini</exclude>
-            <exclude>src/test/resources/123-dn-container.db/**</exclude>
-            <exclude>src/test/resources/123.container</exclude>
-            <exclude>src/main/resources/proto.lock</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>

--- a/hadoop-ozone/dev-support/checks/rat.sh
+++ b/hadoop-ozone/dev-support/checks/rat.sh
@@ -24,13 +24,7 @@ mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-dirs="hadoop-hdds hadoop-ozone"
-
-for d in $dirs; do
-  pushd "$d" || exit 1
-  mvn -B --no-transfer-progress -fn org.apache.rat:apache-rat-plugin:0.13:check
-  popd
-done
+mvn -B --no-transfer-progress -fn org.apache.rat:apache-rat-plugin:0.13:check
 
 grep -r --include=rat.txt "!????" $dirs | tee "$REPORT_FILE"
 

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -243,10 +243,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>${maven-antrun-plugin.version}</version>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -306,66 +306,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>**/*.json</exclude>
-            <exclude>**/hs_err*.log</exclude>
-            <exclude>**/target/**</exclude>
-            <exclude>.gitattributes</exclude>
-            <exclude>**/.attach_*</exclude>
-            <exclude>**/**.rej</exclude>
-            <exclude>**/.factorypath</exclude>
-            <exclude>public</exclude>
-            <exclude>**/*.iml</exclude>
-            <exclude>**/output.xml</exclude>
-            <exclude>**/log.html</exclude>
-            <exclude>**/report.html</exclude>
-            <exclude>**/.idea/**</exclude>
-            <exclude>**/.ssh/id_rsa*</exclude>
-            <exclude>dev-support/*tests</exclude>
-            <exclude>dev-support/checkstyle*</exclude>
-            <exclude>dev-support/jdiff/**</exclude>
-            <exclude>src/contrib/**</exclude>
-            <exclude>src/main/webapps/datanode/robots.txt</exclude>
-            <exclude>src/main/webapps/hdfs/robots.txt</exclude>
-            <exclude>src/main/webapps/journal/robots.txt</exclude>
-            <exclude>src/main/webapps/router/robots.txt</exclude>
-            <exclude>src/main/webapps/secondary/robots.txt</exclude>
-            <exclude>src/site/resources/images/*</exclude>
-            <exclude>src/test/all-tests</exclude>
-            <exclude>src/test/empty-file</exclude>
-            <exclude>src/test/resources/*.log</exclude>
-            <exclude>src/test/resources/*.tgz</exclude>
-            <exclude>src/test/resources/data*</exclude>
-            <exclude>src/test/resources/empty-file</exclude>
-            <exclude>src/test/resources/ssl/*</exclude>
-            <exclude>src/main/compose/ozonesecure/docker-image/runner/build/apache-rat-0.12/README-CLI.txt</exclude>
-            <exclude>src/main/compose/ozonesecure/docker-image/runner/build/apache-rat-0.12/README-ANT.txt</exclude>
-            <exclude>webapps/static/angular-1.8.0.min.js</exclude>
-            <exclude>webapps/static/angular-nvd3-1.0.9.min.js</exclude>
-            <exclude>webapps/static/angular-route-1.8.0.min.js</exclude>
-            <exclude>webapps/static/bootstrap-3.4.1/**</exclude>
-            <exclude>webapps/static/d3-3.5.17.min.js</exclude>
-            <exclude>webapps/static/jquery-3.5.1.min.js</exclude>
-            <exclude>webapps/static/jquery.dataTables.min.js</exclude>
-            <exclude>webapps/static/nvd3-1.8.5.min.css.map</exclude>
-            <exclude>webapps/static/nvd3-1.8.5.min.css</exclude>
-            <exclude>webapps/static/nvd3-1.8.5.min.js.map</exclude>
-            <exclude>webapps/static/nvd3-1.8.5.min.js</exclude>
-            <exclude>**/dependency-reduced-pom.xml</exclude>
-            <exclude>**/node_modules/**</exclude>
-            <exclude>**/yarn.lock</exclude>
-            <exclude>**/pnpm-lock.yaml</exclude>
-            <exclude>**/ozone-recon-web/build/**</exclude>
-            <exclude>src/test/resources/prometheus-test-response.txt</exclude>
-            <exclude>src/main/license/**</exclude>
-            <exclude>src/main/resources/proto.lock</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2105,6 +2105,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludesFile>dev-support/rat/rat-exclusions.txt</excludesFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
To improve Apache Rat configuration and Ozone maven config, I have done:

* Added Rat plugin to the root module (ozone-main) to cover all files in a repo.
* Removed Rat plugin declarations from other modules to make maven and rat configs more readable.
* Moved exclusions to a separate file to make the Maven config more maintainable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10498

## How was this patch tested?

1. I did a manual test by adding a "file.txt" without a license inside to hadoop-hdds-client project and running apache-rat:check goal. The output of the build:

<pre>
[INFO] --- apache-rat:0.16.1:check (default-cli) @ hdds-client ---
[INFO] Rat check: Summary over all files. Unapproved: 1, unknown: 1, generated: 0, approved: 68 licenses.
[WARNING] Files with unapproved licenses:
  /Users/maximmyskov/Projects/github/myskov-ozone/hadoop-hdds/client/file.txt
</pre>
2. As the CI script is also modified, I committed the same "file.txt" to the branch and got the following output from RAT workflow:
<pre>
Run hadoop-ozone/dev-support/checks/_summary.sh target/rat/summary.txt
[10](https://github.com/myskov/ozone/actions/runs/8205987100/job/22444088879#step:7:11)
hadoop-hdds/client/target/rat.txt: !????? /home/runner/work/ozone/ozone/hadoop-hdds/client/file.txt
[11](https://github.com/myskov/ozone/actions/runs/8205987100/job/22444088879#step:7:12)
Error: Process completed with exit code 1.
</pre>