### PR TITLE
HDDS-10097. Intermittent ManagedChannel not shutdown properly in TestWatchForCommit

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -263,38 +263,41 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      assertEquals(1, xceiverClient.getRefcount());
-      assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
-      Pipeline pipeline = xceiverClient.getPipeline();
-      TestHelper.createPipelineOnDatanode(pipeline, cluster);
-      XceiverClientReply reply = xceiverClient.sendCommandAsync(
-          ContainerTestHelper.getCreateContainerRequest(
-              container1.getContainerInfo().getContainerID(),
-              xceiverClient.getPipeline()));
-      reply.getResponse().get();
-      long index = reply.getLogIndex();
-      cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
-      cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
-      // emulate closing pipeline when SCM detects DEAD datanodes
-      cluster.getStorageContainerManager()
-          .getPipelineManager().closePipeline(pipeline, false);
-      // again write data with more than max buffer limit. This wi
-      // just watch for a log index which in not updated in the commitInfo Map
-      // as well as there is no logIndex generate in Ratis.
-      // The basic idea here is just to test if its throws an exception.
-      ExecutionException e = assertThrows(ExecutionException.class,
-          () -> xceiverClient.watchForCommit(index + RandomUtils.nextInt(0, 100) + 10));
-      // since the timeout value is quite long, the watch request will either
-      // fail with NotReplicated exceptio, RetryFailureException or
-      // RuntimeException
-      assertFalse(HddsClientUtils
-          .checkForException(e) instanceof TimeoutException);
-      // client should not attempt to watch with
-      // MAJORITY_COMMITTED replication level, except the grpc IO issue
-      if (!logCapturer.getOutput().contains("Connection refused")) {
-        assertThat(e.getMessage()).doesNotContain("Watch-MAJORITY_COMMITTED");
+      try {
+        assertEquals(1, xceiverClient.getRefcount());
+        assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
+        Pipeline pipeline = xceiverClient.getPipeline();
+        TestHelper.createPipelineOnDatanode(pipeline, cluster);
+        XceiverClientReply reply = xceiverClient.sendCommandAsync(
+            ContainerTestHelper.getCreateContainerRequest(
+                container1.getContainerInfo().getContainerID(),
+                xceiverClient.getPipeline()));
+        reply.getResponse().get();
+        long index = reply.getLogIndex();
+        cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
+        cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
+        // emulate closing pipeline when SCM detects DEAD datanodes
+        cluster.getStorageContainerManager()
+            .getPipelineManager().closePipeline(pipeline, false);
+        // again write data with more than max buffer limit. This wi
+        // just watch for a log index which in not updated in the commitInfo Map
+        // as well as there is no logIndex generate in Ratis.
+        // The basic idea here is just to test if its throws an exception.
+        ExecutionException e = assertThrows(ExecutionException.class,
+            () -> xceiverClient.watchForCommit(index + RandomUtils.nextInt(0, 100) + 10));
+        // since the timeout value is quite long, the watch request will either
+        // fail with NotReplicated exceptio, RetryFailureException or
+        // RuntimeException
+        assertFalse(HddsClientUtils
+            .checkForException(e) instanceof TimeoutException);
+        // client should not attempt to watch with
+        // MAJORITY_COMMITTED replication level, except the grpc IO issue
+        if (!logCapturer.getOutput().contains("Connection refused")) {
+          assertThat(e.getMessage()).doesNotContain("Watch-MAJORITY_COMMITTED");
+        }
+      } finally {
+        clientManager.releaseClient(xceiverClient, false);
       }
-      clientManager.releaseClient(xceiverClient, false);
     }
   }
 
@@ -309,35 +312,38 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      assertEquals(1, xceiverClient.getRefcount());
-      assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
-      Pipeline pipeline = xceiverClient.getPipeline();
-      TestHelper.createPipelineOnDatanode(pipeline, cluster);
-      XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
-      XceiverClientReply reply = xceiverClient.sendCommandAsync(
-          ContainerTestHelper.getCreateContainerRequest(
-              container1.getContainerInfo().getContainerID(),
-              xceiverClient.getPipeline()));
-      reply.getResponse().get();
-      assertEquals(3, ratisClient.getCommitInfoMap().size());
-      List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();
-      for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
-        // shutdown the ratis follower
-        if (nodesInPipeline.contains(dn.getDatanodeDetails())
-            && RatisTestHelper.isRatisFollower(dn, pipeline)) {
-          cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
-          break;
+      try {
+        assertEquals(1, xceiverClient.getRefcount());
+        assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
+        Pipeline pipeline = xceiverClient.getPipeline();
+        TestHelper.createPipelineOnDatanode(pipeline, cluster);
+        XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
+        XceiverClientReply reply = xceiverClient.sendCommandAsync(
+            ContainerTestHelper.getCreateContainerRequest(
+                container1.getContainerInfo().getContainerID(),
+                xceiverClient.getPipeline()));
+        reply.getResponse().get();
+        assertEquals(3, ratisClient.getCommitInfoMap().size());
+        List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();
+        for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
+          // shutdown the ratis follower
+          if (nodesInPipeline.contains(dn.getDatanodeDetails())
+              && RatisTestHelper.isRatisFollower(dn, pipeline)) {
+            cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
+            break;
+          }
         }
-      }
-      reply = xceiverClient.sendCommandAsync(ContainerTestHelper
-          .getCloseContainer(pipeline,
-              container1.getContainerInfo().getContainerID()));
-      reply.getResponse().get();
-      xceiverClient.watchForCommit(reply.getLogIndex());
+        reply = xceiverClient.sendCommandAsync(ContainerTestHelper
+            .getCloseContainer(pipeline,
+                container1.getContainerInfo().getContainerID()));
+        reply.getResponse().get();
+        xceiverClient.watchForCommit(reply.getLogIndex());
 
-      // commitInfo Map will be reduced to 2 here
-      assertEquals(2, ratisClient.getCommitInfoMap().size());
-      clientManager.releaseClient(xceiverClient, false);
+        // commitInfo Map will be reduced to 2 here
+        assertEquals(2, ratisClient.getCommitInfoMap().size());
+      } finally {
+        clientManager.releaseClient(xceiverClient, false);
+      }
       String output = logCapturer.getOutput();
       assertThat(output).contains("3 way commit failed");
       assertThat(output).contains("TimeoutException");
@@ -354,27 +360,30 @@ public class TestWatchForCommit {
               HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       XceiverClientSpi xceiverClient = clientManager
           .acquireClient(container1.getPipeline());
-      assertEquals(1, xceiverClient.getRefcount());
-      assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
-      Pipeline pipeline = xceiverClient.getPipeline();
-      XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
-      long containerId = container1.getContainerInfo().getContainerID();
-      XceiverClientReply reply = xceiverClient.sendCommandAsync(
-          ContainerTestHelper.getCreateContainerRequest(containerId,
-              xceiverClient.getPipeline()));
-      reply.getResponse().get();
-      assertEquals(3, ratisClient.getCommitInfoMap().size());
-      List<Pipeline> pipelineList = new ArrayList<>();
-      pipelineList.add(pipeline);
-      TestHelper.waitForPipelineClose(pipelineList, cluster);
-      // just watch for a log index which in not updated in the commitInfo Map
-      // as well as there is no logIndex generate in Ratis.
-      // The basic idea here is just to test if its throws an exception.
-      Exception e =
-          assertThrows(Exception.class,
-              () -> xceiverClient.watchForCommit(reply.getLogIndex() + RandomUtils.nextInt(0, 100) + 10));
-      assertInstanceOf(GroupMismatchException.class, HddsClientUtils.checkForException(e));
-      clientManager.releaseClient(xceiverClient, false);
+      try {
+        assertEquals(1, xceiverClient.getRefcount());
+        assertEquals(container1.getPipeline(), xceiverClient.getPipeline());
+        Pipeline pipeline = xceiverClient.getPipeline();
+        XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
+        long containerId = container1.getContainerInfo().getContainerID();
+        XceiverClientReply reply = xceiverClient.sendCommandAsync(
+            ContainerTestHelper.getCreateContainerRequest(containerId,
+                xceiverClient.getPipeline()));
+        reply.getResponse().get();
+        assertEquals(3, ratisClient.getCommitInfoMap().size());
+        List<Pipeline> pipelineList = new ArrayList<>();
+        pipelineList.add(pipeline);
+        TestHelper.waitForPipelineClose(pipelineList, cluster);
+        // just watch for a log index which in not updated in the commitInfo Map
+        // as well as there is no logIndex generate in Ratis.
+        // The basic idea here is just to test if its throws an exception.
+        Exception e =
+            assertThrows(Exception.class,
+                () -> xceiverClient.watchForCommit(reply.getLogIndex() + RandomUtils.nextInt(0, 100) + 10));
+        assertInstanceOf(GroupMismatchException.class, HddsClientUtils.checkForException(e));
+      } finally {
+        clientManager.releaseClient(xceiverClient, false);
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ensure `XceiverClientSpi` is released in `TestWatchForCommit` even if any of the test assertions fail.

(Most of the patch is just indentation change due to wrapping in `try-finally` block.  Check it by using `git diff --ignore-space-change` locally.)

https://issues.apache.org/jira/browse/HDDS-10097

## How was this patch tested?

10x10 runs [passed](https://github.com/adoroszlai/ozone/commit/3a364d8a8b58d03ad74900eee5550f24cc0780f4) with a "small" [change](https://github.com/adoroszlai/ozone/commit/3a364d8a8b58d03ad74900eee5550f24cc0780f4) to ignore actual test failures.  So iterations would have been marked as failure only if log postprocessing indicated some problem, e.g. the channel being leaked.  This tweak was necessary to avoid failures reported for known issue HDDS-10788.

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/8920730460