### PR TITLE
HDDS-10717. nodeFailureTimeoutMs should be initialized before syncTimeoutRetry

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -191,7 +191,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     this.streamEnable = conf.getBoolean(
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATASTREAM_ENABLED,
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_DATASTREAM_ENABLED_DEFAULT);
-    RaftProperties serverProperties = newRaftProperties();
     this.context = context;
     this.dispatcher = dispatcher;
     this.containerController = containerController;
@@ -202,6 +201,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     shouldDeleteRatisLogDirectory =
         ratisServerConfig.shouldDeleteRatisLogDirectory();
 
+    RaftProperties serverProperties = newRaftProperties();
     this.server =
         RaftServer.newBuilder().setServerId(raftPeerId)
             .setProperties(serverProperties)


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is found that the Ratis WriteLog retry is "0/0" which means the WriteLog will not retry at all, and the datanode will trigger a pipeline failure to close the pipeline. This might cause a lot of pipeline close events sent by the datanodes during high IO events. Our cluster encountered this issue which caused pipeline thrashing issues (pipeline kept getting closed and created continuously).

The issue was due to `nodeFailureTimeoutMs` initialized AFTER `newRaftProperties` and `setStateMachineDataConfigurations` which causes an issue. HDDS-9821 removed the overwritten configuration, but at the same time exposed the bug.

Need to fix the ordering so that it's the `syncTimeoutRetry` is calculated correctly (default 30 times).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10717

## How was this patch tested?

Clean CI: https://github.com/ivandika3/ozone/actions/runs/8752866026
