### PR TITLE
HDDS-10605. Add a configuration option for compliance mode

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -682,6 +682,10 @@ public final class OzoneConfigKeys {
   public static final String
       OZONE_OM_NETWORK_TOPOLOGY_REFRESH_DURATION_DEFAULT = "1h";
 
+  public static final String OZONE_SECURITY_COMPLIANCE_MODE =
+      "ozone.security.compliance.mode";
+  public static final String OZONE_SECURITY_COMPLIANCE_MODE_DEFAULT = "none";
+
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -682,9 +682,9 @@ public final class OzoneConfigKeys {
   public static final String
       OZONE_OM_NETWORK_TOPOLOGY_REFRESH_DURATION_DEFAULT = "1h";
 
-  public static final String OZONE_SECURITY_COMPLIANCE_MODE =
-      "ozone.security.compliance.mode";
-  public static final String OZONE_SECURITY_COMPLIANCE_MODE_DEFAULT = "none";
+  public static final String OZONE_SECURITY_CRYPTO_COMPLIANCE_MODE =
+      "ozone.security.crypto.compliance.mode";
+  public static final String OZONE_SECURITY_CRYPTO_COMPLIANCE_MODE_UNRESTRICTED = "unrestricted";
 
 
   /**

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1953,13 +1953,22 @@
     <name>ozone.http.filter.initializers</name>
     <value/>
     <tag>OZONE, SECURITY, KERBEROS</tag>
-    <description>Set to org.apache.hadoop.security.AuthenticationFilterInitializer
+    <description>Set to
+      org.apache.hadoop.security.AuthenticationFilterInitializer
       to enable Kerberos authentication for Ozone HTTP web consoles
       is enabled using the SPNEGO protocol. When this property is
       set, ozone.security.http.kerberos.enabled should be set to true.
     </description>
   </property>
-
+  <property>
+    <name>ozone.security.compliance.mode</name>
+    <value>none</value>
+    <tag>OZONE, SECURITY, HDDS</tag>
+    <description>Based on this property the security compliance mode
+      is loaded and enables filtering cryptographic configuration options
+      according to the specified compliance mode.
+    </description>
+  </property>
 
   <property>
     <name>ozone.client.read.timeout</name>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1962,7 +1962,7 @@
   <property>
     <name>ozone.security.crypto.compliance.mode</name>
     <value>none</value>
-    <tag>OZONE, SECURITY, HDDS</tag>
+    <tag>OZONE, SECURITY, HDDS, CRYPTO_COMPLIANCE</tag>
     <description>Based on this property the security compliance mode
       is loaded and enables filtering cryptographic configuration options
       according to the specified compliance mode.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1960,7 +1960,7 @@
     </description>
   </property>
   <property>
-    <name>ozone.security.compliance.mode</name>
+    <name>ozone.security.crypto.compliance.mode</name>
     <value>none</value>
     <tag>OZONE, SECURITY, HDDS</tag>
     <description>Based on this property the security compliance mode

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1953,8 +1953,7 @@
     <name>ozone.http.filter.initializers</name>
     <value/>
     <tag>OZONE, SECURITY, KERBEROS</tag>
-    <description>Set to
-      org.apache.hadoop.security.AuthenticationFilterInitializer
+    <description>Set to org.apache.hadoop.security.AuthenticationFilterInitializer
       to enable Kerberos authentication for Ozone HTTP web consoles
       is enabled using the SPNEGO protocol. When this property is
       set, ozone.security.http.kerberos.enabled should be set to true.

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigTag.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigTag.java
@@ -52,5 +52,6 @@ public enum ConfigTag {
   TLS,
   TOKEN,
   UPGRADE,
-  X509
+  X509,
+  CRYPTO_COMPLIANCE
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Create a configuration option that is going to be later used by issues under [Regulatory compliance for used cryptography](https://issues.apache.org/jira/browse/HDDS-10234). This ticket just aims at creating this configuration option, the usage for it comes in a later issue.

## What is the link to the Apache JIRA

[HDDS-10605](https://issues.apache.org/jira/browse/HDDS-10605)

## How was this patch tested?

green ci with unrelated failure: https://github.com/Galsza/ozone/actions/runs/8515349639/job/23323384841