### PR TITLE
HDDS-10744. Standardize byte array conversion to String for LiveFileMetaData in RocksDB.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaThreeImpl.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.FixedLengthStringCodec;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase.ColumnFamily;
@@ -180,9 +181,9 @@ public class DatanodeStoreSchemaThreeImpl extends AbstractDatanodeStore
             long endCId = Long.MIN_VALUE;
             for (LiveFileMetaData file: innerEntry.getValue()) {
               long firstCId = DatanodeSchemaThreeDBDefinition.getContainerId(
-                  StringUtils.bytes2String(file.smallestKey()));
+                  FixedLengthStringCodec.bytes2String(file.smallestKey()));
               long lastCId = DatanodeSchemaThreeDBDefinition.getContainerId(
-                  StringUtils.bytes2String(file.largestKey()));
+                  FixedLengthStringCodec.bytes2String(file.largestKey()));
               startCId = Math.min(firstCId, startCId);
               endCId = Math.max(lastCId, endCId);
             }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreMetrics.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.utils;
 
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
@@ -25,7 +26,6 @@ import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
-import org.bouncycastle.util.Strings;
 import org.rocksdb.HistogramData;
 import org.rocksdb.HistogramType;
 import org.rocksdb.LiveFileMetaData;
@@ -257,7 +257,7 @@ public class RocksDBStoreMetrics implements MetricsSource {
     Map<String, Long> sizeStat;
     for (LiveFileMetaData file : liveFileMetaDataList) {
       numStat = numStatPerCF.get(file.level());
-      String cf = Strings.fromByteArray(file.columnFamilyName());
+      String cf = StringUtils.bytes2String(file.columnFamilyName());
       if (numStat != null) {
         Long value = numStat.get(cf);
         numStat.put(cf, value == null ? 1L : value + 1);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -65,7 +65,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.utils.db.managed.ManagedColumnFamilyOptions.closeDeeply;
 import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator.managed;
 import static org.apache.hadoop.hdds.utils.db.managed.ManagedTransactionLogIterator.managed;
@@ -848,8 +847,7 @@ public final class RocksDatabase implements Closeable {
       throws IOException, RocksDBException {
     try (UncheckedAutoCloseable ignored = acquire()) {
       for (LiveFileMetaData liveFileMetaData : getSstFileList()) {
-        String sstFileColumnFamily =
-            new String(liveFileMetaData.columnFamilyName(), UTF_8);
+        String sstFileColumnFamily = StringUtils.bytes2String(liveFileMetaData.columnFamilyName());
         int lastLevel = getLastLevel();
 
         if (!prefixPairs.containsKey(sstFileColumnFamily)) {
@@ -867,8 +865,8 @@ public final class RocksDatabase implements Closeable {
         }
 
         String prefixForColumnFamily = prefixPairs.get(sstFileColumnFamily);
-        String firstDbKey = new String(liveFileMetaData.smallestKey(), UTF_8);
-        String lastDbKey = new String(liveFileMetaData.largestKey(), UTF_8);
+        String firstDbKey = StringUtils.bytes2String(liveFileMetaData.smallestKey());
+        String lastDbKey = StringUtils.bytes2String(liveFileMetaData.largestKey());
         boolean isKeyWithPrefixPresent = RocksDiffUtils.isKeyWithPrefixPresent(
             prefixForColumnFamily, firstDbKey, lastDbKey);
         if (!isKeyWithPrefixPresent) {

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/RdbUtil.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdb/util/RdbUtil.java
@@ -41,8 +41,7 @@ public final class RdbUtil {
       final ManagedRocksDB rocksDB, List<String> cfs) {
     final Set<String> cfSet = Sets.newHashSet(cfs);
     return rocksDB.get().getLiveFilesMetaData().stream()
-        .filter(lfm -> cfSet.contains(
-            StringUtils.bytes2String(lfm.columnFamilyName())))
+        .filter(lfm -> cfSet.contains(StringUtils.bytes2String(lfm.columnFamilyName())))
         .collect(Collectors.toList());
   }
 

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -719,7 +719,9 @@ public class TestRocksDBCheckpointDiffer {
         LOG.debug("\tKey Range: {}", bytes2String(m.smallestKey()) + " <-> " + bytes2String(m.largestKey()));
         if (differ.debugEnabled(DEBUG_DAG_LIVE_NODES)) {
           printMutableGraphFromAGivenNode(
-              differ.getCompactionNodeMap(), m.fileName(), m.level(), differ.getForwardCompactionDAG());
+              differ.getCompactionNodeMap(),
+              m.fileName(), m.level(),
+              differ.getForwardCompactionDAG());
         }
       }
 

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -86,6 +86,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+import static org.apache.hadoop.hdds.StringUtils.bytes2String;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_SNAPSHOT_COMPACTION_DAG_MAX_TIME_ALLOWED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_SNAPSHOT_COMPACTION_DAG_MAX_TIME_ALLOWED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_SNAPSHOT_COMPACTION_DAG_PRUNE_DAEMON_RUN_INTERVAL;
@@ -714,25 +715,20 @@ public class TestRocksDBCheckpointDiffer {
       for (LiveFileMetaData m : liveFileMetaDataList) {
         LOG.debug("SST File: {}. ", m.fileName());
         LOG.debug("\tLevel: {}", m.level());
-        LOG.debug("\tTable: {}", toStr(m.columnFamilyName()));
-        LOG.debug("\tKey Range: {}", toStr(m.smallestKey())
-            + " <-> " + toStr(m.largestKey()));
+        LOG.debug("\tTable: {}", bytes2String(m.columnFamilyName()));
+        LOG.debug("\tKey Range: {}", bytes2String(m.smallestKey()) + " <-> " + bytes2String(m.largestKey()));
         if (differ.debugEnabled(DEBUG_DAG_LIVE_NODES)) {
           printMutableGraphFromAGivenNode(
-              differ.getCompactionNodeMap(),
-              m.fileName(), m.level(),
-              differ.getForwardCompactionDAG());
+              differ.getCompactionNodeMap(), m.fileName(), m.level(), differ.getForwardCompactionDAG());
         }
       }
 
       if (differ.debugEnabled(DEBUG_READ_ALL_DB_KEYS)) {
         RocksIterator iter = rocksDB.newIterator();
         for (iter.seekToFirst(); iter.isValid(); iter.next()) {
-          LOG.debug("Iterator key:" + toStr(iter.key()) + ", " +
-              "iter value:" + toStr(iter.value()));
+          LOG.debug("Iterator key:" + bytes2String(iter.key()) + ", iter value:" + bytes2String(iter.value()));
           if (file != null) {
-            file.write("iterator key:" + toStr(iter.key()) + ", iter " +
-                "value:" + toStr(iter.value()));
+            file.write("iterator key:" + bytes2String(iter.key()) + ", iter value:" + bytes2String(iter.value()));
             file.write("\n");
           }
         }
@@ -744,13 +740,6 @@ public class TestRocksDBCheckpointDiffer {
         rocksDB.close();
       }
     }
-  }
-
-  /**
-   * Return String object encoded in UTF-8 from a byte array.
-   */
-  private String toStr(byte[] bytes) {
-    return new String(bytes, UTF_8);
   }
 
   /**
@@ -1888,8 +1877,7 @@ public class TestRocksDBCheckpointDiffer {
       pathStream.forEach(path -> {
         try (SstFileReader fileReader = new SstFileReader(options)) {
           fileReader.open(path.toAbsolutePath().toString());
-          String columnFamily = StringUtils.bytes2String(
-              fileReader.getTableProperties().getColumnFamilyName());
+          String columnFamily = bytes2String(fileReader.getTableProperties().getColumnFamilyName());
           assertThat(COLUMN_FAMILIES_TO_TRACK_IN_DAG).contains(columnFamily);
         } catch (RocksDBException rocksDBException) {
           fail("Failed to read file: " + path.toAbsolutePath());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -24,11 +24,11 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -1949,13 +1949,13 @@ public abstract class TestOmSnapshot {
   private List<LiveFileMetaData> getKeyTableSstFiles()
       throws IOException {
     if (!bucketLayout.isFileSystemOptimized()) {
-      return getRdbStore().getDb().getSstFileList().stream().filter(
-          x -> new String(x.columnFamilyName(), UTF_8).equals(
-              OmMetadataManagerImpl.KEY_TABLE)).collect(Collectors.toList());
+      return getRdbStore().getDb().getSstFileList().stream()
+          .filter(x -> StringUtils.bytes2String(x.columnFamilyName()).equals(OmMetadataManagerImpl.KEY_TABLE))
+          .collect(Collectors.toList());
     }
-    return getRdbStore().getDb().getSstFileList().stream().filter(
-        x -> new String(x.columnFamilyName(), UTF_8).equals(
-            OmMetadataManagerImpl.FILE_TABLE)).collect(Collectors.toList());
+    return getRdbStore().getDb().getSstFileList().stream()
+        .filter(x -> StringUtils.bytes2String(x.columnFamilyName()).equals(OmMetadataManagerImpl.FILE_TABLE))
+        .collect(Collectors.toList());
   }
 
   private void flushKeyTable() throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -2118,7 +2118,7 @@ public abstract class TestOmSnapshot {
     await(POLL_MAX_WAIT_MILLIS, POLL_INTERVAL_MILLIS,
         () -> cluster.getOzoneManager().isRunning());
 
-    while (nextToken == null || StringUtils.isNotEmpty(nextToken)) {
+    while (nextToken == null || !nextToken.isEmpty()) {
       diffReport = fetchReportPage(volumeName, bucketName, snapshot1,
           snapshot2, nextToken, pageSize);
       diffReportEntries.addAll(diffReport.getDiffList());


### PR DESCRIPTION
## What changes were proposed in this pull request?
LiveFileMetaData class in RocksDB has three methods that are returning a byte[] which we convert to String after any call.
These methods are:
- columnFamilyName()
- smallestKey()
- largestKey()

We use 3 different conversion to String for the returned byte arrays.
For largestKey and smallestKey we use FixedLengthStringCodec.bytes2String and new String(byte[], UTF_8)
For columnFamilyName we use org.apache.hadoop.hdds.StringUtils.bytes2String, new String(byte[], UTF_8), and org.bouncycastle.util.Strings.fromByteArray.

From these methods, FixedLengthStringCodec throws an exception if the conversion can not be done, and it uses ISO_8859_1 as the charset for the conversion, while the rest uses UTF_8 charset for the conversion, and replaces the characters that UTF-8 can not represent.

Based on how and where we use these it seems to be safe to settle on UTF-8 as the target charset, and use StringUtils.bytes2String from our own utilities which uses the String constructor as of now by the way.

Removing org.bouncycastle.util.Strings usage is also beneficial for crypto compliance related development.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10744

## How was this patch tested?

CI
