### PR TITLE
HDDS-10436. datanode status decommission command should have json output option

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -171,7 +171,7 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
     detailsMap.put("uuid", datanode.getUuid().toString());
     detailsMap.put("networkLocation", datanode.getNetworkLocation());
     detailsMap.put("ipAddress", datanode.getIpAddress());
-    detailsMap.put("hostName", datanode.getHostName());
+    detailsMap.put("hostname", datanode.getHostName());
     return detailsMap;
   }
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -136,6 +136,8 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
     }
   }
 
+  String errorMessage = "Error getting pipeline and container metrics for ";
+
   private void printDetails(DatanodeDetails datanode) {
     System.out.println("\nDatanode: " + datanode.getUuid().toString() +
         " (" + datanode.getNetworkLocation() + "/" + datanode.getIpAddress()
@@ -168,9 +170,9 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           return;
         }
       }
-      System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
+      System.err.println(errorMessage + datanode.getHostName());
     } catch (IOException e) {
-      System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
+      System.err.println(errorMessage + datanode.getHostName());
     }
   }
 
@@ -209,9 +211,9 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           return countsMap;
         }
       }
-      System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
+      System.err.println(errorMessage + datanode.getHostName());
     } catch (IOException e) {
-      System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
+      System.err.println(errorMessage + datanode.getHostName());
     }
     return countsMap;
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -28,11 +28,14 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.LinkedHashMap;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +65,11 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
       defaultValue = "")
   private String ipAddress;
 
+  @CommandLine.Option(names = { "--json" },
+      description = "Show output in json format",
+      defaultValue = "false")
+  private boolean json;
+
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     List<HddsProtos.Node> decommissioningNodes;
@@ -84,8 +92,10 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
       }
     } else {
       decommissioningNodes = allNodes.collect(Collectors.toList());
-      System.out.println("\nDecommission Status: DECOMMISSIONING - " +
-          decommissioningNodes.size() + " node(s)");
+      if(!json) {
+        System.out.println("\nDecommission Status: DECOMMISSIONING - " +
+                decommissioningNodes.size() + " node(s)");
+      }
     }
 
     String metricsJson = scmClient.getMetrics("Hadoop:service=StorageContainerManager,name=NodeDecommissionMetrics");
@@ -98,6 +108,22 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
       jsonNode = (JsonNode) objectMapper.readTree(parser).get("beans").get(0);
       JsonNode totalDecom = jsonNode.get("DecommissioningMaintenanceNodesTotal");
       numDecomNodes = (totalDecom == null ? -1 : Integer.parseInt(totalDecom.toString()));
+    }
+
+    if(json) {
+      List<Map<String, Object>> decommissioningNodesDetails = new ArrayList<>();
+
+      for (HddsProtos.Node node : decommissioningNodes) {
+        DatanodeDetails datanode = DatanodeDetails.getFromProtoBuf(
+            node.getNodeID());
+        Map<String, Object> datanodeMap = new LinkedHashMap<>();
+        datanodeMap.put("datanodeDetails", getDatanodeDetails(datanode));
+        datanodeMap.put("metrics", getCounts(datanode, jsonNode, numDecomNodes));
+        datanodeMap.put("containers", getContainers(scmClient, datanode));
+        decommissioningNodesDetails.add(datanodeMap);
+      }
+      System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(decommissioningNodesDetails));
+      return;
     }
 
     for (HddsProtos.Node node : decommissioningNodes) {
@@ -138,5 +164,46 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
     } catch (NullPointerException ex) {
       System.err.println("Error getting pipeline and container counts for " + datanode.getHostName());
     }
+  }
+
+  private Map<String, Object> getDatanodeDetails(DatanodeDetails datanode) {
+    Map<String, Object> detailsMap = new LinkedHashMap<>();
+    detailsMap.put("uuid", datanode.getUuid().toString());
+    detailsMap.put("networkLocation", datanode.getNetworkLocation());
+    detailsMap.put("ipAddress", datanode.getIpAddress());
+    detailsMap.put("hostName", datanode.getHostName());
+    return detailsMap;
+  }
+
+  private Map<String, Object> getCounts(DatanodeDetails datanode, JsonNode counts, int numDecomNodes) {
+    Map<String, Object> countsMap = new LinkedHashMap<>();
+    try {
+      for (int i = 1; i <= numDecomNodes; i++) {
+        if (datanode.getHostName().equals(counts.get("tag.datanode." + i).asText())) {
+          long startTime = Long.parseLong(counts.get("StartTimeDN." + i).toString());
+          Date date = new Date(startTime);
+          DateFormat formatter = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss z");
+          countsMap.put("decommissionStartTime", formatter.format(date));
+          countsMap.put("numOfUnclosedPipelines", Integer.parseInt(counts.get("PipelinesWaitingToCloseDN." + i).toString()));
+          countsMap.put("numOfUnderReplicatedContainers", Double.parseDouble(counts.get("UnderReplicatedDN." + i).toString()));
+          countsMap.put("numOfUnclosedContainers", Double.parseDouble(counts.get("UnclosedContainersDN." + i).toString()));
+          return countsMap;
+        }
+      }
+      System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
+    } catch (NullPointerException ex) {
+      System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
+    }
+    return countsMap;
+  }
+
+  private Map<String, Object> getContainers(ScmClient scmClient, DatanodeDetails datanode) throws IOException {
+    Map<String, List<ContainerID>> containers = scmClient.getContainersOnDecomNode(datanode);
+    return containers.entrySet().stream()
+      .collect(Collectors.toMap(
+        Map.Entry::getKey,
+        entry -> entry.getValue().stream().
+                 map(ContainerID::toString).
+                 collect(Collectors.toList())));
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -92,7 +92,7 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
       }
     } else {
       decommissioningNodes = allNodes.collect(Collectors.toList());
-      if(!json) {
+      if (!json) {
         System.out.println("\nDecommission Status: DECOMMISSIONING - " +
                 decommissioningNodes.size() + " node(s)");
       }
@@ -110,7 +110,7 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
       numDecomNodes = (totalDecom == null ? -1 : Integer.parseInt(totalDecom.toString()));
     }
 
-    if(json) {
+    if (json) {
       List<Map<String, Object>> decommissioningNodesDetails = new ArrayList<>();
 
       for (HddsProtos.Node node : decommissioningNodes) {
@@ -184,9 +184,12 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           Date date = new Date(startTime);
           DateFormat formatter = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss z");
           countsMap.put("decommissionStartTime", formatter.format(date));
-          countsMap.put("numOfUnclosedPipelines", Integer.parseInt(counts.get("PipelinesWaitingToCloseDN." + i).toString()));
-          countsMap.put("numOfUnderReplicatedContainers", Double.parseDouble(counts.get("UnderReplicatedDN." + i).toString()));
-          countsMap.put("numOfUnclosedContainers", Double.parseDouble(counts.get("UnclosedContainersDN." + i).toString()));
+          countsMap.put("numOfUnclosedPipelines",
+                  Integer.parseInt(counts.get("PipelinesWaitingToCloseDN." + i).toString()));
+          countsMap.put("numOfUnderReplicatedContainers",
+                  Double.parseDouble(counts.get("UnderReplicatedDN." + i).toString()));
+          countsMap.put("numOfUnclosedContainers",
+                  Double.parseDouble(counts.get("UnclosedContainersDN." + i).toString()));
           return countsMap;
         }
       }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -146,10 +146,18 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
     try {
       for (int i = 1; i <= numDecomNodes; i++) {
         if (datanode.getHostName().equals(counts.get("tag.datanode." + i).asText())) {
-          int pipelines = Integer.parseInt(counts.get("PipelinesWaitingToCloseDN." + i).toString());
-          double underReplicated = Double.parseDouble(counts.get("UnderReplicatedDN." + i).toString());
-          double unclosed = Double.parseDouble(counts.get("UnclosedContainersDN." + i).toString());
-          long startTime = Long.parseLong(counts.get("StartTimeDN." + i).toString());
+          JsonNode pipelinesDN = counts.get("PipelinesWaitingToCloseDN." + i);
+          JsonNode underReplicatedDN = counts.get("UnderReplicatedDN." + i);
+          JsonNode unclosedDN = counts.get("UnclosedContainersDN." + i);
+          JsonNode startTimeDN = counts.get("StartTimeDN." + i);
+          if (pipelinesDN == null || underReplicatedDN == null || unclosedDN == null || startTimeDN == null) {
+            throw new IOException("Error getting pipeline and container metrics for " + datanode.getHostName());
+          }
+
+          int pipelines = Integer.parseInt(pipelinesDN.toString());
+          double underReplicated = Double.parseDouble(underReplicatedDN.toString());
+          double unclosed = Double.parseDouble(unclosedDN.toString());
+          long startTime = Long.parseLong(startTimeDN.toString());
           System.out.print("Decommission Started At : ");
           Date date = new Date(startTime);
           DateFormat formatter = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss z");
@@ -160,9 +168,9 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           return;
         }
       }
-      System.err.println("Error getting pipeline and container counts for " + datanode.getHostName());
-    } catch (NullPointerException ex) {
-      System.err.println("Error getting pipeline and container counts for " + datanode.getHostName());
+      System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
+    } catch (IOException e) {
+      System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
     }
   }
 
@@ -180,21 +188,29 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
     try {
       for (int i = 1; i <= numDecomNodes; i++) {
         if (datanode.getHostName().equals(counts.get("tag.datanode." + i).asText())) {
-          long startTime = Long.parseLong(counts.get("StartTimeDN." + i).toString());
+          JsonNode pipelinesDN = counts.get("PipelinesWaitingToCloseDN." + i);
+          JsonNode underReplicatedDN = counts.get("UnderReplicatedDN." + i);
+          JsonNode unclosedDN = counts.get("UnclosedContainersDN." + i);
+          JsonNode startTimeDN = counts.get("StartTimeDN." + i);
+          if (pipelinesDN == null || underReplicatedDN == null || unclosedDN == null || startTimeDN == null) {
+            throw new IOException("Error getting pipeline and container metrics for " + datanode.getHostName());
+          }
+
+          int pipelines = Integer.parseInt(pipelinesDN.toString());
+          double underReplicated = Double.parseDouble(underReplicatedDN.toString());
+          double unclosed = Double.parseDouble(unclosedDN.toString());
+          long startTime = Long.parseLong(startTimeDN.toString());
           Date date = new Date(startTime);
           DateFormat formatter = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss z");
           countsMap.put("decommissionStartTime", formatter.format(date));
-          countsMap.put("numOfUnclosedPipelines",
-                  Integer.parseInt(counts.get("PipelinesWaitingToCloseDN." + i).toString()));
-          countsMap.put("numOfUnderReplicatedContainers",
-                  Double.parseDouble(counts.get("UnderReplicatedDN." + i).toString()));
-          countsMap.put("numOfUnclosedContainers",
-                  Double.parseDouble(counts.get("UnclosedContainersDN." + i).toString()));
+          countsMap.put("numOfUnclosedPipelines", pipelines);
+          countsMap.put("numOfUnderReplicatedContainers", underReplicated);
+          countsMap.put("numOfUnclosedContainers", unclosed);
           return countsMap;
         }
       }
       System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
-    } catch (NullPointerException ex) {
+    } catch (IOException e) {
       System.err.println("Error getting pipeline and container metrics for " + datanode.getHostName());
     }
     return countsMap;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -136,7 +136,15 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
     }
   }
 
-  String errorMessage = "Error getting pipeline and container metrics for ";
+  private String errorMessage = "Error getting pipeline and container metrics for ";
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public void setErrorMessage(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
 
   private void printDetails(DatanodeDetails datanode) {
     System.out.println("\nDatanode: " + datanode.getUuid().toString() +
@@ -170,9 +178,9 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           return;
         }
       }
-      System.err.println(errorMessage + datanode.getHostName());
+      System.err.println(getErrorMessage() + datanode.getHostName());
     } catch (IOException e) {
-      System.err.println(errorMessage + datanode.getHostName());
+      System.err.println(getErrorMessage() + datanode.getHostName());
     }
   }
 
@@ -211,9 +219,9 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           return countsMap;
         }
       }
-      System.err.println(errorMessage + datanode.getHostName());
+      System.err.println(getErrorMessage() + datanode.getHostName());
     } catch (IOException e) {
-      System.err.println(errorMessage + datanode.getHostName());
+      System.err.println(getErrorMessage() + datanode.getHostName());
     }
     return countsMap;
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionStatusSubCommand.java
@@ -153,6 +153,7 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
   }
 
   private void printCounts(DatanodeDetails datanode, JsonNode counts, int numDecomNodes) {
+    String errMsg = getErrorMessage() + datanode.getHostName();
     try {
       for (int i = 1; i <= numDecomNodes; i++) {
         if (datanode.getHostName().equals(counts.get("tag.datanode." + i).asText())) {
@@ -161,7 +162,7 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           JsonNode unclosedDN = counts.get("UnclosedContainersDN." + i);
           JsonNode startTimeDN = counts.get("StartTimeDN." + i);
           if (pipelinesDN == null || underReplicatedDN == null || unclosedDN == null || startTimeDN == null) {
-            throw new IOException("Error getting pipeline and container metrics for " + datanode.getHostName());
+            throw new IOException(errMsg);
           }
 
           int pipelines = Integer.parseInt(pipelinesDN.toString());
@@ -178,9 +179,9 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           return;
         }
       }
-      System.err.println(getErrorMessage() + datanode.getHostName());
+      System.err.println(errMsg);
     } catch (IOException e) {
-      System.err.println(getErrorMessage() + datanode.getHostName());
+      System.err.println(errMsg);
     }
   }
 
@@ -195,6 +196,7 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
 
   private Map<String, Object> getCounts(DatanodeDetails datanode, JsonNode counts, int numDecomNodes) {
     Map<String, Object> countsMap = new LinkedHashMap<>();
+    String errMsg = getErrorMessage() + datanode.getHostName();
     try {
       for (int i = 1; i <= numDecomNodes; i++) {
         if (datanode.getHostName().equals(counts.get("tag.datanode." + i).asText())) {
@@ -203,7 +205,7 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           JsonNode unclosedDN = counts.get("UnclosedContainersDN." + i);
           JsonNode startTimeDN = counts.get("StartTimeDN." + i);
           if (pipelinesDN == null || underReplicatedDN == null || unclosedDN == null || startTimeDN == null) {
-            throw new IOException("Error getting pipeline and container metrics for " + datanode.getHostName());
+            throw new IOException(errMsg);
           }
 
           int pipelines = Integer.parseInt(pipelinesDN.toString());
@@ -219,9 +221,9 @@ public class DecommissionStatusSubCommand extends ScmSubcommand {
           return countsMap;
         }
       }
-      System.err.println(getErrorMessage() + datanode.getHostName());
+      System.err.println(errMsg);
     } catch (IOException e) {
-      System.err.println(getErrorMessage() + datanode.getHostName());
+      System.err.println(errMsg);
     }
     return countsMap;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added --json option for json formatted output to `ozone admin datanode status decommission` command.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10436

## How was this patch tested?
Tested the format of the output using a docker cluster.
![Screenshot 2024-03-12 at 3 32 59 PM](https://github.com/apache/ozone/assets/79865743/ce264157-2cb4-45fc-8c0b-ff32b1637864)
