### PR TITLE
HDDS-10780. NullPointerException in watchForCommit

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -149,7 +149,8 @@ public final class XceiverClientRatis extends XceiverClientSpi {
     } else {
       stream = commitInfoProtos.stream().map(proto -> commitInfoMap
           .computeIfPresent(RatisHelper.toDatanodeId(proto.getServer()),
-              (address, index) -> proto.getCommitIndex()));
+              (address, index) -> proto.getCommitIndex()))
+          .filter(Objects::nonNull);
     }
     return stream.mapToLong(Long::longValue).min().orElse(0);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
See [HDDS-10780](https://issues.apache.org/jira/browse/HDDS-10780).

We have NPE for the following scenarios. Let's say a pipeline `p1` with dn1, dn2 and dn3.

Some chunks are written to `p1` -> flush 1 -> watchCommit 1 timed out because dn3 hasn't caught up to the latest index. -> dn3 is [removed](https://github.com/apache/ozone/blob/master/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java#L303-L303) from `commitInfoMap`.

Some other chunks are written to ratis -> flush 2 -> watchCommit 2  -> latest index has been committed to all dn1, dn2 and dn3 -> NPE because dn3 has been removed from `commitInfoMap`. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10780

## How was this patch tested?

CI.