### PR TITLE
HDDS-10562. Fix endless loop in ozone fs -ls

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -762,6 +762,8 @@ public class TestOzoneShellHA {
             getClientConfForOFS(hostPrefix, cluster.getConf());
     int pageSize = 20;
     clientConf.setInt(OZONE_FS_LISTING_PAGE_SIZE, pageSize);
+    URI uri = FileSystem.getDefaultUri(clientConf);
+    clientConf.setBoolean(String.format("fs.%s.impl.disable.cache", uri.getScheme()), true);
     OzoneFsShell shell = new OzoneFsShell(clientConf);
 
     String volName = "testlistbucket";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -775,7 +775,7 @@ public class TestOzoneShellHA {
       res = ToolRunner.run(shell, new String[]{"-ls", "/" + volName});
       assertEquals(0, res);
       String r = out.toString(DEFAULT_ENCODING);
-      assertTrue(r.matches("(?s)^Found " + numBuckets + " items.*"));
+      assertThat(r).matches("(?s)^Found " + numBuckets + " items.*");
 
     } finally {
       shell.close();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -771,10 +772,8 @@ public class TestOzoneShellHA {
 
     try {
       generateBuckets("/" + volName, numBuckets);
-      int res;
-
       out.reset();
-      res = ToolRunner.run(shell, new String[]{"-ls", "/" + volName});
+      int res = ToolRunner.run(shell, new String[]{"-ls", "/" + volName});
       assertEquals(0, res);
       String r = out.toString(DEFAULT_ENCODING);
       assertThat(r).matches("(?s)^Found " + numBuckets + " items.*");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -755,6 +755,7 @@ public class TestOzoneShellHA {
   }
 
   @Test
+  @Timeout(10)
   public void testListBucket() throws Exception {
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
     OzoneConfiguration clientConf =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -754,6 +754,31 @@ public class TestOzoneShellHA {
   }
 
   @Test
+  public void testListBucket() throws Exception {
+    final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
+    OzoneConfiguration clientConf =
+            getClientConfForOFS(hostPrefix, cluster.getConf());
+    OzoneFsShell shell = new OzoneFsShell(clientConf);
+
+    String volName = "testlistbucket";
+    int numBuckets = 1025;
+
+    try {
+      generateBuckets("/" + volName, numBuckets);
+      int res;
+
+      out.reset();
+      res = ToolRunner.run(shell, new String[]{"-ls", "/" + volName});
+      assertEquals(0, res);
+      String r = out.toString(DEFAULT_ENCODING);
+      assertTrue(r.matches("(?s)^Found " + numBuckets + " items.*"));
+
+    } finally {
+      shell.close();
+    }
+  }
+
+  @Test
   public void testDeleteTrashNoSkipTrash() throws Exception {
 
     // Test delete from Trash directory removes item from filesystem

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -76,6 +76,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -758,10 +759,12 @@ public class TestOzoneShellHA {
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
     OzoneConfiguration clientConf =
             getClientConfForOFS(hostPrefix, cluster.getConf());
+    int pageSize = 20;
+    clientConf.setInt(OZONE_FS_LISTING_PAGE_SIZE, pageSize);
     OzoneFsShell shell = new OzoneFsShell(clientConf);
 
     String volName = "testlistbucket";
-    int numBuckets = 1025;
+    int numBuckets = pageSize;
 
     try {
       generateBuckets("/" + volName, numBuckets);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -882,9 +882,9 @@ public class BasicRootedOzoneClientAdapterImpl
     }
     OFSPath ofsStartPath = new OFSPath(startPath, config);
     if (ofsPath.isVolume()) {
-      String startBucket = ofsStartPath.getBucketName();
+      String startBucketPath = ofsStartPath.getNonKeyPath();
       return listStatusVolume(ofsPath.getVolumeName(),
-          recursive, startBucket, numEntries, uri, workingDir, username);
+          recursive, startBucketPath, numEntries, uri, workingDir, username);
     }
 
     if (ofsPath.isSnapshotPath()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a volume has more than "1024" buckets, the command of "ozone fs -ls /volume" will reach endless loop.

It's caused by incorrect parameter passing in `listStatus`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10562

## How was this patch tested?

unit test.
