### PR TITLE
HDDS-10564. Make Outputstream writeExecutor daemon threads.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2533,7 +2533,7 @@ public class RpcClient implements ClientProtocol {
        int corePoolSize, int maximumPoolSize, String threadNameFormat) {
     return new ThreadPoolExecutor(corePoolSize, maximumPoolSize,
             60, TimeUnit.SECONDS, new SynchronousQueue<>(),
-               new ThreadFactoryBuilder().setNameFormat(threadNameFormat).build(),
+               new ThreadFactoryBuilder().setNameFormat(threadNameFormat).setDaemon(true).build(),
                new ThreadPoolExecutor.CallerRunsPolicy());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10564. Make Outputstream writeExecutor daemon threads.

Please describe your PR in detail:
[HDDS-10383](https://issues.apache.org/jira/browse/HDDS-10383) added new thread pools in the output stream. They should be made daemon threads so that processes don't wait for them when exiting. (The bug is in the command line which does not close FileSystem object. Nonetheless, it would still be a good idea to make these thread pools daemon)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10564

## How was this patch tested?
Deployed on a real cluster, with HBase on Ozone, repeated the same command to verify that the command no longer hangs.