### PR TITLE
HDDS-10691. CRYPTO_COMPLIANCE tag for cryptography parameters

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2240,7 +2240,24 @@
     <value>2048</value>
     <tag>SCM, HDDS, X509, SECURITY, CRYPTO_COMPLIANCE</tag>
     <description>
-      SCM CA key length.  This is an algorithm-specific metric, such as modulus length, specified in number of bits.
+      SCM CA key length. This is an algorithm-specific metric, such as modulus
+      length, specified in number of bits.
+    </description>
+  </property>
+  <property>
+    <name>hdds.key.algo</name>
+    <value>RSA</value>
+    <tag>SCM, HDDS, X509, SECURITY, CRYPTO_COMPLIANCE</tag>
+    <description>
+      SCM CA key algorithm.
+    </description>
+  </property>
+  <property>
+    <name>hdds.security.provider</name>
+    <value>BC</value>
+    <tag>OZONE, HDDS, X509, SECURITY, CRYPTO_COMPLIANCE</tag>
+    <description>
+      The main security provider used for various cryptographic algorithms.
     </description>
   </property>
   <property>
@@ -2248,7 +2265,8 @@
     <value>keys</value>
     <tag>SCM, HDDS, X509, SECURITY</tag>
     <description>
-      Directory to store public/private key for SCM CA. This is relative to ozone/hdds meteadata dir.
+      Directory to store public/private key for SCM CA. This is relative to
+      ozone/hdds meteadata dir.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2265,8 +2265,7 @@
     <value>keys</value>
     <tag>SCM, HDDS, X509, SECURITY</tag>
     <description>
-      Directory to store public/private key for SCM CA. This is relative to
-      ozone/hdds meteadata dir.
+      Directory to store public/private key for SCM CA. This is relative to ozone/hdds meteadata dir.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2238,7 +2238,7 @@
   <property>
     <name>hdds.key.len</name>
     <value>2048</value>
-    <tag>SCM, HDDS, X509, SECURITY</tag>
+    <tag>SCM, HDDS, X509, SECURITY, CRYPTO_COMPLIANCE</tag>
     <description>
       SCM CA key length.  This is an algorithm-specific metric, such as modulus length, specified in number of bits.
     </description>
@@ -2284,7 +2284,7 @@
   <property>
     <name>hdds.grpc.tls.provider</name>
     <value>OPENSSL</value>
-    <tag>OZONE, HDDS, SECURITY, TLS</tag>
+    <tag>OZONE, HDDS, SECURITY, TLS, CRYPTO_COMPLIANCE</tag>
     <description>HDDS GRPC server TLS provider.</description>
   </property>
   <property>
@@ -2328,7 +2328,7 @@
   <property>
     <name>hdds.x509.signature.algorithm</name>
     <value>SHA256withRSA</value>
-    <tag>OZONE, HDDS, SECURITY</tag>
+    <tag>OZONE, HDDS, SECURITY, CRYPTO_COMPLIANCE</tag>
     <description>X509 signature certificate.</description>
   </property>
   <property>
@@ -4331,7 +4331,7 @@
   <property>
     <name>hdds.secret.key.algorithm</name>
     <value>HmacSHA256</value>
-    <tag>SCM, SECURITY</tag>
+    <tag>SCM, SECURITY, CRYPTO_COMPLIANCE</tag>
     <description>
       The algorithm that SCM uses to generate symmetric secret keys.
       A valid algorithm is the one supported by KeyGenerator, as described at

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -84,8 +84,6 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
     configurationPropsToSkipCompare.addAll(Arrays.asList(
         HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA,
         HddsConfigKeys.HDDS_GRPC_TLS_TEST_CERT,
-        HddsConfigKeys.HDDS_KEY_ALGORITHM,
-        HddsConfigKeys.HDDS_SECURITY_PROVIDER,
         HddsConfigKeys.HDDS_X509_CRL_NAME, // HDDS-2873
         HddsConfigKeys.HDDS_X509_GRACE_DURATION_TOKEN_CHECKS_ENABLED,
         OMConfigKeys.OZONE_OM_NODES_KEY,


### PR DESCRIPTION
## What changes were proposed in this pull request?
For crypto compliance mode the cryptography related configuration options need to be whitelisted in some way. After some deliberate consideration, the CRYPTO_COMPLIANCE tag is used and in [HDDS-10604](https://issues.apache.org/jira/browse/HDDS-10604) the whitelisting will be added for these options.
In this PR the CRYPTO_COMPLIANCE tag is added to all already existing configuration options.

`hdds.key.algo` and `hdds.security.provider` are also exposed to the ozone-default.xml, these properties were missing before.

## What is the link to the Apache JIRA

[HDDS-10691](https://issues.apache.org/jira/browse/HDDS-10691)
(Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
green CI:
https://github.com/Galsza/ozone/actions/runs/8702230425