### PR TITLE
HDDS-9987. [hsync] Client side metrics.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ContainerClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ContainerClientMetrics.java
@@ -57,9 +57,9 @@ public final class ContainerClientMetrics {
   private MutableQuantiles[] getCommittedBlockLengthLatency;
   private MutableQuantiles[] readChunkLatency;
   private MutableQuantiles[] getSmallFileLatency;
-  private MutableQuantiles[] hsyncLatency;
-  private MutableQuantiles[] omHsyncLatency;
-  private MutableQuantiles[] datanodeHsyncLatency;
+  private MutableQuantiles[] hsyncLatencyNs;
+  private MutableQuantiles[] omHsyncLatencyNs;
+  private MutableQuantiles[] datanodeHsyncLatencyNs;
   private final Map<PipelineID, MutableCounterLong> writeChunkCallsByPipeline;
   private final Map<PipelineID, MutableCounterLong> writeChunkBytesByPipeline;
   private final Map<UUID, MutableCounterLong> writeChunksCallsByLeaders;
@@ -99,9 +99,9 @@ public final class ContainerClientMetrics {
     getCommittedBlockLengthLatency = new MutableQuantiles[3];
     readChunkLatency = new MutableQuantiles[3];
     getSmallFileLatency = new MutableQuantiles[3];
-    hsyncLatency = new MutableQuantiles[3];
-    omHsyncLatency = new MutableQuantiles[3];
-    datanodeHsyncLatency = new MutableQuantiles[3];
+    hsyncLatencyNs = new MutableQuantiles[3];
+    omHsyncLatencyNs = new MutableQuantiles[3];
+    datanodeHsyncLatencyNs = new MutableQuantiles[3];
     int[] intervals = {60, 300, 900};
     for (int i = 0; i < intervals.length; i++) {
       int interval = intervals[i];
@@ -125,17 +125,17 @@ public final class ContainerClientMetrics {
           .newQuantiles("getSmallFileLatency" + interval
                   + "s", "GetSmallFile latency in microseconds", "ops",
               "latency", interval);
-      hsyncLatency[i] = registry
+      hsyncLatencyNs[i] = registry
           .newQuantiles("hsyncLatency" + interval
-                  + "s", "client hsync latency in microseconds", "ops",
+                  + "s", "client hsync latency in nanoseconds", "ops",
               "latency", interval);
-      omHsyncLatency[i] = registry
+      omHsyncLatencyNs[i] = registry
           .newQuantiles("omHsyncLatency" + interval
-                  + "s", "client hsync latency to OM in microseconds", "ops",
+                  + "s", "client hsync latency to OM in nanoseconds", "ops",
               "latency", interval);
-      datanodeHsyncLatency[i] = registry
+      datanodeHsyncLatencyNs[i] = registry
           .newQuantiles("dnHsyncLatency" + interval
-                  + "s", "client hsync latency to DN in microseconds", "ops",
+                  + "s", "client hsync latency to DN in nanoseconds", "ops",
               "latency", interval);
     }
   }
@@ -174,7 +174,7 @@ public final class ContainerClientMetrics {
   }
 
   public void addHsyncLatency(long hsyncLatencyTime) {
-    for (MutableQuantiles q : hsyncLatency) {
+    for (MutableQuantiles q : hsyncLatencyNs) {
       if (q != null) {
         q.add(hsyncLatencyTime);
       }
@@ -190,7 +190,7 @@ public final class ContainerClientMetrics {
   }
 
   public void addOMHsyncLatency(long hsyncLatencyTime) {
-    for (MutableQuantiles q : omHsyncLatency) {
+    for (MutableQuantiles q : omHsyncLatencyNs) {
       if (q != null) {
         q.add(hsyncLatencyTime);
       }
@@ -222,7 +222,7 @@ public final class ContainerClientMetrics {
   }
 
   public void addDataNodeHsyncLatency(long hsyncLatencyTime) {
-    for (MutableQuantiles q : datanodeHsyncLatency) {
+    for (MutableQuantiles q : datanodeHsyncLatencyNs) {
       if (q != null) {
         q.add(hsyncLatencyTime);
       }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ContainerClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ContainerClientMetrics.java
@@ -57,6 +57,9 @@ public final class ContainerClientMetrics {
   private MutableQuantiles[] getCommittedBlockLengthLatency;
   private MutableQuantiles[] readChunkLatency;
   private MutableQuantiles[] getSmallFileLatency;
+  private MutableQuantiles[] hsyncLatency;
+  private MutableQuantiles[] omHsyncLatency;
+  private MutableQuantiles[] datanodeHsyncLatency;
   private final Map<PipelineID, MutableCounterLong> writeChunkCallsByPipeline;
   private final Map<PipelineID, MutableCounterLong> writeChunkBytesByPipeline;
   private final Map<UUID, MutableCounterLong> writeChunksCallsByLeaders;
@@ -96,6 +99,9 @@ public final class ContainerClientMetrics {
     getCommittedBlockLengthLatency = new MutableQuantiles[3];
     readChunkLatency = new MutableQuantiles[3];
     getSmallFileLatency = new MutableQuantiles[3];
+    hsyncLatency = new MutableQuantiles[3];
+    omHsyncLatency = new MutableQuantiles[3];
+    datanodeHsyncLatency = new MutableQuantiles[3];
     int[] intervals = {60, 300, 900};
     for (int i = 0; i < intervals.length; i++) {
       int interval = intervals[i];
@@ -118,6 +124,18 @@ public final class ContainerClientMetrics {
       getSmallFileLatency[i] = registry
           .newQuantiles("getSmallFileLatency" + interval
                   + "s", "GetSmallFile latency in microseconds", "ops",
+              "latency", interval);
+      hsyncLatency[i] = registry
+          .newQuantiles("hsyncLatency" + interval
+                  + "s", "client hsync latency in microseconds", "ops",
+              "latency", interval);
+      omHsyncLatency[i] = registry
+          .newQuantiles("omHsyncLatency" + interval
+                  + "s", "client hsync latency to OM in microseconds", "ops",
+              "latency", interval);
+      datanodeHsyncLatency[i] = registry
+          .newQuantiles("dnHsyncLatency" + interval
+                  + "s", "client hsync latency to DN in microseconds", "ops",
               "latency", interval);
     }
   }
@@ -155,10 +173,26 @@ public final class ContainerClientMetrics {
     }
   }
 
+  public void addHsyncLatency(long hsyncLatencyTime) {
+    for (MutableQuantiles q : hsyncLatency) {
+      if (q != null) {
+        q.add(hsyncLatencyTime);
+      }
+    }
+  }
+
   public void addGetBlockLatency(long latency) {
     for (MutableQuantiles q : getBlockLatency) {
       if (q != null) {
         q.add(latency);
+      }
+    }
+  }
+
+  public void addOMHsyncLatency(long hsyncLatencyTime) {
+    for (MutableQuantiles q : omHsyncLatency) {
+      if (q != null) {
+        q.add(hsyncLatencyTime);
       }
     }
   }
@@ -183,6 +217,14 @@ public final class ContainerClientMetrics {
     for (MutableQuantiles q : getSmallFileLatency) {
       if (q != null) {
         q.add(latency);
+      }
+    }
+  }
+
+  public void addDataNodeHsyncLatency(long hsyncLatencyTime) {
+    for (MutableQuantiles q : datanodeHsyncLatency) {
+      if (q != null) {
+        q.add(hsyncLatencyTime);
       }
     }
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
@@ -70,6 +70,15 @@ public final class MetricUtil {
     }
   }
 
+  public static <E extends IOException> void captureLatencyNs(Consumer<Long> latencySetter, CheckedRunnable<E> block) throws E {
+    long start = Time.monotonicNowNanos();
+    try {
+      block.run();
+    } finally {
+      latencySetter.accept(Time.monotonicNowNanos() - start);
+    }
+  }
+
   /**
    * Creates MutableQuantiles metrics with one or multiple intervals.
    *

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/MetricUtil.java
@@ -70,7 +70,8 @@ public final class MetricUtil {
     }
   }
 
-  public static <E extends IOException> void captureLatencyNs(Consumer<Long> latencySetter, CheckedRunnable<E> block) throws E {
+  public static <E extends IOException> void captureLatencyNs(
+      Consumer<Long> latencySetter, CheckedRunnable<E> block) throws E {
     long start = Time.monotonicNowNanos();
     try {
       block.run();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.scm.storage.BufferPool;
 import org.apache.hadoop.hdds.scm.storage.RatisBlockOutputStream;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.Time;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.JavaUtils;
@@ -160,7 +161,10 @@ public class BlockOutputStreamEntry extends OutputStream {
             out.getClass() + " is not " + Syncable.class.getSimpleName());
       }
 
+      long start = Time.monotonicNowNanos();
       ((Syncable)out).hsync();
+      long datanodeHsyncLatency = Time.monotonicNowNanos() - start;
+      clientMetrics.addDataNodeHsyncLatency(datanodeHsyncLatency / 1000);
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdds.scm.storage.BufferPool;
 import org.apache.hadoop.hdds.scm.storage.RatisBlockOutputStream;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.util.Time;
+import org.apache.hadoop.util.MetricUtil;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.JavaUtils;
@@ -161,10 +161,7 @@ public class BlockOutputStreamEntry extends OutputStream {
             out.getClass() + " is not " + Syncable.class.getSimpleName());
       }
 
-      long start = Time.monotonicNowNanos();
-      ((Syncable)out).hsync();
-      long datanodeHsyncLatency = Time.monotonicNowNanos() - start;
-      clientMetrics.addDataNodeHsyncLatency(datanodeHsyncLatency / 1000);
+      MetricUtil.captureLatencyNs(clientMetrics::addDataNodeHsyncLatency, () -> ((Syncable)out).hsync());
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.util.MetricUtil;
-import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.util.MetricUtil;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -350,18 +351,15 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
       if (keyArgs.getIsMultipartKey()) {
         throw new IOException("Hsync is unsupported for multipart keys.");
       } else {
-        long start = Time.monotonicNowNanos();
         if (keyArgs.getLocationInfoList().size() == 0) {
-          omClient.hsyncKey(keyArgs, openID);
-          long datanodeHsyncLatency = Time.monotonicNowNanos() - start;
-          clientMetrics.addOMHsyncLatency(datanodeHsyncLatency / 1000);
+          MetricUtil.captureLatencyNs(clientMetrics::addOMHsyncLatency,
+              () -> omClient.hsyncKey(keyArgs, openID));
         } else {
           ContainerBlockID lastBLockId = keyArgs.getLocationInfoList().get(keyArgs.getLocationInfoList().size() - 1)
               .getBlockID().getContainerBlockID();
           if (!lastUpdatedBlockId.equals(lastBLockId)) {
-            omClient.hsyncKey(keyArgs, openID);
-            long datanodeHsyncLatency = Time.monotonicNowNanos() - start;
-            clientMetrics.addOMHsyncLatency(datanodeHsyncLatency / 1000);
+            MetricUtil.captureLatencyNs(clientMetrics::addOMHsyncLatency,
+                () -> omClient.hsyncKey(keyArgs, openID));
             lastUpdatedBlockId = lastBLockId;
           }
         }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -54,7 +54,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.util.Time;
+import org.apache.hadoop.util.MetricUtil;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
 import org.slf4j.Logger;
@@ -458,15 +458,13 @@ public class KeyOutputStream extends OutputStream
     checkNotClosed();
     final long hsyncPos = writeOffset;
 
-    long start = Time.monotonicNowNanos();
     handleFlushOrClose(StreamAction.HSYNC);
 
     Preconditions.checkState(offset >= hsyncPos,
         "offset = %s < hsyncPos = %s", offset, hsyncPos);
-    blockOutputStreamEntryPool.hsyncKey(hsyncPos);
 
-    long hsyncLatency = Time.monotonicNowNanos() - start;
-    clientMetrics.addHsyncLatency(hsyncLatency / 1000);
+    MetricUtil.captureLatencyNs(clientMetrics::addHsyncLatency,
+        () -> blockOutputStreamEntryPool.hsyncKey(hsyncPos));
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.util.Time;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
 import org.slf4j.Logger;
@@ -105,6 +106,7 @@ public class KeyOutputStream extends OutputStream
    * This is essential for operations like S3 put to ensure atomicity.
    */
   private boolean atomicKeyCreation;
+  private ContainerClientMetrics clientMetrics;
 
   public KeyOutputStream(ReplicationConfig replicationConfig, BlockOutputStreamEntryPool blockOutputStreamEntryPool) {
     this.replication = replicationConfig;
@@ -154,6 +156,7 @@ public class KeyOutputStream extends OutputStream
     this.clientID = b.getOpenHandler().getId();
     this.atomicKeyCreation = b.getAtomicKeyCreation();
     this.streamBufferArgs = b.getStreamBufferArgs();
+    this.clientMetrics = b.getClientMetrics();
   }
 
   /**
@@ -454,10 +457,16 @@ public class KeyOutputStream extends OutputStream
     }
     checkNotClosed();
     final long hsyncPos = writeOffset;
+
+    long start = Time.monotonicNowNanos();
     handleFlushOrClose(StreamAction.HSYNC);
+
     Preconditions.checkState(offset >= hsyncPos,
         "offset = %s < hsyncPos = %s", offset, hsyncPos);
     blockOutputStreamEntryPool.hsyncKey(hsyncPos);
+
+    long hsyncLatency = Time.monotonicNowNanos() - start;
+    clientMetrics.addHsyncLatency(hsyncLatency / 1000);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Create hsync metrics to measure client side latency with microsecond precision.

The PR adds two metrics, one for the Hsync RPC round-trip latency to Ozone Manager, another one for the round-trip latency to DataNode.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9987

## How was this patch tested?

Tested against a real cluster.