### PR TITLE
HDDS-10798. OMLeaderNotReadyException exception on switch leader

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -187,7 +187,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     // notifiedTermIndex), then can update directly to lastNotifiedTermIndex as it ensure previous double buffer's
     // Index is notified or getting notified matching lastSkippedIndex
     if (newTermIndex.getIndex() < getLastNotifiedTermIndex().getIndex()
-        && lastApplied.getIndex() >= lastSkippedIndex) {
+        && newTermIndex.getIndex() >= lastSkippedIndex) {
       newTermIndex = getLastNotifiedTermIndex();
     }
     return super.updateLastAppliedTermIndex(newTermIndex);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -130,6 +130,26 @@ public class TestOzoneManagerStateMachine {
   }
 
   @Test
+  public void testNotifyTermIndexPendingBufferUpdateIndex() {
+    ozoneManagerStateMachine.notifyTermIndexUpdated(0, 0);
+    assertTermIndex(0, 0, ozoneManagerStateMachine.getLastAppliedTermIndex());
+    assertTermIndex(0, 0, ozoneManagerStateMachine.getLastNotifiedTermIndex());
+
+    // notifyTermIndex with skipping one of transaction which is from applyTransaction
+    ozoneManagerStateMachine.notifyTermIndexUpdated(0, 2);
+    ozoneManagerStateMachine.notifyTermIndexUpdated(0, 3);
+    assertTermIndex(0, 0, ozoneManagerStateMachine.getLastAppliedTermIndex());
+    assertTermIndex(0, 3, ozoneManagerStateMachine.getLastNotifiedTermIndex());
+
+    // applyTransaction update with missing transaction as above
+    ozoneManagerStateMachine.updateLastAppliedTermIndex(TermIndex.valueOf(0, 1));
+    assertTermIndex(0, 3, ozoneManagerStateMachine.getLastAppliedTermIndex());
+
+    assertTermIndex(0, 3, ozoneManagerStateMachine.getLastAppliedTermIndex());
+    assertTermIndex(0, 3, ozoneManagerStateMachine.getLastNotifiedTermIndex());
+  }
+
+  @Test
   public void testPreAppendTransaction() throws Exception {
     // Submit write request.
     KeyArgs args = KeyArgs


### PR DESCRIPTION
## What changes were proposed in this pull request?

when ratis index is updated from doubleBuffer to OM StateMachine, its not updating the lastNotifiedTransaction as due to error in check `lastApplied.getIndex() >= lastSkippedIndex` fails, This is fixed using `newTermIndex.getIndex() >= lastSkippedIndex`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10798

## How was this patch tested?

- Unit Test added for the scenario
