### PR TITLE
HDDS-10699. Refactor ContainerBalancerTask and tests in TestContainerBalancerTask

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockedSCM.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockedSCM.java
@@ -66,28 +66,32 @@ public final class MockedSCM {
   private final StorageContainerManager scm;
   private final TestableCluster cluster;
   private final MockNodeManager mockNodeManager;
-  private MockedReplicationManager mockedReplicaManager;
-  private MoveManager moveManager;
-  private ContainerManager containerManager;
-
+  private final MockedReplicationManager mockedReplicaManager;
+  private final MoveManager moveManager;
+  private final ContainerManager containerManager;
   private MockedPlacementPolicies mockedPlacementPolicies;
 
   public MockedSCM(@Nonnull TestableCluster testableCluster) {
     scm = mock(StorageContainerManager.class);
     cluster = testableCluster;
     mockNodeManager = new MockNodeManager(cluster.getDatanodeToContainersMap());
+    try {
+      moveManager = mockMoveManager();
+      containerManager = mockContainerManager(cluster);
+      mockedReplicaManager = MockedReplicationManager.doMock();
+    } catch (NodeNotFoundException | ContainerReplicaNotFoundException | ContainerNotFoundException |
+             TimeoutException e
+    ) {
+      throw new RuntimeException("Can't create MockedSCM instance: ", e);
+    }
   }
 
-  public void init(@Nonnull ContainerBalancerConfiguration balancerConfig) {
-    init(balancerConfig, new OzoneConfiguration());
-  }
-
-  public void init(@Nonnull ContainerBalancerConfiguration balancerConfig, @Nonnull OzoneConfiguration ozoneCfg) {
+  private void init(@Nonnull ContainerBalancerConfiguration balancerConfig, @Nonnull OzoneConfiguration ozoneCfg) {
     ozoneCfg.setFromObject(balancerConfig);
     try {
       doMock(balancerConfig, ozoneCfg);
     } catch (IOException | NodeNotFoundException | TimeoutException e) {
-      throw new RuntimeException("Can't initialize TestOzoneHDDS: ", e);
+      throw new RuntimeException("Can't create MockedSCM instance: ", e);
     }
   }
 
@@ -96,9 +100,6 @@ public final class MockedSCM {
    */
   private void doMock(@Nonnull ContainerBalancerConfiguration cfg, @Nonnull OzoneConfiguration ozoneCfg)
       throws IOException, NodeNotFoundException, TimeoutException {
-    containerManager = mockContainerManager(cluster);
-    mockedReplicaManager = MockedReplicationManager.doMock();
-    moveManager = mockMoveManager();
     StatefulServiceStateManager stateManager = MockedServiceStateManager.doMock();
     SCMServiceManager scmServiceManager = mockSCMServiceManger();
 
@@ -137,6 +138,7 @@ public final class MockedSCM {
   }
 
   public @Nonnull ContainerBalancerTask startBalancerTask(@Nonnull ContainerBalancerConfiguration config) {
+    init(config, new OzoneConfiguration());
     return startBalancerTask(new ContainerBalancer(scm), config);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockedSCM.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockedSCM.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -137,7 +137,6 @@ public final class MockedSCM {
   }
 
   public @Nonnull ContainerBalancerTask startBalancerTask(@Nonnull ContainerBalancerConfiguration config) {
-    init(config);
     return startBalancerTask(new ContainerBalancer(scm), config);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -96,7 +96,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
     }
     config.setIterations(1);
     config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
-    mockedSCM.init(config);
 
     ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
     ContainerBalancerMetrics metrics = task.getMetrics();
@@ -124,7 +123,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
     config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
     // No containers should be selected when the limit is just 2 MB.
     config.setMaxSizeEnteringTarget(2 * OzoneConsts.MB);
-    mockedSCM.init(config);
 
     ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
     // Container balancer still has unbalanced nodes due to MaxSizeEnteringTarget limit
@@ -140,7 +138,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
       balancerConfig.setMaxDatanodesPercentageToInvolvePerIteration(100);
     }
     balancerConfig.setIterations(1);
-    mockedSCM.init(balancerConfig);
 
     task = mockedSCM.startBalancerTask(balancerConfig);
     // Balancer should have identified unbalanced nodes.
@@ -165,7 +162,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
     config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
     // No source containers should be selected when the limit is just 2 MB.
     config.setMaxSizeLeavingSource(2 * OzoneConsts.MB);
-    mockedSCM.init(config);
 
     ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
     // Container balancer still has unbalanced nodes due to MaxSizeLeavingSource limit
@@ -181,7 +177,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
       newBalancerConfig.setMaxDatanodesPercentageToInvolvePerIteration(100);
     }
     newBalancerConfig.setIterations(1);
-    mockedSCM.init(newBalancerConfig);
 
     task = mockedSCM.startBalancerTask(newBalancerConfig);
     // Balancer should have identified unbalanced nodes.
@@ -208,7 +203,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
     config.setIterations(1);
     config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
     config.setMaxSizeEnteringTarget(50 * STORAGE_UNIT);
-    mockedSCM.init(config);
 
     // check for random threshold values
     for (int i = 0; i < 50; i++) {
@@ -257,7 +251,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
     config.setIterations(1);
     config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
     config.setMaxSizeEnteringTarget(50 * STORAGE_UNIT);
-    mockedSCM.init(config);
 
     mockedSCM.disableLegacyReplicationManager();
     mockedSCM.startBalancerTask(config);
@@ -285,7 +278,6 @@ public class TestContainerBalancerDatanodeNodeLimit {
     config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
     config.setMaxSizeEnteringTarget(50 * STORAGE_UNIT);
     config.setThreshold(99.99);
-    mockedSCM.init(config);
 
     ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
     ContainerBalancerMetrics metrics = task.getMetrics();
@@ -309,13 +301,10 @@ public class TestContainerBalancerDatanodeNodeLimit {
     config.setMaxSizeEnteringTarget(6 * STORAGE_UNIT);
     // deliberately set max size per iteration to a low value, 6 GB
     config.setMaxSizeToMovePerIteration(6 * STORAGE_UNIT);
-    mockedSCM.init(config);
 
     when(mockedSCM.getMoveManager().move(any(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(
-            MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY))
-        .thenReturn(CompletableFuture.completedFuture(
-            MoveManager.MoveResult.COMPLETED));
+        .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY))
+        .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
     ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
 
     ContainerBalancerMetrics metrics = task.getMetrics();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerTask.java
@@ -88,7 +88,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -115,7 +114,6 @@ public class TestContainerBalancerTask {
   private ContainerBalancerConfiguration balancerConfiguration;
   private List<DatanodeUsageInfo> nodesInCluster;
   private List<Double> nodeUtilizations;
-  private double averageUtilization;
   private int numberOfNodes;
   private Map<ContainerID, Set<ContainerReplica>> cidToReplicasMap =
       new HashMap<>();
@@ -168,7 +166,7 @@ public class TestContainerBalancerTask {
             .filter(method -> method.getName().equals("balancerShouldMoveOnlyPositiveSizeContainers"))
             .map(method -> new int[]{0, 0, 0, 0, 0, 1, 2, 3, 4, 5})
             .orElse(null);
-    averageUtilization = createCluster(sizeArray);
+    createCluster(sizeArray);
     mockNodeManager = new MockNodeManager(datanodeToContainersMap);
 
     NetworkTopology clusterMap = mockNodeManager.getClusterNetworkTopologyMap();
@@ -251,88 +249,6 @@ public class TestContainerBalancerTask {
   }
 
   @Test
-  public void testCalculationOfUtilization() {
-    assertEquals(nodesInCluster.size(), nodeUtilizations.size());
-    for (int i = 0; i < nodesInCluster.size(); i++) {
-      assertEquals(nodeUtilizations.get(i),
-          nodesInCluster.get(i).calculateUtilization(), 0.0001);
-    }
-
-    // should be equal to average utilization of the cluster
-    assertEquals(averageUtilization, containerBalancerTask.calculateAvgUtilization(nodesInCluster), 0.0001);
-  }
-
-  /**
-   * Checks whether ContainerBalancer is correctly updating the list of
-   * unBalanced nodes with varying values of Threshold.
-   */
-  @Test
-  public void
-      initializeIterationShouldUpdateUnBalancedNodesWhenThresholdChanges() {
-    List<DatanodeUsageInfo> expectedUnBalancedNodes;
-    List<DatanodeUsageInfo> unBalancedNodesAccordingToBalancer;
-
-    // check for random threshold values
-    ContainerBalancer sb = new ContainerBalancer(scm);
-    for (int i = 0; i < 50; i++) {
-      double randomThreshold = RANDOM.nextDouble() * 100;
-
-      expectedUnBalancedNodes =
-          determineExpectedUnBalancedNodes(randomThreshold);
-
-      balancerConfiguration.setThreshold(randomThreshold);
-      containerBalancerTask = new ContainerBalancerTask(scm, 0, sb,
-          sb.getMetrics(), balancerConfiguration, false);
-      containerBalancerTask.run();
-
-      unBalancedNodesAccordingToBalancer =
-          containerBalancerTask.getUnBalancedNodes();
-
-      assertEquals(expectedUnBalancedNodes.size(), unBalancedNodesAccordingToBalancer.size());
-
-      for (int j = 0; j < expectedUnBalancedNodes.size(); j++) {
-        assertEquals(expectedUnBalancedNodes.get(j).getDatanodeDetails(),
-            unBalancedNodesAccordingToBalancer.get(j).getDatanodeDetails());
-      }
-    }
-  }
-
-  @Test
-  public void testBalancerWithMoveManager()
-      throws IllegalContainerBalancerStateException, IOException,
-      InvalidContainerBalancerConfigurationException, TimeoutException,
-      NodeNotFoundException {
-    rmConf.setEnableLegacy(false);
-    startBalancer(balancerConfiguration);
-    verify(moveManager, atLeastOnce())
-        .move(any(ContainerID.class),
-            any(DatanodeDetails.class),
-            any(DatanodeDetails.class));
-
-    verify(replicationManager, times(0))
-        .move(any(ContainerID.class), any(
-            DatanodeDetails.class), any(DatanodeDetails.class));
-  }
-
-  /**
-   * Checks whether the list of unBalanced nodes is empty when the cluster is
-   * balanced.
-   */
-  @Test
-  public void unBalancedNodesListShouldBeEmptyWhenClusterIsBalanced()
-      throws IllegalContainerBalancerStateException, IOException,
-      InvalidContainerBalancerConfigurationException, TimeoutException {
-    balancerConfiguration.setThreshold(99.99);
-    startBalancer(balancerConfiguration);
-
-
-    stopBalancer();
-    ContainerBalancerMetrics metrics = containerBalancerTask.getMetrics();
-    assertEquals(0, containerBalancerTask.getUnBalancedNodes().size());
-    assertEquals(0, metrics.getNumDatanodesUnbalanced());
-  }
-
-  @Test
   public void containerBalancerShouldSelectOnlyClosedContainers()
       throws IllegalContainerBalancerStateException, IOException,
       InvalidContainerBalancerConfigurationException, TimeoutException {
@@ -345,8 +261,7 @@ public class TestContainerBalancerTask {
     stopBalancer();
 
     // balancer should have identified unbalanced nodes
-    assertFalse(containerBalancerTask.getUnBalancedNodes()
-        .isEmpty());
+    assertFalse(TestContainerBalancerDatanodeNodeLimit.getUnBalancedNodes(containerBalancerTask).isEmpty());
     // no container should have been selected
     assertTrue(containerBalancerTask.getContainerToSourceMap()
         .isEmpty());
@@ -407,8 +322,7 @@ public class TestContainerBalancerTask {
     stopBalancer();
 
     // balancer should have identified unbalanced nodes
-    assertFalse(containerBalancerTask.getUnBalancedNodes()
-        .isEmpty());
+    assertFalse(TestContainerBalancerDatanodeNodeLimit.getUnBalancedNodes(containerBalancerTask).isEmpty());
     // no container should have moved because all replicas are CLOSING
     assertTrue(
         containerBalancerTask.getContainerToSourceMap().isEmpty());
@@ -585,46 +499,6 @@ public class TestContainerBalancerTask {
         containerBalancerTask.getContainerToSourceMap().keySet()) {
       assertThat(excludeContainers).doesNotContain(container);
     }
-  }
-
-  @Test
-  public void testMetrics()
-      throws IllegalContainerBalancerStateException, IOException,
-      InvalidContainerBalancerConfigurationException, TimeoutException,
-      NodeNotFoundException {
-    conf.set("hdds.datanode.du.refresh.period", "1ms");
-    balancerConfiguration.setBalancingInterval(Duration.ofMillis(2));
-    balancerConfiguration.setThreshold(10);
-    balancerConfiguration.setIterations(1);
-    balancerConfiguration.setMaxSizeEnteringTarget(6 * STORAGE_UNIT);
-    // deliberately set max size per iteration to a low value, 6 GB
-    balancerConfiguration.setMaxSizeToMovePerIteration(6 * STORAGE_UNIT);
-    balancerConfiguration.setMaxDatanodesPercentageToInvolvePerIteration(100);
-    when(moveManager.move(any(), any(), any()))
-           .thenReturn(CompletableFuture.completedFuture(
-               MoveManager.MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY))
-           .thenReturn(CompletableFuture.completedFuture(
-               MoveManager.MoveResult.COMPLETED));
-
-    startBalancer(balancerConfiguration);
-    stopBalancer();
-
-    ContainerBalancerMetrics metrics = containerBalancerTask.getMetrics();
-    assertEquals(determineExpectedUnBalancedNodes(
-            balancerConfiguration.getThreshold()).size(),
-        metrics.getNumDatanodesUnbalanced());
-    assertThat(metrics.getDataSizeMovedGBInLatestIteration()).isLessThanOrEqualTo(6);
-    assertThat(metrics.getDataSizeMovedGB()).isGreaterThan(0);
-    assertEquals(1, metrics.getNumIterations());
-    assertThat(metrics.getNumContainerMovesScheduledInLatestIteration()).isGreaterThan(0);
-    assertEquals(metrics.getNumContainerMovesScheduled(),
-        metrics.getNumContainerMovesScheduledInLatestIteration());
-    assertEquals(metrics.getNumContainerMovesScheduled(),
-        metrics.getNumContainerMovesCompleted() +
-            metrics.getNumContainerMovesFailed() +
-            metrics.getNumContainerMovesTimeout());
-    assertEquals(0, metrics.getNumContainerMovesTimeout());
-    assertEquals(1, metrics.getNumContainerMovesFailed());
   }
 
   /**
@@ -1078,35 +952,6 @@ public class TestContainerBalancerTask {
   }
 
   /**
-   * Determines unBalanced nodes, that is, over and under utilized nodes,
-   * according to the generated utilization values for nodes and the threshold.
-   *
-   * @param threshold A percentage in the range 0 to 100
-   * @return List of DatanodeUsageInfo containing the expected(correct)
-   * unBalanced nodes.
-   */
-  private List<DatanodeUsageInfo> determineExpectedUnBalancedNodes(
-      double threshold) {
-    threshold /= 100;
-    double lowerLimit = averageUtilization - threshold;
-    double upperLimit = averageUtilization + threshold;
-
-    // use node utilizations to determine over and under utilized nodes
-    List<DatanodeUsageInfo> expectedUnBalancedNodes = new ArrayList<>();
-    for (int i = 0; i < numberOfNodes; i++) {
-      if (nodeUtilizations.get(numberOfNodes - i - 1) > upperLimit) {
-        expectedUnBalancedNodes.add(nodesInCluster.get(numberOfNodes - i - 1));
-      }
-    }
-    for (int i = 0; i < numberOfNodes; i++) {
-      if (nodeUtilizations.get(i) < lowerLimit) {
-        expectedUnBalancedNodes.add(nodesInCluster.get(i));
-      }
-    }
-    return expectedUnBalancedNodes;
-  }
-
-  /**
    * Generates a range of equally spaced utilization(that is, used / capacity)
    * values from 0 to 1.
    *
@@ -1132,10 +977,9 @@ public class TestContainerBalancerTask {
    * cluster have utilization values determined by generateUtilizations method.
    * @return average utilization (used space / capacity) of the cluster
    */
-  private double createCluster(int[] sizeArray) {
+  private void createCluster(int[] sizeArray) {
     generateData(sizeArray);
     createReplicasForContainers();
-    long clusterCapacity = 0, clusterUsedSpace = 0;
 
     // for each node utilization, calculate that datanode's used space and
     // capacity
@@ -1158,10 +1002,7 @@ public class TestContainerBalancerTask {
           datanodeCapacity - datanodeUsedSpace, 0,
           datanodeCapacity - datanodeUsedSpace - 1);
       nodesInCluster.get(i).setScmNodeStat(stat);
-      clusterUsedSpace += datanodeUsedSpace;
-      clusterCapacity += datanodeCapacity;
     }
-    return (double) clusterUsedSpace / clusterCapacity;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestableCluster.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestableCluster.java
@@ -138,8 +138,12 @@ public final class TestableCluster {
     // Use node utilization to determine over and under utilized nodes.
     List<DatanodeUsageInfo> expectedUnBalancedNodes = new ArrayList<>();
     for (int i = 0; i < nodeCount; i++) {
-      double nodeUtilization = nodeUtilizationList[i];
-      if (nodeUtilization < lowerLimit || nodeUtilization > upperLimit) {
+      if (nodeUtilizationList[nodeCount - i - 1] > upperLimit) {
+        expectedUnBalancedNodes.add(nodesInCluster[nodeCount - i - 1]);
+      }
+    }
+    for (int i = 0; i < nodeCount; i++) {
+      if (nodeUtilizationList[i] < lowerLimit) {
         expectedUnBalancedNodes.add(nodesInCluster[i]);
       }
     }


### PR DESCRIPTION
In [PR for HDDS-9889](https://github.com/apache/ozone/pull/5758) we [discussed](https://github.com/apache/ozone/pull/5758#pullrequestreview-1963251436) with [Siddhant Sangwan](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=siddhant) that tests form `org.apache.hadoop.hdds.scm.container.balancer.TestContainerBalancerTask` could be refactored using `MockedSCM` class (introduced in [HDDS-9889](https://issues.apache.org/jira/browse/HDDS-9889))

## What changes were proposed in this pull request?

1. Refactor some tests from `org.apache.hadoop.hdds.scm.container.balancer.TestContainerBalancerTask` 
2. Made some cleanups in `org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancerTask` related to changes in refactored test

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10699

## How was this patch tested?

Use standalone tests
