### PR TITLE
HDDS-10600. Bump nimbus-jose-jwt to 9.37.2

### DIFF
--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -44,6 +44,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${hadoop.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.nimbusds</groupId>
+          <artifactId>nimbus-jose-jwt</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.xerial.snappy</groupId>
           <artifactId>snappy-java</artifactId>
         </exclusion>
@@ -209,6 +213,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>
       <artifactId>hadoop-shaded-guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -44,6 +44,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${hadoop.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.nimbusds</groupId>
+          <artifactId>nimbus-jose-jwt</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.xerial.snappy</groupId>
           <artifactId>snappy-java</artifactId>
         </exclusion>
@@ -116,6 +120,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>
       <artifactId>hadoop-shaded-guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
     <dependency>
       <!-- commons-cli is required by DFSUtil.addPBProtocol -->

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven.core.version>3.9.6</maven.core.version>
     <snappy-java.version>1.1.10.5</snappy-java.version>
     <hadoop-shaded-guava.version>1.2.0</hadoop-shaded-guava.version>
-    <com.nimbusds.nimbus-jose-jwt.version>9.24</com.nimbusds.nimbus-jose-jwt.version>
+    <com.nimbusds.nimbus-jose-jwt.version>9.37.2</com.nimbusds.nimbus-jose-jwt.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven.core.version>3.9.6</maven.core.version>
     <snappy-java.version>1.1.10.5</snappy-java.version>
     <hadoop-shaded-guava.version>1.2.0</hadoop-shaded-guava.version>
+    <com.nimbusds.nimbus-jose-jwt.version>9.24</com.nimbusds.nimbus-jose-jwt.version>
   </properties>
 
   <dependencyManagement>
@@ -1220,6 +1221,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.apache.hadoop.thirdparty</groupId>
         <artifactId>hadoop-shaded-guava</artifactId>
         <version>${hadoop-shaded-guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>${com.nimbusds.nimbus-jose-jwt.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?
It's a continuation of the discussion started here - https://github.com/apache/ozone/pull/6441

hdds-hadoop-dependency-(client|server) modules depend on hadoop-common, the latter depends on com.nimbusds:nimbus-jose-jwt:9.8.1 (through org.apache.hadoop:hadoop-auth).

The 9.8.1th version of the com.nimbusds:nimbus-jose-jwt library contains a shaded version of the net.minidev:json-smart:1.3.2 (https://bitbucket.org/connect2id/nimbus-jose-jwt/src/815b98228df7be7b918ae368ea003a034768f769/pom.xml#lines-59) that has a CVE - https://nvd.nist.gov/vuln/detail/CVE-2021-31684.

Upgrading the nimbus-jose-jwt up to 9.24 will resolve the issue - there the json-smart was replaced with google-gson library

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10600

## How was this patch tested?

Existing hadoop-related robot tests
