### PR TITLE
HDDS-10545. Repeated tests stop if fork does not return

### DIFF
--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -79,7 +79,7 @@ for i in $(seq 1 ${ITERATIONS}); do
   fi
 
   if [[ ${ITERATIONS} -gt 1 ]]; then
-    if ! grep -q "Tests run: [^0]" "${REPORT_DIR}/output.log"; then
+    if ! grep -q "Running .*Test" "${REPORT_DIR}/output.log"; then
       echo "No tests were run" >> "${REPORT_DIR}/summary.txt"
       irc=1
       FAIL_FAST=true


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-10080 added a sanity check in `junit.sh` to stop iterations if no tests were run.  However, it is also triggered if tests are run, but do not complete "normally", e.g. Surefire fork times out or crashes.

Example (each split stopped right after the first crash): https://github.com/adoroszlai/ozone/actions/runs/8191098889/job/22400265006#step:6:11998

This patch slightly tweaks the pattern.

https://issues.apache.org/jira/browse/HDDS-10545

## How was this patch tested?

Valid test class, iterations continue:

```
$ ITERATIONS=3 OZONE_REPO_CACHED=true \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :hdds-config -Dtest='TestConfigFileAppender'
...

$ cat target/unit/summary.txt                                                                                                                   
Iteration 1 exit code: 0
Iteration 2 exit code: 0
Iteration 3 exit code: 0
```

Non-existent class, iterations stop:

```
$ ITERATIONS=3 OZONE_REPO_CACHED=true \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :hdds-config -Dtest='NoSuchTest'
...
[INFO] BUILD SUCCESS
...
Iteration 1 exit code: 1

$ cat target/unit/iteration1/summary.txt 
No tests were run
```

Non-existent method in existing class, iterations stop:

```
$ ITERATIONS=3 OZONE_REPO_CACHED=true \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :hdds-config -Dtest='TestConfigFileAppender#noSuchTest'
...
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
...
[INFO] BUILD SUCCESS
...
Iteration 1 exit code: 1

$ cat target/unit/iteration1/summary.txt 
No tests were run
```

Abstract class, iterations stop:

```
$ ITERATIONS=3 OZONE_REPO_CACHED=true \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :ozone-integration-test -Dtest='AbstractContractGetFileStatusTest'
...
[INFO] BUILD SUCCESS
...
Iteration 1 exit code: 1

$ cat target/unit/iteration1/summary.txt 
No tests were run
```

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/8322917313