### PR TITLE
HDDS-10726. TestAuditParser.testLoadCommand fails with Java 11+

### DIFF
--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/audit/parser/TestAuditParser.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/audit/parser/TestAuditParser.java
@@ -192,7 +192,7 @@ public class TestAuditParser {
     Exception e =
         assertThrows(Exception.class, () -> execute(args1, ""));
     assertInstanceOf(ArrayIndexOutOfBoundsException.class, e.getCause());
-    assertThat(e.getMessage()).contains(": 5");
+    assertThat(e.getMessage()).contains(" 5");
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix test failure with Java 11+:

```
[ERROR] Tests run: 6, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.31 s <<< FAILURE! - in org.apache.hadoop.ozone.audit.parser.TestAuditParser
[ERROR] org.apache.hadoop.ozone.audit.parser.TestAuditParser.testLoadCommand  Time elapsed: 0.01 s  <<< FAILURE!
java.lang.AssertionError: 

Expecting:
 <"Error while calling command (org.apache.hadoop.ozone.audit.parser.handler.LoadCommandHandler@266374ef): java.lang.ArrayIndexOutOfBoundsException: Index 5 out of bounds for length 5">
to contain:
 <": 5"> 
	at org.apache.hadoop.ozone.audit.parser.TestAuditParser.testLoadCommand(TestAuditParser.java:195)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
```

With Java 8 the exception message is:

```
Error while calling command (org.apache.hadoop.ozone.audit.parser.handler.LoadCommandHandler@34f7cfd9): java.lang.ArrayIndexOutOfBoundsException: 5
```

https://issues.apache.org/jira/browse/HDDS-10726

## How was this patch tested?

Tested with Java 11 (and 17):

```
JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
  ./hadoop-ozone/dev-support/checks/junit.sh \
  -am -pl :ozone-tools -Dtest='TestAuditParser'
...
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.276 s - in org.apache.hadoop.ozone.audit.parser.TestAuditParser
```

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/8765370588