### PR TITLE
HDDS-10486. Recon datanode UI to incorporate explicit removal of DEAD

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -23,7 +23,7 @@
       {
         "hostname": "localhost2.storage.enterprise.com",
         "uuid": "b590734e-a5f2-11ea-bb37-0242ac130010",
-        "state": "HEALTHY",
+        "state": "DEAD",
         "opState": "IN_SERVICE",
         "lastHeartbeat": 1574728876059,
         "storageReport": {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -18,11 +18,11 @@
     "keysPendingDeletion": 1000
   },
   "datanodes": {
-    "totalCount": 12,
+    "totalCount": 19,
     "datanodes": [
       {
         "hostname": "localhost2.storage.enterprise.com",
-        "uuid": "b590734e-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b590734e-a5f2-11ea-bb37-0242ac130010",
         "state": "HEALTHY",
         "opState": "IN_SERVICE",
         "lastHeartbeat": 1574728876059,
@@ -92,7 +92,7 @@
       },
       {
         "hostname": "localhost1.storage.enterprise.com",
-        "uuid": "b5907812-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907812-a5f2-11ea-bb37-0242ac130011",
         "state": "HEALTHY",
         "opState": "DECOMMISSIONING",
         "lastHeartbeat": 1574724876059,
@@ -126,7 +126,7 @@
       },
       {
         "hostname": "localhost4.storage.enterprise.com",
-        "uuid": "b5907812-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907812-a5f2-11ea-bb37-0242ac130012",
         "state": "HEALTHY",
         "opState": "DECOMMISSIONED",
         "lastHeartbeat": 1574724876059,
@@ -160,7 +160,7 @@
       },
       {
         "hostname": "localhost3.storage.enterprise.com",
-        "uuid": "b5907812-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907812-a5f2-11ea-bb37-0242ac130013",
         "state": "HEALTHY",
         "opState": "ENTERING_MAINTENANCE",
         "lastHeartbeat": 1574724876059,
@@ -194,7 +194,7 @@
       },
       {
         "hostname": "localhost6.storage.enterprise.com",
-        "uuid": "b5907812-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907812-a5f2-11ea-bb37-0242ac130014",
         "state": "HEALTHY",
         "opState": "IN_MAINTENANCE",
         "lastHeartbeat": 1574724876059,
@@ -228,7 +228,7 @@
       },
       {
         "hostname": "localhost5.storage.enterprise.com",
-        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130015",
         "state": "STALE",
         "opState": "IN_SERVICE",
         "lastHeartbeat": 1343544879843,
@@ -268,7 +268,7 @@
       },
       {
         "hostname": "localhost7.storage.enterprise.com",
-        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130016",
         "state": "STALE",
         "opState": "DECOMMISSIONING",
         "lastHeartbeat": 1343544879843,
@@ -308,7 +308,7 @@
       },
       {
         "hostname": "localhost8.storage.enterprise.com",
-        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130017",
         "state": "STALE",
         "opState": "DECOMMISSIONED",
         "lastHeartbeat": 1343544879843,
@@ -348,7 +348,7 @@
       },
       {
         "hostname": "localhost9.storage.enterprise.com",
-        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130018",
         "state": "STALE",
         "opState": "ENTERING_MAINTENANCE",
         "lastHeartbeat": 1343544879843,
@@ -388,7 +388,7 @@
       },
       {
         "hostname": "localhost10.storage.enterprise.com",
-        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907934-a5f2-11ea-bb37-0242ac130019",
         "state": "STALE",
         "opState": "IN_MAINTENANCE",
         "lastHeartbeat": 1343544879843,
@@ -428,7 +428,7 @@
       },
       {
         "hostname": "localhost11.storage.enterprise.com",
-        "uuid": "b5907a06-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907a06-a5f2-11ea-bb37-0242ac130020",
         "state": "DEAD",
         "opState": "IN_SERVICE",
         "lastHeartbeat": 1074724876059,
@@ -449,7 +449,7 @@
       },
       {
         "hostname": "localhost12.storage.enterprise.com",
-        "uuid": "b5907ac4-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907ac4-a5f2-11ea-bb37-0242ac130021",
         "state": "DEAD",
         "opState": "DECOMMISSIONING",
         "lastHeartbeat": 1574724876059,
@@ -483,7 +483,7 @@
       },
       {
         "hostname": "localhost13.storage.enterprise.com",
-        "uuid": "b5907b82-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907b82-a5f2-11ea-bb37-0242ac130022",
         "state": "DEAD",
         "opState": "DECOMMISSIONED",
         "lastHeartbeat": 1574724876059,
@@ -517,7 +517,7 @@
       },
       {
         "hostname": "localhost14.storage.enterprise.com",
-        "uuid": "b5907c40-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907c40-a5f2-11ea-bb37-0242ac130023",
         "state": "DEAD",
         "opState": "ENTERING_MAINTENANCE",
         "lastHeartbeat": 1574724876059,
@@ -557,7 +557,7 @@
       },
       {
         "hostname": "localhost15.storage.enterprise.com",
-        "uuid": "b5907cf4-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907cf4-a5f2-11ea-bb37-0242ac130024",
         "state": "DEAD",
         "opState": "IN_MAINTENANCE",
         "lastHeartbeat": 1574724876059,
@@ -591,7 +591,7 @@
       },
       {
         "hostname": "localhost16.storage.enterprise.com",
-        "uuid": "b5907f4c-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b5907f4c-a5f2-11ea-bb37-0242ac130025",
         "state": "HEALTHY",
         "opState": "IN_SERVICE",
         "lastHeartbeat": 1574724874011,
@@ -625,7 +625,7 @@
       },
       {
         "hostname": "localhost17.storage.enterprise.com",
-        "uuid": "b590801e-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b590801e-a5f2-11ea-bb37-0242ac130026",
         "state": "HEALTHY",
         "opState": "IN_SERVICE",
         "lastHeartbeat": 1574723876959,
@@ -665,7 +665,7 @@
       },
       {
         "hostname": "localhost18.storage.enterprise.com",
-        "uuid": "b59080e6-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b59080e6-a5f2-11ea-bb37-0242ac130027",
         "state": "STALE",
         "opState": "IN_SERVICE",
         "lastHeartbeat": 1474724876783,
@@ -699,7 +699,7 @@
       },
       {
         "hostname": "localhost19.storage.enterprise.com",
-        "uuid": "b59081a4-a5f2-11ea-bb37-0242ac130002",
+        "uuid": "b59081a4-a5f2-11ea-bb37-0242ac130028",
         "state": "HEALTHY",
         "opState": "IN_SERVICE",
         "lastHeartbeat": 1574724796532,
@@ -6753,5 +6753,10 @@
       }
     ],
     "status": "OK"
+  },
+  "datanodesRemove": {
+    "selectedRowKeys": [
+      "b5907812-a5f2-11ea-bb37-0242ac130011"
+    ]
   }
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
@@ -49,5 +49,6 @@
   "/keys/deletePending?limit=*" : "/keydeletePending",
 
   "/containers/mismatch/deleted?limit=*": "/deleted",
-  "/keys/deletePending/dirs?limit=*": "/dirdeletePending"
+  "/keys/deletePending/dirs?limit=*": "/dirdeletePending",
+  "/datanodes/remove": "/datanodesRemove"
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
@@ -34,6 +34,21 @@ export const AxiosGetHelper = (
   }
 }
 
+export const AxiosPutHelper = (
+  url: string,
+  data: any = {},
+  controller: AbortController,
+  message: string = "",  //optional
+): { "request": Promise<AxiosResponse<any, any>>, "controller": AbortController } => {
+
+  controller && controller.abort(message);
+  controller = new AbortController(); // generate new AbortController for the upcoming request
+  return {
+    request: axios.put(url, data, { signal: controller.signal }),
+    controller: controller
+  }
+}
+
 export const AxiosAllGetHelper = (
   urls: string[],
   controller: AbortController,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
@@ -39,21 +39,6 @@
   }
 }
 
-.ant-popover-inner-content {
-  padding: 26px 30px !important;
-}
-
-.ant-popover-inner-content .ant-popover-message .ant-popover-message-title {
-  font-size: 23px !important;
-  width: 550px
-}
-
-.ant-popover-buttons button {
-  width: 138px;
-  font-size: 20px;
-  padding: 8px 0px;
-  line-height: 25px;
-  display: inline-block;
-  height: auto;
-  margin-left: 15px
+.ant-popover-inner{
+  margin-left: 700px;
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
@@ -40,5 +40,5 @@
 }
 
 .ant-popover-inner{
-  margin-left: 700px;
+  margin-left: 500px;
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
@@ -38,3 +38,22 @@
     z-index: 99;
   }
 }
+
+.ant-popover-inner-content {
+  padding: 26px 30px !important;
+}
+
+.ant-popover-inner-content .ant-popover-message .ant-popover-message-title {
+  font-size: 23px !important;
+  width: 550px
+}
+
+.ant-popover-buttons button {
+  width: 138px;
+  font-size: 20px;
+  padding: 8px 0px;
+  line-height: 25px;
+  display: inline-block;
+  height: auto;
+  margin-left: 15px
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -36,8 +36,7 @@ import {MultiSelect, IOption} from 'components/multiSelect/multiSelect';
 import {ActionMeta, ValueType} from 'react-select';
 import {showDataFetchError} from 'utils/common';
 import {ColumnSearch} from 'utils/columnSearch';
-import { AxiosGetHelper } from 'utils/axiosRequestHelper';
-import axios from "axios";
+import { AxiosGetHelper, AxiosPutHelper } from 'utils/axiosRequestHelper';
 
 interface IDatanodeResponse {
   hostname: string;
@@ -424,24 +423,20 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
     });
   };
   
-  removeDatanode= async (selectedRowKeys: any) => {
-    try {
-      await axios.put('/api/v1/datanodes/remove', selectedRowKeys);
-      //Load Datanodes after removal
+  removeDatanode = async (selectedRowKeys: any) => {
+    const { request, controller } = await AxiosPutHelper('/api/v1/datanodes/remove', selectedRowKeys, cancelSignal);
+    cancelSignal = controller;
+    request.then(() => {
       this._loadData();
-      this.setState({
-        loading: false,
-        selectedRowKeys: []
-      });
-    }
-    catch (error) {
-      this.setState({
-        loading: false,
-        selectedRowKeys: []
-      });
+    }).catch(error => {
       showDataFetchError(error.toString());
-    }
-  };
+    }).finally(() => {
+      this.setState({
+        loading: false,
+        selectedRowKeys: []
+      });
+    });
+  }
 
   componentDidMount(): void {
     // Fetch datanodes on component mount
@@ -533,7 +528,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
                 }
                 onConfirm={this.popConfirm}
               >
-                <Tooltip placement="topLeft" title="Remove and stop tracking the DECOMMISSIONED, IN_MAINTENANCE AND DEAD nodes!!!.">
+                <Tooltip placement="topLeft" title="Remove and stop tracking the DECOMMISSIONED, IN_MAINTENANCE, and DEAD nodes.">
                   <Icon type="info-circle"/>
                 </Tooltip>
                 &nbsp;&nbsp;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -460,7 +460,8 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
   };
 
   onDisable = (record:any) => {
-    //Enable Record for Remove whos state is Dead or operation state Decommissioned or In Maintenance
+    // Will return Disable Checkbox records for remove whos Record state is not DEAD and Opeartional State=['IN_SERVICE','ENTERING_MAINTENANCE','DECOMMISSIONING']
+    //Enable Checkbox for remove who's State is Dead or Operation State=['Decommissioned','In_Maintenance']
     if (record.state !== 'DEAD') {
       return record.opState === 'IN_SERVICE' || record.opState === 'ENTERING_MAINTENANCE' || record.opState === 'DECOMMISSIONING';
     }
@@ -522,13 +523,13 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
               <Popconfirm
                 disabled={!hasSelected}
                 placement="topLeft"
-                title={`Are you sure you want Recon to stop tracking these selected ${selectedRowKeys.length} datanodes ?`}
+                title={`Are you sure you want Recon to stop tracking the selected ${selectedRowKeys.length} datanodes ?`}
                 icon={
                   <Icon type='question-circle-o' style={{ color: 'red' }} />
                 }
                 onConfirm={this.popConfirm}
               >
-                <Tooltip placement="topLeft" title="Remove and stop tracking the DECOMMISSIONED, IN_MAINTENANCE, and DEAD nodes.">
+                <Tooltip placement="topLeft" title="Remove the dead or decommissioned or in maintenance datanodes.">
                   <Icon type="info-circle"/>
                 </Tooltip>
                 &nbsp;&nbsp;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -460,16 +460,20 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
   };
 
   onDisable = (record:any) => {
-    // Will return Disable Checkbox records for remove whos Record state is not DEAD and Opeartional State=['IN_SERVICE','ENTERING_MAINTENANCE','DECOMMISSIONING']
-    // Enable Checkbox for remove who's State is Dead or Operation State=['Decommissioned','In_Maintenance']
+    // Enable Checkbox for explicit removal who's State = DEAD
     if (record.state !== 'DEAD') {
-      return record.opState === 'IN_SERVICE' || record.opState === 'ENTERING_MAINTENANCE' || record.opState === 'DECOMMISSIONING';
+      // Will return disabled checkboxes records who's Record state is not DEAD and Opeartional State=['IN_SERVICE','ENTERING_MAINTENANCE','DECOMMISSIONING','IN_MAINTENANCE','DECOMMISSIONED']
+      return true;
     }
   };
   
   popConfirm = () => {
     this.setState({ loading: true });
     this.removeDatanode(this.state.selectedRowKeys);
+  };
+
+  cancel = () => {
+    this.setState({ selectedRowKeys: [] });
   };
 
   render() {
@@ -528,8 +532,9 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
                   <Icon type='question-circle-o' style={{ color: 'red' }} />
                 }
                 onConfirm={this.popConfirm}
+                onCancel={this.cancel}
               >
-                <Tooltip placement="topLeft" title="Remove the dead or decommissioned or in maintenance datanodes.">
+                <Tooltip placement="topLeft" title="Remove the dead datanodes.">
                   <Icon type="info-circle"/>
                 </Tooltip>
                 &nbsp;&nbsp;

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -463,6 +463,13 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
       selectedRowKeys: newSelectedRowKeys
     });
   };
+
+  onDisable = (record:any) => {
+    //Enable Record for Remove whos state is Dead or operation state Decommissioned or In Maintenance
+    if (record.state !== 'DEAD') {
+      return record.opState === 'IN_SERVICE' || record.opState === 'ENTERING_MAINTENANCE' || record.opState === 'DECOMMISSIONING';
+    }
+  };
   
   popConfirm = () => {
     this.setState({ loading: true });
@@ -476,7 +483,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
       selectedRowKeys,
       onChange: this.onSelectChange,
       getCheckboxProps: record=> ({
-        disabled: record.opState === 'IN_SERVICE' || record.opState === 'ENTERING_MAINTENANCE' || record.opState === 'DECOMMISSIONING', // Column configuration not to be checked
+        disabled:  this.onDisable(record),
         opState: record.opState,
       }),
     };
@@ -515,20 +522,26 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
         </div>
 
         <div className='content-div'>
-          {totalCount > 0 && <div style={{ marginBottom: 16 }}>
-            <Popconfirm
-              placement="right"
-              title={`Are you sure want to remove ${selectedRowKeys.length} Data nodes？`}
-              icon={<Tooltip title='Deleted Data Nodes includes DECOMMISSIONED and  IN_MAINTENANCE.'>
-                <Icon type='question-circle-o' style={{ color: 'red', fontSize: '20px' }} />
-              </Tooltip>}
-              onConfirm={this.popConfirm}
-            >
-              <Button style={{ width: 130, fontSize: "large" }} type="primary" disabled={!hasSelected} loading={loading}>
-                Remove
-              </Button>
-            </Popconfirm>
-          </div>}
+          {totalCount > 0 &&
+            <div style={{ marginBottom: 16 }}>
+              <Popconfirm
+                disabled={!hasSelected}
+                placement="topLeft"
+                title={`Are you sure you want Recon to stop tracking these selected ${selectedRowKeys.length} datanodes ?`}
+                icon={
+                  <Icon type='question-circle-o' style={{ color: 'red' }} />
+                }
+                onConfirm={this.popConfirm}
+              >
+                <Tooltip placement="topLeft" title="Remove and stop tracking the DECOMMISSIONED, IN_MAINTENANCE AND DEAD nodes!!!.">
+                  <Icon type="info-circle"/>
+                </Tooltip>
+                &nbsp;&nbsp;
+                <Button type="primary" shape="round" icon="stop" size="large" disabled={!hasSelected} loading={loading}>
+                </Button>
+              </Popconfirm>
+            </div>
+          }
           <Table
             rowSelection={rowSelection}
             dataSource={dataSource}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -537,7 +537,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
                   <Icon type="info-circle"/>
                 </Tooltip>
                 &nbsp;&nbsp;
-                <Button type="primary" shape="round" icon="stop" size="large" disabled={!hasSelected} loading={loading}>
+                <Button type="primary" shape="round" icon="delete"  disabled={!hasSelected} loading={loading}> Remove
                 </Button>
               </Popconfirm>
             </div>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -461,7 +461,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
 
   onDisable = (record:any) => {
     // Will return Disable Checkbox records for remove whos Record state is not DEAD and Opeartional State=['IN_SERVICE','ENTERING_MAINTENANCE','DECOMMISSIONING']
-    //Enable Checkbox for remove who's State is Dead or Operation State=['Decommissioned','In_Maintenance']
+    // Enable Checkbox for remove who's State is Dead or Operation State=['Decommissioned','In_Maintenance']
     if (record.state !== 'DEAD') {
       return record.opState === 'IN_SERVICE' || record.opState === 'ENTERING_MAINTENANCE' || record.opState === 'DECOMMISSIONING';
     }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -515,7 +515,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
         </div>
 
         <div className='content-div'>
-          <div style={{ marginBottom: 16 }}>
+          {totalCount > 0 && <div style={{ marginBottom: 16 }}>
             <Popconfirm
               placement="right"
               title={`Are you sure want to remove ${selectedRowKeys.length} Data nodes？`}
@@ -528,7 +528,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
                 Remove
               </Button>
             </Popconfirm>
-          </div>
+          </div>}
           <Table
             rowSelection={rowSelection}
             dataSource={dataSource}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recon datanodes listing page should have a mechanism using a button or link which will be enabled once user selects the  State is **DEAD** nodes for explicity removal from Recon memory and ask recon to stop tracking. 

**Node State= DEAD    Operation State=[Any State] ==> Allow for Removal**

Following backend API will be provided by Recon to facilitate this.

1) When totalcount is greater than 0 then we are displaying Remove button.

Please describe your PR in detail:
PUT
api/v1/datanodes/remove
JSON Body input takes UUID list of datanodes to be removed from cluster:
Input:
[
"50ca4c95-2ef3-4430-b944-97d2442c3daf"
]
Output:

Examples of well-written pull requests:


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10486

## Depending on Backend PR
Need to get merge after  below backend  PR gets merged 
https://github.com/apache/ozone/pull/6360

https://issues.apache.org/jira/browse/HDDS-11032)

## How was this patch tested?
Manually

Only Dead node removal

![image](https://github.com/apache/ozone/assets/112169209/37614a69-b6cf-490c-bd54-b5138f44c89c)

![image](https://github.com/apache/ozone/assets/112169209/ee2b846d-b0ca-4034-9557-14602d0267fb)
-----------------------------------------------------------------------------------------------------------
Dead Node Removal
<img width="1482" alt="Screenshot 2024-05-02 at 5 37 43 PM" src="https://github.com/apache/ozone/assets/112169209/6950a96e-9fcd-4570-8b1c-3cac497c2a61">

<img width="1482" alt="Screenshot 2024-05-02 at 5 37 43 PM" src="https://github.com/apache/ozone/assets/112169209/7671e922-b6ef-45dc-a081-d8232547af1e">
----------------------------------------------------------------------------------------------------------
In Case of failure and abort signal
<img width="1687" alt="Screenshot 2024-05-30 at 5 26 06 PM" src="https://github.com/apache/ozone/assets/112169209/373d4322-4a66-4736-a950-bbb241496a1f">

