### PR TITLE
HDDS-10644. Intermittent failure in testBalancer.robot

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-config
@@ -51,9 +51,6 @@ OZONE-SITE.XML_ozone.scm.primordial.node.id=scm1
 OZONE-SITE.XML_hdds.container.report.interval=30s
 OZONE-SITE.XML_ozone.om.s3.grpc.server_enabled=true
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
-OZONE-SITE.XML_ozone.recon.address=recon:9891
-OZONE-SITE.XML_ozone.recon.http-address=0.0.0.0:9888
-OZONE-SITE.XML_ozone.recon.https-address=0.0.0.0:9889
 OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
 
 OZONE_CONF_DIR=/etc/hadoop

--- a/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
@@ -95,15 +95,16 @@ Get Uuid
 Close All Containers
     FOR     ${INDEX}    IN RANGE    15
         ${container} =      Execute          ozone admin container list --state OPEN | jq -r 'select(.replicationConfig.replicationFactor == "THREE") | .containerID' | head -1
-        EXIT FOR LOOP IF    "${container}" == ""
-                            Execute          ozone admin container close "${container}"
+        EXIT FOR LOOP IF    "${container}" == "${EMPTY}"
+                            ${message} =    Execute And Ignore Error    ozone admin container close "${container}"
+                            Run Keyword If    '${message}' != '${EMPTY}'      Should Contain   ${message}   is in closing state
         ${output} =         Execute          ozone admin container info "${container}"
                             Should contain   ${output}   CLOS
     END
     Wait until keyword succeeds    3min    10sec    All container is closed
 
 All container is closed
-    ${output} =         Execute          ozone admin container list --state OPEN
+    ${output} =         Execute           ozone admin container list --state OPEN
                         Should Be Empty   ${output}
 
 Get Datanode Ozone Used Bytes Info


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10644. Intermittent failure in testBalancer.robot

The problem was that there was a delay between the close container event sent to event queue and container close event being processed.
To improve test stability, we need to ignore the exception due to a duplicate container close request so that it doesn't cause the acceptance test to fail.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10644

## How was this patch tested?
The test passed successfully more than 10 times in a row
