### PR TITLE
HDDS-10713. Run JUnit tests with Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
       - name: Execute tests
         continue-on-error: true
         run: |


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Java version to 17 in `integration` check.

https://issues.apache.org/jira/browse/HDDS-10713

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8788103037