### PR TITLE
HDDS-10725. TestContentGenerator#writeWithHsync fails with Java 17

### DIFF
--- a/hadoop-hdds/hadoop-dependency-test/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-test/pom.xml
@@ -92,6 +92,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>
 

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -45,11 +45,6 @@
       <artifactId>hdds-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <properties>
 

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -86,11 +86,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hdds-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -165,11 +165,6 @@
       <artifactId>hdds-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix test failure with Java 17:

```
[ERROR] Tests run: 6, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.323 s <<< FAILURE! - in org.apache.hadoop.ozone.freon.TestContentGenerator
[ERROR] org.apache.hadoop.ozone.freon.TestContentGenerator.writeWithHsync  Time elapsed: 0.294 s  <<< ERROR!
java.lang.NullPointerException: Cannot read the array length because "this.buf" is null
	at java.base/java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:97)
	at java.base/java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:130)
	at org.apache.hadoop.ozone.freon.ContentGenerator.write(ContentGenerator.java:98)
	at org.apache.hadoop.ozone.freon.TestContentGenerator.writeWithHsync(TestContentGenerator.java:113)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

Switching to `mockito-inline` fixes the problem (related issue [1](https://github.com/mockito/mockito/issues/2573), [2](https://github.com/mockito/mockito/issues/2612)).

https://issues.apache.org/jira/browse/HDDS-10725

## How was this patch tested?

Tested with Java 17:

```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :ozone-tools -Dtest='TestContentGenerator'
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.614 s - in org.apache.hadoop.ozone.freon.TestContentGenerator
```

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/8764901899