### PR TITLE
HDDS-10735. `repeat-acceptance-test` workflow always builds Ozone with the branch the workflow is run from.

### DIFF
--- a/.github/workflows/repeat-acceptance.yml
+++ b/.github/workflows/repeat-acceptance.yml
@@ -81,6 +81,8 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
       - name: Cache for npm dependencies
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `repeat-acceptance-test` workflow does not use the `ref` input parameter in the build step. The build will always default to the tip of the branch the workflow is run from (based on the `Use workflow from`) dropdown, according to the [docs](https://github.com/actions/checkout?tab=readme-ov-file#usage).

I first noticed this on [this workflow run](https://github.com/errose28/ozone/actions/runs/8762099500) where I was testing changes on my reconciliation feature branch. We can see from the title that I input `HDDS-10372-reconcile-cli` as the branch to test changes from, and I selected to use the workflow from `master` as shown in the top of that page because the workflow file had not changed on my branch at that time.

- Expected: The workflow file from `master` should have built and tested the code from `HDDS-10372-reconcile-cli`
- Actual: The workflow file from `master` also built and tested the code from `master`. We can see the hash from master (8310617008c07427ae59c6f4a73ee20232340a22) logged in the build step, and the new acceptance tests on that branch were not run.

In this specific case I can work around the issue by setting the branch to run from and the branch to test as the same, but the workflow currently cannot be used for things like testing a previous commit in the master branch for regressions, because there would be no "run from" branch to select for that old commit.

## What is the link to the Apache JIRA

HDDS-10735

## How was this patch tested?

[This run](https://github.com/errose28/ozone/actions/runs/8790917583) is a minimal repro of the issue using the workflow on `master` to test an old master commit (80c2311c1908b7c1c80c8aa23f616a5bef2b20f0). In the checkout portion of the build step, we can see it actually built with a different hash (8310617008c07427ae59c6f4a73ee20232340a22), which is the tip of my fork's master branch.

[This run](https://github.com/errose28/ozone/actions/runs/8790851625) uses the fixed workflow file from this feature branch in my fork to test an old commit to master. In the output of the build step, we can see that the hash specified for testing (80c2311c1908b7c1c80c8aa23f616a5bef2b20f0) matches the one in the title supplied to the inputs.
