### PR TITLE
HDDS-10581. NPE in SummarySubCommand & DiskUsageSubCommand.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -101,18 +101,18 @@ public class DiskUsageSubCommand implements Callable {
 
     JsonNode duResponse = JsonUtils.readTree(response);
 
-    if (duResponse.get("status").asText().equals("PATH_NOT_FOUND")) {
+    if ("PATH_NOT_FOUND".equals(duResponse.path("status").asText(""))) {
       printPathNotFound();
     } else {
       if (parent.isNotValidBucketOrOBSBucket(path)) {
         printBucketReminder();
       }
 
-      long totalSize = duResponse.get("size").asLong();
+      long totalSize = duResponse.path("size").asLong(-1);
       if (!noHeader) {
         printWithUnderline("Path", false);
         printKVSeparator();
-        System.out.println(duResponse.get("path").asText());
+        System.out.println(duResponse.path("path").asText(""));
 
         printWithUnderline("Total Size", false);
         printKVSeparator();
@@ -121,11 +121,11 @@ public class DiskUsageSubCommand implements Callable {
         if (withReplica) {
           printWithUnderline("Total Disk Usage", false);
           printKVSeparator();
-          long du = duResponse.get("sizeWithReplica").asLong();
+          long du = duResponse.path("sizeWithReplica").asLong(-1);
           System.out.println(FileUtils.byteCountToDisplaySize(du));
         }
 
-        long sizeDirectKey = duResponse.get("sizeDirectKey").asLong();
+        long sizeDirectKey = duResponse.path("sizeDirectKey").asLong(-1);
         if (!listFiles && sizeDirectKey != -1) {
           printWithUnderline("Size of Direct Keys", false);
           printKVSeparator();
@@ -134,7 +134,7 @@ public class DiskUsageSubCommand implements Callable {
         printNewLines(1);
       }
 
-      if (duResponse.get("subPathCount").asInt() == 0) {
+      if (duResponse.path("subPathCount").asInt(-1) == 0) {
         if (totalSize == 0) {
           // the object is empty
           System.out.println("The object is empty.\n" +
@@ -157,19 +157,19 @@ public class DiskUsageSubCommand implements Callable {
           seekStr = "";
         }
 
-        ArrayNode subPaths = (ArrayNode) duResponse.get("subPaths");
+        ArrayNode subPaths = (ArrayNode) duResponse.path("subPaths");
         int cnt = 0;
         for (JsonNode subPathDU : subPaths) {
           if (cnt >= limit) {
             break;
           }
-          String subPath = subPathDU.get("path").asText();
+          String subPath = subPathDU.path("path").asText("");
           // differentiate key from other types
-          if (!subPathDU.get("isKey").asBoolean()) {
+          if (!subPathDU.path("isKey").asBoolean(false)) {
             subPath += OM_KEY_PREFIX;
           }
-          long size = subPathDU.get("size").asLong();
-          long sizeWithReplica = subPathDU.get("sizeWithReplica").asLong();
+          long size = subPathDU.path("size").asLong(-1);
+          long sizeWithReplica = subPathDU.path("sizeWithReplica").asLong(-1);
           if (subPath.startsWith(seekStr)) {
             printDURow(subPath, size, sizeWithReplica);
             ++cnt;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -84,10 +84,10 @@ public class SummarySubCommand implements Callable<Void> {
       printKVSeparator();
       System.out.println(summaryResponse.get("type"));
 
-      int numVol = summaryResponse.get("numVolume").asInt();
-      int numBucket = summaryResponse.get("numBucket").asInt();
-      int numDir = summaryResponse.get("numDir").asInt();
-      int numKey = summaryResponse.get("numKey").asInt();
+      int numVol = summaryResponse.path("numVolume").asInt(-1);
+      int numBucket = summaryResponse.path("numBucket").asInt(-1);
+      int numDir = summaryResponse.path("numDir").asInt(-1);
+      int numKey = summaryResponse.path("numKey").asInt(-1);
 
       if (numVol != -1) {
         printWithUnderline("Volumes", false);


### PR DESCRIPTION
## What changes were proposed in this pull request?
- This issue arose from direct calls to methods like `.asInt()` and `.asText()` on potentially null `JsonNode` objects returned by `.get(String)` when the expected keys were missing in the JSON response.
```
Cannot invoke "com.fasterxml.jackson.databind.JsonNode.asInt()" because the return value of
"com.fasterxml.jackson.databind.JsonNode.get(String)" is null
```
- To resolve this, we employed the `.path(String)` method followed by `.asInt(defaultValue)` or `.asText(defaultValue)` to safely access and convert JSON fields. The `.path(String)` method ensures a null-safe way to access JSON fields, returning a "missing node" instead of null for absent keys, thereby preventing NPEs. Furthermore, by specifying default values for `.asInt(defaultValue)` and `.asText(defaultValue)`, we ensured that our code could handle missing or unexpected data gracefully, defaulting to a pre-defined value instead of crashing or behaving unpredictably.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10581
## How was this patch tested?
- Ran `TestNSSummaryAdmin` without a problem.
- And also the Fork CI ran successfully :-
 https://github.com/ArafatKhan2198/ozone/actions/runs/8408238070
