### PR TITLE
HDDS-10579. Remove org.ow2.asm dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <annotation-api.version>1.3.2</annotation-api.version>
     <assertj.version>3.12.2</assertj.version>
-    <asm.version>5.0.4</asm.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <bouncycastle.version>1.77</bouncycastle.version>
     <cglib.version>3.3.0</cglib.version>
@@ -947,12 +946,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-jaxb</artifactId>
         <version>${jersey2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm</artifactId>
-        <version>${asm.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10579. Remove org.ow2.asm dependency

The org.ow2.asm:asm:5.0.4 dependency is not used anywhere in the project and can be safely removed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10579

## How was this patch tested?

Existing tests
