### PR TITLE
HDDS-10510. Improve user experience with containerbalancer CLI

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 public class ContainerBalancerStopSubcommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    System.out.println("ContainerBalancer is in stopping state. Waiting for current iteration to finish");
+    System.out.println("ContainerBalancer is in stopping state. Waiting for current iteration to finish...");
     scmClient.stopContainerBalancer();
-    System.out.println("Stopping ContainerBalancer...");
+    System.out.println("ContainerBalancer stopped.");
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 public class ContainerBalancerStopSubcommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    System.out.println("ContainerBalancer is in stopping state. Waiting for current iteration to finish...");
+    System.out.println("Sending stop command. Waiting for Container Balancer to stop...");
     scmClient.stopContainerBalancer();
-    System.out.println("ContainerBalancer stopped.");
+    System.out.println("Container Balancer stopped.");
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerStopSubcommand.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 public class ContainerBalancerStopSubcommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
+    System.out.println("ContainerBalancer is in stopping state. Waiting for current iteration to finish");
     scmClient.stopContainerBalancer();
     System.out.println("Stopping ContainerBalancer...");
   }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -104,9 +104,9 @@ public class TestContainerBalancerSubCommand {
     ScmClient scmClient = mock(ScmClient.class);
     stopCmd.execute(scmClient);
 
-    Pattern p = Pattern.compile("^ContainerBalancer\\sis\\sin\\sstopping\\sstate." +
-            "\\sWaiting\\sfor\\scurrent\\siteration\\sto\\sfinish...\\n" +
-            "ContainerBalancer\\sstopped.");
+    Pattern p = Pattern.compile("^Sending\\sstop\\scommand." +
+            "\\sWaiting\\sfor\\sContainer\\sBalancer\\sto\\sstop...\\n" +
+            "Container\\sBalancer\\sstopped.");
 
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
     assertTrue(m.find());

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -105,8 +105,9 @@ public class TestContainerBalancerSubCommand {
     stopCmd.execute(scmClient);
 
     Pattern p = Pattern.compile("^ContainerBalancer\\sis\\sin\\sstopping\\sstate." +
-            "\\sWaiting\\sfor\\scurrent\\siteration\\sto\\sfinish\\n" +
-            "Stopping\\sContainerBalancer...");
+            "\\sWaiting\\sfor\\scurrent\\siteration\\sto\\sfinish...\\n" +
+            "ContainerBalancer\\sstopped.");
+
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
     assertTrue(m.find());
   }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -104,7 +104,9 @@ public class TestContainerBalancerSubCommand {
     ScmClient scmClient = mock(ScmClient.class);
     stopCmd.execute(scmClient);
 
-    Pattern p = Pattern.compile("^Stopping\\sContainerBalancer...");
+    Pattern p = Pattern.compile("^ContainerBalancer\\sis\\sin\\sstopping\\sstate." +
+            "\\sWaiting\\sfor\\scurrent\\siteration\\sto\\sfinish\\n" +
+            "Stopping\\sContainerBalancer...");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
     assertTrue(m.find());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`ozone admin containerbalancer stop` command seems stuck and does not return anything while it is in STOPPING state waiting for the current iteration to complete. 
Print progress message to improve the logs for containerbalancer CLI.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10510

## How was this patch tested?
Manually tested this patch using a docker cluster. Also got a clean CI run.

<img width="544" alt="Screenshot 2024-03-26 at 2 16 42 PM" src="https://github.com/apache/ozone/assets/79865743/212a05c8-ceb2-4c4f-851a-2c26757e9c80">



