### PR TITLE
HDDS-10591. [hsync] improve block token refresh message.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -440,7 +440,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         LOG.debug(message + " on the pipeline {}.",
                 processForDebug(request), pipeline);
       } else {
-        LOG.error(message + " on the pipeline {}.",
+        LOG.warn(message + " on the pipeline {}.",
                 request.getCmdType(), pipeline);
       }
       throw ioException;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -236,8 +236,6 @@ public class BlockInputStream extends BlockExtendedInputStream {
           tokenId.readFromByteArray(tokenRef.get().getIdentifier());
           LOG.info("A new token is added for block {}. Expiry: {}",
               blockID, Instant.ofEpochMilli(tokenId.getExpiryDate()));
-        } else {
-          LOG.warn("Unable to add a new block token for block {}", blockID);
         }
       }
     } else {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -230,8 +230,8 @@ public class BlockInputStream extends BlockExtendedInputStream {
         LOG.info("New pipeline for block {}: {}", blockID,
             blockLocationInfo.getPipeline());
 
+        tokenRef.set(blockLocationInfo.getToken());
         if (blockLocationInfo.getToken() != null) {
-          tokenRef.set(blockLocationInfo.getToken());
           OzoneBlockTokenIdentifier tokenId = new OzoneBlockTokenIdentifier();
           tokenId.readFromByteArray(tokenRef.get().getIdentifier());
           LOG.info("A new token is added for block {}. Expiry: {}",

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.scm.storage;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -223,13 +224,15 @@ public class BlockInputStream extends BlockExtendedInputStream {
       LOG.debug("Re-fetching pipeline and block token for block {}", blockID);
       BlockLocationInfo blockLocationInfo = refreshFunction.apply(blockID);
       if (blockLocationInfo == null) {
-        LOG.debug("No new block location info for block {}", blockID);
+        LOG.warn("No new block location info for block {}", blockID);
       } else {
+        OzoneBlockTokenIdentifier tokenId = new OzoneBlockTokenIdentifier();
+        tokenId.readFromByteArray(blockLocationInfo.getToken().getIdentifier());
         setPipeline(blockLocationInfo.getPipeline());
         tokenRef.set(blockLocationInfo.getToken());
         LOG.info("New pipeline for block {}: {}", blockID,
             blockLocationInfo.getPipeline());
-        LOG.info("A new token is added {}", blockLocationInfo.getToken());
+        LOG.info("A new token is added. Expiry: {}", Instant.ofEpochMilli(tokenId.getExpiryDate()));
       }
     } else {
       throw cause;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -217,7 +217,7 @@ public class BlockInputStream extends BlockExtendedInputStream {
   }
 
   private void refreshBlockInfo(IOException cause) throws IOException {
-    LOG.info("Unable to read information for block {} from pipeline {}: {}",
+    LOG.info("Attempting to update pipeline and block token for block {} from pipeline {}: {}",
         blockID, pipelineRef.get().getId(), cause.getMessage());
     if (refreshFunction != null) {
       LOG.debug("Re-fetching pipeline and block token for block {}", blockID);
@@ -225,10 +225,11 @@ public class BlockInputStream extends BlockExtendedInputStream {
       if (blockLocationInfo == null) {
         LOG.debug("No new block location info for block {}", blockID);
       } else {
-        LOG.debug("New pipeline for block {}: {}", blockID,
-            blockLocationInfo.getPipeline());
         setPipeline(blockLocationInfo.getPipeline());
         tokenRef.set(blockLocationInfo.getToken());
+        LOG.info("New pipeline for block {}: {}", blockID,
+            blockLocationInfo.getPipeline());
+        LOG.info("A new token is added {}", blockLocationInfo.getToken());
       }
     } else {
       throw cause;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -226,13 +226,19 @@ public class BlockInputStream extends BlockExtendedInputStream {
       if (blockLocationInfo == null) {
         LOG.warn("No new block location info for block {}", blockID);
       } else {
-        OzoneBlockTokenIdentifier tokenId = new OzoneBlockTokenIdentifier();
-        tokenId.readFromByteArray(blockLocationInfo.getToken().getIdentifier());
         setPipeline(blockLocationInfo.getPipeline());
-        tokenRef.set(blockLocationInfo.getToken());
         LOG.info("New pipeline for block {}: {}", blockID,
             blockLocationInfo.getPipeline());
-        LOG.info("A new token is added. Expiry: {}", Instant.ofEpochMilli(tokenId.getExpiryDate()));
+
+        if (blockLocationInfo.getToken() != null) {
+          tokenRef.set(blockLocationInfo.getToken());
+          OzoneBlockTokenIdentifier tokenId = new OzoneBlockTokenIdentifier();
+          tokenId.readFromByteArray(tokenRef.get().getIdentifier());
+          LOG.info("A new token is added for block {}. Expiry: {}",
+              blockID, Instant.ofEpochMilli(tokenId.getExpiryDate()));
+        } else {
+          LOG.warn("Unable to add a new block token for block {}", blockID);
+        }
       }
     } else {
       throw cause;


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10591. [hsync] improve block token refresh message.

Please describe your PR in detail:
Usually an expired block token received by a DataNode is refreshed properly. However the relevant log messages look scary and confusing.

* Some of the logs should tone down. Instead of ERROR, it should be a WARN, because the exception will be retried.
* The log messages surrounding block token refresh should be more clear.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10591

## How was this patch tested?

Log message only. Existing unit tests should suffice.