### PR TITLE
HDDS-10541. Replace GSON with Jackson in debug commands

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -101,8 +101,7 @@ public class ChunkKeyHandler extends KeyHandler implements
       ContainerLayoutVersion containerLayoutVersion = ContainerLayoutVersion
           .getConfiguredVersion(getConf());
       ArrayNode responseArrayList = JsonUtils.createArrayNode();
-      for (OmKeyLocationInfo keyLocation : keyInfo.getLatestVersionLocations()
-          .getBlocksLatestVersionOnly()) {
+      for (OmKeyLocationInfo keyLocation : locationInfos) {
         ContainerChunkInfo containerChunkInfoVerbose = new ContainerChunkInfo();
         ContainerChunkInfo containerChunkInfo = new ContainerChunkInfo();
         long containerId = keyLocation.getContainerID();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -24,11 +24,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.HashSet;
-import com.google.gson.GsonBuilder;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -43,6 +42,7 @@ import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -80,13 +80,13 @@ public class ChunkKeyHandler extends KeyHandler implements
         XceiverClientManager xceiverClientManager = containerOperationClient.getXceiverClientManager()) {
       OzoneManagerProtocol ozoneManagerClient = client.getObjectStore().getClientProxy().getOzoneManagerClient();
       address.ensureKeyAddress();
-      JsonElement element;
-      JsonObject result = new JsonObject();
+      ObjectMapper objectMapper = new ObjectMapper();
+      ObjectNode result = objectMapper.createObjectNode();
       String volumeName = address.getVolumeName();
       String bucketName = address.getBucketName();
       String keyName = address.getKeyName();
-      List<ContainerProtos.ChunkInfo> tempchunks = null;
-      List<ChunkDetails> chunkDetailsList = new ArrayList<ChunkDetails>();
+      List<ContainerProtos.ChunkInfo> tempchunks;
+      List<ChunkDetails> chunkDetailsList = new ArrayList<>();
       HashSet<String> chunkPaths = new HashSet<>();
       OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
           .setBucketName(bucketName).setKeyName(keyName).build();
@@ -102,8 +102,9 @@ public class ChunkKeyHandler extends KeyHandler implements
       }
       ContainerLayoutVersion containerLayoutVersion = ContainerLayoutVersion
           .getConfiguredVersion(getConf());
-      JsonArray responseArrayList = new JsonArray();
-      for (OmKeyLocationInfo keyLocation : locationInfos) {
+      ArrayNode responseArrayList = objectMapper.createArrayNode();
+      for (OmKeyLocationInfo keyLocation : keyInfo.getLatestVersionLocations()
+          .getBlocksLatestVersionOnly()) {
         ContainerChunkInfo containerChunkInfoVerbose = new ContainerChunkInfo();
         ContainerChunkInfo containerChunkInfo = new ContainerChunkInfo();
         long containerId = keyLocation.getContainerID();
@@ -128,24 +129,17 @@ public class ChunkKeyHandler extends KeyHandler implements
               keyLocation.getBlockID().getDatanodeBlockIDProtobuf();
           // doing a getBlock on all nodes
           Map<DatanodeDetails, ContainerProtos.GetBlockResponseProto>
-              responses = null;
-          Map<DatanodeDetails, ContainerProtos.ReadContainerResponseProto>
-              readContainerResponses = null;
-          try {
-            responses = ContainerProtocolCalls.getBlockFromAllNodes(xceiverClient,
-                datanodeBlockID, keyLocation.getToken());
-            readContainerResponses =
-                containerOperationClient.readContainerFromAllNodes(
-                    keyLocation.getContainerID(), pipeline);
-          } catch (InterruptedException e) {
-            LOG.error("Execution interrupted due to " + e);
-            Thread.currentThread().interrupt();
-          }
-          JsonArray responseFromAllNodes = new JsonArray();
-          for (Map.Entry<DatanodeDetails, ContainerProtos.GetBlockResponseProto>
-              entry : responses.entrySet()) {
+              responses =
+              ContainerProtocolCalls.getBlockFromAllNodes(xceiverClient,
+                  keyLocation.getBlockID().getDatanodeBlockIDProtobuf(),
+                  keyLocation.getToken());
+          Map<DatanodeDetails, ContainerProtos.ReadContainerResponseProto> readContainerResponses =
+              containerOperationClient.readContainerFromAllNodes(
+                  keyLocation.getContainerID(), pipeline);
+          ArrayNode responseFromAllNodes = objectMapper.createArrayNode();
+          for (Map.Entry<DatanodeDetails, ContainerProtos.GetBlockResponseProto> entry : responses.entrySet()) {
             chunkPaths.clear();
-            JsonObject jsonObj = new JsonObject();
+            ObjectNode jsonObj = objectMapper.createObjectNode();
             if (entry.getValue() == null) {
               LOG.error("Cant execute getBlock on this node");
               continue;
@@ -177,29 +171,30 @@ public class ChunkKeyHandler extends KeyHandler implements
               containerChunkInfoVerbose.setChunkType(blockChunksType);
               containerChunkInfo.setChunkType(blockChunksType);
             }
-            Gson gson = new GsonBuilder().create();
+
             if (isVerbose()) {
-              element = gson.toJsonTree(containerChunkInfoVerbose);
+              jsonObj.set("Locations",
+                  objectMapper.valueToTree(containerChunkInfoVerbose));
             } else {
-              element = gson.toJsonTree(containerChunkInfo);
+              jsonObj.set("Locations",
+                  objectMapper.valueToTree(containerChunkInfo));
             }
-            jsonObj.addProperty("Datanode-HostName", entry.getKey()
-                .getHostName());
-            jsonObj.addProperty("Datanode-IP", entry.getKey()
-                .getIpAddress());
-            jsonObj.addProperty("Container-ID", containerId);
-            jsonObj.addProperty("Block-ID", keyLocation.getLocalID());
-            jsonObj.add("Locations", element);
+            jsonObj.put("Datanode-HostName", entry.getKey().getHostName());
+            jsonObj.put("Datanode-IP", entry.getKey().getIpAddress());
+            jsonObj.put("Container-ID", containerId);
+            jsonObj.put("Block-ID", keyLocation.getLocalID());
             responseFromAllNodes.add(jsonObj);
           }
           responseArrayList.add(responseFromAllNodes);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
         } finally {
           xceiverClientManager.releaseClientForReadData(xceiverClient, false);
         }
       }
-      result.add("KeyLocations", responseArrayList);
-      Gson gson2 = new GsonBuilder().setPrettyPrinting().create();
-      String prettyJson = gson2.toJson(result);
+      result.set("KeyLocations", responseArrayList);
+      String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+          .writeValueAsString(result);
       System.out.println(prettyJson);
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ContainerChunkInfo.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ContainerChunkInfo.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 public class ContainerChunkInfo {
   private String containerPath;
   private List<ChunkDetails> chunkInfos;
+
   private HashSet<String> files;
   private UUID pipelineID;
   private Pipeline pipeline;
@@ -64,6 +65,27 @@ public class ContainerChunkInfo {
   public void setChunkType(ChunkType chunkType) {
     this.chunkType = chunkType;
   }
+
+  public String getContainerPath() {
+    return containerPath;
+  }
+
+  public List<ChunkDetails> getChunkInfos() {
+    return chunkInfos;
+  }
+
+  public HashSet<String> getFiles() {
+    return files;
+  }
+
+  public UUID getPipelineID() {
+    return pipelineID;
+  }
+
+  public ChunkType getChunkType() {
+    return chunkType;
+  }
+
 
   @Override
   public String toString() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -208,8 +208,7 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
       blockJson.set(JSON_PROPERTY_BLOCK_REPLICAS, replicasJson);
       blocks.add(blockJson);
 
-      blockReplicasWithoutChecksum.values()
-          .forEach(each -> IOUtils.close(LOG, each));
+      IOUtils.close(LOG, blockReplicasWithoutChecksum.values());
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -214,7 +214,7 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
   }
 
   private Map<DatanodeDetails, OzoneInputStream> replicasOf(BlockID blockID,
-                Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas) {
+      Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas) {
     for (Map.Entry<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>>
         block : replicas.entrySet()) {
       if (block.getKey().getBlockID().equals(blockID)) {
@@ -233,7 +233,7 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
 
   @Nonnull
   private File createDirectory(String volumeName, String bucketName,
-                               String keyName) throws IOException {
+                                 String keyName) throws IOException {
     String fileSuffix
         = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
     String directoryName = volumeName + "_" + bucketName + "_" + keyName +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -218,7 +218,7 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
   }
 
   private Map<DatanodeDetails, OzoneInputStream> replicasOf(BlockID blockID,
-                                                            Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas) {
+                Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas) {
     for (Map.Entry<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>>
         block : replicas.entrySet()) {
       if (block.getKey().getBlockID().equals(blockID)) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ReadReplicas.java
@@ -17,10 +17,6 @@
 
 package org.apache.hadoop.ozone.debug;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -36,6 +32,9 @@ import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.keys.KeyHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.annotation.Nonnull;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
@@ -129,18 +128,20 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
           replicasWithoutChecksum = noChecksumClient
           .getKeysEveryReplicas(volumeName, bucketName, keyName);
 
-      JsonObject result = new JsonObject();
-      result.addProperty(JSON_PROPERTY_FILE_NAME,
+      ObjectMapper objectMapper = new ObjectMapper(); // Jackson's ObjectMapper
+      ObjectNode result = objectMapper.createObjectNode();
+      result.put(JSON_PROPERTY_FILE_NAME,
           volumeName + "/" + bucketName + "/" + keyName);
-      result.addProperty(JSON_PROPERTY_FILE_SIZE, keyInfoDetails.getDataSize());
+      result.put(JSON_PROPERTY_FILE_SIZE, keyInfoDetails.getDataSize());
 
-      JsonArray blocks = new JsonArray();
+      ArrayNode blocks = objectMapper.createArrayNode();
       downloadReplicasAndCreateManifest(keyName, replicas,
           replicasWithoutChecksum, dir, blocks);
-      result.add(JSON_PROPERTY_FILE_BLOCKS, blocks);
+      result.set(JSON_PROPERTY_FILE_BLOCKS, blocks);
 
-      Gson gson = new GsonBuilder().setPrettyPrinting().create();
-      String prettyJson = gson.toJson(result);
+      // For pretty printing JSON output with Jackson
+      String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+          .writeValueAsString(result);
 
       String manifestFileName = keyName + "_manifest";
       System.out.println("Writing manifest file : " + manifestFileName);
@@ -158,25 +159,23 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
       Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas,
       Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>>
           replicasWithoutChecksum,
-      File dir, JsonArray blocks) throws IOException {
+      File dir, ArrayNode blocks) throws IOException {
     int blockIndex = 0;
+    ObjectMapper objectMapper = new ObjectMapper();
 
     for (Map.Entry<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>>
         block : replicas.entrySet()) {
-      JsonObject blockJson = new JsonObject();
-      JsonArray replicasJson = new JsonArray();
+      ObjectNode blockJson = objectMapper.createObjectNode();
+      ArrayNode replicasJson = objectMapper.createArrayNode();
 
       blockIndex += 1;
-      blockJson.addProperty(JSON_PROPERTY_BLOCK_INDEX, blockIndex);
+      blockJson.put(JSON_PROPERTY_BLOCK_INDEX, blockIndex);
       OmKeyLocationInfo locationInfo = block.getKey();
-      blockJson.addProperty(JSON_PROPERTY_BLOCK_CONTAINERID,
+      blockJson.put(JSON_PROPERTY_BLOCK_CONTAINERID,
           locationInfo.getContainerID());
-      blockJson.addProperty(JSON_PROPERTY_BLOCK_LOCALID,
-          locationInfo.getLocalID());
-      blockJson.addProperty(JSON_PROPERTY_BLOCK_LENGTH,
-          locationInfo.getLength());
-      blockJson.addProperty(JSON_PROPERTY_BLOCK_OFFSET,
-          locationInfo.getOffset());
+      blockJson.put(JSON_PROPERTY_BLOCK_LOCALID, locationInfo.getLocalID());
+      blockJson.put(JSON_PROPERTY_BLOCK_LENGTH, locationInfo.getLength());
+      blockJson.put(JSON_PROPERTY_BLOCK_OFFSET, locationInfo.getOffset());
 
       BlockID blockID = locationInfo.getBlockID();
       Map<DatanodeDetails, OzoneInputStream> blockReplicasWithoutChecksum =
@@ -186,12 +185,10 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
           replica : block.getValue().entrySet()) {
         DatanodeDetails datanode = replica.getKey();
 
-        JsonObject replicaJson = new JsonObject();
+        ObjectNode replicaJson = objectMapper.createObjectNode();
 
-        replicaJson.addProperty(JSON_PROPERTY_REPLICA_HOSTNAME,
-            datanode.getHostName());
-        replicaJson.addProperty(JSON_PROPERTY_REPLICA_UUID,
-            datanode.getUuidString());
+        replicaJson.put(JSON_PROPERTY_REPLICA_HOSTNAME, datanode.getHostName());
+        replicaJson.put(JSON_PROPERTY_REPLICA_UUID, datanode.getUuidString());
 
         String fileName = keyName + "_block" + blockIndex + "_" +
             datanode.getHostName();
@@ -202,8 +199,7 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
           Files.copy(is, path, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
           Throwable cause = e.getCause();
-          replicaJson.addProperty(JSON_PROPERTY_REPLICA_EXCEPTION,
-              e.getMessage());
+          replicaJson.put(JSON_PROPERTY_REPLICA_EXCEPTION, e.getMessage());
           if (cause instanceof OzoneChecksumException) {
             try (InputStream is = getReplica(
                 blockReplicasWithoutChecksum, datanode)) {
@@ -213,15 +209,16 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
         }
         replicasJson.add(replicaJson);
       }
-      blockJson.add(JSON_PROPERTY_BLOCK_REPLICAS, replicasJson);
+      blockJson.set(JSON_PROPERTY_BLOCK_REPLICAS, replicasJson);
       blocks.add(blockJson);
 
-      IOUtils.close(LOG, blockReplicasWithoutChecksum.values());
+      blockReplicasWithoutChecksum.values()
+          .forEach(each -> IOUtils.close(LOG, each));
     }
   }
 
   private Map<DatanodeDetails, OzoneInputStream> replicasOf(BlockID blockID,
-      Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas) {
+                                                            Map<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>> replicas) {
     for (Map.Entry<OmKeyLocationInfo, Map<DatanodeDetails, OzoneInputStream>>
         block : replicas.entrySet()) {
       if (block.getKey().getBlockID().equals(blockID)) {
@@ -240,7 +237,7 @@ public class ReadReplicas extends KeyHandler implements SubcommandWithParent {
 
   @Nonnull
   private File createDirectory(String volumeName, String bucketName,
-                                 String keyName) throws IOException {
+                               String keyName) throws IOException {
     String fileSuffix
         = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
     String directoryName = volumeName + "_" + bucketName + "_" + keyName +


### PR DESCRIPTION
## What changes were proposed in this pull request?
This update addresses compatibility concerns with Java 17 by transitioning from GSON to Jackson in the `Debug-Shell` module. This change simplifies dependencies and ensures smooth operation across different Java versions.

Parent Jira Issue: [HDDS-10538](https://issues.apache.org/jira/browse/HDDS-10538)

This patch streamlines our Debug-Shell Implementation.
Affected Classes:

```
- ChunkKeyHandler.java
- ReadReplicas.java
- ContainerChunkInfo.java
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10541
## How was this patch tested?
To test out the changes we have to run :- `TestOzoneDebugShell` Integration test.
The forked CI also ran successfully. 