### PR TITLE
HDDS-10772. [Ozone-Streaming] Stream write metric is wrong

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/KeyValueStreamDataChannel.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/KeyValueStreamDataChannel.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.hdds.scm.storage.BlockDataStreamOutput;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
-import org.apache.hadoop.util.Time;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBuf;
 import org.apache.ratis.thirdparty.io.netty.buffer.Unpooled;
@@ -167,11 +166,7 @@ public class KeyValueStreamDataChannel extends StreamDataChannelBase {
     getMetrics().incContainerOpsMetrics(getType());
     assertOpen();
 
-    final long l = Time.monotonicNow();
-    int len = writeBuffers(referenceCounted, buffers, super::writeFileChannel);
-    getMetrics()
-        .incContainerOpsLatencies(getType(), Time.monotonicNow() - l);
-    return len;
+    return writeBuffers(referenceCounted, buffers, this::writeFileChannel);
   }
 
   static int writeBuffers(ReferenceCountedObject<ByteBuffer> src,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
+import org.apache.hadoop.util.Time;
 import org.apache.ratis.statemachine.StateMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,9 +130,11 @@ abstract class StreamDataChannelBase
 
   final int writeFileChannel(ByteBuffer src) throws IOException {
     try {
+      final long startTime = Time.monotonicNow();
       final int writeBytes = getChannel().write(src);
       metrics.incContainerBytesStats(getType(), writeBytes);
       containerData.updateWriteStats(writeBytes, false);
+      metrics.incContainerOpsLatencies(getType(), Time.monotonicNow() - startTime);
       return writeBytes;
     } catch (IOException e) {
       checkVolume();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Not every channel write generated io, but only added to the Buffers object, and in the close channel will be in the Buffers object has not been written to the disk data, the part also need to record metrics.

For the detailed see jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10772
