### PR TITLE
HDDS-10570. S3A: `fs -touch` creates directory instead of empty file in FSO bucket

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -38,9 +38,11 @@ execute_robot_test ${SCM} -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-ofs-link 
 ## Exclude virtual-host tests. This is tested separately as it requires additional config.
 exclude="--exclude virtual-host"
 for bucket in generated; do
-  execute_robot_test ${SCM} -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
-  # some tests are independent of the bucket type, only need to be run once
-  exclude="--exclude virtual-host --exclude no-bucket-type"
+  for layout in OBJECT_STORE LEGACY FILE_SYSTEM_OPTIMIZED; do
+    execute_robot_test ${SCM} -v BUCKET:${bucket} -v BUCKET_LAYOUT:${layout} -N s3-${layout}-${bucket} ${exclude} s3
+    # some tests are independent of the bucket type, only need to be run once
+    exclude="--exclude virtual-host --exclude no-bucket-type"
+  done
 done
 
 execute_robot_test ${SCM} freon

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objecthead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objecthead.robot
@@ -40,20 +40,21 @@ Head object in non existing bucket
     ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET}-non-existent --key ${PREFIX}/headobject/key=value/f1   255
                         Should contain          ${result}    404
                         Should contain          ${result}    Not Found
+
 Head object where path is a directory
-    ${legacy-bucket} =  Create legacy bucket
-    ${result} =         Execute AWSS3APICli and checkrc    put-object --bucket ${legacy-bucket} --key ${PREFIX}/headobject/keyvalue/f1 --body /tmp/testfile   0
-    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${legacy-bucket} --key ${PREFIX}/headobject/keyvalue/   255
+    Pass Execution If   '${BUCKET_LAYOUT}' == 'FILE_SYSTEM_OPTIMIZED'    does not apply to FSO buckets
+    ${result} =         Execute AWSS3APICli and checkrc    put-object --bucket ${BUCKET} --key ${PREFIX}/headobject/keyvalue/f1 --body /tmp/testfile   0
+    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/headobject/keyvalue/   255
                         Should contain          ${result}    404
                         Should contain          ${result}    Not Found
 
 Head directory objects
-    ${obs-bucket} =     Create obs bucket
-    ${result} =         Execute AWSS3APICli and checkrc    put-object --bucket ${obs-bucket} --key ${PREFIX}/mydir/ --body /tmp/testfile   0
-    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${obs-bucket} --key ${PREFIX}/mydir   255
+    Pass Execution If   '${BUCKET_LAYOUT}' == 'FILE_SYSTEM_OPTIMIZED'    does not apply to FSO buckets
+    ${result} =         Execute AWSS3APICli and checkrc    put-object --bucket ${BUCKET} --key ${PREFIX}/mydir/ --body /tmp/testfile   0
+    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/mydir   255
                         Should contain          ${result}    404
                         Should contain          ${result}    Not Found
-    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${obs-bucket} --key ${PREFIX}/mydir/   0
+    ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/mydir/   0
 
 Head non existing key
     ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/non-existent   255

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
@@ -44,6 +44,8 @@ Put object to s3
 Get object from s3
     ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/putobject/key=value/f1 /tmp/testfile.result
     Compare files               /tmp/testfile              /tmp/testfile.result
+    ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/putobject/key=value/zerobyte /tmp/zerobyte.result
+    Compare files               /tmp/zerobyte              /tmp/zerobyte.result
 
 #This test depends on the previous test case. Can't be executed alone
 Get object with wrong signature
@@ -151,34 +153,14 @@ Incorrect values for end and start offset
                                 Should Be Equal            ${expectedData}            ${actualData}
 
 Zero byte file
-    ${result} =			        Execute                    ozone sh bucket info /s3v/${BUCKET}
-    ${linked} = 		        Execute				       echo '${result}' | jq -j '.sourceVolume,"/",.sourceBucket'
-    ${eval} = 			        Evaluate			       "source" in """${linked}"""
-    	      			        IF	${eval} == ${True}
-    ${result} =                 Execute				       ozone sh bucket info ${linked}
-				                END
-    ${fsolayout} =    		    Evaluate    	   	       "OPTIMIZED" in """${result}"""
-
     ${result} =                 Execute AWSS3APICli and checkrc     get-object --bucket ${BUCKET} --key ${PREFIX}/putobject/key=value/zerobyte --range bytes=0-0 /tmp/testfile2.result   255
-    	      			        IF 	${fsolayout} == ${True}
-                                Should contain              ${result}       NoSuchKey
-				                ELSE
                                 Should contain              ${result}       InvalidRange
-				                END
 
     ${result} =                 Execute AWSS3APICli and checkrc     get-object --bucket ${BUCKET} --key ${PREFIX}/putobject/key=value/zerobyte --range bytes=0-1 /tmp/testfile2.result   255
-                                IF 	${fsolayout} == ${True}
-                                Should contain              ${result}       NoSuchKey
-                                ELSE
                                 Should contain              ${result}       InvalidRange
-				                END
 
     ${result} =                 Execute AWSS3APICli and checkrc     get-object --bucket ${BUCKET} --key ${PREFIX}/putobject/key=value/zerobyte --range bytes=0-10000 /tmp/testfile2.result   255
-    	      			        IF 	${fsolayout} == ${True}
-                                Should contain              ${result}       NoSuchKey
-				                ELSE
                                 Should contain              ${result}       InvalidRange
-				                END
 
 Create file with user defined metadata
                                 Execute                   echo "Randomtext" > /tmp/testfile2

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -274,7 +274,9 @@ public class ObjectEndpoint extends EndpointBase {
       boolean hasAmzDecodedLengthZero = amzDecodedLength != null &&
           Long.parseLong(amzDecodedLength) == 0;
       if (canCreateDirectory &&
-          (length == 0 || hasAmzDecodedLengthZero)) {
+          (length == 0 || hasAmzDecodedLengthZero) &&
+          StringUtils.endsWith(keyPath, "/")
+      ) {
         s3GAction = S3GAction.CREATE_DIRECTORY;
         getClientProtocol()
             .createDirectory(volume.getName(), bucketName, keyPath);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -95,7 +95,9 @@ class TestObjectPut {
     ReplicationConfig ratis3 = RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
     ECReplicationConfig ec = new ECReplicationConfig("rs-3-2-1024K");
     return Stream.of(
+        Arguments.of(0, ratis3),
         Arguments.of(10, ratis3),
+        Arguments.of(0, ec),
         Arguments.of(10, ec)
     );
   }
@@ -410,7 +412,7 @@ class TestObjectPut {
   void testDirectoryCreation() throws IOException,
       OS3Exception {
     // GIVEN
-    final String path = "dir";
+    final String path = "dir/";
 
     // WHEN
     try (Response response = objectEndpoint.put(fsoBucket.getName(), path,
@@ -426,7 +428,7 @@ class TestObjectPut {
   @Test
   void testDirectoryCreationOverFile() throws IOException, OS3Exception {
     // GIVEN
-    final String path = "dir";
+    final String path = "key";
     final ByteArrayInputStream body =
         new ByteArrayInputStream(CONTENT.getBytes(UTF_8));
     objectEndpoint.put(FSO_BUCKET_NAME, path, CONTENT.length(), 0, "", body);
@@ -434,7 +436,7 @@ class TestObjectPut {
     // WHEN
     final OS3Exception exception = assertThrows(OS3Exception.class,
         () -> objectEndpoint
-            .put(FSO_BUCKET_NAME, path, 0, 0, "", null)
+            .put(FSO_BUCKET_NAME, path + "/", 0, 0, "", null)
             .close());
 
     // THEN


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a bug where attempting to create empty file in FSO bucket via S3 Gateway results in creation of a directory.

```
$ ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED /s3v/fso-bucket

$ hdfs dfs -touch s3a://fso-bucket/empty.s3a

$ ozone sh key info /s3v/fso-bucket/empty.s3a
{
  "name" : "empty.s3a/",
  "dataSize" : 0,
  ...
  "ozoneKeyLocations" : [ ],
  "file" : false
}
```

The same works OK in `OBJECT_STORE` and `LEGACY` buckets.

It was broken by HDDS-7594, which fixed a bug where attempt to create directory through S3G created files instead.  In other words, prior behavior was also wrong, just the other way around.

https://issues.apache.org/jira/browse/HDDS-10570

## How was this patch tested?

Added test case in unit test (`TestObjectPut`).

Changed acceptance tests to run tests on all three bucket layout types.

Also tested manually:

```
$ ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED /s3v/fso-bucket

$ export AWS_ACCESS_KEY_ID=any AWS_SECRET_KEY=any
$ export OZONE_CLASSPATH=aws-java-sdk-bundle-1.12.367.jar:hadoop-aws-3.3.6.jar

$ ozone fs -Dfs.s3a.path.style.access=true -Dfs.s3a.endpoint=http://s3g:9878 \
    -touch s3a://fso-bucket/empty.file

$ ozone fs -Dfs.s3a.path.style.access=true -Dfs.s3a.endpoint=http://s3g:9878 \
    -mkdir s3a://fso-bucket/dir

$ ozone fs -ls ofs://om/s3v/fso-bucket/
Found 2 items
drwxrwxrwx   - hadoop hadoop          0 2024-03-27 21:15 ofs://om/s3v/fso-bucket/dir
-rw-rw-rw-   3 hadoop hadoop          0 2024-03-27 21:15 ofs://om/s3v/fso-bucket/empty.file

$ ozone sh key info /s3v/fso-bucket/dir/
{
  "name" : "dir/",
  "dataSize" : 0,
  ...
  "ozoneKeyLocations" : [ ],
  "file" : false
}

$ ozone sh key info /s3v/fso-bucket/empty.file
{
  "name" : "empty.file",
  "dataSize" : 0,
  ...
  "ozoneKeyLocations" : [ ],
  "file" : true
}
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/8456929496