### PR TITLE
HDDS-10614. Recon fails to start with used space cannot be negative.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nullable;
 
-import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.OptionalLong;
 import java.util.concurrent.Executors;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.Nullable;
-
 import java.time.Duration;
 import java.util.OptionalLong;
 import java.util.concurrent.Executors;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -97,10 +97,11 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
     cachedValue.updateAndGet(current -> {
       long newValue = current - reclaimedSpace;
       if (newValue < 0) {
-        LOG.warn(
-            "Attempted to decrement used space to a negative value. Current: {}, Decrement: {}",
-            current, reclaimedSpace);
-        return 0; // Reset to zero
+        if (current > 0) {
+          LOG.warn("Attempted to decrement used space to a negative value. " +
+              "Current: {}, Decrement: {}", current, reclaimedSpace);
+        }
+        return 0;
       } else {
         return newValue;
       }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -95,16 +95,17 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
   }
 
   public void decrementUsedSpace(long reclaimedSpace) {
-    long current = cachedValue.get();
-    long newValue = current - reclaimedSpace;
-    if (newValue < 0) {
-      LOG.warn(
-          "Attempted to decrement used space to a negative value. Current: {}, Decrement: {}",
-          current, reclaimedSpace);
-      cachedValue.set(current); // Retain the previous value
-    } else {
-      cachedValue.set(newValue);
-    }
+    cachedValue.updateAndGet(current -> {
+      long newValue = current - reclaimedSpace;
+      if (newValue < 0) {
+        LOG.warn(
+            "Attempted to decrement used space to a negative value. Current: {}, Decrement: {}",
+            current, reclaimedSpace);
+        return 0; // Reset to zero
+      } else {
+        return newValue;
+      }
+    });
   }
 
   public void start() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -100,7 +100,7 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
         if (current > 0) {
           LOG.warn("Attempted to decrement used space to a negative value. " +
                   "Current: {}, Decrement: {}, Source: {}",
-              current, reclaimedSpace, source.toString());
+              current, reclaimedSpace, source);
         }
         return 0;
       } else {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -99,7 +99,8 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
       if (newValue < 0) {
         if (current > 0) {
           LOG.warn("Attempted to decrement used space to a negative value. " +
-              "Current: {}, Decrement: {}", current, reclaimedSpace);
+                  "Current: {}, Decrement: {}, Source: {}",
+              current, reclaimedSpace, source.toString());
         }
         return 0;
       } else {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -156,13 +156,9 @@ public class TestCachingSpaceUsageSource {
     // Try to decrement more than the current value
     subject.decrementUsedSpace(100);
 
-    // Check that the value has not gone negative
+    // Check that the value has not gone negative and has been reset to 0
     assertTrue(subject.getUsedSpace() >= 0,
         "Cached used space should not be negative");
-
-    // Check that it has retained the previous value
-    assertEquals(50, subject.getUsedSpace(),
-        "Cached used space should remain at the initial value");
   }
 
   private static long missingInitialValue() {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.hadoop.hdds.fs.MockSpaceUsageCheckParams.newBuilder;
-import static org.apache.ratis.util.Preconditions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -145,20 +145,17 @@ public class TestCachingSpaceUsageSource {
 
   @Test
   public void testDecrementDoesNotGoNegative() {
-    CachingSpaceUsageSource subject;
-    SpaceUsageCheckParams params;
-    AtomicLong cachedValue;
-    cachedValue = new AtomicLong(50);
-    params = paramsBuilder(cachedValue)
+    SpaceUsageCheckParams params = paramsBuilder(new AtomicLong(50))
         .withRefresh(Duration.ZERO)
         .build();
-    subject = new CachingSpaceUsageSource(params);
+    CachingSpaceUsageSource subject = new CachingSpaceUsageSource(params);
+    AtomicLong cachedValue = new AtomicLong(50);
+
     // Try to decrement more than the current value
     subject.decrementUsedSpace(100);
 
-    // Check that the value has not gone negative and has been reset to 0
-    assertTrue(subject.getUsedSpace() >= 0,
-        "Cached used space should not be negative");
+    // Check that the value has been set to 0
+    assertEquals(0, subject.getUsedSpace());
   }
 
   private static long missingInitialValue() {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -148,7 +148,6 @@ public class TestCachingSpaceUsageSource {
         .withRefresh(Duration.ZERO)
         .build();
     CachingSpaceUsageSource subject = new CachingSpaceUsageSource(params);
-    AtomicLong cachedValue = new AtomicLong(50);
 
     // Try to decrement more than the current value
     subject.decrementUsedSpace(100);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The root cause seems to be an error during the refresh operation of the `CachingSpaceUsageSource`. Specifically, the underlying `SpaceUsageSource` (likely an instance of DU, which uses the Unix du command to calculate disk usage) is failing due to a permission issue when trying to read the /data3/lost+found directory. This failure might cause the `getUsedSpace()` method to return an incorrect value (possibly zero), which, when decremented, results in a negative value. Here are the steps that are likely leading to the issue:

This PR introduces error handling and validation in the `CachingSpaceUsageSource` class to ensure data integrity. Specifically, it prevents negative values for used space by validating new values before updating the cache and handles exceptions, including `UncheckedIOException`, by maintaining the last known good value and logging errors. These changes ensure that temporary issues, such as permission errors, do not result in invalid state transitions or data corruption.

We catch `UncheckedIOException` because it indicates a problem occurred when the program tried to read or write data, and we saw it during operations like calculating disk space usage. This specific exception wraps lower-level errors, making it a clear sign that something went wrong with I/O operations, which are crucial for accurately tracking disk space.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10614
## How was this patch tested?
CI ran green :- https://github.com/ArafatKhan2198/ozone/actions/runs/8627744703
Will be adding Unit tests for it if the approach is correct 