### PR TITLE
[DO NOT MERGE] Backport some fixes from master to ozone-1.4

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -235,10 +235,12 @@ public class SCMBlockDeletingService extends BackgroundService
   public void notifyStatusChanged() {
     serviceLock.lock();
     try {
-      if (scmContext.isLeaderReady() && !scmContext.isInSafeMode() &&
-          serviceStatus != ServiceStatus.RUNNING) {
-        safemodeExitMillis = clock.millis();
-        serviceStatus = ServiceStatus.RUNNING;
+      if (scmContext.isLeaderReady() && !scmContext.isInSafeMode()) {
+        if (serviceStatus != ServiceStatus.RUNNING) {
+          LOG.info("notifyStatusChanged" + ":" + ServiceStatus.RUNNING);
+          safemodeExitMillis = clock.millis();
+          serviceStatus = ServiceStatus.RUNNING;
+        }
       } else {
         serviceStatus = ServiceStatus.PAUSING;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -168,6 +168,7 @@ public class TestBlockDeletion {
         0,
         TimeUnit.MILLISECONDS);
     conf.setInt("hdds.datanode.block.delete.threads.max", 5);
+    conf.setInt("hdds.datanode.block.delete.queue.limit", 32);
     ReplicationManager.ReplicationManagerConfiguration replicationConf = conf
         .getObject(ReplicationManager.ReplicationManagerConfiguration.class);
     replicationConf.setInterval(Duration.ofSeconds(300));
@@ -292,11 +293,6 @@ public class TestBlockDeletion {
     Assertions.assertFalse(containerIdsWithDeletedBlocks.isEmpty());
     // Containers in the DN and SCM should have same delete transactionIds
     matchContainerTransactionIds();
-    // Containers in the DN and SCM should have same delete transactionIds
-    // after DN restart. The assertion is just to verify that the state of
-    // containerInfos in dn and scm is consistent after dn restart.
-    cluster.restartHddsDatanode(0, true);
-    matchContainerTransactionIds();
 
     // Verify transactions committed
     GenericTestUtils.waitFor(() -> {
@@ -308,6 +304,13 @@ public class TestBlockDeletion {
         return false;
       }
     }, 500, 10000);
+
+    // Containers in the DN and SCM should have same delete transactionIds
+    // after DN restart. The assertion is just to verify that the state of
+    // containerInfos in dn and scm is consistent after dn restart.
+    cluster.restartHddsDatanode(0, true);
+    matchContainerTransactionIds();
+
     Assertions.assertEquals(metrics.getNumBlockDeletionTransactionCreated(),
         metrics.getNumBlockDeletionTransactionCompleted());
     Assertions.assertTrue(metrics.getNumBlockDeletionCommandSent() >=


### PR DESCRIPTION


## What changes were proposed in this pull request?
Backport the following fixes from master to ozone-1.4 for 1.4.1:

HDDS-9962. Intermittent timeout in TestBlockDeletion.testBlockDeletion (#5886) - (to fix the problem described in https://issues.apache.org/jira/browse/HDDS-10799)

## How was this patch tested?

https://github.com/vtutrinov/ozone/actions/runs/8967491544
