### PR TITLE
HDDS-10463. Fail Datanode Maintenance early

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -252,7 +252,7 @@ public interface ScmClient extends Closeable {
    * @throws IOException
    */
   List<DatanodeAdminError> startMaintenanceNodes(List<String> hosts,
-      int endHours) throws IOException;
+      int endHours, boolean force) throws IOException;
 
   /**
    * Creates a specified replication pipeline.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -252,7 +252,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
       throws IOException;
 
   List<DatanodeAdminError> startMaintenanceNodes(List<String> nodes,
-      int endInHours) throws IOException;
+      int endInHours, boolean force) throws IOException;
 
   /**
    * Close a container.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -586,12 +586,13 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    */
   @Override
   public List<DatanodeAdminError> startMaintenanceNodes(
-      List<String> nodes, int endInHours) throws IOException {
+      List<String> nodes, int endInHours, boolean force) throws IOException {
     Preconditions.checkNotNull(nodes);
     StartMaintenanceNodesRequestProto request =
         StartMaintenanceNodesRequestProto.newBuilder()
             .addAllHosts(nodes)
             .setEndInHours(endInHours)
+            .setForce(force)
             .build();
     StartMaintenanceNodesResponseProto response =
         submitRequest(Type.StartMaintenanceNodes,

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -392,6 +392,7 @@ message RecommissionNodesResponseProto {
 message StartMaintenanceNodesRequestProto {
   repeated string hosts = 1;
   optional int64 endInHours = 2;
+  optional bool force = 3;
 }
 
 message StartMaintenanceNodesResponseProto {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -644,4 +644,10 @@ public class NodeDecommissionManager {
       }
     });
   }
+
+  @VisibleForTesting
+  public void setMaintenanceConfigs(int replicaMinimum, int remainingRedundancy) {
+    maintenanceRemainingRedundancy = remainingRedundancy;
+    maintenanceReplicaMinimum = replicaMinimum;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -296,8 +296,8 @@ public class NodeDecommissionManager {
           ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL_DEFAULT,
           TimeUnit.SECONDS);
     }
-    maintenanceReplicaMinimum = config.getInt("hdds.scm.replication.maintenance.replica.minimum", 2);
-    maintenanceRemainingRedundancy = config.getInt("hdds.scm.replication.maintenance.remaining.redundancy", 1);
+    setMaintenanceConfigs(config.getInt("hdds.scm.replication.maintenance.replica.minimum", 2),
+        config.getInt("hdds.scm.replication.maintenance.remaining.redundancy", 1));
 
     monitor = new DatanodeAdminMonitorImpl(config, eventQueue, nodeManager,
         rm);
@@ -647,11 +647,7 @@ public class NodeDecommissionManager {
 
   @VisibleForTesting
   public void setMaintenanceConfigs(int replicaMinimum, int remainingRedundancy) {
-    synchronized (maintenanceReplicaMinimum) {
-      maintenanceRemainingRedundancy = remainingRedundancy;
-    }
-    synchronized (maintenanceRemainingRedundancy) {
-      maintenanceReplicaMinimum = replicaMinimum;
-    }
+    maintenanceRemainingRedundancy = remainingRedundancy;
+    maintenanceReplicaMinimum = replicaMinimum;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -647,7 +647,9 @@ public class NodeDecommissionManager {
 
   @VisibleForTesting
   public void setMaintenanceConfigs(int replicaMinimum, int remainingRedundancy) {
-    maintenanceRemainingRedundancy = remainingRedundancy;
-    maintenanceReplicaMinimum = replicaMinimum;
+    synchronized (this) {
+      maintenanceRemainingRedundancy = remainingRedundancy;
+      maintenanceReplicaMinimum = replicaMinimum;
+    }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -66,8 +66,8 @@ public class NodeDecommissionManager {
   private ContainerManager containerManager;
   private final SCMContext scmContext;
   private final boolean useHostnames;
-  private int maintenanceReplicaMinimum;
-  private int maintenanceRemainingRedundancy;
+  private Integer maintenanceReplicaMinimum;
+  private Integer maintenanceRemainingRedundancy;
 
   // Decommissioning and Maintenance mode progress related metrics.
   private final NodeDecommissionMetrics metrics;
@@ -647,7 +647,11 @@ public class NodeDecommissionManager {
 
   @VisibleForTesting
   public void setMaintenanceConfigs(int replicaMinimum, int remainingRedundancy) {
-    maintenanceRemainingRedundancy = remainingRedundancy;
-    maintenanceReplicaMinimum = replicaMinimum;
+    synchronized (maintenanceReplicaMinimum) {
+      maintenanceRemainingRedundancy = remainingRedundancy;
+    }
+    synchronized (maintenanceRemainingRedundancy) {
+      maintenanceReplicaMinimum = replicaMinimum;
+    }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -1248,7 +1248,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       StartMaintenanceNodesRequestProto request) throws IOException {
     List<DatanodeAdminError> errors =
         impl.startMaintenanceNodes(request.getHostsList(),
-        (int)request.getEndInHours());
+        (int)request.getEndInHours(), request.getForce());
     StartMaintenanceNodesResponseProto.Builder response =
         StartMaintenanceNodesResponseProto.newBuilder();
     for (DatanodeAdminError e : errors) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -671,11 +671,11 @@ public class SCMClientProtocolServer implements
 
   @Override
   public List<DatanodeAdminError> startMaintenanceNodes(List<String> nodes,
-      int endInHours) throws IOException {
+      int endInHours, boolean force) throws IOException {
     try {
       getScm().checkAdminAccess(getRemoteUser(), false);
       return scm.getScmDecommissionManager()
-          .startMaintenanceNodes(nodes, endInHours);
+          .startMaintenanceNodes(nodes, endInHours, force);
     } catch (Exception ex) {
       LOG.error("Failed to place nodes into maintenance mode", ex);
       throw ex;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -667,7 +667,7 @@ public class TestNodeDecommissionManager {
       nodeManager.setContainers(dn, idsRatis);
     }
 
-    decom.setMaintenanceConfigs(2,1); // default config
+    decom.setMaintenanceConfigs(2, 1); // default config
     // putting 4 DNs into maintenance leave the cluster with 1 DN,
     // it should not be allowed as maintenance.replica.minimum is 2
     error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
@@ -698,7 +698,7 @@ public class TestNodeDecommissionManager {
     decom.getMonitor().run();
     assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
 
-    decom.setMaintenanceConfigs(3,1); // non-default config
+    decom.setMaintenanceConfigs(3, 1); // non-default config
     // putting 3 DNs into maintenance leave the cluster with 2 DN,
     // it should not be allowed as maintenance.replica.minimum is 3
     error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
@@ -762,10 +762,11 @@ public class TestNodeDecommissionManager {
       nodeManager.setContainers(dn, idsEC);
     }
 
-    decom.setMaintenanceConfigs(2,1); // default config
+    decom.setMaintenanceConfigs(2, 1); // default config
     // putting 2 DNs into maintenance leave the cluster with 3 DN,
     // it should not be allowed as maintenance.remaining.redundancy is 1 => 3+1=4 DNs are required
-    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()), 100, false);
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()),
+        100, false);
     assertTrue(error.get(0).getHostname().contains("AllHosts"));
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
@@ -782,7 +783,7 @@ public class TestNodeDecommissionManager {
     decom.getMonitor().run();
     assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
 
-    decom.setMaintenanceConfigs(2,2); // non-default config
+    decom.setMaintenanceConfigs(2, 2); // non-default config
     // putting 1 DNs into maintenance leave the cluster with 4 DN,
     // it should not be allowed as maintenance.remaining.redundancy is 2 => 3+2=5 DNs are required
     error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress()), 100, false);
@@ -842,10 +843,11 @@ public class TestNodeDecommissionManager {
       nodeManager.setContainers(dn, idsEC);
     }
 
-    decom.setMaintenanceConfigs(2,1); // default config
+    decom.setMaintenanceConfigs(2, 1); // default config
     // putting 2 DNs into maintenance leave the cluster with 3 DN,
     // it should not be allowed as maintenance.remaining.redundancy is 1 => 3+1=4 DNs are required
-    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()), 100, false);
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()),
+        100, false);
     assertTrue(error.get(0).getHostname().contains("AllHosts"));
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
@@ -862,7 +864,7 @@ public class TestNodeDecommissionManager {
     decom.getMonitor().run();
     assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
 
-    decom.setMaintenanceConfigs(3,2); // non-default config
+    decom.setMaintenanceConfigs(3, 2); // non-default config
     // putting 1 DNs into maintenance leave the cluster with 4 DN,
     // it should not be allowed as for EC, maintenance.remaining.redundancy is 2 => 3+2=5 DNs are required
     error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress()), 100, false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -643,6 +643,359 @@ public class TestNodeDecommissionManager {
         nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
   }
 
+  @Test
+  public void testInsufficientNodeMaintenanceThrowsExceptionForRatis() throws
+      NodeNotFoundException, IOException {
+    when(containerManager.getContainer(any(ContainerID.class)))
+        .thenAnswer(invocation -> getMockContainer(RatisReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE), (ContainerID)invocation.getArguments()[0]));
+    List<DatanodeAdminError> error;
+    List<DatanodeDetails> dns = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
+      dns.add(dn);
+      nodeManager.register(dn, null, null);
+    }
+    Set<ContainerID> idsRatis = new HashSet<>();
+    for (int i = 0; i < 5; i++) {
+      ContainerInfo container = containerManager.allocateContainer(
+          RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), "admin");
+      idsRatis.add(container.containerID());
+    }
+    for (DatanodeDetails dn  : nodeManager.getAllNodes().subList(0, 3)) {
+      nodeManager.setContainers(dn, idsRatis);
+    }
+
+    decom.setMaintenanceConfigs(2,1); // default config
+    // putting 4 DNs into maintenance leave the cluster with 1 DN,
+    // it should not be allowed as maintenance.replica.minimum is 2
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        dns.get(2).getIpAddress(), dns.get(3).getIpAddress(), dns.get(4).getIpAddress()), 100, false);
+    assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(3)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(4)).getOperationalState());
+    // putting 3 DNs into maintenance leave the cluster with 2 DN,
+    // it should be allowed
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        dns.get(2).getIpAddress(), dns.get(3).getIpAddress()), 100, false);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(3)).getOperationalState());
+
+    decom.recommissionNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        dns.get(2).getIpAddress(), dns.get(3).getIpAddress(), dns.get(4).getIpAddress()));
+    decom.getMonitor().run();
+    assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+
+    decom.setMaintenanceConfigs(3,1); // non-default config
+    // putting 3 DNs into maintenance leave the cluster with 2 DN,
+    // it should not be allowed as maintenance.replica.minimum is 3
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        dns.get(2).getIpAddress(), dns.get(3).getIpAddress()), 100, false);
+    assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(3)).getOperationalState());
+    // putting 2 DNs into maintenance leave the cluster with 2 DN,
+    // it should be allowed
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        dns.get(2).getIpAddress()), 100, false);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+
+    decom.recommissionNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        dns.get(2).getIpAddress(), dns.get(3).getIpAddress(), dns.get(4).getIpAddress()));
+    decom.getMonitor().run();
+    assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+
+    // forcing 4 DNs into maintenance should be allowed
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        dns.get(2).getIpAddress(), dns.get(3).getIpAddress(), dns.get(4).getIpAddress()), 100, true);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(3)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(4)).getOperationalState());
+  }
+
+  @Test
+  public void testInsufficientNodeMaintenanceThrowsExceptionForEc() throws
+      NodeNotFoundException, IOException {
+    when(containerManager.getContainer(any(ContainerID.class)))
+        .thenAnswer(invocation -> getMockContainer(new ECReplicationConfig(3, 2),
+            (ContainerID)invocation.getArguments()[0]));
+    List<DatanodeAdminError> error;
+    List<DatanodeDetails> dns = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
+      dns.add(dn);
+      nodeManager.register(dn, null, null);
+    }
+    Set<ContainerID> idsEC = new HashSet<>();
+    for (int i = 0; i < 5; i++) {
+      ContainerInfo container = containerManager.allocateContainer(new ECReplicationConfig(3, 2), "admin");
+      idsEC.add(container.containerID());
+    }
+    for (DatanodeDetails dn  : nodeManager.getAllNodes()) {
+      nodeManager.setContainers(dn, idsEC);
+    }
+
+    decom.setMaintenanceConfigs(2,1); // default config
+    // putting 2 DNs into maintenance leave the cluster with 3 DN,
+    // it should not be allowed as maintenance.remaining.redundancy is 1 => 3+1=4 DNs are required
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()), 100, false);
+    assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+    // putting 1 DN into maintenance leave the cluster with 4 DN,
+    // it should be allowed
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress()), 100, false);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+
+    decom.recommissionNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()));
+    decom.getMonitor().run();
+    assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+
+    decom.setMaintenanceConfigs(2,2); // non-default config
+    // putting 1 DNs into maintenance leave the cluster with 4 DN,
+    // it should not be allowed as maintenance.remaining.redundancy is 2 => 3+2=5 DNs are required
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress()), 100, false);
+    assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+
+    decom.recommissionNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()));
+    decom.getMonitor().run();
+    assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+
+    // forcing 2 DNs into maintenance should be allowed
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()), 100, true);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+  }
+
+  @Test
+  public void testInsufficientNodeMaintenanceThrowsExceptionForRatisAndEc() throws
+      NodeNotFoundException, IOException {
+    when(containerManager.getContainer(any(ContainerID.class)))
+        .thenAnswer(invocation -> getMockContainer(new ECReplicationConfig(3, 2),
+            (ContainerID)invocation.getArguments()[0]));
+    List<DatanodeAdminError> error;
+    List<DatanodeDetails> dns = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
+      dns.add(dn);
+      nodeManager.register(dn, null, null);
+    }
+    Set<ContainerID> idsRatis = new HashSet<>();
+    ContainerInfo containerRatis = containerManager.allocateContainer(
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), "admin");
+    idsRatis.add(containerRatis.containerID());
+    Set<ContainerID> idsEC = new HashSet<>();
+    ContainerInfo containerEC = containerManager.allocateContainer(new ECReplicationConfig(3, 2), "admin");
+    idsEC.add(containerEC.containerID());
+
+    when(containerManager.getContainer(any(ContainerID.class)))
+        .thenAnswer(invocation -> {
+          ContainerID containerID = (ContainerID)invocation.getArguments()[0];
+          if (idsEC.contains(containerID)) {
+            return getMockContainer(new ECReplicationConfig(3, 2),
+                (ContainerID)invocation.getArguments()[0]);
+          }
+          return getMockContainer(RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE),
+              (ContainerID)invocation.getArguments()[0]);
+        });
+    for (DatanodeDetails dn  : nodeManager.getAllNodes().subList(0, 3)) {
+      nodeManager.setContainers(dn, idsRatis);
+    }
+    for (DatanodeDetails dn  : nodeManager.getAllNodes()) {
+      nodeManager.setContainers(dn, idsEC);
+    }
+
+    decom.setMaintenanceConfigs(2,1); // default config
+    // putting 2 DNs into maintenance leave the cluster with 3 DN,
+    // it should not be allowed as maintenance.remaining.redundancy is 1 => 3+1=4 DNs are required
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()), 100, false);
+    assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+    // putting 1 DN into maintenance leave the cluster with 4 DN,
+    // it should be allowed
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress()), 100, false);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+
+    decom.recommissionNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()));
+    decom.getMonitor().run();
+    assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+
+    decom.setMaintenanceConfigs(3,2); // non-default config
+    // putting 1 DNs into maintenance leave the cluster with 4 DN,
+    // it should not be allowed as for EC, maintenance.remaining.redundancy is 2 => 3+2=5 DNs are required
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress()), 100, false);
+    assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+
+    decom.recommissionNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()));
+    decom.getMonitor().run();
+    assertEquals(5, nodeManager.getNodeCount(NodeStatus.inServiceHealthy()));
+
+    // forcing 2 DNs into maintenance should be allowed
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()), 100, true);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+  }
+
+  @Test
+  public void testInsufficientNodeMaintenanceChecksNotInService() throws
+      NodeNotFoundException, IOException {
+    when(containerManager.getContainer(any(ContainerID.class)))
+        .thenAnswer(invocation -> getMockContainer(RatisReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE), (ContainerID)invocation.getArguments()[0]));
+
+    List<DatanodeAdminError> error;
+    List<DatanodeDetails> dns = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
+      dns.add(dn);
+      nodeManager.register(dn, null, null);
+    }
+    Set<ContainerID> idsRatis = new HashSet<>();
+    for (int i = 0; i < 5; i++) {
+      ContainerInfo container = containerManager.allocateContainer(
+          RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), "admin");
+      idsRatis.add(container.containerID());
+    }
+    for (DatanodeDetails dn  : nodeManager.getAllNodes().subList(0, 3)) {
+      nodeManager.setContainers(dn, idsRatis);
+    }
+
+    // put 2 nodes into maintenance successfully
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(0).getIpAddress(), dns.get(1).getIpAddress()),
+        100, false);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(0)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    // try to put 3 nodes into maintenance, 1 in service and 2 in ENTER_MAINTENANCE state, should be successful.
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(0).getIpAddress(),
+        dns.get(1).getIpAddress(), dns.get(2).getIpAddress()), 100, false);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(0)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+  }
+
+  @Test
+  public void testInsufficientNodeMaintenanceChecksForNNF() throws
+      NodeNotFoundException, IOException {
+    List<DatanodeAdminError> error;
+    List<DatanodeDetails> dns = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
+      dns.add(dn);
+    }
+    Set<ContainerID> idsRatis = new HashSet<>();
+    for (int i = 0; i < 3; i++) {
+      ContainerInfo container = containerManager.allocateContainer(
+          RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE), "admin");
+      idsRatis.add(container.containerID());
+    }
+
+    nodeManager = mock(NodeManager.class);
+    decom = new NodeDecommissionManager(conf, nodeManager, containerManager,
+        SCMContext.emptyContext(), new EventQueue(), null);
+    when(containerManager.getContainer(any(ContainerID.class)))
+        .thenAnswer(invocation -> getMockContainer(RatisReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE), (ContainerID)invocation.getArguments()[0]));
+    when(nodeManager.getNodesByAddress(any())).thenAnswer(invocation ->
+        getDatanodeDetailsList((String)invocation.getArguments()[0], dns));
+    when(nodeManager.getContainers(any())).thenReturn(idsRatis);
+    when(nodeManager.getNodeCount(any())).thenReturn(5);
+    when(nodeManager.getNodeStatus(any())).thenAnswer(invocation ->
+        getNodeOpState((DatanodeDetails) invocation.getArguments()[0], dns));
+    Mockito.doAnswer(invocation -> {
+      setNodeOpState((DatanodeDetails)invocation.getArguments()[0],
+          (HddsProtos.NodeOperationalState)invocation.getArguments()[1], dns);
+      return null;
+    }).when(nodeManager).setNodeOperationalState(any(DatanodeDetails.class), any(
+        HddsProtos.NodeOperationalState.class));
+    Mockito.doAnswer(invocation -> {
+      setNodeOpState((DatanodeDetails)invocation.getArguments()[0],
+          (HddsProtos.NodeOperationalState)invocation.getArguments()[1], dns);
+      return null;
+    }).when(nodeManager).setNodeOperationalState(any(DatanodeDetails.class), any(
+        HddsProtos.NodeOperationalState.class), any(Long.class));
+
+    // trying to put 4 available DNs into maintenance,
+    // it should not be allowed as it leaves the cluster with 1 DN and maintenance.replica.minimum is 2
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
+        dns.get(2).getIpAddress(), dns.get(3).getIpAddress(), dns.get(4).getIpAddress()), 100, false);
+    assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(3)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        nodeManager.getNodeStatus(dns.get(4)).getOperationalState());
+    // trying to put 4 DNs (3 available + 1 not found) into maintenance,
+    // it should be allowed as effectively, it tries to move 3 DNs to maintenance,
+    // leaving the cluster with 2 DNs
+    error = decom.startMaintenanceNodes(Arrays.asList(dns.get(0).getIpAddress(),
+        dns.get(1).getIpAddress(), dns.get(2).getIpAddress(), dns.get(3).getIpAddress()), 100, false);
+    assertEquals(0, error.size());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
+    assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+        nodeManager.getNodeStatus(dns.get(3)).getOperationalState());
+  }
+
   private List<DatanodeDetails> getDatanodeDetailsList(String ipaddress, List<DatanodeDetails> dns) {
     List<DatanodeDetails> datanodeDetails = new ArrayList<>();
     for (DatanodeDetails dn : dns) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -302,7 +302,7 @@ public class TestNodeDecommissionManager {
 
     // Put 2 valid nodes into maintenance
     decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
-        dns.get(2).getIpAddress()), 100);
+        dns.get(2).getIpAddress()), 100, true);
     assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     assertNotEquals(0, nodeManager.getNodeStatus(
@@ -315,14 +315,14 @@ public class TestNodeDecommissionManager {
     // Running the command again gives no error - nodes already decommissioning
     // are silently ignored.
     decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
-        dns.get(2).getIpAddress()), 100);
+        dns.get(2).getIpAddress()), 100, true);
 
     // Attempt to decommission dn(10) which has multiple hosts on the same IP
     // and we hardcoded ports to 3456, 4567, 5678
     DatanodeDetails multiDn = dns.get(10);
     String multiAddr =
         multiDn.getIpAddress() + ":" + multiDn.getPorts().get(0).getValue();
-    decom.startMaintenanceNodes(singletonList(multiAddr), 100);
+    decom.startMaintenanceNodes(singletonList(multiAddr), 100, true);
     assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
         nodeManager.getNodeStatus(multiDn).getOperationalState());
 
@@ -331,7 +331,7 @@ public class TestNodeDecommissionManager {
     nodeManager.processHeartbeat(dns.get(9));
     DatanodeDetails duplicatePorts = dns.get(9);
     decom.startMaintenanceNodes(singletonList(duplicatePorts.getIpAddress()),
-        100);
+        100, true);
     assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
         nodeManager.getNodeStatus(duplicatePorts).getOperationalState());
 
@@ -372,7 +372,7 @@ public class TestNodeDecommissionManager {
     // Try to go from decom to maint:
     dn = new ArrayList<>();
     dn.add(dns.get(2).getIpAddress());
-    errors = decom.startMaintenanceNodes(dn, 100);
+    errors = decom.startMaintenanceNodes(dn, 100, true);
     assertEquals(1, errors.size());
     assertEquals(dns.get(2).getHostName(), errors.get(0).getHostname());
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -250,9 +250,9 @@ public class ContainerOperationClient implements ScmClient {
 
   @Override
   public List<DatanodeAdminError> startMaintenanceNodes(List<String> hosts,
-      int endHours) throws IOException {
+      int endHours, boolean force) throws IOException {
     return storageContainerLocationClient.startMaintenanceNodes(
-        hosts, endHours);
+        hosts, endHours, force);
   }
 
   @Override

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
@@ -53,6 +53,12 @@ public class MaintenanceSubCommand extends ScmSubcommand {
           "By default, maintenance must be ended manually.")
   private int endInHours = 0;
 
+  @CommandLine.Option(names = { "--force" },
+      defaultValue = "false",
+      description = "Forcefully try to decommission the datanode(s)")
+  private boolean force;
+
+
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     if (parameters.size() > 0) {
@@ -68,7 +74,7 @@ public class MaintenanceSubCommand extends ScmSubcommand {
         hosts = parameters;
       }
       List<DatanodeAdminError> errors =
-          scmClient.startMaintenanceNodes(hosts, endInHours);
+          scmClient.startMaintenanceNodes(hosts, endInHours, force);
       System.out.println("Entering maintenance mode on datanode(s):\n" +
           String.join("\n", hosts));
       if (errors.size() > 0) {

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
@@ -102,7 +102,7 @@ public class TestMaintenanceSubCommand {
 
   @Test
   public void testNoErrorsWhenEnteringMaintenance() throws IOException  {
-    when(scmClient.startMaintenanceNodes(anyList(), anyInt()))
+    when(scmClient.startMaintenanceNodes(anyList(), anyInt(), true))
         .thenAnswer(invocation -> new ArrayList<DatanodeAdminError>());
 
     CommandLine c = new CommandLine(cmd);
@@ -126,7 +126,7 @@ public class TestMaintenanceSubCommand {
 
   @Test
   public void testErrorsReportedWhenEnteringMaintenance() throws IOException  {
-    when(scmClient.startMaintenanceNodes(anyList(), anyInt()))
+    when(scmClient.startMaintenanceNodes(anyList(), anyInt(), true))
         .thenAnswer(invocation -> {
           ArrayList<DatanodeAdminError> e = new ArrayList<>();
           e.add(new DatanodeAdminError("host1", "host1 error"));

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
@@ -38,6 +38,7 @@ import picocli.CommandLine;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.mock;
@@ -102,7 +103,7 @@ public class TestMaintenanceSubCommand {
 
   @Test
   public void testNoErrorsWhenEnteringMaintenance() throws IOException  {
-    when(scmClient.startMaintenanceNodes(anyList(), anyInt(), true))
+    when(scmClient.startMaintenanceNodes(anyList(), anyInt(), eq(true)))
         .thenAnswer(invocation -> new ArrayList<DatanodeAdminError>());
 
     CommandLine c = new CommandLine(cmd);
@@ -126,7 +127,7 @@ public class TestMaintenanceSubCommand {
 
   @Test
   public void testErrorsReportedWhenEnteringMaintenance() throws IOException  {
-    when(scmClient.startMaintenanceNodes(anyList(), anyInt(), true))
+    when(scmClient.startMaintenanceNodes(anyList(), anyInt(), anyBoolean()))
         .thenAnswer(invocation -> {
           ArrayList<DatanodeAdminError> e = new ArrayList<>();
           e.add(new DatanodeAdminError("host1", "host1 error"));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/node/TestDecommissionAndMaintenance.java
@@ -344,7 +344,7 @@ public class TestDecommissionAndMaintenance {
     final DatanodeDetails dn = nm.getNodeByUuid(dnID.toString());
 
     scmClient.startMaintenanceNodes(Arrays.asList(
-        getDNHostAndPort(dn)), 0);
+        getDNHostAndPort(dn)), 0, true);
 
     waitForDnToReachOpState(nm, dn, IN_MAINTENANCE);
     waitForDnToReachPersistedOpState(dn, IN_MAINTENANCE);
@@ -415,7 +415,7 @@ public class TestDecommissionAndMaintenance {
 
     scmClient.startMaintenanceNodes(forMaintenance.stream()
         .map(TestNodeUtil::getDNHostAndPort)
-        .collect(Collectors.toList()), 0);
+        .collect(Collectors.toList()), 0, true);
 
     // Ensure all 3 DNs go to maintenance
     for (DatanodeDetails dn : forMaintenance) {
@@ -449,7 +449,7 @@ public class TestDecommissionAndMaintenance {
         .collect(Collectors.toList());
     scmClient.startMaintenanceNodes(ecMaintenance.stream()
         .map(TestNodeUtil::getDNHostAndPort)
-        .collect(Collectors.toList()), 0);
+        .collect(Collectors.toList()), 0, true);
     for (DatanodeDetails dn : ecMaintenance) {
       waitForDnToReachPersistedOpState(dn, IN_MAINTENANCE);
     }
@@ -483,7 +483,7 @@ public class TestDecommissionAndMaintenance {
 
     scmClient.startMaintenanceNodes(forMaintenance.stream()
         .map(TestNodeUtil::getDNHostAndPort)
-        .collect(Collectors.toList()), 0);
+        .collect(Collectors.toList()), 0, true);
 
     // Ensure all 3 DNs go to entering_maintenance
     for (DatanodeDetails dn : forMaintenance) {
@@ -521,7 +521,7 @@ public class TestDecommissionAndMaintenance {
     DatanodeDetails dn =
         getOneDNHostingReplica(getContainerReplicas(container));
 
-    scmClient.startMaintenanceNodes(Arrays.asList(getDNHostAndPort(dn)), 0);
+    scmClient.startMaintenanceNodes(Arrays.asList(getDNHostAndPort(dn)), 0, true);
     waitForDnToReachPersistedOpState(dn, IN_MAINTENANCE);
 
     long newEndTime = System.currentTimeMillis() / 1000 + 5;
@@ -534,7 +534,7 @@ public class TestDecommissionAndMaintenance {
 
     // Put the node back into maintenance and then stop it and wait for it to
     // go dead
-    scmClient.startMaintenanceNodes(Arrays.asList(getDNHostAndPort(dn)), 0);
+    scmClient.startMaintenanceNodes(Arrays.asList(getDNHostAndPort(dn)), 0, true);
     waitForDnToReachPersistedOpState(dn, IN_MAINTENANCE);
     cluster.shutdownHddsDatanode(dn);
     waitForDnToReachHealthState(nm, dn, DEAD);
@@ -563,7 +563,7 @@ public class TestDecommissionAndMaintenance {
     DatanodeDetails dn =
         getOneDNHostingReplica(getContainerReplicas(container));
 
-    scmClient.startMaintenanceNodes(Arrays.asList(getDNHostAndPort(dn)), 0);
+    scmClient.startMaintenanceNodes(Arrays.asList(getDNHostAndPort(dn)), 0, true);
     waitForDnToReachPersistedOpState(dn, IN_MAINTENANCE);
 
     cluster.restartStorageContainerManager(true);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAndAdminContainerCLI.java
@@ -243,7 +243,7 @@ class TestReconAndAdminContainerCLI {
     // First node goes offline.
     if (isMaintenance) {
       scmClient.startMaintenanceNodes(Collections.singletonList(
-          TestNodeUtil.getDNHostAndPort(nodeToGoOffline1)), 0);
+          TestNodeUtil.getDNHostAndPort(nodeToGoOffline1)), 0, true);
     } else {
       scmClient.decommissionNodes(Collections.singletonList(
           TestNodeUtil.getDNHostAndPort(nodeToGoOffline1)), false);
@@ -270,7 +270,7 @@ class TestReconAndAdminContainerCLI {
     // Second node goes offline.
     if (isMaintenance) {
       scmClient.startMaintenanceNodes(Collections.singletonList(
-          TestNodeUtil.getDNHostAndPort(nodeToGoOffline2)), 0);
+          TestNodeUtil.getDNHostAndPort(nodeToGoOffline2)), 0, true);
     } else {
       scmClient.decommissionNodes(Collections.singletonList(
           TestNodeUtil.getDNHostAndPort(nodeToGoOffline2)), false);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Many users test out Ozone in small clusters of 15 Datanodes or less. If a 15 DN cluster has some EC 10-4 containers, for example, then it's not possible to put more than 2 datanodes into maintenance (`maintenance.remaining.redundancy` = 1 by default), because EC 10-4 requires at least (10+4-1) = 13 Datanodes. If someone tries to move 3 Datanodes to maintenance, the maintenance process is designed such that it will keep looping and checking every 30 seconds whether it's possible to take the two DNs offline. It will never fail, even though it's clearly not possible to take the Datanodes offline.
In this PR, the maintenance is failed early if sufficient datanodes are not available based on the maximum replication factor of containers present in the cluster, and the configs `maintenance.remaining.redundancy` and `maintenance.replica.minimum`. It returns a corresponding DatanodeAdminError.
The detailed design doc can be found in the EPIC [HDDS-10461](https://issues.apache.org/jira/browse/HDDS-10461)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10463

## How was this patch tested?

Unit tests covering edge cases as well have been added to TestNodeDecommissionManager
