### PR TITLE
HDDS-10813. Improve Recon Debuggability for Snapshot Fetching, Sync Monitoring, and Permission Validation.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -36,7 +36,8 @@ public final class ReconConfigKeys {
 
   public static final String OZONE_RECON_DB_DIRS_PERMISSIONS =
       "ozone.recon.db.dirs.permissions";
-
+  public static final String OZONE_RECON_DB_DIRS_PERMISSIONS_DEFAULT =
+      "750";
   public static final String OZONE_RECON_DATANODE_ADDRESS_KEY =
       "ozone.recon.datanode.address";
   public static final String OZONE_RECON_ADDRESS_KEY =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -415,6 +415,32 @@ public class ReconUtils {
   }
 
   /**
+   * Converts Unix numeric permissions into a symbolic representation.
+   * @param numericPermissions The numeric string, e.g., "750".
+   * @return The symbolic representation, e.g., "rwxr-x---".
+   */
+  public static String convertNumericToSymbolic(String numericPermissions) {
+    int owner = Character.getNumericValue(numericPermissions.charAt(0));
+    int group = Character.getNumericValue(numericPermissions.charAt(1));
+    int others = Character.getNumericValue(numericPermissions.charAt(2));
+
+    return String.format("%s%s%s",
+        convertToSymbolicPermission(owner),
+        convertToSymbolicPermission(group),
+        convertToSymbolicPermission(others));
+  }
+
+  /**
+   * Converts a single digit Unix permission into a symbolic representation.
+   * @param permission The permission digit.
+   * @return The symbolic representation for the digit.
+   */
+  public static String convertToSymbolicPermission(int permission) {
+    String[] symbols = {"---", "--x", "-w-", "-wx", "r--", "r-x", "rw-", "rwx"};
+    return symbols[permission];
+  }
+
+  /**
    * Sorts a list of DiskUsage objects in descending order by size using parallel sorting and
    * returns the top N records as specified by the limit.
    *

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -414,4 +414,31 @@ public class ReconUtils {
         HddsServerUtil.getReconDataNodeBindAddress(conf));
     return builder.build();
   }
+
+  /**
+   * Converts Unix numeric permissions into a symbolic representation.
+   * @param numericPermissions The numeric string, e.g., "750".
+   * @return The symbolic representation, e.g., "rwxr-x---".
+   */
+  public static String convertNumericToSymbolic(String numericPermissions) {
+    int owner = Character.getNumericValue(numericPermissions.charAt(0));
+    int group = Character.getNumericValue(numericPermissions.charAt(1));
+    int others = Character.getNumericValue(numericPermissions.charAt(2));
+
+    return String.format("%s%s%s",
+        convertToSymbolicPermission(owner),
+        convertToSymbolicPermission(group),
+        convertToSymbolicPermission(others));
+  }
+
+  /**
+   * Converts a single digit Unix permission into a symbolic representation.
+   * @param permission The permission digit.
+   * @return The symbolic representation for the digit.
+   */
+  public static String convertToSymbolicPermission(int permission) {
+    String[] symbols = {"---", "--x", "-w-", "-wx", "r--", "r-x", "rw-", "rwx"};
+    return symbols[permission];
+  }
+
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -617,7 +617,7 @@ public class OzoneManagerServiceProviderImpl
         isSyncDataFromOMRunning.set(false);
       }
     } else {
-      LOG.debug("OM DB sync is already running.");
+      LOG.info("OM DB sync is already running.");
       return false;
     }
     return true;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestTriggerDBSyncEndpoint.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.recon.MetricsServiceProviderFactory;
+import org.apache.hadoop.ozone.recon.ReconContext;
 import org.apache.hadoop.ozone.recon.ReconTestInjector;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.common.CommonUtils;
@@ -121,7 +122,7 @@ public class TestTriggerDBSyncEndpoint {
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new OzoneManagerServiceProviderImpl(configuration,
             reconOMMetadataManager, reconTaskController, reconUtilsMock,
-            ozoneManagerProtocol);
+            ozoneManagerProtocol, new ReconContext(configuration, reconUtilsMock));
     ozoneManagerServiceProvider.start();
 
     reconTestInjector =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -66,6 +66,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.recon.ReconContext;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.common.CommonUtils;
 import org.apache.hadoop.ozone.recon.metrics.OzoneManagerSyncMetrics;
@@ -91,6 +92,7 @@ public class TestOzoneManagerServiceProviderImpl {
   private OzoneConfiguration configuration;
   private OzoneManagerProtocol ozoneManagerProtocol;
   private CommonUtils commonUtils;
+  private ReconContext reconContext;
 
   @BeforeEach
   public void setUp(@TempDir File dirReconSnapDB, @TempDir File dirReconDB)
@@ -103,6 +105,7 @@ public class TestOzoneManagerServiceProviderImpl {
     configuration.set("ozone.om.address", "localhost:9862");
     ozoneManagerProtocol = getMockOzoneManagerClient(new DBUpdates());
     commonUtils = new CommonUtils();
+    reconContext = new ReconContext(configuration, new ReconUtils());
   }
 
   @Test
@@ -136,7 +139,7 @@ public class TestOzoneManagerServiceProviderImpl {
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new OzoneManagerServiceProviderImpl(configuration,
             reconOMMetadataManager, reconTaskController, reconUtilsMock,
-            ozoneManagerProtocol);
+            ozoneManagerProtocol, reconContext);
 
     assertNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_one"));
@@ -144,6 +147,81 @@ public class TestOzoneManagerServiceProviderImpl {
         .get("/sampleVol/bucketOne/key_two"));
 
     assertTrue(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
+
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+        .get("/sampleVol/bucketOne/key_one"));
+    assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
+        .get("/sampleVol/bucketOne/key_two"));
+
+    // Verifying if context error GET_OM_DB_SNAPSHOT_FAILED is removed
+    assertFalse(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
+  }
+
+  @Test
+  public void testUpdateReconOmDBWithNewSnapshotFailure(
+      @TempDir File dirOmMetadata, @TempDir File dirReconMetadata)
+      throws Exception {
+
+    OMMetadataManager omMetadataManager =
+        initializeNewOmMetadataManager(dirOmMetadata);
+    ReconOMMetadataManager reconOMMetadataManager =
+        getTestReconOmMetadataManager(omMetadataManager,
+            dirReconMetadata);
+
+    ReconUtils reconUtilsMock = getMockReconUtils();
+    HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
+    when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
+        .thenThrow(new IOException("Mocked IOException"));
+    when(reconUtilsMock.getReconNodeDetails(
+        any(OzoneConfiguration.class))).thenReturn(
+        commonUtils.getReconNodeDetails());
+    ReconTaskController reconTaskController = getMockTaskController();
+
+    OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
+        new OzoneManagerServiceProviderImpl(configuration,
+            reconOMMetadataManager, reconTaskController, reconUtilsMock,
+            ozoneManagerProtocol, reconContext);
+
+    assertFalse(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
+
+    // Verifying if context error GET_OM_DB_SNAPSHOT_FAILED is added
+    assertTrue(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
+  }
+
+  @Test
+  public void testUpdateReconOmDBWithNewSnapshotSuccess(
+      @TempDir File dirOmMetadata, @TempDir File dirReconMetadata) throws Exception {
+
+    OMMetadataManager omMetadataManager =
+        initializeNewOmMetadataManager(dirOmMetadata);
+    ReconOMMetadataManager reconOMMetadataManager =
+        getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata);
+
+    writeDataToOm(omMetadataManager, "key_one");
+    writeDataToOm(omMetadataManager, "key_two");
+
+    DBCheckpoint checkpoint = omMetadataManager.getStore().getCheckpoint(true);
+    File tarFile = createTarFile(checkpoint.getCheckpointLocation());
+    InputStream inputStream = new FileInputStream(tarFile);
+    ReconUtils reconUtilsMock = getMockReconUtils();
+    HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
+    when(httpURLConnectionMock.getInputStream()).thenReturn(inputStream);
+    when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
+        .thenReturn(httpURLConnectionMock);
+    when(reconUtilsMock.getReconNodeDetails(any(OzoneConfiguration.class)))
+        .thenReturn(commonUtils.getReconNodeDetails());
+    ReconTaskController reconTaskController = getMockTaskController();
+
+    reconContext.updateErrors(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED);
+
+    OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
+        new OzoneManagerServiceProviderImpl(configuration,
+            reconOMMetadataManager, reconTaskController, reconUtilsMock,
+            ozoneManagerProtocol, reconContext);
+
+    assertTrue(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
+    assertTrue(ozoneManagerServiceProvider.updateReconOmDBWithNewSnapshot());
+    assertFalse(reconContext.getErrors().contains(ReconContext.ErrorCode.GET_OM_DB_SNAPSHOT_FAILED));
 
     assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_one"));
@@ -182,7 +260,7 @@ public class TestOzoneManagerServiceProviderImpl {
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider1 =
         new OzoneManagerServiceProviderImpl(configuration,
             reconOMMetadataManager, reconTaskController, reconUtilsMock,
-            ozoneManagerProtocol);
+            ozoneManagerProtocol, reconContext);
     assertTrue(ozoneManagerServiceProvider1.updateReconOmDBWithNewSnapshot());
 
     HttpURLConnection httpURLConnectionMock2 = mock(HttpURLConnection.class);
@@ -192,7 +270,7 @@ public class TestOzoneManagerServiceProviderImpl {
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider2 =
         new OzoneManagerServiceProviderImpl(configuration,
             reconOMMetadataManager, reconTaskController, reconUtilsMock,
-            ozoneManagerProtocol);
+            ozoneManagerProtocol, reconContext);
     assertTrue(ozoneManagerServiceProvider2.updateReconOmDBWithNewSnapshot());
   }
 
@@ -238,7 +316,7 @@ public class TestOzoneManagerServiceProviderImpl {
       OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
           new OzoneManagerServiceProviderImpl(configuration,
               reconOMMetadataManager, reconTaskController, reconUtilsMock,
-              ozoneManagerProtocol);
+              ozoneManagerProtocol, reconContext);
 
       DBCheckpoint checkpoint = ozoneManagerServiceProvider
           .getOzoneManagerDBSnapshot();
@@ -288,7 +366,7 @@ public class TestOzoneManagerServiceProviderImpl {
         new OzoneManagerServiceProviderImpl(configuration,
             getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata),
             getMockTaskController(), new ReconUtils(),
-            getMockOzoneManagerClient(dbUpdatesWrapper));
+            getMockOzoneManagerClient(dbUpdatesWrapper), reconContext);
 
     OMDBUpdatesHandler updatesHandler =
         new OMDBUpdatesHandler(omMetadataManager);
@@ -358,7 +436,7 @@ public class TestOzoneManagerServiceProviderImpl {
             getTestReconOmMetadataManager(omMetadataManager, dirReconMetadata),
             getMockTaskController(), new ReconUtils(),
             getMockOzoneManagerClientWith4Updates(dbUpdatesWrapper[0],
-                dbUpdatesWrapper[1], dbUpdatesWrapper[2], dbUpdatesWrapper[3]));
+                dbUpdatesWrapper[1], dbUpdatesWrapper[2], dbUpdatesWrapper[3]), reconContext);
 
     assertTrue(dbUpdatesWrapper[0].isDBUpdateSuccess());
     assertTrue(dbUpdatesWrapper[1].isDBUpdateSuccess());
@@ -414,7 +492,7 @@ public class TestOzoneManagerServiceProviderImpl {
 
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new MockOzoneServiceProvider(configuration, omMetadataManager,
-            reconTaskControllerMock, new ReconUtils(), ozoneManagerProtocol);
+            reconTaskControllerMock, new ReconUtils(), ozoneManagerProtocol, reconContext);
 
     OzoneManagerSyncMetrics metrics = ozoneManagerServiceProvider.getMetrics();
     assertEquals(0, metrics.getNumSnapshotRequests());
@@ -454,7 +532,7 @@ public class TestOzoneManagerServiceProviderImpl {
 
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new OzoneManagerServiceProviderImpl(configuration, omMetadataManager,
-            reconTaskControllerMock, new ReconUtils(), ozoneManagerProtocol);
+            reconTaskControllerMock, new ReconUtils(), ozoneManagerProtocol, reconContext);
 
     OzoneManagerSyncMetrics metrics = ozoneManagerServiceProvider.getMetrics();
 
@@ -495,7 +573,7 @@ public class TestOzoneManagerServiceProviderImpl {
     OzoneManagerProtocol protocol = getMockOzoneManagerClientWithThrow();
     OzoneManagerServiceProviderImpl ozoneManagerServiceProvider =
         new MockOzoneServiceProvider(configuration, omMetadataManager,
-            reconTaskControllerMock, new ReconUtils(), protocol);
+            reconTaskControllerMock, new ReconUtils(), protocol, reconContext);
 
     OzoneManagerSyncMetrics metrics = ozoneManagerServiceProvider.getMetrics();
 
@@ -569,9 +647,10 @@ class MockOzoneServiceProvider extends OzoneManagerServiceProviderImpl {
                            ReconOMMetadataManager omMetadataManager,
                            ReconTaskController reconTaskController,
                            ReconUtils reconUtils,
-                           OzoneManagerProtocol ozoneManagerClient) {
+                           OzoneManagerProtocol ozoneManagerClient,
+                           ReconContext reconContext) {
     super(configuration, omMetadataManager, reconTaskController, reconUtils,
-        ozoneManagerClient);
+        ozoneManagerClient, reconContext);
   }
 
   @Override

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestOzoneManagerServiceProviderImpl.java
@@ -169,7 +169,7 @@ public class TestOzoneManagerServiceProviderImpl {
             dirReconMetadata);
 
     ReconUtils reconUtilsMock = getMockReconUtils();
-    HttpURLConnection httpURLConnectionMock = mock(HttpURLConnection.class);
+
     when(reconUtilsMock.makeHttpCall(any(), anyString(), anyBoolean()))
         .thenThrow(new IOException("Mocked IOException"));
     when(reconUtilsMock.getReconNodeDetails(


### PR DESCRIPTION
## What changes were proposed in this pull request?
**_Changes in this patch include the following :-_** 
### **Enhanced Logging for OM Snapshot Fetching**
We included checks for the presence of SST files, logging a warning if the snapshot is empty or lacks SST files, which could indicate issues such as OM leader instability or snapshot corruption.

### **Logging Last Sequence Number on Periodic Syncs**
The synchronization process between Recon and the OM database now includes logging of the last sequence number before and after each sync. 

### **Permission Checks for Recon DB Directories**
We implemented a method to validate the permissions of the Recon DB directories against the expected configuration settings. The method logs a warning if the actual permissions do not match the expected permissions, enhancing operational awareness.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10813
## How was this patch tested?

Manually Tested out the logs. The required log messages get printed :- 

1. Logging for SST Files Availability on Full DB Fetch: 
```
2024-05-06 02:13:03 2024-05-05 20:43:03,285 [Recon-SyncOM-0] INFO impl.OzoneManagerServiceProviderImpl: Valid OM snapshot with SST files found at: /data/metadata/om.snapshot.db_1714941781590
```
2. Printing the Sequence Number Before and After Sync: 
```
2024-05-06 02:13:01 2024-05-05 20:43:01,587 [Recon-SyncOM-0] INFO impl.OzoneManagerServiceProviderImpl: Last known sequence number before sync: 0
.....
2024-05-06 02:13:03 2024-05-05 20:43:03,620 [Recon-SyncOM-0] INFO impl.OzoneManagerServiceProviderImpl: Sequence number after sync: 2
```
3. Recon Data Directory Permissions:
```
2024-05-06 02:13:01 2024-05-05 20:43:01,590 [Recon-SyncOM-0] INFO impl.OzoneManagerServiceProviderImpl: Permissions for Recon DB directory '/data/metadata' are correctly set to 'rwxr-x---'
```