### PR TITLE
HDDS-9761. Intermittent failure in TestOzoneManagerHAWithStoppedNodes due to OMLeaderNotReadyException

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -474,7 +474,7 @@ public class TestOzoneManagerHAWithStoppedNodes extends TestOzoneManagerHA {
     String leaderOMNodeId = omFailoverProxyProvider.getCurrentProxyOMNodeId();
 
     getCluster().stopOzoneManager(leaderOMNodeId);
-    Thread.sleep(NODE_FAILURE_TIMEOUT * 4);
+    getCluster().waitForLeaderOM();
     createKeyTest(true); // failover should happen to new node
 
     long numTimesTriedToSameNode = omFailoverProxyProvider.getWaitTime()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Resolved Intermittent failure in TestOzoneManagerHAWithStoppedNodes due to OMLeaderNotReadyException
There was mandatory pause of 8seconds, which I replaced by getCluster().waitForLeaderOM(). This will also reduce the time required to completed the test execution.
 
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-9761

## How was this patch tested?
Tested the behavior in CI build https://github.com/raju-balpande/apache_ozone/actions/runs/8921923082, or https://github.com/raju-balpande/apache_ozone/actions/runs/8924750049/job/24511920360 
