### PR TITLE
HDDS-10784. Multipart upload to encrypted bucket fails with ClassCastException

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -84,7 +84,8 @@ OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.container.report.interval=60s
 OZONE-SITE.XML_ozone.scm.close.container.wait.duration=5s
 
-OZONE-SITE.XML_hdds.container.ratis.datastream.enabled=true
+# Ratis streaming is disabled to ensure coverage for both cases
+OZONE-SITE.XML_hdds.container.ratis.datastream.enabled=false
 
 HDFS-SITE.XML_dfs.datanode.kerberos.principal=dn/dn@EXAMPLE.COM
 HDFS-SITE.XML_dfs.datanode.kerberos.keytab.file=/etc/security/keytabs/dn.keytab

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -39,6 +39,15 @@ execute_robot_test scm security
 
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:bucket -N ozonefs-ofs-bucket ozonefs/ozonefs.robot
 
+## Exclude virtual-host tests. This is tested separately as it requires additional config.
+exclude="--exclude virtual-host"
+for bucket in encrypted; do
+  execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
+  # some tests are independent of the bucket type, only need to be run once
+  ## Exclude virtual-host.robot
+  exclude="--exclude virtual-host --exclude no-bucket-type"
+done
+
 #expects 4 pipelines, should be run before
 #admincli which creates STANDALONE pipeline
 execute_robot_test scm recon

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.io.KeyMetadataAware;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
@@ -1000,7 +999,7 @@ public class ObjectEndpoint extends EndpointBase {
           metadataLatencyNs =
               getMetrics().updatePutKeyMetadataStats(startNanos);
           putLength = IOUtils.copyLarge(digestInputStream, ozoneOutputStream);
-          ((KeyMetadataAware)ozoneOutputStream.getOutputStream())
+          ozoneOutputStream
               .getMetadata().put(ETAG, DatatypeConverter.printHexBinary(
                       digestInputStream.getMessageDigest().digest())
                   .toLowerCase());

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -999,12 +999,10 @@ public class ObjectEndpoint extends EndpointBase {
           metadataLatencyNs =
               getMetrics().updatePutKeyMetadataStats(startNanos);
           putLength = IOUtils.copyLarge(digestInputStream, ozoneOutputStream);
-          ozoneOutputStream
-              .getMetadata().put(ETAG, DatatypeConverter.printHexBinary(
-                      digestInputStream.getMessageDigest().digest())
-                  .toLowerCase());
-          keyOutputStream
-              = ozoneOutputStream.getKeyOutputStream();
+          byte[] digest = digestInputStream.getMessageDigest().digest();
+          ozoneOutputStream.getMetadata()
+              .put(ETAG, DatatypeConverter.printHexBinary(digest).toLowerCase());
+          keyOutputStream = ozoneOutputStream.getKeyOutputStream();
         }
         getMetrics().incPutKeySuccessLength(putLength);
         perf.appendSizeBytes(putLength);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix exception:

```
ClassCastException: class org.apache.hadoop.crypto.CryptoOutputStream cannot be cast to class org.apache.hadoop.ozone.client.io.KeyMetadataAware ...
  at org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint.createMultipartKey(ObjectEndpoint.java:1003)
  at org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint.put(ObjectEndpoint.java:239)
```

Steps to reproduce:

0. Start cluster with Ratis streaming disabled (default setting)
1. Create encrypted bucket in S3 volume
2. Upload key via multipart upload to encrypted bucket

https://issues.apache.org/jira/browse/HDDS-10784

## How was this patch tested?

Added acceptance test coverage for S3 with Ratis streaming disabled in encrypted bucket in `ozonesecure` environment.  `ozonesecure-ha` covers the same with Ratis streaming enabled.

CI:
https://github.com/adoroszlai/ozone/actions/runs/8920571448