### PR TITLE
HDDS-10732. Add CRYPTO_COMPLIANCE tag to client checksum type and bytes per checksum configs

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -166,7 +166,7 @@ public class OzoneClientConfig {
       description = "The checksum type [NONE/ CRC32/ CRC32C/ SHA256/ MD5] "
           + "determines which algorithm would be used to compute checksum for "
           + "chunk data. Default checksum type is CRC32.",
-      tags = ConfigTag.CLIENT)
+      tags = { ConfigTag.CLIENT, ConfigTag.CRYPTO_COMPLIANCE })
   private String checksumType = ChecksumType.CRC32.name();
 
   @Config(key = "bytes.per.checksum",
@@ -175,7 +175,7 @@ public class OzoneClientConfig {
       description = "Checksum will be computed for every bytes per checksum "
           + "number of bytes and stored sequentially. The minimum value for "
           + "this config is 16KB.",
-      tags = ConfigTag.CLIENT)
+      tags = { ConfigTag.CLIENT, ConfigTag.CRYPTO_COMPLIANCE })
   private int bytesPerChecksum = 1024 * 1024;
 
   @Config(key = "verify.checksum",


### PR DESCRIPTION
## What changes were proposed in this pull request?
I added the CRYPTO_COMPLIANCE tag to the `ozone.client.checksum.type` and `ozone.client.bytes.per.checksum` config options. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10732

## How was this patch tested?

https://github.com/dombizita/ozone/actions/runs/8874650538
