### PR TITLE
HDDS-10801. Replace GSON with Jackson in hadoop-ozone classes.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.HashMap;
 import java.util.List;
 
@@ -110,6 +111,14 @@ public final class JsonUtils {
         });
   }
 
+  /**
+   * Reads JSON content from a Reader and deserializes it into an array of the
+   * specified type.
+   */
+  public static <T> T[] readArrayFromReader(Reader reader, Class<T[]> valueType)
+      throws IOException {
+    return MAPPER.readValue(reader, valueType);
+  }
 
   /**
    * Utility to sequentially write a large collection of items to a file.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -104,13 +104,6 @@ public final class JsonUtils {
     return MAPPER.readTree(content);
   }
 
-  public static List<HashMap<String, Object>> readTreeAsListOfMaps(String json)
-      throws IOException {
-    return MAPPER.readValue(json,
-        new TypeReference<List<HashMap<String, Object>>>() {
-        });
-  }
-
   /**
    * Reads JSON content from a Reader and deserializes it into an array of the
    * specified type.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -103,11 +103,9 @@ public final class JsonUtils {
   }
 
   /**
-   * Reads JSON content from a Reader and deserializes it into an array of the
-   * specified type.
+   * Reads JSON content from a Reader and deserializes it into a Java object.
    */
-  public static <T> T[] readArrayFromReader(Reader reader, Class<T[]> valueType)
-      throws IOException {
+  public static <T> T readFromReader(Reader reader, Class<T> valueType) throws IOException {
     return MAPPER.readValue(reader, valueType);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -21,12 +21,10 @@ package org.apache.hadoop.hdds.server;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.HashMap;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/JsonTestUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/JsonTestUtils.java
@@ -28,8 +28,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * JSON Utility functions used in ozone for Test classes.
@@ -71,10 +71,10 @@ public final class JsonTestUtils {
     return MAPPER.readTree(content);
   }
 
-  public static List<HashMap<String, Object>> readTreeAsListOfMaps(String json)
+  public static List<Map<String, Object>> readTreeAsListOfMaps(String json)
       throws IOException {
     return MAPPER.readValue(json,
-        new TypeReference<List<HashMap<String, Object>>>() {
+        new TypeReference<List<Map<String, Object>>>() {
         });
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/JsonTestUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/JsonTestUtils.java
@@ -83,31 +83,6 @@ public final class JsonTestUtils {
   }
 
   /**
-   * Utility to sequentially write a large collection of items to a file.
-   */
-  public static <T> void writeToFile(Iterable<T> items, File file)
-      throws IOException {
-    ObjectWriter writer = MAPPER.writer();
-    try (SequenceWriter sequenceWriter = writer.writeValues(file)) {
-      sequenceWriter.init(true);
-      for (T item : items) {
-        sequenceWriter.write(item);
-      }
-    }
-  }
-
-  /**
-   * Utility to sequentially read a large collection of items from a file.
-   */
-  public static <T> List<T> readFromFile(File file, Class<T> itemType)
-      throws IOException {
-    ObjectReader reader = MAPPER.readerFor(itemType);
-    try (MappingIterator<T> mappingIterator = reader.readValues(file)) {
-      return mappingIterator.readAll();
-    }
-  }
-
-  /**
    * Converts a JsonNode into a Java object of the specified type.
    * @param node The JsonNode to convert.
    * @param valueType The target class of the Java object.

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/JsonTestUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/JsonTestUtils.java
@@ -24,13 +24,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.SequenceWriter;
-import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/DeletedBlocksTransactionInfoWrapper.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/DeletedBlocksTransactionInfoWrapper.java
@@ -39,6 +39,13 @@ public class DeletedBlocksTransactionInfoWrapper {
     this.count = count;
   }
 
+  DeletedBlocksTransactionInfoWrapper() {
+    this.txID = 0;
+    this.containerID = 0;
+    this.localIdList = null;
+    this.count = 0;
+  }
+
   public static DeletedBlocksTransactionInfoWrapper fromProtobuf(
       DeletedBlocksTransactionInfo txn) {
     if (txn.hasTxID() && txn.hasContainerID() && txn.hasCount()) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/DeletedBlocksTransactionInfoWrapper.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/DeletedBlocksTransactionInfoWrapper.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hdds.scm.container.common.helpers;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DeletedBlocksTransactionInfo;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import java.util.List;
@@ -31,19 +33,15 @@ public class DeletedBlocksTransactionInfoWrapper {
   private final List<Long> localIdList;
   private final int count;
 
-  public DeletedBlocksTransactionInfoWrapper(long txID, long containerID,
-      List<Long> localIdList, int count) {
+  @JsonCreator
+  public DeletedBlocksTransactionInfoWrapper(@JsonProperty("txID") long txID,
+                                             @JsonProperty("containerID") long containerID,
+                                             @JsonProperty("localIdList") List<Long> localIdList,
+                                             @JsonProperty("count") int count) {
     this.txID = txID;
     this.containerID = containerID;
     this.localIdList = localIdList;
     this.count = count;
-  }
-
-  DeletedBlocksTransactionInfoWrapper() {
-    this.txID = 0;
-    this.containerID = 0;
-    this.localIdList = null;
-    this.count = 0;
   }
 
   public static DeletedBlocksTransactionInfoWrapper fromProtobuf(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -41,13 +41,13 @@ import java.util.Optional;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.hdds.JsonTestUtils;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -384,7 +384,7 @@ public class TestReconWithOzoneManager {
                                              String entityAttribute)
       throws IOException {
     List<HashMap<String, Object>> taskStatusList =
-        JsonUtils.readTreeAsListOfMaps(taskStatusResponse);
+        JsonTestUtils.readTreeAsListOfMaps(taskStatusResponse);
 
     // Stream through the list to find the task entity matching the taskName
     Optional<HashMap<String, Object>> taskEntity = taskStatusList.stream()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -38,7 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.JsonTestUtils;
@@ -383,11 +383,11 @@ public class TestReconWithOzoneManager {
                                              String taskName,
                                              String entityAttribute)
       throws IOException {
-    List<HashMap<String, Object>> taskStatusList =
+    List<Map<String, Object>> taskStatusList =
         JsonTestUtils.readTreeAsListOfMaps(taskStatusResponse);
 
     // Stream through the list to find the task entity matching the taskName
-    Optional<HashMap<String, Object>> taskEntity = taskStatusList.stream()
+    Optional<Map<String, Object>> taskEntity = taskStatusList.stream()
         .filter(task -> taskName.equals(task.get("taskName")))
         .findFirst();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -68,10 +68,9 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.ozone.om.TrashPolicyOzone;
+import org.apache.hadoop.hdds.JsonTestUtils;
 
 import com.google.common.base.Strings;
-import com.google.gson.Gson;
-import com.google.gson.internal.LinkedTreeMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
@@ -409,12 +408,12 @@ public class TestOzoneShellHA {
   }
 
   /**
-   * Parse output into ArrayList with Gson.
+   * Parse output into ArrayList with Jackson.
    * @return ArrayList
    */
-  private ArrayList<LinkedTreeMap<String, String>> parseOutputIntoArrayList()
-      throws UnsupportedEncodingException {
-    return new Gson().fromJson(out.toString(DEFAULT_ENCODING), ArrayList.class);
+  private List<HashMap<String, Object>> parseOutputIntoArrayList() throws IOException {
+    String jsonInput = out.toString(DEFAULT_ENCODING);
+    return JsonTestUtils.readTreeAsListOfMaps(jsonInput);
   }
 
   @Test
@@ -488,7 +487,7 @@ public class TestOzoneShellHA {
    * Test ozone shell list command.
    */
   @Test
-  public void testOzoneShCmdList() throws UnsupportedEncodingException {
+  public void testOzoneShCmdList() throws IOException {
     // Part of listing keys test.
     generateKeys("/volume4", "/bucket", "");
     final String destinationBucket = "o3://" + omServiceId + "/volume4/bucket";
@@ -1671,7 +1670,7 @@ public class TestOzoneShellHA {
   }
 
   public void testListVolumeBucketKeyShouldPrintValidJsonArray()
-      throws UnsupportedEncodingException {
+      throws IOException {
 
     final List<String> testVolumes =
         Arrays.asList("jsontest-vol1", "jsontest-vol2", "jsontest-vol3");
@@ -1696,7 +1695,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"volume", "list"});
 
     // Expect valid JSON array
-    final ArrayList<LinkedTreeMap<String, String>> volumeListOut =
+    final List<HashMap<String, Object>> volumeListOut =
         parseOutputIntoArrayList();
     // Can include s3v and volumes from other test cases that aren't cleaned up,
     //  hence >= instead of equals.
@@ -1711,7 +1710,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", firstVolumePrefix});
 
     // Expect valid JSON array as well
-    final ArrayList<LinkedTreeMap<String, String>> bucketListOut =
+    final List<HashMap<String, Object>> bucketListOut =
         parseOutputIntoArrayList();
     assertEquals(testBuckets.size(), bucketListOut.size());
     final HashSet<String> bucketSet = new HashSet<>(testBuckets);
@@ -1724,7 +1723,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"key", "list", keyPathPrefix});
 
     // Expect valid JSON array as well
-    final ArrayList<LinkedTreeMap<String, String>> keyListOut =
+    final List<HashMap<String, Object>> keyListOut =
         parseOutputIntoArrayList();
     assertEquals(testKeys.size(), keyListOut.size());
     final HashSet<String> keySet = new HashSet<>(testKeys);
@@ -1977,7 +1976,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", "/volume1"});
 
     // Expect valid JSON array
-    final ArrayList<LinkedTreeMap<String, String>> bucketListOut =
+    final List<HashMap<String, Object>> bucketListOut =
         parseOutputIntoArrayList();
 
     assertEquals(1, bucketListOut.size());
@@ -1996,7 +1995,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", "/volume1"});
 
     // Expect valid JSON array
-    final ArrayList<LinkedTreeMap<String, String>> bucketListLinked =
+    final List<HashMap<String, Object>> bucketListLinked =
         parseOutputIntoArrayList();
 
     assertEquals(2, bucketListLinked.size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -411,7 +411,7 @@ public class TestOzoneShellHA {
    * Parse output into ArrayList with Jackson.
    * @return ArrayList
    */
-  private List<HashMap<String, Object>> parseOutputIntoArrayList() throws IOException {
+  private List<Map<String, Object>> parseOutputIntoArrayList() throws IOException {
     String jsonInput = out.toString(DEFAULT_ENCODING);
     return JsonTestUtils.readTreeAsListOfMaps(jsonInput);
   }
@@ -1695,7 +1695,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"volume", "list"});
 
     // Expect valid JSON array
-    final List<HashMap<String, Object>> volumeListOut =
+    final List<Map<String, Object>> volumeListOut =
         parseOutputIntoArrayList();
     // Can include s3v and volumes from other test cases that aren't cleaned up,
     //  hence >= instead of equals.
@@ -1710,7 +1710,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", firstVolumePrefix});
 
     // Expect valid JSON array as well
-    final List<HashMap<String, Object>> bucketListOut =
+    final List<Map<String, Object>> bucketListOut =
         parseOutputIntoArrayList();
     assertEquals(testBuckets.size(), bucketListOut.size());
     final HashSet<String> bucketSet = new HashSet<>(testBuckets);
@@ -1723,7 +1723,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"key", "list", keyPathPrefix});
 
     // Expect valid JSON array as well
-    final List<HashMap<String, Object>> keyListOut =
+    final List<Map<String, Object>> keyListOut =
         parseOutputIntoArrayList();
     assertEquals(testKeys.size(), keyListOut.size());
     final HashSet<String> keySet = new HashSet<>(testKeys);
@@ -1976,7 +1976,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", "/volume1"});
 
     // Expect valid JSON array
-    final List<HashMap<String, Object>> bucketListOut =
+    final List<Map<String, Object>> bucketListOut =
         parseOutputIntoArrayList();
 
     assertEquals(1, bucketListOut.size());
@@ -1995,7 +1995,7 @@ public class TestOzoneShellHA {
     execute(ozoneShell, new String[] {"bucket", "list", "/volume1"});
 
     // Expect valid JSON array
-    final List<HashMap<String, Object>> bucketListLinked =
+    final List<Map<String, Object>> bucketListLinked =
         parseOutputIntoArrayList();
 
     assertEquals(2, bucketListLinked.size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -412,8 +412,7 @@ public class TestOzoneShellHA {
    * @return ArrayList
    */
   private List<Map<String, Object>> parseOutputIntoArrayList() throws IOException {
-    String jsonInput = out.toString(DEFAULT_ENCODING);
-    return JsonTestUtils.readTreeAsListOfMaps(jsonInput);
+    return JsonTestUtils.readTreeAsListOfMaps(out.toString(DEFAULT_ENCODING));
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
@@ -751,12 +751,8 @@ public class TestHeatMapInfo {
     JsonNode resourcesNode = facetsNode.path("resources");
 
     // Deserialize the resources node directly if it's not missing
-    HeatMapProviderDataResource auditLogFacetsResources = null;
-
-//    assumeThat(resourcesNode.isMissingNode()).isFalse();
-
-    auditLogFacetsResources = JsonTestUtils.treeToValue(resourcesNode,
-        HeatMapProviderDataResource.class);
+    HeatMapProviderDataResource auditLogFacetsResources =
+        JsonTestUtils.treeToValue(resourcesNode, HeatMapProviderDataResource.class);
 
     if (auditLogFacetsResources != null) {
       EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
@@ -844,11 +840,8 @@ public class TestHeatMapInfo {
     JsonNode resourcesNode = facetsNode.path("resources");
 
     // Deserialize the resources node directly if it's not missing
-    HeatMapProviderDataResource auditLogFacetsResources = null;
-
-//    assumeThat(resourcesNode.isMissingNode()).isFalse();
-    auditLogFacetsResources = JsonTestUtils.treeToValue(resourcesNode,
-        HeatMapProviderDataResource.class);
+    HeatMapProviderDataResource auditLogFacetsResources =
+        JsonTestUtils.treeToValue(resourcesNode, HeatMapProviderDataResource.class);
 
     if (auditLogFacetsResources != null) {
       EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
@@ -979,7 +972,6 @@ public class TestHeatMapInfo {
     JsonNode resourcesNode = facetsNode.path("resources");
     // Deserialize the resources node directly if it's not missing
     HeatMapProviderDataResource auditLogFacetsResources = null;
-//    assumeThat(resourcesNode.isMissingNode()).isFalse();
     auditLogFacetsResources =
         JsonTestUtils.treeToValue(resourcesNode, HeatMapProviderDataResource.class);
 
@@ -1103,7 +1095,9 @@ public class TestHeatMapInfo {
         //}
         EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
             heatMapUtil.generateHeatMap(entityMetaDataList);
-        assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
+        assertThat(
+            entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(
+            0);
         assertEquals(2,
             entityReadAccessHeatMapResponse.getChildren().size());
         assertEquals(0.0,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/heatmap/TestHeatMapInfo.java
@@ -18,11 +18,10 @@
 
 package org.apache.hadoop.ozone.recon.heatmap;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.hadoop.hdds.JsonTestUtils;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.ozone.recon.ReconTestInjector;
 import org.apache.hadoop.ozone.recon.api.types.EntityMetaData;
 import org.apache.hadoop.ozone.recon.api.types.EntityReadAccessHeatMapResponse;
@@ -745,35 +744,43 @@ public class TestHeatMapInfo {
   public void testHeatMapGeneratedInfo() throws IOException {
     // Setup
     // Run the test
-    JsonElement jsonElement = JsonParser.parseString(auditRespStr);
-    JsonObject jsonObject = jsonElement.getAsJsonObject();
-    JsonElement facets = jsonObject.get("facets");
-    JsonObject facetsBucketsObject =
-        facets.getAsJsonObject().get("resources")
-            .getAsJsonObject();
-    ObjectMapper objectMapper = new ObjectMapper();
+    // Parse the JSON string to JsonNode
+    JsonNode rootNode = JsonUtils.readTree(auditRespStr);
 
-    HeatMapProviderDataResource auditLogFacetsResources =
-        objectMapper.readValue(
-            facetsBucketsObject.toString(), HeatMapProviderDataResource.class);
-    EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
-    List<EntityMetaData> entityMetaDataList =
-        Arrays.stream(entities).collect(Collectors.toList());
-    EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
-        heatMapUtil.generateHeatMap(entityMetaDataList);
-    assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
-    assertEquals(12, entityReadAccessHeatMapResponse.getChildren().size());
-    assertEquals(25600, entityReadAccessHeatMapResponse.getSize());
-    assertEquals(2924, entityReadAccessHeatMapResponse.getMinAccessCount());
-    assertEquals(155074, entityReadAccessHeatMapResponse.getMaxAccessCount());
-    assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
-    assertEquals(0.0, entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
-    assertEquals(0.442,
-        entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
-            .get(0).getChildren().get(1).getColor());
-    assertEquals(0.058,
-        entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
-            .get(1).getChildren().get(3).getColor());
+    JsonNode facetsNode = rootNode.path("facets");
+    JsonNode resourcesNode = facetsNode.path("resources");
+
+    // Deserialize the resources node directly if it's not missing
+    HeatMapProviderDataResource auditLogFacetsResources = null;
+
+//    assumeThat(resourcesNode.isMissingNode()).isFalse();
+
+    auditLogFacetsResources = JsonTestUtils.treeToValue(resourcesNode,
+        HeatMapProviderDataResource.class);
+
+    if (auditLogFacetsResources != null) {
+      EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
+      List<EntityMetaData> entityMetaDataList =
+          Arrays.stream(entities).collect(Collectors.toList());
+      EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
+          heatMapUtil.generateHeatMap(entityMetaDataList);
+      assertThat(
+          entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(
+          0);
+      assertEquals(12, entityReadAccessHeatMapResponse.getChildren().size());
+      assertEquals(25600, entityReadAccessHeatMapResponse.getSize());
+      assertEquals(2924, entityReadAccessHeatMapResponse.getMinAccessCount());
+      assertEquals(155074, entityReadAccessHeatMapResponse.getMaxAccessCount());
+      assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
+      assertEquals(0.0,
+          entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
+      assertEquals(0.442,
+          entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
+              .get(0).getChildren().get(1).getColor());
+      assertEquals(0.058,
+          entityReadAccessHeatMapResponse.getChildren().get(0).getChildren()
+              .get(1).getChildren().get(3).getColor());
+    }
   }
 
   @Test
@@ -831,54 +838,54 @@ public class TestHeatMapInfo {
         "    }\n" +
         "  }\n" +
         "}";
-    JsonElement jsonElement =
-        JsonParser.parseString(auditRespStrWithVolumeEntityType);
-    JsonObject jsonObject = jsonElement.getAsJsonObject();
-    JsonElement facets = jsonObject.get("facets");
-    JsonElement resources = facets.getAsJsonObject().get("resources");
-    JsonObject facetsBucketsObject = new JsonObject();
-    if (null != resources) {
-      facetsBucketsObject = resources.getAsJsonObject();
-    }
-    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode rootNode = JsonUtils.readTree(auditRespStrWithVolumeEntityType);
 
-    HeatMapProviderDataResource auditLogFacetsResources =
-        objectMapper.readValue(
-            facetsBucketsObject.toString(), HeatMapProviderDataResource.class);
-    EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
-    if (null != entities && entities.length > 0) {
-      List<EntityMetaData> entityMetaDataList =
-          Arrays.stream(entities).collect(Collectors.toList());
-      // Below heatmap response would be of format like:
-      //{
-      //  "label": "root",
-      //  "path": "/",
-      //  "children": [
-      //    {
-      //      "label": "s3v",
-      //      "path": "s3v",
-      //      "size": 256
-      //    },
-      //    {
-      //      "label": "testnewvol2",
-      //      "path": "testnewvol2",
-      //      "size": 256
-      //    }
-      //  ],
-      //  "size": 512,
-      //  "minAccessCount": 19263
-      //}
-      EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
-          heatMapUtil.generateHeatMap(entityMetaDataList);
-      assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
-      assertEquals(2, entityReadAccessHeatMapResponse.getChildren().size());
-      assertEquals(512, entityReadAccessHeatMapResponse.getSize());
-      assertEquals(8590, entityReadAccessHeatMapResponse.getMinAccessCount());
-      assertEquals(19263, entityReadAccessHeatMapResponse.getMaxAccessCount());
-      assertEquals(1.0, entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
-      assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
-    } else {
-      assertNull(entities);
+    JsonNode facetsNode = rootNode.path("facets");
+    JsonNode resourcesNode = facetsNode.path("resources");
+
+    // Deserialize the resources node directly if it's not missing
+    HeatMapProviderDataResource auditLogFacetsResources = null;
+
+//    assumeThat(resourcesNode.isMissingNode()).isFalse();
+    auditLogFacetsResources = JsonTestUtils.treeToValue(resourcesNode,
+        HeatMapProviderDataResource.class);
+
+    if (auditLogFacetsResources != null) {
+      EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
+      if (null != entities && entities.length > 0) {
+        List<EntityMetaData> entityMetaDataList =
+            Arrays.stream(entities).collect(Collectors.toList());
+        // Below heatmap response would be of format like:
+        //{
+        //  "label": "root",
+        //  "path": "/",
+        //  "children": [
+        //    {
+        //      "label": "s3v",
+        //      "path": "s3v",
+        //      "size": 256
+        //    },
+        //    {
+        //      "label": "testnewvol2",
+        //      "path": "testnewvol2",
+        //      "size": 256
+        //    }
+        //  ],
+        //  "size": 512,
+        //  "minAccessCount": 19263
+        //}
+        EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
+            heatMapUtil.generateHeatMap(entityMetaDataList);
+        assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
+        assertEquals(2, entityReadAccessHeatMapResponse.getChildren().size());
+        assertEquals(512, entityReadAccessHeatMapResponse.getSize());
+        assertEquals(8590, entityReadAccessHeatMapResponse.getMinAccessCount());
+        assertEquals(19263, entityReadAccessHeatMapResponse.getMaxAccessCount());
+        assertEquals(1.0, entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
+        assertEquals("root", entityReadAccessHeatMapResponse.getLabel());
+      } else {
+        assertNull(entities);
+      }
     }
   }
 
@@ -965,150 +972,149 @@ public class TestHeatMapInfo {
         "    }\n" +
         "  }\n" +
         "}";
-    JsonElement jsonElement =
-        JsonParser.parseString(auditRespStrWithPathAndBucketEntityType);
-    JsonObject jsonObject = jsonElement.getAsJsonObject();
-    JsonElement facets = jsonObject.get("facets");
-    JsonElement resources = facets.getAsJsonObject().get("resources");
-    JsonObject facetsBucketsObject = new JsonObject();
-    if (null != resources) {
-      facetsBucketsObject = resources.getAsJsonObject();
-    }
-    ObjectMapper objectMapper = new ObjectMapper();
 
-    HeatMapProviderDataResource auditLogFacetsResources =
-        objectMapper.readValue(
-            facetsBucketsObject.toString(), HeatMapProviderDataResource.class);
-    EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
-    if (null != entities && entities.length > 0) {
-      List<EntityMetaData> entityMetaDataList =
-          Arrays.stream(entities).collect(Collectors.toList());
-      // Below heatmap response would be of format like:
-      //{
-      //    "label": "root",
-      //    "path": "/",
-      //    "children": [
-      //        {
-      //            "label": "testnewvol2",
-      //            "path": "testnewvol2",
-      //            "children": [
-      //                {
-      //                    "label": "fsobuck11",
-      //                    "path": "/testnewvol2/fsobuck11",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/fsobuck11/",
-      //                            "size": 100,
-      //                            "accessCount": 701,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 701,
-      //                    "maxAccessCount": 701
-      //                },
-      //                {
-      //                    "label": "fsobuck12",
-      //                    "path": "/testnewvol2/fsobuck12",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/fsobuck12/",
-      //                            "size": 100,
-      //                            "accessCount": 701,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 701,
-      //                    "maxAccessCount": 701
-      //                },
-      //                {
-      //                    "label": "fsobuck13",
-      //                    "path": "/testnewvol2/fsobuck13",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/fsobuck13/",
-      //                            "size": 100,
-      //                            "accessCount": 701,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 701,
-      //                    "maxAccessCount": 701
-      //                },
-      //                {
-      //                    "label": "obsbuck11",
-      //                    "path": "/testnewvol2/obsbuck11",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/obsbuck11/",
-      //                            "size": 107,
-      //                            "accessCount": 263,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 107,
-      //                    "minAccessCount": 263,
-      //                    "maxAccessCount": 263
-      //                },
-      //                {
-      //                    "label": "obsbuck12",
-      //                    "path": "/testnewvol2/obsbuck12",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/obsbuck12/",
-      //                            "size": 100,
-      //                            "accessCount": 200,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 200,
-      //                    "maxAccessCount": 200
-      //                },
-      //                {
-      //                    "label": "obsbuck13",
-      //                    "path": "/testnewvol2/obsbuck13",
-      //                    "children": [
-      //                        {
-      //                            "label": "",
-      //                            "path": "/testnewvol2/obsbuck13/",
-      //                            "size": 100,
-      //                            "accessCount": 200,
-      //                            "color": 1.0
-      //                        }
-      //                    ],
-      //                    "size": 100,
-      //                    "minAccessCount": 200,
-      //                    "maxAccessCount": 200
-      //                }
-      //            ],
-      //            "size": 607
-      //        }
-      //    ],
-      //    "size": 607,
-      //    "minAccessCount": 200,
-      //    "maxAccessCount": 701
-      //}
-      EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
-          heatMapUtil.generateHeatMap(entityMetaDataList);
-      assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
-      assertEquals(2,
-          entityReadAccessHeatMapResponse.getChildren().size());
-      assertEquals(0.0,
-          entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
-      String path =
-          entityReadAccessHeatMapResponse.getChildren().get(1).getChildren()
-              .get(0).getPath();
-      assertEquals("/testnewvol2/fsobuck11", path);
-    } else {
-      assertNull(entities);
+    JsonNode rootNode = JsonUtils.readTree(auditRespStrWithPathAndBucketEntityType);
+    // Navigate to the nested JSON objects
+    JsonNode facetsNode = rootNode.path("facets");
+    JsonNode resourcesNode = facetsNode.path("resources");
+    // Deserialize the resources node directly if it's not missing
+    HeatMapProviderDataResource auditLogFacetsResources = null;
+//    assumeThat(resourcesNode.isMissingNode()).isFalse();
+    auditLogFacetsResources =
+        JsonTestUtils.treeToValue(resourcesNode, HeatMapProviderDataResource.class);
+
+    if (auditLogFacetsResources != null) {
+      EntityMetaData[] entities = auditLogFacetsResources.getMetaDataList();
+      if (null != entities && entities.length > 0) {
+        List<EntityMetaData> entityMetaDataList =
+            Arrays.stream(entities).collect(Collectors.toList());
+        // Below heatmap response would be of format like:
+        //{
+        //    "label": "root",
+        //    "path": "/",
+        //    "children": [
+        //        {
+        //            "label": "testnewvol2",
+        //            "path": "testnewvol2",
+        //            "children": [
+        //                {
+        //                    "label": "fsobuck11",
+        //                    "path": "/testnewvol2/fsobuck11",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/fsobuck11/",
+        //                            "size": 100,
+        //                            "accessCount": 701,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 701,
+        //                    "maxAccessCount": 701
+        //                },
+        //                {
+        //                    "label": "fsobuck12",
+        //                    "path": "/testnewvol2/fsobuck12",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/fsobuck12/",
+        //                            "size": 100,
+        //                            "accessCount": 701,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 701,
+        //                    "maxAccessCount": 701
+        //                },
+        //                {
+        //                    "label": "fsobuck13",
+        //                    "path": "/testnewvol2/fsobuck13",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/fsobuck13/",
+        //                            "size": 100,
+        //                            "accessCount": 701,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 701,
+        //                    "maxAccessCount": 701
+        //                },
+        //                {
+        //                    "label": "obsbuck11",
+        //                    "path": "/testnewvol2/obsbuck11",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/obsbuck11/",
+        //                            "size": 107,
+        //                            "accessCount": 263,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 107,
+        //                    "minAccessCount": 263,
+        //                    "maxAccessCount": 263
+        //                },
+        //                {
+        //                    "label": "obsbuck12",
+        //                    "path": "/testnewvol2/obsbuck12",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/obsbuck12/",
+        //                            "size": 100,
+        //                            "accessCount": 200,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 200,
+        //                    "maxAccessCount": 200
+        //                },
+        //                {
+        //                    "label": "obsbuck13",
+        //                    "path": "/testnewvol2/obsbuck13",
+        //                    "children": [
+        //                        {
+        //                            "label": "",
+        //                            "path": "/testnewvol2/obsbuck13/",
+        //                            "size": 100,
+        //                            "accessCount": 200,
+        //                            "color": 1.0
+        //                        }
+        //                    ],
+        //                    "size": 100,
+        //                    "minAccessCount": 200,
+        //                    "maxAccessCount": 200
+        //                }
+        //            ],
+        //            "size": 607
+        //        }
+        //    ],
+        //    "size": 607,
+        //    "minAccessCount": 200,
+        //    "maxAccessCount": 701
+        //}
+        EntityReadAccessHeatMapResponse entityReadAccessHeatMapResponse =
+            heatMapUtil.generateHeatMap(entityMetaDataList);
+        assertThat(entityReadAccessHeatMapResponse.getChildren().size()).isGreaterThan(0);
+        assertEquals(2,
+            entityReadAccessHeatMapResponse.getChildren().size());
+        assertEquals(0.0,
+            entityReadAccessHeatMapResponse.getChildren().get(0).getColor());
+        String path =
+            entityReadAccessHeatMapResponse.getChildren().get(1).getChildren()
+                .get(0).getPath();
+        assertEquals("/testnewvol2/fsobuck11", path);
+      } else {
+        assertNull(entities);
+      }
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.ozone.admin.scm;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
@@ -90,14 +89,12 @@ public class ResetDeletedBlockRetryCountSubcommand extends ScmSubcommand {
           System.out.println("The last loaded txID: " +
               txIDs.get(txIDs.size() - 1));
         }
-      } catch (JsonProcessingException ex) {
-        final String message = "Failed to parse the file " + group.fileName;
+      } catch (IOException ex) {
+        final String message = "Failed to parse the file " + group.fileName + ": " + ex.getMessage();
         System.out.println(message);
         throw new IOException(message, ex);
-      } catch (IOException ex) {
-        System.out.println("Error reading file: " + ex.getMessage());
-        throw ex;
       }
+
       count = client.resetDeletedBlockRetryCount(txIDs);
     } else {
       if (group.txList == null || group.txList.isEmpty()) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
@@ -91,8 +91,9 @@ public class ResetDeletedBlockRetryCountSubcommand extends ScmSubcommand {
               txIDs.get(txIDs.size() - 1));
         }
       } catch (JsonProcessingException ex) {
-        System.out.println("Error parsing JSON: " + ex.getMessage());
-        throw new IOException(ex);
+        final String message = "Failed to parse the file " + group.fileName;
+        System.out.println(message);
+        throw new IOException(message, ex);
       } catch (IOException ex) {
         System.out.println("Error reading file: " + ex.getMessage());
         throw ex;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
@@ -16,13 +16,12 @@
  */
 package org.apache.hadoop.ozone.admin.scm;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonSyntaxException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.common.helpers.DeletedBlocksTransactionInfoWrapper;
+import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine;
 
 import java.io.FileInputStream;
@@ -74,12 +73,11 @@ public class ResetDeletedBlockRetryCountSubcommand extends ScmSubcommand {
     if (group.resetAll) {
       count = client.resetDeletedBlockRetryCount(new ArrayList<>());
     } else if (group.fileName != null) {
-      Gson gson = new Gson();
       List<Long> txIDs;
       try (InputStream in = new FileInputStream(group.fileName);
            Reader fileReader = new InputStreamReader(in,
                StandardCharsets.UTF_8)) {
-        DeletedBlocksTransactionInfoWrapper[] txns = gson.fromJson(fileReader,
+        DeletedBlocksTransactionInfoWrapper[] txns = JsonUtils.readArrayFromReader(fileReader,
             DeletedBlocksTransactionInfoWrapper[].class);
         txIDs = Arrays.stream(txns)
             .map(DeletedBlocksTransactionInfoWrapper::getTxID)
@@ -92,9 +90,12 @@ public class ResetDeletedBlockRetryCountSubcommand extends ScmSubcommand {
           System.out.println("The last loaded txID: " +
               txIDs.get(txIDs.size() - 1));
         }
-      } catch (JsonIOException | JsonSyntaxException | IOException ex) {
-        System.out.println("Cannot parse the file " + group.fileName);
+      } catch (JsonProcessingException ex) {
+        System.out.println("Error parsing JSON: " + ex.getMessage());
         throw new IOException(ex);
+      } catch (IOException ex) {
+        System.out.println("Error reading file: " + ex.getMessage());
+        throw ex;
       }
       count = client.resetDeletedBlockRetryCount(txIDs);
     } else {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ResetDeletedBlockRetryCountSubcommand.java
@@ -77,7 +77,7 @@ public class ResetDeletedBlockRetryCountSubcommand extends ScmSubcommand {
       try (InputStream in = new FileInputStream(group.fileName);
            Reader fileReader = new InputStreamReader(in,
                StandardCharsets.UTF_8)) {
-        DeletedBlocksTransactionInfoWrapper[] txns = JsonUtils.readArrayFromReader(fileReader,
+        DeletedBlocksTransactionInfoWrapper[] txns = JsonUtils.readFromReader(fileReader,
             DeletedBlocksTransactionInfoWrapper[].class);
         txIDs = Arrays.stream(txns)
             .map(DeletedBlocksTransactionInfoWrapper::getTxID)


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pull request introduces a migration from Gson to Jackson for the remaining classes of the `hadoop-ozone` module, specifically focusing on replacing Gson's JsonParser with Jackson's ObjectMapper. It involves using ObjectMapper's `readValue()` method to deserialise JSON strings into Java objects. Additionally, the code utilises Jackson's JsonNode to navigate and extract data from JSON structures.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10801
## How was this patch tested?
Ran the UT's and the forked CI
