### PR TITLE
HDDS-10719. Empty ETag for key created outside of S3

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.helpers;
 import java.io.IOException;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BasicKeyInfo;
@@ -51,7 +52,7 @@ public final class BasicOmKeyInfo {
     this.modificationTime = b.modificationTime;
     this.replicationConfig = b.replicationConfig;
     this.isFile = b.isFile;
-    this.eTag = b.eTag != null && !b.eTag.isEmpty() ? b.eTag : null;
+    this.eTag = StringUtils.isNotEmpty(b.eTag) ? b.eTag : null;
   }
 
   private BasicOmKeyInfo(OmKeyInfo b) {
@@ -179,7 +180,7 @@ public final class BasicOmKeyInfo {
     } else {
       builder.setFactor(ReplicationConfig.getLegacyFactor(replicationConfig));
     }
-    if (eTag != null) {
+    if (StringUtils.isNotEmpty(eTag)) {
       builder.setETag(eTag);
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/BasicOmKeyInfo.java
@@ -51,7 +51,7 @@ public final class BasicOmKeyInfo {
     this.modificationTime = b.modificationTime;
     this.replicationConfig = b.replicationConfig;
     this.isFile = b.isFile;
-    this.eTag = b.eTag;
+    this.eTag = b.eTag != null && !b.eTag.isEmpty() ? b.eTag : null;
   }
 
   private BasicOmKeyInfo(OmKeyInfo b) {

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -167,6 +167,7 @@ Test key handling
                     Should Not Contain  ${result}       NOTICE.txt.1 exists
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq -r '. | select(.name=="key1")'
                     Should contain      ${result}       creationTime
+                    Should not contain  ${result}       ETag
     ${result} =     Execute             ozone sh key list ${protocol}${server}/${volume}/bb1 | jq -r '.[] | select(.name=="key1") | .name'
                     Should Be Equal     ${result}       key1
                     Execute             ozone sh key rename ${protocol}${server}/${volume}/bb1 key1 key2


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid introducing empty `ETag` in response for keys created outside of S3 Gateway (e.g. via Ozone CLI).

https://issues.apache.org/jira/browse/HDDS-10719

## How was this patch tested?

Added assertion in existing Robot test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/8758764190