### PR TITLE
HDDS-10496. Fetch dependencies using actual build

### DIFF
--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Fetch dependencies
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: mvn --batch-mode --fail-never --no-transfer-progress --show-version dependency:go-offline
+        run: mvn --batch-mode --fail-never --no-transfer-progress --show-version -Pgo-offline -Pdist clean verify
 
       - name: Delete Ozone jars from repo
         if: steps.restore-cache.outputs.cache-hit != 'true'

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -123,6 +123,7 @@
               <goal>unpack</goal>
             </goals>
             <configuration>
+              <skip>${maven.shade.skip}</skip>
               <excludes>META-INF/versions/**/*.*</excludes>
               <artifactItems>
                 <artifactItem>

--- a/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3-client/pom.xml
@@ -54,6 +54,7 @@
               <goal>unpack</goal>
             </goals>
             <configuration>
+              <skip>${maven.shade.skip}</skip>
               <excludes>META-INF/versions/**/*.*</excludes>
               <artifactItems>
                 <artifactItem>
@@ -77,6 +78,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <skip>${maven.shade.skip}</skip>
               <transformers>
                 <transformer
                         implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -74,6 +74,7 @@
               <goal>unpack</goal>
             </goals>
             <configuration>
+              <skip>${maven.shade.skip}</skip>
               <excludes>META-INF/versions/**/*.*</excludes>
               <artifactItems>
                 <artifactItem>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -91,6 +91,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <skip>${maven.shade.skip}</skip>
               <transformers>
                 <transformer
                         implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -407,6 +407,13 @@
       </modules>
     </profile>
     <profile>
+      <id>go-offline</id>
+      <modules>
+        <module>ozonefs-shaded</module>
+        <module>ozonefs-hadoop2</module>
+      </modules>
+    </profile>
+    <profile>
       <id>build-with-recon</id>
       <activation>
         <property>

--- a/pom.xml
+++ b/pom.xml
@@ -2246,6 +2246,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </build>
     </profile>
     <profile>
+      <id>go-offline</id>
+      <properties>
+        <test>void</test>
+        <skip.npx>true</skip.npx>
+        <skip.installnpx>true</skip.installnpx>
+        <skipDocs>true</skipDocs>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.shade.skip>true</maven.shade.skip>
+      </properties>
+    </profile>
+    <profile>
       <id>client</id>
       <build>
         <plugins>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`maven-dependency-plugin` seems to ignore exclusions of transitive dependencies ([MDEP-844](https://issues.apache.org/jira/browse/MDEP-844)), resulting in larger than necessary Maven cache (including a 250MB jar for `aws-java-sdk-bundle` via Ranger).

This PR changes the `populate-cache` workflow to run a regular build for creating the cache (suggested in [MDEP-904](https://issues.apache.org/jira/browse/MDEP-904)).  This reduces cache size from 750MB to 360MB.

Shading is skipped to speed up the build.  A new property `maven.shade.skip` is added to only skip actual shading while still building (some) `ozonefs` modules.  Only `ozonefs-hadoop2` is included, not the ones for Hadoop 3.  The latter are unnecessary, since we already get the same dependencies by using the same version of Hadoop for Ozone elsewhere.

Few plugins are not included in the cache this way, but they do not affect build time significantly.

https://issues.apache.org/jira/browse/HDDS-10496

## How was this patch tested?

cache build:
https://github.com/adoroszlai/ozone/actions/runs/8215546994/job/22469127579

regular CI (using cache):
https://github.com/adoroszlai/ozone/actions/runs/8215582668