### PR TITLE
HDDS-10594. File encryption info is not properly set when overwrite a file

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -284,6 +284,17 @@ class TestOzoneAtRestEncryption {
       out.write(value.getBytes(StandardCharsets.UTF_8));
     }
     verifyKeyData(bucket, keyName, value, testStartTime);
+    OzoneKeyDetails key1 = bucket.getKey(keyName);
+
+    // Overwrite the key
+    try (OzoneOutputStream out = bucket.createKey(keyName,
+        value.getBytes(StandardCharsets.UTF_8).length,
+        ReplicationConfig.fromTypeAndFactor(RATIS, ONE),
+        new HashMap<>())) {
+      out.write(value.getBytes(StandardCharsets.UTF_8));
+    }
+    OzoneKeyDetails key2 = bucket.getKey(keyName);
+    assertNotEquals(key1.getFileEncryptionInfo().toString(), key2.getFileEncryptionInfo().toString());
   }
 
   static void createAndVerifyFileSystemData(
@@ -324,7 +335,6 @@ class TestOzoneAtRestEncryption {
       fileContent = new byte[value.getBytes(StandardCharsets.UTF_8).length];
       len = is.read(fileContent);
     }
-
 
     assertEquals(len, value.length());
     assertTrue(verifyRatisReplication(bucket.getVolumeName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -779,6 +779,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
       dbKeyInfo.getMetadata().clear();
       dbKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
           keyArgs.getMetadataList()));
+
+      dbKeyInfo.setFileEncryptionInfo(encInfo);
       return dbKeyInfo;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
fix the issue that a overwrite file's encryption info is not properly set. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10594

## How was this patch tested?

new unit test logic
