### PR TITLE
HDDS-10559. Add a warning or a check to run repair tool as System user

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
@@ -22,7 +22,10 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import picocli.CommandLine;
+
+import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 
 /**
  * Ozone Repair Command line tool.
@@ -32,6 +35,13 @@ import picocli.CommandLine;
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 public class OzoneRepair extends GenericCli {
+
+  public static final String WARNING_SYS_USER_MESSAGE =
+      "ATTENTION: You are currently logged in as user '%s'. Ozone typically runs as user '%s'." +
+          " If you proceed with this command, it may change the ownership of RocksDB files " +
+          " used by the Ozone Manager (OM). This ownership change could prevent OM from starting successfully." +
+          " Are you sure you want to continue (y/N)? ";
+
 
   private OzoneConfiguration ozoneConf;
 
@@ -61,4 +71,33 @@ public class OzoneRepair extends GenericCli {
   public static void main(String[] argv) throws Exception {
     new OzoneRepair().run(argv);
   }
+
+  @Override
+  public int execute(String[] argv) {
+    String currentUser = getSystemUserName();
+    boolean shouldProceed = true;
+    if (!currentUser.equals(OZONE_DEFAULT_USER)) {
+      String s = getConsoleReadLineWithFormat(currentUser, OZONE_DEFAULT_USER);
+      shouldProceed = Boolean.parseBoolean(s) || "y".equalsIgnoreCase(s);
+    }
+    if (!shouldProceed) {
+      System.out.println("Aborting command.");
+      return 1;
+    }
+    System.out.println("Run as user: " + currentUser);
+
+    TracingUtil.initTracing("shell", createOzoneConfiguration());
+    String spanName = "ozone repair " + String.join(" ", argv);
+    return TracingUtil.executeInNewSpan(spanName,
+        () -> super.execute(argv));
+  }
+
+  public  String getSystemUserName() {
+    return System.getProperty("user.name");
+  }
+
+  public  String getConsoleReadLineWithFormat(String currentUser, String defaultUser) {
+    return System.console().readLine(String.format(WARNING_SYS_USER_MESSAGE, currentUser, defaultUser));
+  }
+
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
@@ -24,6 +24,9 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import picocli.CommandLine;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
 /**
  * Ozone Repair Command line tool.
  */
@@ -34,7 +37,7 @@ import picocli.CommandLine;
 public class OzoneRepair extends GenericCli {
 
   public static final String WARNING_SYS_USER_MESSAGE =
-      "ATTENTION: Running as user '%s'. Make sure this is the same user used to run the Ozone process." +
+      "ATTENTION: Running as user %s. Make sure this is the same user used to run the Ozone process." +
           " Are you sure you want to continue (y/N)? ";
 
 
@@ -70,9 +73,7 @@ public class OzoneRepair extends GenericCli {
   @Override
   public int execute(String[] argv) {
     String currentUser = getSystemUserName();
-    String s = getConsoleReadLineWithFormat(currentUser);
-    boolean shouldProceed = Boolean.parseBoolean(s) || "y".equalsIgnoreCase(s);
-    if (!shouldProceed) {
+    if (!( "y".equalsIgnoreCase(getConsoleReadLineWithFormat(currentUser)))) {
       System.out.println("Aborting command.");
       return 1;
     }
@@ -86,7 +87,8 @@ public class OzoneRepair extends GenericCli {
   }
 
   public  String getConsoleReadLineWithFormat(String currentUser) {
-    return System.console().readLine(String.format(WARNING_SYS_USER_MESSAGE, currentUser));
+    System.err.printf(WARNING_SYS_USER_MESSAGE, currentUser);
+    return (new Scanner(System.in, StandardCharsets.UTF_8.name())).nextLine().trim();
   }
 
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/OzoneRepair.java
@@ -73,7 +73,7 @@ public class OzoneRepair extends GenericCli {
   @Override
   public int execute(String[] argv) {
     String currentUser = getSystemUserName();
-    if (!( "y".equalsIgnoreCase(getConsoleReadLineWithFormat(currentUser)))) {
+    if (!("y".equalsIgnoreCase(getConsoleReadLineWithFormat(currentUser)))) {
       System.out.println("Aborting command.");
       return 1;
     }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.repair;
 
-import org.jooq.meta.derby.sys.Sys;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
@@ -66,21 +67,25 @@ public class TestOzoneRepair {
 
   @Test
   void testOzoneRepairWhenUserIsRemindedSystemUserAndDeclinesToProceed() throws Exception {
-    OzoneRepair ozoneRepair = spy(new OzoneRepair());
-    doReturn("N").when(ozoneRepair).getConsoleReadLineWithFormat(anyString());
+    OzoneRepair ozoneRepair = new OzoneRepair();
+    System.setIn(new ByteArrayInputStream("N".getBytes(DEFAULT_ENCODING)));
 
     int res = ozoneRepair.execute(new String[]{});
     assertEquals(1, res);
     assertThat(out.toString(DEFAULT_ENCODING)).contains("Aborting command.");
+    // prompt should contain the current user name as well
+    assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
   }
 
   @Test
   void testOzoneRepairWhenUserIsRemindedSystemUserAndAgreesToProceed() throws Exception {
-    OzoneRepair ozoneRepair = spy(new OzoneRepair());
-    doReturn("y").when(ozoneRepair).getConsoleReadLineWithFormat(anyString());
+    OzoneRepair ozoneRepair = new OzoneRepair();
+    System.setIn(new ByteArrayInputStream("y".getBytes(DEFAULT_ENCODING)));
 
     ozoneRepair.execute(new String[]{});
     assertThat(out.toString(DEFAULT_ENCODING)).contains("Run as user: " + OZONE_USER);
+    // prompt should contain the current user name as well
+    assertThat(err.toString(DEFAULT_ENCODING)).contains("ATTENTION: Running as user " + OZONE_USER);
   }
 
 }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -28,9 +28,6 @@ import java.io.PrintStream;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 /**
  * Tests the ozone repair command.

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/repair/TestOzoneRepair.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.repair;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Tests the ozone repair command.
+ */
+public class TestOzoneRepair {
+
+  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+  private static final PrintStream OLD_OUT = System.out;
+  private static final PrintStream OLD_ERR = System.err;
+  private static final String DEFAULT_ENCODING = UTF_8.name();
+
+  @BeforeEach
+  public void setup() throws Exception {
+    System.setOut(new PrintStream(out, false, DEFAULT_ENCODING));
+    System.setErr(new PrintStream(err, false, DEFAULT_ENCODING));
+  }
+
+  @AfterEach
+  public void reset() {
+    // reset stream after each unit test
+    out.reset();
+    err.reset();
+
+    // restore system streams
+    System.setOut(OLD_OUT);
+    System.setErr(OLD_ERR);
+  }
+
+  @Test
+  void testOzoneRepairWhenUserIsOzoneDefaultUser() throws Exception {
+    OzoneRepair ozoneRepair = spy(new OzoneRepair());
+    doReturn(OZONE_DEFAULT_USER).when(ozoneRepair).getSystemUserName();
+
+    ozoneRepair.execute(new String[]{});
+    assertThat(out.toString(DEFAULT_ENCODING)).contains("Run as user: " + OZONE_DEFAULT_USER);
+  }
+
+  @Test
+  void testOzoneRepairWhenUserIsNotOzoneDefaultUserAndDeclinesToProceed() throws Exception {
+    OzoneRepair ozoneRepair = spy(new OzoneRepair());
+    doReturn("non-ozone").when(ozoneRepair).getSystemUserName();
+    doReturn("N").when(ozoneRepair).getConsoleReadLineWithFormat(anyString(), anyString());
+
+    int res = ozoneRepair.execute(new String[]{});
+    assertEquals(1, res);
+    assertThat(out.toString(DEFAULT_ENCODING)).contains("Aborting command.");
+  }
+
+  @Test
+  void testOzoneRepairWhenUserIsNotOzoneDefaultUserAndAgreesToProceed() throws Exception {
+    OzoneRepair ozoneRepair = spy(new OzoneRepair());
+    String currentUser = "non-ozone";
+    doReturn(currentUser).when(ozoneRepair).getSystemUserName();
+    doReturn("y").when(ozoneRepair).getConsoleReadLineWithFormat(anyString(), anyString());
+
+    ozoneRepair.execute(new String[]{});
+    assertThat(out.toString(DEFAULT_ENCODING)).contains("Run as user: " + currentUser);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
We added a repair tool for snapshot chain fix as part of PR: https://github.com/apache/ozone/pull/6386

This check was missed in the original PR. This task is to add a check or warning to make sure that the repair tool is run as system user (default to hdfs)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10559

## How was this patch tested?
Unit test