### PR TITLE
HDDS-10830. Replace ConcurrentHashMap with HashMap protected by ReadWriteLock in NodeStateMap

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -738,7 +738,7 @@ public class NodeStateManager implements Runnable, Closeable {
    */
   public synchronized void forceNodesToHealthyReadOnly() {
     try {
-      List<DatanodeInfo> nodes = nodeStateMap.filterNodes(null, HEALTHY);
+      List<DatanodeInfo> nodes = nodeStateMap.getDatanodeInfos(null, HEALTHY);
       for (DatanodeInfo node : nodes) {
         nodeStateMap.updateNodeHealthState(node.getUuid(),
             HEALTHY_READONLY);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -47,9 +47,7 @@ import org.apache.hadoop.hdds.scm.node.NodeStatus;
  * this class.
  * <p>
  * Concurrency consideration:
- *   - assumes thread-safe usage
- *   - all public WRITE methods are protected by WRITE_LOCK
- *   - all public READ methods are protected by READ_LOCK
+ *   - thread-safe
  */
 public class NodeStateMap {
   /**
@@ -196,8 +194,7 @@ public class NodeStateMap {
   public DatanodeInfo getNodeInfo(UUID uuid) throws NodeNotFoundException {
     lock.readLock().lock();
     try {
-      checkIfNodeExist(uuid);
-      return nodeMap.get(uuid);
+      return getNodeInfoUnsafe(uuid);
     } finally {
       lock.readLock().unlock();
     }


### PR DESCRIPTION
There is a class [NodeStateMap](https://github.com/apache/ozone/blob/master/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java#L47) with 3 fields:
1. `ConcurrentHashMap<UUID, DatanodeInfo> nodeMap`
2. `ConcurrentHashMap<UUID, Set<ContainerID>> nodeToContainer`
3. `private final ReadWriteLock lock`

Both `read` and `write` operations in `NodeStateMap` are protected by `lock`.

## What changes were proposed in this pull request?

1. Replace `ConcurrentHashMap` with pure `HashMap` to avoid extra lock operations.
2. Create `private NodeStateMap::getNodeInfoUnsafe` method without `lock.readLock.lock()` to use it when `lock.writeLock.lock()` has already acquired:
    -  `NodeStateMap::updateNodeHealthState`
    - `NodeStateMap::updateNodeOperationalState`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10830

## How was this patch tested?

Use standalone tests