### PR TITLE
HDDS-10636. Ozone Recon - Filter EMPTY MISSING Containers in UnHealthy State Containers API

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -397,10 +397,12 @@ public class ContainerEndpoint {
       summary = containerHealthSchemaManager.getUnhealthyContainersSummary();
       List<UnhealthyContainers> containers = containerHealthSchemaManager
           .getUnhealthyContainers(internalState, offset, limit);
-      containers.stream()
+      List<UnhealthyContainers> emptyMissingFiltered = containers.stream()
           .filter(
-              container -> !container.getContainerState().equals(UnHealthyContainerStates.EMPTY_MISSING.toString()));
-      for (UnhealthyContainers c : containers) {
+              container -> !container.getContainerState().equals(UnHealthyContainerStates.EMPTY_MISSING.toString()))
+          .collect(
+              Collectors.toList());
+      for (UnhealthyContainers c : emptyMissingFiltered) {
         long containerID = c.getContainerId();
         ContainerInfo containerInfo =
             containerManager.getContainer(ContainerID.valueOf(containerID));

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -885,6 +885,7 @@ public class TestContainerEndpoint {
   public void testUnhealthyContainersFilteredResponse()
       throws IOException, TimeoutException {
     String missing = UnHealthyContainerStates.MISSING.toString();
+    String emptyMissing = UnHealthyContainerStates.EMPTY_MISSING.toString();
 
     Response response = containerEndpoint
         .getUnhealthyContainers(missing, 1000, 1);
@@ -904,6 +905,7 @@ public class TestContainerEndpoint {
     uuid3 = newDatanode("host3", "127.0.0.3");
     uuid4 = newDatanode("host4", "127.0.0.4");
     createUnhealthyRecords(5, 4, 3, 2);
+    createEmptyMissingUnhealthyRecords(2);
 
     response = containerEndpoint.getUnhealthyContainers(missing, 1000, 1);
 
@@ -926,6 +928,13 @@ public class TestContainerEndpoint {
     for (UnhealthyContainerMetadata r : records) {
       assertEquals(missing, r.getContainerState());
     }
+
+    Response filteredEmptyMissingResponse = containerEndpoint
+        .getUnhealthyContainers(emptyMissing, 1000, 1);
+    responseObject = (UnhealthyContainersResponse) filteredEmptyMissingResponse.getEntity();
+    records = responseObject.getContainers();
+    // Assert for zero empty missing containers.
+    assertEquals(0, records.size());
   }
 
   @Test
@@ -1024,6 +1033,14 @@ public class TestContainerEndpoint {
             .setIpAddress(ipAddress)
             .build());
     return uuid;
+  }
+
+  private void createEmptyMissingUnhealthyRecords(int emptyMissing) {
+    int cid = 0;
+    for (int i = 0; i < emptyMissing; i++) {
+      createUnhealthyRecord(++cid, UnHealthyContainerStates.EMPTY_MISSING.toString(),
+          3, 3, 0, null);
+    }
   }
 
   private void createUnhealthyRecords(int missing, int overRep, int underRep,


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to address a bug in filtering the EMPTY_MISSING containers in ContainerEndPoint API `"api/v1/unhealthy/{state}"`

ContainerEndPoint API `"api/v1/unhealthy/{state}"` is not filtering the EMPTY_MISSING containers as expected.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10636

## How was this patch tested?
Tested with adding Junit manual test cases. Here is green CI [link](https://github.com/devmadhuu/ozone/actions/runs/8524543190).
