### PR TITLE
HDDS-10120. BindException in integration tests with Java 17

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManager.java
@@ -143,6 +143,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_C
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.mockRemoteUser;
 import static org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils.setInternalState;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
+import static org.apache.ozone.test.GenericTestUtils.PortAllocator.getFreePort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -979,6 +980,8 @@ public class TestStorageContainerManager {
       DefaultConfigManager.clearDefaultConfigs();
       conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
       StorageContainerManager.scmInit(conf, cluster.getClusterId());
+      conf.setInt(ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY, getFreePort());
+      conf.unset(ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY);
       cluster.restartStorageContainerManager(false);
 
       final StorageContainerManager ratisSCM = cluster


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid `BindException` in two integration tests when run with Java 17.

```
	at org.apache.hadoop.ozone.om.OzoneManager.startRpcServer(OzoneManager.java:1273)
	at org.apache.hadoop.ozone.om.OzoneManager.getRpcServer(OzoneManager.java:1247)
	at org.apache.hadoop.ozone.om.OzoneManager.<init>(OzoneManager.java:702)
	at org.apache.hadoop.ozone.om.OzoneManager.createOm(OzoneManager.java:768)
	at org.apache.hadoop.ozone.TestSecureOzoneCluster.testSecureOmReInit(TestSecureOzoneCluster.java:887)
```

```
	at org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer(StorageContainerManager.java:1126)
	at org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer.<init>(SCMDatanodeProtocolServer.java:173)
	at org.apache.hadoop.hdds.scm.server.StorageContainerManager.<init>(StorageContainerManager.java:442)
	at org.apache.hadoop.hdds.scm.server.StorageContainerManager.createSCM(StorageContainerManager.java:617)
	at org.apache.hadoop.hdds.scm.HddsTestUtils.getScmSimple(HddsTestUtils.java:604)
	at org.apache.hadoop.ozone.MiniOzoneClusterImpl.restartStorageContainerManager(MiniOzoneClusterImpl.java:366)
	at org.apache.hadoop.ozone.scm.TestStorageContainerManager.testNonRatisToRatis(TestStorageContainerManager.java:1099)
```

https://issues.apache.org/jira/browse/HDDS-10120

## How was this patch tested?

```
$ JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn clean test \
  -am -pl :ozone-integration-test -Dskip.npx -Dskip.installnpx -DskipShade \
  -DexcludedGroups='unhealthy,slow' \
  -Dtest='TestStorageContainerManager#testNonRatisToRatis,TestSecureOzoneCluster'
...
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 115.364 s - in org.apache.hadoop.ozone.TestSecureOzoneCluster
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.603 s - in org.apache.hadoop.hdds.scm.TestStorageContainerManager
```