### PR TITLE
HDDS-10796. Avoid dummy KeyOutputStream in OzoneOutputStreamStub

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -556,7 +556,7 @@ public class KeyOutputStream extends OutputStream
     }
   }
 
-  public synchronized OmMultipartCommitUploadPartInfo
+  synchronized OmMultipartCommitUploadPartInfo
       getCommitUploadPartInfo() {
     return blockOutputStreamEntryPool.getCommitUploadPartInfo();
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -920,10 +919,8 @@ public class ObjectEndpoint extends EndpointBase {
                 uploadID, chunkSize, digestInputStream, perf);
       }
       // OmMultipartCommitUploadPartInfo can only be gotten after the
-      // OzoneOutputStream is closed, so we need to save the KeyOutputStream
-      // in the OzoneOutputStream and use it to get the
-      // OmMultipartCommitUploadPartInfo after OzoneOutputStream is closed.
-      KeyOutputStream keyOutputStream = null;
+      // OzoneOutputStream is closed, so we need to save the OzoneOutputStream
+      final OzoneOutputStream outputStream;
       long metadataLatencyNs;
       if (copyHeader != null) {
         Pair<String, String> result = parseSourceHeader(copyHeader);
@@ -974,7 +971,7 @@ public class ObjectEndpoint extends EndpointBase {
                   sourceObject, ozoneOutputStream, 0, length);
               ozoneOutputStream.getMetadata()
                   .putAll(sourceKeyDetails.getMetadata());
-              keyOutputStream = ozoneOutputStream.getKeyOutputStream();
+              outputStream = ozoneOutputStream;
             }
           } else {
             try (OzoneOutputStream ozoneOutputStream = getClientProtocol()
@@ -985,7 +982,7 @@ public class ObjectEndpoint extends EndpointBase {
               copyLength = IOUtils.copyLarge(sourceObject, ozoneOutputStream);
               ozoneOutputStream.getMetadata()
                   .putAll(sourceKeyDetails.getMetadata());
-              keyOutputStream = ozoneOutputStream.getKeyOutputStream();
+              outputStream = ozoneOutputStream;
             }
           }
           getMetrics().incCopyObjectSuccessLength(copyLength);
@@ -1002,16 +999,15 @@ public class ObjectEndpoint extends EndpointBase {
           byte[] digest = digestInputStream.getMessageDigest().digest();
           ozoneOutputStream.getMetadata()
               .put(ETAG, DatatypeConverter.printHexBinary(digest).toLowerCase());
-          keyOutputStream = ozoneOutputStream.getKeyOutputStream();
+          outputStream = ozoneOutputStream;
         }
         getMetrics().incPutKeySuccessLength(putLength);
         perf.appendSizeBytes(putLength);
       }
       perf.appendMetaLatencyNanos(metadataLatencyNs);
 
-      assert keyOutputStream != null;
       OmMultipartCommitUploadPartInfo omMultipartCommitUploadPartInfo =
-          keyOutputStream.getCommitUploadPartInfo();
+          outputStream.getCommitUploadPartInfo();
       String eTag = omMultipartCommitUploadPartInfo.getETag();
       // If the OmMultipartCommitUploadPartInfo does not contain eTag,
       // fall back to MPU part name for compatibility in case the (old) OM

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneOutputStreamStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneOutputStreamStub.java
@@ -20,11 +20,8 @@
 
 package org.apache.hadoop.ozone.client;
 
-import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.io.KeyMetadataAware;
-import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 
@@ -75,23 +72,8 @@ public class OzoneOutputStreamStub extends OzoneOutputStream {
   }
 
   @Override
-  public KeyOutputStream getKeyOutputStream() {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    ReplicationConfig replicationConfig =
-        ReplicationConfig.getDefault(conf);
-    return new KeyOutputStream(replicationConfig, null) {
-      @Override
-      public synchronized OmMultipartCommitUploadPartInfo
-          getCommitUploadPartInfo() {
-        return OzoneOutputStreamStub.this.getCommitUploadPartInfo();
-      }
-    };
-  }
-
-  @Override
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
     return closed ? new OmMultipartCommitUploadPartInfo(partName,
         ((KeyMetadataAware)getOutputStream()).getMetadata().get(OzoneConsts.ETAG)) : null;
   }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OzoneOutputStreamStub.getKeyOutputStream()` returns a dummy `KeyOutputStream`, which has no relation to the underlying stream (the one passed to parent `OzoneOutputStream` class).

This PR eliminates the need for the dummy `KeyOutputStream`.  The only caller (`ObjectEndpoint`) can access it via `OzoneOutputStream`, so the stub's custom logic is not bypassed.

https://issues.apache.org/jira/browse/HDDS-10796

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/8928970232