### PR TITLE
HDDS-10584. Exclude proto3 classes from coverage

### DIFF
--- a/hadoop-ozone/dev-support/checks/coverage.sh
+++ b/hadoop-ozone/dev-support/checks/coverage.sh
@@ -30,7 +30,7 @@ JACOCO_VERSION=$(mvn help:evaluate -Dexpression=jacoco.version -q -DforceStdout)
 
 #Install jacoco cli
 mvn --non-recursive --no-transfer-progress \
-  org.apache.maven.plugins:maven-dependency-plugin:3.1.2:copy \
+  org.apache.maven.plugins:maven-dependency-plugin:copy \
   -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps
 
 jacoco() {
@@ -49,10 +49,8 @@ find hadoop-ozone/dist/target/*/share/ozone/lib -name 'hdds-*.jar' -or -name 'oz
     xargs -n1 unzip -o -q -d target/coverage-classes
 
 #Exclude some classes from the coverage
-find target/coverage-classes -name proto -type d | xargs rm -rf
-find target/coverage-classes -name generated -type d | xargs rm -rf
-find target/coverage-classes -name v1 -type d | xargs rm -rf
-find target/coverage-classes -name freon -type d | xargs rm -rf
+find target/coverage-classes -type d \( -name proto -or -name proto3 -or -name generated -or -name v1 -or -name freon \) \
+  | xargs rm -rf
 
 #generate the reports
 jacoco report "$REPORT_DIR/jacoco-all.exec" --classfiles target/coverage-classes --html "$REPORT_DIR/all" --xml "$REPORT_DIR/all.xml"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude Protobuf v3 generated code from coverage calculation.

Other minor improvements:
- Combine `find` commands.
- Use version from `pom.xml` for `maven-dependency-plugin`.

https://issues.apache.org/jira/browse/HDDS-10584

## How was this patch tested?

Temporarily enabled coverage for fork build, compared results:

https://github.com/adoroszlai/ozone/actions/runs/8409710921 (without fix)
vs.
https://github.com/adoroszlai/ozone/actions/runs/8409713572 (with fix)