### PR TITLE
HDDS-10643. Avoid terminating SCM by statemachine during normal SCM stop.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -440,7 +440,7 @@ public class SCMStateMachine extends BaseStateMachine {
       transactionBuffer.close();
       HadoopExecutors.
           shutdown(installSnapshotExecutor, LOG, 5, TimeUnit.SECONDS);
-    } else {
+    } else if (!scm.isStopped()) {
       scm.shutDown("scm statemachine is closed by ratis, terminate SCM");
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1796,6 +1796,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     ExitUtils.terminate(0, message, LOG);
   }
 
+  public boolean isStopped() {
+    return isStopped.get();
+  }
+
   /**
    * Wait until service has completed shutdown.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently during normal SCM stop it's going into deadlock situation, detail is in Jira.
During normal SCM stop we should not terminate SCM through statemachine when called by ratis. Instead SCM should stop all the worker threads and shutdown gracefully.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10643

## How was this patch tested?

Verified in the cluster for graceful exit
