### PR TITLE
HDDS-10752. OmBucketInfo/OmMultipartKeyInfo/OmPrefixInfo should implement CopyObject.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.CopyObject;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -42,7 +43,7 @@ import com.google.common.base.Preconditions;
 /**
  * A class that encapsulates Bucket Info.
  */
-public final class OmBucketInfo extends WithObjectID implements Auditable {
+public final class OmBucketInfo extends WithObjectID implements Auditable, CopyObject<OmBucketInfo> {
   private static final Codec<OmBucketInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(BucketInfo.getDefaultInstance()),
       OmBucketInfo::getFromProtobuf,
@@ -104,7 +105,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
   /**
    * Bucket Layout.
    */
-  private BucketLayout bucketLayout;
+  private final BucketLayout bucketLayout;
 
   private String owner;
 
@@ -340,9 +341,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     return auditMap;
   }
 
-  /**
-   * Return a new copy of the object.
-   */
+  @Override
   public OmBucketInfo copyObject() {
     Builder builder = toBuilder();
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.helpers;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.CopyObject;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartKeyInfo;
@@ -37,7 +38,7 @@ import java.util.TreeMap;
  * This class represents multipart upload information for a key, which holds
  * upload part information of the key.
  */
-public final class OmMultipartKeyInfo extends WithObjectID {
+public final class OmMultipartKeyInfo extends WithObjectID implements CopyObject<OmMultipartKeyInfo> {
   private static final Codec<OmMultipartKeyInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(MultipartKeyInfo.getDefaultInstance()),
       OmMultipartKeyInfo::getFromProto,
@@ -355,6 +356,7 @@ public final class OmMultipartKeyInfo extends WithObjectID {
     return uploadID.hashCode();
   }
 
+  @Override
   public OmMultipartKeyInfo copyObject() {
     return new OmMultipartKeyInfo(this);
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 public class TestOmMultipartKeyInfo {
 
   @Test
-  public void copyObject() {
+  public void testCopyObject() {
     for (ReplicationConfig param : replicationConfigs().collect(toList())) {
       testCopyObject(param);
     }

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.CopyObject;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -36,7 +37,7 @@ import java.util.Objects;
  * can be extended for other OzFS optimizations in future.
  */
 // TODO: support Auditable interface
-public final class OmPrefixInfo extends WithObjectID {
+public final class OmPrefixInfo extends WithObjectID implements CopyObject<OmPrefixInfo> {
   private static final Codec<OmPrefixInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(PersistedPrefixInfo.getDefaultInstance()),
       OmPrefixInfo::getFromProtobuf,
@@ -230,9 +231,7 @@ public final class OmPrefixInfo extends WithObjectID {
         '}';
   }
 
-  /**
-   * Return a new copy of the object.
-   */
+  @Override
   public OmPrefixInfo copyObject() {
     return toBuilder().build();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

@xichen01  pointed out in https://github.com/apache/ozone/discussions/6518#discussioncomment-9192008 that OmBucketInfo did not implement CopyObject.

Also found that OmMultipartKeyInfo/OmPrefixInfo should implement CopyObject.

## What is the link to the Apache JIRA

HDDS-10752

## How was this patch tested?

By existing tests.