### PR TITLE
HDDS-10679. Enable ITestS3ACommitterMRJob

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
@@ -60,8 +60,23 @@ execute_s3a_tests() {
     </property>
 
     <property>
+      <name>fs.s3a.access.key</name>
+      <value>${AWS_ACCESS_KEY_ID}</value>
+    </property>
+
+    <property>
+      <name>fs.s3a.secret.key</name>
+      <value>${AWS_SECRET_ACCESS_KEY}</value>
+    </property>
+
+    <property>
       <name>test.fs.s3a.sts.enabled</name>
       <value>false</value>
+    </property>
+
+    <property>
+      <name>fs.s3a.committer.staging.conflict-mode</name>
+      <value>replace</value>
     </property>
 
     <property>
@@ -83,7 +98,7 @@ EOF
   # - ITestS3AContractMkdir: HDDS-10572
   # - ITestS3AContractRename: HDDS-10665
   mvn -B -V --fail-never --no-transfer-progress \
-    -Dtest='ITestS3AContract*, !ITestS3AContractDistCp, !ITestS3AContractGetFileStatusV1List, !ITestS3AContractMkdir, !ITestS3AContractRename' \
+    -Dtest='ITestS3AContract*, ITestS3ACommitterMRJob, !ITestS3AContractDistCp, !ITestS3AContractGetFileStatusV1List, !ITestS3AContractMkdir, !ITestS3AContractRename' \
     clean test
 
   local target="${RESULT_DIR}/junit/${bucket}/target"


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ITestS3ACommitterMRJob` can be enabled now that HDDS-8450, HDDS-10615 and HDDS-10630 are all merged.

https://issues.apache.org/jira/browse/HDDS-10679

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8706136476/job/23878960130