### PR TITLE
HDDS-10797. Remove unused UserGroupInformation object in DataNode token verifier.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -497,7 +497,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   private void validateToken(
       ContainerCommandRequestProto msg) throws IOException {
     tokenVerifier.verify(
-        msg, UserGroupInformation.getCurrentUser().getShortUserName(),
+        msg,
         msg.getEncodedToken()
     );
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -62,7 +62,6 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.ozoneimpl.OnDemandContainerDataScanner;
 import org.apache.hadoop.ozone.container.common.volume.VolumeUsage;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.thirdparty.com.google.protobuf.ProtocolMessageEnum;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -713,12 +713,12 @@ public class TestHddsDispatcher {
 
         @Override
         public void verify(ContainerCommandRequestProtoOrBuilder cmd,
-            String user, String encodedToken) {
+            String encodedToken) {
           verify();
         }
 
         @Override
-        public void verify(String user, Token<?> token,
+        public void verify(Token<?> token,
             ContainerCommandRequestProtoOrBuilder cmd) {
           verify();
         }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/CompositeTokenVerifier.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/CompositeTokenVerifier.java
@@ -36,11 +36,11 @@ public class CompositeTokenVerifier implements TokenVerifier {
   }
 
   @Override
-  public void verify(String user, Token<?> token,
+  public void verify(Token<?> token,
       ContainerCommandRequestProtoOrBuilder cmd) throws SCMSecurityException {
 
     for (TokenVerifier verifier : delegates) {
-      verifier.verify(user, token, cmd);
+      verifier.verify(token, cmd);
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/NoopTokenVerifier.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/NoopTokenVerifier.java
@@ -24,13 +24,13 @@ import org.apache.hadoop.security.token.Token;
 public class NoopTokenVerifier implements TokenVerifier {
 
   @Override
-  public void verify(String user, Token<?> token,
+  public void verify(Token<?> token,
       ContainerCommandRequestProtoOrBuilder cmd) {
     // no-op
   }
 
   @Override // to avoid "failed to find token"
-  public void verify(ContainerCommandRequestProtoOrBuilder cmd, String user,
+  public void verify(ContainerCommandRequestProtoOrBuilder cmd,
       String encodedToken) {
     // no-op
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenVerifier.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenVerifier.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.symmetric.ManagedSecretKey;
 import org.apache.hadoop.hdds.security.symmetric.SecretKeyVerifierClient;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 
 import java.io.IOException;
@@ -80,10 +79,9 @@ public abstract class
 
     verifyTokenPassword(tokenId, token.getPassword());
 
-    UserGroupInformation tokenUser = tokenId.getUser();
     // check expiration
     if (tokenId.isExpired(Instant.now())) {
-      throw new BlockTokenException("Expired token for user: " + tokenUser);
+      throw new BlockTokenException("Expired token for user: " + tokenId.getUser());
     }
 
     // check token service (blockID or containerID)
@@ -91,7 +89,7 @@ public abstract class
     if (!Objects.equals(service, tokenId.getService())) {
       throw new BlockTokenException("ID mismatch. Token for ID: " +
           tokenId.getService() + " can't be used to access: " + service +
-          " by user: " + tokenUser);
+          " by user: " + tokenId.getUser());
     }
 
     verify(tokenId, cmd);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenVerifier.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ShortLivedTokenVerifier.java
@@ -64,7 +64,7 @@ public abstract class
   }
 
   @Override
-  public void verify(String user, Token<?> token,
+  public void verify(Token<?> token,
       ContainerCommandRequestProtoOrBuilder cmd) throws SCMSecurityException {
 
     if (!isTokenRequired(cmd.getCmdType())) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/TokenVerifier.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/TokenVerifier.java
@@ -42,18 +42,17 @@ public interface TokenVerifier {
    * Verify if {@code token} is valid to allow execution of {@code cmd} for
    * {@code user}.
    *
-   * @param user user of the request
    * @param token the token to verify
    * @param cmd container command
    * @throws SCMSecurityException if token verification fails.
    */
-  void verify(String user, Token<?> token,
+  void verify(Token<?> token,
       ContainerCommandRequestProtoOrBuilder cmd)
       throws SCMSecurityException;
 
-  /** Same as {@link #verify(String, Token,
+  /** Same as {@link #verify(Token,
    * ContainerCommandRequestProtoOrBuilder)}, but with encoded token. */
-  default void verify(ContainerCommandRequestProtoOrBuilder cmd, String user,
+  default void verify(ContainerCommandRequestProtoOrBuilder cmd,
       String encodedToken) throws SCMSecurityException {
 
     if (Strings.isNullOrEmpty(encodedToken)) {
@@ -68,7 +67,7 @@ public interface TokenVerifier {
       throw new BlockTokenException("Failed to decode token : " + encodedToken);
     }
 
-    verify(user, token, cmd);
+    verify(token, cmd);
   }
 
   /** Create appropriate token verifier based on the configuration. */

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenSecretManager.java
@@ -152,7 +152,7 @@ public class TestOzoneBlockTokenSecretManager {
         .build();
 
     // THEN
-    tokenVerifier.verify("testUser", token, putBlockCommand);
+    tokenVerifier.verify(token, putBlockCommand);
   }
 
   @Test
@@ -172,7 +172,7 @@ public class TestOzoneBlockTokenSecretManager {
 
     // THEN
     BlockTokenException e = assertThrows(BlockTokenException.class,
-        () -> tokenVerifier.verify("testUser", token, writeChunkRequest));
+        () -> tokenVerifier.verify(token, writeChunkRequest));
 
     assertThat(e.getMessage()).contains("Token for ID: " +
         OzoneBlockTokenIdentifier.getTokenService(blockID) +
@@ -200,12 +200,12 @@ public class TestOzoneBlockTokenSecretManager {
         pipeline, putBlockCommand.getPutBlock());
 
     BlockTokenException e = assertThrows(BlockTokenException.class,
-        () -> tokenVerifier.verify(testUser1, token, putBlockCommand));
+        () -> tokenVerifier.verify(token, putBlockCommand));
 
     assertThat(e.getMessage())
         .contains("doesn't have WRITE permission");
 
-    tokenVerifier.verify(testUser1, token, getBlockCommand);
+    tokenVerifier.verify(token, getBlockCommand);
   }
 
   @Test
@@ -223,10 +223,10 @@ public class TestOzoneBlockTokenSecretManager {
     ContainerCommandRequestProto readChunkRequest =
         getReadChunkRequest(pipeline, writeChunkRequest.getWriteChunk());
 
-    tokenVerifier.verify(testUser2, token, writeChunkRequest);
+    tokenVerifier.verify(token, writeChunkRequest);
 
     BlockTokenException e = assertThrows(BlockTokenException.class,
-        () -> tokenVerifier.verify(testUser2, token, readChunkRequest));
+        () -> tokenVerifier.verify(token, readChunkRequest));
     assertThat(e.getMessage())
         .contains("doesn't have READ permission");
   }
@@ -243,14 +243,14 @@ public class TestOzoneBlockTokenSecretManager {
         .setEncodedToken(token.encodeToUrlString())
         .build();
 
-    tokenVerifier.verify("testUser", token, writeChunkRequest);
+    tokenVerifier.verify(token, writeChunkRequest);
 
     // Mock client with an expired cert
     ManagedSecretKey expiredSecretKey = generateExpiredSecretKey();
     when(secretKeyClient.getSecretKey(any())).thenReturn(expiredSecretKey);
 
     BlockTokenException e = assertThrows(BlockTokenException.class,
-        () -> tokenVerifier.verify(user, token, writeChunkRequest));
+        () -> tokenVerifier.verify(token, writeChunkRequest));
     assertThat(e.getMessage())
         .contains("Token can't be verified due to expired secret key");
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
@@ -90,7 +90,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     TokenVerifier subject = newTestSubject(tokenDisabled(), secretKeyClient);
 
     // WHEN
-    subject.verify("anyUser", anyToken(), verifiedRequest(newTokenId()));
+    subject.verify(anyToken(), verifiedRequest(newTokenId()));
 
     // THEN
     verify(secretKeyClient, never()).getSecretKey(any());
@@ -104,7 +104,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     TokenVerifier subject = newTestSubject(tokenEnabled(), secretKeyClient);
 
     // WHEN
-    subject.verify("anyUser", anyToken(), unverifiedRequest());
+    subject.verify(anyToken(), unverifiedRequest());
 
     // THEN
     verify(secretKeyClient, never()).getSecretKey(any());
@@ -130,7 +130,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     ShortLivedTokenSecretManager<T> secretManager = new MockTokenManager();
     Token<T> token = secretManager.generateToken(tokenId);
     BlockTokenException ex = assertThrows(BlockTokenException.class, () ->
-        subject.verify("anyUser", token, cmd));
+        subject.verify(token, cmd));
     assertThat(ex.getMessage()).contains("expired secret key");
   }
 
@@ -149,7 +149,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     ShortLivedTokenSecretManager<T> secretManager = new MockTokenManager();
     Token<T> token = secretManager.generateToken(tokenId);
     BlockTokenException ex = assertThrows(BlockTokenException.class, () ->
-        subject.verify("anyUser", token, cmd));
+        subject.verify(token, cmd));
     assertThat(ex.getMessage())
         .contains("Can't find the signing secret key");
   }
@@ -169,7 +169,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     // WHEN+THEN
     BlockTokenException ex =
         assertThrows(BlockTokenException.class, () ->
-            subject.verify("anyUser", invalidToken, cmd));
+            subject.verify(invalidToken, cmd));
     assertThat(ex.getMessage())
         .contains("Invalid token for user");
   }
@@ -201,7 +201,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     // WHEN+THEN
     BlockTokenException ex =
         assertThrows(BlockTokenException.class, () ->
-            subject.verify("anyUser", token, cmd));
+            subject.verify(token, cmd));
     assertThat(ex.getMessage())
         .contains("Expired token for user");
   }
@@ -219,7 +219,7 @@ public abstract class TokenVerifierTests<T extends ShortLivedTokenIdentifier> {
     TokenVerifier subject = newTestSubject(conf, secretKeyClient);
 
     // WHEN+THEN
-    subject.verify("anyUser", token, cmd);
+    subject.verify(token, cmd);
   }
 
   private T expired(T tokenId) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10797. Remove unused UserGroupInformation object in DataNode token verifier.

Please describe your PR in detail:
freon dn-echo tool examines the baseline client to DataNode communication performance. The flamegraph shows token verifier at DataNode instantiates current user UGI, which is meaningless for DataNode. Furthermore, it is unused at all.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10797

## How was this patch tested?

Patched the jars in a real cluster. Flamegraph after the change confimred UGI is no longer seen.