### PR TITLE
HDDS-10524. [Snapshot] Invalidate the cache entry from snapshotInfoTable cache in OMSnapshotPurgeRequest

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -718,7 +718,7 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
   @Override
   public String toString() {
     return "SnapshotInfo{" +
-        ", snapshotId: '" + snapshotId + '\'' +
+        "snapshotId: '" + snapshotId + '\'' +
         ", name: '" + name + "'," +
         ", volumeName: '" + volumeName + '\'' +
         ", bucketName: '" + bucketName + '\'' +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -362,14 +362,15 @@ public class SnapshotChainManager {
   public synchronized boolean deleteSnapshot(SnapshotInfo snapshotInfo)
       throws IOException {
     validateSnapshotChain();
-    return deleteSnapshotGlobal(snapshotInfo.getSnapshotId()) &&
+    boolean status = deleteSnapshotGlobal(snapshotInfo.getSnapshotId()) &&
         deleteSnapshotPath(snapshotInfo.getSnapshotPath(),
             snapshotInfo.getSnapshotId());
+    if (status) {
+      snapshotIdToTableKey.remove(snapshotInfo.getSnapshotId());
+    }
+    return status;
   }
 
-  public synchronized void deleteSnapshotFromSnapshotIdToTableKey(UUID snapshotId) {
-    snapshotIdToTableKey.remove(snapshotId);
-  }
   /**
    * Get latest global snapshot in snapshot chain.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -362,15 +362,14 @@ public class SnapshotChainManager {
   public synchronized boolean deleteSnapshot(SnapshotInfo snapshotInfo)
       throws IOException {
     validateSnapshotChain();
-    boolean status = deleteSnapshotGlobal(snapshotInfo.getSnapshotId()) &&
+    return deleteSnapshotGlobal(snapshotInfo.getSnapshotId()) &&
         deleteSnapshotPath(snapshotInfo.getSnapshotPath(),
             snapshotInfo.getSnapshotId());
-    if (status) {
-      snapshotIdToTableKey.remove(snapshotInfo.getSnapshotId());
-    }
-    return status;
   }
 
+  public synchronized void deleteSnapshotFromSnapshotIdToTableKey(UUID snapshotId) {
+    snapshotIdToTableKey.remove(snapshotId);
+  }
   /**
    * Get latest global snapshot in snapshot chain.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -102,7 +102,11 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
             trxnLogIndex, updatedSnapInfos);
         updateSnapshotChainAndCache(omMetadataManager, fromSnapshot,
             trxnLogIndex, updatedPathPreviousAndGlobalSnapshots);
+        // Remove and close snapshot's RocksDB instance from SnapshotCache.
         ozoneManager.getOmSnapshotManager().invalidateCacheEntry(fromSnapshot.getSnapshotId());
+        // Update SnapshotInfoTable cache.
+        ozoneManager.getMetadataManager().getSnapshotInfoTable()
+            .addCacheEntry(new CacheKey<>(fromSnapshot.getTableKey()), CacheValue.get(trxnLogIndex));
       }
 
       omClientResponse = new OMSnapshotPurgeResponse(omResponse.build(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
@@ -84,8 +84,9 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
     updateSnapInfo(metadataManager, batchOperation,
         updatedPreviousAndGlobalSnapInfos);
     for (String dbKey: snapshotDbKeys) {
+      // Skip the cache here because snapshot is purged from cache in OMSnapshotPurgeRequest.
       SnapshotInfo snapshotInfo = omMetadataManager
-          .getSnapshotInfoTable().get(dbKey);
+          .getSnapshotInfoTable().getSkipCache(dbKey);
       // Even though snapshot existed when SnapshotDeletingService
       // was running. It might be deleted in the previous run and
       // the DB might not have been updated yet. So snapshotInfo
@@ -96,8 +97,9 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
 
       // Delete Snapshot checkpoint directory.
       deleteCheckpointDirectory(omMetadataManager, snapshotInfo);
-      omMetadataManager.getSnapshotInfoTable().deleteWithBatch(batchOperation,
-          dbKey);
+      omMetadataManager.getSnapshotInfoTable().deleteWithBatch(batchOperation, dbKey);
+      ((OmMetadataManagerImpl) omMetadataManager).getSnapshotChainManager()
+          .deleteSnapshotFromSnapshotIdToTableKey(snapshotInfo.getSnapshotId());
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
@@ -98,8 +98,6 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
       // Delete Snapshot checkpoint directory.
       deleteCheckpointDirectory(omMetadataManager, snapshotInfo);
       omMetadataManager.getSnapshotInfoTable().deleteWithBatch(batchOperation, dbKey);
-      ((OmMetadataManagerImpl) omMetadataManager).getSnapshotChainManager()
-          .deleteSnapshotFromSnapshotIdToTableKey(snapshotInfo.getSnapshotId());
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotPurgeRequestAndResponse.java
@@ -67,6 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -77,8 +78,6 @@ import static org.mockito.Mockito.when;
  * Tests OMSnapshotPurgeRequest class.
  */
 public class TestOMSnapshotPurgeRequestAndResponse {
-
-  private BatchOperation batchOperation;
   private List<Path> checkpointPaths = new ArrayList<>();
 
   private OzoneManager ozoneManager;
@@ -177,7 +176,6 @@ public class TestOMSnapshotPurgeRequestAndResponse {
   private void createSnapshotCheckpoint(String volume,
                                         String bucket,
                                         String snapshotName) throws Exception {
-    batchOperation = omMetadataManager.getStore().initBatchOperation();
     OMRequest omRequest = OMRequestTestUtils
         .createSnapshotRequest(volume, bucket, snapshotName);
     // Pre-Execute OMSnapshotCreateRequest.
@@ -188,9 +186,10 @@ public class TestOMSnapshotPurgeRequestAndResponse {
     OMSnapshotCreateResponse omClientResponse = (OMSnapshotCreateResponse)
         omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 1);
     // Add to batch and commit to DB.
-    omClientResponse.addToDBBatch(omMetadataManager, batchOperation);
-    omMetadataManager.getStore().commitBatchOperation(batchOperation);
-    batchOperation.close();
+    try (BatchOperation batchOperation = omMetadataManager.getStore().initBatchOperation()) {
+      omClientResponse.addToDBBatch(omMetadataManager, batchOperation);
+      omMetadataManager.getStore().commitBatchOperation(batchOperation);
+    }
 
     String key = SnapshotInfo.getTableKey(volume, bucket, snapshotName);
     SnapshotInfo snapshotInfo =
@@ -226,9 +225,10 @@ public class TestOMSnapshotPurgeRequestAndResponse {
         omSnapshotPurgeRequest.validateAndUpdateCache(ozoneManager, 200L);
 
     // Commit to DB.
-    batchOperation = omMetadataManager.getStore().initBatchOperation();
-    omSnapshotPurgeResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
-    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+    try (BatchOperation batchOperation = omMetadataManager.getStore().initBatchOperation()) {
+      omSnapshotPurgeResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+      omMetadataManager.getStore().commitBatchOperation(batchOperation);
+    }
   }
 
   @Test
@@ -238,7 +238,20 @@ public class TestOMSnapshotPurgeRequestAndResponse {
     assertFalse(omMetadataManager.getSnapshotInfoTable().isEmpty());
     OMRequest snapshotPurgeRequest = createPurgeKeysRequest(
         snapshotDbKeysToPurge);
-    purgeSnapshots(snapshotPurgeRequest);
+
+    OMSnapshotPurgeRequest omSnapshotPurgeRequest = preExecute(snapshotPurgeRequest);
+
+    OMSnapshotPurgeResponse omSnapshotPurgeResponse = (OMSnapshotPurgeResponse)
+        omSnapshotPurgeRequest.validateAndUpdateCache(ozoneManager, 200L);
+
+    for (String snapshotTableKey: snapshotDbKeysToPurge) {
+      assertNull(omMetadataManager.getSnapshotInfoTable().get(snapshotTableKey));
+    }
+
+    try (BatchOperation batchOperation = omMetadataManager.getStore().initBatchOperation()) {
+      omSnapshotPurgeResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+      omMetadataManager.getStore().commitBatchOperation(batchOperation);
+    }
 
     // Check if the entries are deleted.
     assertTrue(omMetadataManager.getSnapshotInfoTable().isEmpty());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently when snapshot is purged, it is not removed from the snapshotInfoTable cache. Because of which it is possible that a purged snapshot is added by `SnapshotSetProperty` API.

`KeyDeletingService` and `SnapshotDeletingService` are two background service which run in parallel.
1). KeyDeletingService updates deep clean flag and exclusive size for a snapshot.
2). SnapshotDeletingService purges a deleted snapshot.

KeyDeletionService will try to mark a snapshot deep clean here: [code](https://github.com/apache/ozone/blob/2f2234c7b61714404399ada8f31b3fb4772b613a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java#L475)
Since it is in a loop, it is possible when KeyDeletingService is going over all the snapshot. Meanwhile user deletes the snapshot, SnapshotDeletingService kicks in and purge the snapshot [code here](https://github.com/apache/ozone/blob/2f2234c7b61714404399ada8f31b3fb4772b613a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java#L457).
Now when `OMSnapshotSetPropertyRequest` gets request to update deep clean for the same snapshot (purged by SnapshotDeletingService), it gets the value from cache because we don’t purge snapshot from cache on the purge path and wait for double buffer flush.
Now there are two transaction in double buffer one for purge and other for updating deep clean.  Some time snapshot can be present in the cache and sometime it doesn’t. When it has snapshot in cache, it causes snapshot chain corruption because both of the transaction will succeed.

In this change, we are invalidating the cache entry in `OMSnapshotPurgeRequest` so that other APIs don't see the snapshot.

## What is the link to the Apache JIRA
HDDS-10524

## How was this patch tested?
1. Wrote a [test](https://github.com/hemantk-12/ozone/blob/HDDS-10524-with-fix/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotDeletingService.java#L577) to mimic the same behavior as in described in the details. This test was run against existing code and with fix. It failed all the time in the existing code and passed in fixed code.
    - Flaky test workflow run without fix: https://github.com/hemantk-12/ozone/actions/runs/8431100252/job/23088281011
    - Flaky test workflow run with fix: https://github.com/hemantk-12/ozone/actions/runs/8431105487/job/23088316218


2. Also updated existing unit test to validate before and after snapshot purge transaction is committed.