### PR TITLE
HDDS-10589. set the net.minidev:json-smart dependency version up to 2.5.0

### DIFF
--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -1,8 +1,10 @@
+share/ozone/lib/accessors-smart.jar
 share/ozone/lib/animal-sniffer-annotations.jar
 share/ozone/lib/annotations.jar
 share/ozone/lib/annotations.jar
 share/ozone/lib/aopalliance.jar
 share/ozone/lib/aopalliance-repackaged.jar
+share/ozone/lib/asm.jar
 share/ozone/lib/aspectjrt.jar
 share/ozone/lib/aspectjweaver.jar
 share/ozone/lib/aws-java-sdk-core.jar
@@ -154,6 +156,7 @@ share/ozone/lib/jooq.jar
 share/ozone/lib/jooq-meta.jar
 share/ozone/lib/jsch.jar
 share/ozone/lib/json-simple.jar
+share/ozone/lib/json-smart.jar
 share/ozone/lib/jsp-api.jar
 share/ozone/lib/jsr311-api.jar
 share/ozone/lib/kerb-core.jar

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -84,7 +84,16 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>${net.minidev.json-smart.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.reload4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <properties.maven.plugin.version>1.2.1</properties.maven.plugin.version>
     <maven.core.version>3.9.6</maven.core.version>
     <snappy-java.version>1.1.10.5</snappy-java.version>
+    <net.minidev.json-smart.version>2.5.0</net.minidev.json-smart.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?
ozone-filesystem-hadoop2 transitively depends on net.minidev:json-smart:2.3 that contains a CVE-2021-31684:

https://nvd.nist.gov/vuln/detail/CVE-2021-31684
https://github.com/netplex/json-smart-v2/issues/67

The version of the library needs to be upgraded to 2.5.0

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10589

## How was this patch tested?

Existing hadoop related robot tests
