### PR TITLE
HDDS-10544. Move LMAX Disruptor to runtime scope

### DIFF
--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -83,8 +83,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
+      <!-- required for async logging in Log4j2 -->
       <groupId>com.lmax</groupId>
       <artifactId>disruptor</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

LMAX Disruptor is required by Log4j2 async loggers, used by audit logging in Ozone.  The goal of this change is to mark it as a runtime dependency for clarification.

https://issues.apache.org/jira/browse/HDDS-10544

## How was this patch tested?

`dependency` check verifies the jar is still included in `share/ozone/lib`.

CI:
https://github.com/adoroszlai/ozone/actions/runs/8322480289