### PR TITLE
HDDS-10781. Do not use OFSPath in O3FS BasicOzoneClientAdapterImpl

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -2169,15 +2169,11 @@ abstract class AbstractOzoneFileSystemTest {
     ContractTestUtils.touch(fs, file3);
     Path snapPath3 = fs.createSnapshot(new Path("/"), "snap3");
 
-    try {
-      FileStatus[] f1 = fs.listStatus(snapPath1);
-      FileStatus[] f2 = fs.listStatus(snapPath2);
-      FileStatus[] f3 = fs.listStatus(snapPath3);
-      assertEquals(0, f1.length);
-      assertEquals(2, f2.length);
-      assertEquals(3, f3.length);
-    } catch (Exception e) {
-      fail("Failed to read/list on snapshotPath, exception: " + e);
-    }
+    FileStatus[] f1 = fs.listStatus(snapPath1);
+    FileStatus[] f2 = fs.listStatus(snapPath2);
+    FileStatus[] f3 = fs.listStatus(snapPath3);
+    assertEquals(0, f1.length);
+    assertEquals(2, f2.length);
+    assertEquals(3, f3.length);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -2154,4 +2154,30 @@ abstract class AbstractOzoneFileSystemTest {
     assertEquals(value, statistics.getLong(key).longValue());
   }
 
+  @Test
+  void testSnapshotRead() throws Exception {
+    // Init data
+    Path snapPath1 = fs.createSnapshot(new Path("/"), "snap1");
+
+    Path file1 = new Path("/key1");
+    Path file2 = new Path("/key2");
+    ContractTestUtils.touch(fs, file1);
+    ContractTestUtils.touch(fs, file2);
+    Path snapPath2 = fs.createSnapshot(new Path("/"), "snap2");
+
+    Path file3 = new Path("/key3");
+    ContractTestUtils.touch(fs, file3);
+    Path snapPath3 = fs.createSnapshot(new Path("/"), "snap3");
+
+    try {
+      FileStatus[] f1 = fs.listStatus(snapPath1);
+      FileStatus[] f2 = fs.listStatus(snapPath2);
+      FileStatus[] f3 = fs.listStatus(snapPath3);
+      assertEquals(0, f1.length);
+      assertEquals(2, f2.length);
+      assertEquals(3, f3.length);
+    } catch (Exception e) {
+      fail("Failed to read/list on snapshotPath, exception: " + e);
+    }
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTestWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTestWithFSO.java
@@ -497,7 +497,7 @@ abstract class AbstractOzoneFileSystemTestWithFSO extends AbstractOzoneFileSyste
   @Test
   public void testLeaseRecoverable() throws Exception {
     // Create a file
-    Path parent = new Path("/d1/d2/");
+    Path parent = new Path("/d1");
     Path source = new Path(parent, "file1");
 
     LeaseRecoverable fs = (LeaseRecoverable)getFs();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -706,8 +706,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public boolean isFileClosed(String pathStr) throws IOException {
     incrementCounter(Statistic.INVOCATION_IS_FILE_CLOSED, 1);
-    OFSPath ofsPath = new OFSPath(pathStr, config);
-    if (!ofsPath.isKey()) {
+    if (StringUtils.isEmpty(pathStr)) {
       throw new IOException("not a file");
     }
     OzoneFileStatus status = bucket.getFileStatus(pathStr);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -45,7 +45,6 @@ import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -598,18 +597,14 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public String createSnapshot(String pathStr, String snapshotName)
       throws IOException {
-    OFSPath ofsPath = new OFSPath(pathStr, config);
-    return objectStore.createSnapshot(ofsPath.getVolumeName(),
-        ofsPath.getBucketName(),
-        snapshotName);
+    return objectStore.createSnapshot(volume.getName(), bucket.getName(), snapshotName);
   }
 
   @Override
   public void renameSnapshot(String pathStr, String snapshotOldName, String snapshotNewName)
       throws IOException {
-    OFSPath ofsPath = new OFSPath(pathStr, config);
-    objectStore.renameSnapshot(ofsPath.getVolumeName(),
-        ofsPath.getBucketName(),
+    objectStore.renameSnapshot(volume.getName(),
+        bucket.getName(),
         snapshotOldName,
         snapshotNewName);
   }
@@ -617,9 +612,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public void deleteSnapshot(String pathStr, String snapshotName)
       throws IOException {
-    OFSPath ofsPath = new OFSPath(pathStr, config);
-    objectStore.deleteSnapshot(ofsPath.getVolumeName(),
-        ofsPath.getBucketName(),
+    objectStore.deleteSnapshot(volume.getName(),
+        bucket.getName(),
         snapshotName);
   }
 
@@ -662,12 +656,11 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     } finally {
       // delete the temp snapshot
       if (takeTemporaryToSnapshot || takeTemporaryFromSnapshot) {
-        OFSPath snapPath = new OFSPath(snapshotDir.toString(), config);
         if (takeTemporaryToSnapshot) {
-          OzoneClientUtils.deleteSnapshot(objectStore, toSnapshot, snapPath);
+          OzoneClientUtils.deleteSnapshot(objectStore, toSnapshot, volume.getName(), bucket.getName());
         }
         if (takeTemporaryFromSnapshot) {
-          OzoneClientUtils.deleteSnapshot(objectStore, fromSnapshot, snapPath);
+          OzoneClientUtils.deleteSnapshot(objectStore, fromSnapshot, volume.getName(), bucket.getName());
         }
       }
     }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1317,10 +1317,10 @@ public class BasicRootedOzoneClientAdapterImpl
     } finally {
       // delete the temp snapshot
       if (takeTemporaryToSnapshot) {
-        OzoneClientUtils.deleteSnapshot(objectStore, toSnapshot, ofsPath);
+        OzoneClientUtils.deleteSnapshot(objectStore, toSnapshot, volume, bucket);
       }
       if (takeTemporaryFromSnapshot) {
-        OzoneClientUtils.deleteSnapshot(objectStore, fromSnapshot, ofsPath);
+        OzoneClientUtils.deleteSnapshot(objectStore, fromSnapshot, volume, bucket);
       }
     }
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
-import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.client.checksum.BaseFileChecksumHelper;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -270,14 +269,14 @@ public final class OzoneClientUtils {
   }
 
   public static void deleteSnapshot(ObjectStore objectStore,
-      String snapshot, OFSPath snapPath) {
+                                    String snapshot, String volumeName, String bucketName) {
     try {
-      objectStore.deleteSnapshot(snapPath.getVolumeName(),
-          snapPath.getBucketName(), snapshot);
+      objectStore.deleteSnapshot(volumeName,
+          bucketName, snapshot);
     } catch (IOException exception) {
       LOG.warn("Failed to delete the temp snapshot with name {} in bucket"
               + " {} and volume {} after snapDiff op. Exception : {}", snapshot,
-          snapPath.getBucketName(), snapPath.getVolumeName(),
+          bucketName, volumeName,
           exception.getMessage());
     }
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -269,7 +269,7 @@ public final class OzoneClientUtils {
   }
 
   public static void deleteSnapshot(ObjectStore objectStore,
-                                    String snapshot, String volumeName, String bucketName) {
+      String snapshot, String volumeName, String bucketName) {
     try {
       objectStore.deleteSnapshot(volumeName,
           bucketName, snapshot);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In BasicOzoneClientAdapterImpl#isFileClosed we use OFSPath to check if the path was a key, but it Utility class for OFS not O3FS. That is to say, the pathStr doen't include volume and bucket but the OFSPath still setting the first two levels of directories or key as volume and bucket. If the path was less than two level it comes out an error.

https://github.com/apache/ozone/blob/HDDS-7593/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java#L774



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10781

## How was this patch tested?

There are some existing lease recovery tests.