### PR TITLE
HDDS-10630. Add missing parent directories deleted between initiate and complete MPU

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -196,7 +196,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
             bucketName);
 
         // add all missing parents to directory table
-        addMissingParentsToTable(omBucketInfo, missingParentInfos,
+        addMissingParentsToCache(omBucketInfo, missingParentInfos,
             omMetadataManager, volumeId, bucketId, trxnLogIndex);
 
         String multipartOpenKey = omMetadataManager
@@ -244,9 +244,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
               .build();
 
           // Add missing multi part info to open key table
-          addMultiParttoOpenTable(omMetadataManager, multipartOpenKey,
-              multipartKeyInfoFromArgs, pathInfoFSO, keyInfoFromArgs,
-              volumeId, bucketId, trxnLogIndex);
+          addMultiPartToCache(omMetadataManager, multipartOpenKey,
+              pathInfoFSO, keyInfoFromArgs, trxnLogIndex);
         }
       }
 
@@ -358,7 +357,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         omClientResponse =
             getOmClientResponse(multipartKey, omResponse, dbMultipartOpenKey,
                 omKeyInfo, allKeyInfoToRemove, omBucketInfo,
-                volumeId, bucketId);
+                volumeId, bucketId, missingParentInfos, multipartKeyInfo);
 
         result = Result.SUCCESS;
       } else {
@@ -399,7 +398,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       OMResponse.Builder omResponse, String dbMultipartOpenKey,
       OmKeyInfo omKeyInfo,  List<OmKeyInfo> allKeyInfoToRemove,
       OmBucketInfo omBucketInfo,
-      long volumeId, long bucketId) {
+      long volumeId, long bucketId, List<OmDirectoryInfo> missingParentInfos,
+      OmMultipartKeyInfo multipartKeyInfo) {
 
     return new S3MultipartUploadCompleteResponse(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, allKeyInfoToRemove,
@@ -538,7 +538,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     return omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
   }
 
-  protected void addMissingParentsToTable(OmBucketInfo omBucketInfo,
+  protected void addMissingParentsToCache(OmBucketInfo omBucketInfo,
       List<OmDirectoryInfo> missingParentInfos,
       OMMetadataManager omMetadataManager,
       long volumeId, long bucketId, long transactionLogIndex
@@ -546,12 +546,10 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     // FSO is disabled. Do nothing.
   }
 
-  @SuppressWarnings("checkstyle:ParameterNumber")
-  protected void addMultiParttoOpenTable(
+  protected void addMultiPartToCache(
       OMMetadataManager omMetadataManager, String multipartOpenKey,
-      OmMultipartKeyInfo multipartKeyInfo,
       OMFileRequest.OMPathInfoWithFSO pathInfoFSO, OmKeyInfo omKeyInfo,
-      long volumeId, long bucketId, long transactionLogIndex
+      long transactionLogIndex
   ) throws IOException {
     // FSO is disabled. Do nothing.
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -520,16 +520,17 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       OMMetadataManager omMetadataManager,
       String volumeName, String bucketName, long transactionLogIndex
   ) throws IOException {
-    return;
+    // FSO is disabled. Do nothing.
   }
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   protected void addPrefixDirstoOpenTable(
       OMMetadataManager omMetadataManager, String multipartOpenKey,
       OMFileRequest.OMPathInfoWithFSO pathInfoFSO, OmKeyInfo omKeyInfo,
       OmMultipartKeyInfo multipartKeyInfo, long transactionLogIndex,
       String volumeName, String bucketName
   ) throws IOException {
-    return;
+    // FSO is disabled. Do nothing.
   }
 
   protected OmKeyInfo getOmKeyInfoFromKeyTable(String dbOzoneKey,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -81,8 +81,7 @@ public class S3MultipartUploadCompleteRequestWithFSO
   protected void addMissingParentsToTable(OmBucketInfo omBucketInfo,
       List<OmDirectoryInfo> missingParentInfos,
       OMMetadataManager omMetadataManager, String volumeName, String bucketName,
-      long transactionLogIndex
-      ) throws IOException {
+      long transactionLogIndex) throws IOException {
 
     if (null == missingParentInfos) {
       return;
@@ -101,8 +100,8 @@ public class S3MultipartUploadCompleteRequestWithFSO
         missingParentInfos, null);
 
     // Create missing parent directory entries.
-    try(BatchOperation batchOperation = omMetadataManager.getStore()
-        .initBatchOperation()){
+    try (BatchOperation batchOperation = omMetadataManager.getStore()
+        .initBatchOperation()) {
       for (OmDirectoryInfo parentDirInfo : missingParentInfos) {
         final String parentKey = omMetadataManager.getOzonePathKey(
             volumeId, bucketId, parentDirInfo.getParentObjectID(),
@@ -140,8 +139,8 @@ public class S3MultipartUploadCompleteRequestWithFSO
         transactionLogIndex);
 
     // Create missing parent directory entries.
-    try(BatchOperation batchOperation = omMetadataManager.getStore()
-        .initBatchOperation()){
+    try (BatchOperation batchOperation = omMetadataManager.getStore()
+        .initBatchOperation()) {
 
       OMFileRequest.addToOpenFileTableForMultipart(omMetadataManager,
           batchOperation,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
-import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -80,15 +80,8 @@ public class S3MultipartUploadCompleteRequestWithFSO
   @Override
   protected void addMissingParentsToTable(OmBucketInfo omBucketInfo,
       List<OmDirectoryInfo> missingParentInfos,
-      OMMetadataManager omMetadataManager, String volumeName, String bucketName,
+      OMMetadataManager omMetadataManager, long volumeId, long bucketId,
       long transactionLogIndex) throws IOException {
-
-    if (null == missingParentInfos) {
-      return;
-    }
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-        bucketName);
 
     // validate and update namespace for missing parent directory.
     checkBucketQuotaInNamespace(omBucketInfo, missingParentInfos.size());
@@ -122,23 +115,19 @@ public class S3MultipartUploadCompleteRequestWithFSO
   }
 
   @Override
-  protected void addPrefixDirstoOpenTable(
+  protected void addMultiParttoOpenTable(
       OMMetadataManager omMetadataManager, String multipartOpenKey,
+      OmMultipartKeyInfo multipartKeyInfo,
       OMFileRequest.OMPathInfoWithFSO pathInfoFSO, OmKeyInfo omKeyInfo,
-      OmMultipartKeyInfo multipartKeyInfo, long transactionLogIndex,
-      String volumeName, String bucketName
+      long volumeId, long bucketId, long transactionLogIndex
   ) throws IOException {
 
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-        bucketName);
-
-    // Add to prefix directories to cache
+    // Add multi part to cache
     OMFileRequest.addOpenFileTableCacheEntry(omMetadataManager,
         multipartOpenKey, omKeyInfo, pathInfoFSO.getLeafNodeName(),
         transactionLogIndex);
 
-    // Create missing parent directory entries.
+    // Add multi part to open key table.
     try (BatchOperation batchOperation = omMetadataManager.getStore()
         .initBatchOperation()) {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -129,4 +129,12 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
   protected OmKeyInfo getOmKeyInfo() {
     return omKeyInfo;
   }
+
+  protected OmBucketInfo getOmBucketInfo() {
+    return omBucketInfo;
+  }
+
+  protected String getMultiPartKey() {
+    return multipartKey;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -20,9 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.*;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -52,6 +50,10 @@ public class S3MultipartUploadCompleteResponseWithFSO
   private long volumeId;
   private long bucketId;
 
+  private List<OmDirectoryInfo> missingParentInfos;
+
+  private OmMultipartKeyInfo multipartKeyInfo;
+
   @SuppressWarnings("checkstyle:ParameterNumber")
   public S3MultipartUploadCompleteResponseWithFSO(
       @Nonnull OMResponse omResponse,
@@ -61,11 +63,15 @@ public class S3MultipartUploadCompleteResponseWithFSO
       @Nonnull List<OmKeyInfo> allKeyInfoToRemove,
       @Nonnull BucketLayout bucketLayout,
       OmBucketInfo omBucketInfo,
-      @Nonnull long volumeId, @Nonnull long bucketId) {
+      @Nonnull long volumeId, @Nonnull long bucketId,
+      List<OmDirectoryInfo> missingParentInfos,
+      OmMultipartKeyInfo multipartKeyInfo) {
     super(omResponse, multipartKey, multipartOpenKey, omKeyInfo,
         allKeyInfoToRemove, bucketLayout, omBucketInfo);
     this.volumeId = volumeId;
     this.bucketId = bucketId;
+    this.missingParentInfos = missingParentInfos;
+    this.multipartKeyInfo = multipartKeyInfo;
   }
 
   /**
@@ -76,6 +82,39 @@ public class S3MultipartUploadCompleteResponseWithFSO
       @Nonnull OMResponse omResponse, @Nonnull BucketLayout bucketLayout) {
     super(omResponse, bucketLayout);
     checkStatusNotOK();
+  }
+
+  @Override
+  public void addToDBBatch(OMMetadataManager omMetadataManager,
+                           BatchOperation batchOperation) throws IOException {
+    if (missingParentInfos != null) {
+      // Create missing parent directory entries.
+      for (OmDirectoryInfo parentDirInfo : missingParentInfos) {
+        final String parentKey = omMetadataManager.getOzonePathKey(
+            volumeId, bucketId, parentDirInfo.getParentObjectID(),
+            parentDirInfo.getName());
+        omMetadataManager.getDirectoryTable().putWithBatch(batchOperation,
+            parentKey, parentDirInfo);
+      }
+
+      // namespace quota changes for parent directory
+      String bucketKey = omMetadataManager.getBucketKey(
+          getOmBucketInfo().getVolumeName(),
+          getOmBucketInfo().getBucketName());
+      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+          bucketKey, getOmBucketInfo());
+
+      if (OMFileRequest.getOmKeyInfoFromFileTable(true,
+          omMetadataManager, getMultiPartKey(), getOmKeyInfo().getKeyName())
+          != null) {
+        // Add multi part to open key table.
+        OMFileRequest.addToOpenFileTableForMultipart(omMetadataManager,
+            batchOperation,
+            getOmKeyInfo(), multipartKeyInfo.getUploadID(), volumeId,
+            bucketId);
+      }
+    }
+    super.addToDBBatch(omMetadataManager, batchOperation);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -20,7 +20,11 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.helpers.*;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -306,6 +306,8 @@ public class TestS3MultipartResponse {
 
     String multipartKey = omMetadataManager
         .getMultipartKey(volumeName, bucketName, keyName, multipartUploadID);
+    OmMultipartKeyInfo multipartKeyInfo = omMetadataManager
+        .getMultipartInfoTable().get(multipartKey);
 
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
     final long bucketId = omMetadataManager.getBucketId(volumeName,
@@ -324,7 +326,8 @@ public class TestS3MultipartResponse {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse,
         multipartKey, multipartOpenKey, omKeyInfo,  allKeyInfoToRemove,
-        getBucketLayout(), omBucketInfo, volumeId, bucketId);
+        getBucketLayout(), omBucketInfo, volumeId, bucketId, null,
+        multipartKeyInfo);
   }
 
   protected S3InitiateMultipartUploadResponse getS3InitiateMultipartUploadResp(


### PR DESCRIPTION
## What changes were proposed in this pull request?
S3a provides multiple mapreduce [committers](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/committers.html). When using the directory staging committer `fs.s3a.committer.name=directory` with replace conflict mode `fs.s3a.committer.staging.conflict-mode=replace` and writing to FSO buckets, the job fails with the following errors.

This is because the logic to add back missing parent directories and missing output prefix directories similar to Initiate MPU request ([S3InitiateMultipartUploadRequestWithFSO.java](https://github.com/apache/ozone/blob/83d75861b0266160b219acde72d769eb0f9d5ac4/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java#L192-L207), [S3InitiateMultipartUploadResponseWithFSO.java](https://github.com/apache/ozone/blob/83d75861b0266160b219acde72d769eb0f9d5ac4/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3InitiateMultipartUploadResponseWithFSO.java#L83-L107)) is missing in the Complete MPU request.

The proposed solution adds the missing parent and output prefix directories back to DB before completing the MPU. 

Errors:
```
##When creating getDBOzoneKey
StateMachine ApplyTransaction Thread - 0]-org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCompleteRequest: MultipartUpload Complete request failed for Key: st-data-con-jqmmwt/qetest/terasort/output-1710494153/part-r-00000 in Volume/Bucket s3v/qe-dataconn-bucket
DIRECTORY_NOT_FOUND org.apache.hadoop.ozone.om.exceptions.OMException: Failed to find parent directory of st-data-con-jqmmwt/qetest/terasort/output-1710494153/part-r-00000
	at org.apache.hadoop.ozone.om.request.file.OMFileRequest.getParentID(OMFileRequest.java:1008)
	at org.apache.hadoop.ozone.om.request.file.OMFileRequest.getParentID(OMFileRequest.java:958)
	at org.apache.hadoop.ozone.om.request.file.OMFileRequest.getParentId(OMFileRequest.java:1038)
	at org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCompleteRequestWithFSO.getDBOzoneKey(S3MultipartUploadCompleteRequestWithFSO.java:114)
	at org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCompleteRequest.validateAndUpdateCache(S3MultipartUploadCompleteRequest.java:157)
	at org.apache.hadoop.ozone.protocolPB.OzoneManagerRequestHandler.handleWriteRequest(OzoneManagerRequestHandler.java:378)
	at org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine.runCommand(OzoneManagerStateMachine.java:568)
	at org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine.lambda$1(OzoneManagerStateMachine.java:363)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

```
## When getting omKeyInfo from DB
StateMachine ApplyTransaction Thread - 0]-org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine: Terminating with exit status 1: Request cmdType: CompleteMultiPartUpload
traceID: ""
clientId: "client-5168AA460706"
userInfo {
  userName: "xxx"
  remoteAddress: "..."
  hostName: "..."
}
version: 3
completeMultiPartUploadRequest {
  keyArgs {
    volumeName: "s3v"
    bucketName: "qe-dataconn-bucket"
    keyName: "st-data-con-jqmmwt/qetest/terasort/output-1710494153/part-r-00000"
    multipartUploadID: "e1c08d2c-5798-4c81-ab2c-7a0bd0fea4c9-112101950169613319"
    acls {
      type: USER
      name: "..."
      rights: "\200"
      aclScope: ACCESS
    }
    acls {
      type: GROUP
      name: "hrt_qa"
      rights: "\000\001"
      aclScope: ACCESS
    }
    acls {
      type: GROUP
      name: "users"
      rights: "\000\001"
      aclScope: ACCESS
    }
    acls {
      type: GROUP
      name: "hivetest"
      rights: "\000\001"
      aclScope: ACCESS
    }
    modificationTime: 1710540186541
  }
  partsList {
    partNumber: 1
    partName: "/s3v/qe-dataconn-bucket/st-data-con-jqmmwt/qetest/terasort/output-1710494153/part-r-00000-e1c08d2c-5798-4c81-ab2c-7a0bd0fea4c9-112101950169613319-1"
  }
}
s3Authentication {
  stringToSign: "..."
  signature: "..."
  accessId: "..."
}
 failed with exception
java.lang.NullPointerException
	at org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCompleteRequest.getOmKeyInfo(S3MultipartUploadCompleteRequest.java:378)
	at org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCompleteRequest.validateAndUpdateCache(S3MultipartUploadCompleteRequest.java:202)
	at org.apache.hadoop.ozone.protocolPB.OzoneManagerRequestHandler.handleWriteRequest(OzoneManagerRequestHandler.java:378)
	at org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine.runCommand(OzoneManagerStateMachine.java:568)
	at org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine.lambda$1(OzoneManagerStateMachine.java:363)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834) 
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10630

## How was this patch tested?

Ran the s3a hadoop contract test `ITestS3ACommitterMRJob` to verify. There is another [PR](https://github.com/apache/ozone/pull/6458/files) out to add s3a contract tests to acceptance testing.

```
 ## Startup unsecure ozone cluster using docker-compose and create an FSO bucket
cd hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/ozone
docker-compose up -d --scale datanode=3
ozone sh bucket create /s3v/fso-bucket -l FILE_SYSTEM_OPTIMIZED

## Download the hadoop-aws source
curl -LSs -o "hadoop-src.tar.gz" https://archive.apache.org/dist/hadoop/common/hadoop-3.3.6/hadoop-3.3.6-src.tar.gz
tar -x -z -C "hadoop-src" --strip-components=3 -f "hadoop-src.tar.gz" 'hadoop-*-src/hadoop-tools/hadoop-aws'

## Create auth-keys.xml
vi hadoop-src/src/test/resources/auth-keys.xml 
<configuration>

  <property>
    <name>fs.s3a.endpoint</name>
    <value>http://localhost:9878</value>
  </property>

  <property>
    <name>fs.s3a.access.key</name>
    <value>s3a-contract</value>
  </property>

  <property>
    <name>fs.s3a.secret.key</name>
    <value>unsecure</value>
  </property>

 <property>
    <name>fs.s3a.committer.staging.conflict-mode</name>
    <value>replace</value>
  </property>

  <property>
    <name>fs.contract.test.fs.s3a</name>
    <value>s3a://fso-bucket/</value>
  </property>

  <property>
    <name>test.fs.s3a.name</name>
    <value>s3a://fso-bucket/</value>
  </property>

  <property>
    <name>test.fs.s3a.sts.enabled</name>
    <value>false</value>
  </property>

  <property>
    <name>fs.s3a.path.style.access</name>
    <value>true</value>
  </property>

  <property>
    <name>fs.s3a.directory.marker.retention</name>
    <value>keep</value>
  </property>

</configuration>

## Run the ITestS3ACommitterMRJob contract test
mvn clean test -B -V --no-transfer-progress -Dtest='ITestS3ACommitterMRJob' 
```



