### PR TITLE
HDDS-10407. Introduce metrics for deleteKey operation in SCM service.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
@@ -1,0 +1,65 @@
+package org.apache.hadoop.hdds.scm.container.placement.metrics;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.metrics2.*;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.*;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.util.Time;
+
+@InterfaceAudience.Private
+@Metrics(about = "SCM Performance Metrics", context = OzoneConsts.OZONE)
+public final class SCMPerformanceMetrics implements MetricsSource {
+  private static final String SOURCE_NAME =
+      SCMPerformanceMetrics.class.getSimpleName();
+
+  private MetricsRegistry registry;
+  private static SCMPerformanceMetrics instance;
+
+  @Metric private MutableCounterLong deleteKeyFailure;
+  @Metric private MutableCounterLong deleteKeySuccess;
+  @Metric(about = "Latency for deleteKey failure in nanoseconds")
+  private MutableRate deleteKeyFailureLatencyNs;
+  @Metric(about = "Latency for deleteKey success in nanoseconds")
+  private MutableRate deleteKeySuccessLatencyNs;
+
+  public SCMPerformanceMetrics() {
+    this.registry = new MetricsRegistry(SOURCE_NAME);
+  }
+
+  public static SCMPerformanceMetrics create() {
+    if (instance != null) {
+      return instance;
+    }
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    instance = ms.register(SOURCE_NAME, "SCM Performance Metrics",
+        new SCMPerformanceMetrics());
+    return instance;
+  }
+
+  public void unRegister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(SOURCE_NAME);
+  }
+
+  @Override
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    MetricsRecordBuilder recordBuilder = collector.addRecord(SOURCE_NAME);
+    deleteKeySuccess.snapshot(recordBuilder, true);
+    deleteKeySuccessLatencyNs.snapshot(recordBuilder, true);
+    deleteKeyFailure.snapshot(recordBuilder, true);
+    deleteKeyFailureLatencyNs.snapshot(recordBuilder, true);
+  }
+
+  public void updateDeleteKeySuccessStats(long startNanos) {
+    deleteKeySuccess.incr();
+    deleteKeySuccessLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+
+  public void updateDeleteKeyFailureStats(long startNanos) {
+    deleteKeyFailure.incr();
+    deleteKeyFailureLatencyNs.add(Time.monotonicNowNanos() - startNanos);
+  }
+}
+

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
@@ -44,8 +44,10 @@ public final class SCMPerformanceMetrics implements MetricsSource {
   private MetricsRegistry registry;
   private static SCMPerformanceMetrics instance;
 
-  @Metric private MutableCounterLong deleteKeyFailure;
-  @Metric private MutableCounterLong deleteKeySuccess;
+  @Metric(about = "Number of failed deleteKey operations")
+  private MutableCounterLong deleteKeyFailure;
+  @Metric(about = "Number of successful deleteKey operations")
+  private MutableCounterLong deleteKeySuccess;
   @Metric(about = "Latency for deleteKey failure in nanoseconds")
   private MutableRate deleteKeyFailureLatencyNs;
   @Metric(about = "Latency for deleteKey success in nanoseconds")

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMPerformanceMetrics.java
@@ -1,13 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hdds.scm.container.placement.metrics;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
-import org.apache.hadoop.metrics2.*;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
-import org.apache.hadoop.metrics2.lib.*;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.util.Time;
 
+/**
+ * Including SCM performance related metrics.
+ */
 @InterfaceAudience.Private
 @Metrics(about = "SCM Performance Metrics", context = OzoneConsts.OZONE)
 public final class SCMPerformanceMetrics implements MetricsSource {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -274,7 +274,7 @@ public class SCMBlockProtocolServer implements
           DeleteScmBlockResult.Result.success;
     } catch (IOException ioe) {
       e = ioe;
-     perfMetrics.updateDeleteKeyFailureStats(startNanos);
+      perfMetrics.updateDeleteKeyFailureStats(startNanos);
       LOG.warn("Fail to delete {} keys", keyBlocksInfoList.size(), ioe);
       switch (ioe instanceof SCMException ? ((SCMException) ioe).getResult() :
           IO_EXCEPTION) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
 import org.apache.hadoop.hdds.scm.PlacementPolicyValidateProxy;
 import org.apache.hadoop.hdds.scm.container.balancer.MoveManager;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMPerformanceMetrics;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaPendingOps;
 import org.apache.hadoop.hdds.scm.container.replication.DatanodeCommandCountUpdatedHandler;
 import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
@@ -236,6 +237,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    * SCM metrics.
    */
   private static SCMMetrics metrics;
+  private static SCMPerformanceMetrics perfMetrics;
   private SCMHAMetrics scmHAMetrics;
 
   /*
@@ -1428,6 +1430,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    */
   public static SCMMetrics getMetrics() {
     return metrics == null ? SCMMetrics.create() : metrics;
+  }
+
+  public static SCMPerformanceMetrics getPerfMetrics() {
+    return perfMetrics == null ? SCMPerformanceMetrics.create() : perfMetrics;
   }
 
   public SCMStorageConfig getScmStorageConfig() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -369,6 +369,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     scmHANodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf, scmStorageConfig);
     configuration = conf;
     initMetrics();
+    initPerfMetrics();
 
     boolean ratisEnabled = SCMHAUtils.isSCMHAEnabled(conf);
     if (scmStorageConfig.getState() != StorageState.INITIALIZED) {
@@ -1431,7 +1432,15 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   public static SCMMetrics getMetrics() {
     return metrics == null ? SCMMetrics.create() : metrics;
   }
-
+  /**
+   * Initialize SCMPerformance metrics.
+   */
+  public static void initPerfMetrics() {
+    perfMetrics = SCMPerformanceMetrics.create();
+  }
+  /**
+   * Return SCMPerformance metrics instance.
+   */
   public static SCMPerformanceMetrics getPerfMetrics() {
     return perfMetrics == null ? SCMPerformanceMetrics.create() : perfMetrics;
   }
@@ -1722,6 +1731,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     if (metrics != null) {
       metrics.unRegister();
+    }
+
+    if (perfMetrics != null) {
+      perfMetrics.unRegister();
     }
 
     unregisterMXBean();


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this PR few performance metrics are introduced in SCM Service for deleteKey operation.

Please describe your PR in detail:
In this PR following metrics are introduced in SCM service for deleteKey operation:
- deleteKeyFailure
- deleteKeySuccess
- deleteKeyFailureLatencyNs
- deleteKeySuccessLatencyNs

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10407

## How was this patch tested?

Tested manually on the cluster.