### PR TITLE
HDDS-10756. Avoid proto2 ByteString#copyFrom(byte[]).

### DIFF
--- a/hadoop-hdds/common/src/main/java/com/google/protobuf/Proto2Utils.java
+++ b/hadoop-hdds/common/src/main/java/com/google/protobuf/Proto2Utils.java
@@ -25,7 +25,7 @@ public final class Proto2Utils {
    * Otherwise, it violates the immutability of {@link ByteString}.
    */
   public static ByteString unsafeByteString(byte[] array) {
-    return new LiteralByteString(array);
+    return array != null && array.length > 0 ? new LiteralByteString(array) : ByteString.EMPTY;
   }
 
   private Proto2Utils() { }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.ozone.protocol.commands;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.HddsIdFactory;
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -41,12 +41,12 @@ public class ReconstructECContainersCommand
   private final long containerID;
   private final List<DatanodeDetailsAndReplicaIndex> sources;
   private final List<DatanodeDetails> targetDatanodes;
-  private final byte[] missingContainerIndexes;
+  private final ByteString missingContainerIndexes;
   private final ECReplicationConfig ecReplicationConfig;
 
   public ReconstructECContainersCommand(long containerID,
       List<DatanodeDetailsAndReplicaIndex> sources,
-      List<DatanodeDetails> targetDatanodes, byte[] missingContainerIndexes,
+      List<DatanodeDetails> targetDatanodes, ByteString missingContainerIndexes,
       ECReplicationConfig ecReplicationConfig) {
     this(containerID, sources, targetDatanodes, missingContainerIndexes,
         ecReplicationConfig, HddsIdFactory.getLongId());
@@ -54,16 +54,15 @@ public class ReconstructECContainersCommand
 
   public ReconstructECContainersCommand(long containerID,
       List<DatanodeDetailsAndReplicaIndex> sourceDatanodes,
-      List<DatanodeDetails> targetDatanodes, byte[] missingContainerIndexes,
+      List<DatanodeDetails> targetDatanodes, ByteString missingContainerIndexes,
       ECReplicationConfig ecReplicationConfig, long id) {
     super(id);
     this.containerID = containerID;
     this.sources = sourceDatanodes;
     this.targetDatanodes = targetDatanodes;
-    this.missingContainerIndexes =
-        Arrays.copyOf(missingContainerIndexes, missingContainerIndexes.length);
+    this.missingContainerIndexes = missingContainerIndexes;
     this.ecReplicationConfig = ecReplicationConfig;
-    if (targetDatanodes.size() != missingContainerIndexes.length) {
+    if (targetDatanodes.size() != missingContainerIndexes.size()) {
       throw new IllegalArgumentException("Number of target datanodes and " +
           "container indexes should be same");
     }
@@ -85,13 +84,9 @@ public class ReconstructECContainersCommand
     for (DatanodeDetails dd : targetDatanodes) {
       builder.addTargets(dd.getProtoBufMessage());
     }
-    builder.setMissingContainerIndexes(getByteString(missingContainerIndexes));
+    builder.setMissingContainerIndexes(missingContainerIndexes);
     builder.setEcReplicationConfig(ecReplicationConfig.toProto());
     return builder.build();
-  }
-
-  public static ByteString getByteString(byte[] bytes) {
-    return (bytes.length == 0) ? ByteString.EMPTY : ByteString.copyFrom(bytes);
   }
 
   public static ReconstructECContainersCommand getFromProtobuf(
@@ -108,7 +103,7 @@ public class ReconstructECContainersCommand
 
     return new ReconstructECContainersCommand(protoMessage.getContainerID(),
         srcDatanodeDetails, targetDatanodeDetails,
-        protoMessage.getMissingContainerIndexes().toByteArray(),
+        protoMessage.getMissingContainerIndexes(),
         new ECReplicationConfig(protoMessage.getEcReplicationConfig()),
         protoMessage.getCmdId());
   }
@@ -125,9 +120,8 @@ public class ReconstructECContainersCommand
     return targetDatanodes;
   }
 
-  public byte[] getMissingContainerIndexes() {
-    return Arrays
-        .copyOf(missingContainerIndexes, missingContainerIndexes.length);
+  public ByteString getMissingContainerIndexes() {
+    return missingContainerIndexes;
   }
 
   public ECReplicationConfig getEcReplicationConfig() {
@@ -146,7 +140,7 @@ public class ReconstructECContainersCommand
             .collect(Collectors.joining(", "))).append("]")
         .append(", targets: ").append(getTargetDatanodes())
         .append(", missingIndexes: ").append(
-            Arrays.toString(missingContainerIndexes));
+            StringUtils.bytes2String(missingContainerIndexes.asReadOnlyByteBuffer()));
     return sb.toString();
   }
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.OptionalLong;
 import java.util.UUID;
 
+import com.google.protobuf.Proto2Utils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -79,7 +80,8 @@ public class TestHeartbeatEndpointTask {
     targetDns.add(MockDatanodeDetails.randomDatanodeDetails());
     targetDns.add(MockDatanodeDetails.randomDatanodeDetails());
     ReconstructECContainersCommand cmd = new ReconstructECContainersCommand(
-        1, emptyList(), targetDns, new byte[]{2, 5},
+        1, emptyList(), targetDns,
+        Proto2Utils.unsafeByteString(new byte[]{2, 5}),
         new ECReplicationConfig(3, 2));
 
     when(scm.sendHeartbeat(any()))

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import com.google.protobuf.Proto2Utils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -570,7 +571,7 @@ public class TestReplicationSupervisor {
         new ReconstructECContainersCommand(containerId,
             sources,
             target,
-            missingIndexes,
+            Proto2Utils.unsafeByteString(missingIndexes),
             new ECReplicationConfig(3, 2));
 
     return new ECReconstructionCommandInfo(cmd);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/protocol/commands/TestReconstructionECContainersCommands.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/protocol/commands/TestReconstructionECContainersCommands.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.ozone.protocol.commands;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Proto2Utils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -28,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -40,7 +41,7 @@ public class TestReconstructionECContainersCommands {
   @Test
   public void testExceptionIfSourceAndMissingNotSameLength() {
     ECReplicationConfig ecReplicationConfig = new ECReplicationConfig(3, 2);
-    byte[] missingContainerIndexes = {1, 2};
+    final ByteString missingContainerIndexes = Proto2Utils.unsafeByteString(new byte[]{1, 2});
 
     List<DatanodeDetails> targetDns = new ArrayList<>();
     targetDns.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -52,7 +53,7 @@ public class TestReconstructionECContainersCommands {
 
   @Test
   public void protobufConversion() {
-    byte[] missingContainerIndexes = {1, 2};
+    final ByteString missingContainerIndexes = Proto2Utils.unsafeByteString(new byte[]{1, 2});
     List<Long> srcNodesIndexes = new ArrayList<>();
     for (int i = 0; i < srcNodesIndexes.size(); i++) {
       srcNodesIndexes.add(i + 1L);
@@ -82,8 +83,7 @@ public class TestReconstructionECContainersCommands {
     assertEquals(1L, proto.getContainerID());
     assertEquals(sources, srcDnsFromProto);
     assertEquals(targets, targetDnsFromProto);
-    assertArrayEquals(missingContainerIndexes,
-        proto.getMissingContainerIndexes().toByteArray());
+    assertEquals(missingContainerIndexes, proto.getMissingContainerIndexes());
     assertEquals(ecReplicationConfig,
         new ECReplicationConfig(proto.getEcReplicationConfig()));
 
@@ -96,8 +96,7 @@ public class TestReconstructionECContainersCommands {
         fromProtobuf.getSources());
     assertEquals(reconstructECContainersCommand.getTargetDatanodes(),
         fromProtobuf.getTargetDatanodes());
-    assertArrayEquals(
-        reconstructECContainersCommand.getMissingContainerIndexes(),
+    assertEquals(reconstructECContainersCommand.getMissingContainerIndexes(),
         fromProtobuf.getMissingContainerIndexes());
     assertEquals(
         reconstructECContainersCommand.getEcReplicationConfig(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.scm.container.replication;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Proto2Utils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -365,7 +367,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         final ReconstructECContainersCommand reconstructionCommand =
             new ReconstructECContainersCommand(container.getContainerID(),
                 sourceDatanodesWithIndex, selectedDatanodes,
-                int2byte(missingIndexes),
+                integers2ByteString(missingIndexes),
                 repConfig);
         // This can throw a CommandTargetOverloadedException, but there is no
         // point in retrying here. The sources we picked already have the
@@ -623,13 +625,13 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
         Long.MAX_VALUE));
   }
 
-  private static byte[] int2byte(List<Integer> src) {
+  static ByteString integers2ByteString(List<Integer> src) {
     byte[] dst = new byte[src.size()];
 
     for (int i = 0; i < src.size(); i++) {
       dst[i] = src.get(i).byteValue();
     }
-    return dst;
+    return Proto2Utils.unsafeByteString(dst);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -704,10 +705,10 @@ public class ReplicationManager implements SCMService {
     } else if (cmd.getType() == Type.reconstructECContainersCommand) {
       ReconstructECContainersCommand rcc = (ReconstructECContainersCommand) cmd;
       List<DatanodeDetails> targets = rcc.getTargetDatanodes();
-      byte[] targetIndexes = rcc.getMissingContainerIndexes();
-      for (int i = 0; i < targetIndexes.length; i++) {
+      final ByteString targetIndexes = rcc.getMissingContainerIndexes();
+      for (int i = 0; i < targetIndexes.size(); i++) {
         containerReplicaPendingOps.scheduleAddReplica(
-            containerInfo.containerID(), targets.get(i), targetIndexes[i],
+            containerInfo.containerID(), targets.get(i), targetIndexes.byteAt(i),
             scmDeadlineEpochMs);
       }
       getMetrics().incrEcReconstructionCmdsSentTotal();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/BigIntegerCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/BigIntegerCodec.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.ha.io;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Proto2Utils;
 
 import java.math.BigInteger;
 
@@ -28,7 +29,8 @@ public class BigIntegerCodec implements Codec {
 
   @Override
   public ByteString serialize(Object object) {
-    return ByteString.copyFrom(((BigInteger)object).toByteArray());
+    // BigInteger returns a new byte[].
+    return Proto2Utils.unsafeByteString(((BigInteger)object).toByteArray());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/BooleanCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/BooleanCodec.java
@@ -19,19 +19,20 @@ package org.apache.hadoop.hdds.scm.ha.io;
 
 import com.google.protobuf.ByteString;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 /**
  * {@link Codec} for {@code Boolean} objects.
  */
 public class BooleanCodec implements Codec {
+  static final ByteString TRUE = ByteString.copyFromUtf8(Boolean.TRUE.toString());
+  static final ByteString FALSE = ByteString.copyFromUtf8(Boolean.FALSE.toString());
+
   @Override
   public ByteString serialize(Object object) {
-    return ByteString.copyFrom(((Boolean) object).toString().getBytes(UTF_8));
+    return ((Boolean) object) ? TRUE : FALSE;
   }
 
   @Override
-  public Object deserialize(Class<?> type, ByteString value) {
-    return Boolean.parseBoolean(new String(value.toByteArray(), UTF_8));
+  public Boolean deserialize(Class<?> type, ByteString value) {
+    return value.equals(TRUE) ? Boolean.TRUE : Boolean.FALSE;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/EnumCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/EnumCodec.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.ha.io;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Proto2Utils;
 import com.google.protobuf.ProtocolMessageEnum;
 import org.apache.hadoop.hdds.scm.ha.ReflectionUtil;
 
@@ -33,7 +34,8 @@ public class EnumCodec implements Codec {
   @Override
   public ByteString serialize(Object object)
       throws InvalidProtocolBufferException {
-    return ByteString.copyFrom(Ints.toByteArray(
+    // toByteArray returns a new array
+    return Proto2Utils.unsafeByteString(Ints.toByteArray(
         ((ProtocolMessageEnum) object).getNumber()));
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/IntegerCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/IntegerCodec.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.scm.ha.io;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Proto2Utils;
 
 /**
  * Encodes/decodes an integer to a byte string.
@@ -29,7 +30,8 @@ public class IntegerCodec implements Codec {
   @Override
   public ByteString serialize(Object object)
       throws InvalidProtocolBufferException {
-    return ByteString.copyFrom(Ints.toByteArray((Integer) object));
+    // toByteArray returns a new array
+    return Proto2Utils.unsafeByteString(Ints.toByteArray((Integer) object));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/LongCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/LongCodec.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.ha.io;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Proto2Utils;
 
 /**
  * {@link Codec} for {@code Long} objects.
@@ -29,7 +30,8 @@ public class LongCodec implements Codec {
   @Override
   public ByteString serialize(Object object)
       throws InvalidProtocolBufferException {
-    return ByteString.copyFrom(Longs.toByteArray((Long) object));
+    // toByteArray returns a new array
+    return Proto2Utils.unsafeByteString(Longs.toByteArray((Long) object));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ManagedSecretKeyCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/ManagedSecretKeyCodec.java
@@ -31,7 +31,7 @@ public class ManagedSecretKeyCodec implements Codec {
   public ByteString serialize(Object object)
       throws InvalidProtocolBufferException {
     ManagedSecretKey secretKey = (ManagedSecretKey) object;
-    return ByteString.copyFrom(secretKey.toProtobuf().toByteArray());
+    return secretKey.toProtobuf().toByteString();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/StringCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/StringCodec.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.ha.io;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Proto2Utils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -27,7 +28,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class StringCodec implements Codec {
   @Override
   public ByteString serialize(Object object) {
-    return ByteString.copyFrom(((String) object).getBytes(UTF_8));
+    // getBytes returns a new array
+    return Proto2Utils.unsafeByteString(((String) object).getBytes(UTF_8));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/X509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/io/X509CertificateCodec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.ha.io;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Proto2Utils;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 
 import java.security.cert.X509Certificate;
@@ -35,7 +36,8 @@ public class X509CertificateCodec implements Codec {
     try {
       String certString =
           CertificateCodec.getPEMEncodedString((X509Certificate) object);
-      return ByteString.copyFrom(certString.getBytes(UTF_8));
+      // getBytes returns a new array
+      return Proto2Utils.unsafeByteString(certString.getBytes(UTF_8));
     } catch (Exception ex) {
       throw new InvalidProtocolBufferException(
           "X509Certificate cannot be decoded: " + ex.getMessage());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -83,7 +83,6 @@ import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUt
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1171,10 +1170,6 @@ public class TestECUnderReplicationHandler {
         result, remainingMaintenanceRedundancy);
     int replicateCommand = 0;
     int reconstructCommand = 0;
-    byte[] missingIndexesByteArr = new byte[missingIndexes.size()];
-    for (int i = 0; i < missingIndexes.size(); i++) {
-      missingIndexesByteArr[i] = missingIndexes.get(i).byteValue();
-    }
     boolean shouldReconstructCommandExist =
         missingIndexes.size() > 0 && missingIndexes.size() <= repConfig
             .getParity();
@@ -1184,7 +1179,7 @@ public class TestECUnderReplicationHandler {
       } else if (dnCommand
           .getValue() instanceof ReconstructECContainersCommand) {
         if (shouldReconstructCommandExist) {
-          assertArrayEquals(missingIndexesByteArr,
+          assertEquals(ECUnderReplicationHandler.integers2ByteString(missingIndexes),
               ((ReconstructECContainersCommand) dnCommand.getValue())
               .getMissingContainerIndexes());
         }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Proto2Utils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
@@ -1281,7 +1282,7 @@ public class TestReplicationManager {
 
     ReconstructECContainersCommand command = new ReconstructECContainersCommand(
         containerInfo.getContainerID(), sourceNodes, targetNodes,
-        missingIndexes, ecRepConfig);
+        Proto2Utils.unsafeByteString(missingIndexes), ecRepConfig);
 
     replicationManager.sendDatanodeCommand(command, containerInfo, target4);
 
@@ -1608,7 +1609,7 @@ public class TestReplicationManager {
     byte[] missingIndexes = new byte[]{4, 5};
     return new ReconstructECContainersCommand(
         containerInfo.getContainerID(), sources,
-        new ArrayList<>(Arrays.asList(targets)), missingIndexes,
+        Arrays.asList(targets), Proto2Utils.unsafeByteString(missingIndexes),
         (ECReplicationConfig) repConfig);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestX509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestX509CertificateCodec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.ha.io;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Proto2Utils;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +56,7 @@ public class TestX509CertificateCodec {
   public void testCodecError() {
 
     X509CertificateCodec x509CertificateCodec = new X509CertificateCodec();
-    ByteString byteString = ByteString.copyFrom("dummy".getBytes(UTF_8));
+    final ByteString byteString = Proto2Utils.unsafeByteString("dummy".getBytes(UTF_8));
 
     assertThrows(InvalidProtocolBufferException.class, () ->
         x509CertificateCodec.deserialize(X509Certificate.class, byteString));

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.google.protobuf.Proto2Utils;
 import jakarta.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.SafeModeAction;
@@ -239,16 +240,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_S3_CALLER_CONTEXT_PREFIX;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.SCM_IN_SAFE_MODE;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CancelPrepareRequest;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CancelPrepareResponse;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareRequest;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareRequestArgs;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareResponse;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusRequest;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Authentication;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetBucketPropertyResponse;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetVolumePropertyResponse;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.ACCESS_DENIED;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.DIRECTORY_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
@@ -2496,7 +2487,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
                                     boolean writeToRatis) throws IOException {
     EchoRPCRequest echoRPCRequest =
             EchoRPCRequest.newBuilder()
-                    .setPayloadReq(ByteString.copyFrom(payloadReq))
+                    .setPayloadReq(Proto2Utils.unsafeByteString(payloadReq))
                     .setPayloadSizeResp(payloadSizeRespBytes)
                     .setReadOnly(!writeToRatis)
                     .build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/PayloadUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/PayloadUtils.java
@@ -17,6 +17,9 @@
 
 package org.apache.hadoop.ozone.util;
 
+import com.google.protobuf.Proto2Utils;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.com.google.protobuf.UnsafeByteOperations;
 import org.apache.ratis.util.Preconditions;
 
 import java.util.Random;
@@ -35,6 +38,7 @@ public final class PayloadUtils {
   private PayloadUtils() {
   }
 
+  /** @return a new byte[] containing */
   public static byte[] generatePayload(int payloadSizeBytes) {
     byte[] result = new byte[Math.min(payloadSizeBytes, MAX_SIZE)];
 
@@ -50,5 +54,13 @@ public final class PayloadUtils {
     Preconditions.assertTrue(curIdx == result.length);
 
     return result;
+  }
+
+  public static com.google.protobuf.ByteString generatePayloadProto2(int payloadSizeBytes) {
+    return Proto2Utils.unsafeByteString(generatePayload(payloadSizeBytes));
+  }
+
+  public static ByteString generatePayloadProto3(int payloadSizeBytes) {
+    return UnsafeByteOperations.unsafeWrap(generatePayload(payloadSizeBytes));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OMEchoRPCWriteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/util/OMEchoRPCWriteRequest.java
@@ -44,11 +44,9 @@ public class OMEchoRPCWriteRequest extends OMClientRequest {
 
     EchoRPCRequest echoRPCRequest = getOmRequest().getEchoRPCRequest();
 
-    byte[] payloadBytes =
-        PayloadUtils.generatePayload(echoRPCRequest.getPayloadSizeResp());
-
+    final ByteString payloadBytes = PayloadUtils.generatePayloadProto2(echoRPCRequest.getPayloadSizeResp());
     EchoRPCResponse echoRPCResponse = EchoRPCResponse.newBuilder()
-        .setPayload(ByteString.copyFrom(payloadBytes))
+        .setPayload(payloadBytes)
         .build();
 
     OMResponse.Builder omResponse =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -1430,9 +1430,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
   private EchoRPCResponse echoRPC(EchoRPCRequest req) {
     EchoRPCResponse.Builder builder = EchoRPCResponse.newBuilder();
-    byte[] payloadBytes =
-        PayloadUtils.generatePayload(req.getPayloadSizeResp());
-    builder.setPayload(ByteString.copyFrom(payloadBytes));
+    final ByteString payloadBytes = PayloadUtils.generatePayloadProto2(req.getPayloadSizeResp());
+    builder.setPayload(payloadBytes);
     return builder.build();
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DNRPCLoadGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DNRPCLoadGenerator.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.scm.client.ClientTrustManager;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CACertificateProvider;
 import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
+import org.apache.hadoop.ozone.util.PayloadUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -35,7 +36,6 @@ import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
-import org.apache.ratis.thirdparty.com.google.protobuf.UnsafeByteOperations;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -43,8 +43,6 @@ import picocli.CommandLine.Option;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-
-import static org.apache.hadoop.ozone.util.PayloadUtils.generatePayload;
 
 /**
  * Utility to generate RPC request to DN.
@@ -139,7 +137,7 @@ public class DNRPCLoadGenerator extends BaseFreonGenerator
     }
 
     init();
-    payloadReqBytes = UnsafeByteOperations.unsafeWrap(generatePayload(payloadSizeInBytes(payloadReqSizeKB)));
+    payloadReqBytes = PayloadUtils.generatePayloadProto3(payloadSizeInBytes(payloadReqSizeKB));
     payloadRespSize = calculateMaxPayloadSize(payloadRespSizeKB);
     timer = getMetrics().timer("rpc-payload");
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

As the name implied, `ByteString#copyFrom(byte[])` creates a ByteString by copying the given byte array. In some cases (e.g. the byte array is already copied), the copying can be avoided by using `Proto2Utils.unsafeByteString(byte[])`.

## What is the link to the Apache JIRA

HDDS-10756

## How was this patch tested?

By existing tests.