### PR TITLE
HDDS-10483. Container Balancer should only move containers with size greater than 0 bytes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
@@ -152,11 +152,12 @@ public class FindSourceGreedy implements FindSourceStrategy {
     if (sizeLeavingNode.containsKey(source)) {
       long sizeLeavingAfterMove = sizeLeavingNode.get(source) + size;
       //size can be moved out of source datanode only when the following
-      //two condition are met.
+      //three conditions are met.
       //1 sizeLeavingAfterMove does not succeed the configured
       // MaxSizeLeavingTarget
       //2 after subtracting sizeLeavingAfterMove, the usage is bigger
       // than or equal to lowerLimit
+      //3 size should be greater than zero bytes
       if (sizeLeavingAfterMove > config.getMaxSizeLeavingSource()) {
         LOG.debug("{} bytes cannot leave datanode {} because 'size.leaving" +
                 ".source.max' limit is {} and {} bytes have already left.",
@@ -169,6 +170,10 @@ public class FindSourceGreedy implements FindSourceStrategy {
         LOG.debug("{} bytes cannot leave datanode {} because its utilization " +
                 "will drop below the lower limit of {}.", size,
             source.getUuidString(), lowerLimit);
+        return false;
+      }
+      if (size <= 0) {
+        LOG.debug("{} bytes container cannot leave datanode {}", size, source.getUuidString());
         return false;
       }
       return true;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -1219,10 +1219,10 @@ public class TestContainerBalancerTask {
       // create containers with varying used space
       int sizeMultiple = 0;
       for (int j = 0; j < i; j++) {
-        sizeMultiple %= 5;
-        sizeMultiple++;
         ContainerInfo container =
             createContainer((long) i * i + j, sizeMultiple);
+        sizeMultiple %= 5;
+        sizeMultiple++;
 
         cidToInfoMap.put(container.containerID(), container);
         containerIDSet.add(container.containerID());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added a check on the size of the container allowed to move during the balancing process.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10483

## How was this patch tested?
Existing test `balancerShouldObeyMaxSizeLeavingSourceLimit()` in `TestContainerBalancerTask.java` passed when the balancer picked up only containers of size > 0 even when zero byte containers were present.