### PR TITLE
HDDS-10638. Add config for whitelisting hdds.grpc.tls.provider

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -290,6 +290,9 @@ public final class HddsConfigKeys {
   // Choose TLS provider the default is set to OPENSSL for better performance.
   public static final String HDDS_GRPC_TLS_PROVIDER = "hdds.grpc.tls.provider";
   public static final String HDDS_GRPC_TLS_PROVIDER_DEFAULT = "OPENSSL";
+  // Allowed TLS providers
+  public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_GRPC_TLS_PROVIDER = "ozone.compliance.allowed.hdds.grpc.tls.provider";
+  public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_GRPC_TLS_PROVIDER_DEFAULT = "*";
 
   // Test only settings for using test signed certificate, authority assume to
   // be localhost.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -291,7 +291,8 @@ public final class HddsConfigKeys {
   public static final String HDDS_GRPC_TLS_PROVIDER = "hdds.grpc.tls.provider";
   public static final String HDDS_GRPC_TLS_PROVIDER_DEFAULT = "OPENSSL";
   // Allowed TLS providers
-  public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_GRPC_TLS_PROVIDER = "ozone.compliance.allowed.hdds.grpc.tls.provider";
+  public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_GRPC_TLS_PROVIDER =
+      "ozone.compliance.allowed.hdds.grpc.tls.provider";
   public static final String OZONE_COMPLIANCE_ALLOWED_HDDS_GRPC_TLS_PROVIDER_DEFAULT = "*";
 
   // Test only settings for using test signed certificate, authority assume to

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2296,6 +2296,12 @@
     <description>HDDS GRPC server TLS provider.</description>
   </property>
   <property>
+    <name>ozone.compliance.allowed.hdds.grpc.tls.provider</name>
+    <value>*</value>
+    <tag>OZONE, HDDS, SECURITY</tag>
+    <description>Allowed HDDS GRPC server TLS providers.</description>
+  </property>
+  <property>
     <name>hdds.grpc.tls.enabled</name>
     <value>false</value>
     <tag>OZONE, HDDS, SECURITY, TLS</tag>


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added config option to be able to whitelist the providers defined in hdds.grpc.tls.provider, defaults to *.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10638

## How was this patch tested?

This config is not used currently, CI on my fork (unrelated failure): https://github.com/dombizita/ozone/actions/runs/8540392118
