### PR TITLE
HDDS-10507. Use equals() instead of == for nodes in NetworkTopology

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -232,7 +232,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
 
   private boolean containsNode(Node node) {
     Node parent = node.getParent();
-    while ((parent != null && !parent.equals(clusterTree))) {
+    while (parent != null && !parent.equals(clusterTree)) {
       parent = parent.getParent();
     }
     return (parent != null && parent.equals(clusterTree)) ||

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -744,10 +744,10 @@ public class NetworkTopologyImpl implements NetworkTopology {
       Node ancestor2 = node2.getAncestor(level2 - 1);
       boolean node1Topology = (ancestor1 != null &&
           !ancestor1.equals(clusterTree)) ||
-          !(ancestor1 == null && clusterTree == null);
+          (ancestor1 == null && clusterTree != null);
       boolean node2Topology = (ancestor2 != null &&
           !ancestor2.equals(clusterTree)) ||
-          !(ancestor2 == null && clusterTree == null);
+          (ancestor2 == null && clusterTree != null);
       if (node1Topology || node2Topology) {
         LOG.debug("One of the nodes is outside of network topology");
         return Integer.MAX_VALUE;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -252,8 +252,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
     try {
       Node ancestor1 = node1.getAncestor(ancestorGen);
       Node ancestor2 = node2.getAncestor(ancestorGen);
-      return (ancestor1 != null && ancestor1.equals(ancestor2)) ||
-          (ancestor1 == null && ancestor2 == null);
+      return Objects.equals(ancestor1, ancestor2);
     } finally {
       netlock.readLock().unlock();
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -232,10 +232,12 @@ public class NetworkTopologyImpl implements NetworkTopology {
 
   private boolean containsNode(Node node) {
     Node parent = node.getParent();
-    while (parent != null && !parent.equals(clusterTree)) {
+    while ((parent != null && clusterTree != null &&
+        !parent.equals(clusterTree)) || (parent != clusterTree)) {
       parent = parent.getParent();
     }
-    return parent.equals(clusterTree);
+    return (parent != null && clusterTree != null &&
+        parent.equals(clusterTree)) || parent == clusterTree;
   }
 
   /**
@@ -249,8 +251,10 @@ public class NetworkTopologyImpl implements NetworkTopology {
     }
     netlock.readLock().lock();
     try {
-      return node1.getAncestor(ancestorGen)
-          .equals(node2.getAncestor(ancestorGen));
+      Node ancestor1 = node1.getAncestor(ancestorGen);
+      Node ancestor2 = node2.getAncestor(ancestorGen);
+      return (ancestor1 != null && ancestor2 != null &&
+          ancestor1.equals(ancestor2)) || ancestor1 == ancestor2;
     } finally {
       netlock.readLock().unlock();
     }
@@ -269,7 +273,8 @@ public class NetworkTopologyImpl implements NetworkTopology {
     try {
       node1 = node1.getParent();
       node2 = node2.getParent();
-      return node1.equals(node2);
+      return (node1 != null && node2 != null && node1.equals(node2)) ||
+          node1 == node2;
     } finally {
       netlock.readLock().unlock();
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -232,10 +232,10 @@ public class NetworkTopologyImpl implements NetworkTopology {
 
   private boolean containsNode(Node node) {
     Node parent = node.getParent();
-    while (parent != null && parent != clusterTree) {
+    while (parent != null && !parent.equals(clusterTree)) {
       parent = parent.getParent();
     }
-    return parent == clusterTree;
+    return parent.equals(clusterTree);
   }
 
   /**
@@ -249,7 +249,8 @@ public class NetworkTopologyImpl implements NetworkTopology {
     }
     netlock.readLock().lock();
     try {
-      return node1.getAncestor(ancestorGen) == node2.getAncestor(ancestorGen);
+      return node1.getAncestor(ancestorGen)
+          .equals(node2.getAncestor(ancestorGen));
     } finally {
       netlock.readLock().unlock();
     }
@@ -268,7 +269,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
     try {
       node1 = node1.getParent();
       node2 = node2.getParent();
-      return node1 == node2;
+      return node1.equals(node2);
     } finally {
       netlock.readLock().unlock();
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -232,12 +232,11 @@ public class NetworkTopologyImpl implements NetworkTopology {
 
   private boolean containsNode(Node node) {
     Node parent = node.getParent();
-    while ((parent != null && clusterTree != null &&
-        !parent.equals(clusterTree)) || (parent != clusterTree)) {
+    while ((parent != null && !parent.equals(clusterTree))) {
       parent = parent.getParent();
     }
-    return (parent != null && clusterTree != null &&
-        parent.equals(clusterTree)) || parent == clusterTree;
+    return (parent != null && parent.equals(clusterTree)) ||
+        (parent == null && clusterTree == null);
   }
 
   /**
@@ -253,8 +252,8 @@ public class NetworkTopologyImpl implements NetworkTopology {
     try {
       Node ancestor1 = node1.getAncestor(ancestorGen);
       Node ancestor2 = node2.getAncestor(ancestorGen);
-      return (ancestor1 != null && ancestor2 != null &&
-          ancestor1.equals(ancestor2)) || ancestor1 == ancestor2;
+      return (ancestor1 != null && ancestor1.equals(ancestor2)) ||
+          (ancestor1 == null && ancestor2 == null);
     } finally {
       netlock.readLock().unlock();
     }
@@ -273,8 +272,8 @@ public class NetworkTopologyImpl implements NetworkTopology {
     try {
       node1 = node1.getParent();
       node2 = node2.getParent();
-      return (node1 != null && node2 != null && node1.equals(node2)) ||
-          node1 == node2;
+      return (node1 != null && node1.equals(node2)) ||
+          (node1 == null && node2 == null);
     } finally {
       netlock.readLock().unlock();
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -232,11 +233,10 @@ public class NetworkTopologyImpl implements NetworkTopology {
 
   private boolean containsNode(Node node) {
     Node parent = node.getParent();
-    while (parent != null && !parent.equals(clusterTree)) {
+    while (parent != null && !Objects.equals(parent, clusterTree)) {
       parent = parent.getParent();
     }
-    return (parent != null && parent.equals(clusterTree)) ||
-        (parent == null && clusterTree == null);
+    return Objects.equals(parent, clusterTree);
   }
 
   /**
@@ -271,8 +271,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
     try {
       node1 = node1.getParent();
       node2 = node2.getParent();
-      return (node1 != null && node1.equals(node2)) ||
-          (node1 == null && node2 == null);
+      return Objects.equals(node1, node2);
     } finally {
       netlock.readLock().unlock();
     }
@@ -717,8 +716,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
    */
   @Override
   public int getDistanceCost(Node node1, Node node2) {
-    if ((node1 != null && node1.equals(node2)) ||
-        (node1 == null && node2 == null))  {
+    if (Objects.equals(node1, node2)) {
       return 0;
     }
     if (node1 == null || node2 == null) {
@@ -741,13 +739,8 @@ public class NetworkTopologyImpl implements NetworkTopology {
     try {
       Node ancestor1 = node1.getAncestor(level1 - 1);
       Node ancestor2 = node2.getAncestor(level2 - 1);
-      boolean node1Topology = (ancestor1 != null &&
-          !ancestor1.equals(clusterTree)) ||
-          (ancestor1 == null && clusterTree != null);
-      boolean node2Topology = (ancestor2 != null &&
-          !ancestor2.equals(clusterTree)) ||
-          (ancestor2 == null && clusterTree != null);
-      if (node1Topology || node2Topology) {
+      if (!Objects.equals(ancestor1, clusterTree) ||
+          !Objects.equals(ancestor2, clusterTree)) {
         LOG.debug("One of the nodes is outside of network topology");
         return Integer.MAX_VALUE;
       }
@@ -761,7 +754,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
         level2--;
         cost += node2 == null ? 0 : node2.getCost();
       }
-      while (node1 != null && node2 != null && !node1.equals(node2)) {
+      while (node1 != null && node2 != null && !Objects.equals(node1, node2)) {
         node1 = node1.getParent();
         node2 = node2.getParent();
         cost += node1 == null ? 0 : node1.getCost();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -741,11 +741,13 @@ public class NetworkTopologyImpl implements NetworkTopology {
     netlock.readLock().lock();
     try {
       Node ancestor1 = node1.getAncestor(level1 - 1);
-      boolean node1Topology = (ancestor1 != null && clusterTree != null &&
-          !ancestor1.equals(clusterTree)) || (ancestor1 != clusterTree);
       Node ancestor2 = node2.getAncestor(level2 - 1);
-      boolean node2Topology = (ancestor2 != null && clusterTree != null &&
-          !ancestor2.equals(clusterTree)) || (ancestor2 != clusterTree);
+      boolean node1Topology = (ancestor1 != null &&
+          !ancestor1.equals(clusterTree)) ||
+          !(ancestor1 == null && clusterTree == null);
+      boolean node2Topology = (ancestor2 != null &&
+          !ancestor2.equals(clusterTree)) ||
+          !(ancestor2 == null && clusterTree == null);
       if (node1Topology || node2Topology) {
         LOG.debug("One of the nodes is outside of network topology");
         return Integer.MAX_VALUE;


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. The changes introduced in PR: [#5391](https://github.com/apache/ozone/pull/5391) involve reconstructing the hierarchical cluster tree object (that represents the network topology) on the Ozone Manager side.
2. Under the `NetworkTopology` class, various operations employ the **`==`/`!=`** operator for comparison.
3. However, this comparator needs to be modified to utilize the `InnerNode#equals` method instead. This adjustment is required as certain use cases, as described in **`1`**., involve object reconstruction necessitating custom equality comparisons based on individual object attributes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10507

## How was this patch tested?

Existing tests should cover the changes, Green Git CI: https://github.com/tanvipenumudy/ozone/actions/runs/8433408560

