### PR TITLE
HDDS-10814. Log addSCM failure as warn, not error

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -335,8 +335,11 @@ public class SCMRatisServerImpl implements SCMRatisServer {
       }
       return raftClientReply.isSuccess();
     } catch (IOException e) {
-      LOG.error("Failed to update Ratis configuration and add new peer. " +
-          "Cannot add new SCM: {}.", scm.getScmId(), e);
+      LOG.warn("Failed to update Ratis configuration and add new peer. " +
+          "Cannot add new SCM: {}. {}", scm.getScmId(), e.getMessage());
+      if (LOG.isDebugEnabled()) {
+        LOG.info("Cannot add new SCM: {}. {}", scm.getScmId(), e);
+      }
       throw e;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -335,7 +335,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     } catch (IOException e) {
       LOG.warn("Failed to update Ratis configuration and add new peer. " +
           "Cannot add new SCM: {}. {}", scm.getScmId(), e.getMessage());
-      LOG.debug("addSCM call failed due to: " + e);
+      LOG.debug("addSCM call failed due to: ", e);
       throw e;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -230,9 +230,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     final RaftClientReply raftClientReply =
         server.submitClientRequestAsync(raftClientRequest)
             .get(requestTimeout, TimeUnit.MILLISECONDS);
-    if (LOG.isDebugEnabled()) {
-      LOG.info("request {} Reply {}", raftClientRequest, raftClientReply);
-    }
+    LOG.debug("request {} Reply {}", raftClientRequest, raftClientReply);
     return SCMRatisResponse.decode(raftClientReply);
   }
 
@@ -337,9 +335,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     } catch (IOException e) {
       LOG.warn("Failed to update Ratis configuration and add new peer. " +
           "Cannot add new SCM: {}. {}", scm.getScmId(), e.getMessage());
-      if (LOG.isDebugEnabled()) {
-        LOG.info("Cannot add new SCM: {}. {}", scm.getScmId(), e);
-      }
+      LOG.debug(String.valueOf(e));
       throw e;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -335,7 +335,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     } catch (IOException e) {
       LOG.warn("Failed to update Ratis configuration and add new peer. " +
           "Cannot add new SCM: {}. {}", scm.getScmId(), e.getMessage());
-      LOG.debug(String.valueOf(e));
+      LOG.debug("addSCM call failed due to: " + e);
       throw e;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Failure in adding scm during setup for SCM-HA is logged with a big stack in scm logs trace even though the addSCM call is successful eventually due to the retry logic.
Log level is reduced to warn. And the stackTrace is printed as a debug log.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10814

## How was this patch tested?

As it is log change, no intensive testing is required. 
