### PR TITLE
HDDS-10554. Bump Zookeeper to 3.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <mockito.version>4.11.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
     <junit5.version>5.10.2</junit5.version>
-    <zookeeper.version>3.7.2</zookeeper.version>
+    <zookeeper.version>3.8.4</zookeeper.version>
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
@@ -1228,6 +1228,16 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>${zookeeper.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Zookeeper to 3.8.4 due to ZOOKEEPER-4799.

https://issues.apache.org/jira/browse/HDDS-10554

## How was this patch tested?

```
$ ls -1 hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/share/ozone/lib/zookeeper-*
hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/share/ozone/lib/zookeeper-3.8.4.jar
hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/share/ozone/lib/zookeeper-jute-3.8.4.jar
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/8346528435