### PR TITLE
HDDS-10625. Remove unused netty-related config options from SCM

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -224,16 +224,6 @@ public final class ScmConfigKeys {
   public static final String HDDS_DATANODE_DIR_DU_RESERVED_PERCENT =
       "hdds.datanode.dir.du.reserved.percent";
   public static final float HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT = 0;
-  public static final String HDDS_REST_CSRF_ENABLED_KEY =
-      "hdds.rest.rest-csrf.enabled";
-  public static final boolean HDDS_REST_CSRF_ENABLED_DEFAULT = false;
-  public static final String HDDS_REST_NETTY_HIGH_WATERMARK =
-      "hdds.rest.netty.high.watermark";
-  public static final int HDDS_REST_NETTY_HIGH_WATERMARK_DEFAULT = 65536;
-  public static final int HDDS_REST_NETTY_LOW_WATERMARK_DEFAULT = 32768;
-  public static final String HDDS_REST_NETTY_LOW_WATERMARK =
-      "hdds.rest.netty.low.watermark";
-
   public static final String OZONE_SCM_HANDLER_COUNT_KEY =
       "ozone.scm.handler.count.key";
   public static final String OZONE_SCM_CLIENT_HANDLER_COUNT_KEY =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1484,40 +1484,12 @@
       to the OM.
     </description>
   </property>
-
-  <property>
-    <name>hdds.rest.rest-csrf.enabled</name>
-    <value>false</value>
-    <description>
-      If true, then enables Object Store REST server protection against
-      cross-site request forgery (CSRF).
-    </description>
-  </property>
-
   <property>
     <name>hdds.rest.http-address</name>
     <value>0.0.0.0:9880</value>
     <description>The http address of Object Store REST server inside the
       datanode.</description>
   </property>
-
-
-  <property>
-    <name>hdds.rest.netty.high.watermark</name>
-    <value>65535</value>
-    <description>
-      High watermark configuration to Netty for Object Store REST server.
-    </description>
-  </property>
-
-  <property>
-    <name>hdds.rest.netty.low.watermark</name>
-    <value>32768</value>
-    <description>
-      Low watermark configuration to Netty for Object Store REST server.
-    </description>
-  </property>
-
   <property>
     <name>hdds.datanode.plugins</name>
     <value/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed non-used properties:
* hdds.rest.netty.high.watermark
* hdds.rest.netty.low.watermark

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10625

## How was this patch tested?

Existing tests
