### PR TITLE
HDDS-10540. Replace GSON with Jackson in nssummary.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -20,9 +20,12 @@ package org.apache.hadoop.hdds.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -80,6 +83,22 @@ public final class JsonUtils {
   public static JsonNode readTree(String content) throws IOException {
     return MAPPER.readTree(content);
   }
+
+  public static HashMap<String, Object> getResponseMap(String response)
+      throws IOException {
+    return MAPPER.readValue(response,
+        new TypeReference<HashMap<String, Object>>() {
+        });
+  }
+
+  public static List<HashMap<String, Object>> readTreeAsListOfMaps(String json)
+      throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.readValue(json,
+        new TypeReference<List<HashMap<String, Object>>>() {
+        });
+  }
+
 
   /**
    * Utility to sequentially write a large collection of items to a file.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -83,13 +83,6 @@ public final class JsonUtils {
     return MAPPER.readTree(content);
   }
 
-  public static HashMap<String, Object> readTreeAsMap(String response)
-      throws IOException {
-    return MAPPER.readValue(response,
-        new TypeReference<HashMap<String, Object>>() {
-        });
-  }
-
   public static List<HashMap<String, Object>> readTreeAsListOfMaps(String json)
       throws IOException {
     return MAPPER.readValue(json,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -83,7 +83,7 @@ public final class JsonUtils {
     return MAPPER.readTree(content);
   }
 
-  public static HashMap<String, Object> getResponseMap(String response)
+  public static HashMap<String, Object> readTreeAsMap(String response)
       throws IOException {
     return MAPPER.readValue(response,
         new TypeReference<HashMap<String, Object>>() {
@@ -92,8 +92,7 @@ public final class JsonUtils {
 
   public static List<HashMap<String, Object>> readTreeAsListOfMaps(String json)
       throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper();
-    return objectMapper.readValue(json,
+    return MAPPER.readValue(json,
         new TypeReference<List<HashMap<String, Object>>>() {
         });
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import com.google.gson.internal.LinkedTreeMap;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -64,9 +65,9 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 
-import com.google.gson.Gson;
-import com.google.gson.internal.LinkedTreeMap;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -381,16 +382,21 @@ public class TestReconWithOzoneManager {
 
   private long getReconTaskAttributeFromJson(String taskStatusResponse,
                                              String taskName,
-                                             String entityAttribute) {
-    ArrayList<LinkedTreeMap> taskStatusList = new Gson()
-        .fromJson(taskStatusResponse, ArrayList.class);
+                                             String entityAttribute)
+      throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    ArrayList<LinkedTreeMap> taskStatusList = objectMapper.readValue(
+        taskStatusResponse, new TypeReference<ArrayList<LinkedTreeMap>>() {
+        });
+
     Optional<LinkedTreeMap> taskEntity =
         taskStatusList
             .stream()
             .filter(task -> task.get("taskName").equals(taskName))
             .findFirst();
     assertTrue(taskEntity.isPresent());
-    return (long) (double) taskEntity.get().get(entityAttribute);
+    Number number = (Number) taskEntity.get().get(entityAttribute);
+    return number.longValue();
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -34,10 +34,13 @@ import static org.slf4j.event.Level.INFO;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
-import com.google.gson.internal.LinkedTreeMap;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -63,7 +66,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import com.fasterxml.jackson.core.type.TypeReference;
 
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -22,15 +22,11 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.shell.ListOptions;
 import picocli.CommandLine;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.concurrent.Callable;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
-import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getResponseMap;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.parseInputPath;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -19,12 +19,12 @@ package org.apache.hadoop.ozone.admin.nssummary;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.ozone.shell.ListOptions;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
@@ -99,8 +99,7 @@ public class DiskUsageSubCommand implements Callable {
       return null;
     }
 
-    ObjectMapper objectMapper = new ObjectMapper();
-    JsonNode duResponse = objectMapper.readTree(response);
+    JsonNode duResponse = JsonUtils.readTree(response);
 
     if (duResponse.get("status").asText().equals("PATH_NOT_FOUND")) {
       printPathNotFound();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.admin.nssummary;
 
-import com.google.gson.internal.LinkedTreeMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.ozone.shell.ListOptions;
@@ -26,7 +25,10 @@ import picocli.CommandLine;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.Callable;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getResponseMap;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
@@ -101,21 +103,21 @@ public class DiskUsageSubCommand implements Callable {
       return null;
     }
 
-    HashMap<String, Object> duResponse = getResponseMap(response);
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode duResponse = objectMapper.readTree(response);
 
-    if (duResponse.get("status").equals("PATH_NOT_FOUND")) {
+    if (duResponse.get("status").asText().equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
       if (parent.isNotValidBucketOrOBSBucket(path)) {
         printBucketReminder();
       }
 
-      long totalSize = (long)(double)duResponse.get("size");
-
+      long totalSize = duResponse.get("size").asLong();
       if (!noHeader) {
         printWithUnderline("Path", false);
         printKVSeparator();
-        System.out.println(duResponse.get("path"));
+        System.out.println(duResponse.get("path").asText());
 
         printWithUnderline("Total Size", false);
         printKVSeparator();
@@ -124,11 +126,11 @@ public class DiskUsageSubCommand implements Callable {
         if (withReplica) {
           printWithUnderline("Total Disk Usage", false);
           printKVSeparator();
-          long du = (long)(double)duResponse.get("sizeWithReplica");
+          long du = duResponse.get("sizeWithReplica").asLong();
           System.out.println(FileUtils.byteCountToDisplaySize(du));
         }
 
-        long sizeDirectKey = (long)(double)duResponse.get("sizeDirectKey");
+        long sizeDirectKey = duResponse.get("sizeDirectKey").asLong();
         if (!listFiles && sizeDirectKey != -1) {
           printWithUnderline("Size of Direct Keys", false);
           printKVSeparator();
@@ -137,7 +139,7 @@ public class DiskUsageSubCommand implements Callable {
         printNewLines(1);
       }
 
-      if ((double)duResponse.get("subPathCount") == 0) {
+      if (duResponse.get("subPathCount").asInt() == 0) {
         if (totalSize == 0) {
           // the object is empty
           System.out.println("The object is empty.\n" +
@@ -160,20 +162,19 @@ public class DiskUsageSubCommand implements Callable {
           seekStr = "";
         }
 
-        ArrayList duData = (ArrayList)duResponse.get("subPaths");
+        ArrayNode subPaths = (ArrayNode) duResponse.get("subPaths");
         int cnt = 0;
-        for (int i = 0; i < duData.size(); ++i) {
+        for (JsonNode subPathDU : subPaths) {
           if (cnt >= limit) {
             break;
           }
-          LinkedTreeMap subPathDU = (LinkedTreeMap) duData.get(i);
-          String subPath = subPathDU.get("path").toString();
+          String subPath = subPathDU.get("path").asText();
           // differentiate key from other types
-          if (!(boolean)subPathDU.get("isKey")) {
+          if (!subPathDU.get("isKey").asBoolean()) {
             subPath += OM_KEY_PREFIX;
           }
-          long size = (long)(double)subPathDU.get("size");
-          long sizeWithReplica = (long)(double)subPathDU.get("sizeWithReplica");
+          long size = subPathDU.get("size").asLong();
+          long sizeWithReplica = subPathDU.get("sizeWithReplica").asLong();
           if (subPath.startsWith(seekStr)) {
             printDURow(subPath, size, sizeWithReplica);
             ++cnt;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -23,8 +23,6 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.concurrent.Callable;
 
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -85,11 +85,11 @@ public class FileSizeDistSubCommand implements Callable {
       }
 
       printWithUnderline("File Size Distribution", true);
-      ArrayList fileSizeDist = (ArrayList) distResponse.get("dist");
+      ArrayList<?> fileSizeDist = (ArrayList<?>) distResponse.get("dist");
       double sum = 0;
 
-      for (int i = 0; i < fileSizeDist.size(); ++i) {
-        sum += (double) fileSizeDist.get(i);
+      for (Object obj : fileSizeDist) {
+        sum += ((Number) obj).doubleValue();
       }
       if (sum == 0) {
         printSpaces(2);
@@ -100,11 +100,12 @@ public class FileSizeDistSubCommand implements Callable {
       }
 
       for (int i = 0; i < fileSizeDist.size(); ++i) {
-        if ((double)fileSizeDist.get(i) == 0) {
+        double count = ((Number) fileSizeDist.get(i)).doubleValue();
+        if (count == 0) {
           continue;
         }
         String label = convertBinIndexToReadableRange(i);
-        printDistRow(label, (double) fileSizeDist.get(i), sum);
+        printDistRow(label, count, sum);
       }
     }
     printNewLines(1);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -76,7 +76,7 @@ public class FileSizeDistSubCommand implements Callable {
 
     if ("PATH_NOT_FOUND".equals(distResponse.path("status").asText())) {
       printPathNotFound();
-    } else if (distResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
+    } else if ("TYPE_NOT_APPLICABLE".equals(distResponse.path("status").asText())) {
       printTypeNA("File Size Distribution");
     } else {
       if (parent.isNotValidBucketOrOBSBucket(path)) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -74,7 +74,7 @@ public class FileSizeDistSubCommand implements Callable {
     }
     JsonNode distResponse = JsonUtils.readTree(response);
 
-    if (distResponse.get("status").equals("PATH_NOT_FOUND")) {
+    if ("PATH_NOT_FOUND".equals(distResponse.path("status").asText())) {
       printPathNotFound();
     } else if (distResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("File Size Distribution");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -21,18 +21,15 @@ package org.apache.hadoop.ozone.admin.nssummary;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import picocli.CommandLine.Help.Ansi;
 
 import javax.security.sasl.AuthenticationException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.admin.nssummary;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -110,7 +110,7 @@ public final class NSSummaryCLIUtils {
 
   public static HashMap<String, Object> getResponseMap(String response)
       throws IOException {
-    return JsonUtils.getResponseMap(response);
+    return JsonUtils.readTreeAsMap(response);
   }
 
   public static void printNewLines(int cnt) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -19,10 +19,10 @@
 package org.apache.hadoop.ozone.admin.nssummary;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import picocli.CommandLine.Help.Ansi;
 
@@ -111,10 +111,7 @@ public final class NSSummaryCLIUtils {
 
   public static HashMap<String, Object> getResponseMap(String response)
       throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper();
-    return objectMapper.readValue(response,
-        new TypeReference<HashMap<String, Object>>() {
-        });
+    return JsonUtils.getResponseMap(response);
   }
 
   public static void printNewLines(int cnt) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -108,11 +108,6 @@ public final class NSSummaryCLIUtils {
     }
   }
 
-  public static HashMap<String, Object> getResponseMap(String response)
-      throws IOException {
-    return JsonUtils.readTreeAsMap(response);
-  }
-
   public static void printNewLines(int cnt) {
     for (int i = 0; i < cnt; ++i) {
       System.out.println();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -18,7 +18,8 @@
 
 package org.apache.hadoop.ozone.admin.nssummary;
 
-import com.google.gson.Gson;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -26,6 +27,7 @@ import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import picocli.CommandLine.Help.Ansi;
 
 import javax.security.sasl.AuthenticationException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
@@ -107,8 +109,12 @@ public final class NSSummaryCLIUtils {
     }
   }
 
-  public static HashMap<String, Object> getResponseMap(String response) {
-    return new Gson().fromJson(response, HashMap.class);
+  public static HashMap<String, Object> getResponseMap(String response)
+      throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.readValue(response,
+        new TypeReference<HashMap<String, Object>>() {
+        });
   }
 
   public static void printNewLines(int cnt) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -77,7 +77,7 @@ public class QuotaUsageSubCommand implements Callable {
 
     if ("PATH_NOT_FOUND".equals(quotaResponse.path("status").asText())) {
       printPathNotFound();
-    } else if (quotaResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
+    } else if ("TYPE_NOT_APPLICABLE".equals(quotaResponse.path("status").asText())) {
       printTypeNA("Quota");
     } else {
       if (parent.isNotValidBucketOrOBSBucket(path)) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -85,8 +85,10 @@ public class QuotaUsageSubCommand implements Callable {
       }
 
       printWithUnderline("Quota", true);
-      long quotaAllowed = (long)(double)quotaResponse.get("allowed");
-      long quotaUsed = (long)(double)quotaResponse.get("used");
+
+      long quotaAllowed = ((Number) quotaResponse.get("allowed")).longValue();
+      long quotaUsed = ((Number) quotaResponse.get("used")).longValue();
+
       printSpaces(2);
       System.out.print("Allowed");
       printKVSeparator();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -17,14 +17,15 @@
  */
 package org.apache.hadoop.ozone.admin.nssummary;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
 import java.util.HashMap;
 import java.util.concurrent.Callable;
 
-import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getResponseMap;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printBucketReminder;
@@ -73,7 +74,7 @@ public class QuotaUsageSubCommand implements Callable {
       return null;
     }
 
-    HashMap<String, Object> quotaResponse = getResponseMap(response);
+    JsonNode quotaResponse = JsonUtils.readTree(response);
 
     if (quotaResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
@@ -86,8 +87,8 @@ public class QuotaUsageSubCommand implements Callable {
 
       printWithUnderline("Quota", true);
 
-      long quotaAllowed = ((Number) quotaResponse.get("allowed")).longValue();
-      long quotaUsed = ((Number) quotaResponse.get("used")).longValue();
+      long quotaAllowed = quotaResponse.get("allowed").asLong();
+      long quotaUsed = quotaResponse.get("used").asLong();
 
       printSpaces(2);
       System.out.print("Allowed");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
-import java.util.HashMap;
 import java.util.concurrent.Callable;
 
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -75,7 +75,7 @@ public class QuotaUsageSubCommand implements Callable {
 
     JsonNode quotaResponse = JsonUtils.readTree(response);
 
-    if (quotaResponse.get("status").equals("PATH_NOT_FOUND")) {
+    if ("PATH_NOT_FOUND".equals(quotaResponse.path("status").asText())) {
       printPathNotFound();
     } else if (quotaResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("Quota");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
-import java.util.HashMap;
 import java.util.concurrent.Callable;
 
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -73,7 +73,7 @@ public class SummarySubCommand implements Callable<Void> {
     }
     JsonNode summaryResponse = JsonUtils.readTree(response);
 
-    if (summaryResponse.get("status").equals("PATH_NOT_FOUND")) {
+    if ("PATH_NOT_FOUND".equals(summaryResponse.path("status").asText())) {
       printPathNotFound();
     } else {
       if (parent.isNotValidBucketOrOBSBucket(path)) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -83,10 +83,11 @@ public class SummarySubCommand implements Callable<Void> {
       printWithUnderline("Entity Type", false);
       printKVSeparator();
       System.out.println(summaryResponse.get("type"));
-      int numVol = ((Double) summaryResponse.get("numVolume")).intValue();
-      int numBucket = ((Double) summaryResponse.get("numBucket")).intValue();
-      int numDir = ((Double) summaryResponse.get("numDir")).intValue();
-      int numKey = ((Double) summaryResponse.get("numKey")).intValue();
+
+      int numVol = ((Number) summaryResponse.get("numVolume")).intValue();
+      int numBucket = ((Number) summaryResponse.get("numBucket")).intValue();
+      int numDir = ((Number) summaryResponse.get("numDir")).intValue();
+      int numKey = ((Number) summaryResponse.get("numKey")).intValue();
 
       if (numVol != -1) {
         printWithUnderline("Volumes", false);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -17,13 +17,14 @@
  */
 package org.apache.hadoop.ozone.admin.nssummary;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
 import java.util.HashMap;
 import java.util.concurrent.Callable;
 
-import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getResponseMap;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.parseInputPath;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
@@ -71,7 +72,7 @@ public class SummarySubCommand implements Callable<Void> {
       printNewLines(1);
       return null;
     }
-    HashMap<String, Object> summaryResponse = getResponseMap(response);
+    JsonNode summaryResponse = JsonUtils.readTree(response);
 
     if (summaryResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
@@ -84,10 +85,10 @@ public class SummarySubCommand implements Callable<Void> {
       printKVSeparator();
       System.out.println(summaryResponse.get("type"));
 
-      int numVol = ((Number) summaryResponse.get("numVolume")).intValue();
-      int numBucket = ((Number) summaryResponse.get("numBucket")).intValue();
-      int numDir = ((Number) summaryResponse.get("numDir")).intValue();
-      int numKey = ((Number) summaryResponse.get("numKey")).intValue();
+      int numVol = summaryResponse.get("numVolume").asInt();
+      int numBucket = summaryResponse.get("numBucket").asInt();
+      int numDir = summaryResponse.get("numDir").asInt();
+      int numKey = summaryResponse.get("numKey").asInt();
 
       if (numVol != -1) {
         printWithUnderline("Volumes", false);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This update addresses compatibility concerns with Java 17 by transitioning from GSON to Jackson in the `NSSummary` code. This change simplifies dependencies and ensures smooth operation across different Java versions.

Parent Jira Issue: [HDDS-10538](https://issues.apache.org/jira/browse/HDDS-10538)

This patch streamlines our Subcommands Implementation.
Affected NSSummary-Subcommands Classes:

```
- FileSizeDistSubCommand.java
- DiskUsageSubCommand.java
- NSSummaryCLIUtils.java
- QuotaUsageSubCommand.java
- SummarySubCommand.java
- TestReconWithOzoneManager.java
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10540
## How was this patch tested?

The existing UT's passed successfully. 
And the forked CI passed successfully as well. 