### PR TITLE
HDDS-9764. Add Robot test for JSON output where missing

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
@@ -71,6 +71,19 @@ Verbose container info
     ${output} =         Execute          ozone admin --verbose container info "${CONTAINER}"
                         Should contain   ${output}   Pipeline Info
 
+List containers as JSON
+    ${output} =         Execute          ozone admin container info "${CONTAINER}" --json | jq -r '.'
+                        Should contain   ${output}    containerInfo
+                        Should contain   ${output}    pipeline
+                        Should contain   ${output}    replicas
+                        Should contain   ${output}    writePipelineID
+
+Report containers as JSON
+     ${output} =         Execute          ozone admin container report --json | jq -r '.'
+                         Should contain   ${output}   reportTimeStamp
+                         Should contain   ${output}   stats
+                         Should contain   ${output}   samples
+
 Close container
     ${container} =      Execute          ozone admin container list --state OPEN | jq -r 'select(.replicationConfig.replicationFactor == "THREE") | .containerID' | head -1
                         Execute          ozone admin container close "${container}"
@@ -85,6 +98,8 @@ Incomplete command
                         Should contain   ${output}   info
                         Should contain   ${output}   create
                         Should contain   ${output}   close
+                        Should contain   ${output}   report
+                        Should contain   ${output}   upgrade
 
 #List containers on unknown host
 #    ${output} =         Execute And Ignore Error     ozone admin --verbose container list --scm unknown-host

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
@@ -99,3 +99,17 @@ List datanodes as JSON
                         Should contain   ${output}    datanodeDetails
                         Should contain   ${output}    healthState
                         Should contain   ${output}    opState
+
+Get usage info as JSON
+    ${output} =         Execute          ozone admin datanode usageinfo -m --json | jq -r '.'
+                        Should contain   ${output}  capacity
+                        Should contain   ${output}  committed
+                        Should contain   ${output}  containerCount
+                        Should contain   ${output}  datanodeDetails
+                        Should contain   ${output}  freeSpaceToSpare
+                        Should contain   ${output}  ozoneUsed
+                        Should contain   ${output}  ozoneUsedPercent
+                        Should contain   ${output}  remaining
+                        Should contain   ${output}  remainingPercent
+                        Should contain   ${output}  totalUsed
+                        Should contain   ${output}  totalUsedPercent


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9764. Add Robot test for JSON output where missing

Please describe your PR in detail:
- Added robot test for:
`ozone admin container info "${CONTAINER}" --json`
`ozone admin container report --json`
`ozone admin datanode usageinfo -m --json`
- Added missing JSON keys in incomplete command `ozone admin container`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9764

## How was this patch tested?
CI/acceptance workflow run on the fork git repo

Test Incomplete command:
https://github.com/will-sh/ozone/actions/runs/8447788465/job/23139219880#step:5:733
Test List containers as JSON:
https://github.com/will-sh/ozone/actions/runs/8447788465/job/23139219880#step:5:727
Test Report containers as JSON :
https://github.com/will-sh/ozone/actions/runs/8447788465/job/23139219880#step:5:729
Get usage info as JSON:
https://github.com/will-sh/ozone/actions/runs/8447788465/job/23139219880#step:5:772