### PR TITLE
HDDS-10539. Replace GSON with Jackson in multitenancy code.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -30,7 +30,7 @@ ${S3G_ENDPOINT_URL}     http://s3g:9878
 Create Tenant Success with Cluster Admin
     Run Keyword         Kinit test user     testuser     testuser.keytab
     ${output} =         Execute          ozone tenant --verbose create tenantone
-                        Should contain   ${output}         "tenantId": "tenantone"
+                        Should contain   ${output}         "tenantId" : "tenantone"
 
 Assign User Success with Cluster Admin
     ${output} =         Execute          ozone tenant --verbose user assign testuser --tenant=tenantone

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/RangerUserRequest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/RangerUserRequest.java
@@ -17,10 +17,9 @@
  */
 package org.apache.hadoop.ozone.om.multitenant;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kerby.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -191,7 +190,7 @@ public class RangerUserRequest {
   }
 
   private HttpURLConnection makeHttpGetCall(String urlString,
-      String method, boolean isSpnego) throws IOException {
+                                            String method, boolean isSpnego) throws IOException {
 
     URL url = new URL(urlString);
     final HttpURLConnection urlConnection = openURLConnection(url);
@@ -215,14 +214,16 @@ public class RangerUserRequest {
     String response = getResponseData(conn);
     String userIDCreated = null;
     try {
-      JsonObject jResonse = JsonParser.parseString(response).getAsJsonObject();
-      JsonArray userinfo = jResonse.get("vXUsers").getAsJsonArray();
+      ObjectMapper objectMapper = new ObjectMapper();
+      JsonNode jResponse = objectMapper.readTree(response);
+      JsonNode userinfo = jResponse.path("vXUsers");
       int numIndex = userinfo.size();
+
       for (int i = 0; i < numIndex; ++i) {
-        if (userinfo.get(i).getAsJsonObject().get("name").getAsString()
-            .equals(userPrincipal)) {
-          userIDCreated =
-              userinfo.get(i).getAsJsonObject().get("id").getAsString();
+        JsonNode userNode = userinfo.get(i);
+        String name = userNode.path("name").asText();
+        if (name.equals(userPrincipal)) {
+          userIDCreated = userNode.path("id").asText();
           break;
         }
       }
@@ -231,6 +232,7 @@ public class RangerUserRequest {
       e.printStackTrace();
       throw e;
     }
+
     return userIDCreated;
   }
 
@@ -253,8 +255,9 @@ public class RangerUserRequest {
     String userId;
     try {
       assert userInfo != null;
-      JsonObject jObject = JsonParser.parseString(userInfo).getAsJsonObject();
-      userId = jObject.get("id").getAsString();
+      ObjectMapper objectMapper = new ObjectMapper();
+      JsonNode jNode = objectMapper.readTree(userInfo);
+      userId = jNode.get("id").asText();
       LOG.debug("Ranger returned userId: {}", userId);
     } catch (JsonParseException e) {
       e.printStackTrace();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -375,17 +375,17 @@ public class TestOzoneTenantShell {
       executeHA(tenantShell, new String[] {"--verbose", "user", "assign-admin",
           tenantName + "$" + userName, "--tenant=" + tenantName,
           "--delegated=true"});
-      checkOutput(out, "{\n" + "  \"accessId\": \"devaa$alice\",\n"
-          + "  \"tenantId\": \"devaa\",\n" + "  \"isAdmin\": true,\n"
-          + "  \"isDelegatedAdmin\": true\n" + "}\n", true, true);
+      checkOutput(out, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
+          + "  \"tenantId\" : \"devaa\",\n" + "  \"isAdmin\" : true,\n"
+          + "  \"isDelegatedAdmin\" : true\n" + "}\n", true, true);
       checkOutput(err, "", true);
 
       // Clean up
       executeHA(tenantShell, new String[] {"--verbose", "user", "revoke-admin",
           tenantName + "$" + userName, "--tenant=" + tenantName});
-      checkOutput(out, "{\n" + "  \"accessId\": \"devaa$alice\",\n"
-          + "  \"tenantId\": \"devaa\",\n" + "  \"isAdmin\": false,\n"
-          + "  \"isDelegatedAdmin\": false\n" + "}\n", true, true);
+      checkOutput(out, "{\n" + "  \"accessId\" : \"devaa$alice\",\n"
+          + "  \"tenantId\" : \"devaa\",\n" + "  \"isAdmin\" : false,\n"
+          + "  \"isDelegatedAdmin\" : false\n" + "}\n", true, true);
       checkOutput(err, "", true);
 
       executeHA(tenantShell, new String[] {
@@ -458,7 +458,7 @@ public class TestOzoneTenantShell {
 
     executeHA(tenantShell, new String[] {"list", "--json"});
     // Not checking the full output here
-    checkOutput(out, "\"tenantId\": \"dev\",", false);
+    checkOutput(out, "\"tenantId\" : \"dev\",", false);
     checkOutput(err, "", true);
 
     // Attempt user getsecret before assignment, should fail
@@ -527,16 +527,26 @@ public class TestOzoneTenantShell {
 
     executeHA(tenantShell, new String[] {
         "user", "info", "--json", "bob"});
-    checkOutput(out, "{\n" + "  \"user\": \"bob\",\n" + "  \"tenants\": [\n"
-        + "    {\n" + "      \"accessId\": \"research$bob\",\n"
-        + "      \"tenantId\": \"research\",\n" + "      \"isAdmin\": false,\n"
-        + "      \"isDelegatedAdmin\": false\n" + "    },\n" + "    {\n"
-        + "      \"accessId\": \"finance$bob\",\n"
-        + "      \"tenantId\": \"finance\",\n" + "      \"isAdmin\": false,\n"
-        + "      \"isDelegatedAdmin\": false\n" + "    },\n" + "    {\n"
-        + "      \"accessId\": \"dev$bob\",\n"
-        + "      \"tenantId\": \"dev\",\n" + "      \"isAdmin\": true,\n"
-        + "      \"isDelegatedAdmin\": true\n" + "    }\n" + "  ]\n" + "}\n",
+    checkOutput(out,
+        "{\n" +
+            "  \"user\" : \"bob\",\n" +
+            "  \"tenants\" : [ {\n" +
+            "    \"accessId\" : \"research$bob\",\n" +
+            "    \"tenantId\" : \"research\",\n" +
+            "    \"isAdmin\" : false,\n" +
+            "    \"isDelegatedAdmin\" : false\n" +
+            "  }, {\n" +
+            "    \"accessId\" : \"finance$bob\",\n" +
+            "    \"tenantId\" : \"finance\",\n" +
+            "    \"isAdmin\" : false,\n" +
+            "    \"isDelegatedAdmin\" : false\n" +
+            "  }, {\n" +
+            "    \"accessId\" : \"dev$bob\",\n" +
+            "    \"tenantId\" : \"dev\",\n" +
+            "    \"isAdmin\" : true,\n" +
+            "    \"isDelegatedAdmin\" : true\n" +
+            "  } ]\n" +
+            "}\n",
         true, true);
     checkOutput(err, "", true);
 
@@ -662,8 +672,8 @@ public class TestOzoneTenantShell {
 
     // Then delete tenant, should succeed
     executeHA(tenantShell, new String[] {"--verbose", "delete", "dev"});
-    checkOutput(out, "{\n" + "  \"tenantId\": \"dev\",\n"
-        + "  \"volumeName\": \"dev\",\n" + "  \"volumeRefCount\": 0\n" + "}\n",
+    checkOutput(out, "{\n" + "  \"tenantId\" : \"dev\",\n"
+            + "  \"volumeName\" : \"dev\",\n" + "  \"volumeRefCount\" : 0\n" + "}\n",
         true, true);
     checkOutput(err, "Deleted tenant 'dev'.\n", false);
     deleteVolume("dev");
@@ -678,7 +688,7 @@ public class TestOzoneTenantShell {
   public void testListTenantUsers() throws IOException {
     executeHA(tenantShell, new String[] {"--verbose", "create", "tenant1"});
     checkOutput(out, "{\n" +
-        "  \"tenantId\": \"tenant1\"\n" + "}\n", true, true);
+        "  \"tenantId\" : \"tenant1\"\n" + "}\n", true, true);
     checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
@@ -702,10 +712,14 @@ public class TestOzoneTenantShell {
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1", "--json"});
-    checkOutput(out, "[\n" + "  {\n" + "    \"user\": \"bob\",\n"
-        + "    \"accessId\": \"tenant1$bob\"\n" + "  },\n" + "  {\n"
-        + "    \"user\": \"alice\",\n" + "    \"accessId\": \"tenant1$alice\"\n"
-        + "  }\n" + "]\n", true);
+    checkOutput(out,
+        "[ {\n" +
+            "  \"user\" : \"bob\",\n" +
+            "  \"accessId\" : \"tenant1$bob\"\n" +
+            "}, {\n" +
+            "  \"user\" : \"alice\",\n" +
+            "  \"accessId\" : \"tenant1$alice\"\n" +
+            "} ]\n", true);
     checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
@@ -716,8 +730,10 @@ public class TestOzoneTenantShell {
 
     executeHA(tenantShell, new String[] {
         "user", "list", "tenant1", "--prefix=b", "--json"});
-    checkOutput(out, "[\n" + "  {\n" + "    \"user\": \"bob\",\n"
-        + "    \"accessId\": \"tenant1$bob\"\n" + "  }\n" + "]\n", true);
+    checkOutput(out, "[ {\n" +
+        "  \"user\" : \"bob\",\n" +
+        "  \"accessId\" : \"tenant1$bob\"\n" +
+        "} ]\n", true);
     checkOutput(err, "", true);
 
     int exitCode = executeHA(tenantShell, new String[] {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java
@@ -17,10 +17,9 @@
  */
 package org.apache.hadoop.ozone.shell.tenant;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
@@ -71,39 +70,34 @@ public class GetUserInfoHandler extends TenantHandler {
     if (!printJson) {
       out().println("User '" + userPrincipal + "' is assigned to:");
       accessIdInfoList.forEach(accessIdInfo -> {
-        // Get admin info
-        final String adminInfoString;
-        if (accessIdInfo.getIsAdmin()) {
-          adminInfoString = accessIdInfo.getIsDelegatedAdmin() ?
-              " delegated admin" : " admin";
-        } else {
-          adminInfoString = "";
-        }
+        final String adminInfoString = accessIdInfo.getIsAdmin() ?
+            (accessIdInfo.getIsDelegatedAdmin() ? " delegated admin" :
+                " admin") : "";
         out().format("- Tenant '%s'%s with accessId '%s'%n",
             accessIdInfo.getTenantId(),
             adminInfoString,
             accessIdInfo.getAccessId());
       });
     } else {
+      ObjectMapper objectMapper = new ObjectMapper();
+      ObjectNode resObj = objectMapper.createObjectNode();
+      resObj.put("user", userPrincipal);
 
-      final JsonObject resObj = new JsonObject();
-      resObj.addProperty("user", userPrincipal);
-
-      final JsonArray arr = new JsonArray();
+      ArrayNode arr = objectMapper.createArrayNode();
       accessIdInfoList.forEach(accessIdInfo -> {
-        final JsonObject tenantObj = new JsonObject();
-        tenantObj.addProperty("accessId", accessIdInfo.getAccessId());
-        tenantObj.addProperty("tenantId", accessIdInfo.getTenantId());
-        tenantObj.addProperty("isAdmin", accessIdInfo.getIsAdmin());
-        tenantObj.addProperty("isDelegatedAdmin",
-            accessIdInfo.getIsDelegatedAdmin());
+        ObjectNode tenantObj = objectMapper.createObjectNode();
+        tenantObj.put("accessId", accessIdInfo.getAccessId());
+        tenantObj.put("tenantId", accessIdInfo.getTenantId());
+        tenantObj.put("isAdmin", accessIdInfo.getIsAdmin());
+        tenantObj.put("isDelegatedAdmin", accessIdInfo.getIsDelegatedAdmin());
         arr.add(tenantObj);
       });
 
-      resObj.add("tenants", arr);
+      resObj.set("tenants", arr);
 
-      final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-      out().println(gson.toJson(resObj));
+      String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+          .writeValueAsString(resObj);
+      out().println(prettyJson);
     }
 
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantAssignAdminHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantAssignAdminHandler.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.ozone.shell.tenant;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import picocli.CommandLine;
@@ -55,14 +55,17 @@ public class TenantAssignAdminHandler extends TenantHandler {
     client.getObjectStore().tenantAssignAdmin(accessId, tenantId, delegated);
 
     if (isVerbose()) {
-      final JsonObject obj = new JsonObject();
-      obj.addProperty("accessId", accessId);
-      obj.addProperty("tenantId", tenantId);
-      obj.addProperty("isAdmin", true);
-      obj.addProperty("isDelegatedAdmin", delegated);
-      final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-      out().println(gson.toJson(obj));
-    }
+      ObjectMapper objectMapper = new ObjectMapper();
+      ObjectNode obj = objectMapper.createObjectNode();
+      obj.put("accessId", accessId);
+      obj.put("tenantId", tenantId);
+      obj.put("isAdmin", true);
+      obj.put("isDelegatedAdmin", delegated);
 
+      // Enable pretty printing
+      objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+      String jsonString = objectMapper.writeValueAsString(obj);
+      out().println(jsonString);
+    }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantCreateHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantCreateHandler.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.ozone.shell.tenant;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.TenantArgs;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
@@ -58,11 +58,14 @@ public class TenantCreateHandler extends TenantHandler {
     // RpcClient#createTenant prints INFO level log of tenant and volume name
 
     if (isVerbose()) {
-      final JsonObject obj = new JsonObject();
-      obj.addProperty("tenantId", tenantId);
-      final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-      out().println(gson.toJson(obj));
-    }
+      ObjectMapper objectMapper = new ObjectMapper();
+      ObjectNode obj = objectMapper.createObjectNode();
+      obj.put("tenantId", tenantId);
 
+      // Enable pretty printing
+      objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+      String jsonString = objectMapper.writeValueAsString(obj);
+      out().println(jsonString);
+    }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantDeleteHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantDeleteHandler.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.ozone.shell.tenant;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
@@ -60,13 +60,14 @@ public class TenantDeleteHandler extends TenantHandler {
     }
 
     if (isVerbose()) {
-      final JsonObject obj = new JsonObject();
-      obj.addProperty("tenantId", tenantId);
-      obj.addProperty("volumeName", resp.getVolumeName());
-      obj.addProperty("volumeRefCount", resp.getVolRefCount());
-      final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+      ObjectMapper objectMapper = new ObjectMapper();
+      objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+      ObjectNode obj = objectMapper.createObjectNode();
+      obj.put("tenantId", tenantId);
+      obj.put("volumeName", resp.getVolumeName());
+      obj.put("volumeRefCount", resp.getVolRefCount());
       // Print raw response to stderr if verbose
-      out().println(gson.toJson(obj));
+      out().println(objectMapper.writeValueAsString(obj));
     }
 
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.ozone.shell.tenant;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
@@ -50,23 +50,24 @@ public class TenantListHandler extends TenantHandler {
       tenantStateList.getTenantStateList().forEach(tenantState ->
           out().println(tenantState.getTenantId()));
     } else {
-      final JsonArray resArray = new JsonArray();
+      ObjectMapper objectMapper = new ObjectMapper();
+      ArrayNode resArray = objectMapper.createArrayNode();
       tenantStateList.getTenantStateList().forEach(tenantState -> {
-        final JsonObject obj = new JsonObject();
-        obj.addProperty("tenantId", tenantState.getTenantId());
-        obj.addProperty("bucketNamespaceName",
-            tenantState.getBucketNamespaceName());
-        obj.addProperty("userRoleName", tenantState.getUserRoleName());
-        obj.addProperty("adminRoleName", tenantState.getAdminRoleName());
-        obj.addProperty("bucketNamespacePolicyName",
+        ObjectNode obj = objectMapper.createObjectNode();
+        obj.put("tenantId", tenantState.getTenantId());
+        obj.put("bucketNamespaceName", tenantState.getBucketNamespaceName());
+        obj.put("userRoleName", tenantState.getUserRoleName());
+        obj.put("adminRoleName", tenantState.getAdminRoleName());
+        obj.put("bucketNamespacePolicyName",
             tenantState.getBucketNamespacePolicyName());
-        obj.addProperty("bucketPolicyName",
-            tenantState.getBucketPolicyName());
+        obj.put("bucketPolicyName", tenantState.getBucketPolicyName());
         resArray.add(obj);
       });
-      final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-      out().println(gson.toJson(resArray));
+      if (printJson) {
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+      }
+      String jsonString = objectMapper.writeValueAsString(resArray);
+      out().println(jsonString);
     }
-
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListUsersHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListUsersHandler.java
@@ -20,10 +20,9 @@ package org.apache.hadoop.ozone.shell.tenant;
 
 import java.io.IOException;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
@@ -66,15 +65,15 @@ public class TenantListUsersHandler extends S3Handler {
             "' with accessId '" + accessIdInfo.getAccessId() + "'");
       });
     } else {
-      final JsonArray resArray = new JsonArray();
+      final ArrayNode resArray = new ObjectMapper().createArrayNode();
       usersInTenant.getUserAccessIds().forEach(accessIdInfo -> {
-        final JsonObject obj = new JsonObject();
-        obj.addProperty("user", accessIdInfo.getUserPrincipal());
-        obj.addProperty("accessId", accessIdInfo.getAccessId());
+        final ObjectNode obj = new ObjectMapper().createObjectNode();
+        obj.put("user", accessIdInfo.getUserPrincipal());
+        obj.put("accessId", accessIdInfo.getAccessId());
         resArray.add(obj);
       });
-      final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-      out().println(gson.toJson(resArray));
+      out().println(new ObjectMapper().writerWithDefaultPrettyPrinter()
+          .writeValueAsString(resArray));
     }
 
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantRevokeAdminHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantRevokeAdminHandler.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.ozone.shell.tenant;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import picocli.CommandLine;
@@ -48,14 +48,16 @@ public class TenantRevokeAdminHandler extends TenantHandler {
     client.getObjectStore().tenantRevokeAdmin(accessId, tenantId);
 
     if (isVerbose()) {
-      final JsonObject obj = new JsonObject();
-      obj.addProperty("accessId", accessId);
-      obj.addProperty("tenantId", tenantId);
-      obj.addProperty("isAdmin", false);
-      obj.addProperty("isDelegatedAdmin", false);
-      final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-      out().println(gson.toJson(obj));
-    }
+      ObjectMapper objectMapper = new ObjectMapper();
+      ObjectNode obj = objectMapper.createObjectNode();
+      obj.put("accessId", accessId);
+      obj.put("tenantId", tenantId);
+      obj.put("isAdmin", false);
+      obj.put("isDelegatedAdmin", false);
 
+      objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+      String jsonString = objectMapper.writeValueAsString(obj);
+      out().println(jsonString);
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This update addresses compatibility concerns with Java 17 by transitioning from GSON to Jackson in the `Multitenancy` code. This change simplifies dependencies and ensures smooth operation across different Java versions.

Parent Jira Issue: [HDDS-10538](https://issues.apache.org/jira/browse/HDDS-10538)

This patch streamlines our Multitenancy implementation.
Affected Multitenancy Classes:
```
- GetUserInfoHandler.java
- RangerUserRequest.java
- ozone-secure-tenant.robot
- TenantAssignAdminHandler.java
- TenantCreateHandler.java
- TenantDeleteHandler.java
- TenantListHandler.java
- TenantListUsersHandler.java
- TenantRevokeAdminHandler.java
- TestOzoneTenantShell
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10539
## How was this patch tested?

The existing UT's passed successfully. 
And the forked CI passed successfully as well. 
