### PR TITLE
HDDS-10803. HttpServer fails to start with wildcard principal

### DIFF
--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -163,6 +163,14 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerb-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
     </dependency>

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -115,7 +115,7 @@ OZONE-SITE.XML_ozone.s3g.http.auth.kerberos.keytab=/etc/security/keytabs/s3g.key
 OZONE-SITE.XML_ozone.s3g.http.auth.kerberos.principal=HTTP/s3g@EXAMPLE.COM
 OZONE-SITE.XML_ozone.httpfs.http.auth.kerberos.keytab=/etc/security/keytabs/httpfs.keytab
 OZONE-SITE.XML_ozone.httpfs.http.auth.kerberos.principal=HTTP/httpfs@EXAMPLE.COM
-OZONE-SITE.XML_ozone.recon.http.auth.kerberos.principal=HTTP/recon@EXAMPLE.COM
+OZONE-SITE.XML_ozone.recon.http.auth.kerberos.principal=*
 OZONE-SITE.XML_ozone.recon.http.auth.kerberos.keytab=/etc/security/keytabs/recon.keytab
 
 CORE-SITE.XML_hadoop.http.authentication.simple.anonymous.allowed=false

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -157,7 +157,10 @@ share/ozone/lib/json-simple.jar
 share/ozone/lib/jsp-api.jar
 share/ozone/lib/jsr311-api.jar
 share/ozone/lib/kerb-core.jar
+share/ozone/lib/kerb-crypto.jar
+share/ozone/lib/kerb-util.jar
 share/ozone/lib/kerby-asn1.jar
+share/ozone/lib/kerby-config.jar
 share/ozone/lib/kerby-pkix.jar
 share/ozone/lib/kerby-util.jar
 share/ozone/lib/kotlin-stdlib-common.jar

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <disruptor.version>3.4.4</disruptor.version>
     <reload4j.version>1.2.25</reload4j.version>
 
+    <kerby.version>1.0.1</kerby.version>
     <kotlin.version>1.9.22</kotlin.version>
     <metainf-services.version>1.11</metainf-services.version>
     <picocli.version>4.7.5</picocli.version>
@@ -450,6 +451,16 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore-nio</artifactId>
         <version>${httpcore.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-core</artifactId>
+        <version>${kerby.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-util</artifactId>
+        <version>${kerby.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix:

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/kerby/kerberos/kerb/keytab/Keytab
  at org.apache.hadoop.security.authentication.util.KerberosUtil.getPrincipalNames(KerberosUtil.java:238)
  at org.apache.hadoop.security.authentication.util.KerberosUtil.getPrincipalNames(KerberosUtil.java:257)
  at org.apache.hadoop.security.authentication.server.KerberosAuthenticationHandler.init(KerberosAuthenticationHandler.java:163)
  at org.apache.hadoop.security.authentication.server.AuthenticationFilter.initializeAuthHandler(AuthenticationFilter.java:194)
  at org.apache.hadoop.security.authentication.server.AuthenticationFilter.init(AuthenticationFilter.java:180)
  ...
  at org.apache.hadoop.hdds.server.http.HttpServer2.start(HttpServer2.java:1184)
  at org.apache.hadoop.hdds.server.http.BaseHttpServer.start(BaseHttpServer.java:322)
```

Hadoop's `KerberosUtil` requires `kerb-util` to be on the classpath to use `Keytab`.  However, this code path is hit only in specific cases.  One of these is when HTTP principal is set to wildcard (`*`).

Similarly, `kerb-core` may be required for using `PrincipalName`.

https://issues.apache.org/jira/browse/HDDS-10803

## How was this patch tested?

The patch changes Recon's HTTP principal in `ozonesecure` acceptance test environment to `*` to have coverage for this case.

Also verified `kerb-util` is on the classpath (logged in `STARTUP_MSG`).

CI:
https://github.com/adoroszlai/ozone/actions/runs/8943525426/job/24569000209
https://github.com/adoroszlai/ozone/actions/runs/8943794693 (with dependency check fixed)