### PR TITLE
HDDS-10542. Replace remaining GSON usage with Jackson.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.net;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
@@ -36,6 +37,7 @@ public class NodeImpl implements Node {
   // which level of the tree the node resides, start from 1 for root
   private int level;
   // node's parent
+  @JsonIgnore
   private InnerNode parent;
   // the cost to go through this node
   private final int cost;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -20,7 +20,9 @@ package org.apache.hadoop.hdds.server;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -79,14 +81,18 @@ public final class JsonUtils {
     return MAPPER.valueToTree(next);
   }
 
+  public static JsonNode valueToJsonNode(Object value) {
+    return MAPPER.valueToTree(value);
+  }
+
   public static JsonNode readTree(String content) throws IOException {
     return MAPPER.readTree(content);
   }
 
-  public static List<HashMap<String, Object>> readTreeAsListOfMaps(String json)
+  public static ArrayList<LinkedHashMap<String, Object>> readTreeAsListOfMaps(String json)
       throws IOException {
     return MAPPER.readValue(json,
-        new TypeReference<List<HashMap<String, Object>>>() {
+        new TypeReference<ArrayList<LinkedHashMap<String, Object>>>() {
         });
   }
 
@@ -114,6 +120,28 @@ public final class JsonUtils {
     try (MappingIterator<T> mappingIterator = reader.readValues(file)) {
       return mappingIterator.readAll();
     }
+  }
+
+  /**
+   * Reads JSON content from a Reader and deserializes it into an array of the
+   * specified type.
+   */
+  public static <T> T[] readArrayFromReader(Reader reader, Class<T[]> valueType)
+      throws IOException {
+    return MAPPER.readValue(reader, valueType);
+  }
+
+  /**
+   * Converts a JsonNode into a Java object of the specified type.
+   * @param node The JsonNode to convert.
+   * @param valueType The target class of the Java object.
+   * @param <T> The type of the Java object.
+   * @return A Java object of type T, populated with data from the JsonNode.
+   * @throws IOException
+   */
+  public static <T> T treeToValue(JsonNode node, Class<T> valueType)
+      throws IOException {
+    return MAPPER.treeToValue(node, valueType);
   }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerMetadataInspector.java
@@ -17,14 +17,15 @@
  */
 package org.apache.hadoop.ozone.container.keyvalue;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -53,7 +54,7 @@ import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContain
  * Container inspector for key value container metadata. It is capable of
  * logging metadata information about a container, and repairing the metadata
  * database values of #BLOCKCOUNT and #BYTESUSED.
- *
+ * <p>
  * To enable this inspector in inspect mode, pass the java system property
  * -Dozone.datanode.container.metadata.inspector=inspect on datanode startup.
  * This will cause the inspector to log metadata information about all
@@ -62,12 +63,12 @@ import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContain
  * ERROR level, and information about correct containers at the TRACE level.
  * Changing the `inspect` argument to `repair` will update these aggregate
  * values to match the database.
- *
+ * <p>
  * When run, the inspector will output json to the logger named in the
  * {@link KeyValueContainerMetadataInspector#REPORT_LOG} variable. The log4j
  * configuration can be modified to send this output to a separate file
  * without log information prefixes interfering with the json. For example:
- *
+ * <p>
  * log4j.logger.ContainerMetadataInspectorReport=INFO,inspectorAppender
  * log4j.appender.inspectorAppender=org.apache.log4j.FileAppender
  * log4j.appender.inspectorAppender.File=${hadoop.log.dir}/\
@@ -165,7 +166,7 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
   }
 
   public String process(ContainerData containerData, DatanodeStore store,
-      Logger log) {
+                        Logger log) {
     // If the system property to process container metadata was not
     // specified, or the inspector is unloaded, this method is a no-op.
     if (mode == Mode.OFF) {
@@ -181,55 +182,63 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
       return null;
     }
 
-    JsonObject containerJson = inspectContainer(kvData, store);
-    boolean correct = checkAndRepair(containerJson, kvData, store);
+    // Assuming inspectContainer method returns an ObjectNode instead of JsonObject
+    // You will need to refactor inspectContainer to construct an ObjectNode using Jackson
+    ObjectNode containerJson = inspectContainer(kvData, store);
+    boolean correct = checkAndRepair(containerJson, kvData,
+        store); // This method also needs to accept ObjectNode instead of JsonObject
 
-    Gson gson = new GsonBuilder()
-        .setPrettyPrinting()
-        .serializeNulls()
-        .create();
-    String jsonReport = gson.toJson(containerJson);
-    if (log != null) {
-      if (correct) {
-        log.trace(jsonReport);
-      } else {
-        log.error(jsonReport);
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.enable(
+        SerializationFeature.INDENT_OUTPUT);
+    String jsonReport = null;
+    try {
+      jsonReport = objectMapper.writeValueAsString(containerJson);
+      if (log != null) {
+        if (correct) {
+          log.trace(jsonReport);
+        } else {
+          log.error(jsonReport);
+        }
       }
+    } catch (Exception e) {
+      LOG.error("Error serializing container JSON", e);
     }
+
     return jsonReport;
   }
 
-  static JsonObject inspectContainer(KeyValueContainerData containerData,
-      DatanodeStore store) {
+  static ObjectNode inspectContainer(KeyValueContainerData containerData,
+                                     DatanodeStore store) {
 
-    JsonObject containerJson = new JsonObject();
+    ObjectNode containerJson = JsonUtils.createObjectNode(null);
 
     try {
       // Build top level container properties.
-      containerJson.addProperty("containerID", containerData.getContainerID());
+      containerJson.put("containerID", containerData.getContainerID());
       String schemaVersion = containerData.getSchemaVersion();
-      containerJson.addProperty("schemaVersion", schemaVersion);
-      containerJson.addProperty("containerState",
-          containerData.getState().toString());
-      containerJson.addProperty("currentDatanodeID",
+      containerJson.put("schemaVersion", schemaVersion);
+      containerJson.put("containerState", containerData.getState().toString());
+      containerJson.put("currentDatanodeID",
           containerData.getVolume().getDatanodeUuid());
-      containerJson.addProperty("originDatanodeID",
-          containerData.getOriginNodeId());
+      containerJson.put("originDatanodeID", containerData.getOriginNodeId());
 
       // Build DB metadata values.
-      Table<String, Long> metadataTable = store.getMetadataTable();
-      JsonObject dBMetadata = getDBMetadataJson(metadataTable, containerData);
-      containerJson.add("dBMetadata", dBMetadata);
+      // Assuming getDBMetadataJson and getAggregateValues methods return ObjectNode and are refactored to use Jackson
+      ObjectNode dBMetadata =
+          getDBMetadataJson(store.getMetadataTable(), containerData);
+      containerJson.set("dBMetadata", dBMetadata);
 
       // Build aggregate values.
-      JsonObject aggregates = getAggregateValues(store,
-          containerData, schemaVersion);
-      containerJson.add("aggregates", aggregates);
+      ObjectNode aggregates =
+          getAggregateValues(store, containerData, schemaVersion);
+      containerJson.set("aggregates", aggregates);
 
       // Build info about chunks directory.
-      JsonObject chunksDirectory =
+      // Assuming getChunksDirectoryJson method returns ObjectNode and is refactored to use Jackson
+      ObjectNode chunksDirectory =
           getChunksDirectoryJson(new File(containerData.getChunksPath()));
-      containerJson.add("chunksDirectory", chunksDirectory);
+      containerJson.set("chunksDirectory", chunksDirectory);
     } catch (IOException ex) {
       LOG.error("Inspecting container {} failed",
           containerData.getContainerID(), ex);
@@ -238,28 +247,31 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
     return containerJson;
   }
 
-  static JsonObject getDBMetadataJson(Table<String, Long> metadataTable,
-      KeyValueContainerData containerData) throws IOException {
-    JsonObject dBMetadata = new JsonObject();
+  static ObjectNode getDBMetadataJson(Table<String, Long> metadataTable,
+                                      KeyValueContainerData containerData)
+      throws IOException {
+    ObjectNode dBMetadata = JsonUtils.createObjectNode(null);
 
-    dBMetadata.addProperty(OzoneConsts.BLOCK_COUNT,
+    dBMetadata.put(OzoneConsts.BLOCK_COUNT,
         metadataTable.get(containerData.getBlockCountKey()));
-    dBMetadata.addProperty(OzoneConsts.CONTAINER_BYTES_USED,
+    dBMetadata.put(OzoneConsts.CONTAINER_BYTES_USED,
         metadataTable.get(containerData.getBytesUsedKey()));
-    dBMetadata.addProperty(OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
+    dBMetadata.put(OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
         metadataTable.get(containerData.getPendingDeleteBlockCountKey()));
-    dBMetadata.addProperty(OzoneConsts.DELETE_TRANSACTION_KEY,
+    dBMetadata.put(OzoneConsts.DELETE_TRANSACTION_KEY,
         metadataTable.get(containerData.getLatestDeleteTxnKey()));
-    dBMetadata.addProperty(OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID,
+    dBMetadata.put(OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID,
         metadataTable.get(containerData.getBcsIdKey()));
 
     return dBMetadata;
   }
 
-  static JsonObject getAggregateValues(DatanodeStore store,
-      KeyValueContainerData containerData, String schemaVersion)
+  static ObjectNode getAggregateValues(DatanodeStore store,
+                                       KeyValueContainerData containerData,
+                                       String schemaVersion)
       throws IOException {
-    JsonObject aggregates = new JsonObject();
+
+    ObjectNode aggregates = JsonUtils.createObjectNode(null);
 
     long usedBytesTotal = 0;
     long blockCountTotal = 0;
@@ -308,19 +320,19 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
               "container schema " + schemaVersion);
     }
 
-    aggregates.addProperty("blockCount", blockCountTotal);
-    aggregates.addProperty("usedBytes", usedBytesTotal);
+    aggregates.put("blockCount", blockCountTotal);
+    aggregates.put("usedBytes", usedBytesTotal);
     pendingDelete.addToJson(aggregates);
 
     return aggregates;
   }
 
-  static JsonObject getChunksDirectoryJson(File chunksDir) throws IOException {
-    JsonObject chunksDirectory = new JsonObject();
+  static ObjectNode getChunksDirectoryJson(File chunksDir) throws IOException {
+    ObjectNode chunksDirectory = JsonUtils.createObjectNode(null);
 
-    chunksDirectory.addProperty("path", chunksDir.getAbsolutePath());
+    chunksDirectory.put("path", chunksDir.getAbsolutePath());
     boolean chunksDirPresent = FileUtils.isDirectory(chunksDir);
-    chunksDirectory.addProperty("present", chunksDirPresent);
+    chunksDirectory.put("present", chunksDirPresent);
 
     long fileCount = 0;
     if (chunksDirPresent) {
@@ -328,43 +340,38 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
         fileCount = stream.count();
       }
     }
-    chunksDirectory.addProperty("fileCount", fileCount);
+    chunksDirectory.put("fileCount", fileCount);
 
     return chunksDirectory;
   }
 
-  private boolean checkAndRepair(JsonObject parent,
-      KeyValueContainerData containerData, DatanodeStore store) {
-    JsonArray errors = new JsonArray();
+  private boolean checkAndRepair(ObjectNode parent,
+                                 KeyValueContainerData containerData,
+                                 DatanodeStore store) {
+    ArrayNode errors = JsonUtils.createArrayNode();
     boolean passed = true;
 
     Table<String, Long> metadataTable = store.getMetadataTable();
 
-    final JsonObject dBMetadata = parent.getAsJsonObject("dBMetadata");
-    final JsonObject aggregates = parent.getAsJsonObject("aggregates");
+    ObjectNode dBMetadata = (ObjectNode) parent.get("dBMetadata");
+    ObjectNode aggregates = (ObjectNode) parent.get("aggregates");
 
     // Check and repair block count.
-    JsonElement blockCountDB = parent.getAsJsonObject("dBMetadata")
-        .get(OzoneConsts.BLOCK_COUNT);
-
-    JsonElement blockCountAggregate = parent.getAsJsonObject("aggregates")
-        .get("blockCount");
+    JsonNode blockCountDB = dBMetadata.get(OzoneConsts.BLOCK_COUNT);
+    JsonNode blockCountAggregate = aggregates.get("blockCount");
 
     // If block count is absent from the DB, it is only an error if there are
     // a non-zero amount of block keys in the DB.
-    long blockCountDBLong = 0;
-    if (!blockCountDB.isJsonNull()) {
-      blockCountDBLong = blockCountDB.getAsLong();
-    }
+    long blockCountDBLong = blockCountDB.isNull() ? 0 : blockCountDB.asLong();
 
-    if (blockCountDBLong != blockCountAggregate.getAsLong()) {
+    if (blockCountDBLong != blockCountAggregate.asLong()) {
       passed = false;
 
       BooleanSupplier keyRepairAction = () -> {
         boolean repaired = false;
         try {
           metadataTable.put(containerData.getBlockCountKey(),
-              blockCountAggregate.getAsLong());
+              blockCountAggregate.asLong());
           repaired = true;
         } catch (IOException ex) {
           LOG.error("Error repairing block count for container {}.",
@@ -373,33 +380,32 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
         return repaired;
       };
 
-      JsonObject blockCountError = buildErrorAndRepair("dBMetadata." +
-              OzoneConsts.BLOCK_COUNT, blockCountAggregate, blockCountDB,
-          keyRepairAction);
+      ObjectNode blockCountError =
+          buildErrorAndRepair("dBMetadata." + OzoneConsts.BLOCK_COUNT,
+              blockCountAggregate, blockCountDB, keyRepairAction);
       errors.add(blockCountError);
     }
 
     // Check and repair used bytes.
-    JsonElement usedBytesDB = parent.getAsJsonObject("dBMetadata")
-        .get(OzoneConsts.CONTAINER_BYTES_USED);
-    JsonElement usedBytesAggregate = parent.getAsJsonObject("aggregates")
-        .get("usedBytes");
+    JsonNode usedBytesDB =
+        parent.path("dBMetadata").path(OzoneConsts.CONTAINER_BYTES_USED);
+    JsonNode usedBytesAggregate = parent.path("aggregates").path("usedBytes");
 
     // If used bytes is absent from the DB, it is only an error if there is
     // a non-zero aggregate of used bytes among the block keys.
     long usedBytesDBLong = 0;
-    if (!usedBytesDB.isJsonNull()) {
-      usedBytesDBLong = usedBytesDB.getAsLong();
+    if (!usedBytesDB.isMissingNode()) {
+      usedBytesDBLong = usedBytesDB.asLong();
     }
 
-    if (usedBytesDBLong != usedBytesAggregate.getAsLong()) {
+    if (usedBytesDBLong != usedBytesAggregate.asLong()) {
       passed = false;
 
       BooleanSupplier keyRepairAction = () -> {
         boolean repaired = false;
         try {
           metadataTable.put(containerData.getBytesUsedKey(),
-              usedBytesAggregate.getAsLong());
+              usedBytesAggregate.asLong());
           repaired = true;
         } catch (IOException ex) {
           LOG.error("Error repairing used bytes for container {}.",
@@ -408,18 +414,19 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
         return repaired;
       };
 
-      JsonObject usedBytesError = buildErrorAndRepair("dBMetadata." +
-              OzoneConsts.CONTAINER_BYTES_USED, usedBytesAggregate, usedBytesDB,
-          keyRepairAction);
-      errors.add(usedBytesError);
+      ObjectNode usedBytesError =
+          buildErrorAndRepair("dBMetadata." + OzoneConsts.CONTAINER_BYTES_USED,
+              usedBytesAggregate,
+          usedBytesDB, keyRepairAction);
+      ((ArrayNode) errors).add(usedBytesError);
     }
 
     // check and repair if db delete count mismatches delete transaction count.
-    final JsonElement pendingDeleteCountDB = dBMetadata.get(
-        OzoneConsts.PENDING_DELETE_BLOCK_COUNT);
+    JsonNode pendingDeleteCountDB =
+        dBMetadata.path(OzoneConsts.PENDING_DELETE_BLOCK_COUNT);
     final long dbDeleteCount = jsonToLong(pendingDeleteCountDB);
-    final JsonElement pendingDeleteCountAggregate
-        = aggregates.get(PendingDelete.COUNT);
+    final JsonNode pendingDeleteCountAggregate
+        = aggregates.path(PendingDelete.COUNT);
     final long deleteTransactionCount = jsonToLong(pendingDeleteCountAggregate);
     if (dbDeleteCount != deleteTransactionCount) {
       passed = false;
@@ -437,17 +444,16 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
         return false;
       };
 
-      final JsonObject deleteCountError = buildErrorAndRepair(
-          "dBMetadata." + OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
-          pendingDeleteCountAggregate, pendingDeleteCountDB,
+      final ObjectNode deleteCountError = buildErrorAndRepair("dBMetadata." + OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
+          pendingDeleteCountAggregate,
+          pendingDeleteCountDB,
           deleteCountRepairAction);
-      errors.add(deleteCountError);
+      ((ArrayNode) errors).add(deleteCountError);
     }
 
     // check and repair chunks dir.
-    JsonElement chunksDirPresent = parent.getAsJsonObject("chunksDirectory")
-        .get("present");
-    if (!chunksDirPresent.getAsBoolean()) {
+    JsonNode chunksDirPresent = parent.path("chunksDirectory").path("present");
+    if (!chunksDirPresent.asBoolean()) {
       passed = false;
 
       BooleanSupplier dirRepairAction = () -> {
@@ -463,32 +469,37 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
         return repaired;
       };
 
-      JsonObject chunksDirError = buildErrorAndRepair("chunksDirectory.present",
-          new JsonPrimitive(true), chunksDirPresent, dirRepairAction);
-      errors.add(chunksDirError);
+      ObjectNode chunksDirError =
+          buildErrorAndRepair("chunksDirectory.present",
+              JsonNodeFactory.instance.booleanNode(true), chunksDirPresent,
+              dirRepairAction);
+      ((ArrayNode) errors).add(
+          chunksDirError); // Assuming 'errors' is an ArrayNode
     }
 
-    parent.addProperty("correct", passed);
-    parent.add("errors", errors);
+    parent.put("correct", passed);
+    parent.set("errors", errors);
     return passed;
   }
 
-  static long jsonToLong(JsonElement e) {
-    return e == null || e.isJsonNull() ? 0 : e.getAsLong();
+  private static long jsonToLong(JsonNode e) {
+    return e == null || e.isNull() ? 0 : e.asLong();
   }
 
-  private JsonObject buildErrorAndRepair(String property, JsonElement expected,
-      JsonElement actual, BooleanSupplier repairAction) {
-    JsonObject error = new JsonObject();
-    error.addProperty("property", property);
-    error.add("expected", expected);
-    error.add("actual", actual);
+  private ObjectNode buildErrorAndRepair(String property,
+                                         JsonNode expected,
+                                         JsonNode actual,
+                                         BooleanSupplier repairAction) {
+    ObjectNode error = JsonUtils.createObjectNode(null);
+    error.put("property", property);
+    error.set("expected", expected);
+    error.set("actual", actual);
 
     boolean repaired = false;
     if (mode == Mode.REPAIR) {
       repaired = repairAction.getAsBoolean();
     }
-    error.addProperty("repaired", repaired);
+    error.put("repaired", repaired);
 
     return error;
   }
@@ -505,9 +516,9 @@ public class KeyValueContainerMetadataInspector implements ContainerInspector {
       this.bytes = bytes;
     }
 
-    void addToJson(JsonObject json) {
-      json.addProperty(COUNT, count);
-      json.addProperty(BYTES, bytes);
+    void addToJson(ObjectNode json) {
+      json.put(COUNT, count);
+      json.put(BYTES, bytes);
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMetadataInspector.java
@@ -17,12 +17,9 @@
  */
 package org.apache.hadoop.ozone.container.keyvalue;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -312,7 +309,7 @@ public class TestKeyValueContainerMetadataInspector
     String containerState = containerData.getState().toString();
 
     // First inspect the container.
-    JsonObject inspectJson = runInspectorAndGetReport(containerData,
+    JsonNode inspectJson = runInspectorAndGetReport(containerData,
         KeyValueContainerMetadataInspector.Mode.INSPECT);
 
     checkJsonReportForIncorrectContainer(inspectJson,
@@ -322,7 +319,7 @@ public class TestKeyValueContainerMetadataInspector
     checkDbCounts(containerData, setBlocks, setBytes, deleteCount);
 
     // Now repair the container.
-    JsonObject repairJson = runInspectorAndGetReport(containerData,
+    JsonNode repairJson = runInspectorAndGetReport(containerData,
         KeyValueContainerMetadataInspector.Mode.REPAIR);
     checkJsonReportForIncorrectContainer(repairJson,
         containerState, createdBlocks, setBlocks, createdBytes, setBytes,
@@ -333,38 +330,32 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
-  private void checkJsonReportForIncorrectContainer(JsonObject inspectJson,
+  private void checkJsonReportForIncorrectContainer(JsonNode inspectJson,
       String expectedContainerState, long createdBlocks,
       long setBlocks, long createdBytes, long setBytes, long createdFiles,
       long setPendingDeleteCount, long createdPendingDeleteCount,
       boolean shouldRepair) {
     // Check main container properties.
-    assertEquals(inspectJson.get("containerID").getAsLong(),
-        CONTAINER_ID);
-    assertEquals(inspectJson.get("containerState").getAsString(),
-        expectedContainerState);
+    assertEquals(inspectJson.get("containerID").asLong(), CONTAINER_ID);
+    assertEquals(inspectJson.get("containerState").asText(), expectedContainerState);
 
     // Check DB metadata.
-    JsonObject jsonDbMetadata = inspectJson.getAsJsonObject("dBMetadata");
+    JsonNode jsonDbMetadata = inspectJson.get("dBMetadata");
     assertEquals(setBlocks,
-        jsonDbMetadata.get(OzoneConsts.BLOCK_COUNT).getAsLong());
+        jsonDbMetadata.get(OzoneConsts.BLOCK_COUNT).asLong());
     assertEquals(setBytes,
-        jsonDbMetadata.get(OzoneConsts.CONTAINER_BYTES_USED).getAsLong());
+        jsonDbMetadata.get(OzoneConsts.CONTAINER_BYTES_USED).asLong());
 
     // Check aggregate metadata values.
-    JsonObject jsonAggregates = inspectJson.getAsJsonObject("aggregates");
-    assertEquals(createdBlocks,
-        jsonAggregates.get("blockCount").getAsLong());
-    assertEquals(createdBytes,
-        jsonAggregates.get("usedBytes").getAsLong());
-    assertEquals(createdPendingDeleteCount,
-        jsonAggregates.get("pendingDeleteBlocks").getAsLong());
+    JsonNode jsonAggregates = inspectJson.get("aggregates");
+    assertEquals(createdBlocks, jsonAggregates.get("blockCount").asLong());
+    assertEquals(createdBytes, jsonAggregates.get("usedBytes").asLong());
+    assertEquals(createdPendingDeleteCount, jsonAggregates.get("pendingDeleteBlocks").asLong());
 
     // Check chunks directory.
-    JsonObject jsonChunksDir = inspectJson.getAsJsonObject("chunksDirectory");
-    assertTrue(jsonChunksDir.get("present").getAsBoolean());
-    assertEquals(createdFiles,
-        jsonChunksDir.get("fileCount").getAsLong());
+    JsonNode jsonChunksDir = inspectJson.get("chunksDirectory");
+    assertTrue(jsonChunksDir.get("present").asBoolean());
+    assertEquals(createdFiles, jsonChunksDir.get("fileCount").asLong());
 
     // Check errors.
     checkJsonErrorsReport(inspectJson, "dBMetadata.#BLOCKCOUNT",
@@ -376,48 +367,42 @@ public class TestKeyValueContainerMetadataInspector
   }
 
   private void checkJsonErrorsReport(
-      JsonObject jsonReport, String propertyValue,
+      JsonNode jsonReport, String propertyValue,
       long correctExpected, long correctActual,
       boolean correctRepair) {
     if (correctExpected == correctActual) {
       return;
     }
-    checkJsonErrorsReport(jsonReport, propertyValue,
-        new JsonPrimitive(correctExpected),
-        new JsonPrimitive(correctActual),
-        correctRepair);
+    JsonNode correctExpectedNode = JsonUtils.valueToJsonNode(correctExpected);
+    JsonNode correctActualNode = JsonUtils.valueToJsonNode(correctActual);
+
+    checkJsonErrorsReport(jsonReport, propertyValue, correctExpectedNode,
+        correctActualNode, correctRepair);
   }
 
   /**
    * Checks the erorr list in the provided JsonReport for an error matching
    * the template passed in with the parameters.
    */
-  private void checkJsonErrorsReport(JsonObject jsonReport,
-      String propertyValue, JsonPrimitive correctExpected,
-      JsonPrimitive correctActual, boolean correctRepair) {
+  private void checkJsonErrorsReport(JsonNode jsonReport,
+                                     String propertyValue,
+                                     JsonNode correctExpected,
+                                     JsonNode correctActual,
+                                     boolean correctRepair) {
 
-    assertFalse(jsonReport.get("correct").getAsBoolean());
+    assertFalse(jsonReport.get("correct").asBoolean());
 
-    JsonArray jsonErrors = jsonReport.getAsJsonArray("errors");
+    JsonNode jsonErrors = jsonReport.get("errors");
     boolean matchFound = false;
-    for (JsonElement jsonErrorElem: jsonErrors) {
-      JsonObject jsonErrorObject = jsonErrorElem.getAsJsonObject();
-      String thisProperty =
-          jsonErrorObject.get("property").getAsString();
+    for (JsonNode jsonErrorElem : jsonErrors) {
+      String thisProperty = jsonErrorElem.get("property").asText();
 
       if (thisProperty.equals(propertyValue)) {
         matchFound = true;
+        assertEquals(correctExpected.asLong(), jsonErrorElem.get("expected").asLong());
+        assertEquals(correctActual.asLong(), jsonErrorElem.get("actual").asLong());
 
-        JsonPrimitive expectedJsonPrim =
-            jsonErrorObject.get("expected").getAsJsonPrimitive();
-        assertEquals(correctExpected, expectedJsonPrim);
-
-        JsonPrimitive actualJsonPrim =
-            jsonErrorObject.get("actual").getAsJsonPrimitive();
-        assertEquals(correctActual, actualJsonPrim);
-
-        boolean repaired =
-            jsonErrorObject.get("repaired").getAsBoolean();
+        boolean repaired = jsonErrorElem.get("repaired").asBoolean();
         assertEquals(correctRepair, repaired);
         break;
       }
@@ -425,6 +410,7 @@ public class TestKeyValueContainerMetadataInspector
 
     assertTrue(matchFound);
   }
+
 
   public void setDBBlockAndByteCounts(KeyValueContainerData containerData,
       long blockCount, long byteCount) throws Exception {
@@ -496,20 +482,22 @@ public class TestKeyValueContainerMetadataInspector
     }
   }
 
-  private JsonObject runInspectorAndGetReport(
+  private JsonNode runInspectorAndGetReport(
       KeyValueContainerData containerData,
       KeyValueContainerMetadataInspector.Mode mode) throws Exception {
     System.setProperty(KeyValueContainerMetadataInspector.SYSTEM_PROPERTY,
         mode.toString());
     ContainerInspectorUtil.load();
-    JsonObject json = runInspectorAndGetReport(containerData);
+
+    JsonNode json = runInspectorAndGetReport(containerData);
+
     ContainerInspectorUtil.unload();
     System.clearProperty(KeyValueContainerMetadataInspector.SYSTEM_PROPERTY);
 
     return json;
   }
 
-  private JsonObject runInspectorAndGetReport(
+  private JsonNode runInspectorAndGetReport(
       KeyValueContainerData containerData) throws Exception {
     // Use an empty layout so the captured log has no prefix and can be
     // parsed as json.
@@ -521,8 +509,11 @@ public class TestKeyValueContainerMetadataInspector
     capturer.stopCapturing();
     String output = capturer.getOutput();
     capturer.clearOutput();
-
-    return new Gson().fromJson(output, JsonObject.class);
+    // Check if the output is effectively empty
+    if (output.trim().isEmpty()) {
+      return null;
+    }
+    return JsonUtils.readTree(output);
   }
 
   private KeyValueContainer createClosedContainer(int normalBlocks)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/HddsConfServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/HddsConfServlet.java
@@ -28,13 +28,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.common.base.Strings;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdds.server.http.HttpServer2;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.Gson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,18 +143,18 @@ public class HddsConfServlet extends HttpServlet {
   }
 
   private void processConfigTagRequest(HttpServletRequest request, String cmd,
-      Writer out) throws IOException {
-    Gson gson = new Gson();
+                                       Writer out) throws IOException {
     OzoneConfiguration config = getOzoneConfig();
 
     switch (cmd) {
     case "getOzoneTags":
-      out.write(gson.toJson(OzoneConfiguration.TAGS));
+      out.write(JsonUtils.toJsonString(OzoneConfiguration.TAGS));
       break;
     case "getPropertyByTag":
       String tags = request.getParameter("tags");
-      if (Strings.isNullOrEmpty(tags)) {
-        throw new IllegalArgumentException("The tags parameter should be set" +
+      if (tags == null || tags.isEmpty()) {
+        throw new IllegalArgumentException(
+            "The tags parameter should be set " +
                 " when using the getPropertyByTag command.");
       }
       Map<String, Properties> propMap = new HashMap<>();
@@ -170,7 +169,7 @@ public class HddsConfServlet extends HttpServlet {
           }
         }
       }
-      out.write(gson.toJsonTree(propMap).toString());
+      out.write(JsonUtils.toJsonString(propMap));
       break;
     default:
       throw new IllegalArgumentException(cmd + " is not a valid command.");

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/DeletedBlocksTransactionInfoWrapper.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/DeletedBlocksTransactionInfoWrapper.java
@@ -38,6 +38,12 @@ public class DeletedBlocksTransactionInfoWrapper {
     this.localIdList = localIdList;
     this.count = count;
   }
+  public DeletedBlocksTransactionInfoWrapper() {
+    this.txID = 0;
+    this.containerID = 0;
+    this.localIdList = null;
+    this.count = 0;
+  }
 
   public static DeletedBlocksTransactionInfoWrapper fromProtobuf(
       DeletedBlocksTransactionInfo txn) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/conf/TestHddsConfServlet.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Strings;
-import com.google.gson.Gson;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdds.server.http.HttpServer2;
 import org.apache.hadoop.util.XMLUtils;
 import org.eclipse.jetty.util.ajax.JSON;
@@ -109,8 +109,7 @@ public class TestHddsConfServlet {
     conf.getObject(OzoneTestConfig.class);
     // test cmd is getOzoneTags
     String result = getResultWithCmd(conf, "getOzoneTags");
-    Gson gson = new Gson();
-    String tags = gson.toJson(OzoneConfiguration.TAGS);
+    String tags = JsonUtils.toJsonString(OzoneConfiguration.TAGS);
     assertEquals(result, tags);
     // cmd is getPropertyByTag
     result = getResultWithCmd(conf, "getPropertyByTag");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -34,11 +34,11 @@ import static org.slf4j.event.Level.INFO;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.LinkedHashMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.client.BlockID;
@@ -383,11 +383,11 @@ public class TestReconWithOzoneManager {
                                              String taskName,
                                              String entityAttribute)
       throws IOException {
-    List<HashMap<String, Object>> taskStatusList =
+    List<LinkedHashMap<String, Object>> taskStatusList =
         JsonUtils.readTreeAsListOfMaps(taskStatusResponse);
 
     // Stream through the list to find the task entity matching the taskName
-    Optional<HashMap<String, Object>> taskEntity = taskStatusList.stream()
+    Optional<LinkedHashMap<String, Object>> taskEntity = taskStatusList.stream()
         .filter(task -> taskName.equals(task.get("taskName")))
         .findFirst();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -24,15 +24,17 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+import java.util.ArrayList;
 
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.kms.KMSClientProvider;
 import org.apache.hadoop.crypto.key.kms.server.MiniKMS;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileChecksum;
@@ -70,8 +72,6 @@ import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.ozone.om.TrashPolicyOzone;
 
 import com.google.common.base.Strings;
-import com.google.gson.Gson;
-import com.google.gson.internal.LinkedTreeMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
@@ -412,10 +412,12 @@ public class TestOzoneShellHA {
    * Parse output into ArrayList with Gson.
    * @return ArrayList
    */
-  private ArrayList<LinkedTreeMap<String, String>> parseOutputIntoArrayList()
-      throws UnsupportedEncodingException {
-    return new Gson().fromJson(out.toString(DEFAULT_ENCODING), ArrayList.class);
+  private ArrayList<LinkedHashMap<String, Object>> parseOutputIntoArrayList()
+      throws IOException {
+    String jsonInput = out.toString(DEFAULT_ENCODING);
+    return JsonUtils.readTreeAsListOfMaps(jsonInput);
   }
+
 
   @Test
   public void testRATISTypeECReplication() {
@@ -488,7 +490,8 @@ public class TestOzoneShellHA {
    * Test ozone shell list command.
    */
   @Test
-  public void testOzoneShCmdList() throws UnsupportedEncodingException {
+  public void testOzoneShCmdList()
+      throws IOException {
     // Part of listing keys test.
     generateKeys("/volume4", "/bucket", "");
     final String destinationBucket = "o3://" + omServiceId + "/volume4/bucket";
@@ -1671,7 +1674,7 @@ public class TestOzoneShellHA {
   }
 
   public void testListVolumeBucketKeyShouldPrintValidJsonArray()
-      throws UnsupportedEncodingException {
+      throws IOException {
 
     final List<String> testVolumes =
         Arrays.asList("jsontest-vol1", "jsontest-vol2", "jsontest-vol3");
@@ -1696,7 +1699,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"volume", "list"});
 
     // Expect valid JSON array
-    final ArrayList<LinkedTreeMap<String, String>> volumeListOut =
+    final ArrayList<LinkedHashMap<String, Object>> volumeListOut =
         parseOutputIntoArrayList();
     // Can include s3v and volumes from other test cases that aren't cleaned up,
     //  hence >= instead of equals.
@@ -1711,7 +1714,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", firstVolumePrefix});
 
     // Expect valid JSON array as well
-    final ArrayList<LinkedTreeMap<String, String>> bucketListOut =
+    final ArrayList<LinkedHashMap<String, Object>> bucketListOut =
         parseOutputIntoArrayList();
     assertEquals(testBuckets.size(), bucketListOut.size());
     final HashSet<String> bucketSet = new HashSet<>(testBuckets);
@@ -1724,7 +1727,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"key", "list", keyPathPrefix});
 
     // Expect valid JSON array as well
-    final ArrayList<LinkedTreeMap<String, String>> keyListOut =
+    final ArrayList<LinkedHashMap<String, Object>> keyListOut =
         parseOutputIntoArrayList();
     assertEquals(testKeys.size(), keyListOut.size());
     final HashSet<String> keySet = new HashSet<>(testKeys);
@@ -1977,7 +1980,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", "/volume1"});
 
     // Expect valid JSON array
-    final ArrayList<LinkedTreeMap<String, String>> bucketListOut =
+    final ArrayList<LinkedHashMap<String, Object>> bucketListOut =
         parseOutputIntoArrayList();
 
     assertEquals(1, bucketListOut.size());
@@ -1996,7 +1999,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", "/volume1"});
 
     // Expect valid JSON array
-    final ArrayList<LinkedTreeMap<String, String>> bucketListLinked =
+    final ArrayList<LinkedHashMap<String, Object>> bucketListLinked =
         parseOutputIntoArrayList();
 
     assertEquals(2, bucketListLinked.size());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
@@ -18,11 +18,9 @@
 
 package org.apache.hadoop.ozone.recon.heatmap;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.ozone.recon.ReconTestInjector;
 import org.apache.hadoop.ozone.recon.api.types.EntityMetaData;
 import org.apache.hadoop.ozone.recon.api.types.EntityReadAccessHeatMapResponse;
@@ -745,17 +743,20 @@ public class TestHeatMapInfo {
   public void testHeatMapGeneratedInfo() throws IOException {
     // Setup
     // Run the test
-    JsonElement jsonElement = JsonParser.parseString(auditRespStr);
-    JsonObject jsonObject = jsonElement.getAsJsonObject();
-    JsonElement facets = jsonObject.get("facets");
-    JsonObject facetsBucketsObject =
-        facets.getAsJsonObject().get("resources")
-            .getAsJsonObject();
-    ObjectMapper objectMapper = new ObjectMapper();
+    // Parse the JSON string to JsonNode
+    JsonNode rootNode = JsonUtils.readTree(auditRespStr);
 
-    HeatMapProviderDataResource auditLogFacetsResources =
-        objectMapper.readValue(
-            facetsBucketsObject.toString(), HeatMapProviderDataResource.class);
+    JsonNode facetsNode = rootNode.path("facets");
+    JsonNode resourcesNode = facetsNode.path("resources");
+
+    // Deserialize the resources node directly if it's not missing
+    HeatMapProviderDataResource auditLogFacetsResources = null;
+
+    if (!resourcesNode.isMissingNode()) {
+      auditLogFacetsResources = JsonUtils.treeToValue(resourcesNode,
+          HeatMapProviderDataResource.class);
+    }
+
     EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
     List<EntityMetaData> entityMetaDataList =
         Arrays.stream(entities).collect(Collectors.toList());
@@ -831,20 +832,18 @@ public class TestHeatMapInfo {
         "    }\n" +
         "  }\n" +
         "}";
-    JsonElement jsonElement =
-        JsonParser.parseString(auditRespStrWithVolumeEntityType);
-    JsonObject jsonObject = jsonElement.getAsJsonObject();
-    JsonElement facets = jsonObject.get("facets");
-    JsonElement resources = facets.getAsJsonObject().get("resources");
-    JsonObject facetsBucketsObject = new JsonObject();
-    if (null != resources) {
-      facetsBucketsObject = resources.getAsJsonObject();
-    }
-    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode rootNode = JsonUtils.readTree(auditRespStrWithVolumeEntityType);
 
-    HeatMapProviderDataResource auditLogFacetsResources =
-        objectMapper.readValue(
-            facetsBucketsObject.toString(), HeatMapProviderDataResource.class);
+    JsonNode facetsNode = rootNode.path("facets");
+    JsonNode resourcesNode = facetsNode.path("resources");
+
+    // Deserialize the resources node directly if it's not missing
+    HeatMapProviderDataResource auditLogFacetsResources = null;
+    if (!resourcesNode.isMissingNode()) {
+      auditLogFacetsResources = JsonUtils.treeToValue(resourcesNode,
+          HeatMapProviderDataResource.class);
+    }
+
     EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
     if (null != entities && entities.length > 0) {
       List<EntityMetaData> entityMetaDataList =
@@ -965,20 +964,17 @@ public class TestHeatMapInfo {
         "    }\n" +
         "  }\n" +
         "}";
-    JsonElement jsonElement =
-        JsonParser.parseString(auditRespStrWithPathAndBucketEntityType);
-    JsonObject jsonObject = jsonElement.getAsJsonObject();
-    JsonElement facets = jsonObject.get("facets");
-    JsonElement resources = facets.getAsJsonObject().get("resources");
-    JsonObject facetsBucketsObject = new JsonObject();
-    if (null != resources) {
-      facetsBucketsObject = resources.getAsJsonObject();
-    }
-    ObjectMapper objectMapper = new ObjectMapper();
 
-    HeatMapProviderDataResource auditLogFacetsResources =
-        objectMapper.readValue(
-            facetsBucketsObject.toString(), HeatMapProviderDataResource.class);
+    JsonNode rootNode = JsonUtils.readTree(auditRespStrWithPathAndBucketEntityType);
+    // Navigate to the nested JSON objects
+    JsonNode facetsNode = rootNode.path("facets");
+    JsonNode resourcesNode = facetsNode.path("resources");
+    // Deserialize the resources node directly if it's not missing
+    HeatMapProviderDataResource auditLogFacetsResources = null;
+    if (!resourcesNode.isMissingNode()) {
+      auditLogFacetsResources = JsonUtils.treeToValue(resourcesNode, HeatMapProviderDataResource.class);
+    }
+
     EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
     if (null != entities && entities.length > 0) {
       List<EntityMetaData> entityMetaDataList =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
@@ -757,24 +757,29 @@ public class TestHeatMapInfo {
           HeatMapProviderDataResource.class);
     }
 
-    EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
-    List<EntityMetaData> entityMetaDataList =
-        Arrays.stream(entities).collect(Collectors.toList());
-    EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
-        heatMapUtil.generateHeatMap(entityMetaDataList);
-    assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
-    assertEquals(12, entityReadAccessHeatMapResponse.getChildren().size());
-    assertEquals(25600, entityReadAccessHeatMapResponse.getSize());
-    assertEquals(2924, entityReadAccessHeatMapResponse.getMinAccessCount());
-    assertEquals(155074, entityReadAccessHeatMapResponse.getMaxAccessCount());
-    assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
-    assertEquals(0.0, entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
-    assertEquals(0.442,
-        entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
-            .get(0).getChildren().get(1).getColor());
-    assertEquals(0.058,
-        entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
-            .get(1).getChildren().get(3).getColor());
+    if (auditLogFacetsResources != null) {
+      EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
+      List<EntityMetaData> entityMetaDataList =
+          Arrays.stream(entities).collect(Collectors.toList());
+      EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
+          heatMapUtil.generateHeatMap(entityMetaDataList);
+      assertThat(
+          entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(
+          0);
+      assertEquals(12, entityReadAccessHeatMapResponse.getChildren().size());
+      assertEquals(25600, entityReadAccessHeatMapResponse.getSize());
+      assertEquals(2924, entityReadAccessHeatMapResponse.getMinAccessCount());
+      assertEquals(155074, entityReadAccessHeatMapResponse.getMaxAccessCount());
+      assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
+      assertEquals(0.0,
+          entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
+      assertEquals(0.442,
+          entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
+              .get(0).getChildren().get(1).getColor());
+      assertEquals(0.058,
+          entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
+              .get(1).getChildren().get(3).getColor());
+    }
   }
 
   @Test
@@ -844,40 +849,42 @@ public class TestHeatMapInfo {
           HeatMapProviderDataResource.class);
     }
 
-    EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
-    if (null != entities && entities.length > 0) {
-      List<EntityMetaData> entityMetaDataList =
-          Arrays.stream(entities).collect(Collectors.toList());
-      // Below heatmap response would be of format like:
-      //{
-      //  "label": "root",
-      //  "path": "/",
-      //  "children": [
-      //    {
-      //      "label": "s3v",
-      //      "path": "s3v",
-      //      "size": 256
-      //    },
-      //    {
-      //      "label": "testnewvol2",
-      //      "path": "testnewvol2",
-      //      "size": 256
-      //    }
-      //  ],
-      //  "size": 512,
-      //  "minAccessCount": 19263
-      //}
-      EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
-          heatMapUtil.generateHeatMap(entityMetaDataList);
-      assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
-      assertEquals(2, entityReadAccessHeatMapResponse.getChildren().size());
-      assertEquals(512, entityReadAccessHeatMapResponse.getSize());
-      assertEquals(8590, entityReadAccessHeatMapResponse.getMinAccessCount());
-      assertEquals(19263, entityReadAccessHeatMapResponse.getMaxAccessCount());
-      assertEquals(1.0, entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
-      assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
-    } else {
-      assertNull(entities);
+    if (auditLogFacetsResources != null) {
+      EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
+      if (null != entities && entities.length > 0) {
+        List<EntityMetaData> entityMetaDataList =
+            Arrays.stream(entities).collect(Collectors.toList());
+        // Below heatmap response would be of format like:
+        //{
+        //  "label": "root",
+        //  "path": "/",
+        //  "children": [
+        //    {
+        //      "label": "s3v",
+        //      "path": "s3v",
+        //      "size": 256
+        //    },
+        //    {
+        //      "label": "testnewvol2",
+        //      "path": "testnewvol2",
+        //      "size": 256
+        //    }
+        //  ],
+        //  "size": 512,
+        //  "minAccessCount": 19263
+        //}
+        EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
+            heatMapUtil.generateHeatMap(entityMetaDataList);
+        assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
+        assertEquals(2, entityReadAccessHeatMapResponse.getChildren().size());
+        assertEquals(512, entityReadAccessHeatMapResponse.getSize());
+        assertEquals(8590, entityReadAccessHeatMapResponse.getMinAccessCount());
+        assertEquals(19263, entityReadAccessHeatMapResponse.getMaxAccessCount());
+        assertEquals(1.0, entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
+        assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
+      } else {
+        assertNull(entities);
+      }
     }
   }
 
@@ -975,136 +982,138 @@ public class TestHeatMapInfo {
       auditLogFacetsResources = JsonUtils.treeToValue(resourcesNode, HeatMapProviderDataResource.class);
     }
 
-    EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
-    if (null != entities && entities.length > 0) {
-      List<EntityMetaData> entityMetaDataList =
-          Arrays.stream(entities).collect(Collectors.toList());
-      // Below heatmap response would be of format like:
-      //{
-      //    "label": "root",
-      //    "path": "/",
-      //    "children": [
-      //        {
-      //            "label": "testnewvol2",
-      //            "path": "testnewvol2",
-      //            "children": [
-      //                {
-      //                    "label": "fsobuck11",
-      //                    "path": "/testnewvol2/fsobuck11",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/fsobuck11/",
-      //                            "size": 100,
-      //                            "accessCount": 701,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 701,
-      //                    "maxAccessCount": 701
-      //                },
-      //                {
-      //                    "label": "fsobuck12",
-      //                    "path": "/testnewvol2/fsobuck12",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/fsobuck12/",
-      //                            "size": 100,
-      //                            "accessCount": 701,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 701,
-      //                    "maxAccessCount": 701
-      //                },
-      //                {
-      //                    "label": "fsobuck13",
-      //                    "path": "/testnewvol2/fsobuck13",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/fsobuck13/",
-      //                            "size": 100,
-      //                            "accessCount": 701,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 701,
-      //                    "maxAccessCount": 701
-      //                },
-      //                {
-      //                    "label": "obsbuck11",
-      //                    "path": "/testnewvol2/obsbuck11",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/obsbuck11/",
-      //                            "size": 107,
-      //                            "accessCount": 263,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 107,
-      //                    "minAccessCount": 263,
-      //                    "maxAccessCount": 263
-      //                },
-      //                {
-      //                    "label": "obsbuck12",
-      //                    "path": "/testnewvol2/obsbuck12",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/obsbuck12/",
-      //                            "size": 100,
-      //                            "accessCount": 200,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 200,
-      //                    "maxAccessCount": 200
-      //                },
-      //                {
-      //                    "label": "obsbuck13",
-      //                    "path": "/testnewvol2/obsbuck13",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/obsbuck13/",
-      //                            "size": 100,
-      //                            "accessCount": 200,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 200,
-      //                    "maxAccessCount": 200
-      //                }
-      //            ],
-      //            "size": 607
-      //        }
-      //    ],
-      //    "size": 607,
-      //    "minAccessCount": 200,
-      //    "maxAccessCount": 701
-      //}
-      EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
-          heatMapUtil.generateHeatMap(entityMetaDataList);
-      assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
-      assertEquals(2,
-          entityReadAccessHeatMapResponse.getChildren().size());
-      assertEquals(0.0,
-          entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
-      String path =
-          entityReadAccessHeatMapResponse.getChildren().get(1).getChildren()
-              .get(0).getPath();
-      assertEquals("/testnewvol2/fsobuck11", path);
-    } else {
-      assertNull(entities);
+    if (auditLogFacetsResources != null) {
+      EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
+      if (null != entities && entities.length > 0) {
+        List<EntityMetaData> entityMetaDataList =
+            Arrays.stream(entities).collect(Collectors.toList());
+        // Below heatmap response would be of format like:
+        //{
+        //    "label": "root",
+        //    "path": "/",
+        //    "children": [
+        //        {
+        //            "label": "testnewvol2",
+        //            "path": "testnewvol2",
+        //            "children": [
+        //                {
+        //                    "label": "fsobuck11",
+        //                    "path": "/testnewvol2/fsobuck11",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/fsobuck11/",
+        //                            "size": 100,
+        //                            "accessCount": 701,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 701,
+        //                    "maxAccessCount": 701
+        //                },
+        //                {
+        //                    "label": "fsobuck12",
+        //                    "path": "/testnewvol2/fsobuck12",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/fsobuck12/",
+        //                            "size": 100,
+        //                            "accessCount": 701,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 701,
+        //                    "maxAccessCount": 701
+        //                },
+        //                {
+        //                    "label": "fsobuck13",
+        //                    "path": "/testnewvol2/fsobuck13",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/fsobuck13/",
+        //                            "size": 100,
+        //                            "accessCount": 701,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 701,
+        //                    "maxAccessCount": 701
+        //                },
+        //                {
+        //                    "label": "obsbuck11",
+        //                    "path": "/testnewvol2/obsbuck11",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/obsbuck11/",
+        //                            "size": 107,
+        //                            "accessCount": 263,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 107,
+        //                    "minAccessCount": 263,
+        //                    "maxAccessCount": 263
+        //                },
+        //                {
+        //                    "label": "obsbuck12",
+        //                    "path": "/testnewvol2/obsbuck12",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/obsbuck12/",
+        //                            "size": 100,
+        //                            "accessCount": 200,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 200,
+        //                    "maxAccessCount": 200
+        //                },
+        //                {
+        //                    "label": "obsbuck13",
+        //                    "path": "/testnewvol2/obsbuck13",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/obsbuck13/",
+        //                            "size": 100,
+        //                            "accessCount": 200,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 200,
+        //                    "maxAccessCount": 200
+        //                }
+        //            ],
+        //            "size": 607
+        //        }
+        //    ],
+        //    "size": 607,
+        //    "minAccessCount": 200,
+        //    "maxAccessCount": 701
+        //}
+        EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
+            heatMapUtil.generateHeatMap(entityMetaDataList);
+        assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
+        assertEquals(2,
+            entityReadAccessHeatMapResponse.getChildren().size());
+        assertEquals(0.0,
+            entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
+        String path =
+            entityReadAccessHeatMapResponse.getChildren().get(1).getChildren()
+                .get(0).getPath();
+        assertEquals("/testnewvol2/fsobuck11", path);
+      } else {
+        assertNull(entities);
+      }
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
@@ -16,13 +16,12 @@
  */
 package org.apache.hadoop.ozone.admin.scm;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonSyntaxException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.common.helpers.DeletedBlocksTransactionInfoWrapper;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
 import java.io.FileInputStream;
@@ -74,12 +73,11 @@ public class ResetDeletedBlockRetryCountSubcommand extends ScmSubcommand {
     if (group.resetAll) {
       count = client.resetDeletedBlockRetryCount(new ArrayList<>());
     } else if (group.fileName != null) {
-      Gson gson = new Gson();
       List<Long> txIDs;
       try (InputStream in = new FileInputStream(group.fileName);
            Reader fileReader = new InputStreamReader(in,
                StandardCharsets.UTF_8)) {
-        DeletedBlocksTransactionInfoWrapper[] txns = gson.fromJson(fileReader,
+        DeletedBlocksTransactionInfoWrapper[] txns = JsonUtils.readArrayFromReader(fileReader,
             DeletedBlocksTransactionInfoWrapper[].class);
         txIDs = Arrays.stream(txns)
             .map(DeletedBlocksTransactionInfoWrapper::getTxID)
@@ -92,9 +90,12 @@ public class ResetDeletedBlockRetryCountSubcommand extends ScmSubcommand {
           System.out.println("The last loaded txID: " +
               txIDs.get(txIDs.size() - 1));
         }
-      } catch (JsonIOException | JsonSyntaxException | IOException ex) {
-        System.out.println("Cannot parse the file " + group.fileName);
+      } catch (JsonProcessingException ex) {
+        System.out.println("Error parsing JSON: " + ex.getMessage());
         throw new IOException(ex);
+      } catch (IOException ex) {
+        System.out.println("Error reading file: " + ex.getMessage());
+        throw ex;
       }
       count = client.resetDeletedBlockRetryCount(txIDs);
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pull request introduces a migration from Gson to Jackson, specifically focusing on replacing Gson's JsonParser with Jackson's `ObjectMapper`. It involves using ObjectMapper's `readValue() `method to deserialize JSON strings into Java objects. Additionally, the code utilizes Jackson's `JsonNode` to navigate and extract data from JSON structures.

### Important mention ➖
In the `EventQueue` class our Gson setup included custom serialization strategies (like excluding certain fields **`ExclusionStrategy`**) Jackson does not inherently support exclusion strategies like Gson's **`ExclusionStrategy`**, which dynamically includes or excludes fields from serialization at runtime. Instead, to achieve similar functionality, we have used the **`@JsonIgnore`** in the `NodeImpl` class annotation directly on fields we wish to exclude, marking them statically for omission in the serialization process. 

We also improved the **`JsonUtils`** class by introducing new utility methods for more flexible JSON processing with Jackson. We added **`readArrayFromReader`** to deserialize JSON content from a **`Reader`** into Java arrays, and **`convertValueOrObjectNode`** to efficiently convert any given value into a **`JsonNode`**, ensuring compatibility with various JSON structures. These improvements streamline JSON operations across our project, for both serialization and deserialization tasks.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10542

## How was this patch tested?
Ran the Unit Tests for the changed classes.