### PR TITLE
HDDS-10802. Improve logging for signature verification

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -441,7 +441,7 @@ public class OzoneDelegationTokenSecretManager
       signerCert = getCertClient().getCertificate(
           identifier.getOmCertSerialId());
     } catch (CertificateException e) {
-      LOG.error("getCertificate with identifier {} failed", identifier, e);
+      LOG.error("getCertificate failed for serialId {}", identifier.getOmCertSerialId(), e);
       return false;
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -446,7 +446,7 @@ public class OzoneDelegationTokenSecretManager
     }
 
     if (signerCert == null) {
-      LOG.error("signerCert is null");
+      LOG.error("signerCert is null for serialId {}", identifier.getOmCertSerialId());
       return false;
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -441,10 +441,12 @@ public class OzoneDelegationTokenSecretManager
       signerCert = getCertClient().getCertificate(
           identifier.getOmCertSerialId());
     } catch (CertificateException e) {
+      LOG.error("getCertificate with identifier {} failed", identifier, e);
       return false;
     }
 
     if (signerCert == null) {
+      LOG.error("signerCert is null");
       return false;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When one encounters a 'Tampered/Invalid token' exception, it may occur due to 
OzoneDelegationTokenSecretManager#verifySignature failing in any one of the following scenarios:

1. Failure when obtaining the signer's certificate (CertificateClient#getCertificate call).
2. In case the signer's certificate returned from this code is simply null.
3. In case of an expired certificate or a certificate not yet valid.
4. Failure during CertificateClient#verifySignature (with the signer's certificate).

Related code snippet [link](https://github.com/apache/ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java#L437-L466).
While we are already logging an error for the latter two cases, this patch introduces additional logging for the former two cases.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10802

## How was this patch tested?

Trivial logging change.
