### PR TITLE
HDDS-10767. Reducing DatanodeDetails in the ContainerLocationCache

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ScmClient.java
@@ -113,11 +113,16 @@ public class ScmClient {
     for (DatanodeDetails node : pipeline.getNodes()) {
       DatanodeDetails datanodeDetails =
           datanodeDetailsCache.get(node.getUuid());
-      if (node.equals(datanodeDetails)) {
-        nodes.add(datanodeDetails);
-      } else {
+      if (datanodeDetails == null) {
         datanodeDetailsCache.put(node.getUuid(), node);
         nodes.add(node);
+      } else {
+        if (node.equals(datanodeDetails)) {
+          nodes.add(datanodeDetails);
+        } else {
+          datanodeDetailsCache.put(node.getUuid(), node);
+          nodes.add(node);
+        }
       }
     }
     builder.setNodes(nodes);


### PR DESCRIPTION
## What changes were proposed in this pull request?
 
In the Ozone Community Meeting, it was discussed that DiDi company's om often occurs full gc, after jmap, it was found too many DatanodeDetails objects occupy memory, this pr will reduce the generation of DatanodeDetails objects.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10767

## How was this patch tested?

UT
