### PR TITLE
HDDS-10516. Add metrics for chunk read from internal ratis

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -52,6 +52,9 @@ public class ContainerMetrics {
   @Metric private MutableCounterLong containerDeleteFailedNonEmpty;
   @Metric private MutableCounterLong containerDeleteFailedBlockCountNotZero;
   @Metric private MutableCounterLong containerForceDelete;
+  @Metric private MutableCounterLong numReadStateMachine;
+  @Metric private MutableCounterLong bytesReadStateMachine;
+
 
   private MutableCounterLong[] numOpsArray;
   private MutableCounterLong[] opsBytesArray;
@@ -151,5 +154,21 @@ public class ContainerMetrics {
 
   public long getContainerForceDelete() {
     return containerForceDelete.value();
+  }
+
+  public void incNumReadStateMachine() {
+    numReadStateMachine.incr();
+  }
+
+  public long getNumReadStateMachine() {
+    return numReadStateMachine.value();
+  }
+
+  public void incBytesReadStateMachine(long bytes) {
+    bytesReadStateMachine.incr(bytes);
+  }
+
+  public long getBytesReadStateMachine() {
+    return bytesReadStateMachine.value();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -722,6 +722,8 @@ public class KeyValueHandler extends Handler {
       //  For client reads, the client is expected to validate.
       if (DispatcherContext.op(dispatcherContext).readFromTmpFile()) {
         validateChunkChecksumData(data, chunkInfo);
+        metrics.incBytesReadStateMachine(chunkInfo.getLen());
+        metrics.incNumReadStateMachine();
       }
       metrics.incContainerBytesStats(Type.ReadChunk, chunkInfo.getLen());
     } catch (StorageContainerException ex) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
add metrics for chunk read from internal ratis. 

Currently, there are following metrics on every datanode for chunk reads.

"numReadChunk" : 136237,
"bytesReadChunk" : 1395066880,
"LatencyReadChunkNumOps" : 136237,
"LatencyReadChunkAvgTime" : 1.0, 

The chunk read requests come from both remote user client and internal ratis if the datanode is the leader of the ratis group. Currently, we cannot tell how much data is read by user client, and how much data is read by ratis leader itself. So this task is to introduce a new set of following metrics for read by ratis, 

numReadStateMachine // the request counts from ratis
bytesReadStateMachine // the total bytes read by ratis

So the final goal is we want to know how much data is read by user client. So for read from user client,

bytesReadChunk - bytesReadStateMachine = bytes read by user clients

numReadChunk - numReadStateMachine = request counts from user clients



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10516

## How was this patch tested?

Manual test. 
1. start a three datanode docket cluster
2. check both metrics are 0 on leader Datanode
 
![image](https://github.com/apache/ozone/assets/19790142/5ea69621-a9aa-4756-88c1-a5c3dbd46e31)
![image](https://github.com/apache/ozone/assets/19790142/8ba76116-ba3e-4d5f-90d6-8ad00390d9c9)

3. run freon
ozone freon randomkeys --num-of-volumes=5 --num-of-buckets=2 --num-of-keys=10000  --replication-type=RATIS --replication=THREE --validate-writes --num-of-validate-threads=10
4. check both metrics again on leader Datanode. 
 
![image](https://github.com/apache/ozone/assets/19790142/b2d0e513-a4d2-44b0-95b7-5e6948ae9ef4)
![image](https://github.com/apache/ozone/assets/19790142/c7099009-a722-49cd-8a50-f74bbe5c71ca)

For leader datanode, it's bytesReadChunk equal to bytesReadStateMachine now. 
And bytesReadChunk and bytesReadStateMachine are all 0 on other two follower datanodes.
5. Use "ozone fs -get" command to read several keys created by freon.
6. check both metrics again on leader Datanode, bytesReadChunk value is increased, while bytesReadStateMachine still remains the same. 
   
![image](https://github.com/apache/ozone/assets/19790142/d030f86c-cea2-446e-81e6-4b231e130398)

    
 