### PR TITLE
HDDS-10311. Speed up TestOmMetrics

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -322,143 +322,143 @@ public class TestOmMetrics {
         "metadataManager", metadataManager);
   }
 
-    @Test
-    public void testKeyOps() throws Exception {
-      String volumeName = UUID.randomUUID().toString();
-      String bucketName = UUID.randomUUID().toString();
-      KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
-          .getInternalState(ozoneManager, "keyManager");
-      KeyManager mockKm = spy(keyManager);
+  @Test
+  public void testKeyOps() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
+        .getInternalState(ozoneManager, "keyManager");
+    KeyManager mockKm = spy(keyManager);
 
-      // get initial values for metrics
-      MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
-      long initialNumKeyOps = getLongCounter("NumKeyOps", omMetrics);
-      long initialNumKeyAllocate = getLongCounter("NumKeyAllocate", omMetrics);
-      long initialNumKeyLookup = getLongCounter("NumKeyLookup", omMetrics);
-      long initialNumKeyDeletes = getLongCounter("NumKeyDeletes", omMetrics);
-      long initialNumKeyLists = getLongCounter("NumKeyLists", omMetrics);
-      long initialNumTrashKeyLists = getLongCounter("NumTrashKeyLists", omMetrics);
-      long initialNumKeys = getLongCounter("NumKeys", omMetrics);
-      long initialNumInitiateMultipartUploads = getLongCounter("NumInitiateMultipartUploads", omMetrics);
+    // get initial values for metrics
+    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
+    long initialNumKeyOps = getLongCounter("NumKeyOps", omMetrics);
+    long initialNumKeyAllocate = getLongCounter("NumKeyAllocate", omMetrics);
+    long initialNumKeyLookup = getLongCounter("NumKeyLookup", omMetrics);
+    long initialNumKeyDeletes = getLongCounter("NumKeyDeletes", omMetrics);
+    long initialNumKeyLists = getLongCounter("NumKeyLists", omMetrics);
+    long initialNumTrashKeyLists = getLongCounter("NumTrashKeyLists", omMetrics);
+    long initialNumKeys = getLongCounter("NumKeys", omMetrics);
+    long initialNumInitiateMultipartUploads = getLongCounter("NumInitiateMultipartUploads", omMetrics);
 
-      long initialEcKeyCreateTotal = getLongCounter("EcKeyCreateTotal", omMetrics);
-      long initialNumKeyAllocateFails = getLongCounter("NumKeyAllocateFails", omMetrics);
-      long initialNumKeyLookupFails = getLongCounter("NumKeyLookupFails", omMetrics);
-      long initialNumKeyDeleteFails = getLongCounter("NumKeyDeleteFails", omMetrics);
-      long initialNumTrashKeyListFails = getLongCounter("NumTrashKeyListFails", omMetrics);
-      long initialNumInitiateMultipartUploadFails = getLongCounter("NumInitiateMultipartUploadFails", omMetrics);
-      long initialNumBlockAllocationFails = getLongCounter("NumBlockAllocationFails", omMetrics);
-      long initialNumKeyListFails = getLongCounter("NumKeyListFails", omMetrics);
-      long initialEcKeyCreateFailsTotal = getLongCounter("EcKeyCreateFailsTotal", omMetrics);
+    long initialEcKeyCreateTotal = getLongCounter("EcKeyCreateTotal", omMetrics);
+    long initialNumKeyAllocateFails = getLongCounter("NumKeyAllocateFails", omMetrics);
+    long initialNumKeyLookupFails = getLongCounter("NumKeyLookupFails", omMetrics);
+    long initialNumKeyDeleteFails = getLongCounter("NumKeyDeleteFails", omMetrics);
+    long initialNumTrashKeyListFails = getLongCounter("NumTrashKeyListFails", omMetrics);
+    long initialNumInitiateMultipartUploadFails = getLongCounter("NumInitiateMultipartUploadFails", omMetrics);
+    long initialNumBlockAllocationFails = getLongCounter("NumBlockAllocationFails", omMetrics);
+    long initialNumKeyListFails = getLongCounter("NumKeyListFails", omMetrics);
+    long initialEcKeyCreateFailsTotal = getLongCounter("EcKeyCreateFailsTotal", omMetrics);
 
-      // see HDDS-10078 for making this work with FILE_SYSTEM_OPTIMIZED layout
-      TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
-      OmKeyArgs keyArgs = createKeyArgs(volumeName, bucketName,
-          RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
-      doKeyOps(keyArgs);
+    // see HDDS-10078 for making this work with FILE_SYSTEM_OPTIMIZED layout
+    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
+    OmKeyArgs keyArgs = createKeyArgs(volumeName, bucketName,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+    doKeyOps(keyArgs);
 
-      omMetrics = getMetrics("OMMetrics");
+    omMetrics = getMetrics("OMMetrics");
 
-      assertEquals(initialNumKeyOps + 7, getLongCounter("NumKeyOps", omMetrics));
-      assertEquals(initialNumKeyAllocate + 1, getLongCounter("NumKeyAllocate", omMetrics));
-      assertEquals(initialNumKeyLookup + 1, getLongCounter("NumKeyLookup", omMetrics));
-      assertEquals(initialNumKeyDeletes + 1, getLongCounter("NumKeyDeletes", omMetrics));
-      assertEquals(initialNumKeyLists + 1, getLongCounter("NumKeyLists", omMetrics));
-      assertEquals(initialNumTrashKeyLists + 1, getLongCounter("NumTrashKeyLists", omMetrics));
-      assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
-      assertEquals(initialNumInitiateMultipartUploads + 1, getLongCounter("NumInitiateMultipartUploads", omMetrics));
+    assertEquals(initialNumKeyOps + 7, getLongCounter("NumKeyOps", omMetrics));
+    assertEquals(initialNumKeyAllocate + 1, getLongCounter("NumKeyAllocate", omMetrics));
+    assertEquals(initialNumKeyLookup + 1, getLongCounter("NumKeyLookup", omMetrics));
+    assertEquals(initialNumKeyDeletes + 1, getLongCounter("NumKeyDeletes", omMetrics));
+    assertEquals(initialNumKeyLists + 1, getLongCounter("NumKeyLists", omMetrics));
+    assertEquals(initialNumTrashKeyLists + 1, getLongCounter("NumTrashKeyLists", omMetrics));
+    assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialNumInitiateMultipartUploads + 1, getLongCounter("NumInitiateMultipartUploads", omMetrics));
 
-      keyArgs = createKeyArgs(volumeName, bucketName,
-          new ECReplicationConfig("rs-3-2-1024K"));
-      doKeyOps(keyArgs);
+    keyArgs = createKeyArgs(volumeName, bucketName,
+        new ECReplicationConfig("rs-3-2-1024K"));
+    doKeyOps(keyArgs);
 
-      omMetrics = getMetrics("OMMetrics");
-      assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
-      assertEquals(initialEcKeyCreateTotal + 1, getLongCounter("EcKeyCreateTotal", omMetrics));
+    omMetrics = getMetrics("OMMetrics");
+    assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialEcKeyCreateTotal + 1, getLongCounter("EcKeyCreateTotal", omMetrics));
 
-      keyArgs = createKeyArgs(volumeName, bucketName,
-          RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
-      OpenKeySession keySession = writeClient.openKey(keyArgs);
-      writeClient.commitKey(keyArgs, keySession.getId());
-      keyArgs = createKeyArgs(volumeName, bucketName,
-          RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+    keyArgs = createKeyArgs(volumeName, bucketName,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+    OpenKeySession keySession = writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, keySession.getId());
+    keyArgs = createKeyArgs(volumeName, bucketName,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+    keySession = writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, keySession.getId());
+    keyArgs = createKeyArgs(volumeName, bucketName,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+    keySession = writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, keySession.getId());
+    writeClient.deleteKey(keyArgs);
+
+    keyArgs = createKeyArgs(volumeName, bucketName,
+        new ECReplicationConfig("rs-6-3-1024K"));
+    try {
       keySession = writeClient.openKey(keyArgs);
       writeClient.commitKey(keyArgs, keySession.getId());
-      keyArgs = createKeyArgs(volumeName, bucketName,
-          RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
-      keySession = writeClient.openKey(keyArgs);
-      writeClient.commitKey(keyArgs, keySession.getId());
-      writeClient.deleteKey(keyArgs);
-
-      keyArgs = createKeyArgs(volumeName, bucketName,
-          new ECReplicationConfig("rs-6-3-1024K"));
-      try {
-        keySession = writeClient.openKey(keyArgs);
-        writeClient.commitKey(keyArgs, keySession.getId());
-      } catch (Exception e) {
-        //Expected Failure in preExecute due to not enough datanode
-        assertThat(e.getMessage()).contains("No enough datanodes to choose");
-      }
-
-      omMetrics = getMetrics("OMMetrics");
-      assertEquals(initialNumKeys + 2, getLongCounter("NumKeys", omMetrics));
-      assertEquals(initialNumBlockAllocationFails + 1, getLongCounter("NumBlockAllocationFails", omMetrics));
-
-      // inject exception to test for Failure Metrics on the read path
-      doThrow(exception).when(mockKm).lookupKey(any(), any(), any());
-      doThrow(exception).when(mockKm).listKeys(
-          any(), any(), any(), any(), anyInt());
-      doThrow(exception).when(mockKm).listTrash(
-          any(), any(), any(), any(), anyInt());
-      OmMetadataReader omMetadataReader =
-          (OmMetadataReader) ozoneManager.getOmMetadataReader().get();
-      HddsWhiteboxTestUtils.setInternalState(
-          ozoneManager, "keyManager", mockKm);
-
-      HddsWhiteboxTestUtils.setInternalState(
-          omMetadataReader, "keyManager", mockKm);
-
-      // inject exception to test for Failure Metrics on the write path
-      OMMetadataManager metadataManager = mockWritePathExceptions(OmBucketInfo.class);
-      keyArgs = createKeyArgs(volumeName, bucketName,
-          RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
-      doKeyOps(keyArgs);
-
-      omMetrics = getMetrics("OMMetrics");
-      assertEquals(initialNumKeyOps + 28, getLongCounter("NumKeyOps", omMetrics));
-      assertEquals(initialNumKeyAllocate + 6, getLongCounter("NumKeyAllocate", omMetrics));
-      assertEquals(initialNumKeyLookup + 3, getLongCounter("NumKeyLookup", omMetrics));
-      assertEquals(initialNumKeyDeletes + 4, getLongCounter("NumKeyDeletes", omMetrics));
-      assertEquals(initialNumKeyLists + 3, getLongCounter("NumKeyLists", omMetrics));
-      assertEquals(initialNumTrashKeyLists + 3, getLongCounter("NumTrashKeyLists", omMetrics));
-      assertEquals(initialNumInitiateMultipartUploads + 3, getLongCounter("NumInitiateMultipartUploads", omMetrics));
-
-      assertEquals(initialNumKeyAllocateFails + 1, getLongCounter("NumKeyAllocateFails", omMetrics));
-      assertEquals(initialNumKeyLookupFails + 1, getLongCounter("NumKeyLookupFails", omMetrics));
-      assertEquals(initialNumKeyDeleteFails + 1, getLongCounter("NumKeyDeleteFails", omMetrics));
-      assertEquals(initialNumKeyListFails + 1, getLongCounter("NumKeyListFails", omMetrics));
-      assertEquals(initialNumTrashKeyListFails + 1, getLongCounter("NumTrashKeyListFails", omMetrics));
-      assertEquals(initialNumInitiateMultipartUploadFails + 1, getLongCounter(
-          "NumInitiateMultipartUploadFails", omMetrics));
-      assertEquals(initialNumKeys + 2, getLongCounter("NumKeys", omMetrics));
-
-      keyArgs = createKeyArgs(volumeName, bucketName,
-          new ECReplicationConfig("rs-3-2-1024K"));
-      try {
-        keySession = writeClient.openKey(keyArgs);
-        writeClient.commitKey(keyArgs, keySession.getId());
-      } catch (Exception e) {
-        //Expected Failure
-      }
-      omMetrics = getMetrics("OMMetrics");
-      assertEquals(initialEcKeyCreateFailsTotal + 1, getLongCounter("EcKeyCreateFailsTotal", omMetrics));
-
-      // restore state
-      HddsWhiteboxTestUtils.setInternalState(ozoneManager,
-          "keyManager", keyManager);
-      HddsWhiteboxTestUtils.setInternalState(ozoneManager,
-          "metadataManager", metadataManager);
+    } catch (Exception e) {
+      //Expected Failure in preExecute due to not enough datanode
+      assertThat(e.getMessage()).contains("No enough datanodes to choose");
     }
+
+    omMetrics = getMetrics("OMMetrics");
+    assertEquals(initialNumKeys + 2, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialNumBlockAllocationFails + 1, getLongCounter("NumBlockAllocationFails", omMetrics));
+
+    // inject exception to test for Failure Metrics on the read path
+    doThrow(exception).when(mockKm).lookupKey(any(), any(), any());
+    doThrow(exception).when(mockKm).listKeys(
+        any(), any(), any(), any(), anyInt());
+    doThrow(exception).when(mockKm).listTrash(
+        any(), any(), any(), any(), anyInt());
+    OmMetadataReader omMetadataReader =
+        (OmMetadataReader) ozoneManager.getOmMetadataReader().get();
+    HddsWhiteboxTestUtils.setInternalState(
+        ozoneManager, "keyManager", mockKm);
+
+    HddsWhiteboxTestUtils.setInternalState(
+        omMetadataReader, "keyManager", mockKm);
+
+    // inject exception to test for Failure Metrics on the write path
+    OMMetadataManager metadataManager = mockWritePathExceptions(OmBucketInfo.class);
+    keyArgs = createKeyArgs(volumeName, bucketName,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
+    doKeyOps(keyArgs);
+
+    omMetrics = getMetrics("OMMetrics");
+    assertEquals(initialNumKeyOps + 28, getLongCounter("NumKeyOps", omMetrics));
+    assertEquals(initialNumKeyAllocate + 6, getLongCounter("NumKeyAllocate", omMetrics));
+    assertEquals(initialNumKeyLookup + 3, getLongCounter("NumKeyLookup", omMetrics));
+    assertEquals(initialNumKeyDeletes + 4, getLongCounter("NumKeyDeletes", omMetrics));
+    assertEquals(initialNumKeyLists + 3, getLongCounter("NumKeyLists", omMetrics));
+    assertEquals(initialNumTrashKeyLists + 3, getLongCounter("NumTrashKeyLists", omMetrics));
+    assertEquals(initialNumInitiateMultipartUploads + 3, getLongCounter("NumInitiateMultipartUploads", omMetrics));
+
+    assertEquals(initialNumKeyAllocateFails + 1, getLongCounter("NumKeyAllocateFails", omMetrics));
+    assertEquals(initialNumKeyLookupFails + 1, getLongCounter("NumKeyLookupFails", omMetrics));
+    assertEquals(initialNumKeyDeleteFails + 1, getLongCounter("NumKeyDeleteFails", omMetrics));
+    assertEquals(initialNumKeyListFails + 1, getLongCounter("NumKeyListFails", omMetrics));
+    assertEquals(initialNumTrashKeyListFails + 1, getLongCounter("NumTrashKeyListFails", omMetrics));
+    assertEquals(initialNumInitiateMultipartUploadFails + 1, getLongCounter(
+        "NumInitiateMultipartUploadFails", omMetrics));
+    assertEquals(initialNumKeys + 2, getLongCounter("NumKeys", omMetrics));
+
+    keyArgs = createKeyArgs(volumeName, bucketName,
+        new ECReplicationConfig("rs-3-2-1024K"));
+    try {
+      keySession = writeClient.openKey(keyArgs);
+      writeClient.commitKey(keyArgs, keySession.getId());
+    } catch (Exception e) {
+      //Expected Failure
+    }
+    omMetrics = getMetrics("OMMetrics");
+    assertEquals(initialEcKeyCreateFailsTotal + 1, getLongCounter("EcKeyCreateFailsTotal", omMetrics));
+
+    // restore state
+    HddsWhiteboxTestUtils.setInternalState(ozoneManager,
+        "keyManager", keyManager);
+    HddsWhiteboxTestUtils.setInternalState(ozoneManager,
+        "metadataManager", metadataManager);
+  }
 
   @ParameterizedTest
   @EnumSource(value = BucketLayout.class, names = {"FILE_SYSTEM_OPTIMIZED", "LEGACY"})

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -16,53 +16,25 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
-import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.BUCKET;
-import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
-import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
-import static org.apache.ozone.test.MetricsAsserts.assertCounter;
-import static org.apache.ozone.test.MetricsAsserts.getMetrics;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.spy;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.apache.hadoop.hdds.utils.IOUtils;
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -80,19 +52,46 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
-import org.apache.ozone.test.MetricsAsserts;
 import org.apache.ozone.test.GenericTestUtils;
 import org.assertj.core.util.Lists;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_ROOT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.BUCKET;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
+import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
+import static org.apache.ozone.test.MetricsAsserts.getLongCounter;
+import static org.apache.ozone.test.MetricsAsserts.getMetrics;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+
 /**
  * Test for OM metrics.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
 public class TestOmMetrics {
   private MiniOzoneCluster cluster;
@@ -106,16 +105,21 @@ public class TestOmMetrics {
   private final OMException exception =
       new OMException("dummyException", OMException.ResultCodes.TIMEOUT);
   private OzoneClient client;
-
   /**
    * Create a MiniDFSCluster for testing.
    */
-  @BeforeEach
+
+  @BeforeAll
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.setTimeDuration(OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL,
         1000, TimeUnit.MILLISECONDS);
-    clusterBuilder = MiniOzoneCluster.newBuilder(conf).withoutDatanodes();
+    // Speed up background directory deletion for this test.
+    conf.setTimeDuration(OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL, 1000, TimeUnit.MILLISECONDS);
+    // For testing fs operations with legacy buckets.
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
+    clusterBuilder = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5);
+    startCluster();
   }
 
   private void startCluster() throws Exception {
@@ -130,7 +134,7 @@ public class TestOmMetrics {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterEach
+  @AfterAll
   public void shutdown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -140,22 +144,38 @@ public class TestOmMetrics {
 
   @Test
   public void testVolumeOps() throws Exception {
-    startCluster();
     VolumeManager volumeManager =
         (VolumeManager) HddsWhiteboxTestUtils.getInternalState(
             ozoneManager, "volumeManager");
     VolumeManager mockVm = spy(volumeManager);
 
+    // get initial values for metrics
+    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
+    long initialNumVolumeOps = getLongCounter("NumVolumeOps", omMetrics);
+    long initialNumVolumeCreates = getLongCounter("NumVolumeCreates", omMetrics);
+    long initialNumVolumeUpdates = getLongCounter("NumVolumeUpdates", omMetrics);
+    long initialNumVolumeInfos = getLongCounter("NumVolumeInfos", omMetrics);
+    long initialNumVolumeDeletes = getLongCounter("NumVolumeDeletes", omMetrics);
+    long initialNumVolumeLists = getLongCounter("NumVolumeLists", omMetrics);
+    long initialNumVolumes = getLongCounter("NumVolumes", omMetrics);
+
+    long initialNumVolumeCreateFails = getLongCounter("NumVolumeCreateFails", omMetrics);
+    long initialNumVolumeUpdateFails = getLongCounter("NumVolumeUpdateFails", omMetrics);
+    long initialNumVolumeInfoFails = getLongCounter("NumVolumeInfoFails", omMetrics);
+    long initialNumVolumeDeleteFails = getLongCounter("NumVolumeDeleteFails", omMetrics);
+    long initialNumVolumeListFails = getLongCounter("NumVolumeListFails", omMetrics);
+
     OmVolumeArgs volumeArgs = createVolumeArgs();
     doVolumeOps(volumeArgs);
-    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumVolumeOps", 5L, omMetrics);
-    assertCounter("NumVolumeCreates", 1L, omMetrics);
-    assertCounter("NumVolumeUpdates", 1L, omMetrics);
-    assertCounter("NumVolumeInfos", 1L, omMetrics);
-    assertCounter("NumVolumeDeletes", 1L, omMetrics);
-    assertCounter("NumVolumeLists", 1L, omMetrics);
-    assertCounter("NumVolumes", 1L, omMetrics);
+
+    omMetrics = getMetrics("OMMetrics");
+    assertEquals(initialNumVolumeOps + 5, getLongCounter("NumVolumeOps", omMetrics));
+    assertEquals(initialNumVolumeCreates + 1, getLongCounter("NumVolumeCreates", omMetrics));
+    assertEquals(initialNumVolumeUpdates + 1, getLongCounter("NumVolumeUpdates", omMetrics));
+    assertEquals(initialNumVolumeInfos + 1, getLongCounter("NumVolumeInfos", omMetrics));
+    assertEquals(initialNumVolumeDeletes + 1, getLongCounter("NumVolumeDeletes", omMetrics));
+    assertEquals(initialNumVolumeLists + 1, getLongCounter("NumVolumeLists", omMetrics));
+    assertEquals(initialNumVolumes, getLongCounter("NumVolumes", omMetrics));
 
     volumeArgs = createVolumeArgs();
     writeClient.createVolume(volumeArgs);
@@ -166,10 +186,8 @@ public class TestOmMetrics {
     writeClient.deleteVolume(volumeArgs.getVolume());
 
     omMetrics = getMetrics("OMMetrics");
-
     // Accounting 's3v' volume which is created by default.
-    assertCounter("NumVolumes", 3L, omMetrics);
-
+    assertEquals(initialNumVolumes + 2, getLongCounter("NumVolumes", omMetrics));
 
     // inject exception to test for Failure Metrics on the read path
     doThrow(exception).when(mockVm).getVolumeInfo(any());
@@ -184,55 +202,65 @@ public class TestOmMetrics {
     doVolumeOps(volumeArgs);
 
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumVolumeOps", 14L, omMetrics);
-    assertCounter("NumVolumeCreates", 5L, omMetrics);
-    assertCounter("NumVolumeUpdates", 2L, omMetrics);
-    assertCounter("NumVolumeInfos", 2L, omMetrics);
-    assertCounter("NumVolumeDeletes", 3L, omMetrics);
-    assertCounter("NumVolumeLists", 2L, omMetrics);
+    assertEquals(initialNumVolumeOps + 14, getLongCounter("NumVolumeOps", omMetrics));
+    assertEquals(initialNumVolumeCreates + 5, getLongCounter("NumVolumeCreates", omMetrics));
+    assertEquals(initialNumVolumeUpdates + 2, getLongCounter("NumVolumeUpdates", omMetrics));
+    assertEquals(initialNumVolumeInfos + 2, getLongCounter("NumVolumeInfos", omMetrics));
+    assertEquals(initialNumVolumeDeletes + 3, getLongCounter("NumVolumeDeletes", omMetrics));
+    assertEquals(initialNumVolumeLists + 2, getLongCounter("NumVolumeLists", omMetrics));
 
-    assertCounter("NumVolumeCreateFails", 1L, omMetrics);
-    assertCounter("NumVolumeUpdateFails", 1L, omMetrics);
-    assertCounter("NumVolumeInfoFails", 1L, omMetrics);
-    assertCounter("NumVolumeDeleteFails", 1L, omMetrics);
-    assertCounter("NumVolumeListFails", 1L, omMetrics);
-
-    // As last call for volumesOps does not increment numVolumes as those are
-    // failed.
-    assertCounter("NumVolumes", 3L, omMetrics);
-
-    cluster.restartOzoneManager();
-    assertCounter("NumVolumes", 3L, omMetrics);
-
-
+    assertEquals(initialNumVolumeCreateFails + 1, getLongCounter("NumVolumeCreateFails", omMetrics));
+    assertEquals(initialNumVolumeUpdateFails + 1, getLongCounter("NumVolumeUpdateFails", omMetrics));
+    assertEquals(initialNumVolumeInfoFails + 1, getLongCounter("NumVolumeInfoFails", omMetrics));
+    assertEquals(initialNumVolumeDeleteFails + 1, getLongCounter("NumVolumeDeleteFails", omMetrics));
+    assertEquals(initialNumVolumeListFails + 1, getLongCounter("NumVolumeListFails", omMetrics));
+    assertEquals(initialNumVolumes + 2, getLongCounter("NumVolumes", omMetrics));
   }
 
   @Test
   public void testBucketOps() throws Exception {
-    startCluster();
     BucketManager bucketManager =
         (BucketManager) HddsWhiteboxTestUtils.getInternalState(
             ozoneManager, "bucketManager");
     BucketManager mockBm = spy(bucketManager);
 
+    // get initial values for metrics
+    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
+    long initialNumBucketOps = getLongCounter("NumBucketOps", omMetrics);
+    long initialNumBucketCreates = getLongCounter("NumBucketCreates", omMetrics);
+    long initialNumBucketUpdates = getLongCounter("NumBucketUpdates", omMetrics);
+    long initialNumBucketInfos = getLongCounter("NumBucketInfos", omMetrics);
+    long initialNumBucketDeletes = getLongCounter("NumBucketDeletes", omMetrics);
+    long initialNumBucketLists = getLongCounter("NumBucketLists", omMetrics);
+    long initialNumBuckets = getLongCounter("NumBuckets", omMetrics);
+    long initialEcBucketCreateTotal = getLongCounter("EcBucketCreateTotal", omMetrics);
+    long initialEcBucketCreateFailsTotal = getLongCounter("EcBucketCreateFailsTotal", omMetrics);
+
+    long initialNumBucketCreateFails = getLongCounter("NumBucketCreateFails", omMetrics);
+    long initialNumBucketUpdateFails = getLongCounter("NumBucketUpdateFails", omMetrics);
+    long initialNumBucketInfoFails = getLongCounter("NumBucketInfoFails", omMetrics);
+    long initialNumBucketDeleteFails = getLongCounter("NumBucketDeleteFails", omMetrics);
+    long initialNumBucketListFails = getLongCounter("NumBucketListFails", omMetrics);
+
     OmBucketInfo bucketInfo = createBucketInfo(false);
     doBucketOps(bucketInfo);
 
-    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumBucketOps", 5L, omMetrics);
-    assertCounter("NumBucketCreates", 1L, omMetrics);
-    assertCounter("NumBucketUpdates", 1L, omMetrics);
-    assertCounter("NumBucketInfos", 1L, omMetrics);
-    assertCounter("NumBucketDeletes", 1L, omMetrics);
-    assertCounter("NumBucketLists", 1L, omMetrics);
-    assertCounter("NumBuckets", 0L, omMetrics);
+    omMetrics = getMetrics("OMMetrics");
+    assertEquals(initialNumBucketOps + 5, getLongCounter("NumBucketOps", omMetrics));
+    assertEquals(initialNumBucketCreates + 1, getLongCounter("NumBucketCreates", omMetrics));
+    assertEquals(initialNumBucketUpdates + 1, getLongCounter("NumBucketUpdates", omMetrics));
+    assertEquals(initialNumBucketInfos + 1, getLongCounter("NumBucketInfos", omMetrics));
+    assertEquals(initialNumBucketDeletes + 1, getLongCounter("NumBucketDeletes", omMetrics));
+    assertEquals(initialNumBucketLists + 1, getLongCounter("NumBucketLists", omMetrics));
+    assertEquals(initialNumBuckets, getLongCounter("NumBuckets", omMetrics));
 
     OmBucketInfo ecBucketInfo = createBucketInfo(true);
     writeClient.createBucket(ecBucketInfo);
     writeClient.deleteBucket(ecBucketInfo.getVolumeName(),
         ecBucketInfo.getBucketName());
+
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("EcBucketCreateTotal", 1L, omMetrics);
+    assertEquals(initialEcBucketCreateTotal + 1, getLongCounter("EcBucketCreateTotal", omMetrics));
 
     bucketInfo = createBucketInfo(false);
     writeClient.createBucket(bucketInfo);
@@ -244,7 +272,7 @@ public class TestOmMetrics {
         bucketInfo.getBucketName());
 
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumBuckets", 2L, omMetrics);
+    assertEquals(initialNumBuckets + 2, getLongCounter("NumBuckets", omMetrics));
 
     // inject exception to test for Failure Metrics on the read path
     doThrow(exception).when(mockBm).getBucketInfo(any(), any());
@@ -265,61 +293,78 @@ public class TestOmMetrics {
       //Expected failure
     }
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("EcBucketCreateFailsTotal", 1L, omMetrics);
+    assertEquals(initialEcBucketCreateFailsTotal + 1, getLongCounter("EcBucketCreateFailsTotal", omMetrics));
+    assertEquals(initialNumBucketOps + 17, getLongCounter("NumBucketOps", omMetrics));
+    assertEquals(initialNumBucketCreates + 7, getLongCounter("NumBucketCreates", omMetrics));
+    assertEquals(initialNumBucketUpdates + 2, getLongCounter("NumBucketUpdates", omMetrics));
+    assertEquals(initialNumBucketInfos + 2, getLongCounter("NumBucketInfos", omMetrics));
+    assertEquals(initialNumBucketDeletes + 4, getLongCounter("NumBucketDeletes", omMetrics));
+    assertEquals(initialNumBucketLists + 2, getLongCounter("NumBucketLists", omMetrics));
 
-    omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumBucketOps", 17L, omMetrics);
-    assertCounter("NumBucketCreates", 7L, omMetrics);
-    assertCounter("NumBucketUpdates", 2L, omMetrics);
-    assertCounter("NumBucketInfos", 2L, omMetrics);
-    assertCounter("NumBucketDeletes", 4L, omMetrics);
-    assertCounter("NumBucketLists", 2L, omMetrics);
-
-    assertCounter("NumBucketCreateFails", 2L, omMetrics);
-    assertCounter("NumBucketUpdateFails", 1L, omMetrics);
-    assertCounter("NumBucketInfoFails", 1L, omMetrics);
-    assertCounter("NumBucketDeleteFails", 1L, omMetrics);
-    assertCounter("NumBucketListFails", 1L, omMetrics);
-
-    assertCounter("NumBuckets", 2L, omMetrics);
-
-    cluster.restartOzoneManager();
-    assertCounter("NumBuckets", 2L, omMetrics);
+    assertEquals(initialNumBucketCreateFails + 2, getLongCounter("NumBucketCreateFails", omMetrics));
+    assertEquals(initialNumBucketUpdateFails + 1, getLongCounter("NumBucketUpdateFails", omMetrics));
+    assertEquals(initialNumBucketInfoFails + 1, getLongCounter("NumBucketInfoFails", omMetrics));
+    assertEquals(initialNumBucketDeleteFails + 1, getLongCounter("NumBucketDeleteFails", omMetrics));
+    assertEquals(initialNumBucketListFails + 1, getLongCounter("NumBucketListFails", omMetrics));
+    assertEquals(initialNumBuckets + 2, getLongCounter("NumBuckets", omMetrics));
   }
 
   @Test
   public void testKeyOps() throws Exception {
-    // This test needs a cluster with DNs and SCM to wait on safemode
-    clusterBuilder.setNumDatanodes(5);
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, true);
+    shutdown();
     startCluster();
+
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "keyManager");
     KeyManager mockKm = spy(keyManager);
+
+    // get initial values for metrics
+    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
+    long initialNumKeyOps = getLongCounter("NumKeyOps", omMetrics);
+    long initialNumKeyAllocate = getLongCounter("NumKeyAllocate", omMetrics);
+    long initialNumKeyLookup = getLongCounter("NumKeyLookup", omMetrics);
+    long initialNumKeyDeletes = getLongCounter("NumKeyDeletes", omMetrics);
+    long initialNumKeyLists = getLongCounter("NumKeyLists", omMetrics);
+    long initialNumTrashKeyLists = getLongCounter("NumTrashKeyLists", omMetrics);
+    long initialNumKeys = getLongCounter("NumKeys", omMetrics);
+    long initialNumInitiateMultipartUploads = getLongCounter("NumInitiateMultipartUploads", omMetrics);
+
+    long initialEcKeyCreateTotal = getLongCounter("EcKeyCreateTotal", omMetrics);
+    long initialNumKeyAllocateFails = getLongCounter("NumKeyAllocateFails", omMetrics);
+    long initialNumKeyLookupFails = getLongCounter("NumKeyLookupFails", omMetrics);
+    long initialNumKeyDeleteFails = getLongCounter("NumKeyDeleteFails", omMetrics);
+    long initialNumTrashKeyListFails = getLongCounter("NumTrashKeyListFails", omMetrics);
+    long initialNumInitiateMultipartUploadFails = getLongCounter("NumInitiateMultipartUploadFails", omMetrics);
+    long initialNumBlockAllocationFails = getLongCounter("NumBlockAllocationFails", omMetrics);
+    long initialNumKeyListFails = getLongCounter("NumKeyListFails", omMetrics);
+    long initialEcKeyCreateFailsTotal = getLongCounter("EcKeyCreateFailsTotal", omMetrics);
+
     // see HDDS-10078 for making this work with FILE_SYSTEM_OPTIMIZED layout
     TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
     OmKeyArgs keyArgs = createKeyArgs(volumeName, bucketName,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
     doKeyOps(keyArgs);
 
-    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeyOps", 7L, omMetrics);
-    assertCounter("NumKeyAllocate", 1L, omMetrics);
-    assertCounter("NumKeyLookup", 1L, omMetrics);
-    assertCounter("NumKeyDeletes", 1L, omMetrics);
-    assertCounter("NumKeyLists", 1L, omMetrics);
-    assertCounter("NumTrashKeyLists", 1L, omMetrics);
-    assertCounter("NumKeys", 0L, omMetrics);
-    assertCounter("NumInitiateMultipartUploads", 1L, omMetrics);
+    omMetrics = getMetrics("OMMetrics");
+
+    assertEquals(initialNumKeyOps + 7, getLongCounter("NumKeyOps", omMetrics));
+    assertEquals(initialNumKeyAllocate + 1, getLongCounter("NumKeyAllocate", omMetrics));
+    assertEquals(initialNumKeyLookup + 1, getLongCounter("NumKeyLookup", omMetrics));
+    assertEquals(initialNumKeyDeletes + 1, getLongCounter("NumKeyDeletes", omMetrics));
+    assertEquals(initialNumKeyLists + 1, getLongCounter("NumKeyLists", omMetrics));
+    assertEquals(initialNumTrashKeyLists + 1, getLongCounter("NumTrashKeyLists", omMetrics));
+    assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialNumInitiateMultipartUploads + 1, getLongCounter("NumInitiateMultipartUploads", omMetrics));
 
     keyArgs = createKeyArgs(volumeName, bucketName,
         new ECReplicationConfig("rs-3-2-1024K"));
     doKeyOps(keyArgs);
+
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeyOps", 14L, omMetrics);
-    assertCounter("EcKeyCreateTotal", 1L, omMetrics);
+    assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialEcKeyCreateTotal + 1, getLongCounter("EcKeyCreateTotal", omMetrics));
 
     keyArgs = createKeyArgs(volumeName, bucketName,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
@@ -346,8 +391,8 @@ public class TestOmMetrics {
     }
 
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeys", 2L, omMetrics);
-    assertCounter("NumBlockAllocationFails", 1L, omMetrics);
+    assertEquals(initialNumKeys + 2, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialNumBlockAllocationFails + 1, getLongCounter("NumBlockAllocationFails", omMetrics));
 
     // inject exception to test for Failure Metrics on the read path
     doThrow(exception).when(mockKm).lookupKey(any(), any(), any());
@@ -370,21 +415,22 @@ public class TestOmMetrics {
     doKeyOps(keyArgs);
 
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeyOps", 28L, omMetrics);
-    assertCounter("NumKeyAllocate", 6L, omMetrics);
-    assertCounter("NumKeyLookup", 3L, omMetrics);
-    assertCounter("NumKeyDeletes", 4L, omMetrics);
-    assertCounter("NumKeyLists", 3L, omMetrics);
-    assertCounter("NumTrashKeyLists", 3L, omMetrics);
-    assertCounter("NumInitiateMultipartUploads", 3L, omMetrics);
+    assertEquals(initialNumKeyOps + 28, getLongCounter("NumKeyOps", omMetrics));
+    assertEquals(initialNumKeyAllocate + 6, getLongCounter("NumKeyAllocate", omMetrics));
+    assertEquals(initialNumKeyLookup + 3, getLongCounter("NumKeyLookup", omMetrics));
+    assertEquals(initialNumKeyDeletes + 4, getLongCounter("NumKeyDeletes", omMetrics));
+    assertEquals(initialNumKeyLists + 3, getLongCounter("NumKeyLists", omMetrics));
+    assertEquals(initialNumTrashKeyLists + 3, getLongCounter("NumTrashKeyLists", omMetrics));
+    assertEquals(initialNumInitiateMultipartUploads + 3, getLongCounter("NumInitiateMultipartUploads", omMetrics));
 
-    assertCounter("NumKeyAllocateFails", 1L, omMetrics);
-    assertCounter("NumKeyLookupFails", 1L, omMetrics);
-    assertCounter("NumKeyDeleteFails", 1L, omMetrics);
-    assertCounter("NumKeyListFails", 1L, omMetrics);
-    assertCounter("NumTrashKeyListFails", 1L, omMetrics);
-    assertCounter("NumInitiateMultipartUploadFails", 1L, omMetrics);
-    assertCounter("NumKeys", 2L, omMetrics);
+    assertEquals(initialNumKeyAllocateFails + 1, getLongCounter("NumKeyAllocateFails", omMetrics));
+    assertEquals(initialNumKeyLookupFails + 1, getLongCounter("NumKeyLookupFails", omMetrics));
+    assertEquals(initialNumKeyDeleteFails + 1, getLongCounter("NumKeyDeleteFails", omMetrics));
+    assertEquals(initialNumKeyListFails + 1, getLongCounter("NumKeyListFails", omMetrics));
+    assertEquals(initialNumTrashKeyListFails + 1, getLongCounter("NumTrashKeyListFails", omMetrics));
+    assertEquals(initialNumInitiateMultipartUploadFails + 1, getLongCounter(
+        "NumInitiateMultipartUploadFails", omMetrics));
+    assertEquals(initialNumKeys + 2, getLongCounter("NumKeys", omMetrics));
 
     keyArgs = createKeyArgs(volumeName, bucketName,
         new ECReplicationConfig("rs-3-2-1024K"));
@@ -395,24 +441,18 @@ public class TestOmMetrics {
       //Expected Failure
     }
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("EcKeyCreateFailsTotal", 1L, omMetrics);
-
-    cluster.restartOzoneManager();
-    assertCounter("NumKeys", 2L, omMetrics);
-
+    assertEquals(initialEcKeyCreateFailsTotal + 1, getLongCounter("EcKeyCreateFailsTotal", omMetrics));
   }
 
   @ParameterizedTest
   @EnumSource(value = BucketLayout.class, names = {"FILE_SYSTEM_OPTIMIZED", "LEGACY"})
   public void testDirectoryOps(BucketLayout bucketLayout) throws Exception {
-    clusterBuilder.setNumDatanodes(3);
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, true);
-    // Speed up background directory deletion for this test.
-    conf.setTimeDuration(OMConfigKeys.OZONE_DIR_DELETING_SERVICE_INTERVAL, 1, TimeUnit.SECONDS);
-    conf.set(OzoneConfigKeys.OZONE_CLIENT_FS_DEFAULT_BUCKET_LAYOUT, bucketLayout.name());
-    // For testing fs operations with legacy buckets.
-    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
-    startCluster();
+    // get initial values for metrics
+    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
+    long initialNumKeys = getLongCounter("NumKeys", omMetrics);
+    long initialNumCreateDirectory = getLongCounter("NumCreateDirectory", omMetrics);
+    long initialNumKeyDeletes = getLongCounter("NumKeyDeletes", omMetrics);
+    long initialNumKeyRenames = getLongCounter("NumKeyRenames", omMetrics);
 
     // How long to wait for directory deleting service to clean up the files before aborting the test.
     final int timeoutMillis =
@@ -423,13 +463,8 @@ public class TestOmMetrics {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-    // Cluster should be empty.
-    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeys", 0L, omMetrics);
-    assertCounter("NumCreateDirectory", 0L, omMetrics);
-    // These key operations include directory operations.
-    assertCounter("NumKeyDeletes", 0L, omMetrics);
-    assertCounter("NumKeyRenames", 0L, omMetrics);
+    // create bucket with different layout in each ParameterizedTest
+    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, bucketLayout);
 
     // Create bucket with 2 nested directories.
     String rootPath = String.format("%s://%s/",
@@ -442,72 +477,83 @@ public class TestOmMetrics {
     assertEquals(bucketLayout,
         client.getObjectStore().getVolume(volumeName).getBucket(bucketName).getBucketLayout());
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeys", 2L, omMetrics);
+    assertEquals(initialNumKeys + 2, getLongCounter("NumKeys", omMetrics));
     // Only one directory create command is given, even though it created two directories.
-    assertCounter("NumCreateDirectory", 1L, omMetrics);
-    assertCounter("NumKeyDeletes", 0L, omMetrics);
-    assertCounter("NumKeyRenames", 0L, omMetrics);
+    assertEquals(initialNumCreateDirectory + 1, getLongCounter("NumCreateDirectory", omMetrics));
+    assertEquals(initialNumKeyDeletes, getLongCounter("NumKeyDeletes", omMetrics));
+    assertEquals(initialNumKeyRenames, getLongCounter("NumKeyRenames", omMetrics));
+
 
     // Add 2 files at different parts of the tree.
     ContractTestUtils.touch(fs, new Path(dirPath, "file1"));
     ContractTestUtils.touch(fs, new Path(dirPath.getParent(), "file2"));
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeys", 4L, omMetrics);
-    assertCounter("NumCreateDirectory", 1L, omMetrics);
-    assertCounter("NumKeyDeletes", 0L, omMetrics);
-    assertCounter("NumKeyRenames", 0L, omMetrics);
+    assertEquals(initialNumKeys + 4, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialNumCreateDirectory + 1, getLongCounter("NumCreateDirectory", omMetrics));
+    assertEquals(initialNumKeyDeletes, getLongCounter("NumKeyDeletes", omMetrics));
+    assertEquals(initialNumKeyRenames, getLongCounter("NumKeyRenames", omMetrics));
 
     // Rename the child directory.
     fs.rename(dirPath, new Path(dirPath.getParent(), "new-name"));
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeys", 4L, omMetrics);
-    assertCounter("NumCreateDirectory", 1L, omMetrics);
-    assertCounter("NumKeyDeletes", 0L, omMetrics);
+    assertEquals(initialNumKeys + 4, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialNumCreateDirectory + 1, getLongCounter("NumCreateDirectory", omMetrics));
+    assertEquals(initialNumKeyDeletes, getLongCounter("NumKeyDeletes", omMetrics));
     long expectedRenames = 1;
     if (bucketLayout == BucketLayout.LEGACY) {
       // Legacy bucket must rename keys individually.
       expectedRenames = 2;
     }
-    assertCounter("NumKeyRenames", expectedRenames, omMetrics);
+    assertEquals(initialNumKeyRenames + expectedRenames, getLongCounter("NumKeyRenames", omMetrics));
 
     // Delete metric should be decremented by directory deleting service in the background.
     fs.delete(dirPath.getParent(), true);
     GenericTestUtils.waitFor(() -> {
-      long keyCount = MetricsAsserts.getLongCounter("NumKeys", getMetrics("OMMetrics"));
+      long keyCount = getLongCounter("NumKeys", getMetrics("OMMetrics"));
       return keyCount == 0;
     }, timeoutMillis / 5, timeoutMillis);
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeys", 0L, omMetrics);
+    assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
     // This is the number of times the create directory command was given, not the current number of directories.
-    assertCounter("NumCreateDirectory", 1L, omMetrics);
+    assertEquals(initialNumCreateDirectory + 1, getLongCounter("NumCreateDirectory", omMetrics));
     // Directory delete counts as key delete. One command was given so the metric is incremented once.
-    assertCounter("NumKeyDeletes", 1L, omMetrics);
-    assertCounter("NumKeyRenames", expectedRenames, omMetrics);
+    assertEquals(initialNumKeyDeletes + 1, getLongCounter("NumKeyDeletes", omMetrics));
+    assertEquals(initialNumKeyRenames + expectedRenames, getLongCounter("NumKeyRenames", omMetrics));
 
     // Re-create the same tree as before, but this time delete the bucket recursively.
     // All metrics should still be properly updated.
     fs.mkdirs(dirPath);
     ContractTestUtils.touch(fs, new Path(dirPath, "file1"));
     ContractTestUtils.touch(fs, new Path(dirPath.getParent(), "file2"));
-    assertCounter("NumKeys", 4L, getMetrics("OMMetrics"));
+    assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
     fs.delete(bucketPath, true);
     GenericTestUtils.waitFor(() -> {
-      long keyCount = MetricsAsserts.getLongCounter("NumKeys", getMetrics("OMMetrics"));
+      long keyCount = getLongCounter("NumKeys", getMetrics("OMMetrics"));
       return keyCount == 0;
     }, timeoutMillis / 5, timeoutMillis);
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeys", 0L, omMetrics);
-    assertCounter("NumCreateDirectory", 2L, omMetrics);
+    assertEquals(initialNumKeys, getLongCounter("NumKeys", omMetrics));
+    assertEquals(initialNumCreateDirectory + 2, getLongCounter("NumCreateDirectory", omMetrics));
     // One more keys delete request is given as part of the bucket delete to do a batch delete of its keys.
-    assertCounter("NumKeyDeletes", 2L, omMetrics);
-    assertCounter("NumKeyRenames", expectedRenames, omMetrics);
+    assertEquals(initialNumKeyDeletes + 2, getLongCounter("NumKeyDeletes", omMetrics));
+    assertEquals(initialNumKeyRenames + expectedRenames, getLongCounter("NumKeyRenames", omMetrics));
   }
 
   @Test
   public void testSnapshotOps() throws Exception {
-    // This tests needs enough dataNodes to allocate the blocks for the keys.
-    clusterBuilder.setNumDatanodes(3);
+    shutdown();
     startCluster();
+    // This tests needs enough dataNodes to allocate the blocks for the keys.
+    // get initial values for metrics
+    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
+    long initialNumSnapshotCreateFails = getLongCounter("NumSnapshotCreateFails", omMetrics);
+    long initialNumSnapshotCreates = getLongCounter("NumSnapshotCreates", omMetrics);
+    long initialNumSnapshotListFails = getLongCounter("NumSnapshotListFails", omMetrics);
+    long initialNumSnapshotLists = getLongCounter("NumSnapshotLists", omMetrics);
+    long initialNumSnapshotActive = getLongCounter("NumSnapshotActive", omMetrics);
+    long initialNumSnapshotDeleted = getLongCounter("NumSnapshotDeleted", omMetrics);
+    long initialNumSnapshotDiffJobs = getLongCounter("NumSnapshotDiffJobs", omMetrics);
+    long initialNumSnapshotDiffJobFails = getLongCounter("NumSnapshotDiffJobFails", omMetrics);
 
     OmBucketInfo omBucketInfo = createBucketInfo(false);
 
@@ -527,16 +573,15 @@ public class TestOmMetrics {
     // Create first snapshot
     writeClient.createSnapshot(volumeName, bucketName, snapshot1);
 
-    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
-
-    assertCounter("NumSnapshotCreateFails", 0L, omMetrics);
-    assertCounter("NumSnapshotCreates", 1L, omMetrics);
-    assertCounter("NumSnapshotListFails", 0L, omMetrics);
-    assertCounter("NumSnapshotLists", 0L, omMetrics);
-    assertCounter("NumSnapshotActive", 1L, omMetrics);
-    assertCounter("NumSnapshotDeleted", 0L, omMetrics);
-    assertCounter("NumSnapshotDiffJobs", 0L, omMetrics);
-    assertCounter("NumSnapshotDiffJobFails", 0L, omMetrics);
+    omMetrics = getMetrics("OMMetrics");
+    assertEquals(initialNumSnapshotCreateFails, getLongCounter("NumSnapshotCreateFails", omMetrics));
+    assertEquals(initialNumSnapshotCreates + 1, getLongCounter("NumSnapshotCreates", omMetrics));
+    assertEquals(initialNumSnapshotListFails, getLongCounter("NumSnapshotListFails", omMetrics));
+    assertEquals(initialNumSnapshotLists, getLongCounter("NumSnapshotLists", omMetrics));
+    assertEquals(initialNumSnapshotActive + 1, getLongCounter("NumSnapshotActive", omMetrics));
+    assertEquals(initialNumSnapshotDeleted, getLongCounter("NumSnapshotDeleted", omMetrics));
+    assertEquals(initialNumSnapshotDiffJobs, getLongCounter("NumSnapshotDiffJobs", omMetrics));
+    assertEquals(initialNumSnapshotDiffJobFails, getLongCounter("NumSnapshotDiffJobFails", omMetrics));
 
     // Create second key
     OmKeyArgs keyArgs2 = createKeyArgs(volumeName, bucketName,
@@ -559,32 +604,25 @@ public class TestOmMetrics {
       }
     }
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumSnapshotDiffJobs", 1L, omMetrics);
-    assertCounter("NumSnapshotDiffJobFails", 0L, omMetrics);
+    assertEquals(initialNumSnapshotDiffJobs + 1, getLongCounter("NumSnapshotDiffJobs", omMetrics));
+    assertEquals(initialNumSnapshotDiffJobFails, getLongCounter("NumSnapshotDiffJobFails", omMetrics));
 
     // List snapshots
     writeClient.listSnapshot(
         volumeName, bucketName, null, null, Integer.MAX_VALUE);
 
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumSnapshotActive", 2L, omMetrics);
-    assertCounter("NumSnapshotCreates", 2L, omMetrics);
-    assertCounter("NumSnapshotLists", 1L, omMetrics);
-    assertCounter("NumSnapshotListFails", 0L, omMetrics);
+    assertEquals(initialNumSnapshotActive + 2, getLongCounter("NumSnapshotActive", omMetrics));
+    assertEquals(initialNumSnapshotCreates + 2, getLongCounter("NumSnapshotCreates", omMetrics));
+    assertEquals(initialNumSnapshotListFails, getLongCounter("NumSnapshotListFails", omMetrics));
+    assertEquals(initialNumSnapshotLists + 1, getLongCounter("NumSnapshotLists", omMetrics));
 
     // List snapshot: invalid bucket case.
     assertThrows(OMException.class, () -> writeClient.listSnapshot(volumeName,
         "invalidBucket", null, null, Integer.MAX_VALUE));
     omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumSnapshotLists", 2L, omMetrics);
-    assertCounter("NumSnapshotListFails", 1L, omMetrics);
-
-    // restart OM
-    cluster.restartOzoneManager();
-
-    // Check number of active snapshots in the snapshot table
-    // is the same after OM restart
-    assertCounter("NumSnapshotActive", 2L, omMetrics);
+    assertEquals(initialNumSnapshotLists + 2, getLongCounter("NumSnapshotLists", omMetrics));
+    assertEquals(initialNumSnapshotListFails + 1, getLongCounter("NumSnapshotListFails", omMetrics));
   }
 
   private <T> void mockWritePathExceptions(Class<T>klass) throws Exception {
@@ -613,67 +651,60 @@ public class TestOmMetrics {
 
   @Test
   public void testAclOperations() throws Exception {
+    shutdown();
     startCluster();
-    try {
-      // Create a volume.
-      client.getObjectStore().createVolume("volumeacl");
+    // get initial values for metrics
+    MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
+    long initialNumGetAcl = getLongCounter("NumGetAcl", omMetrics);
+    long initialNumAddAcl = getLongCounter("NumAddAcl", omMetrics);
+    long initialNumSetAcl = getLongCounter("NumSetAcl", omMetrics);
+    long initialNumRemoveAcl = getLongCounter("NumRemoveAcl", omMetrics);
+    // Create a volume.
+    client.getObjectStore().createVolume("volumeacl");
 
-      OzoneObj volObj = new OzoneObjInfo.Builder().setVolumeName("volumeacl")
-          .setResType(VOLUME).setStoreType(OZONE).build();
+    OzoneObj volObj = new OzoneObjInfo.Builder().setVolumeName("volumeacl")
+        .setResType(VOLUME).setStoreType(OZONE).build();
 
-      // Test getAcl
-      List<OzoneAcl> acls = ozoneManager.getAcl(volObj);
-      MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
-      assertCounter("NumGetAcl", 1L, omMetrics);
+    // Test getAcl, addAcl, setAcl, removeAcl
+    List<OzoneAcl> acls = ozoneManager.getAcl(volObj);
+    writeClient.addAcl(volObj,
+        new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, "ozoneuser",
+            IAccessAuthorizer.ACLType.ALL, ACCESS));
+    writeClient.setAcl(volObj, acls);
+    writeClient.removeAcl(volObj, acls.get(0));
 
-      // Test addAcl
-      writeClient.addAcl(volObj,
-          new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, "ozoneuser",
-              IAccessAuthorizer.ACLType.ALL, ACCESS));
-      omMetrics = getMetrics("OMMetrics");
-      assertCounter("NumAddAcl", 1L, omMetrics);
+    omMetrics = getMetrics("OMMetrics");
+    assertEquals(initialNumGetAcl + 1, getLongCounter("NumGetAcl", omMetrics));
+    assertEquals(initialNumAddAcl + 1, getLongCounter("NumAddAcl", omMetrics));
+    assertEquals(initialNumSetAcl + 1, getLongCounter("NumSetAcl", omMetrics));
+    assertEquals(initialNumRemoveAcl + 1, getLongCounter("NumRemoveAcl", omMetrics));
 
-      // Test setAcl
-      writeClient.setAcl(volObj, acls);
-      omMetrics = getMetrics("OMMetrics");
-      assertCounter("NumSetAcl", 1L, omMetrics);
-
-      // Test removeAcl
-      writeClient.removeAcl(volObj, acls.get(0));
-      omMetrics = getMetrics("OMMetrics");
-      assertCounter("NumRemoveAcl", 1L, omMetrics);
-
-    } finally {
-      client.getObjectStore().deleteVolume("volumeacl");
-    }
+    client.getObjectStore().deleteVolume("volumeacl");
   }
 
   @Test
   public void testAclOperationsHA() throws Exception {
-    // This test needs a cluster with DNs and SCM to wait on safemode
-    clusterBuilder.setNumDatanodes(3);
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, true);
+    shutdown();
     startCluster();
-
     ObjectStore objectStore = client.getObjectStore();
     // Create a volume.
-    objectStore.createVolume("volumeacl");
+    objectStore.createVolume("volumeaclha");
     // Create a bucket.
-    objectStore.getVolume("volumeacl").createBucket("bucketacl");
+    objectStore.getVolume("volumeaclha").createBucket("bucketaclha");
     // Create a key.
-    objectStore.getVolume("volumeacl").getBucket("bucketacl")
-        .createKey("keyacl", 0).close();
+    objectStore.getVolume("volumeaclha").getBucket("bucketaclha")
+        .createKey("keyaclha", 0).close();
 
     OzoneObj volObj =
-        new OzoneObjInfo.Builder().setVolumeName("volumeacl").setResType(VOLUME)
+        new OzoneObjInfo.Builder().setVolumeName("volumeaclha").setResType(VOLUME)
             .setStoreType(OZONE).build();
 
-    OzoneObj buckObj = new OzoneObjInfo.Builder().setVolumeName("volumeacl")
-        .setBucketName("bucketacl").setResType(BUCKET).setStoreType(OZONE)
+    OzoneObj buckObj = new OzoneObjInfo.Builder().setVolumeName("volumeaclha")
+        .setBucketName("bucketaclha").setResType(BUCKET).setStoreType(OZONE)
         .build();
 
-    OzoneObj keyObj = new OzoneObjInfo.Builder().setVolumeName("volumeacl")
-        .setBucketName("bucketacl").setResType(BUCKET).setKeyName("keyacl")
+    OzoneObj keyObj = new OzoneObjInfo.Builder().setVolumeName("volumeaclha")
+        .setBucketName("bucketaclha").setResType(BUCKET).setKeyName("keyaclha")
         .setStoreType(OZONE).build();
 
     List<OzoneAcl> acls = ozoneManager.getAcl(volObj);
@@ -794,13 +825,13 @@ public class TestOmMetrics {
 
     try {
       ozoneManager.listKeys(keyArgs.getVolumeName(),
-                            keyArgs.getBucketName(), null, null, 0);
+          keyArgs.getBucketName(), null, null, 0);
     } catch (IOException ignored) {
     }
 
     try {
       ozoneManager.listTrash(keyArgs.getVolumeName(),
-                             keyArgs.getBucketName(), null, null, 0);
+          keyArgs.getBucketName(), null, null, 0);
     } catch (IOException ignored) {
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Start/Stop cluster in `@BeforeAll`,`@AfterAll`, aim to only start one cluster for all tests
- change assertCounter to assertEqual to assert the "current value" with "initial value" + "expected increment value" , the "initial value" is fetched at the beginning of each subtest. 
- modified some resource names between subtests to ensure no conflict in the same cluster.

This PR isn't finished yet and I face a problem, I would like to solve this and commit again.
Problem:
Some tests likely cannot use the same cluster, if I comment out all the startCluster() and shutdown(), the below OM dummyException happens:
```
[ERROR]   TestOmMetrics.testAclOperations:663 » OM dummyException
663   client.getObjectStore().createVolume("volumeacl");
[ERROR]   TestOmMetrics.testAclOperationsHA:691 » OM dummyException
691    objectStore.createVolume("volumeaclha");
[ERROR]   TestOmMetrics.testKeyOps:345 » OM dummyException
345    TestDataUtil.createVolumeAndBucket(client, volumeName, bucketName, BucketLayout.LEGACY);
[ERROR]   TestOmMetrics.testSnapshotOps:558->createBucketInfo:884 » OM dummyException
558    OmBucketInfo omBucketInfo = createBucketInfo(false);
884    writeClient.createVolume(volumeArgs);
```

If make these 4 tests shutdown(); startCluster(); in the beginning, the test is successful and test time is:
```
[INFO] org.apache.hadoop.ozone.om.TestOmMetrics.testDirectoryOps(BucketLayout)[1]  Time elapsed: 4.643 s
[INFO] org.apache.hadoop.ozone.om.TestOmMetrics.testDirectoryOps(BucketLayout)[2]  Time elapsed: 0.349 s
[INFO] org.apache.hadoop.ozone.om.TestOmMetrics.testBucketOps  Time elapsed: 0.791 s
[INFO] org.apache.hadoop.ozone.om.TestOmMetrics.testVolumeOps  Time elapsed: 0.184 s
[INFO] org.apache.hadoop.ozone.om.TestOmMetrics.testSnapshotOps  Time elapsed: 26.363 s
[INFO] org.apache.hadoop.ozone.om.TestOmMetrics.testAclOperationsHA  Time elapsed: 21.584 s
[INFO] org.apache.hadoop.ozone.om.TestOmMetrics.testAclOperations  Time elapsed: 21.613 s
[INFO] org.apache.hadoop.ozone.om.TestOmMetrics.testKeyOps  Time elapsed: 21.907 s
```
Compared to those that don't restart the cluster, the most time may spent on shutdown() startCluster().

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10311

## How was this patch tested?

`mvn test -Dtest=TestOmMetrics -Dsurefire.reportFormat='plain'`