### PR TITLE
HDDS-10789. Check policy based on original replicas instead of eligibleReplicas

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
@@ -325,7 +325,7 @@ public class RatisOverReplicationHandler
     return commandsSent;
   }
 
-  class EligibleAndReserveReplicas {
+  static class EligibleAndReserveReplicas {
     private List<ContainerReplica> eligibleReplicas;
     private List<ContainerReplica> reserveReplicas;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java
@@ -130,7 +130,7 @@ public class RatisOverReplicationHandler
     // get number of excess replicas
     int excess = replicaCount.getExcessRedundancy(true);
 
-    return createCommands(containerInfo, eligibleReplicas, excess);
+    return createCommands(containerInfo, replicas, eligibleReplicas, excess);
   }
 
   private boolean verifyOverReplication(
@@ -241,8 +241,9 @@ public class RatisOverReplicationHandler
   }
 
   private int createCommands(
-      ContainerInfo containerInfo, List<ContainerReplica> replicas,
-      int excess) throws NotLeaderException, CommandTargetOverloadedException {
+      ContainerInfo containerInfo, Set<ContainerReplica> originalReplicas,
+      List<ContainerReplica> replicas, int excess)
+      throws NotLeaderException, CommandTargetOverloadedException {
 
     /*
     Being in the over replication queue means we have enough replicas that
@@ -286,7 +287,8 @@ public class RatisOverReplicationHandler
     If the container was already mis replicated, then remove replicas if that
     does not change the placement count.
      */
-    Set<ContainerReplica> replicaSet = new HashSet<>(replicas);
+    Set<ContainerReplica> replicaSet = new HashSet<>(originalReplicas);
+    replicasRemoved.forEach(replicaSet::remove);
     // iterate through replicas in deterministic order
     for (ContainerReplica replica : replicas) {
       if (excess == 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [RatisOverReplicationHandler](https://github.com/apache/ozone/blob/a658802d628271efa82824dc3c316f8eebfc75d3/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java#L123), the eligibleReplicas might be trimmed due to uniqueness check, and the [check of placement policy](https://github.com/apache/ozone/blob/a658802d628271efa82824dc3c316f8eebfc75d3/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/RatisOverReplicationHandler.java#L296) should be done on the original replicas set, instead of the trimmed eligibleReplicas.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10789

## How was this patch tested?

Original tests.
