### PR TITLE
HDDS-10705. Avoid persist duplicate DeleteBlockCommands on DN

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -635,15 +635,16 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     boolean duplicate = false;
 
     if (delTX.getTxID() < containerData.getDeleteTransactionId()) {
-      metrics.incOutOfOrderDeleteBlockTransactionCount();
+      if (metrics != null) {
+        metrics.incOutOfOrderDeleteBlockTransactionCount();
+      }
       LOG.info(String.format("Delete blocks for containerId: %d"
               + " is received out of order, %d < %d", containerId, delTX.getTxID(),
           containerData.getDeleteTransactionId()));
     } else if (delTX.getTxID() == containerData.getDeleteTransactionId()) {
       duplicate = true;
-      LOG.info(String.format("Delete blocks with txID {} for containerId: %d"
-              + " is retried.", delTX.getTxID(), containerId,
-          containerData.getDeleteTransactionId()));
+      LOG.info(String.format("Delete blocks with txID %d for containerId: %d"
+              + " is retried.", delTX.getTxID(), containerId));
     } else {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Processing Container : {}, DB path : {}, transaction {}",

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -514,7 +514,9 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       throws IOException {
     int newDeletionBlocks = 0;
     long containerId = delTX.getContainerID();
-    logDeleteTransaction(containerId, containerData, delTX);
+    if (isDuplicateTransaction(containerId, containerData, delTX, blockDeleteMetrics)) {
+      return;
+    }
     try (DBHandle containerDB = BlockUtils.getDB(containerData, conf)) {
       DeleteTransactionStore<?> store =
           (DeleteTransactionStore<?>) containerDB.getStore();
@@ -536,7 +538,9 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       KeyValueContainerData containerData, DeletedBlocksTransaction delTX)
       throws IOException {
     long containerId = delTX.getContainerID();
-    logDeleteTransaction(containerId, containerData, delTX);
+    if (isDuplicateTransaction(containerId, containerData, delTX, blockDeleteMetrics)) {
+      return;
+    }
     int newDeletionBlocks = 0;
     try (DBHandle containerDB = BlockUtils.getDB(containerData, conf)) {
       Table<String, BlockData> blockDataTable =
@@ -626,20 +630,27 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
     }
   }
 
-  private void logDeleteTransaction(long containerId,
-      KeyValueContainerData containerData, DeletedBlocksTransaction delTX) {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Processing Container : {}, DB path : {}, transaction {}",
-          containerId, containerData.getMetadataPath(), delTX.getTxID());
-    }
+  public static boolean isDuplicateTransaction(long containerId, KeyValueContainerData containerData,
+      DeletedBlocksTransaction delTX, BlockDeletingServiceMetrics metrics) {
+    boolean duplicate = false;
 
-    if (delTX.getTxID() <= containerData.getDeleteTransactionId()) {
-      blockDeleteMetrics.incOutOfOrderDeleteBlockTransactionCount();
+    if (delTX.getTxID() < containerData.getDeleteTransactionId()) {
+      metrics.incOutOfOrderDeleteBlockTransactionCount();
       LOG.info(String.format("Delete blocks for containerId: %d"
-              + " is either received out of order or retried,"
-              + " %d <= %d", containerId, delTX.getTxID(),
+              + " is received out of order, %d < %d", containerId, delTX.getTxID(),
           containerData.getDeleteTransactionId()));
+    } else if (delTX.getTxID() == containerData.getDeleteTransactionId()) {
+      duplicate = true;
+      LOG.info(String.format("Delete blocks with txID {} for containerId: %d"
+              + " is retried.", delTX.getTxID(), containerId,
+          containerData.getDeleteTransactionId()));
+    } else {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Processing Container : {}, DB path : {}, transaction {}",
+            containerId, containerData.getMetadataPath(), delTX.getTxID());
+      }
     }
+    return duplicate;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -221,7 +221,7 @@ public class BlockManagerImpl implements BlockManager {
     long containerBCSId = containerData.getBlockCommitSequenceId();
     if (containerBCSId < bcsId) {
       throw new StorageContainerException(
-          "Unable to find the block with bcsID " + bcsId + " .Container "
+          "Unable to find the block with bcsID " + bcsId + ". Container "
               + containerData.getContainerID() + " bcsId is "
               + containerBCSId + ".", UNKNOWN_BCSID);
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -333,6 +333,38 @@ public class TestDeleteBlocksCommandHandler {
     }
   }
 
+  @ContainerTestVersionInfo.ContainerTest
+  public void testDuplicateDeleteBlocksCommand(
+      ContainerTestVersionInfo versionInfo) throws Exception {
+    prepareTest(versionInfo);
+    assertThat(containerSet.containerCount()).isGreaterThan(0);
+    Container<?> container = containerSet.getContainerIterator(volume1).next();
+    DeletedBlocksTransaction transaction = createDeletedBlocksTransaction(1,
+        container.getContainerData().getContainerID());
+
+    List<DeleteBlockTransactionResult> results1 =
+        handler.executeCmdWithRetry(Arrays.asList(transaction));
+    List<DeleteBlockTransactionResult> results2 =
+        handler.executeCmdWithRetry(Arrays.asList(transaction));
+
+    String schemaVersionOrDefault = ((KeyValueContainerData)
+        container.getContainerData()).getSupportedSchemaVersionOrDefault();
+    verify(handler.getSchemaHandlers().get(schemaVersionOrDefault),
+        times(2)).handle(any(), any());
+    // submitTasks will be executed twice
+    verify(handler, times(2)).submitTasks(any());
+
+    assertEquals(1, results1.size());
+    assertTrue(results1.get(0).getSuccess());
+    assertEquals(1, results2.size());
+    assertTrue(results2.get(0).getSuccess());
+    assertEquals(0,
+        blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
+    // Duplicate cmd content will not be persisted.
+    assertEquals(1,
+        ((KeyValueContainerData) container.getContainerData()).getNumPendingDeletionBlocks());
+  }
+
   private DeletedBlocksTransaction createDeletedBlocksTransaction(long txID,
       long containerID) {
     return DeletedBlocksTransaction.newBuilder()
@@ -347,7 +379,11 @@ public class TestDeleteBlocksCommandHandler {
     @Override
     public void handle(KeyValueContainerData containerData,
         DeletedBlocksTransaction tx) throws IOException {
-      // doNoting just for Test
+      if (DeleteBlocksCommandHandler.isDuplicateTransaction(containerData.getContainerID(), containerData, tx, null)) {
+        return;
+      }
+      containerData.incrPendingDeletionBlocks(tx.getLocalIDCount());
+      containerData.updateDeleteTransactionId(tx.getTxID());
     }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteBlocksCommandHandler.java
@@ -339,7 +339,7 @@ public class TestDeleteBlocksCommandHandler {
     prepareTest(versionInfo);
     assertThat(containerSet.containerCount()).isGreaterThan(0);
     Container<?> container = containerSet.getContainerIterator(volume1).next();
-    DeletedBlocksTransaction transaction = createDeletedBlocksTransaction(1,
+    DeletedBlocksTransaction transaction = createDeletedBlocksTransaction(100,
         container.getContainerData().getContainerID());
 
     List<DeleteBlockTransactionResult> results1 =
@@ -347,21 +347,28 @@ public class TestDeleteBlocksCommandHandler {
     List<DeleteBlockTransactionResult> results2 =
         handler.executeCmdWithRetry(Arrays.asList(transaction));
 
+    transaction = createDeletedBlocksTransaction(99,
+        container.getContainerData().getContainerID());
+    List<DeleteBlockTransactionResult> results3 =
+        handler.executeCmdWithRetry(Arrays.asList(transaction));
+
     String schemaVersionOrDefault = ((KeyValueContainerData)
         container.getContainerData()).getSupportedSchemaVersionOrDefault();
     verify(handler.getSchemaHandlers().get(schemaVersionOrDefault),
-        times(2)).handle(any(), any());
-    // submitTasks will be executed twice
-    verify(handler, times(2)).submitTasks(any());
+        times(3)).handle(any(), any());
+    // submitTasks will be executed three times
+    verify(handler, times(3)).submitTasks(any());
 
     assertEquals(1, results1.size());
     assertTrue(results1.get(0).getSuccess());
     assertEquals(1, results2.size());
     assertTrue(results2.get(0).getSuccess());
+    assertEquals(1, results3.size());
+    assertTrue(results3.get(0).getSuccess());
     assertEquals(0,
         blockDeleteMetrics.getTotalLockTimeoutTransactionCount());
     // Duplicate cmd content will not be persisted.
-    assertEquals(1,
+    assertEquals(2,
         ((KeyValueContainerData) container.getContainerData()).getNumPendingDeletionBlocks());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
DeleteBlockCommands can be sent out of order, so even DeleteBlockCommand's tx is smaller than container's deleteTransactionId, we cannot tell it's duplicate or not. But if the DeleteBlockCommand's tx is equal to container's current deleteTransactionId, then it's duplicate no doubt. Tx ID is unique ID. There will be no Tx with same ID but different pending deleting blocks. 

It's observed that large duplicate DeleteBlockCommands are received on DN and persist into DB in user's cluster. This task is going to skip the persist to avoid unnecessary DN resources used on these duplicate commands handling. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10705

## How was this patch tested?
new UT
