### PR TITLE
HDDS-10716. Remove skipTrash option from IOException message in recursive volume delete.

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -719,7 +719,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         LOG.warn("Recursive volume delete using ofs is not supported");
         throw new IOException("Recursive volume delete using " +
             "ofs is not supported. " +
-            "Instead use 'ozone sh volume delete -r -skipTrash " +
+            "Instead use 'ozone sh volume delete -r " +
             "-id <OM_SERVICE_ID> <Volume_URI>' command");
       }
       return deleteVolume(f, ofsPath);


### PR DESCRIPTION
## What changes were proposed in this pull request?
skipTrash option is not applicable for `ozone sh` commands. We can remove from suggestion message while deleting volume recursively.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10716

## How was this patch tested?

Manually verified in cluster
