### PR TITLE
HDDS-10671. Wrong size of response data in om-echo.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2491,12 +2491,12 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public EchoRPCResponse echoRPCReq(byte[] payloadReq, int payloadSizeResp,
+  public EchoRPCResponse echoRPCReq(byte[] payloadReq, int payloadSizeRespBytes,
                                     boolean writeToRatis) throws IOException {
     EchoRPCRequest echoRPCRequest =
             EchoRPCRequest.newBuilder()
                     .setPayloadReq(ByteString.copyFrom(payloadReq))
-                    .setPayloadSizeResp(payloadSizeResp)
+                    .setPayloadSizeResp(payloadSizeRespBytes)
                     .setReadOnly(!writeToRatis)
                     .build();
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/PayloadUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/PayloadUtils.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.util;
+
+import org.apache.ratis.util.Preconditions;
+
+import java.util.Random;
+
+/**
+ * Utility class for payload operations.
+ */
+public final class PayloadUtils {
+  private static final int MAX_SIZE = 2097151 * 1024;
+  private static final byte[] SEED = new byte[1024];
+
+  static {
+    new Random().nextBytes(SEED);
+  }
+
+  private PayloadUtils() {
+  }
+
+  public static byte[] generatePayload(int payloadSizeBytes) {
+    byte[] result = new byte[Math.min(payloadSizeBytes, MAX_SIZE)];
+
+    // duplicate SEED to create the required payload.
+    int curIdx = 0;
+    while (curIdx < result.length) {
+      int remaining = result.length - curIdx;
+      int copySize = Math.min(SEED.length, remaining);
+      System.arraycopy(SEED, 0, result, curIdx, copySize);
+      curIdx += copySize;
+    }
+
+    Preconditions.assertTrue(curIdx == result.length);
+
+    return result;
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/util/TestPayloadUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/util/TestPayloadUtils.java
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+/**
+ * Tests {@link PayloadUtils}.
+ */
 public class TestPayloadUtils {
 
   @ParameterizedTest

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/util/TestPayloadUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/util/TestPayloadUtils.java
@@ -14,31 +14,18 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package org.apache.hadoop.ozone.util;
 
-package org.apache.hadoop.ozone.common;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import org.apache.commons.lang3.RandomUtils;
+public class TestPayloadUtils {
 
-/**
- * Utility class for payload operations.
- */
-public final class PayloadUtils {
-
-  private static final int RPC_PAYLOAD_MULTIPLICATION_FACTOR = 1024;
-  private static final int MAX_SIZE_KB = 2097151;
-
-  private PayloadUtils() {
-  }
-
-  public static byte[] generatePayloadBytes(int payloadSize) {
-
-    byte[] payloadBytes = new byte[0];
-    int payloadRespSize =
-        Math.min(payloadSize * RPC_PAYLOAD_MULTIPLICATION_FACTOR, MAX_SIZE_KB);
-    if (payloadRespSize > 0) {
-      payloadBytes = RandomUtils.nextBytes(payloadRespSize);
-    }
-
-    return payloadBytes;
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 1023, 1024, 1025, 2048})
+  public void testGeneratePayload(int payload) {
+    byte[] generated = PayloadUtils.generatePayload(payload);
+    Assertions.assertEquals(payload, generated.length);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OMEchoRPCWriteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OMEchoRPCWriteRequest.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.om.request.util;
 
 import com.google.protobuf.ByteString;
 import org.apache.ratis.server.protocol.TermIndex;
-import org.apache.hadoop.ozone.common.PayloadUtils;
+import org.apache.hadoop.ozone.util.PayloadUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -45,7 +45,7 @@ public class OMEchoRPCWriteRequest extends OMClientRequest {
     EchoRPCRequest echoRPCRequest = getOmRequest().getEchoRPCRequest();
 
     byte[] payloadBytes =
-        PayloadUtils.generatePayloadBytes(echoRPCRequest.getPayloadSizeResp());
+        PayloadUtils.generatePayload(echoRPCRequest.getPayloadSizeResp());
 
     EchoRPCResponse echoRPCResponse = EchoRPCResponse.newBuilder()
         .setPayload(ByteString.copyFrom(payloadBytes))

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.protocolPB.OzonePBHelper;
 import org.apache.hadoop.hdds.utils.FaultInjector;
 import org.apache.hadoop.ozone.OzoneAcl;
-import org.apache.hadoop.ozone.common.PayloadUtils;
+import org.apache.hadoop.ozone.util.PayloadUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -1431,7 +1431,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   private EchoRPCResponse echoRPC(EchoRPCRequest req) {
     EchoRPCResponse.Builder builder = EchoRPCResponse.newBuilder();
     byte[] payloadBytes =
-        PayloadUtils.generatePayloadBytes(req.getPayloadSizeResp());
+        PayloadUtils.generatePayload(req.getPayloadSizeResp());
     builder.setPayload(ByteString.copyFrom(payloadBytes));
     return builder.build();
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmRPCLoadGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmRPCLoadGenerator.java
@@ -19,11 +19,12 @@ package org.apache.hadoop.ozone.freon;
 
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import java.util.concurrent.Callable;
+
+import org.apache.hadoop.ozone.util.PayloadUtils;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -42,8 +43,6 @@ import picocli.CommandLine.Option;
 public class OmRPCLoadGenerator extends BaseFreonGenerator
         implements Callable<Void> {
 
-  private static final int RPC_PAYLOAD_MULTIPLICATION_FACTOR = 1024;
-  private static final int MAX_SIZE_KB = 2097151;
   private Timer timer;
   private OzoneConfiguration configuration;
   private OzoneManagerProtocolClientSideTranslatorPB[] clients;
@@ -88,9 +87,8 @@ public class OmRPCLoadGenerator extends BaseFreonGenerator
     }
 
     init();
-    payloadReqBytes = RandomUtils.nextBytes(
-            calculateMaxPayloadSize(payloadReqSizeKB));
-    payloadRespSize = calculateMaxPayloadSize(payloadRespSizeKB);
+    payloadReqBytes = PayloadUtils.generatePayload(payloadSizeInBytes(payloadReqSizeKB));
+    payloadRespSize = payloadSizeInBytes(payloadRespSizeKB);
     timer = getMetrics().timer("rpc-payload");
     try {
       runTests(this::sendRPCReq);
@@ -104,14 +102,8 @@ public class OmRPCLoadGenerator extends BaseFreonGenerator
     return null;
   }
 
-  private int calculateMaxPayloadSize(int payloadSizeKB) {
-    if (payloadSizeKB > 0) {
-      return Math.min(
-              Math.toIntExact((long)payloadSizeKB *
-                      RPC_PAYLOAD_MULTIPLICATION_FACTOR),
-              MAX_SIZE_KB);
-    }
-    return 0;
+  private int payloadSizeInBytes(int payloadSizeKB) {
+    return payloadSizeKB > 0 ? payloadSizeKB * 1024 : 0;
   }
 
   private void sendRPCReq(long l) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?
"freon om-echo" command generates a wrong payload response size. 

The parameter `--payload-resp` (in KB) is converted to bytes before sent to OM, but OM interprets the number as in KB. This makes the actual generated response payload 1024x larger than expected.

Also, this PR optimizes the response payload generation to maintain the tool purpose: to evaluate RPC performance only.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10671

## How was this patch tested?

CI.
