### PR TITLE
HDDS-10553. Add test case for creating file with EC replication config

### DIFF
--- a/hadoop-hdds/docs/content/feature/ErasureCoding.md
+++ b/hadoop-hdds/docs/content/feature/ErasureCoding.md
@@ -174,7 +174,9 @@ the configuration keys `ozone.server.default.replication.type` and `ozone.server
    <name>ozone.server.default.replication.type</name>
    <value>EC</value>
 </property>
+```
 
+```XML
 <property>
    <name>ozone.server.default.replication</name>
    <value>RS-6-3-1024k</value>
@@ -206,6 +208,22 @@ We can pass the EC Replication Config while creating the keys irrespective of bu
 
 ```shell
 ozone sh key put <Ozone Key Object Path> <Local File> --type EC --replication rs-6-3-1024k
+```
+
+When using ofs/o3fs, we can pass the EC Replication Config by setting the configuration keys `ozone.replication.type` and `ozone.replication`.
+
+```XML
+<property>
+   <name>ozone.replication.type</name>
+   <value>EC</value>
+</property>
+```
+
+```XML
+<property>
+   <name>ozone.replication</name>
+   <value>rs-3-2-1024k</value>
+</property>
 ```
 
 In the case bucket already has default EC Replication Config, there is no need of passing EC Replication Config while creating key.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -110,7 +110,7 @@ import static org.apache.hadoop.fs.StorageStatistics.CommonStatisticNames.OP_OPE
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasPathCapabilities;
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
-import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.testCreateKeyWithECReplicationConfiguration;
+import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.createKeyWithECReplicationConfiguration;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -429,7 +429,15 @@ abstract class AbstractOzoneFileSystemTest {
 
   @Test
   public void testCreateKeyWithECReplicationConfig() throws Exception {
-    testCreateKeyWithECReplicationConfiguration(cluster.getConf(), volumeName, bucketName, client);
+    Path root = new Path("/" + volumeName + "/" + bucketName);
+    Path testKeyPath = new Path(root, "testKey");
+    createKeyWithECReplicationConfiguration(cluster.getConf(), testKeyPath);
+
+    OzoneKeyDetails key = getKey(testKeyPath, false);
+    assertEquals(HddsProtos.ReplicationType.EC,
+        key.getReplicationConfig().getReplicationType());
+    assertEquals("rs-3-2-1024k",
+        key.getReplicationConfig().getReplication());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -110,7 +110,7 @@ import static org.apache.hadoop.fs.StorageStatistics.CommonStatisticNames.OP_OPE
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasPathCapabilities;
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
-import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.createKeyWithECReplicationConfiguration;
+import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.testCreateKeyWithECReplicationConfiguration;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -429,15 +429,7 @@ abstract class AbstractOzoneFileSystemTest {
 
   @Test
   public void testCreateKeyWithECReplicationConfig() throws Exception {
-    Path root = new Path("/" + volumeName + "/" + bucketName);
-    Path testKeyPath = new Path(root, "testKey");
-    createKeyWithECReplicationConfiguration(cluster.getConf(), testKeyPath);
-
-    OzoneKeyDetails key = getKey(testKeyPath, false);
-    assertEquals(HddsProtos.ReplicationType.EC,
-        key.getReplicationConfig().getReplicationType());
-    assertEquals("rs-3-2-1024k",
-        key.getReplicationConfig().getReplication());
+    testCreateKeyWithECReplicationConfiguration(cluster.getConf(), volumeName, bucketName, client);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -115,7 +115,7 @@ import static org.apache.hadoop.fs.CommonPathCapabilities.FS_CHECKSUMS;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasPathCapabilities;
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
-import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.testCreateKeyWithECReplicationConfiguration;
+import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.createKeyWithECReplicationConfiguration;
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -328,7 +328,15 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
   @Test
   public void testCreateKeyWithECReplicationConfig() throws Exception {
-    testCreateKeyWithECReplicationConfiguration(cluster.getConf(), volumeName, bucketName, client);
+    String testKeyName = "testKey";
+    Path testKeyPath = new Path(bucketPath, testKeyName);
+    createKeyWithECReplicationConfiguration(cluster.getConf(), testKeyPath);
+
+    OzoneKeyDetails key = getKey(testKeyPath, false);
+    assertEquals(HddsProtos.ReplicationType.EC,
+        key.getReplicationConfig().getReplicationType());
+    assertEquals("rs-3-2-1024k",
+        key.getReplicationConfig().getReplication());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -115,11 +115,10 @@ import static org.apache.hadoop.fs.CommonPathCapabilities.FS_CHECKSUMS;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasPathCapabilities;
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
+import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.createKeyWithECReplicationConfiguration;
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_OFS_SHARED_TMP_DIR;
@@ -234,7 +233,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
   @BeforeAll
   void initClusterAndEnv() throws IOException, InterruptedException, TimeoutException {
     conf = new OzoneConfiguration();
-    conf.set("fs.ofs.impl.disable.cache", "true");
     conf.setFloat(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
     conf.setFloat(FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
     conf.setFloat(FS_TRASH_CHECKPOINT_INTERVAL_KEY, TRASH_INTERVAL / 2);
@@ -332,17 +330,13 @@ abstract class AbstractRootedOzoneFileSystemTest {
   public void testCreateKeyWithECReplicationConfig() throws Exception {
     String testKeyName = "testKey";
     Path testKeyPath = new Path(bucketPath, testKeyName);
-    conf.set(OZONE_REPLICATION, "rs-3-2-1024k");
-    conf.set(OZONE_REPLICATION_TYPE, "EC");
-    FileSystem fileSystem = FileSystem.get(conf);
-    ContractTestUtils.touch(fileSystem, testKeyPath);
+    createKeyWithECReplicationConfiguration(cluster.getConf(), testKeyPath);
 
     OzoneKeyDetails key = getKey(testKeyPath, false);
     assertEquals(HddsProtos.ReplicationType.EC,
         key.getReplicationConfig().getReplicationType());
     assertEquals("rs-3-2-1024k",
         key.getReplicationConfig().getReplication());
-    fileSystem.close();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -118,6 +118,8 @@ import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_OFS_SHARED_TMP_DIR;
@@ -232,6 +234,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
   @BeforeAll
   void initClusterAndEnv() throws IOException, InterruptedException, TimeoutException {
     conf = new OzoneConfiguration();
+    conf.set("fs.ofs.impl.disable.cache", "true");
     conf.setFloat(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
     conf.setFloat(FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
     conf.setFloat(FS_TRASH_CHECKPOINT_INTERVAL_KEY, TRASH_INTERVAL / 2);
@@ -323,6 +326,23 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
     // Cleanup
     fs.delete(grandparent, true);
+  }
+
+  @Test
+  public void testCreateKeyWithECReplicationConfig() throws Exception {
+    String testKeyName = "testKey";
+    Path testKeyPath = new Path(bucketPath, testKeyName);
+    conf.set(OZONE_REPLICATION, "rs-3-2-1024k");
+    conf.set(OZONE_REPLICATION_TYPE, "EC");
+    FileSystem fileSystem = FileSystem.get(conf);
+    ContractTestUtils.touch(fileSystem, testKeyPath);
+
+    OzoneKeyDetails key = getKey(testKeyPath, false);
+    assertEquals(HddsProtos.ReplicationType.EC,
+        key.getReplicationConfig().getReplicationType());
+    assertEquals("rs-3-2-1024k",
+        key.getReplicationConfig().getReplication());
+    fileSystem.close();
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -115,7 +115,7 @@ import static org.apache.hadoop.fs.CommonPathCapabilities.FS_CHECKSUMS;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertHasPathCapabilities;
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
-import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.createKeyWithECReplicationConfiguration;
+import static org.apache.hadoop.fs.ozone.OzoneFileSystemTests.testCreateKeyWithECReplicationConfiguration;
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -328,15 +328,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
   @Test
   public void testCreateKeyWithECReplicationConfig() throws Exception {
-    String testKeyName = "testKey";
-    Path testKeyPath = new Path(bucketPath, testKeyName);
-    createKeyWithECReplicationConfiguration(cluster.getConf(), testKeyPath);
-
-    OzoneKeyDetails key = getKey(testKeyPath, false);
-    assertEquals(HddsProtos.ReplicationType.EC,
-        key.getReplicationConfig().getReplicationType());
-    assertEquals("rs-3-2-1024k",
-        key.getReplicationConfig().getReplication());
+    testCreateKeyWithECReplicationConfiguration(cluster.getConf(), volumeName, bucketName, client);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/OzoneFileSystemTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/OzoneFileSystemTests.java
@@ -99,19 +99,16 @@ final class OzoneFileSystemTests {
     assertEquals(total, iCount);
   }
 
-  static void createKeyWithECReplicationConfiguration(OzoneConfiguration conf, Path keyPath) throws IOException {
+  static void createKeyWithECReplicationConfiguration(OzoneConfiguration inputConf, Path keyPath)
+      throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration(inputConf);
     conf.set(OZONE_REPLICATION, "rs-3-2-1024k");
     conf.set(OZONE_REPLICATION_TYPE, "EC");
     URI uri = FileSystem.getDefaultUri(conf);
     conf.setBoolean(
         String.format("fs.%s.impl.disable.cache", uri.getScheme()), true);
-    FileSystem fileSystem = FileSystem.get(uri, conf);
-    ContractTestUtils.touch(fileSystem, keyPath);
-
-    // Refresh the cache of FileSystem
-    conf.unset(OZONE_REPLICATION);
-    conf.unset(OZONE_REPLICATION_TYPE);
-    fileSystem = FileSystem.get(uri, conf);
-    fileSystem.close();
+    try (FileSystem fileSystem = FileSystem.get(uri, conf)) {
+      ContractTestUtils.touch(fileSystem, keyPath);
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/OzoneFileSystemTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/OzoneFileSystemTests.java
@@ -23,10 +23,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 
 import java.io.IOException;
 import java.net.URI;
@@ -103,34 +99,19 @@ final class OzoneFileSystemTests {
     assertEquals(total, iCount);
   }
 
-  static void testCreateKeyWithECReplicationConfiguration(OzoneConfiguration inputConf,
-      String volumeName, String bucketName, OzoneClient client) throws IOException {
-    String keyName = "testKey";
-    Path keyPath = new Path("/" + volumeName + "/" + bucketName + "/" + keyName);
-    OzoneConfiguration conf = new OzoneConfiguration(inputConf);
+  static void createKeyWithECReplicationConfiguration(OzoneConfiguration conf, Path keyPath) throws IOException {
     conf.set(OZONE_REPLICATION, "rs-3-2-1024k");
     conf.set(OZONE_REPLICATION_TYPE, "EC");
     URI uri = FileSystem.getDefaultUri(conf);
     conf.setBoolean(
         String.format("fs.%s.impl.disable.cache", uri.getScheme()), true);
-    try (FileSystem fileSystem = FileSystem.get(uri, conf)) {
-      ContractTestUtils.touch(fileSystem, keyPath);
-      OzoneKeyDetails key;
-      if (uri.getScheme().equals(OzoneConsts.OZONE_OFS_URI_SCHEME)) {
-        key = client.getObjectStore()
-            .getVolume(volumeName)
-            .getBucket(bucketName)
-            .getKey(keyName);
-      } else {
-        key = client.getObjectStore()
-            .getVolume(volumeName)
-            .getBucket(bucketName)
-            .getKey(volumeName + "/" + bucketName + "/" + keyName);
-      }
-      assertEquals(HddsProtos.ReplicationType.EC,
-          key.getReplicationConfig().getReplicationType());
-      assertEquals("rs-3-2-1024k",
-          key.getReplicationConfig().getReplication());
-    }
+    FileSystem fileSystem = FileSystem.get(uri, conf);
+    ContractTestUtils.touch(fileSystem, keyPath);
+
+    // Refresh the cache of FileSystem
+    conf.unset(OZONE_REPLICATION);
+    conf.unset(OZONE_REPLICATION_TYPE);
+    fileSystem = FileSystem.get(uri, conf);
+    fileSystem.close();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

ofs/o3fs is able to write keys/files with EC replication config, but there is no unit test and doc to explain how to do it. So this pr makes it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10553

## How was this patch tested?

1) Unit Test

2) Tested locally.

hadoop client write:

<img width="1493" alt="hadoop-client-write" src="https://github.com/apache/ozone/assets/48795318/5e0db528-cdde-4e9b-abf6-024c9543098d">

<img width="1487" alt="hadoop-client-write-o3fs" src="https://github.com/apache/ozone/assets/48795318/131ddf32-3532-4a65-9b0d-32a5d895e118">


key info:


<img width="708" alt="key-info" src="https://github.com/apache/ozone/assets/48795318/40d35ce7-3c5a-4860-b126-0087741204e0">


<img width="649" alt="key-info2" src="https://github.com/apache/ozone/assets/48795318/6f8cc649-8be3-415d-96ac-9cd69d2f9471">
