### PR TITLE
HDDS-10551. Improve HTTPFS Documentation for Iterative Liststatus Functionality

### DIFF
--- a/hadoop-hdds/docs/content/interface/HttpFS.md
+++ b/hadoop-hdds/docs/content/interface/HttpFS.md
@@ -84,7 +84,7 @@ Truncate a File                 | not implemented in Ozone
 Status of a File/Directory      | supported
 List a Directory                | supported
 List a File                     | supported
-Iteratively List a Directory    | supported
+Iteratively List a Directory    | unsupported
 
 
 ### Other File System Operations


### PR DESCRIPTION
## What changes were proposed in this pull request?
ListStatus Iterative is currently a unsupported operation, but in the docs it is shown as supported. 
Mark this as unsupported in the docs as well.

Please describe your PR in detail:
Mark ListStatus Iterative as an unsupported operation.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10551

## How was this patch tested?

Build the project, checked the generated httpfs.html files.
<img width="816" alt="image" src="https://github.com/apache/ozone/assets/67139753/163ac3ab-6650-48f9-905f-b531a86e841e">
