### PR TITLE
HDDS-10552. Downgrade Surefire to 3.0.0-M4

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -203,11 +203,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>

--- a/hadoop-hdds/hadoop-dependency-test/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-test/pom.xml
@@ -77,6 +77,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
     <dependency>
+      <!-- required for Surefire versions before 3.0.0-M5 -->
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
@@ -35,11 +35,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -120,11 +120,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-surefire-plugin.argLine>-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
     <maven-surefire-plugin.argLineAccessArgs></maven-surefire-plugin.argLineAccessArgs>
     <unstable-test-groups>flaky | slow | unhealthy</unstable-test-groups>
-    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Workaround for [SUREFIRE-1815](https://issues.apache.org/jira/browse/SUREFIRE-1815), which affects 3.0.0-M5, by downgrading to M4.  Cannot upgrade to M6 or newer, because forks are not killed correctly ([SUREFIRE-1722](https://issues.apache.org/jira/browse/SUREFIRE-1722), HDDS-10174) as of 3.2.5.

SUREFIRE-1815 causes intermittent fork timeout due to not being able to interrupt e.g. container scanner thread:

```
"main" 
   java.lang.Thread.State: WAITING
        at java.lang.Object.wait(Native Method)
        at java.lang.Thread.join(Thread.java:1257)
        at java.lang.Thread.join(Thread.java:1331)
        at org.apache.hadoop.ozone.container.ozoneimpl.AbstractBackgroundContainerScanner.shutdown(AbstractBackgroundContainerScanner.java:149)
        at org.apache.hadoop.ozone.container.ozoneimpl.BackgroundContainerDataScanner.shutdown(BackgroundContainerDataScanner.java:143)
        at org.apache.hadoop.ozone.container.ozoneimpl.BackgroundContainerDataScanner.shutdown(BackgroundContainerDataScanner.java:135)
        at org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer.stopContainerScrub(OzoneContainer.java:406)
        at org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer.stop(OzoneContainer.java:482)
        at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.close(DatanodeStateMachine.java:447)
        at org.apache.hadoop.ozone.container.upgrade.TestDatanodeUpgradeToSchemaV3.teardown(TestDatanodeUpgradeToSchemaV3.java:124)

"ContainerDataScanner(/tmp/junit2150526860730266625/7d8911bf-6e2c-4707-8262-2995b687ba41/hdds)" 
   java.lang.Thread.State: TIMED_WAITING
        at java.lang.Thread.sleep(Native Method)
        at org.apache.hadoop.ozone.container.ozoneimpl.AbstractBackgroundContainerScanner.handleRemainingSleep(AbstractBackgroundContainerScanner.java:131)
        at org.apache.hadoop.ozone.container.ozoneimpl.AbstractBackgroundContainerScanner.runIteration(AbstractBackgroundContainerScanner.java:98)
        at org.apache.hadoop.ozone.container.ozoneimpl.AbstractBackgroundContainerScanner.run(AbstractBackgroundContainerScanner.java:57)
```

https://issues.apache.org/jira/browse/HDDS-10552

## How was this patch tested?

Already verified that M4 correctly kills forks when needed (#6075).

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/8341980137

Flaky test check:
https://github.com/adoroszlai/ozone/actions/runs/8342506669 (unit)
https://github.com/adoroszlai/ozone/actions/runs/8342512159 (integration)