### PR TITLE
HDDS-10720. Datanode volume DU reserved percent should have a non-zero default value.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -223,7 +223,7 @@ public final class ScmConfigKeys {
       "hdds.datanode.dir.du.reserved";
   public static final String HDDS_DATANODE_DIR_DU_RESERVED_PERCENT =
       "hdds.datanode.dir.du.reserved.percent";
-  public static final float HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT = 0;
+  public static final float HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT = 0.0001f;
   public static final String OZONE_SCM_HANDLER_COUNT_KEY =
       "ozone.scm.handler.count.key";
   public static final String OZONE_SCM_CLIENT_HANDLER_COUNT_KEY =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -213,17 +213,16 @@ public class VolumeUsage {
     }
 
     // 2. If hdds.datanode.dir.du.reserved not set and
-    // hdds.datanode.dir.du.reserved.percent is set, fall back to this config.
-    if (conf.isConfigured(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT)) {
-      float percentage = conf.getFloat(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT,
-          HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT);
-      if (0 <= percentage && percentage <= 1) {
-        return (long) Math.ceil(capacity * percentage);
-      }
-      //If it comes here then the percentage is not between 0-1.
-      LOG.error("The value of {} should be between 0 to 1. Defaulting to 0.",
-          HDDS_DATANODE_DIR_DU_RESERVED_PERCENT);
+    // then fall back to hdds.datanode.dir.du.reserved.percent, using either its set value or default value if it has
+    // not been set.
+    float percentage = conf.getFloat(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT,
+        HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT);
+    if (0 <= percentage && percentage <= 1) {
+      return (long) Math.ceil(capacity * percentage);
     }
+    // If it comes here then the percentage is not between 0-1.
+    LOG.error("The value of {} should be between 0 to 1. Defaulting to 0.",
+        HDDS_DATANODE_DIR_DU_RESERVED_PERCENT);
 
     //Both configs are not set, return 0.
     return 0;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -212,9 +212,8 @@ public class VolumeUsage {
       }
     }
 
-    // 2. If hdds.datanode.dir.du.reserved not set and
-    // then fall back to hdds.datanode.dir.du.reserved.percent, using either its set value or default value if it has
-    // not been set.
+    // 2. If hdds.datanode.dir.du.reserved not set then fall back to hdds.datanode.dir.du.reserved.percent, using
+    // either its set value or default value if it has not been set.
     float percentage = conf.getFloat(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT,
         HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT);
     if (0 <= percentage && percentage <= 1) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -60,6 +61,9 @@ public class TestCapacityVolumeChoosingPolicy {
     String volume2 = baseDir + "disk2";
     String volume3 = baseDir + "disk3";
     policy = new CapacityVolumeChoosingPolicy();
+    // Use the exact capacity and availability specified in this test. Do not reserve space to prevent volumes from
+    // filling up.
+    CONF.setFloat(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT, 0);
 
     SpaceUsageSource source1 = MockSpaceUsageSource.fixed(500, 100);
     SpaceUsageCheckFactory factory1 = MockSpaceUsageCheckFactory.of(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 
@@ -68,9 +70,8 @@ public class TestReservedVolumeSpace {
     // Gets the actual total capacity without accounting for DU reserved space configurations.
     long totalCapacity = usage.realUsage().getCapacity();
     long reservedCapacity = usage.getReservedBytes();
-    long expectedReservedCapacity = (long) Math.ceil(totalCapacity * percentage);
 
-    assertEquals(expectedReservedCapacity, reservedCapacity);
+    assertEquals(getExpectedDefaultReserved(hddsVolume), reservedCapacity);
     assertEquals(totalCapacity - reservedCapacity, volumeCapacity);
   }
 
@@ -114,17 +115,7 @@ public class TestReservedVolumeSpace {
 
     long reservedFromVolume = hddsVolume.getVolumeInfo().get()
             .getReservedInBytes();
-    assertEquals(reservedFromVolume, 500);
-  }
-
-  @Test
-  public void testReservedToZeroWhenBothConfigNotSet() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    HddsVolume hddsVolume = volumeBuilder.conf(conf).build();
-
-    long reservedFromVolume = hddsVolume.getVolumeInfo().get()
-            .getReservedInBytes();
-    assertEquals(reservedFromVolume, 0);
+    assertEquals(500, reservedFromVolume);
   }
 
   @Test
@@ -158,7 +149,7 @@ public class TestReservedVolumeSpace {
 
     long reservedFromVolume1 = hddsVolume1.getVolumeInfo().get()
             .getReservedInBytes();
-    assertEquals(reservedFromVolume1, 0);
+    assertEquals(getExpectedDefaultReserved(hddsVolume1), reservedFromVolume1);
 
     OzoneConfiguration conf2 = new OzoneConfiguration();
 
@@ -168,6 +159,27 @@ public class TestReservedVolumeSpace {
 
     long reservedFromVolume2 = hddsVolume2.getVolumeInfo().get()
             .getReservedInBytes();
-    assertEquals(reservedFromVolume2, 0);
+    assertEquals(getExpectedDefaultReserved(hddsVolume2), reservedFromVolume2);
+  }
+
+  @Test
+  public void testPathsCanonicalized() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    // Create symlink in folder (which is the root of the volume)
+    Path symlink = new File(temp.toFile(), "link").toPath();
+    Files.createSymbolicLink(symlink, folder);
+
+    // Use the symlink in the configuration. Canonicalization should still match it to folder used in the volume config.
+    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED, symlink + ":500B");
+    HddsVolume hddsVolume = volumeBuilder.conf(conf).build();
+
+    long reservedFromVolume = hddsVolume.getVolumeInfo().get().getReservedInBytes();
+    assertEquals(500, reservedFromVolume);
+  }
+
+  private long getExpectedDefaultReserved(HddsVolume volume) {
+    long totalCapacity = volume.getVolumeInfo().get().getUsageForTesting().realUsage().getCapacity();
+    return (long) Math.ceil(totalCapacity * HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -57,6 +58,10 @@ public class TestRoundRobinVolumeChoosingPolicy {
     String volume1 = baseDir + "disk1";
     String volume2 = baseDir + "disk2";
     policy = new RoundRobinVolumeChoosingPolicy();
+
+    // Use the exact capacity and availability specified in this test. Do not reserve space to prevent volumes from
+    // filling up.
+    CONF.setFloat(HDDS_DATANODE_DIR_DU_RESERVED_PERCENT, 0);
 
     SpaceUsageSource source1 = MockSpaceUsageSource.fixed(500, 100);
     SpaceUsageCheckFactory factory1 = MockSpaceUsageCheckFactory.of(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently there are two ways to reserve space in datanode volumes:

1. `hdds.datanode.dir.du.reserved.percent` allows specifying a percentage of the volume's space to be unused. It applies to all volumes
2. `hdds.datanode.dir.du.reserved` allows specifying a map of volume name to bytes reserved. Since it depends on a volume path, it cannot have a default value.

By default Ozone should not allow datanode volumes to get 100% full. This can cause the drive to "lock up" because some operations like block delete that would free up space still need extra disk space before they can complete because they must append to the RocksDB WAL. Once encountered, such issues are difficult to resolve. Add a default value for `hdds.datanode.dir.du.reserved.percent` to prevent this from happening.

A default value of `0.0001f` is currently chosen. This is 0.01% which reserves 1GB out of a 10TB volume, 1MB out of a 1TB volume, etc. Ideally we could reserve a fixed size (like 1GB) regardless of drive size, but we would need to re-work the configs before we can do that which might need more discussion. See HDDS-10721.

This PR also fixes a few other bugs that prevented tests from passing after the change:
- A non-zero default value for `hdds.datanode.dir.du.reserved.percent` would not be used.
- Canonicalization was not done on paths in `hdds.datanode.dir.du.reserved`. This may have passed in CI but was failing due to my local filesystem setup.
- Invalid space reserved configurations would fall back to 0 (hardcoded) instead of the default value.

## What is the link to the Apache JIRA

HDDS-10720

## How was this patch tested?

Unit test added.
