### PR TITLE
HDDS-10829. Suppress extra INFO log lines from ozone shell commands output

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/ClientTrustManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/ClientTrustManager.java
@@ -145,7 +145,7 @@ public class ClientTrustManager extends X509ExtendedTrustManager {
   private List<X509Certificate> loadCerts(CACertificateProvider caCertsProvider)
       throws CertificateException {
     try {
-      LOG.info("Loading certificates for client.");
+      LOG.debug("Loading certificates for client.");
       if (caCertsProvider == null) {
         return remoteProvider.provideCACerts();
       }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransportFactory.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransportFactory.java
@@ -53,13 +53,13 @@ public interface OmTransportFactory {
       Iterator<OmTransportFactory> iterator = transportFactoryServiceLoader.iterator();
       if (iterator.hasNext()) {
         OmTransportFactory next = iterator.next();
-        LOG.info("Found OM transport implementation {} from service loader.", next.getClass().getName());
+        LOG.debug("Found OM transport implementation {} from service loader.", next.getClass().getName());
         return next;
       }
 
       // Otherwise, load the transport implementation specified by configuration.
       String transportClassName = conf.get(OZONE_OM_TRANSPORT_CLASS, OZONE_OM_TRANSPORT_CLASS_DEFAULT);
-      LOG.info("Loading OM transport implementation {} as specified by configuration.", transportClassName);
+      LOG.debug("Loading OM transport implementation {} as specified by configuration.", transportClassName);
       return OmTransportFactory.class.getClassLoader()
           .loadClass(transportClassName)
           .asSubclass(OmTransportFactory.class)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -50,6 +50,9 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -81,6 +84,7 @@ import static org.apache.hadoop.ozone.container.ContainerTestHelper.getCreateCon
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getTestContainerID;
 import static org.apache.hadoop.ozone.container.replication.CopyContainerCompression.NO_COMPRESSION;
 import static org.apache.ozone.test.GenericTestUtils.LogCapturer.captureLogs;
+import static org.apache.ozone.test.GenericTestUtils.setLogLevel;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -140,6 +144,9 @@ public class TestOzoneContainerWithTLS {
 
     dn = aDatanode();
     pipeline = createPipeline(singletonList(dn));
+
+    Logger logger = LoggerFactory.getLogger(ClientTrustManager.class);
+    setLogLevel(logger, Level.DEBUG);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changed the log level of the extra log lines from INFO to DEBUG. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10829

## How was this patch tested?
This patch was tested by running the ozone shell commands on docker. 
(disabled the function `ozone_suppress_shell_log` for testing purpose)
Before suppressing the logs:
<img width="695" alt="Screenshot 2024-05-08 at 4 17 15 PM" src="https://github.com/apache/ozone/assets/79865743/27e04440-8fd4-4d89-adcc-811868471f10">

After suppressing the logs:
<img width="707" alt="Screenshot 2024-05-08 at 4 03 20 PM" src="https://github.com/apache/ozone/assets/79865743/13a6a184-ffd1-43ec-9f9b-77ecac41f9d7">
