### PR TITLE
HDDS-10118. hdds-rocks-native fails to build with Java11+

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -393,7 +393,7 @@
                     <argument>-h</argument>
                     <argument>${project.build.directory}/native/javah</argument>
                     <argument>${project.basedir}/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRawSSTFileReader.java</argument>
-                    <argument>${project.basedir}/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRawSSTFileReaderIterator.java</argument>
+                    <argument>${project.basedir}/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedRawSSTFileIterator.java</argument>
                   </arguments>
                 </configuration>
               </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?
 Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.0.2:copy-dependencies (copy-jars) on project hdds-rocks-native: Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187.

I found the file names mismatch in the the referred directory

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10118

## How was this patch tested?
Tested with command line 
alias mvn11="JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home && mvn"
mvn11 clean install -DskipTests -e -DskipShade -X -Drocks_tools_native