### PR TITLE
HDDS-10659. Remove cglib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <asm.version>5.0.4</asm.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>
     <bouncycastle.version>1.77</bouncycastle.version>
-    <cglib.version>3.3.0</cglib.version>
     <derby.version>10.14.2.0</derby.version>
     <codahale-metrics.version>3.0.2</codahale-metrics.version>
     <dropwizard-metrics.version>3.2.4</dropwizard-metrics.version>
@@ -1008,13 +1007,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>bonecp</artifactId>
         <version>${bonecp.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>cglib</groupId>
-        <artifactId>cglib</artifactId>
-        <version>${cglib.version}</version>
-      </dependency>
-
       <dependency>
         <groupId>com.sun.jersey.contribs</groupId>
         <artifactId>jersey-guice</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The cglib:cglib:3.3.0 dependency is not used anywhere in the project and can be safely removed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10659

## How was this patch tested?

Existing tests
