### PR TITLE
HDDS-10309. Speed up TestSnapshotDeletingService

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingService.java
@@ -71,7 +71,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SE
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_TIMEOUT;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test Snapshot Deleting Service.
@@ -140,18 +139,7 @@ public class TestSnapshotDeletingService {
   @Order(2)
   public void testSnapshotSplitAndMove() throws Exception {
 
-//    SnapshotDeletingService snapshotDeletingService =
-//        om.getKeyManager().getSnapshotDeletingService();
-//    Table<String, SnapshotInfo> snapshotInfoTable =
-//        om.getMetadataManager().getSnapshotInfoTable();
-//
-//    createSnapshotDataForBucket1();
-//
-//    assertTableRowCount(snapshotInfoTable, 2);
-//    GenericTestUtils.waitFor(() -> snapshotDeletingService
-//            .getSuccessfulRunCount() >= 1, 1000, 10000);
-
-    if(runIndividualTest) {
+    if (runIndividualTest) {
       SnapshotDeletingService snapshotDeletingService =
           om.getKeyManager().getSnapshotDeletingService();
       Table<String, SnapshotInfo> snapshotInfoTable =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingService.java
@@ -44,9 +44,14 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.service.SnapshotDeletingService;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,10 +71,15 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SE
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_TIMEOUT;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test Snapshot Deleting Service.
  */
+
+@Timeout(300)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(OrderAnnotation.class)
 public class TestSnapshotDeletingService {
 
   private static final Logger LOG =
@@ -85,8 +95,11 @@ public class TestSnapshotDeletingService {
   private static final String VOLUME_NAME = "vol1";
   private static final String BUCKET_NAME_ONE = "bucket1";
   private static final String BUCKET_NAME_TWO = "bucket2";
+  private static final String BUCKET_NAME_FSO = "bucketfso";
 
-  @BeforeEach
+  private boolean runIndividualTest = true;
+
+  @BeforeAll
   public void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE,
@@ -115,7 +128,7 @@ public class TestSnapshotDeletingService {
         client, VOLUME_NAME, BUCKET_NAME_ONE, BucketLayout.DEFAULT);
   }
 
-  @AfterEach
+  @AfterAll
   public void teardown() {
     IOUtils.closeQuietly(client);
     if (cluster != null) {
@@ -124,18 +137,32 @@ public class TestSnapshotDeletingService {
   }
 
   @Test
+  @Order(2)
   public void testSnapshotSplitAndMove() throws Exception {
-    SnapshotDeletingService snapshotDeletingService =
-        om.getKeyManager().getSnapshotDeletingService();
-    Table<String, SnapshotInfo> snapshotInfoTable =
-        om.getMetadataManager().getSnapshotInfoTable();
 
-    createSnapshotDataForBucket1();
+//    SnapshotDeletingService snapshotDeletingService =
+//        om.getKeyManager().getSnapshotDeletingService();
+//    Table<String, SnapshotInfo> snapshotInfoTable =
+//        om.getMetadataManager().getSnapshotInfoTable();
+//
+//    createSnapshotDataForBucket1();
+//
+//    assertTableRowCount(snapshotInfoTable, 2);
+//    GenericTestUtils.waitFor(() -> snapshotDeletingService
+//            .getSuccessfulRunCount() >= 1, 1000, 10000);
 
-    assertTableRowCount(snapshotInfoTable, 2);
-    GenericTestUtils.waitFor(() -> snapshotDeletingService
-            .getSuccessfulRunCount() >= 1, 1000, 10000);
+    if(runIndividualTest) {
+      SnapshotDeletingService snapshotDeletingService =
+          om.getKeyManager().getSnapshotDeletingService();
+      Table<String, SnapshotInfo> snapshotInfoTable =
+          om.getMetadataManager().getSnapshotInfoTable();
 
+      createSnapshotDataForBucket1();
+
+      assertTableRowCount(snapshotInfoTable, 2);
+      GenericTestUtils.waitFor(() -> snapshotDeletingService
+          .getSuccessfulRunCount() >= 1, 1000, 10000);
+    }
     OmSnapshot bucket1snap3 = om.getOmSnapshotManager()
         .getSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap3").get();
 
@@ -148,12 +175,14 @@ public class TestSnapshotDeletingService {
   }
 
   @Test
+  @Order(1)
   public void testMultipleSnapshotKeyReclaim() throws Exception {
 
     Table<String, RepeatedOmKeyInfo> deletedTable =
         om.getMetadataManager().getDeletedTable();
     Table<String, SnapshotInfo> snapshotInfoTable =
         om.getMetadataManager().getSnapshotInfoTable();
+    runIndividualTest = false;
 
     createSnapshotDataForBucket1();
 
@@ -193,10 +222,16 @@ public class TestSnapshotDeletingService {
     // verify the cache of purged snapshot
     // /vol1/bucket2/bucket2snap1 has been cleaned up from cache map
     assertEquals(2, om.getOmSnapshotManager().getSnapshotCacheSize());
+    //clean data
+    //    // cleaning up the data
+    client.getProxy().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap1");
+    client.getProxy().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap3");
+    client.getProxy().deleteBucket(VOLUME_NAME, BUCKET_NAME_TWO);
   }
 
   @SuppressWarnings("checkstyle:MethodLength")
   @Test
+  @Order(3)
   public void testSnapshotWithFSO() throws Exception {
     Table<String, OmDirectoryInfo> dirTable =
         om.getMetadataManager().getDirectoryTable();
@@ -216,7 +251,7 @@ public class TestSnapshotDeletingService {
         .build();
 
     OzoneBucket bucket2 = TestDataUtil.createBucket(
-        client, VOLUME_NAME, bucketArgs, BUCKET_NAME_TWO);
+        client, VOLUME_NAME, bucketArgs, BUCKET_NAME_FSO);
 
     // Create 10 keys
     for (int i = 1; i <= 10; i++) {
@@ -234,12 +269,12 @@ public class TestSnapshotDeletingService {
     for (int i = 1; i <= 3; i++) {
       String parent = "parent" + i;
       client.getProxy().createDirectory(VOLUME_NAME,
-          BUCKET_NAME_TWO, parent);
+          BUCKET_NAME_FSO, parent);
       for (int j = 1; j <= 3; j++) {
         String childFile = "/childFile" + j;
         String childDir = "/childDir" + j;
         client.getProxy().createDirectory(VOLUME_NAME,
-            BUCKET_NAME_TWO, parent + childDir);
+            BUCKET_NAME_FSO, parent + childDir);
         TestDataUtil.createKey(bucket2, parent + childFile,
             ReplicationFactor.THREE, ReplicationType.RATIS, CONTENT);
       }
@@ -251,7 +286,7 @@ public class TestSnapshotDeletingService {
     assertTableRowCount(deletedDirTable, 0);
 
     // Create Snapshot1
-    client.getObjectStore().createSnapshot(VOLUME_NAME, BUCKET_NAME_TWO,
+    client.getObjectStore().createSnapshot(VOLUME_NAME, BUCKET_NAME_FSO,
         "snap1");
     assertTableRowCount(snapshotInfoTable, 1);
 
@@ -264,37 +299,37 @@ public class TestSnapshotDeletingService {
 
     // Delete 5 Keys
     for (int i = 1; i <= 5; i++) {
-      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_TWO,
+      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_FSO,
           "key" + i, false);
     }
     // Rename Keys 3 keys
     for (int i = 6; i <= 8; i++) {
-      client.getProxy().renameKey(VOLUME_NAME, BUCKET_NAME_TWO, "key" + i,
+      client.getProxy().renameKey(VOLUME_NAME, BUCKET_NAME_FSO, "key" + i,
           "renamedKey" + i);
     }
 
     // Rename 1 Dir
     for (int i = 1; i <= 1; i++) {
-      client.getProxy().renameKey(VOLUME_NAME, BUCKET_NAME_TWO, "/parent" + i,
+      client.getProxy().renameKey(VOLUME_NAME, BUCKET_NAME_FSO, "/parent" + i,
           "/renamedParent" + i);
     }
 
     // Delete 2 Dirs
     for (int i = 2; i <= 3; i++) {
-      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_TWO, "/parent" + i,
+      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_FSO, "/parent" + i,
           true);
     }
 
     assertTableRowCount(renamedTable, 4);
     // Delete Renamed Keys
     for (int i = 6; i <= 8; i++) {
-      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_TWO,
+      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_FSO,
           "renamedKey" + i, false);
     }
 
     // Delete Renamed Dir
     for (int i = 1; i <= 1; i++) {
-      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_TWO,
+      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_FSO,
           "/renamedParent" + i, true);
     }
 
@@ -304,7 +339,7 @@ public class TestSnapshotDeletingService {
     assertTableRowCount(renamedTable, 4);
 
     // Create Snapshot2
-    client.getObjectStore().createSnapshot(VOLUME_NAME, BUCKET_NAME_TWO,
+    client.getObjectStore().createSnapshot(VOLUME_NAME, BUCKET_NAME_FSO,
         "snap2");
 
     assertTableRowCount(snapshotInfoTable, 2);
@@ -316,7 +351,7 @@ public class TestSnapshotDeletingService {
 
     // Delete 3 overwritten keys
     for (int i = 11; i <= 13; i++) {
-      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_TWO,
+      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_FSO,
           "key" + i, false);
     }
 
@@ -328,14 +363,14 @@ public class TestSnapshotDeletingService {
 
     // Delete 2 more keys
     for (int i = 9; i <= 10; i++) {
-      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_TWO,
+      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_FSO,
           "key" + i, false);
     }
 
     assertTableRowCount(deletedTable, 7);
 
     // Create Snapshot3
-    client.getObjectStore().createSnapshot(VOLUME_NAME, BUCKET_NAME_TWO,
+    client.getObjectStore().createSnapshot(VOLUME_NAME, BUCKET_NAME_FSO,
         "snap3");
     assertTableRowCount(snapshotInfoTable, 3);
 
@@ -344,24 +379,24 @@ public class TestSnapshotDeletingService {
     assertTableRowCount(deletedTable, 0);
     assertTableRowCount(keyTable, 11);
     SnapshotInfo deletedSnap = om.getMetadataManager()
-        .getSnapshotInfoTable().get("/vol1/bucket2/snap2");
+        .getSnapshotInfoTable().get("/vol1/bucketfso/snap2");
 
-    client.getObjectStore().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_TWO,
+    client.getObjectStore().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_FSO,
         "snap2");
     assertTableRowCount(snapshotInfoTable, 2);
 
     // Delete 2 overwritten keys
     for (int i = 14; i <= 15; i++) {
-      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_TWO,
+      client.getProxy().deleteKey(VOLUME_NAME, BUCKET_NAME_FSO,
           "key" + i, false);
     }
     assertTableRowCount(deletedTable, 2);
     // Once all the tables are moved, the snapshot is deleted
     assertTableRowCount(om.getMetadataManager().getSnapshotInfoTable(), 2);
 
-    verifySnapshotChain(deletedSnap, "/vol1/bucket2/snap3");
+    verifySnapshotChain(deletedSnap, "/vol1/bucketfso/snap3");
     OmSnapshot snap3 = om.getOmSnapshotManager()
-        .getSnapshot(VOLUME_NAME, BUCKET_NAME_TWO, "snap3").get();
+        .getSnapshot(VOLUME_NAME, BUCKET_NAME_FSO, "snap3").get();
 
     Table<String, OmKeyInfo> snapDeletedDirTable =
         snap3.getMetadataManager().getDeletedDirTable();
@@ -380,7 +415,7 @@ public class TestSnapshotDeletingService {
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(deletedTable, 2);
     // Delete Snapshot3 and check entries moved to active DB
-    client.getObjectStore().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_TWO,
+    client.getObjectStore().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_FSO,
         "snap3");
 
     // Check entries moved to active DB
@@ -390,7 +425,7 @@ public class TestSnapshotDeletingService {
 
     ReferenceCounted<OmSnapshot> rcSnap1 =
         om.getOmSnapshotManager().getSnapshot(
-            VOLUME_NAME, BUCKET_NAME_TWO, "snap1");
+            VOLUME_NAME, BUCKET_NAME_FSO, "snap1");
     OmSnapshot snap1 = rcSnap1.get();
     Table<String, OmKeyInfo> snap1KeyTable =
         snap1.getMetadataManager().getFileTable();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingService.java
@@ -210,8 +210,8 @@ public class TestSnapshotDeletingService {
     // verify the cache of purged snapshot
     // /vol1/bucket2/bucket2snap1 has been cleaned up from cache map
     assertEquals(2, om.getOmSnapshotManager().getSnapshotCacheSize());
-    //clean data
-    //    // cleaning up the data
+
+    // cleaning up the data
     client.getProxy().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap1");
     client.getProxy().deleteSnapshot(VOLUME_NAME, BUCKET_NAME_ONE, "bucket1snap3");
     client.getProxy().deleteBucket(VOLUME_NAME, BUCKET_NAME_TWO);

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -103,7 +103,7 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v20.11.1</nodeVersion>
+              <nodeVersion>v16.14.2</nodeVersion>
             </configuration>
           </execution>
           <execution>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -103,7 +103,7 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v16.14.2</nodeVersion>
+              <nodeVersion>v20.11.1</nodeVersion>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Speed up TestSnapshotDeletingService
The time span is improved to 250.118 seconds from 321.147 seconds earlier.
https://github.com/raju-balpande/apache_ozone/actions/runs/8339044173/job/22820842037

Please describe your PR in detail:
We have managed the cluster creation part to be executed once.
What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10309?
How was this patch tested?

Tested each method independently and in sequence locally and Tested the sequence in Ci
### Note:
 I recreated this pull request to solve some of conflicts that the original file got replaced to a package and wasn't allowing to fix the conflicts. I recreated the branch and cherry-picked my changes. the earlier pull request was https://github.com/apache/ozone/pull/6403 