### PR TITLE
HDDS-10512. Refactor initialization of ScmTopologyClient in OM

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -391,7 +391,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private OzoneManagerHttpServer httpServer;
   private final OMStorage omStorage;
   private ObjectName omInfoBeanName;
-  private NetworkTopology clusterMap;
   private Timer metricsTimer;
   private ScheduleOMMetricsWriteTask scheduleOMMetricsWriteTask;
   private static final ObjectWriter WRITER =
@@ -1696,8 +1695,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     metricsTimer = new Timer();
     metricsTimer.schedule(scheduleOMMetricsWriteTask, 0, period);
 
-    keyManager.start(configuration);
-
     try {
       scmTopologyClient.start(configuration);
     } catch (IOException ex) {
@@ -1705,10 +1702,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throw new UncheckedIOException(ex);
     }
 
-    clusterMap = new NetworkTopologyImpl(configuration.get(
-        ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE,
-        ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE_DEFAULT),
-        scmTopologyClient.getClusterTree());
+    keyManager.start(configuration);
 
     try {
       httpServer = new OzoneManagerHttpServer(configuration, this);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- As part of a [review comment](https://github.com/apache/ozone/pull/5391#discussion_r1513498047) on PR: [#5391](https://github.com/apache/ozone/pull/5391), it has been observed that since `KeyManager` is dependent on `ScmTopologyClient`, we should start the client before the `KeyManager` in `OzoneManager`.
- Cleanup unused code.
- `KeyManager` is already being stopped prior to the client.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10512

## How was this patch tested?

Existing tests should cover the changes, Green Git CI: https://github.com/tanvipenumudy/ozone/actions/runs/8261507655/
