### PR TITLE
HDDS-10556. Checkstyle summary excludes errors with xml

### DIFF
--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -42,7 +42,7 @@ cat "${REPORT_DIR}/output.log"
 find "." -name checkstyle-errors.xml -print0 \
   | xargs -0 sed '$!N; /<file.*\n<\/file/d;P;D' \
   | sed \
-      -e '/<\?xml.*>/d' \
+      -e '/<?xml.*>/d' \
       -e '/<checkstyle.*/d' \
       -e '/<\/.*/d' \
       -e 's/<file name="\([^"]*\)".*/\1/' \


### PR DESCRIPTION
## What changes were proposed in this pull request?

`summary.txt` for checkstyle incorrectly removes failure message that matches the string `xml`, e.g. unused import from `com.fasterxml.jackson`.

`checkstyle-errors.xml`:

```
<file name="hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java">
<error line="20" column="8" severity="error" message="Unused import - com.fasterxml.jackson.databind.ObjectMapper." source="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"/>
</file>
```

`summary.txt`:

```
hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java
```

The problem is that `<\?xml` matches `<xml` or `xml` instead of `<?xml` as intended.

https://issues.apache.org/jira/browse/HDDS-10556

## How was this patch tested?

Checked out https://github.com/ArafatKhan2198/ozone/commit/9d4b3e58077a1f6c8c5c4ecc67716e8c670098c6, ran checkstyle:

```
$ ./hadoop-ozone/dev-support/checks/checkstyle.sh
hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java
 20: Unused import - com.fasterxml.jackson.databind.ObjectMapper.
```