### PR TITLE
HDDS-10690. SCMStateMachine Override LeaderEventApi.notifyLeaderReady

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -352,31 +352,33 @@ public class SCMStateMachine extends BaseStateMachine {
     if (transactionBuffer != null) {
       transactionBuffer.updateLatestTrxInfo(TransactionInfo.valueOf(term, index));
     }
+
+    if (currentLeaderTerm.get() == term) {
+      // Means all transactions before this term have been applied.
+      // This means after a restart, all pending transactions have been applied.
+      // Perform
+      // 1. Refresh Safemode rules state.
+      // 2. Start DN Rpc server.
+      if (!refreshedAfterLeaderReady.get()) {
+        scm.getScmSafeModeManager().refresh();
+        scm.getDatanodeProtocolServer().start();
+
+        refreshedAfterLeaderReady.set(true);
+      }
+      currentLeaderTerm.set(-1L);
+    }
   }
 
   @Override
   public void notifyLeaderReady() {
+    if (!isInitialized) {
+      return;
+    }
     // On leader SCM once after it is ready, notify SCM services and also set
     // leader ready  in SCMContext.
-    if (scm.getScmHAManager().getRatisServer().getDivision().getInfo()
-        .isLeaderReady()) {
-      scm.getScmContext().setLeaderReady();
-      scm.getSCMServiceManager().notifyStatusChanged();
-      scm.getFinalizationManager().onLeaderReady();
-    }
-
-    // Means all transactions before this term have been applied.
-    // This means after a restart, all pending transactions have been applied.
-    // Perform
-    // 1. Refresh Safemode rules state.
-    // 2. Start DN Rpc server.
-    if (!refreshedAfterLeaderReady.get()) {
-      scm.getScmSafeModeManager().refresh();
-      scm.getDatanodeProtocolServer().start();
-
-      refreshedAfterLeaderReady.set(true);
-    }
-    currentLeaderTerm.set(-1L);
+    scm.getScmContext().setLeaderReady();
+    scm.getSCMServiceManager().notifyStatusChanged();
+    scm.getFinalizationManager().onLeaderReady();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -352,30 +352,31 @@ public class SCMStateMachine extends BaseStateMachine {
     if (transactionBuffer != null) {
       transactionBuffer.updateLatestTrxInfo(TransactionInfo.valueOf(term, index));
     }
+  }
 
-    if (currentLeaderTerm.get() == term) {
-      // On leader SCM once after it is ready, notify SCM services and also set
-      // leader ready  in SCMContext.
-      if (scm.getScmHAManager().getRatisServer().getDivision().getInfo()
-          .isLeaderReady()) {
-        scm.getScmContext().setLeaderReady();
-        scm.getSCMServiceManager().notifyStatusChanged();
-        scm.getFinalizationManager().onLeaderReady();
-      }
-
-      // Means all transactions before this term have been applied.
-      // This means after a restart, all pending transactions have been applied.
-      // Perform
-      // 1. Refresh Safemode rules state.
-      // 2. Start DN Rpc server.
-      if (!refreshedAfterLeaderReady.get()) {
-        scm.getScmSafeModeManager().refresh();
-        scm.getDatanodeProtocolServer().start();
-
-        refreshedAfterLeaderReady.set(true);
-      }
-      currentLeaderTerm.set(-1L);
+  @Override
+  public void notifyLeaderReady() {
+    // On leader SCM once after it is ready, notify SCM services and also set
+    // leader ready  in SCMContext.
+    if (scm.getScmHAManager().getRatisServer().getDivision().getInfo()
+        .isLeaderReady()) {
+      scm.getScmContext().setLeaderReady();
+      scm.getSCMServiceManager().notifyStatusChanged();
+      scm.getFinalizationManager().onLeaderReady();
     }
+
+    // Means all transactions before this term have been applied.
+    // This means after a restart, all pending transactions have been applied.
+    // Perform
+    // 1. Refresh Safemode rules state.
+    // 2. Start DN Rpc server.
+    if (!refreshedAfterLeaderReady.get()) {
+      scm.getScmSafeModeManager().refresh();
+      scm.getDatanodeProtocolServer().start();
+
+      refreshedAfterLeaderReady.set(true);
+    }
+    currentLeaderTerm.set(-1L);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the check leader ready logic is bounded inside "EventApi.
notifyTermIndexUpdated", since Ratis now provide an separate "notifyLeaderReady", it should be better to use the new API now.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10690

## How was this patch tested?

Existing tests.
