### PR TITLE
HDDS-10546. OM startup failure as leader is not getting ready

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -172,7 +172,9 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     }
     final TermIndex newTermIndex = TermIndex.valueOf(currentTerm, newIndex);
     lastNotifiedTermIndex = assertUpdateIncreasingly("lastNotified", lastNotifiedTermIndex, newTermIndex);
-    updateLastAppliedTermIndex(lastNotifiedTermIndex);
+    if (lastNotifiedTermIndex.getIndex() - getLastAppliedTermIndex().getIndex() == 1) {
+      updateLastAppliedTermIndex(lastNotifiedTermIndex);
+    }
   }
 
   public TermIndex getLastNotifiedTermIndex() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -183,12 +183,13 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
   @Override
   protected synchronized boolean updateLastAppliedTermIndex(TermIndex newTermIndex) {
-    assertUpdateIncreasingly("lastApplied", getLastAppliedTermIndex(), newTermIndex);
+    TermIndex lastApplied = getLastAppliedTermIndex();
+    assertUpdateIncreasingly("lastApplied", lastApplied, newTermIndex);
     // if newTermIndex getting updated is within sequence of notifiedTermIndex (i.e. from lastSkippedIndex and
     // notifiedTermIndex), then can update directly to lastNotifiedTermIndex as it ensure previous double buffer's
     // Index is notified or getting notified matching lastSkippedIndex
-    if (newTermIndex.getIndex() <= getLastNotifiedTermIndex().getIndex()
-        && getLastAppliedTermIndex().getIndex() >= lastSkippedIndex) {
+    if (newTermIndex.getIndex() < getLastNotifiedTermIndex().getIndex()
+        && lastApplied.getIndex() >= lastSkippedIndex) {
       newTermIndex = getLastNotifiedTermIndex();
     }
     return super.updateLastAppliedTermIndex(newTermIndex);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.protocol.TermIndex;
-import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -101,12 +101,12 @@ public class TestOzoneManagerStateMachine {
   @Test
   public void testLastAppliedIndex() {
     ozoneManagerStateMachine.notifyTermIndexUpdated(0, 0);
-    assertTermIndex(0, RaftLog.INVALID_LOG_INDEX, ozoneManagerStateMachine.getLastAppliedTermIndex());
+    assertTermIndex(0, 0, ozoneManagerStateMachine.getLastAppliedTermIndex());
     assertTermIndex(0, 0, ozoneManagerStateMachine.getLastNotifiedTermIndex());
 
     // Conf/metadata transaction.
     ozoneManagerStateMachine.notifyTermIndexUpdated(0, 1);
-    assertTermIndex(0, RaftLog.INVALID_LOG_INDEX, ozoneManagerStateMachine.getLastAppliedTermIndex());
+    assertTermIndex(0, 1, ozoneManagerStateMachine.getLastAppliedTermIndex());
     assertTermIndex(0, 1, ozoneManagerStateMachine.getLastNotifiedTermIndex());
 
     // call update last applied index
@@ -119,7 +119,7 @@ public class TestOzoneManagerStateMachine {
     // Conf/metadata transaction.
     ozoneManagerStateMachine.notifyTermIndexUpdated(1L, 4L);
 
-    assertTermIndex(0, 3, ozoneManagerStateMachine.getLastAppliedTermIndex());
+    assertTermIndex(1, 4, ozoneManagerStateMachine.getLastAppliedTermIndex());
     assertTermIndex(1, 4, ozoneManagerStateMachine.getLastNotifiedTermIndex());
 
     // Add some apply transactions.


### PR DESCRIPTION
## What changes were proposed in this pull request?
OM is not getting stopped even after Leader is elected but Leader is not ready. This is an impact of HDDS-10026.

As solution, need update lastAppliedTransactionId with notifiedIndex if that is in sequence. So that Ratis can also get latest sequenceId as updated.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10546

## How was this patch tested?

- Unit test covers the update of appliedTransaction
- Impacted area by Integration test
