### PR TITLE
HDDS-10639. Add config for whitelisting hdds.secret.key.algorithm

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -272,6 +272,9 @@ public final class HddsConfigKeys {
   public static final String HDDS_SECRET_KEY_ALGORITHM_DEFAULT =
       "HmacSHA256";
 
+  public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_SECRET_KEY_ALGORITHM = "ozone.compliance.allowed.hdds.secret.key.algorithm";
+  public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_SECRET_KEY_ALGORITHM_DEFAULT = "*";
+
   public static final String HDDS_SECRET_KEY_ROTATE_CHECK_DURATION =
       "hdds.secret.key.rotate.check.duration";
   public static final String HDDS_SECRET_KEY_ROTATE_CHECK_DURATION_DEFAULT

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -272,7 +272,8 @@ public final class HddsConfigKeys {
   public static final String HDDS_SECRET_KEY_ALGORITHM_DEFAULT =
       "HmacSHA256";
 
-  public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_SECRET_KEY_ALGORITHM = "ozone.compliance.allowed.hdds.secret.key.algorithm";
+  public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_SECRET_KEY_ALGORITHM =
+      "ozone.compliance.allowed.hdds.secret.key.algorithm";
   public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_SECRET_KEY_ALGORITHM_DEFAULT = "*";
 
   public static final String HDDS_SECRET_KEY_ROTATE_CHECK_DURATION =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4349,6 +4349,14 @@
     </description>
   </property>
   <property>
+    <name>ozone.compliance.allowed.hdds.secret.key.algorithm</name>
+    <value>*</value>
+    <tag>SCM, SECURITY</tag>
+    <description>
+      Allowed algorithms that SCM can use to generate symmetric secret keys.
+    </description>
+  </property>
+  <property>
     <name>ozone.om.upgrade.quota.recalculate.enabled</name>
     <value>true</value>
     <tag>OZONE, OM</tag>


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added config option to be able to whitelist the algorithms defined in `hdds.secret.key.algorithm`, defaults to `*`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10639

## How was this patch tested?

This config is not used currently, CI on my fork (unrelated failure): https://github.com/dombizita/ozone/actions/runs/8540401619
