### PR TITLE
HDDS-10811. Reduce UTF8 string encoding by caching encoding result

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -801,7 +801,7 @@ public final class HddsUtils {
   }
 
   @Nonnull
-  public static String threadNamePrefix(@Nullable String id) {
+  public static String threadNamePrefix(@Nullable Object id) {
     return id != null && !"".equals(id)
         ? id + "-"
         : "";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -23,16 +23,14 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.Cache;
-import com.google.common.cache.RemovalListener;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.DatanodeVersion;
 import org.apache.hadoop.hdds.HddsUtils;
+import org.apache.hadoop.hdds.scm.net.NetUtils;
+import org.apache.hadoop.util.StringWithByteString;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
@@ -83,37 +81,13 @@ public class DatanodeDetails extends NodeImpl implements
   }
 
   /**
-   * Provides caching for fixed strings such as hostname, ip, etc. Normally, the number
-   * of these strings is fixed, not too many, so cache deprecation shouldn't happen in general.
-   */
-  private static final Cache<String, ByteString> FIXED_BYTE_STRING_CACHE = CacheBuilder.newBuilder()
-      .maximumSize(50000)
-      .removalListener((RemovalListener<String, ByteString>) notification -> {
-        if (notification.wasEvicted()) {
-          LOG.info("Removal cause: " + notification.getCause() + " for key: " + notification.getKey()
-              + ". The number of cached keys is too many, exceeding the expected number");
-        }
-      })
-      .build();
-
-  public static ByteString getFixedByteString(String key) {
-    try {
-      return FIXED_BYTE_STRING_CACHE.get(key, () -> ByteString.copyFromUtf8(key));
-    } catch (ExecutionException e) {
-      LOG.debug("Failed to retrieve or generate ByteString for key '{}'. Exception: {}", key, e.getMessage(), e);
-      return ByteString.copyFromUtf8(key);
-    }
-  }
-
-  /**
    * DataNode's unique identifier in the cluster.
    */
   private final UUID uuid;
-  private final String uuidString;
+  private final StringWithByteString uuidString;
   private final String threadNamePrefix;
-
-  private String ipAddress;
-  private String hostName;
+  private StringWithByteString ipAddress;
+  private StringWithByteString hostName;
   private final List<Port> ports;
   private String certSerialId;
   private String version;
@@ -128,7 +102,7 @@ public class DatanodeDetails extends NodeImpl implements
   private DatanodeDetails(Builder b) {
     super(b.hostName, b.networkLocation, NetConstants.NODE_COST_DEFAULT);
     uuid = b.id;
-    uuidString = uuid.toString();
+    uuidString = new StringWithByteString(uuid.toString());
     threadNamePrefix = HddsUtils.threadNamePrefix(uuidString);
     ipAddress = b.ipAddress;
     hostName = b.hostName;
@@ -151,17 +125,17 @@ public class DatanodeDetails extends NodeImpl implements
   }
 
   public DatanodeDetails(DatanodeDetails datanodeDetails) {
-    super(datanodeDetails.getHostName(), datanodeDetails.getNetworkLocation(),
+    super(datanodeDetails.getHostNameAsByteString(), datanodeDetails.getNetworkLocationAsByteString(),
         datanodeDetails.getParent(), datanodeDetails.getLevel(),
         datanodeDetails.getCost());
     this.uuid = datanodeDetails.uuid;
-    this.uuidString = uuid.toString();
+    this.uuidString = new StringWithByteString(uuid.toString());
     threadNamePrefix = HddsUtils.threadNamePrefix(uuidString);
     this.ipAddress = datanodeDetails.ipAddress;
     this.hostName = datanodeDetails.hostName;
     this.ports = datanodeDetails.ports;
     this.certSerialId = datanodeDetails.certSerialId;
-    this.setNetworkName(datanodeDetails.getNetworkName());
+    this.setNetworkName(datanodeDetails.getNetworkNameAsByteString());
     this.setParent(datanodeDetails.getParent());
     this.version = datanodeDetails.version;
     this.setupTime = datanodeDetails.setupTime;
@@ -189,7 +163,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @return UUID of DataNode
    */
   public String getUuidString() {
-    return uuidString;
+    return uuidString.toString();
   }
 
   /**
@@ -198,7 +172,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @param ip IP Address
    */
   public void setIpAddress(String ip) {
-    this.ipAddress = ip;
+    this.ipAddress = new StringWithByteString(ip);
   }
 
   /**
@@ -207,6 +181,15 @@ public class DatanodeDetails extends NodeImpl implements
    * @return IP address
    */
   public String getIpAddress() {
+    return ipAddress.toString();
+  }
+
+  /**
+   * Returns IP address of DataNode as a StringWithByteString object.
+   *
+   * @return IP address as ByteString
+   */
+  public StringWithByteString getIpAddressAsByteString() {
     return ipAddress;
   }
 
@@ -216,7 +199,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @param host hostname
    */
   public void setHostName(String host) {
-    this.hostName = host;
+    this.hostName = new StringWithByteString(host);
   }
 
   /**
@@ -225,6 +208,15 @@ public class DatanodeDetails extends NodeImpl implements
    * @return Hostname
    */
   public String getHostName() {
+    return hostName.toString();
+  }
+
+  /**
+   * Returns IP address of DataNode as a StringWithByteString object.
+   *
+   * @return Hostname
+   */
+  public StringWithByteString getHostNameAsByteString() {
     return hostName;
   }
 
@@ -355,10 +347,10 @@ public class DatanodeDetails extends NodeImpl implements
     }
 
     if (datanodeDetailsProto.hasIpAddress()) {
-      builder.setIpAddress(datanodeDetailsProto.getIpAddress());
+      builder.setIpAddress(datanodeDetailsProto.getIpAddress(), datanodeDetailsProto.getIpAddressBytes());
     }
     if (datanodeDetailsProto.hasHostName()) {
-      builder.setHostName(datanodeDetailsProto.getHostName());
+      builder.setHostName(datanodeDetailsProto.getHostName(), datanodeDetailsProto.getHostNameBytes());
     }
     if (datanodeDetailsProto.hasCertSerialId()) {
       builder.setCertSerialId(datanodeDetailsProto.getCertSerialId());
@@ -371,7 +363,7 @@ public class DatanodeDetails extends NodeImpl implements
       }
     }
     if (datanodeDetailsProto.hasNetworkName()) {
-      builder.setNetworkName(datanodeDetailsProto.getNetworkName());
+      builder.setNetworkName(datanodeDetailsProto.getNetworkName(), datanodeDetailsProto.getNetworkNameBytes());
     }
     if (datanodeDetailsProto.hasNetworkLocation()) {
       builder.setNetworkLocation(datanodeDetailsProto.getNetworkLocation());
@@ -454,22 +446,22 @@ public class DatanodeDetails extends NodeImpl implements
         HddsProtos.DatanodeDetailsProto.newBuilder()
             .setUuid128(uuid128);
 
-    builder.setUuidBytes(getFixedByteString(getUuidString()));
+    builder.setUuidBytes(uuidString.getBytes());
 
     if (ipAddress != null) {
-      builder.setIpAddressBytes(getFixedByteString(ipAddress));
+      builder.setIpAddressBytes(ipAddress.getBytes());
     }
     if (hostName != null) {
-      builder.setHostNameBytes(getFixedByteString(hostName));
+      builder.setHostNameBytes(hostName.getBytes());
     }
     if (certSerialId != null) {
       builder.setCertSerialId(certSerialId);
     }
     if (!Strings.isNullOrEmpty(getNetworkName())) {
-      builder.setNetworkNameBytes(getFixedByteString(getNetworkName()));
+      builder.setNetworkNameBytes(getNetworkNameAsByteString().getBytes());
     }
     if (!Strings.isNullOrEmpty(getNetworkLocation())) {
-      builder.setNetworkLocationBytes(getFixedByteString(getNetworkLocation()));
+      builder.setNetworkLocationBytes(getNetworkLocationAsByteString().getBytes());
     }
     if (getLevel() > 0) {
       builder.setLevel(getLevel());
@@ -599,10 +591,10 @@ public class DatanodeDetails extends NodeImpl implements
    */
   public static final class Builder {
     private UUID id;
-    private String ipAddress;
-    private String hostName;
-    private String networkName;
-    private String networkLocation;
+    private StringWithByteString ipAddress;
+    private StringWithByteString hostName;
+    private StringWithByteString networkName;
+    private StringWithByteString networkLocation;
     private int level;
     private List<Port> ports;
     private String certSerialId;
@@ -631,10 +623,10 @@ public class DatanodeDetails extends NodeImpl implements
      */
     public Builder setDatanodeDetails(DatanodeDetails details) {
       this.id = details.getUuid();
-      this.ipAddress = details.getIpAddress();
-      this.hostName = details.getHostName();
-      this.networkName = details.getNetworkName();
-      this.networkLocation = details.getNetworkLocation();
+      this.ipAddress = details.getIpAddressAsByteString();
+      this.hostName = details.getHostNameAsByteString();
+      this.networkName = details.getHostNameAsByteString();
+      this.networkLocation = details.getNetworkLocationAsByteString();
       this.level = details.getLevel();
       this.ports = details.getPorts();
       this.certSerialId = details.getCertSerialId();
@@ -666,7 +658,19 @@ public class DatanodeDetails extends NodeImpl implements
      * @return DatanodeDetails.Builder
      */
     public Builder setIpAddress(String ip) {
-      this.ipAddress = ip;
+      this.ipAddress = new StringWithByteString(ip);
+      return this;
+    }
+
+    /**
+     * Sets the IP address of DataNode.
+     *
+     * @param ip address
+     * @param ipBytes address in Bytes
+     * @return DatanodeDetails.Builder
+     */
+    public Builder setIpAddress(String ip, ByteString ipBytes) {
+      this.ipAddress = new StringWithByteString(ip, ipBytes);
       return this;
     }
 
@@ -677,7 +681,19 @@ public class DatanodeDetails extends NodeImpl implements
      * @return DatanodeDetails.Builder
      */
     public Builder setHostName(String host) {
-      this.hostName = host;
+      this.hostName = new StringWithByteString(host);
+      return this;
+    }
+
+    /**
+     * Sets the hostname of DataNode.
+     *
+     * @param host hostname
+     * @param hostBytes hostname
+     * @return DatanodeDetails.Builder
+     */
+    public Builder setHostName(String host, ByteString hostBytes) {
+      this.hostName = new StringWithByteString(host, hostBytes);
       return this;
     }
 
@@ -688,7 +704,19 @@ public class DatanodeDetails extends NodeImpl implements
      * @return DatanodeDetails.Builder
      */
     public Builder setNetworkName(String name) {
-      this.networkName = name;
+      this.networkName = new StringWithByteString(name);
+      return this;
+    }
+
+    /**
+     * Sets the network name of DataNode.
+     *
+     * @param name network name
+     * @param nameBytes network name
+     * @return DatanodeDetails.Builder
+     */
+    public Builder setNetworkName(String name, ByteString nameBytes) {
+      this.networkName = new StringWithByteString(name, nameBytes);
       return this;
     }
 
@@ -699,7 +727,7 @@ public class DatanodeDetails extends NodeImpl implements
      * @return DatanodeDetails.Builder
      */
     public Builder setNetworkLocation(String loc) {
-      this.networkLocation = loc;
+      this.networkLocation = new StringWithByteString(NetUtils.normalize(loc));
       return this;
     }
 
@@ -823,7 +851,7 @@ public class DatanodeDetails extends NodeImpl implements
     public DatanodeDetails build() {
       Preconditions.checkNotNull(id);
       if (networkLocation == null) {
-        networkLocation = NetConstants.DEFAULT_RACK;
+        networkLocation = NetConstants.BYTE_STRING_DEFAULT_RACK;
       }
       return new DatanodeDetails(this);
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -850,7 +850,7 @@ public class DatanodeDetails extends NodeImpl implements
      */
     public DatanodeDetails build() {
       Preconditions.checkNotNull(id);
-      if (networkLocation == null) {
+      if (networkLocation == null || networkLocation.toString().isEmpty()) {
         networkLocation = NetConstants.BYTE_STRING_DEFAULT_RACK;
       }
       return new DatanodeDetails(this);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -102,7 +102,7 @@ public class DatanodeDetails extends NodeImpl implements
   private DatanodeDetails(Builder b) {
     super(b.hostName, b.networkLocation, NetConstants.NODE_COST_DEFAULT);
     uuid = b.id;
-    uuidString = new StringWithByteString(uuid.toString());
+    uuidString = StringWithByteString.valueOf(uuid.toString());
     threadNamePrefix = HddsUtils.threadNamePrefix(uuidString);
     ipAddress = b.ipAddress;
     hostName = b.hostName;
@@ -129,7 +129,7 @@ public class DatanodeDetails extends NodeImpl implements
         datanodeDetails.getParent(), datanodeDetails.getLevel(),
         datanodeDetails.getCost());
     this.uuid = datanodeDetails.uuid;
-    this.uuidString = new StringWithByteString(uuid.toString());
+    this.uuidString = datanodeDetails.uuidString;
     threadNamePrefix = HddsUtils.threadNamePrefix(uuidString);
     this.ipAddress = datanodeDetails.ipAddress;
     this.hostName = datanodeDetails.hostName;
@@ -163,7 +163,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @return UUID of DataNode
    */
   public String getUuidString() {
-    return uuidString.toString();
+    return uuidString.getString();
   }
 
   /**
@@ -172,7 +172,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @param ip IP Address
    */
   public void setIpAddress(String ip) {
-    this.ipAddress = new StringWithByteString(ip);
+    this.ipAddress = StringWithByteString.valueOf(ip);
   }
 
   /**
@@ -181,7 +181,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @return IP address
    */
   public String getIpAddress() {
-    return ipAddress.toString();
+    return ipAddress.getString();
   }
 
   /**
@@ -199,7 +199,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @param host hostname
    */
   public void setHostName(String host) {
-    this.hostName = new StringWithByteString(host);
+    this.hostName = StringWithByteString.valueOf(host);
   }
 
   /**
@@ -208,7 +208,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @return Hostname
    */
   public String getHostName() {
-    return hostName.toString();
+    return hostName.getString();
   }
 
   /**
@@ -363,10 +363,12 @@ public class DatanodeDetails extends NodeImpl implements
       }
     }
     if (datanodeDetailsProto.hasNetworkName()) {
-      builder.setNetworkName(datanodeDetailsProto.getNetworkName(), datanodeDetailsProto.getNetworkNameBytes());
+      builder.setNetworkName(
+          datanodeDetailsProto.getNetworkName(), datanodeDetailsProto.getNetworkNameBytes());
     }
     if (datanodeDetailsProto.hasNetworkLocation()) {
-      builder.setNetworkLocation(datanodeDetailsProto.getNetworkLocation());
+      builder.setNetworkLocation(
+          datanodeDetailsProto.getNetworkLocation(), datanodeDetailsProto.getNetworkLocationBytes());
     }
     if (datanodeDetailsProto.hasLevel()) {
       builder.setLevel(datanodeDetailsProto.getLevel());
@@ -658,7 +660,7 @@ public class DatanodeDetails extends NodeImpl implements
      * @return DatanodeDetails.Builder
      */
     public Builder setIpAddress(String ip) {
-      this.ipAddress = new StringWithByteString(ip);
+      this.ipAddress = StringWithByteString.valueOf(ip);
       return this;
     }
 
@@ -681,7 +683,7 @@ public class DatanodeDetails extends NodeImpl implements
      * @return DatanodeDetails.Builder
      */
     public Builder setHostName(String host) {
-      this.hostName = new StringWithByteString(host);
+      this.hostName = StringWithByteString.valueOf(host);
       return this;
     }
 
@@ -694,17 +696,6 @@ public class DatanodeDetails extends NodeImpl implements
      */
     public Builder setHostName(String host, ByteString hostBytes) {
       this.hostName = new StringWithByteString(host, hostBytes);
-      return this;
-    }
-
-    /**
-     * Sets the network name of DataNode.
-     *
-     * @param name network name
-     * @return DatanodeDetails.Builder
-     */
-    public Builder setNetworkName(String name) {
-      this.networkName = new StringWithByteString(name);
       return this;
     }
 
@@ -727,7 +718,14 @@ public class DatanodeDetails extends NodeImpl implements
      * @return DatanodeDetails.Builder
      */
     public Builder setNetworkLocation(String loc) {
-      this.networkLocation = new StringWithByteString(NetUtils.normalize(loc));
+      return setNetworkLocation(loc, null);
+    }
+
+    public Builder setNetworkLocation(String loc, ByteString locBytes) {
+      final String normalized = NetUtils.normalize(loc);
+      this.networkLocation = normalized.equals(loc) && locBytes != null
+          ? new StringWithByteString(normalized, locBytes)
+          : StringWithByteString.valueOf(normalized);
       return this;
     }
 
@@ -850,7 +848,7 @@ public class DatanodeDetails extends NodeImpl implements
      */
     public DatanodeDetails build() {
       Preconditions.checkNotNull(id);
-      if (networkLocation == null || networkLocation.toString().isEmpty()) {
+      if (networkLocation == null || networkLocation.getString().isEmpty()) {
         networkLocation = NetConstants.BYTE_STRING_DEFAULT_RACK;
       }
       return new DatanodeDetails(this);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetConstants.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetConstants.java
@@ -33,13 +33,13 @@ public final class NetConstants {
   public static final String SCOPE_REVERSE_STR = "~";
   /** string representation of root. */
   public static final String ROOT = "";
-  public static final StringWithByteString BYTE_STRING_ROOT = new StringWithByteString(ROOT);
+  public static final StringWithByteString BYTE_STRING_ROOT = StringWithByteString.valueOf(ROOT);
   public static final int INNER_NODE_COST_DEFAULT = 1;
   public static final int NODE_COST_DEFAULT = 0;
   public static final int ANCESTOR_GENERATION_DEFAULT = 0;
   public static final int ROOT_LEVEL = 1;
   public static final String DEFAULT_RACK = "/default-rack";
-  public static final StringWithByteString BYTE_STRING_DEFAULT_RACK = new StringWithByteString(DEFAULT_RACK);
+  public static final StringWithByteString BYTE_STRING_DEFAULT_RACK = StringWithByteString.valueOf(DEFAULT_RACK);
   public static final String DEFAULT_NODEGROUP = "/default-nodegroup";
   public static final String DEFAULT_DATACENTER = "/default-datacenter";
   public static final String DEFAULT_REGION = "/default-dataregion";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetConstants.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetConstants.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.net;
 
 import  org.apache.hadoop.hdds.scm.net.NodeSchema.LayerType;
+import org.apache.hadoop.util.StringWithByteString;
 
 /**
  * Class to hold network topology related constants and configurations.
@@ -32,11 +33,13 @@ public final class NetConstants {
   public static final String SCOPE_REVERSE_STR = "~";
   /** string representation of root. */
   public static final String ROOT = "";
+  public static final StringWithByteString BYTE_STRING_ROOT = new StringWithByteString(ROOT);
   public static final int INNER_NODE_COST_DEFAULT = 1;
   public static final int NODE_COST_DEFAULT = 0;
   public static final int ANCESTOR_GENERATION_DEFAULT = 0;
   public static final int ROOT_LEVEL = 1;
   public static final String DEFAULT_RACK = "/default-rack";
+  public static final StringWithByteString BYTE_STRING_DEFAULT_RACK = new StringWithByteString(DEFAULT_RACK);
   public static final String DEFAULT_NODEGROUP = "/default-nodegroup";
   public static final String DEFAULT_DATACENTER = "/default-datacenter";
   public static final String DEFAULT_REGION = "/default-dataregion";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -19,8 +19,9 @@ package org.apache.hadoop.hdds.scm.net;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.util.StringWithByteString;
 
-import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT;
+import static org.apache.hadoop.hdds.scm.net.NetConstants.BYTE_STRING_ROOT;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.PATH_SEPARATOR_STR;
 
 /**
@@ -28,9 +29,9 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.PATH_SEPARATOR_STR;
  */
 public class NodeImpl implements Node {
   // host:port#
-  private String name;
+  private StringWithByteString name;
   // string representation of this node's location, such as /dc1/rack1
-  private String location;
+  private StringWithByteString location;
   // location + "/" + name
   private String path;
   // which level of the tree the node resides, start from 1 for root
@@ -46,16 +47,20 @@ public class NodeImpl implements Node {
    * {@link NetConstants#PATH_SEPARATOR})
    * @param location this node's location
    */
-  public NodeImpl(String name, String location, int cost) {
-    if (name != null && name.contains(PATH_SEPARATOR_STR)) {
+  public NodeImpl(StringWithByteString name, StringWithByteString location, int cost) {
+    if (name != null && name.toString() != null && name.toString().contains(PATH_SEPARATOR_STR)) {
       throw new IllegalArgumentException(
           "Network location name:" + name + " should not contain " +
               PATH_SEPARATOR_STR);
     }
-    this.name = (name == null) ? ROOT : name;
-    this.location = NetUtils.normalize(location);
+    this.name = (name == null || name.toString() == null) ? BYTE_STRING_ROOT : name;
+    this.location = location;
     this.path = getPath();
     this.cost = cost;
+  }
+
+  public NodeImpl(String name, String location, int cost) {
+    this(new StringWithByteString(name), new StringWithByteString(NetUtils.normalize(location)), cost);
   }
 
   /**
@@ -75,11 +80,25 @@ public class NodeImpl implements Node {
     this.level = level;
   }
 
+  public NodeImpl(StringWithByteString name, StringWithByteString location, InnerNode parent, int level,
+      int cost) {
+    this(name, location, cost);
+    this.parent = parent;
+    this.level = level;
+  }
+
   /**
    * @return this node's name
    */
   @Override
   public String getNetworkName() {
+    return name.toString();
+  }
+
+  /**
+   * @return this node's name
+   */
+  public StringWithByteString getNetworkNameAsByteString() {
     return name;
   }
 
@@ -89,6 +108,15 @@ public class NodeImpl implements Node {
    */
   @Override
   public void setNetworkName(String networkName) {
+    this.name = new StringWithByteString(networkName);
+    this.path = getPath();
+  }
+
+  /**
+   * Set this node's name, can be hostname or Ipaddress.
+   * @param networkName it's network name
+   */
+  public void setNetworkName(StringWithByteString networkName) {
     this.name = networkName;
     this.path = getPath();
   }
@@ -98,6 +126,13 @@ public class NodeImpl implements Node {
    */
   @Override
   public String getNetworkLocation() {
+    return location.toString();
+  }
+
+  /**
+   * @return this node's network location
+   */
+  public StringWithByteString getNetworkLocationAsByteString() {
     return location;
   }
 
@@ -107,7 +142,7 @@ public class NodeImpl implements Node {
    */
   @Override
   public void setNetworkLocation(String networkLocation) {
-    this.location = networkLocation;
+    this.location = new StringWithByteString(networkLocation);
     this.path = getPath();
   }
 
@@ -269,8 +304,8 @@ public class NodeImpl implements Node {
   }
 
   private String getPath() {
-    return this.location.equals(PATH_SEPARATOR_STR) ?
-        this.location + this.name :
-        this.location + PATH_SEPARATOR_STR + this.name;
+    return this.location.toString().equals(PATH_SEPARATOR_STR) ?
+        this.location + this.name.toString() :
+        this.location + PATH_SEPARATOR_STR + this.name.toString();
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -48,19 +48,19 @@ public class NodeImpl implements Node {
    * @param location this node's location
    */
   public NodeImpl(StringWithByteString name, StringWithByteString location, int cost) {
-    if (name != null && name.toString() != null && name.toString().contains(PATH_SEPARATOR_STR)) {
+    if (name != null && name.getString().contains(PATH_SEPARATOR_STR)) {
       throw new IllegalArgumentException(
           "Network location name:" + name + " should not contain " +
               PATH_SEPARATOR_STR);
     }
-    this.name = (name == null || name.toString() == null) ? BYTE_STRING_ROOT : name;
+    this.name = name == null ? BYTE_STRING_ROOT : name;
     this.location = location;
     this.path = getPath();
     this.cost = cost;
   }
 
   public NodeImpl(String name, String location, int cost) {
-    this(new StringWithByteString(name), new StringWithByteString(NetUtils.normalize(location)), cost);
+    this(StringWithByteString.valueOf(name), StringWithByteString.valueOf(NetUtils.normalize(location)), cost);
   }
 
   /**
@@ -92,7 +92,7 @@ public class NodeImpl implements Node {
    */
   @Override
   public String getNetworkName() {
-    return name.toString();
+    return name.getString();
   }
 
   /**
@@ -108,7 +108,7 @@ public class NodeImpl implements Node {
    */
   @Override
   public void setNetworkName(String networkName) {
-    this.name = new StringWithByteString(networkName);
+    this.name = StringWithByteString.valueOf(networkName);
     this.path = getPath();
   }
 
@@ -126,7 +126,7 @@ public class NodeImpl implements Node {
    */
   @Override
   public String getNetworkLocation() {
-    return location.toString();
+    return location.getString();
   }
 
   /**
@@ -142,7 +142,7 @@ public class NodeImpl implements Node {
    */
   @Override
   public void setNetworkLocation(String networkLocation) {
-    this.location = new StringWithByteString(networkLocation);
+    this.location = StringWithByteString.valueOf(networkLocation);
     this.path = getPath();
   }
 
@@ -304,8 +304,8 @@ public class NodeImpl implements Node {
   }
 
   private String getPath() {
-    return this.location.toString().equals(PATH_SEPARATOR_STR) ?
-        this.location + this.name.toString() :
-        this.location + PATH_SEPARATOR_STR + this.name.toString();
+    return this.location.getString().equals(PATH_SEPARATOR_STR) ?
+        this.location + this.name.getString() :
+        this.location + PATH_SEPARATOR_STR + this.name;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/StringWithByteString.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/StringWithByteString.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util;
+
+import com.google.protobuf.ByteString;
+import net.jcip.annotations.Immutable;
+
+/**
+ * Class to encapsulate and cache the conversion of a Java String to a ByteString.
+ */
+@Immutable
+public final class StringWithByteString {
+  private final String string;
+  private final ByteString bytes;
+
+  public StringWithByteString(String string) {
+    this(string, ByteString.copyFromUtf8(string));
+  }
+
+  public StringWithByteString(String string, ByteString bytes) {
+    this.string = string;
+    this.bytes = bytes;
+  }
+
+  @Override
+  public String toString() {
+    return string;
+  }
+
+  public ByteString getBytes() {
+    return bytes;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/StringWithByteString.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/StringWithByteString.java
@@ -20,29 +20,35 @@ package org.apache.hadoop.util;
 import com.google.protobuf.ByteString;
 import net.jcip.annotations.Immutable;
 
+import java.util.Objects;
+
 /**
  * Class to encapsulate and cache the conversion of a Java String to a ByteString.
  */
 @Immutable
 public final class StringWithByteString {
+  public static StringWithByteString valueOf(String string) {
+    return string != null ? new StringWithByteString(string, ByteString.copyFromUtf8(string)) : null;
+  }
+
   private final String string;
   private final ByteString bytes;
 
-  public StringWithByteString(String string) {
-    this(string, ByteString.copyFromUtf8(string));
-  }
-
   public StringWithByteString(String string, ByteString bytes) {
-    this.string = string;
-    this.bytes = bytes;
+    this.string = Objects.requireNonNull(string, "string == null");
+    this.bytes = Objects.requireNonNull(bytes, "bytes == null");
   }
 
-  @Override
-  public String toString() {
+  public String getString() {
     return string;
   }
 
   public ByteString getBytes() {
     return bytes;
+  }
+
+  @Override
+  public String toString() {
+    return getString();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reduce `com/google/protobuf/ByteString.copyFromUtf8` when encode a protobuf Object.
- For a String type protobuf field, if you use the `setXXX` method (such as `builder.setHostName`), the protobuf will call `ByteString.copyFromUtf8` convert UTF8 String to `ByteString`. 
- For some UTF8 String with fixed content, we can cache its `ByteString` value, and use `setXXXBytes` to avoid calling `ByteString.copyFromUtf8`

Before
https://issues.apache.org/jira/secure/attachment/13068731/om-create-key-alloc-profiler-setxxxString.html

After
The `com/google/protobuf/ByteString.copyFromUtf8` in the `DatanodeDetail` disappear.
https://issues.apache.org/jira/secure/attachment/13068732/om-create-key-alloc-profiler-setxxbytes.html

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10811

## How was this patch tested?
Existing Test.
