### PR TITLE
HDDS-10615. ETag change detected in S3A contract test

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BasicKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListKeysRequest;
 
+import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
+
 /**
  * Lightweight OmKeyInfo class.
  */
@@ -38,6 +40,7 @@ public final class BasicOmKeyInfo {
   private final long modificationTime;
   private final ReplicationConfig replicationConfig;
   private final boolean isFile;
+  private final String eTag;
 
   private BasicOmKeyInfo(Builder b) {
     this.volumeName = b.volumeName;
@@ -48,6 +51,7 @@ public final class BasicOmKeyInfo {
     this.modificationTime = b.modificationTime;
     this.replicationConfig = b.replicationConfig;
     this.isFile = b.isFile;
+    this.eTag = b.eTag;
   }
 
   private BasicOmKeyInfo(OmKeyInfo b) {
@@ -59,6 +63,7 @@ public final class BasicOmKeyInfo {
     this.modificationTime = b.getModificationTime();
     this.replicationConfig = b.getReplicationConfig();
     this.isFile = b.isFile();
+    this.eTag = b.getMetadata().get(ETAG);
   }
 
   public String getVolumeName() {
@@ -93,6 +98,10 @@ public final class BasicOmKeyInfo {
     return isFile;
   }
 
+  public String getETag() {
+    return eTag;
+  }
+
   /**
    * Builder of BasicOmKeyInfo.
    */
@@ -105,6 +114,7 @@ public final class BasicOmKeyInfo {
     private long modificationTime;
     private ReplicationConfig replicationConfig;
     private boolean isFile;
+    private String eTag;
 
     public Builder setVolumeName(String volumeName) {
       this.volumeName = volumeName;
@@ -146,6 +156,11 @@ public final class BasicOmKeyInfo {
       return this;
     }
 
+    public Builder setETag(String etag) {
+      this.eTag = etag;
+      return this;
+    }
+
     public BasicOmKeyInfo build() {
       return new BasicOmKeyInfo(this);
     }
@@ -163,6 +178,9 @@ public final class BasicOmKeyInfo {
           ((ECReplicationConfig) replicationConfig).toProto());
     } else {
       builder.setFactor(ReplicationConfig.getLegacyFactor(replicationConfig));
+    }
+    if (eTag != null) {
+      builder.setETag(eTag);
     }
 
     return builder.build();
@@ -188,6 +206,7 @@ public final class BasicOmKeyInfo {
             basicKeyInfo.getType(),
             basicKeyInfo.getFactor(),
             basicKeyInfo.getEcReplicationConfig()))
+        .setETag(basicKeyInfo.getETag())
         .setIsFile(!keyName.endsWith("/"));
 
     return builder.build();
@@ -212,6 +231,7 @@ public final class BasicOmKeyInfo {
             basicKeyInfo.getType(),
             basicKeyInfo.getFactor(),
             basicKeyInfo.getEcReplicationConfig()))
+        .setETag(basicKeyInfo.getETag())
         .setIsFile(!keyName.endsWith("/"));
 
     return builder.build();
@@ -232,6 +252,7 @@ public final class BasicOmKeyInfo {
         creationTime == basicOmKeyInfo.creationTime &&
         modificationTime == basicOmKeyInfo.modificationTime &&
         replicationConfig.equals(basicOmKeyInfo.replicationConfig) &&
+        Objects.equals(eTag, basicOmKeyInfo.eTag) &&
         isFile == basicOmKeyInfo.isFile;
   }
 

--- a/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
@@ -79,11 +79,11 @@ EOF
 
   # Some tests are skipped due to known issues.
   # - ITestS3AContractDistCp: HDDS-10616
-  # - ITestS3AContractEtag, ITestS3AContractRename: HDDS-10615
   # - ITestS3AContractGetFileStatusV1List: HDDS-10617
   # - ITestS3AContractMkdir: HDDS-10572
+  # - ITestS3AContractRename: HDDS-10665
   mvn -B -V --fail-never --no-transfer-progress \
-    -Dtest='ITestS3AContract*, !ITestS3AContractDistCp, !ITestS3AContractEtag, !ITestS3AContractGetFileStatusV1List, !ITestS3AContractMkdir, !ITestS3AContractRename' \
+    -Dtest='ITestS3AContract*, !ITestS3AContractDistCp, !ITestS3AContractGetFileStatusV1List, !ITestS3AContractMkdir, !ITestS3AContractRename' \
     clean test
 
   local target="${RESULT_DIR}/junit/${bucket}/target"

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1117,6 +1117,7 @@ message BasicKeyInfo {
     optional hadoop.hdds.ReplicationType type = 5;
     optional hadoop.hdds.ReplicationFactor factor = 6;
     optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 7;
+    optional string eTag = 8;
 }
 
 message DirectoryInfo {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -32,6 +32,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .UserInfo;
 
+import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
+
 /**
  * Interface for OM Requests to convert to audit objects.
  */
@@ -79,6 +81,11 @@ public interface RequestAuditor {
       if (keyArgs.hasEcReplicationConfig()) {
         auditMap.put(OzoneConsts.REPLICATION_CONFIG,
             ECReplicationConfig.toString(keyArgs.getEcReplicationConfig()));
+      }
+      for (HddsProtos.KeyValue item : keyArgs.getMetadataList()) {
+        if (ETAG.equals(item.getKey())) {
+          auditMap.put(ETAG, item.getValue());
+        }
       }
       return auditMap;
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -712,7 +712,7 @@ public class BucketEndpoint extends EndpointBase {
     keyMetadata.setSize(next.getDataSize());
     String eTag = next.getMetadata().get(ETAG);
     if (eTag != null) {
-      keyMetadata.setETag(eTag);
+      keyMetadata.setETag(ObjectEndpoint.wrapInQuotes(eTag));
     }
     if (next.getReplicationType().toString().equals(ReplicationType
         .STAND_ALONE.toString())) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -69,6 +69,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
 import static org.apache.hadoop.ozone.audit.AuditLogger.PerformanceStringBuilder;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
@@ -709,7 +710,10 @@ public class BucketEndpoint extends EndpointBase {
     keyMetadata.setKey(EncodingTypeObject.createNullable(next.getName(),
         response.getEncodingType()));
     keyMetadata.setSize(next.getDataSize());
-    keyMetadata.setETag("" + next.getModificationTime());
+    String eTag = next.getMetadata().get(ETAG);
+    if (eTag != null) {
+      keyMetadata.setETag(eTag);
+    }
     if (next.getReplicationType().toString().equals(ReplicationType
         .STAND_ALONE.toString())) {
       keyMetadata.setStorageClass(S3StorageType.REDUCED_REDUNDANCY.toString());

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -611,7 +611,7 @@ public class ObjectEndpoint extends EndpointBase {
       // Should not return ETag header if the ETag is not set
       // doing so will result in "null" string being returned instead
       // which breaks some AWS SDK implementation
-      response.header(ETAG, "" + wrapInQuotes(key.getMetadata().get(ETAG)));
+      response.header(ETAG, wrapInQuotes(key.getMetadata().get(ETAG)));
     }
 
     addLastModifiedDate(response, key);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -1356,7 +1356,7 @@ public class ObjectEndpoint extends EndpointBase {
     return datastreamEnabled;
   }
 
-  private String wrapInQuotes(String value) {
+  static String wrapInQuotes(String value) {
     return "\"" + value + "\"";
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix test failures related to in S3A contract test.  The problem is that some parts of the code use "modification time" instead of content hash as ETag.

```
Tests run: 11, Failures: 0, Errors: 3, Skipped: 1, Time elapsed: 2.998 s <<< FAILURE! - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractRename
testRenamePopulatesFileAncestors2(org.apache.hadoop.fs.contract.s3a.ITestS3AContractRename)  Time elapsed: 1.04 s  <<< ERROR!
org.apache.hadoop.fs.s3a.RemoteFileChangedException: copy `s3a://obs-bucket/test/testRenamePopulatesFileAncestors2/src/dir1/dir2/dir3/fileA': ETag change detected on client during copy. Expected 2024-03-29T18:34:05.086Z got f41ee8006d26bd7fc73828b0a0b350a8

testRenameWithNonEmptySubDir(org.apache.hadoop.fs.contract.s3a.ITestS3AContractRename)  Time elapsed: 0.281 s  <<< ERROR!
org.apache.hadoop.fs.s3a.RemoteFileChangedException: copy `s3a://obs-bucket/test/testRenameWithNonEmptySubDir/src1/source.txt': ETag change detected on client during copy. Expected 2024-03-29T18:34:05.352Z got 046d1988b7a01316bb47905ccf3b584a

testRenamePopulatesFileAncestors(org.apache.hadoop.fs.contract.s3a.ITestS3AContractRename)  Time elapsed: 0.219 s  <<< ERROR!
org.apache.hadoop.fs.s3a.RemoteFileChangedException: copy `s3a://obs-bucket/test/testRenamePopulatesFileAncestors/source/dir1/dir2/dir3/file4': ETag change detected on client during copy. Expected 2024-03-29T18:34:05.609Z got 67e95334b751fbfc6570e8228183c074


Tests run: 4, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 1.314 s <<< FAILURE! - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractEtag
testLocatedStatusAlsoHasEtag(org.apache.hadoop.fs.contract.s3a.ITestS3AContractEtag)  Time elapsed: 0.117 s  <<< FAILURE!
org.junit.ComparisonFailure: [etag of listLocatedStatus (S3ALocatedFileStatus{path=s3a://obs-bucket/test/testLocatedStatusAlsoHasEtag/src; isDirectory=false; length=11; replication=1; blocksize=33554432; modification_time=1711737272164; access_time=0; owner=...; group=...; permission=rw-rw-rw-; isSymlink=false; hasAcl=false; isEncrypted=true; isErasureCoded=false}[eTag='2024-03-29T18:34:32.164Z', versionId='']) compared to HEAD value of S3AFileStatus{path=s3a://obs-bucket/test/testLocatedStatusAlsoHasEtag/src; isDirectory=false; length=11; replication=1; blocksize=33554432; modification_time=1711737272000; access_time=0; owner=...; group=...; permission=rw-rw-rw-; isSymlink=false; hasAcl=false; isEncrypted=true; isErasureCoded=false} isEmptyDirectory=FALSE eTag=26e078b87fdaa3206ab8bf63a6096c07 versionId=null] expected:<"2[6e078b87fdaa3206ab8bf63a6096c07]"> but was:<"2[024-03-29T18:34:32.164Z]">
```

https://issues.apache.org/jira/browse/HDDS-10615

## How was this patch tested?

`ITestS3AContractEtag` is enabled as part of the change.

`ITestS3AContractRename` is still failing with another error for FSO buckets only (HDDS-10665), but the ones related to ETag change are fixed.  The test is passing with OBS bucket:

```
Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.289 s - in org.apache.hadoop.fs.contract.s3a.ITestS3AContractRename
```

https://github.com/adoroszlai/ozone/actions/runs/8661440172