### PR TITLE
HDDS-10464. Add Integration Tests for Failing Datanode Decommission.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
@@ -152,7 +152,7 @@ public class TestDecommissionAndMaintenance {
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(DATANODE_COUNT);
 
-    clusterProvider = new MiniOzoneClusterProvider(builder, 7);
+    clusterProvider = new MiniOzoneClusterProvider(builder, 8);
   }
 
   @AfterAll
@@ -331,6 +331,19 @@ public class TestDecommissionAndMaintenance {
         DECOMMISSIONED,
         HEALTHY);
     assertEquals(0, decomNodes.size());
+
+    generateData(20, "eckey", ecRepConfig);
+    // trying to decommission 3 nodes should leave the cluster with 4 nodes,
+    // which is not sufficient for EC(3,2) replication. It should not be allowed.
+    scmClient.decommissionNodes(Arrays.asList(toDecommission.get(0).getIpAddress(),
+        toDecommission.get(1).getIpAddress(), toDecommission.get(2).getIpAddress()), false);
+
+    // Ensure no nodes transitioned to DECOMMISSIONING
+    decomNodes = nm.getNodes(
+        DECOMMISSIONED,
+        HEALTHY);
+    assertEquals(0, decomNodes.size());
+
 
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-10462 added fail early conditions for datanode decommission. This PR adds few integration tests in TestDecommissionAndMaintenance for the same.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10464

## How was this patch tested?

Green CI on my fork: https://github.com/Tejaskriya/ozone/actions/runs/8594587395
