### PR TITLE
HDDS-10475. Refine audit logging for bucket creation operation

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -329,6 +329,17 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     auditMap.put(OzoneConsts.USED_BYTES, String.valueOf(this.usedBytes));
     auditMap.put(OzoneConsts.USED_NAMESPACE,
         String.valueOf(this.usedNamespace));
+    auditMap.put(OzoneConsts.OWNER, this.owner);
+    auditMap.put(OzoneConsts.REPLICATION_TYPE,
+        (this.defaultReplicationConfig != null) ?
+            String.valueOf(this.defaultReplicationConfig.getType()) : null);
+    auditMap.put(OzoneConsts.REPLICATION_CONFIG,
+        (this.defaultReplicationConfig != null) ?
+            this.defaultReplicationConfig.getReplicationConfig()
+                .getReplication() : null);
+    auditMap.put(OzoneConsts.QUOTA_IN_BYTES, String.valueOf(this.quotaInBytes));
+    auditMap.put(OzoneConsts.QUOTA_IN_NAMESPACE,
+        String.valueOf(this.quotaInNamespace));
     return auditMap;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of a [review comment](https://github.com/apache/ozone/pull/6329#pullrequestreview-1918970353) over [HDDS-10460](https://issues.apache.org/jira/browse/HDDS-10460) (PR: [#6329](https://github.com/apache/ozone/pull/6329)), it has been observed that the audit logs pertaining to the bucket creation operation do not capture the bucket quota, owner and replication-related properties. 

Capturing these details is important for improving debugging capabilities.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10475

## How was this patch tested?

- Green Git CI: https://github.com/tanvipenumudy/ozone/actions/runs/8243755358/
- The patch has been tested manually on a docker-compose cluster.

**Before changes:**

```
bash-4.2$ ozone sh bucket create voltest/bucktest2 --type=RATIS --replication=THREE --space-quota=1GB --namespace-quota=5

bash-4.2$ ozone sh bucket info voltest/bucktest2
{
  "metadata" : { },
  "volumeName" : "voltest",
  "name" : "bucktest2",
  "storageType" : "DISK",
  "versioning" : false,
  "listCacheSize" : 1000,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2024-03-12T05:11:15.574Z",
  "modificationTime" : "2024-03-12T05:11:15.574Z",
  "sourcePathExist" : true,
  "quotaInBytes" : 1073741824,
  "quotaInNamespace" : 5,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "owner" : "hadoop",
  "link" : false,
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  }
}
```

`om-audit.log:`
```
2024-03-12 05:11:15,577 | INFO  | OMAudit | user=hadoop | ip=172.18.0.2 | op=CREATE_BUCKET {volume=voltest, bucket=bucktest2, bucketLayout=FILE_SYSTEM_OPTIMIZED, gdprEnabled=null, acls=[user:hadoop:a[ACCESS], group:hadoop:a[ACCESS]], isVersionEnabled=false, storageType=DISK, creationTime=1710220275574, bucketEncryptionKey=null, modificationTime=1710220275574, usedBytes=0, usedNamespace=0} | ret=SUCCESS | 
```

**After changes:**

```
bash-4.2$ ozone sh bucket create voltest/bucktest --type=RATIS --replication=THREE --space-quota=1GB --namespace-quota=5

bash-4.2$ ozone sh bucket info voltest/bucktest
{
  "metadata" : { },
  "volumeName" : "voltest",
  "name" : "bucktest",
  "storageType" : "DISK",
  "versioning" : false,
  "listCacheSize" : 1000,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2024-03-12T05:05:40.002Z",
  "modificationTime" : "2024-03-12T05:05:40.002Z",
  "sourcePathExist" : true,
  "quotaInBytes" : 1073741824,
  "quotaInNamespace" : 5,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "owner" : "hadoop",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  "link" : false
}
```

`om-audit.log:`
```
2024-03-12 05:05:40,008 | INFO  | OMAudit | user=hadoop | ip=172.18.0.3 | op=CREATE_BUCKET {volume=voltest, bucket=bucktest, bucketLayout=FILE_SYSTEM_OPTIMIZED, gdprEnabled=null, acls=[user:hadoop:a[ACCESS], group:hadoop:a[ACCESS]], isVersionEnabled=false, storageType=DISK, creationTime=1710219940002, bucketEncryptionKey=null, modificationTime=1710219940002, usedBytes=0, usedNamespace=0, owner=hadoop, replicationType=RATIS, replicationConfig=THREE, quotaInBytes=1073741824, quotaInNamespace=5} | ret=SUCCESS |  
```