### PR TITLE
HDDS-10692. ozone s3 getsecret prints some internal details

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
@@ -101,9 +101,7 @@ public final class S3SecretValue {
 
   @Override
   public String toString() {
-    return "awsAccessKey=" + kerberosID + "\nawsSecret=" + awsSecret +
-        "\nisDeleted=" + isDeleted + "\ntransactionLogIndex=" +
-        transactionLogIndex;
+    return "awsAccessKey=" + kerberosID + "\nawsSecret=" + awsSecret;
   }
 
   @Override

--- a/hadoop-ozone/dist/src/main/smoketest/security/S3-secret.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/S3-secret.robot
@@ -26,6 +26,8 @@ GetSecret success
     ${output}=             Execute             ozone s3 getsecret -u testuser2
     Should contain         ${output}           awsAccessKey
     Should contain         ${output}           awsSecret
+    Should not contain     ${output}           isDeleted
+    Should not contain     ${output}           transactionLogIndex
 
 GetSecret failure
     ${output2}=            Execute and Ignore Error    ozone s3 getsecret -u testuser2


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone s3 getsecret` prints some additional items since HDDS-9444.

```
awsAccessKey=...
awsSecret=...
isDeleted=false
transactionLogIndex=0
```

The last two lines are internal details, should be omitted.

https://issues.apache.org/jira/browse/HDDS-10692

## How was this patch tested?

Added assertion in robot test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/8693821050