### PR TITLE
HDDS-10557. TestBlockOutputStream#testWriteExactlyFlushSize is flaky

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -312,11 +312,12 @@ class TestBlockOutputStream {
       // The previously written data is equal to flushSize, so no action is
       // triggered when execute flush, if flushDelay is enabled.
       // If flushDelay is disabled, it will call waitOnFlushFutures to wait all
-      // putBlocks finished.
+      // putBlocks finished. It was broken because WriteChunk and PutBlock
+      // can be complete regardless of whether the flush executed or not.
       if (flushDelay) {
         assertThat(metrics.getPendingContainerOpCountMetrics(WriteChunk))
             .isLessThanOrEqualTo(pendingWriteChunkCount + 2);
-        assertThat(metrics.getPendingContainerOpCountMetrics(GetBlock))
+        assertThat(metrics.getPendingContainerOpCountMetrics(PutBlock))
             .isLessThanOrEqualTo(pendingWriteChunkCount + 1);
       } else {
         assertEquals(pendingWriteChunkCount,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.GetBlock;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.PutBlock;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.WriteChunk;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
@@ -512,7 +511,8 @@ class TestBlockOutputStream {
         // If the flushDelay feature is enabled, nothing happens.
         // The assertions will be as same as those before flush.
         assertEquals(FLUSH_SIZE, blockOutputStream.getTotalDataFlushedLength());
-        assertEquals((metrics.getPendingContainerOpCountMetrics(PutBlock) == pendingPutBlockCount) ? 1 : 0, blockOutputStream.getCommitIndex2flushedDataMap().size());
+        assertEquals((metrics.getPendingContainerOpCountMetrics(PutBlock) == pendingPutBlockCount) ? 1 : 0,
+            blockOutputStream.getCommitIndex2flushedDataMap().size());
 
         assertEquals(0, blockOutputStream.getTotalAckDataLength());
         assertEquals(1, keyOutputStream.getStreamEntries().size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -281,6 +281,7 @@ class TestBlockOutputStream {
           metrics.getContainerOpCountMetrics(WriteChunk));
       assertEquals(putBlockCount + 1,
           metrics.getContainerOpCountMetrics(PutBlock));
+      // The WriteChunk and PutBlock can be completed soon.
       assertThat(metrics.getPendingContainerOpCountMetrics(WriteChunk))
           .isLessThanOrEqualTo(pendingWriteChunkCount + 2);
       assertThat(metrics.getPendingContainerOpCountMetrics(PutBlock))
@@ -523,7 +524,7 @@ class TestBlockOutputStream {
           metrics.getPendingContainerOpCountMetrics(PutBlock));
       assertEquals(writeChunkCount + 3,
           metrics.getContainerOpCountMetrics(WriteChunk));
-      // If the flushDelay was enabled,
+      // If the flushDelay was disabled, it sends PutBlock with the data in the buffer.
       assertEquals(putBlockCount + (flushDelay ? 2 : 3),
           metrics.getContainerOpCountMetrics(PutBlock));
       assertEquals(totalOpCount + (flushDelay ? 5 : 6), metrics.getTotalOpCount());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -482,6 +482,7 @@ class TestBlockOutputStream {
       int dataLength = FLUSH_SIZE + 50;
       byte[] data1 = RandomUtils.nextBytes(dataLength);
       key.write(data1);
+
       assertEquals(totalOpCount + 3, metrics.getTotalOpCount());
       KeyOutputStream keyOutputStream =
           assertInstanceOf(KeyOutputStream.class, key.getOutputStream());


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix test failure:
```
Error:  org.apache.hadoop.ozone.client.rpc.TestBlockOutputStream.testWriteExactlyFlushSize(boolean)[2]  Time elapsed: 0.06 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <2> but was: <1>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:166)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:161)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:632)
	at org.apache.hadoop.ozone.client.rpc.TestBlockOutputStream.testWriteExactlyFlushSize(TestBlockOutputStream.java:279)
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10557

## How was this patch tested?
Before fixed:
https://github.com/chungen0126/ozone/actions/runs/8740583632

Tested successful 10*30 times after fixed:
https://github.com/chungen0126/ozone/actions/runs/8780103858
