### PR TITLE
HDDS-10695. Remove unused plugin maven-failsafe-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <unstable-test-groups>flaky | native | slow | unhealthy</unstable-test-groups>
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
-    <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>
 
     <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
@@ -1313,11 +1312,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`maven-failsafe-plugin` is unused, version definition can be removed.

https://issues.apache.org/jira/browse/HDDS-10695

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8693895117