### PR TITLE
HDDS-10587. Reset the thread-local MessageDigest instance during exception

### DIFF
--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -165,6 +165,11 @@
       <artifactId>hdds-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -217,13 +217,14 @@ public class ObjectEndpoint extends EndpointBase {
       @HeaderParam("Content-Length") long length,
       @QueryParam("partNumber")  int partNumber,
       @QueryParam("uploadId") @DefaultValue("") String uploadID,
-      InputStream body) throws IOException, OS3Exception {
+      final InputStream body) throws IOException, OS3Exception {
     long startNanos = Time.monotonicNowNanos();
     S3GAction s3GAction = S3GAction.CREATE_KEY;
     boolean auditSuccess = true;
     PerformanceStringBuilder perf = new PerformanceStringBuilder();
 
     String copyHeader = null, storageType = null;
+    DigestInputStream digestInputStream = null;
     try {
       OzoneVolume volume = getVolume();
       if (uploadID != null && !uploadID.equals("")) {
@@ -297,11 +298,11 @@ public class ObjectEndpoint extends EndpointBase {
 
       if ("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
           .equals(headers.getHeaderString("x-amz-content-sha256"))) {
-        body = new DigestInputStream(new SignedChunksInputStream(body),
+        digestInputStream = new DigestInputStream(new SignedChunksInputStream(body),
             E_TAG_PROVIDER.get());
         length = Long.parseLong(amzDecodedLength);
       } else {
-        body = new DigestInputStream(body, E_TAG_PROVIDER.get());
+        digestInputStream = new DigestInputStream(body, E_TAG_PROVIDER.get());
       }
 
       long putLength;
@@ -310,7 +311,7 @@ public class ObjectEndpoint extends EndpointBase {
         perf.appendStreamMode();
         Pair<String, Long> keyWriteResult = ObjectEndpointStreaming
             .put(bucket, keyPath, length, replicationConfig, chunkSize,
-                customMetadata, (DigestInputStream) body, perf);
+                customMetadata, (DigestInputStream) digestInputStream, perf);
         eTag = keyWriteResult.getKey();
         putLength = keyWriteResult.getValue();
       } else {
@@ -320,9 +321,9 @@ public class ObjectEndpoint extends EndpointBase {
           long metadataLatencyNs =
               getMetrics().updatePutKeyMetadataStats(startNanos);
           perf.appendMetaLatencyNanos(metadataLatencyNs);
-          putLength = IOUtils.copyLarge(body, output);
+          putLength = IOUtils.copyLarge(digestInputStream, output);
           eTag = DatatypeConverter.printHexBinary(
-                  ((DigestInputStream) body).getMessageDigest().digest())
+                  digestInputStream.getMessageDigest().digest())
               .toLowerCase();
           output.getMetadata().put(ETAG, eTag);
         }
@@ -369,7 +370,9 @@ public class ObjectEndpoint extends EndpointBase {
     } finally {
       // Reset the thread-local message digest instance in case of exception
       // and MessageDigest#digest is never called
-      ((DigestInputStream) body).getMessageDigest().reset();
+      if (digestInputStream != null) {
+        digestInputStream.getMessageDigest().reset();
+      }
       if (auditSuccess) {
         long opLatencyNs = getMetrics().updateCreateKeySuccessStats(startNanos);
         perf.appendOpLatencyNanos(opLatencyNs);
@@ -882,20 +885,21 @@ public class ObjectEndpoint extends EndpointBase {
   @SuppressWarnings({"checkstyle:MethodLength", "checkstyle:ParameterNumber"})
   private Response createMultipartKey(OzoneVolume volume, String bucket,
       String key, long length, int partNumber, String uploadID,
-      InputStream body, PerformanceStringBuilder perf)
+      final InputStream body, PerformanceStringBuilder perf)
       throws IOException, OS3Exception {
     long startNanos = Time.monotonicNowNanos();
     String copyHeader = null;
+    DigestInputStream digestInputStream = null;
     try {
 
       if ("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
           .equals(headers.getHeaderString("x-amz-content-sha256"))) {
-        body = new DigestInputStream(new SignedChunksInputStream(body),
+        digestInputStream = new DigestInputStream(new SignedChunksInputStream(body),
             E_TAG_PROVIDER.get());
         length = Long.parseLong(
             headers.getHeaderString(DECODED_CONTENT_LENGTH_HEADER));
       } else {
-        body = new DigestInputStream(body, E_TAG_PROVIDER.get());
+        digestInputStream = new DigestInputStream(body, E_TAG_PROVIDER.get());
       }
 
       copyHeader = headers.getHeaderString(COPY_SOURCE_HEADER);
@@ -915,7 +919,7 @@ public class ObjectEndpoint extends EndpointBase {
         perf.appendStreamMode();
         return ObjectEndpointStreaming
             .createMultipartKey(ozoneBucket, key, length, partNumber,
-                uploadID, chunkSize, (DigestInputStream) body, perf);
+                uploadID, chunkSize, digestInputStream, perf);
       }
       // OmMultipartCommitUploadPartInfo can only be gotten after the
       // OzoneOutputStream is closed, so we need to save the KeyOutputStream
@@ -996,10 +1000,10 @@ public class ObjectEndpoint extends EndpointBase {
                 partNumber, uploadID)) {
           metadataLatencyNs =
               getMetrics().updatePutKeyMetadataStats(startNanos);
-          putLength = IOUtils.copyLarge(body, ozoneOutputStream);
+          putLength = IOUtils.copyLarge(digestInputStream, ozoneOutputStream);
           ((KeyMetadataAware)ozoneOutputStream.getOutputStream())
               .getMetadata().put(ETAG, DatatypeConverter.printHexBinary(
-                      ((DigestInputStream) body).getMessageDigest().digest())
+                      digestInputStream.getMessageDigest().digest())
                   .toLowerCase());
           keyOutputStream
               = ozoneOutputStream.getKeyOutputStream();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -1049,6 +1049,12 @@ public class ObjectEndpoint extends EndpointBase {
         throw os3Exception;
       }
       throw ex;
+    } finally {
+      // Reset the thread-local message digest instance in case of exception
+      // and MessageDigest#digest is never called
+      if (digestInputStream != null) {
+        digestInputStream.getMessageDigest().reset();
+      }
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -367,6 +367,8 @@ public class ObjectEndpoint extends EndpointBase {
       }
       throw ex;
     } finally {
+      // Reset the thread-local message digest instance in case of exception
+      // and MessageDigest#digest is never called
       ((DigestInputStream) body).getMessageDigest().reset();
       if (auditSuccess) {
         long opLatencyNs = getMetrics().updateCreateKeySuccessStats(startNanos);
@@ -1221,6 +1223,8 @@ public class ObjectEndpoint extends EndpointBase {
       }
       throw ex;
     } finally {
+      // Reset the thread-local message digest instance in case of exception
+      // and MessageDigest#digest is never called
       if (sourceDigestInputStream != null) {
         sourceDigestInputStream.getMessageDigest().reset();
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -299,10 +299,10 @@ public class ObjectEndpoint extends EndpointBase {
       if ("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
           .equals(headers.getHeaderString("x-amz-content-sha256"))) {
         digestInputStream = new DigestInputStream(new SignedChunksInputStream(body),
-            E_TAG_PROVIDER.get());
+            getMessageDigestInstance());
         length = Long.parseLong(amzDecodedLength);
       } else {
-        digestInputStream = new DigestInputStream(body, E_TAG_PROVIDER.get());
+        digestInputStream = new DigestInputStream(body, getMessageDigestInstance());
       }
 
       long putLength;
@@ -895,11 +895,11 @@ public class ObjectEndpoint extends EndpointBase {
       if ("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
           .equals(headers.getHeaderString("x-amz-content-sha256"))) {
         digestInputStream = new DigestInputStream(new SignedChunksInputStream(body),
-            E_TAG_PROVIDER.get());
+            getMessageDigestInstance());
         length = Long.parseLong(
             headers.getHeaderString(DECODED_CONTENT_LENGTH_HEADER));
       } else {
-        digestInputStream = new DigestInputStream(body, E_TAG_PROVIDER.get());
+        digestInputStream = new DigestInputStream(body, getMessageDigestInstance());
       }
 
       copyHeader = headers.getHeaderString(COPY_SOURCE_HEADER);
@@ -1209,7 +1209,7 @@ public class ObjectEndpoint extends EndpointBase {
       try (OzoneInputStream src = getClientProtocol().getKey(volume.getName(),
           sourceBucket, sourceKey)) {
         getMetrics().updateCopyKeyMetadataStats(startNanos);
-        sourceDigestInputStream = new DigestInputStream(src, E_TAG_PROVIDER.get());
+        sourceDigestInputStream = new DigestInputStream(src, getMessageDigestInstance());
         copy(volume, sourceDigestInputStream, sourceKeyLen, destkey, destBucket, replicationConfig,
                 sourceKeyDetails.getMetadata(), perf, startNanos);
       }
@@ -1336,6 +1336,11 @@ public class ObjectEndpoint extends EndpointBase {
 
   private String wrapInQuotes(String value) {
     return "\"" + value + "\"";
+  }
+
+  @VisibleForTesting
+  public MessageDigest getMessageDigestInstance() {
+    return E_TAG_PROVIDER.get();
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -311,7 +311,7 @@ public class ObjectEndpoint extends EndpointBase {
         perf.appendStreamMode();
         Pair<String, Long> keyWriteResult = ObjectEndpointStreaming
             .put(bucket, keyPath, length, replicationConfig, chunkSize,
-                customMetadata, (DigestInputStream) digestInputStream, perf);
+                customMetadata, digestInputStream, perf);
         eTag = keyWriteResult.getKey();
         putLength = keyWriteResult.getValue();
       } else {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -23,6 +23,8 @@ package org.apache.hadoop.ozone.s3.endpoint;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.MessageDigest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.IOUtils;
@@ -46,6 +48,7 @@ import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.DECODED_CONTENT_LENGTH_HEADER;
@@ -57,10 +60,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -88,7 +94,7 @@ public class TestObjectPut {
     clientStub.getObjectStore().createS3Bucket(destBucket);
 
     // Create PutObject and setClient to OzoneClientStub
-    objectEndpoint = new ObjectEndpoint();
+    objectEndpoint = spy(new ObjectEndpoint());
     objectEndpoint.setClient(clientStub);
     objectEndpoint.setOzoneConfiguration(new OzoneConfiguration());
   }
@@ -227,6 +233,31 @@ public class TestObjectPut {
   }
 
   @Test
+  public void testPutObjectMessageDigestResetDuringException() throws OS3Exception {
+    MessageDigest messageDigest = mock(MessageDigest.class);
+    try (MockedStatic<IOUtils> mocked = mockStatic(IOUtils.class)) {
+      // For example, EOFException during put-object due to client cancelling the operation before it completes
+      mocked.when(() -> IOUtils.copyLarge(any(InputStream.class), any(OutputStream.class)))
+          .thenThrow(IOException.class);
+      when(objectEndpoint.getMessageDigestInstance()).thenReturn(messageDigest);
+
+      HttpHeaders headers = mock(HttpHeaders.class);
+      ByteArrayInputStream body =
+          new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
+      objectEndpoint.setHeaders(headers);
+      try {
+        objectEndpoint.put(bucketName, keyName, CONTENT
+            .length(), 1, null, body);
+        fail("Should throw IOException");
+      } catch (IOException ignored) {
+        // Verify that the message digest is reset so that the instance can be reused for the
+        // next request in the same thread
+        verify(messageDigest, times(1)).reset();
+      }
+    }
+  }
+
+  @Test
   public void testCopyObject() throws IOException, OS3Exception {
     // Put object in to source bucket
     HttpHeaders headers = mock(HttpHeaders.class);
@@ -312,6 +343,53 @@ public class TestObjectPut {
         "nonexistent", keyName, CONTENT.length(), 1, null, body),
         "test copy object failed");
     assertThat(e.getCode()).contains("NoSuchBucket");
+  }
+
+  @Test
+  public void testCopyObjectMessageDigestResetDuringException() throws IOException, OS3Exception {
+    // Put object in to source bucket
+    HttpHeaders headers = mock(HttpHeaders.class);
+    ByteArrayInputStream body =
+        new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
+    objectEndpoint.setHeaders(headers);
+    keyName = "sourceKey";
+
+    Response response = objectEndpoint.put(bucketName, keyName,
+        CONTENT.length(), 1, null, body);
+
+    OzoneInputStream ozoneInputStream = clientStub.getObjectStore()
+        .getS3Bucket(bucketName)
+        .readKey(keyName);
+
+    String keyContent = IOUtils.toString(ozoneInputStream, UTF_8);
+    OzoneKeyDetails keyDetails = clientStub.getObjectStore().getS3Bucket(bucketName).getKey(keyName);
+
+    assertEquals(200, response.getStatus());
+    assertEquals(CONTENT, keyContent);
+    assertNotNull(keyDetails.getMetadata());
+    assertTrue(StringUtils.isNotEmpty(keyDetails.getMetadata().get(OzoneConsts.ETAG)));
+
+    MessageDigest messageDigest = mock(MessageDigest.class);
+    try (MockedStatic<IOUtils> mocked = mockStatic(IOUtils.class)) {
+      // Add the mocked methods only during the copy request
+      when(objectEndpoint.getMessageDigestInstance()).thenReturn(messageDigest);
+      mocked.when(() -> IOUtils.copyLarge(any(InputStream.class), any(OutputStream.class)))
+          .thenThrow(IOException.class);
+
+      // Add copy header, and then call put
+      when(headers.getHeaderString(COPY_SOURCE_HEADER)).thenReturn(
+          bucketName  + "/" + urlEncode(keyName));
+
+      try {
+        objectEndpoint.put(destBucket, destkey, CONTENT.length(), 1,
+            null, body);
+        fail("Should throw IOException");
+      } catch (IOException ignored) {
+        // Verify that the message digest is reset so that the instance can be reused for the
+        // next request in the same thread
+        verify(messageDigest, times(1)).reset();
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the MessageDigest instance is a thread local variable (one per S3G Jetty thread). MessageDigest requires the call to either `MessageDigest#digest` or `MessageDigest#reset` to reset the digest.

In normal ObjectEndpoint#put flow, MessageDigest#digest is called after the data has been written to the datanodes, before the key is committed. However, **if an IOException happens (e.g. EOFException due to client cancelling during the write), the digest will not be reset and remains in the inconsistent state.** This will affect the subsequent request that uses the same thread and therefore the ETag generated will be completely different from the md5 hash of the object causing AWS S3 SDK to detect inconsistent hash when downloading the object.

The issue can be replicated using an S3G with a few threads and doing three put-object operations for the same key and same payload. You can set the `hadoop.http.max.threads` in `ozone-site.xml` to a small value (e.g. 4) to increase the chance of the same thread handling the request.

- 1st put-object: cancel the operation before it put-object operation can finish, ensure the EOFException is thrown in the S3Gateway logs

- 2nd put-object: let the put-object finish. The resulting ETag will not be the same as the md5 digest of the payload (you might need to do this for a few time since the S3G thread might not be the same from the previous call)

- 3rd put-object: also let the put-object finish. Since the previous put-object reset the digest, the resulting ETag will be correct. 

This patch adds a call to `MessageDigest#reset` in ObjectEndpoint#put to reset the digest in case of exception. Another valid alternative is to call the `MessageDigest#reset` just after the `DigestInputStream` initialization.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10587

## How was this patch tested?

Manual test from Ozone Intellij IDE setup as shown in the description.

Ref: https://cwiki.apache.org/confluence/display/OZONE/Run+Ozone+cluster+from+IDE

Clean CI run: https://github.com/ivandika3/ozone/actions/runs/8421982154
