### PR TITLE
HDDS-10504. Remove unused VolumeInfo#configuredCapacity

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -100,11 +100,6 @@ public final class VolumeInfo {
   // Space usage calculator
   private final VolumeUsage usage;
 
-  // Capacity configured. This is useful when we want to
-  // limit the visible capacity for tests. If negative, then we just
-  // query from the filesystem.
-  private long configuredCapacity;
-
   private long reservedInBytes;
 
   /**
@@ -115,7 +110,6 @@ public final class VolumeInfo {
     private final String rootDir;
     private SpaceUsageCheckFactory usageCheckFactory;
     private StorageType storageType;
-    private long configuredCapacity;
 
     public Builder(String root, ConfigurationSource config) {
       this.rootDir = root;
@@ -124,11 +118,6 @@ public final class VolumeInfo {
 
     public Builder storageType(StorageType st) {
       this.storageType = st;
-      return this;
-    }
-
-    public Builder configuredCapacity(long capacity) {
-      this.configuredCapacity = capacity;
       return this;
     }
 
@@ -206,9 +195,6 @@ public final class VolumeInfo {
     this.storageType = (b.storageType != null ?
         b.storageType : StorageType.DEFAULT);
 
-    this.configuredCapacity = (b.configuredCapacity != 0 ?
-        b.configuredCapacity : -1);
-
     SpaceUsageCheckFactory usageCheckFactory = b.usageCheckFactory;
     if (usageCheckFactory == null) {
       usageCheckFactory = SpaceUsageCheckFactory.create(b.conf);
@@ -222,10 +208,7 @@ public final class VolumeInfo {
   }
 
   public long getCapacity() {
-    if (configuredCapacity < 0) {
-      return Math.max(usage.getCapacity() - reservedInBytes, 0);
-    }
-    return configuredCapacity;
+    return Math.max(usage.getCapacity() - reservedInBytes, 0);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -34,7 +34,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_MIN_FRE
  * Class that wraps the space df of the Datanode Volumes used by SCM
  * containers.
  */
-public class VolumeUsage implements SpaceUsageSource {
+public class VolumeUsage {
 
   private final CachingSpaceUsageSource source;
   private boolean shutdownComplete;
@@ -47,7 +47,6 @@ public class VolumeUsage implements SpaceUsageSource {
     start(); // TODO should start only on demand
   }
 
-  @Override
   public long getCapacity() {
     return Math.max(source.getCapacity(), 0);
   }
@@ -60,7 +59,6 @@ public class VolumeUsage implements SpaceUsageSource {
    *                      remainingReserved
    * B) avail = fsAvail - Max(reserved - other, 0);
    */
-  @Override
   public long getAvailable() {
     return source.getAvailable() - getRemainingReserved();
   }
@@ -70,12 +68,10 @@ public class VolumeUsage implements SpaceUsageSource {
     return available - getRemainingReserved(precomputedVolumeSpace);
   }
 
-  @Override
   public long getUsedSpace() {
     return source.getUsedSpace();
   }
 
-  @Override
   public SpaceUsageSource snapshot() {
     return source.snapshot();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`VolumeInfo#configuredCapacity` is unused, can be removed.

Also: let `VolumeUsage` not implement `SpaceUsageSource`.  Long term goal is to access all space usage properties of `VolumeUsage`  via a single call to `snapshot()`.  Removing `implements` is a first step to removing individual methods like `getAvailable()`.

https://issues.apache.org/jira/browse/HDDS-10504

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8231787063