### PR TITLE
HDDS-10761. Add raft close threshold config to OM RaftProperties

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2117,7 +2117,7 @@
   </property>
 
   <property>
-    <name>ozone.om.ratis.server.leaderelection.pre-vote </name>
+    <name>ozone.om.ratis.server.leaderelection.pre-vote</name>
     <value>true</value>
     <tag>OZONE, OM, RATIS, MANAGEMENT</tag>
     <description>Enable/disable OM HA leader election pre-vote phase.
@@ -2131,6 +2131,15 @@
     <description>The timeout duration for ratis server failure detection,
       once the threshold has reached, the ratis state machine will be informed
       about the failure in the ratis ring.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.om.ratis.server.close.threshold</name>
+    <value>60s</value>
+    <tag>OZONE, OM, RATIS</tag>
+    <description>
+      Raft Server will close if JVM pause longer than the threshold.
     </description>
   </property>
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -247,6 +247,10 @@ public final class OMConfigKeys {
   public static final boolean
       OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT = true;
 
+  public static final String OZONE_OM_RATIS_SERVER_CLOSE_THRESHOLD_KEY =
+      "ozone.om.ratis.server.close.threshold";
+  public static final TimeDuration OZONE_OM_RATIS_SERVER_CLOSE_THRESHOLD_DEFAULT =
+      TimeDuration.valueOf(60, TimeUnit.SECONDS);
 
   // OM SnapshotProvider configurations
   public static final String OZONE_OM_RATIS_SNAPSHOT_DIR =


### PR DESCRIPTION
## What changes were proposed in this pull request?
OM crash as the following logs:
```java
2024-04-26 13:29:26,517 [JvmPauseMonitor0] ERROR org.apache.ratis.server.RaftServer: om2: JVM pause detected 145.979s longer than the close-threshold 60s, shutting down ... 
```
This pr makes the close-threshold value configurable from the OM side.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10761

## How was this patch tested?

manual tests: debug ratis and trace the value.
