### PR TITLE
HDDS-10583. Thread name prefix in ReplicationSupervisor is null

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -106,7 +106,6 @@ public final class ReplicationSupervisor {
     private Clock clock;
     private IntConsumer executorThreadUpdater = threadCount -> {
     };
-    private String threadNamePrefix;
 
     public Builder clock(Clock newClock) {
       clock = newClock;
@@ -138,11 +137,6 @@ public final class ReplicationSupervisor {
       return this;
     }
 
-    public Builder threadNamePrefix(String threadPrefix) {
-      this.threadNamePrefix = threadPrefix;
-      return this;
-    }
-
     public ReplicationSupervisor build() {
       if (replicationConfig == null || datanodeConfig == null) {
         ConfigurationSource conf = new OzoneConfiguration();
@@ -162,6 +156,7 @@ public final class ReplicationSupervisor {
       if (executor == null) {
         LOG.info("Initializing replication supervisor with thread count = {}",
             replicationConfig.getReplicationMaxStreams());
+        String threadNamePrefix = context != null ? context.getThreadNamePrefix() : "";
         ThreadFactory threadFactory = new ThreadFactoryBuilder()
             .setDaemon(true)
             .setNameFormat(threadNamePrefix + "ContainerReplicationThread-%d")


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ReplicationSupervisor#Builder#threadNamePrefix` is never called, prefix is null:

```
2024-03-24 12:17:18,388 [nullContainerReplicationThread-0] INFO reconstruction.ECReconstructionCoordinatorTask: IN_PROGRESS reconstructECContainersCommand ...
```

Fix it by using `threadNamePrefix` from `StateContext`, remove unnecessary variable from `ReplicationSupervisor#Builder`.

https://issues.apache.org/jira/browse/HDDS-10583

## How was this patch tested?

```
$ mvn clean test -Dtest='TestECContainerRecovery,TestReconAndAdminContainerCLI'
...

$ grep -m1 ContainerReplicationThread hadoop-ozone/integration-test/target/surefire-reports/*txt

hadoop-ozone/integration-test/target/surefire-reports/org.apache.hadoop.ozone.recon.TestReconAndAdminContainerCLI-output.txt
2024-03-24 13:39:15,367 [0e4795b1-1dfe-4ad0-8460-f5f86ed0131d-ContainerReplicationThread-0] INFO  replication.PushReplicator (PushReplicator.java:replicate(58)) - Starting replication of container 1 ...

hadoop-ozone/integration-test/target/surefire-reports/org.apache.hadoop.ozone.container.TestECContainerRecovery-output.txt
2024-03-24 13:40:19,646 [0d3b1861-d867-40cd-988f-80f5fb631379-ContainerReplicationThread-0] INFO  reconstruction.ECReconstructionCoordinatorTask (ECReconstructionCoordinatorTask.java:runTask(65)) - IN_PROGRESS reconstructECContainersCommand: ...
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/8409345087