### PR TITLE
HDDS-10787. Use ManagedObject in rocksdb-checkpoint-differ instead of RocksObject

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -163,7 +163,7 @@ public class RDBStore implements DBStore {
         rocksDBCheckpointDiffer.setCompactionLogTableCFHandle(
             compactionLogTableCF.getHandle());
         // Set activeRocksDB in differ to access compaction log CF.
-        rocksDBCheckpointDiffer.setActiveRocksDB(db.getManagedRocksDb().get());
+        rocksDBCheckpointDiffer.setActiveRocksDB(db.getManagedRocksDb());
         // Load all previous compaction logs
         rocksDBCheckpointDiffer.loadAllCompactionLogs();
       }

--- a/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedSstFileReader.java
+++ b/hadoop-hdds/managed-rocksdb/src/main/java/org/apache/hadoop/hdds/utils/db/managed/ManagedSstFileReader.java
@@ -18,18 +18,29 @@
  */
 package org.apache.hadoop.hdds.utils.db.managed;
 
+import org.apache.ratis.util.UncheckedAutoCloseable;
+import org.rocksdb.Options;
 import org.rocksdb.SstFileReader;
+
+import static org.apache.hadoop.hdds.utils.db.managed.ManagedRocksObjectUtils.track;
 
 /**
  * Managed SstFileReader.
  */
-public class ManagedSstFileReader extends ManagedObject<SstFileReader> {
+public class ManagedSstFileReader extends SstFileReader {
 
-  ManagedSstFileReader(SstFileReader original) {
-    super(original);
+  private final UncheckedAutoCloseable leakTracker = track(this);
+
+  public ManagedSstFileReader(final Options options) {
+    super(options);
   }
 
-  public static ManagedSstFileReader managed(SstFileReader reader) {
-    return new ManagedSstFileReader(reader);
+  @Override
+  public void close() {
+    try {
+      super.close();
+    } finally {
+      leakTracker.close();
+    }
   }
 }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -106,43 +106,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             <id>depcheck</id>
             <phase></phase>
           </execution>
-          <execution>
-            <id>banned-rocksdb-imports</id>
-            <phase>process-sources</phase>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <RestrictImports>
-                  <includeTestCode>false</includeTestCode>
-                  <reason>Use managed RocksObjects under org.apache.hadoop.hdds.utils.db.managed instead.</reason>
-                  <!-- By default, ban all the classes in org.rocksdb -->
-                  <bannedImport>org.rocksdb.**</bannedImport>
-                  <allowedImports>
-                    <allowedImport>org.rocksdb.AbstractEventListener</allowedImport>
-                    <allowedImport>org.rocksdb.Checkpoint</allowedImport>
-                    <allowedImport>org.rocksdb.ColumnFamilyDescriptor</allowedImport>
-                    <allowedImport>org.rocksdb.ColumnFamilyHandle</allowedImport>
-                    <allowedImport>org.rocksdb.ColumnFamilyOptions</allowedImport>
-                    <allowedImport>org.rocksdb.CompactionJobInfo</allowedImport>
-                    <allowedImport>org.rocksdb.CompressionType</allowedImport>
-                    <allowedImport>org.rocksdb.DBOptions</allowedImport>
-                    <allowedImport>org.rocksdb.FlushOptions</allowedImport>
-                    <allowedImport>org.rocksdb.LiveFileMetaData</allowedImport>
-                    <allowedImport>org.rocksdb.Options</allowedImport>
-                    <allowedImport>org.rocksdb.RocksDB</allowedImport>
-                    <allowedImport>org.rocksdb.RocksDBException</allowedImport>
-                    <allowedImport>org.rocksdb.SstFileReader</allowedImport>
-                    <allowedImport>org.rocksdb.TableProperties</allowedImport>
-                    <allowedImport>org.rocksdb.ReadOptions</allowedImport>
-                    <allowedImport>org.rocksdb.SstFileReaderIterator</allowedImport>
-                  </allowedImports>
-                  <exclusion>org.apache.hadoop.hdds.utils.db.managed.*</exclusion>
-                </RestrictImports>
-              </rules>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.CompactionLogEntryProto;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.Scheduler;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
@@ -55,12 +56,9 @@ import org.apache.ozone.graph.PrintableGraph.GraphType;
 import org.rocksdb.AbstractEventListener;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.CompactionJobInfo;
-import org.rocksdb.DBOptions;
 import org.rocksdb.LiveFileMetaData;
-import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
-import org.rocksdb.SstFileReader;
 import org.rocksdb.TableProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -177,7 +175,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
   private AtomicBoolean suspended;
 
   private ColumnFamilyHandle compactionLogTableCFHandle;
-  private RocksDB activeRocksDB;
+  private ManagedRocksDB activeRocksDB;
 
   /**
    * For snapshot diff calculation we only need to track following column
@@ -349,32 +347,11 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     DEBUG_LEVEL.add(level);
   }
 
-  /**
-   * Takes {@link org.rocksdb.Options}.
-   */
-  public void setRocksDBForCompactionTracking(Options rocksOptions,
-      List<AbstractEventListener> list) {
-    list.add(newCompactionBeginListener());
-    list.add(newCompactionCompletedListener());
-    rocksOptions.setListeners(list);
-  }
-
-  public void setRocksDBForCompactionTracking(Options rocksOptions) {
-    setRocksDBForCompactionTracking(rocksOptions, new ArrayList<>());
-  }
-
-  /**
-   * Takes {@link org.rocksdb.DBOptions}.
-   */
-  public void setRocksDBForCompactionTracking(DBOptions rocksOptions,
-      List<AbstractEventListener> list) {
-    list.add(newCompactionBeginListener());
-    list.add(newCompactionCompletedListener());
-    rocksOptions.setListeners(list);
-  }
-
-  public void setRocksDBForCompactionTracking(DBOptions rocksOptions) {
-    setRocksDBForCompactionTracking(rocksOptions, new ArrayList<>());
+  public void setRocksDBForCompactionTracking(ManagedDBOptions rocksOptions) {
+    List<AbstractEventListener> events = new ArrayList<>();
+    events.add(newCompactionBeginListener());
+    events.add(newCompactionCompletedListener());
+    rocksOptions.setListeners(events);
   }
 
   /**
@@ -403,7 +380,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
    * Set activeRocksDB to access CompactionLogTable.
    * @param activeRocksDB RocksDB
    */
-  public synchronized void setActiveRocksDB(RocksDB activeRocksDB) {
+  public synchronized void setActiveRocksDB(ManagedRocksDB activeRocksDB) {
     Preconditions.checkNotNull(activeRocksDB, "RocksDB should not be null.");
     this.activeRocksDB = activeRocksDB;
   }
@@ -436,8 +413,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     // Note the goal of compaction DAG is to track all compactions that happened
     // _after_ a DB checkpoint is taken.
 
-    try (ManagedRocksIterator it = ManagedRocksIterator.managed(
-        db.newIterator(snapshotInfoTableCFHandle))) {
+    try (ManagedRocksIterator it = ManagedRocksIterator.managed(db.newIterator(snapshotInfoTableCFHandle))) {
       it.get().seekToFirst();
       return !it.get().isValid();
     }
@@ -498,7 +474,6 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
       }
     };
   }
-
 
   private AbstractEventListener newCompactionCompletedListener() {
     return new AbstractEventListener() {
@@ -577,7 +552,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     byte[] key = keyString.getBytes(UTF_8);
     byte[] value = compactionLogEntry.getProtobuf().toByteArray();
     try {
-      activeRocksDB.put(compactionLogTableCFHandle, key, value);
+      activeRocksDB.get().put(compactionLogTableCFHandle, key, value);
     } catch (RocksDBException exception) {
       // TODO: Revisit exception handling before merging the PR.
       throw new RuntimeException(exception);
@@ -631,11 +606,11 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     }
 
     try (ManagedOptions option = new ManagedOptions();
-         ManagedSstFileReader reader = ManagedSstFileReader.managed(new SstFileReader(option))) {
+         ManagedSstFileReader reader = new ManagedSstFileReader(option)) {
 
-      reader.get().open(getAbsoluteSstFilePath(filename));
+      reader.open(getAbsoluteSstFilePath(filename));
 
-      TableProperties properties = reader.get().getTableProperties();
+      TableProperties properties = reader.getTableProperties();
       if (LOG.isDebugEnabled()) {
         LOG.debug("{} has {} keys", filename, properties.getNumEntries());
       }
@@ -801,7 +776,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
       preconditionChecksForLoadAllCompactionLogs();
       addEntriesFromLogFilesToDagAndCompactionLogTable();
       try (ManagedRocksIterator managedRocksIterator = new ManagedRocksIterator(
-          activeRocksDB.newIterator(compactionLogTableCFHandle))) {
+          activeRocksDB.get().newIterator(compactionLogTableCFHandle))) {
         managedRocksIterator.get().seekToFirst();
         while (managedRocksIterator.get().isValid()) {
           byte[] value = managedRocksIterator.get().value();
@@ -1252,7 +1227,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     List<byte[]> keysToRemove = new ArrayList<>();
 
     try (ManagedRocksIterator managedRocksIterator = new ManagedRocksIterator(
-        activeRocksDB.newIterator(compactionLogTableCFHandle))) {
+        activeRocksDB.get().newIterator(compactionLogTableCFHandle))) {
       managedRocksIterator.get().seekToFirst();
       while (managedRocksIterator.get().isValid()) {
         CompactionLogEntry compactionLogEntry = CompactionLogEntry
@@ -1282,7 +1257,7 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
       List<byte[]> keysToRemove) {
     try {
       for (byte[] key: keysToRemove) {
-        activeRocksDB.delete(compactionLogTableCFHandle, key);
+        activeRocksDB.get().delete(compactionLogTableCFHandle, key);
       }
     } catch (RocksDBException exception) {
       // TODO Handle exception properly before merging the PR.
@@ -1575,11 +1550,11 @@ public class RocksDBCheckpointDiffer implements AutoCloseable,
     CompactionFileInfo.Builder fileInfoBuilder =
         new CompactionFileInfo.Builder(fileName);
 
-    try (ManagedSstFileReader fileReader = ManagedSstFileReader.managed(new SstFileReader(options))) {
-      fileReader.get().open(sstFile);
-      String columnFamily = StringUtils.bytes2String(fileReader.get().getTableProperties().getColumnFamilyName());
+    try (ManagedSstFileReader fileReader = new ManagedSstFileReader(options)) {
+      fileReader.open(sstFile);
+      String columnFamily = StringUtils.bytes2String(fileReader.getTableProperties().getColumnFamilyName());
       try (ManagedSstFileReaderIterator iterator =
-               ManagedSstFileReaderIterator.managed(fileReader.get().newIterator(readOptions))) {
+               ManagedSstFileReaderIterator.managed(fileReader.newIterator(readOptions))) {
         iterator.get().seekToFirst();
         String startKey = StringUtils.bytes2String(iterator.get().key());
         iterator.get().seekToLast();

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/rocksdiff/RocksDiffUtils.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedReadOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedSstFileReader;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedSstFileReaderIterator;
-import org.rocksdb.SstFileReader;
 import org.rocksdb.TableProperties;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
@@ -90,9 +89,9 @@ public final class RocksDiffUtils {
 
     try (
         ManagedOptions options = new ManagedOptions();
-        ManagedSstFileReader sstFileReader = ManagedSstFileReader.managed(new SstFileReader(options))) {
-      sstFileReader.get().open(filepath);
-      TableProperties properties = sstFileReader.get().getTableProperties();
+        ManagedSstFileReader sstFileReader = new ManagedSstFileReader(options)) {
+      sstFileReader.open(filepath);
+      TableProperties properties = sstFileReader.getTableProperties();
       String tableName = new String(properties.getColumnFamilyName(), UTF_8);
       if (tableToPrefixMap.containsKey(tableName)) {
         String prefix = tableToPrefixMap.get(tableName);
@@ -100,7 +99,7 @@ public final class RocksDiffUtils {
         try (
             ManagedReadOptions readOptions = new ManagedReadOptions();
             ManagedSstFileReaderIterator iterator = ManagedSstFileReaderIterator.managed(
-                sstFileReader.get().newIterator(readOptions))) {
+                sstFileReader.newIterator(readOptions))) {
           iterator.get().seek(prefix.getBytes(UTF_8));
           String seekResultKey = new String(iterator.get().key(), UTF_8);
           return seekResultKey.startsWith(prefix);

--- a/pom.xml
+++ b/pom.xml
@@ -1440,6 +1440,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                       <allowedImport>org.rocksdb.OptionsUtil</allowedImport>
                       <allowedImport>org.rocksdb.RocksDBException</allowedImport>
                       <allowedImport>org.rocksdb.StatsLevel</allowedImport>
+                      <allowedImport>org.rocksdb.TableProperties</allowedImport>
                       <allowedImport>org.rocksdb.TransactionLogIterator.BatchResult</allowedImport>
                       <allowedImport>org.rocksdb.TickerType</allowedImport>
                       <allowedImport>org.rocksdb.LiveFileMetaData</allowedImport>
@@ -1452,7 +1453,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                       <!-- Allow RocksDB constants and static methods to be used. -->
                       <allowedImport>org.rocksdb.RocksDB.*</allowedImport>
                     </allowedImports>
-                    <exclusion>org.apache.hadoop.hdds.utils.db.managed.*</exclusion>
+                    <exclusions>
+                      <exclusion>org.apache.hadoop.hdds.utils.db.managed.*</exclusion>
+                      <exclusion>org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer</exclusion>
+                    </exclusions>
                   </RestrictImports>
                 </rules>
               </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?
`rocksdb-checkpoint-differ` package is directly using `RocksObject` which causes a leak if not closed properly e.g. HDDS-10783, HDDS-10001. 
This change is to address RocksObject leak issue as described in HDDS-10008 and HDDS-10787.
* Use `ManagedObject` everywhere in `rocksdb-checkpoint-differ` except the CompactionListener.
* Remove the import restriction override from pom.xml of `rocksdb-checkpoint-differ`
* Update root's pom.xml to allow RocksDB only in `RocksDBCheckpointDiffer`.

## What is the link to the Apache JIRA
HDDS-10787, HDDS-10008

## How was this patch tested?
No functional change so relying on exiting unit tests.