### PR TITLE
HDDS-10686. Bump npm packages only for security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ version: 2
 updates:
   - package-ecosystem: maven
     directory: "/"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     schedule:
       interval: "weekly"
       day: "saturday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,26 +14,6 @@
 # limitations under the License.
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "npm"
-    directory: "hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "[Recon] Dependabot Package Upgrade: "
-    groups:
-      minor-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    pull-request-branch-name:
-      separator: "-"
-
   - package-ecosystem: maven
     directory: "/"
     schedule:


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Upgrade npm dependencies only for security fixes.
2. Disable major version upgrades for Maven dependencies.

https://issues.apache.org/jira/browse/HDDS-10686

## How was this patch tested?

N/A