### PR TITLE
HDDS-10497. [hsync] Refresh block token immediately if block token expires.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -76,6 +76,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Collections.singletonList;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.BLOCK_TOKEN_VERIFICATION_FAILED;
 
 /**
  * Implementation of all container protocol calls performed by Container
@@ -146,6 +147,14 @@ public final class ContainerProtocolCalls  {
       try {
         return op.apply(d);
       } catch (IOException e) {
+        if (e instanceof StorageContainerException) {
+          StorageContainerException sce = (StorageContainerException)e;
+          // Block token expired. There's no point retrying other DN.
+          // Throw the exception to request a new block token right away.
+          if (sce.getResult() == BLOCK_TOKEN_VERIFICATION_FAILED) {
+            throw e;
+          }
+        }
         excluded.add(d);
         if (excluded.size() < pipeline.size()) {
           LOG.warn(toErrorMessage.apply(d)


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the block token expires, request an up-to-date token immediately. Prior to this PR, the client would try each DN in the pipeline before it refreshes block token. In this case, trying every DN doesn't help so it better refresh immediately.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10497

(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

