### PR TITLE
HDDS-10628. Display if safemode exit was via force exit command.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -174,7 +174,7 @@ public class SCMSafeModeManager implements SafeModeManager {
     SafeModeStatus safeModeStatus =
         new SafeModeStatus(getInSafeMode(), getPreCheckComplete());
 
-    safeModeStatus.setForceExitSafeMode(getForceExitSafeMode());
+    safeModeStatus.setForceExitSafeMode(isSafeModeExitForceful());
 
     // update SCMContext
     scmContext.updateSafeModeStatus(safeModeStatus);
@@ -294,11 +294,6 @@ public class SCMSafeModeManager implements SafeModeManager {
     }
     return inSafeMode.get();
   }
-
-  public boolean isSafeModeExitForceful() {
-    return forceExitSafeMode.get();
-  }
-
   /**
    * Get the safe mode status of all rules.
    *
@@ -328,7 +323,7 @@ public class SCMSafeModeManager implements SafeModeManager {
     this.preCheckComplete.set(newState);
   }
 
-  public boolean getForceExitSafeMode() {
+  public boolean isSafeModeExitForceful() {
     return forceExitSafeMode.get();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -88,6 +88,7 @@ public class SCMSafeModeManager implements SafeModeManager {
   private final boolean isSafeModeEnabled;
   private AtomicBoolean inSafeMode = new AtomicBoolean(true);
   private AtomicBoolean preCheckComplete = new AtomicBoolean(false);
+  private AtomicBoolean forceExitSafeMode = new AtomicBoolean(false);
 
   private Map<String, SafeModeExitRule> exitRules = new HashMap(1);
   private Set<String> preCheckRules = new HashSet<>(1);
@@ -151,7 +152,7 @@ public class SCMSafeModeManager implements SafeModeManager {
       }
     } else {
       this.safeModeMetrics = null;
-      exitSafeMode(eventQueue);
+      exitSafeMode(eventQueue, true);
     }
   }
 
@@ -172,6 +173,8 @@ public class SCMSafeModeManager implements SafeModeManager {
   public void emitSafeModeStatus() {
     SafeModeStatus safeModeStatus =
         new SafeModeStatus(getInSafeMode(), getPreCheckComplete());
+
+    safeModeStatus.setForceExitSafeMode(getForceExitSafeMode());
 
     // update SCMContext
     scmContext.updateSafeModeStatus(safeModeStatus);
@@ -213,7 +216,7 @@ public class SCMSafeModeManager implements SafeModeManager {
     if (validatedRules.size() == exitRules.size()) {
       // All rules are satisfied, we can exit safe mode.
       LOG.info("ScmSafeModeManager, all rules are successfully validated");
-      exitSafeMode(eventQueue);
+      exitSafeMode(eventQueue, false);
     }
 
   }
@@ -240,12 +243,13 @@ public class SCMSafeModeManager implements SafeModeManager {
    * @param eventQueue
    */
   @VisibleForTesting
-  public void exitSafeMode(EventPublisher eventQueue) {
+  public void exitSafeMode(EventPublisher eventQueue, boolean force) {
     LOG.info("SCM exiting safe mode.");
     // If safemode is exiting, then pre check must also have passed so
     // set it to true.
     setPreCheckComplete(true);
     setInSafeMode(false);
+    setForceExitSafeMode(force);
 
     // TODO: Remove handler registration as there is no need to listen to
     // register events anymore.
@@ -290,6 +294,10 @@ public class SCMSafeModeManager implements SafeModeManager {
     return inSafeMode.get();
   }
 
+  public boolean isSafeModeExitForceful() {
+    return forceExitSafeMode.get();
+  }
+
   /**
    * Get the safe mode status of all rules.
    *
@@ -317,6 +325,14 @@ public class SCMSafeModeManager implements SafeModeManager {
 
   public void setPreCheckComplete(boolean newState) {
     this.preCheckComplete.set(newState);
+  }
+
+  public boolean getForceExitSafeMode() {
+    return forceExitSafeMode.get();
+  }
+
+  public void setForceExitSafeMode(boolean forceExitSafeMode) {
+    this.forceExitSafeMode.set(forceExitSafeMode);
   }
 
   public static Logger getLogger() {
@@ -350,6 +366,8 @@ public class SCMSafeModeManager implements SafeModeManager {
     private final boolean safeModeStatus;
     private final boolean preCheckPassed;
 
+    private boolean forceExitSafeMode;
+
     public SafeModeStatus(boolean safeModeState, boolean preCheckPassed) {
       this.safeModeStatus = safeModeState;
       this.preCheckPassed = preCheckPassed;
@@ -361,6 +379,14 @@ public class SCMSafeModeManager implements SafeModeManager {
 
     public boolean isPreCheckComplete() {
       return preCheckPassed;
+    }
+
+    public void setForceExitSafeMode(boolean forceExitSafeMode) {
+      this.forceExitSafeMode = forceExitSafeMode;
+    }
+
+    public boolean isForceExitSafeMode() {
+      return forceExitSafeMode;
     }
 
     @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -241,6 +241,7 @@ public class SCMSafeModeManager implements SafeModeManager {
    * 3. Cleanup resources.
    * 4. Emit safe mode status.
    * @param eventQueue
+   * @param force
    */
   @VisibleForTesting
   public void exitSafeMode(EventPublisher eventQueue, boolean force) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -174,7 +174,7 @@ public class SCMSafeModeManager implements SafeModeManager {
     SafeModeStatus safeModeStatus =
         new SafeModeStatus(getInSafeMode(), getPreCheckComplete());
 
-    safeModeStatus.setForceExitSafeMode(isSafeModeExitForceful());
+    safeModeStatus.setForceExitSafeMode(isForceExitSafeMode());
 
     // update SCMContext
     scmContext.updateSafeModeStatus(safeModeStatus);
@@ -323,7 +323,7 @@ public class SCMSafeModeManager implements SafeModeManager {
     this.preCheckComplete.set(newState);
   }
 
-  public boolean isSafeModeExitForceful() {
+  public boolean isForceExitSafeMode() {
     return forceExitSafeMode.get();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
@@ -48,6 +48,13 @@ public interface SCMMXBean extends ServiceRuntimeInfo {
    */
   boolean isInSafeMode();
 
+
+  /**
+   * Returns if safe mode exit is forceful
+   * @return boolean
+   */
+  public boolean isSafeModeExitForceful();
+
   /**
    * Returns live safe mode container threshold.
    * @return String

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
@@ -50,10 +50,10 @@ public interface SCMMXBean extends ServiceRuntimeInfo {
 
 
   /**
-   * Returns if safe mode exit is forceful
+   * Returns if safe mode exit is forceful.
    * @return boolean
    */
-  public boolean isSafeModeExitForceful();
+  boolean isSafeModeExitForceful();
 
   /**
    * Returns live safe mode container threshold.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1981,7 +1981,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
   @Override
   public boolean isSafeModeExitForceful() {
-    return scmSafeModeManager.isSafeModeExitForceful();
+    return scmSafeModeManager.isForceExitSafeMode();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1979,6 +1979,11 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     return scmSafeModeManager.getInSafeMode();
   }
 
+  @Override
+  public boolean isSafeModeExitForceful() {
+    return scmSafeModeManager.isSafeModeExitForceful();
+  }
+
   /**
    * Returns EventPublisher.
    */
@@ -2011,7 +2016,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    * Force SCM out of safe mode.
    */
   public boolean exitSafeMode() {
-    scmSafeModeManager.exitSafeMode(eventQueue);
+    scmSafeModeManager.exitSafeMode(eventQueue, true);
     return true;
   }
 

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -124,6 +124,10 @@
         <td>Node Manager: Safe mode status</td>
         <td>{{$ctrl.overview.jmx.InSafeMode}}</td>
     </tr>
+    <tr ng-hide="!$ctrl.overview.jmx.SafeModeExitForceful">
+        <td> Force Exit Safe Mode </td>
+        <td>{{$ctrl.overview.jmx.SafeModeExitForceful}}</td>
+    </tr>
     <tr>
         <td> SCM Roles (HA) </td>
         <td>{{$ctrl.overview.jmx.ScmRatisRoles}}</td>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Safe mode rules are not calculated/updated after a safemode force exit, If a user looks at the SCM web UI after a force exit , it would give an impression that SCM is in safemode by looking at the rules not being satisfied.
Displaying if safe mode was forcefully exited will be helpful in  this case.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10628

## How was this patch tested?
Manually
<img width="1392" alt="Screenshot 2024-04-08 at 4 59 22 PM" src="https://github.com/apache/ozone/assets/31859223/86e6bc44-155b-4b91-b54c-aad253244cf0">

