### PR TITLE
HDDS-10634. Recon - listKeys API for listing keys with optional filters

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -44,6 +44,7 @@ public final class ReconConstants {
   public static final String DEFAULT_OPEN_KEY_INCLUDE_NON_FSO = "false";
   public static final String DEFAULT_OPEN_KEY_INCLUDE_FSO = "false";
   public static final String DEFAULT_FETCH_COUNT = "1000";
+  public static final String DEFAULT_KEY_SIZE = "0";
   public static final String DEFAULT_BATCH_NUMBER = "1";
   public static final String RECON_QUERY_BATCH_PARAM = "batchNum";
   public static final String RECON_QUERY_PREVKEY = "prevKey";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconResponseUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconResponseUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon;
+
+import com.google.inject.Singleton;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Recon API Response Utility class.
+ */
+@Singleton
+public final class ReconResponseUtils {
+
+  // Declared a private constructor to avoid checkstyle issues.
+  private ReconResponseUtils() {
+
+  }
+
+  /**
+   * Returns a response indicating that no keys matched the search prefix.
+   *
+   * @param startPrefix The search prefix that was used.
+   * @return The response indicating that no keys matched the search prefix.
+   */
+  public static Response noMatchedKeysResponse(String startPrefix) {
+    String jsonResponse = String.format(
+        "{\"message\": \"No keys matched the search prefix: '%s'.\"}",
+        startPrefix);
+    return Response.status(Response.Status.NOT_FOUND)
+        .entity(jsonResponse)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  /**
+   * Utility method to create a bad request response with a custom message.
+   * Which means the request sent by the client to the server is incorrect
+   * or malformed and cannot be processed by the server.
+   *
+   * @param message The message to include in the response body.
+   * @return A Response object configured with the provided message.
+   */
+  public static Response createBadRequestResponse(String message) {
+    String jsonResponse = String.format("{\"message\": \"%s\"}", message);
+    return Response.status(Response.Status.BAD_REQUEST)
+        .entity(jsonResponse)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  /**
+   * Utility method to create an internal server error response with a custom message.
+   * Which means the server encountered an unexpected condition that prevented it
+   * from fulfilling the request.
+   *
+   * @param message The message to include in the response body.
+   * @return A Response object configured with the provided message.
+   */
+  public static Response createInternalServerErrorResponse(String message) {
+    String jsonResponse = String.format("{\"message\": \"%s\"}", message);
+    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .entity(jsonResponse)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -603,4 +603,18 @@ public class ReconUtils {
     // If all checks pass, the name is valid
     return null;
   }
+
+  /**
+   * Constructs an object path with the given IDs.
+   *
+   * @param ids The IDs to construct the object path with.
+   * @return The constructed object path.
+   */
+  public static String constructObjectPathWithPrefix(long... ids) {
+    StringBuilder pathBuilder = new StringBuilder();
+    for (long id : ids) {
+      pathBuilder.append(OM_KEY_PREFIX).append(id);
+    }
+    return pathBuilder.toString();
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NSSummaryEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NSSummaryEndpoint.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.ozone.recon.api;
 
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
-import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.handlers.EntityHandler;
 import org.apache.hadoop.ozone.recon.api.types.NamespaceSummaryResponse;
 import org.apache.hadoop.ozone.recon.api.types.DUResponse;
@@ -78,7 +78,7 @@ public class NSSummaryEndpoint {
     }
 
     NamespaceSummaryResponse namespaceSummaryResponse;
-    if (!isInitializationComplete()) {
+    if (!ReconUtils.isInitializationComplete(omMetadataManager)) {
       namespaceSummaryResponse =
           NamespaceSummaryResponse.newBuilder()
               .setEntityType(EntityType.UNKNOWN)
@@ -119,7 +119,7 @@ public class NSSummaryEndpoint {
     }
 
     DUResponse duResponse = new DUResponse();
-    if (!isInitializationComplete()) {
+    if (!ReconUtils.isInitializationComplete(omMetadataManager)) {
       duResponse.setStatus(ResponseStatus.INITIALIZING);
       return Response.ok(duResponse).build();
     }
@@ -150,7 +150,7 @@ public class NSSummaryEndpoint {
     }
 
     QuotaUsageResponse quotaUsageResponse = new QuotaUsageResponse();
-    if (!isInitializationComplete()) {
+    if (!ReconUtils.isInitializationComplete(omMetadataManager)) {
       quotaUsageResponse.setResponseCode(ResponseStatus.INITIALIZING);
       return Response.ok(quotaUsageResponse).build();
     }
@@ -181,7 +181,7 @@ public class NSSummaryEndpoint {
 
     FileSizeDistributionResponse distResponse =
         new FileSizeDistributionResponse();
-    if (!isInitializationComplete()) {
+    if (!ReconUtils.isInitializationComplete(omMetadataManager)) {
       distResponse.setStatus(ResponseStatus.INITIALIZING);
       return Response.ok(distResponse).build();
     }
@@ -193,21 +193,6 @@ public class NSSummaryEndpoint {
     distResponse = handler.getDistResponse();
 
     return Response.ok(distResponse).build();
-  }
-
-  /**
-   * Return if all OMDB tables that will be used are initialized.
-   * @return if tables are initialized
-   */
-  private boolean isInitializationComplete() {
-    if (omMetadataManager == null) {
-      return false;
-    }
-    return omMetadataManager.getVolumeTable() != null
-        && omMetadataManager.getBucketTable() != null
-        && omMetadataManager.getDirectoryTable() != null
-        && omMetadataManager.getFileTable() != null
-        && omMetadataManager.getKeyTable(BucketLayout.LEGACY) != null;
   }
 
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -1018,17 +1018,18 @@ public class OMDBInsightEndpoint {
       return Response.ok(listKeysResponse).build();
     } catch (IOException e) {
       return ReconResponseUtils.createInternalServerErrorResponse(
-          "Error searching keys in OM DB: " + e.getMessage());
-    } catch (IllegalArgumentException e) {
-      return ReconResponseUtils.createBadRequestResponse("Invalid startPrefix: " + e.getMessage());
+          "Error listing keys from OM DB: " + e.getMessage());
     } catch (RuntimeException e) {
       return ReconResponseUtils.createInternalServerErrorResponse(
           "Unexpected runtime error while searching keys in OM DB: " + e.getMessage());
+    } catch (Exception e) {
+      return ReconResponseUtils.createInternalServerErrorResponse(
+          "Error listing keys from OM DB: " + e.getMessage());
     }
   }
 
   public Map<String, OmKeyInfo> searchKeysInFSO(ParamInfo paramInfo)
-      throws IOException, IllegalArgumentException {
+      throws IOException {
     int originalLimit = paramInfo.getLimit();
     Map<String, OmKeyInfo> matchedKeys = new LinkedHashMap<>();
     // Convert the search prefix to an object path for FSO buckets
@@ -1132,7 +1133,7 @@ public class OMDBInsightEndpoint {
    * @throws IOException If database access fails.
    */
   public String convertStartPrefixPathToObjectIdPath(String startPrefixPath)
-      throws IOException, IllegalArgumentException {
+      throws IOException {
 
     String[] names = parseRequestPath(
         normalizePath(startPrefixPath, BucketLayout.FILE_SYSTEM_OPTIMIZED));

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -966,6 +966,7 @@ public class OMDBInsightEndpoint {
 
   public Map<String, OmKeyInfo> searchKeysInFSO(ParamInfo paramInfo)
       throws IOException, IllegalArgumentException {
+    int originalLimit = paramInfo.getLimit();
     Map<String, OmKeyInfo> matchedKeys = new LinkedHashMap<>();
     // Convert the search prefix to an object path for FSO buckets
     String startPrefixObjectPath = convertToObjectPath(paramInfo.getStartPrefix());
@@ -995,10 +996,10 @@ public class OMDBInsightEndpoint {
       // Iterate over the subpaths and retrieve the files
       for (String subPath : subPaths) {
         paramInfo.setStartPrefix(subPath);
-        paramInfo.setLimit(paramInfo.getLimit() - matchedKeys.size());
         matchedKeys.putAll(
             retrieveKeysFromTable(fileTable, paramInfo));
-        if (matchedKeys.size() >= paramInfo.getLimit()) {
+        paramInfo.setLimit(originalLimit - matchedKeys.size());
+        if (matchedKeys.size() >= originalLimit) {
           break;
         }
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -1375,27 +1375,15 @@ public class OMDBInsightEndpoint {
   private KeyEntityInfo createKeyEntityInfoFromOmKeyInfo(String dbKey,
                                                          OmKeyInfo keyInfo) throws IOException {
     KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
-    setKeyNameAndFullPath(dbKey, keyInfo, keyEntityInfo);
+    keyEntityInfo.setKey(dbKey); // Set the DB key
+    keyEntityInfo.setPath(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
+        omMetadataManager));
     keyEntityInfo.setSize(keyInfo.getDataSize());
     keyEntityInfo.setCreationTime(keyInfo.getCreationTime());
     keyEntityInfo.setModificationTime(keyInfo.getModificationTime());
     keyEntityInfo.setReplicatedSize(keyInfo.getReplicatedSize());
     keyEntityInfo.setReplicationConfig(keyInfo.getReplicationConfig());
     return keyEntityInfo;
-  }
-
-  private void setKeyNameAndFullPath(String dbKey, OmKeyInfo keyInfo, KeyEntityInfo keyEntityInfo) throws IOException {
-    String bucketKey = omMetadataManager.getBucketKey(keyInfo.getVolumeName(), keyInfo.getBucketName());
-    OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().getSkipCache(bucketKey);
-    if (omBucketInfo.getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
-      keyEntityInfo.setKey(dbKey); // Set the DB key
-      keyEntityInfo.setPath(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
-          omMetadataManager));
-    } else {
-      keyEntityInfo.setKey(dbKey);
-      keyEntityInfo.setPath(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
-          omMetadataManager));
-    }
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -1228,11 +1228,11 @@ public class OMDBInsightEndpoint {
           continue;
         }
         if (applyFilters(entry, paramInfo)) {
+          matchedKeys.put(dbKey, entry.getValue());
+          paramInfo.setLastKey(dbKey);
           if (matchedKeys.size() >= paramInfo.getLimit()) {
             break;
           }
-          matchedKeys.put(dbKey, entry.getValue());
-          paramInfo.setLastKey(dbKey);
         }
       }
     } catch (IOException exception) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -692,7 +692,7 @@ public class OMDBInsightEndpoint {
    *       replication type.
    *    -- creationTime - empty string and filter will not be applied, so list out keys irrespective of age.
    *    -- keySize - 0 bytes, which means all keys greater than zero bytes will be listed, effectively all.
-   *    -- startPrefix - /
+   *    -- startPrefix - /, API assumes that startPrefix path always starts with /. E.g. /volume/bucket
    *    -- prevKey - ""
    *    -- limit - 1000
    *
@@ -738,44 +738,97 @@ public class OMDBInsightEndpoint {
    * Output Response:
    *
    * {
-   *    "status": "OK",
-   *    "path": "/volume1/obs-bucket",
-   *    "replicatedDataSize": 20971520,
-   *    "unReplicatedDataSize": 20971520,
-   *    "keyCount": 2,
-   *    "lastKey": "/volume1/obs-bucket/key1/key2",
-   *    "keys": [
-   *        {
-   *            "key": "/volume1/obs-bucket/key1",
-   *            "path": "key1",
-   *            "inStateSince": 1715174266126,
-   *            "size": 10485760,
-   *            "replicatedSize": 10485760,
-   *            "replicationInfo": {
-   *                "replicationFactor": "ONE",
-   *                "requiredNodes": 1,
-   *                "replicationType": "RATIS"
-   *            },
-   *            "creationTime": 1715174266126,
-   *            "modificationTime": 1715174267480,
-   *            "isKey": true
-   *        },
-   *        {
-   *            "key": "/volume1/obs-bucket/key1/key2",
-   *            "path": "key1/key2",
-   *            "inStateSince": 1715174269510,
-   *            "size": 10485760,
-   *            "replicatedSize": 10485760,
-   *            "replicationInfo": {
-   *                "replicationFactor": "ONE",
-   *                "requiredNodes": 1,
-   *                "replicationType": "RATIS"
-   *            },
-   *            "creationTime": 1715174269510,
-   *            "modificationTime": 1715174270410,
-   *            "isKey": true
-   *        }
-   *    ]
+   *     "status": "OK",
+   *     "path": "/volume1/obs-bucket",
+   *     "replicatedDataSize": 62914560,
+   *     "unReplicatedDataSize": 62914560,
+   *     "lastKey": "/volume1/obs-bucket/key6",
+   *     "keys": [
+   *         {
+   *             "key": "/volume1/obs-bucket/key1",
+   *             "path": "volume1/obs-bucket/key1",
+   *             "size": 10485760,
+   *             "replicatedSize": 10485760,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781418742,
+   *             "modificationTime": 1715781419762,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/obs-bucket/key1/key2",
+   *             "path": "volume1/obs-bucket/key1/key2",
+   *             "size": 10485760,
+   *             "replicatedSize": 10485760,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781421716,
+   *             "modificationTime": 1715781422723,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/obs-bucket/key1/key2/key3",
+   *             "path": "volume1/obs-bucket/key1/key2/key3",
+   *             "size": 10485760,
+   *             "replicatedSize": 10485760,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781424718,
+   *             "modificationTime": 1715781425598,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/obs-bucket/key4",
+   *             "path": "volume1/obs-bucket/key4",
+   *             "size": 10485760,
+   *             "replicatedSize": 10485760,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781427561,
+   *             "modificationTime": 1715781428407,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/obs-bucket/key5",
+   *             "path": "volume1/obs-bucket/key5",
+   *             "size": 10485760,
+   *             "replicatedSize": 10485760,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781430347,
+   *             "modificationTime": 1715781431185,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/obs-bucket/key6",
+   *             "path": "volume1/obs-bucket/key6",
+   *             "size": 10485760,
+   *             "replicatedSize": 10485760,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781433154,
+   *             "modificationTime": 1715781433962,
+   *             "isKey": true
+   *         }
+   *     ]
    * }
    * Input Request for FSO bucket:
    *
@@ -785,15 +838,13 @@ public class OMDBInsightEndpoint {
    * {
    *     "status": "OK",
    *     "path": "/volume1/fso-bucket",
-   *     "replicatedDataSize": 62914560,
-   *     "unReplicatedDataSize": 20971520,
-   *     "keyCount": 2,
-   *     "lastKey": "/-9223372036854775552/-9223372036854775040/-9223372036854774525/testfile",
+   *     "replicatedDataSize": 188743680,
+   *     "unReplicatedDataSize": 62914560,
+   *     "lastKey": "/-9223372036854775552/-9223372036854774016/-9223372036854773503/testfile",
    *     "keys": [
    *         {
-   *             "key": "/-9223372036854775552/-9223372036854775040/-9223372036854774525/file1",
-   *             "path": "file1",
-   *             "inStateSince": 1715174237440,
+   *             "key": "/-9223372036854775552/-9223372036854774016/-9223372036854773501/file1",
+   *             "path": "volume1/fso-bucket/dir1/dir2/dir3/file1",
    *             "size": 10485760,
    *             "replicatedSize": 31457280,
    *             "replicationInfo": {
@@ -801,14 +852,13 @@ public class OMDBInsightEndpoint {
    *                 "requiredNodes": 3,
    *                 "replicationType": "RATIS"
    *             },
-   *             "creationTime": 1715174237440,
-   *             "modificationTime": 1715174238161,
+   *             "creationTime": 1715781411785,
+   *             "modificationTime": 1715781415119,
    *             "isKey": true
    *         },
    *         {
-   *             "key": "/-9223372036854775552/-9223372036854775040/-9223372036854774525/testfile",
-   *             "path": "testfile",
-   *             "inStateSince": 1715174234840,
+   *             "key": "/-9223372036854775552/-9223372036854774016/-9223372036854773501/testfile",
+   *             "path": "volume1/fso-bucket/dir1/dir2/dir3/testfile",
    *             "size": 10485760,
    *             "replicatedSize": 31457280,
    *             "replicationInfo": {
@@ -816,12 +866,69 @@ public class OMDBInsightEndpoint {
    *                 "requiredNodes": 3,
    *                 "replicationType": "RATIS"
    *             },
-   *             "creationTime": 1715174234840,
-   *             "modificationTime": 1715174235562,
+   *             "creationTime": 1715781409146,
+   *             "modificationTime": 1715781409882,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/-9223372036854775552/-9223372036854774016/-9223372036854773502/file1",
+   *             "path": "volume1/fso-bucket/dir1/dir2/file1",
+   *             "size": 10485760,
+   *             "replicatedSize": 31457280,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "THREE",
+   *                 "requiredNodes": 3,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781406333,
+   *             "modificationTime": 1715781407140,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/-9223372036854775552/-9223372036854774016/-9223372036854773502/testfile",
+   *             "path": "volume1/fso-bucket/dir1/dir2/testfile",
+   *             "size": 10485760,
+   *             "replicatedSize": 31457280,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "THREE",
+   *                 "requiredNodes": 3,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781403655,
+   *             "modificationTime": 1715781404460,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/-9223372036854775552/-9223372036854774016/-9223372036854773503/file1",
+   *             "path": "volume1/fso-bucket/dir1/file1",
+   *             "size": 10485760,
+   *             "replicatedSize": 31457280,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "THREE",
+   *                 "requiredNodes": 3,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781400980,
+   *             "modificationTime": 1715781401768,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/-9223372036854775552/-9223372036854774016/-9223372036854773503/testfile",
+   *             "path": "volume1/fso-bucket/dir1/testfile",
+   *             "size": 10485760,
+   *             "replicatedSize": 31457280,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "THREE",
+   *                 "requiredNodes": 3,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781397636,
+   *             "modificationTime": 1715781398919,
    *             "isKey": true
    *         }
    *     ]
    * }
+   *
    * Input Request for Legacy bucket:
    *
    *        `api/v1/keys/listKeys?startPrefix=/volume1/legacy-bucket&limit=2&replicationType=RATIS`
@@ -830,15 +937,13 @@ public class OMDBInsightEndpoint {
    * {
    *     "status": "OK",
    *     "path": "/volume1/legacy-bucket",
-   *     "replicatedDataSize": 52428800,
-   *     "unReplicatedDataSize": 52428800,
-   *     "keyCount": 2,
-   *     "lastKey": "/volume1/legacy-bucket/key1/key2",
+   *     "replicatedDataSize": 157286400,
+   *     "unReplicatedDataSize": 157286400,
+   *     "lastKey": "/volume1/legacy-bucket/key6",
    *     "keys": [
    *         {
    *             "key": "/volume1/legacy-bucket/key1",
-   *             "path": "key1",
-   *             "inStateSince": 1715174303702,
+   *             "path": "volume1/legacy-bucket/key1",
    *             "size": 10485760,
    *             "replicatedSize": 10485760,
    *             "replicationInfo": {
@@ -846,14 +951,13 @@ public class OMDBInsightEndpoint {
    *                 "requiredNodes": 1,
    *                 "replicationType": "RATIS"
    *             },
-   *             "creationTime": 1715174303702,
-   *             "modificationTime": 1715174304619,
+   *             "creationTime": 1715781440620,
+   *             "modificationTime": 1715781441448,
    *             "isKey": true
    *         },
    *         {
    *             "key": "/volume1/legacy-bucket/key1/key2",
-   *             "path": "key1/key2",
-   *             "inStateSince": 1715174306641,
+   *             "path": "volume1/legacy-bucket/key1/key2",
    *             "size": 41943040,
    *             "replicatedSize": 41943040,
    *             "replicationInfo": {
@@ -861,8 +965,64 @@ public class OMDBInsightEndpoint {
    *                 "requiredNodes": 1,
    *                 "replicationType": "RATIS"
    *             },
-   *             "creationTime": 1715174306641,
-   *             "modificationTime": 1715174307994,
+   *             "creationTime": 1715781443431,
+   *             "modificationTime": 1715781444680,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/legacy-bucket/key1/key2/key3",
+   *             "path": "volume1/legacy-bucket/key1/key2/key3",
+   *             "size": 10485760,
+   *             "replicatedSize": 10485760,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781446657,
+   *             "modificationTime": 1715781447476,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/legacy-bucket/key4",
+   *             "path": "volume1/legacy-bucket/key4",
+   *             "size": 41943040,
+   *             "replicatedSize": 41943040,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781449445,
+   *             "modificationTime": 1715781450464,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/legacy-bucket/key5",
+   *             "path": "volume1/legacy-bucket/key5",
+   *             "size": 10485760,
+   *             "replicatedSize": 10485760,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781452476,
+   *             "modificationTime": 1715781453335,
+   *             "isKey": true
+   *         },
+   *         {
+   *             "key": "/volume1/legacy-bucket/key6",
+   *             "path": "volume1/legacy-bucket/key6",
+   *             "size": 41943040,
+   *             "replicatedSize": 41943040,
+   *             "replicationInfo": {
+   *                 "replicationFactor": "ONE",
+   *                 "requiredNodes": 1,
+   *                 "replicationType": "RATIS"
+   *             },
+   *             "creationTime": 1715781477894,
+   *             "modificationTime": 1715781479351,
    *             "isKey": true
    *         }
    *     ]
@@ -905,7 +1065,6 @@ public class OMDBInsightEndpoint {
     if (!keyInfoList.isEmpty()) {
       listKeysResponse.setLastKey(keyInfoList.get(keyInfoList.size() - 1).getKey());
     }
-    listKeysResponse.setCount(keyInfoList.size());
     return Response.ok(listKeysResponse).build();
   }
 
@@ -969,7 +1128,7 @@ public class OMDBInsightEndpoint {
     int originalLimit = paramInfo.getLimit();
     Map<String, OmKeyInfo> matchedKeys = new LinkedHashMap<>();
     // Convert the search prefix to an object path for FSO buckets
-    String startPrefixObjectPath = convertToObjectPath(paramInfo.getStartPrefix());
+    String startPrefixObjectPath = convertStartPrefixPathToObjectIdPath(paramInfo.getStartPrefix());
     String[] names = parseRequestPath(startPrefixObjectPath);
     Table<String, OmKeyInfo> fileTable =
         omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED);
@@ -1058,25 +1217,25 @@ public class OMDBInsightEndpoint {
 
 
   /**
-   * Converts a key prefix into an object path for FSO buckets, using IDs.
+   * Converts a startPrefix path into an objectId path for FSO buckets, using IDs.
    * <p>
    * This method transforms a user-provided path (e.g., "volume/bucket/dir1") into
    * a database-friendly format ("/volumeID/bucketID/ParentId/") by replacing names
    * with their corresponding IDs. It simplifies database queries for FSO bucket operations.
    *
-   * @param prevKeyPrefix The path to be converted, not including key or directory names/IDs.
-   * @return The object path as "/volumeID/bucketID/ParentId/".
+   * @param startPrefixPath The path to be converted.
+   * @return The objectId path as "/volumeID/bucketID/ParentId/".
    * @throws IOException If database access fails.
    */
-  public String convertToObjectPath(String prevKeyPrefix)
+  public String convertStartPrefixPathToObjectIdPath(String startPrefixPath)
       throws IOException, IllegalArgumentException {
 
     String[] names = parseRequestPath(
-        normalizePath(prevKeyPrefix, BucketLayout.FILE_SYSTEM_OPTIMIZED));
+        normalizePath(startPrefixPath, BucketLayout.FILE_SYSTEM_OPTIMIZED));
 
     // Root-Level :- Return the original path
     if (names.length == 0) {
-      return prevKeyPrefix;
+      return startPrefixPath;
     }
 
     // Volume-Level :- Fetch the volumeID
@@ -1217,7 +1376,6 @@ public class OMDBInsightEndpoint {
                                                          OmKeyInfo keyInfo) throws IOException {
     KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
     setKeyNameAndFullPath(dbKey, keyInfo, keyEntityInfo);
-    keyEntityInfo.setInStateSince(keyInfo.getCreationTime());
     keyEntityInfo.setSize(keyInfo.getDataSize());
     keyEntityInfo.setCreationTime(keyInfo.getCreationTime());
     keyEntityInfo.setModificationTime(keyInfo.getModificationTime());
@@ -1234,9 +1392,9 @@ public class OMDBInsightEndpoint {
       keyEntityInfo.setPath(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
           omMetadataManager));
     } else {
-      keyEntityInfo.setKey(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
-          omMetadataManager)); // Set the DB key
-      keyEntityInfo.setPath(dbKey);
+      keyEntityInfo.setKey(dbKey);
+      keyEntityInfo.setPath(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
+          omMetadataManager));
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -23,12 +23,19 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.recon.ReconUtils;
+import org.apache.hadoop.ozone.recon.api.handlers.BucketHandler;
 import org.apache.hadoop.ozone.recon.api.types.KeyEntityInfo;
 import org.apache.hadoop.ozone.recon.api.types.KeyInsightInfoResponse;
+import org.apache.hadoop.ozone.recon.api.types.ListKeysResponse;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
+import org.apache.hadoop.ozone.recon.api.types.ParamInfo;
+import org.apache.hadoop.ozone.recon.api.types.ResponseStatus;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.scm.ReconContainerManager;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
@@ -49,10 +56,17 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
@@ -60,12 +74,16 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_DIR_TABLE;
 import static org.apache.hadoop.ozone.recon.ReconConstants.DEFAULT_FETCH_COUNT;
+import static org.apache.hadoop.ozone.recon.ReconConstants.DEFAULT_KEY_SIZE;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_LIMIT;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_PREVKEY;
 import static org.apache.hadoop.ozone.recon.ReconConstants.DEFAULT_OPEN_KEY_INCLUDE_FSO;
 import static org.apache.hadoop.ozone.recon.ReconConstants.DEFAULT_OPEN_KEY_INCLUDE_NON_FSO;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OPEN_KEY_INCLUDE_FSO;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OPEN_KEY_INCLUDE_NON_FSO;
+import static org.apache.hadoop.ozone.recon.api.handlers.BucketHandler.getBucketHandler;
+import static org.apache.hadoop.ozone.recon.api.handlers.EntityHandler.normalizePath;
+import static org.apache.hadoop.ozone.recon.api.handlers.EntityHandler.parseRequestPath;
 
 
 /**
@@ -93,6 +111,7 @@ public class OMDBInsightEndpoint {
       LoggerFactory.getLogger(OMDBInsightEndpoint.class);
   private final GlobalStatsDao globalStatsDao;
   private ReconNamespaceSummaryManagerImpl reconNamespaceSummaryManager;
+  private final OzoneStorageContainerManager reconSCM;
 
 
   @Inject
@@ -106,6 +125,7 @@ public class OMDBInsightEndpoint {
     this.omMetadataManager = omMetadataManager;
     this.globalStatsDao = globalStatsDao;
     this.reconNamespaceSummaryManager = reconNamespaceSummaryManager;
+    this.reconSCM = reconSCM;
   }
 
   /**
@@ -672,6 +692,515 @@ public class OMDBInsightEndpoint {
     // Create a keys summary for deleted directories
     createSummaryForDeletedDirectories(dirSummary);
     return Response.ok(dirSummary).build();
+  }
+
+  /**
+   * This API will list out limited 'count' number of keys after applying below filters in API parameters:
+   * Default Values of API param filters:
+   *    -- replicationType - empty string and filter will not be applied, so list out all keys irrespective of
+   *       replication type.
+   *    -- creationTime - empty string and filter will not be applied, so list out keys irrespective of age.
+   *    -- keySize - 0 bytes, which means all keys greater than zero bytes will be listed, effectively all.
+   *    -- startPrefix - /
+   *    -- count - 1000
+   *
+   * @param replicationType Filter for RATIS or EC replication keys
+   * @param creationDate Filter for keys created after creationDate in "MM-dd-yyyy HH:mm:ss" string format.
+   * @param keySize Filter for Keys greater than keySize in bytes.
+   * @param startPrefix Filter for startPrefix path.
+   * @param limit Filter for limited count of keys.
+   * @return the list of keys in below structured format:
+   * Response For OBS Bucket keys:
+   * ********************************************************
+   * {
+   *     "status": "OK",
+   *     "path": "/volume1/obs-bucket/",
+   *     "size": 73400320,
+   *     "sizeWithReplica": 81788928,
+   *     "subPathCount": 1,
+   *     "totalKeyCount": 7,
+   *     "lastKey": "/volume1/obs-bucket/key7",
+   *     "subPaths": [
+   *         {
+   *             "key": true,
+   *             "path": "key1",
+   *             "size": 10485760,
+   *             "sizeWithReplica": 18874368,
+   *             "isKey": true,
+   *             "replicationType": "RATIS",
+   *             "creationTime": 1712321367060,
+   *             "modificationTime": 1712321368190
+   *         },
+   *         {
+   *             "key": true,
+   *             "path": "key7",
+   *             "size": 10485760,
+   *             "sizeWithReplica": 18874368,
+   *             "isKey": true,
+   *             "replicationType": "EC",
+   *             "creationTime": 1713261005555,
+   *             "modificationTime": 1713261006728
+   *         }
+   *     ],
+   *     "sizeDirectKey": 73400320
+   * }
+   * ********************************************************
+   * @throws IOException
+   */
+  @GET
+  @Path("/listKeys")
+  @SuppressWarnings("methodlength")
+  public Response listKeys(@QueryParam("replicationType") String replicationType,
+                           @QueryParam("creationDate") String creationDate,
+                           @DefaultValue(DEFAULT_KEY_SIZE) @QueryParam("keySize") long keySize,
+                           @DefaultValue(OM_KEY_PREFIX) @QueryParam("startPrefix") String startPrefix,
+                           @DefaultValue(StringUtils.EMPTY) @QueryParam(RECON_QUERY_PREVKEY) String prevKey,
+                           @DefaultValue(DEFAULT_FETCH_COUNT) @QueryParam("limit") int limit) {
+
+    String[] names = startPrefix.split(OM_KEY_PREFIX);
+    // This API supports startPrefix from bucket level.
+    if (startPrefix == null || startPrefix.length() == 0 || names.length < 3) {
+      return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+    ListKeysResponse listKeysResponse = new ListKeysResponse();
+    if (!ReconUtils.isInitializationComplete(omMetadataManager)) {
+      listKeysResponse.setStatus(ResponseStatus.INITIALIZING);
+      return Response.ok(listKeysResponse).build();
+    }
+    ParamInfo paramInfo = new ParamInfo(replicationType, creationDate, keySize, startPrefix, prevKey,
+        limit, false, "");
+    Response response = getListKeysResponse(paramInfo);
+    if (response.getEntity() instanceof ListKeysResponse) {
+      listKeysResponse = (ListKeysResponse) response.getEntity();
+    }
+
+    List<KeyEntityInfo> keyInfoList = listKeysResponse.getKeys();
+    if (!keyInfoList.isEmpty()) {
+      listKeysResponse.setLastKey(keyInfoList.get(keyInfoList.size() - 1).getKey());
+    }
+    listKeysResponse.setCount(keyInfoList.size());
+    return Response.ok(listKeysResponse).build();
+  }
+
+  private Response getListKeysResponse(ParamInfo paramInfo) {
+    try {
+      paramInfo.setLimit(Math.max(0, paramInfo.getLimit())); // Ensure limit is non-negative
+      ListKeysResponse listKeysResponse = new ListKeysResponse();
+      listKeysResponse.setPath(paramInfo.getStartPrefix());
+      long replicatedTotal = 0;
+      long unreplicatedTotal = 0;
+      boolean keysFound = false; // Flag to track if any keys are found
+
+      // Search keys from non-FSO layout.
+      Map<String, OmKeyInfo> obsKeys = new LinkedHashMap<>();
+      Table<String, OmKeyInfo> keyTable =
+          omMetadataManager.getKeyTable(BucketLayout.LEGACY);
+      obsKeys = retrieveKeysFromTable(keyTable, paramInfo);
+      for (Map.Entry<String, OmKeyInfo> entry : obsKeys.entrySet()) {
+        keysFound = true;
+        KeyEntityInfo keyEntityInfo =
+            createKeyEntityInfoFromOmKeyInfo(entry.getKey(), entry.getValue());
+
+        listKeysResponse.getKeys().add(keyEntityInfo);
+        replicatedTotal += entry.getValue().getReplicatedSize();
+        unreplicatedTotal += entry.getValue().getDataSize();
+      }
+
+      // Search keys from FSO layout.
+      Map<String, OmKeyInfo> fsoKeys = searchKeysInFSO(paramInfo);
+      for (Map.Entry<String, OmKeyInfo> entry : fsoKeys.entrySet()) {
+        keysFound = true;
+        KeyEntityInfo keyEntityInfo =
+            createKeyEntityInfoFromOmKeyInfo(entry.getKey(), entry.getValue());
+
+        listKeysResponse.getKeys().add(keyEntityInfo);
+        replicatedTotal += entry.getValue().getReplicatedSize();
+        unreplicatedTotal += entry.getValue().getDataSize();
+      }
+
+      // If no keys were found, return a response indicating that no keys matched
+      if (!keysFound) {
+        return noMatchedKeysResponse(paramInfo.getStartPrefix());
+      }
+
+      // Set the aggregated totals in the response
+      listKeysResponse.setReplicatedDataSize(replicatedTotal);
+      listKeysResponse.setUnReplicatedDataSize(unreplicatedTotal);
+
+      return Response.ok(listKeysResponse).build();
+    } catch (IOException e) {
+      return createInternalServerErrorResponse(
+          "Error searching keys in OM DB: " + e.getMessage());
+    } catch (IllegalArgumentException e) {
+      return createBadRequestResponse(
+          "Invalid startPrefix: " + e.getMessage());
+    }
+  }
+
+  public Map<String, OmKeyInfo> searchKeysInFSO(ParamInfo paramInfo)
+      throws IOException, IllegalArgumentException {
+    Map<String, OmKeyInfo> matchedKeys = new LinkedHashMap<>();
+    // Convert the search prefix to an object path for FSO buckets
+    String startPrefixObjectPath = convertToObjectPath(paramInfo.getStartPrefix());
+    String[] names = parseRequestPath(startPrefixObjectPath);
+    Table<String, OmKeyInfo> fileTable =
+        omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+    // If names.length > 2, then the search prefix is at the volume or bucket level hence
+    // no need to find parent or extract id's or find subpaths as the fileTable is
+    // suitable for volume and bucket level search
+    if (names.length > 2) {
+      // Fetch the parent ID to search for
+      long parentId = Long.parseLong(names[names.length - 1]);
+
+      // Fetch the nameSpaceSummary for the parent ID
+      NSSummary parentSummary =
+          reconNamespaceSummaryManager.getNSSummary(parentId);
+      if (parentSummary == null) {
+        return matchedKeys;
+      }
+      List<String> subPaths = new ArrayList<>();
+      // Add the initial search prefix object path because it can have both files and subdirectories with files.
+      subPaths.add(startPrefixObjectPath);
+
+      // Recursively gather all subpaths
+      gatherSubPaths(parentId, subPaths, Long.parseLong(names[0]), Long.parseLong(names[1]));
+      // Iterate over the subpaths and retrieve the files
+      for (String subPath : subPaths) {
+        paramInfo.setStartPrefix(subPath);
+        paramInfo.setLimit(paramInfo.getLimit() - matchedKeys.size());
+        matchedKeys.putAll(
+            retrieveKeysFromTable(fileTable, paramInfo));
+        if (matchedKeys.size() >= paramInfo.getLimit()) {
+          break;
+        }
+      }
+      return matchedKeys;
+    }
+
+    paramInfo.setStartPrefix(startPrefixObjectPath);
+    // Iterate over for bucket and volume level search
+    matchedKeys.putAll(
+        retrieveKeysFromTable(fileTable, paramInfo));
+    return matchedKeys;
+  }
+
+  /**
+   * Finds all subdirectories under a parent directory in an FSO bucket. It builds
+   * a list of paths for these subdirectories. These sub-directories are then used
+   * to search for files in the fileTable.
+   * <p>
+   * How it works:
+   * - Starts from a parent directory identified by parentId.
+   * - Looks through all child directories of this parent.
+   * - For each child, it creates a path that starts with volumeID/bucketID/parentId,
+   * following our fileTable format
+   * - Adds these paths to a list and explores each child further for more subdirectories.
+   *
+   * @param parentId The ID of the directory we start exploring from.
+   * @param subPaths A list where we collect paths to all subdirectories.
+   * @param volumeID
+   * @param bucketID
+   * @throws IOException If there are problems accessing directory information.
+   */
+  private void gatherSubPaths(long parentId, List<String> subPaths,
+                              long volumeID, long bucketID) throws IOException {
+    // Fetch the NSSummary object for parentId
+    NSSummary parentSummary =
+        reconNamespaceSummaryManager.getNSSummary(parentId);
+    if (parentSummary == null) {
+      return;
+    }
+
+    Set<Long> childDirIds = parentSummary.getChildDir();
+    for (Long childId : childDirIds) {
+      // Fetch the NSSummary for each child directory
+      NSSummary childSummary =
+          reconNamespaceSummaryManager.getNSSummary(childId);
+      if (childSummary != null) {
+        String subPath =
+            constructObjectPathWithPrefix(volumeID, bucketID, childId);
+        // Add to subPaths
+        subPaths.add(subPath);
+        // Recurse into this child directory
+        gatherSubPaths(childId, subPaths, volumeID, bucketID);
+      }
+    }
+  }
+
+
+  /**
+   * Converts a key prefix into an object path for FSO buckets, using IDs.
+   * <p>
+   * This method transforms a user-provided path (e.g., "volume/bucket/dir1") into
+   * a database-friendly format ("/volumeID/bucketID/ParentId/") by replacing names
+   * with their corresponding IDs. It simplifies database queries for FSO bucket operations.
+   *
+   * @param prevKeyPrefix The path to be converted, not including key or directory names/IDs.
+   * @return The object path as "/volumeID/bucketID/ParentId/".
+   * @throws IOException If database access fails.
+   */
+  public String convertToObjectPath(String prevKeyPrefix)
+      throws IOException, IllegalArgumentException {
+
+    String[] names = parseRequestPath(
+        normalizePath(prevKeyPrefix, BucketLayout.FILE_SYSTEM_OPTIMIZED));
+
+    // Root-Level :- Return the original path
+    if (names.length == 0) {
+      return prevKeyPrefix;
+    }
+
+    // Volume-Level :- Fetch the volumeID
+    String volumeName = names[0];
+    validateNames(volumeName);
+    String volumeKey = omMetadataManager.getVolumeKey(volumeName);
+    long volumeId = omMetadataManager.getVolumeTable().getSkipCache(volumeKey)
+        .getObjectID();
+    if (names.length == 1) {
+      return constructObjectPathWithPrefix(volumeId);
+    }
+
+    // Bucket-Level :- Fetch the bucketID
+    String bucketName = names[1];
+    validateNames(bucketName);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo bucketInfo =
+        omMetadataManager.getBucketTable().getSkipCache(bucketKey);
+    long bucketId = bucketInfo.getObjectID();
+    if (names.length == 2) {
+      return constructObjectPathWithPrefix(volumeId, bucketId);
+    }
+
+    // Fetch the immediate parentID which could be a directory or the bucket itself
+    BucketHandler handler =
+        getBucketHandler(reconNamespaceSummaryManager, omMetadataManager,
+            reconSCM, bucketInfo);
+    long dirObjectId = handler.getDirInfo(names).getObjectID();
+    return constructObjectPathWithPrefix(volumeId, bucketId, dirObjectId);
+  }
+
+  /**
+   * Common method to retrieve keys from a table based on a search prefix and a limit.
+   *
+   * @param table     The table to retrieve keys from.
+   * @param paramInfo The stats object holds total count, count and limit.
+   * @return A map of keys and their corresponding OmKeyInfo objects.
+   * @throws IOException If there are problems accessing the table.
+   */
+  private Map<String, OmKeyInfo> retrieveKeysFromTable(
+      Table<String, OmKeyInfo> table, ParamInfo paramInfo)
+      throws IOException {
+    boolean skipPrevKey = false;
+    String seekKey = paramInfo.getPrevKey();
+    Map<String, OmKeyInfo> matchedKeys = new LinkedHashMap<>();
+    try (
+        TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> keyIter = table.iterator()) {
+
+      if (!paramInfo.isSkipPrevKeyDone() && StringUtils.isNotBlank(seekKey)) {
+        skipPrevKey = true;
+        Table.KeyValue<String, OmKeyInfo> seekKeyValue =
+            keyIter.seek(seekKey);
+
+        // check if RocksDB was able to seek correctly to the given key prefix
+        // if not, then return empty result
+        // In case of an empty prevKeyPrefix, all the keys are returned
+        if (seekKeyValue == null ||
+            (StringUtils.isNotBlank(paramInfo.getPrevKey()) &&
+                !seekKeyValue.getKey().equals(paramInfo.getPrevKey()))) {
+          return matchedKeys;
+        }
+      } else {
+        keyIter.seek(paramInfo.getStartPrefix());
+      }
+
+      while (keyIter.hasNext()) {
+        Table.KeyValue<String, OmKeyInfo> entry = keyIter.next();
+        String dbKey = entry.getKey();
+        paramInfo.setLastKey(dbKey);
+        if (!dbKey.startsWith(paramInfo.getStartPrefix())) {
+          break; // Exit the loop if the key no longer matches the prefix
+        }
+        if (skipPrevKey && dbKey.equals(paramInfo.getPrevKey())) {
+          paramInfo.setSkipPrevKeyDone(true);
+          continue;
+        }
+        if (applyFilters(entry, paramInfo) && matchedKeys.size() < paramInfo.getLimit()) {
+          matchedKeys.put(dbKey, entry.getValue());
+        }
+      }
+    } catch (IOException exception) {
+      LOG.error("Error retrieving keys from table for path: {}", paramInfo.getStartPrefix(), exception);
+      throw exception;
+    }
+    return matchedKeys;
+  }
+
+  private boolean applyFilters(Table.KeyValue<String, OmKeyInfo> entry, ParamInfo paramInfo) throws IOException {
+
+    LOG.error("Applying filters on : {}", entry.getKey());
+
+    long epochMillis =
+        ReconUtils.convertToEpochMillis(paramInfo.getCreationDate(), "MM-dd-yyyy HH:mm:ss", TimeZone.getDefault());
+    Predicate<Table.KeyValue<String, OmKeyInfo>> keyAgeFilter = keyData -> {
+      try {
+        return keyData.getValue().getCreationTime() >= epochMillis;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+    Predicate<Table.KeyValue<String, OmKeyInfo>> keyReplicationFilter =
+        keyData -> {
+          try {
+            return keyData.getValue().getReplicationConfig().getReplicationType().name()
+                .equals(paramInfo.getReplicationType());
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        };
+    Predicate<Table.KeyValue<String, OmKeyInfo>> keySizeFilter = keyData -> {
+      try {
+        return keyData.getValue().getDataSize() > paramInfo.getKeySize();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    List<Table.KeyValue<String, OmKeyInfo>> filteredKeyList = Stream.of(entry)
+        .filter(keyData -> !StringUtils.isEmpty(paramInfo.getCreationDate()) ? keyAgeFilter.test(keyData) : true)
+        .filter(
+            keyData -> !StringUtils.isEmpty(paramInfo.getReplicationType()) ? keyReplicationFilter.test(keyData) : true)
+        .filter(keySizeFilter)
+        .collect(Collectors.toList());
+
+    LOG.error("After filtering listKeys:");
+    filteredKeyList.forEach(keyInfo -> {
+      try {
+        LOG.error("Key name - {}", keyInfo.getValue().getKeyName());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    return (filteredKeyList.size() > 0);
+  }
+
+  /**
+   * Creates a KeyEntityInfo object from an OmKeyInfo object and the corresponding key.
+   *
+   * @param dbKey   The key in the database corresponding to the OmKeyInfo object.
+   * @param keyInfo The OmKeyInfo object to create the KeyEntityInfo from.
+   * @return The KeyEntityInfo object created from the OmKeyInfo object and the key.
+   */
+  private KeyEntityInfo createKeyEntityInfoFromOmKeyInfo(String dbKey,
+                                                         OmKeyInfo keyInfo) {
+    KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
+    keyEntityInfo.setKey(dbKey); // Set the DB key
+    keyEntityInfo.setPath(keyInfo.getKeyName()); // Assuming path is the same as key name
+    keyEntityInfo.setInStateSince(keyInfo.getCreationTime());
+    keyEntityInfo.setSize(keyInfo.getDataSize());
+    keyEntityInfo.setCreationTime(keyInfo.getCreationTime());
+    keyEntityInfo.setModificationTime(keyInfo.getModificationTime());
+    keyEntityInfo.setReplicatedSize(keyInfo.getReplicatedSize());
+    keyEntityInfo.setReplicationConfig(keyInfo.getReplicationConfig());
+    return keyEntityInfo;
+  }
+
+  /**
+   * Constructs an object path with the given IDs.
+   *
+   * @param ids The IDs to construct the object path with.
+   * @return The constructed object path.
+   */
+  private String constructObjectPathWithPrefix(long... ids) {
+    StringBuilder pathBuilder = new StringBuilder();
+    for (long id : ids) {
+      pathBuilder.append(OM_KEY_PREFIX).append(id);
+    }
+    return pathBuilder.toString();
+  }
+
+  /**
+   * Validates volume or bucket names according to specific rules.
+   *
+   * @param resName The name to validate (volume or bucket).
+   * @return A Response object if validation fails, or null if the name is valid.
+   */
+  public Response validateNames(String resName)
+      throws IllegalArgumentException {
+    if (resName.length() < OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH ||
+        resName.length() > OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH) {
+      throw new IllegalArgumentException(
+          "Bucket or Volume name length should be between " +
+              OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH + " and " +
+              OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH);
+    }
+
+    if (resName.charAt(0) == '.' || resName.charAt(0) == '-' ||
+        resName.charAt(resName.length() - 1) == '.' ||
+        resName.charAt(resName.length() - 1) == '-') {
+      throw new IllegalArgumentException(
+          "Bucket or Volume name cannot start or end with " +
+              "hyphen or period");
+    }
+
+    // Regex to check for lowercase letters, numbers, hyphens, underscores, and periods only.
+    if (!resName.matches("^[a-z0-9._-]+$")) {
+      throw new IllegalArgumentException(
+          "Bucket or Volume name can only contain lowercase " +
+              "letters, numbers, hyphens, underscores, and periods");
+    }
+
+    // If all checks pass, the name is valid
+    return null;
+  }
+
+  /**
+   * Returns a response indicating that no keys matched the search prefix.
+   *
+   * @param startPrefix The search prefix that was used.
+   * @return The response indicating that no keys matched the search prefix.
+   */
+  private Response noMatchedKeysResponse(String startPrefix) {
+    String jsonResponse = String.format(
+        "{\"message\": \"No keys matched the search prefix: '%s'.\"}",
+        startPrefix);
+    return Response.status(Response.Status.NOT_FOUND)
+        .entity(jsonResponse)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  /**
+   * Utility method to create a bad request response with a custom message.
+   * Which means the request sent by the client to the server is incorrect
+   * or malformed and cannot be processed by the server.
+   *
+   * @param message The message to include in the response body.
+   * @return A Response object configured with the provided message.
+   */
+  private Response createBadRequestResponse(String message) {
+    String jsonResponse = String.format("{\"message\": \"%s\"}", message);
+    return Response.status(Response.Status.BAD_REQUEST)
+        .entity(jsonResponse)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
+  /**
+   * Utility method to create an internal server error response with a custom message.
+   * Which means the server encountered an unexpected condition that prevented it
+   * from fulfilling the request.
+   *
+   * @param message The message to include in the response body.
+   * @return A Response object configured with the provided message.
+   */
+  private Response createInternalServerErrorResponse(String message) {
+    String jsonResponse = String.format("{\"message\": \"%s\"}", message);
+    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .entity(jsonResponse)
+        .type(MediaType.APPLICATION_JSON)
+        .build();
   }
 
   private void createSummaryForDeletedDirectories(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -1215,9 +1215,7 @@ public class OMDBInsightEndpoint {
   private KeyEntityInfo createKeyEntityInfoFromOmKeyInfo(String dbKey,
                                                          OmKeyInfo keyInfo) throws IOException {
     KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
-    keyEntityInfo.setKey(dbKey); // Set the DB key
-    keyEntityInfo.setPath(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
-        omMetadataManager));
+    setKeyNameAndFullPath(dbKey, keyInfo, keyEntityInfo);
     keyEntityInfo.setInStateSince(keyInfo.getCreationTime());
     keyEntityInfo.setSize(keyInfo.getDataSize());
     keyEntityInfo.setCreationTime(keyInfo.getCreationTime());
@@ -1225,6 +1223,20 @@ public class OMDBInsightEndpoint {
     keyEntityInfo.setReplicatedSize(keyInfo.getReplicatedSize());
     keyEntityInfo.setReplicationConfig(keyInfo.getReplicationConfig());
     return keyEntityInfo;
+  }
+
+  private void setKeyNameAndFullPath(String dbKey, OmKeyInfo keyInfo, KeyEntityInfo keyEntityInfo) throws IOException {
+    String bucketKey = omMetadataManager.getBucketKey(keyInfo.getVolumeName(), keyInfo.getBucketName());
+    OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().getSkipCache(bucketKey);
+    if (omBucketInfo.getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
+      keyEntityInfo.setKey(dbKey); // Set the DB key
+      keyEntityInfo.setPath(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
+          omMetadataManager));
+    } else {
+      keyEntityInfo.setKey(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
+          omMetadataManager)); // Set the DB key
+      keyEntityInfo.setPath(dbKey);
+    }
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -1178,6 +1178,8 @@ public class OMDBInsightEndpoint {
       OmDirectoryInfo dirInfo = handler.getDirInfo(names);
       if (null != dirInfo) {
         dirObjectId = dirInfo.getObjectID();
+      } else {
+        throw new IllegalArgumentException("Not valid path");
       }
     } catch (Exception ioe) {
       throw new IllegalArgumentException("Not valid path: " + ioe);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -960,6 +960,10 @@ public class OMDBInsightEndpoint {
     ParamInfo paramInfo = new ParamInfo(replicationType, creationDate, keySize, startPrefix, prevKey,
         limit, false, "");
     Response response = getListKeysResponse(paramInfo);
+    if ((response.getStatus() != Response.Status.OK.getStatusCode()) &&
+        (response.getStatus() != Response.Status.NOT_FOUND.getStatusCode())) {
+      return response;
+    }
     if (response.getEntity() instanceof ListKeysResponse) {
       listKeysResponse = (ListKeysResponse) response.getEntity();
     }
@@ -1039,7 +1043,7 @@ public class OMDBInsightEndpoint {
     Table<String, OmKeyInfo> fileTable =
         omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
-    // If names.length > 2, then the search prefix is at the volume or bucket level hence
+    // If names.length > 2, then the search prefix is at the level above bucket level hence
     // no need to find parent or extract id's or find subpaths as the fileTable is
     // suitable for volume and bucket level search
     if (names.length > 2) {
@@ -1176,7 +1180,7 @@ public class OMDBInsightEndpoint {
         dirObjectId = dirInfo.getObjectID();
       }
     } catch (Exception ioe) {
-      LOG.error("Not valid directory :{}", ioe);
+      throw new IllegalArgumentException("Not valid path: " + ioe);
     }
     return ReconUtils.constructObjectPathWithPrefix(volumeId, bucketId, dirObjectId);
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/EntityHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/EntityHandler.java
@@ -322,7 +322,7 @@ public abstract class EntityHandler {
    * @param bucketLayout
    * @return A normalized path
    */
-  private static String normalizePath(String path, BucketLayout bucketLayout) {
+  public static String normalizePath(String path, BucketLayout bucketLayout) {
     if (bucketLayout == BucketLayout.OBJECT_STORE) {
       return OM_KEY_PREFIX + OmUtils.normalizePathUptoBucket(path);
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/FSOBucketHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/handlers/FSOBucketHandler.java
@@ -300,5 +300,4 @@ public class FSOBucketHandler extends BucketHandler {
         .getDirectoryTable().getSkipCache(dirKey);
     return dirInfo;
   }
-
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
@@ -49,6 +49,18 @@ public class KeyEntityInfo {
   @JsonProperty("replicationInfo")
   private ReplicationConfig replicationConfig;
 
+  /** key creation time. */
+  @JsonProperty("creationTime")
+  private long creationTime;
+
+  /** key modification time. */
+  @JsonProperty("modificationTime")
+  private long modificationTime;
+
+  /** Indicate if the path is a key for Web UI. */
+  @JsonProperty("isKey")
+  private boolean isKey;
+
   public KeyEntityInfo() {
     key = "";
     path = "";
@@ -56,6 +68,9 @@ public class KeyEntityInfo {
     size = 0L;
     replicatedSize = 0L;
     replicationConfig = null;
+    creationTime = Instant.now().toEpochMilli();
+    modificationTime = Instant.now().toEpochMilli();
+    isKey = true;
   }
 
   public String getKey() {
@@ -105,5 +120,29 @@ public class KeyEntityInfo {
   public void setReplicationConfig(
       ReplicationConfig replicationConfig) {
     this.replicationConfig = replicationConfig;
+  }
+
+  public long getCreationTime() {
+    return creationTime;
+  }
+
+  public void setCreationTime(long creationTime) {
+    this.creationTime = creationTime;
+  }
+
+  public long getModificationTime() {
+    return modificationTime;
+  }
+
+  public void setModificationTime(long modificationTime) {
+    this.modificationTime = modificationTime;
+  }
+
+  public boolean isKey() {
+    return isKey;
+  }
+
+  public void setKey(boolean key) {
+    isKey = key;
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.api.types;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 
@@ -38,6 +39,7 @@ public class KeyEntityInfo {
   private String path;
 
   @JsonProperty("inStateSince")
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   private long inStateSince;
 
   @JsonProperty("size")

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
@@ -66,7 +66,6 @@ public class KeyEntityInfo {
   public KeyEntityInfo() {
     key = "";
     path = "";
-    inStateSince = Instant.now().toEpochMilli();
     size = 0L;
     replicatedSize = 0L;
     replicationConfig = null;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ListKeysResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ListKeysResponse.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.api.types;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * HTTP Response wrapped for listKeys requests.
+ */
+public class ListKeysResponse {
+  /** Path status. */
+  @JsonProperty("status")
+  private ResponseStatus status;
+
+  /** The current path request. */
+  @JsonProperty("path")
+  private String path;
+
+  /** Amount of data mapped to all keys and files in a cluster across all DNs. */
+  @JsonProperty("replicatedDataSize")
+  private long replicatedDataSize;
+
+  /** Amount of data mapped to all keys and files on a single DN. */
+  @JsonProperty("unReplicatedDataSize")
+  private long unReplicatedDataSize;
+
+  /** The number of keys based on limit under the request path. */
+  @JsonProperty("keyCount")
+  private int count;
+
+  /** last key sent. */
+  @JsonProperty("lastKey")
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private String lastKey;
+
+  /** list of keys. */
+  @JsonProperty("keys")
+  private List<KeyEntityInfo> keys;
+
+
+  public ListKeysResponse() {
+    this.status = ResponseStatus.OK;
+    this.path = "";
+    this.keys = new ArrayList<>();
+    this.replicatedDataSize = -1L;
+    this.unReplicatedDataSize = -1L;
+    this.count = 0;
+    this.lastKey = "";
+  }
+
+  public ResponseStatus getStatus() {
+    return this.status;
+  }
+
+  public void setStatus(ResponseStatus status) {
+    this.status = status;
+  }
+
+  public long getReplicatedDataSize() {
+    return replicatedDataSize;
+  }
+
+  public void setReplicatedDataSize(long replicatedDataSize) {
+    this.replicatedDataSize = replicatedDataSize;
+  }
+
+  public long getUnReplicatedDataSize() {
+    return unReplicatedDataSize;
+  }
+
+  public void setUnReplicatedDataSize(long unReplicatedDataSize) {
+    this.unReplicatedDataSize = unReplicatedDataSize;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public void setCount(int count) {
+    this.count = count;
+  }
+
+  public List<KeyEntityInfo> getKeys() {
+    return keys;
+  }
+
+  public void setKeys(List<KeyEntityInfo> keys) {
+    this.keys = keys;
+  }
+
+  public String getLastKey() {
+    return lastKey;
+  }
+
+  public void setLastKey(String lastKey) {
+    this.lastKey = lastKey;
+  }
+
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ListKeysResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ListKeysResponse.java
@@ -44,10 +44,6 @@ public class ListKeysResponse {
   @JsonProperty("unReplicatedDataSize")
   private long unReplicatedDataSize;
 
-  /** The number of keys based on limit under the request path. */
-  @JsonProperty("keyCount")
-  private int count;
-
   /** last key sent. */
   @JsonProperty("lastKey")
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -64,7 +60,6 @@ public class ListKeysResponse {
     this.keys = new ArrayList<>();
     this.replicatedDataSize = -1L;
     this.unReplicatedDataSize = -1L;
-    this.count = 0;
     this.lastKey = "";
   }
 
@@ -98,14 +93,6 @@ public class ListKeysResponse {
 
   public void setPath(String path) {
     this.path = path;
-  }
-
-  public int getCount() {
-    return count;
-  }
-
-  public void setCount(int count) {
-    this.count = count;
   }
 
   public List<KeyEntityInfo> getKeys() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ParamInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ParamInfo.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.recon.api.types;
+
+/**
+ * Wrapper object for statistics of records of a page in API response.
+ */
+public class ParamInfo {
+
+  /**
+   * start prefix path to start search.
+   */
+  private String startPrefix;
+
+  /**
+   * key size filter.
+   */
+  private long keySize;
+
+  /**
+   * creation date filter for keys to filter.
+   */
+  private String creationDate;
+
+  /**
+   *
+   */
+  private String replicationType;
+
+  /**
+   * limit the number of records to return in API response.
+   */
+  private int limit;
+
+  private String prevKey;
+
+  private String lastKey;
+
+  private boolean skipPrevKeyDone = false;
+
+  /**
+   * counter to track the number of records added in API response.
+   */
+  private long currentCount;
+
+  @SuppressWarnings("parameternumber")
+  public ParamInfo(String replicationType, String creationDate, long keySize, String startPrefix, String prevKey,
+                   int limit, boolean skipPrevKeyDone, String lastKey) {
+    this.replicationType = replicationType;
+    this.creationDate = creationDate;
+    this.keySize = keySize;
+    this.startPrefix = startPrefix;
+    this.prevKey = prevKey;
+    this.limit = limit;
+    this.skipPrevKeyDone = skipPrevKeyDone;
+    this.lastKey = lastKey;
+  }
+
+  public String getStartPrefix() {
+    return startPrefix;
+  }
+
+  public void setStartPrefix(String startPrefix) {
+    this.startPrefix = startPrefix;
+  }
+
+  public long getKeySize() {
+    return keySize;
+  }
+
+  public String getCreationDate() {
+    return creationDate;
+  }
+
+  public String getReplicationType() {
+    return replicationType;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public void setLimit(int limit) {
+    this.limit = limit;
+  }
+
+  public long getCurrentCount() {
+    return currentCount;
+  }
+
+  public void setCurrentCount(long currentCount) {
+    this.currentCount = currentCount;
+  }
+
+  public String getPrevKey() {
+    return prevKey;
+  }
+
+  public void setPrevKey(String prevKey) {
+    this.prevKey = prevKey;
+  }
+
+  public boolean isSkipPrevKeyDone() {
+    return skipPrevKeyDone;
+  }
+
+  public void setSkipPrevKeyDone(boolean skipPrevKeyDone) {
+    this.skipPrevKeyDone = skipPrevKeyDone;
+  }
+
+  public String getLastKey() {
+    return lastKey;
+  }
+
+  public void setLastKey(String lastKey) {
+    this.lastKey = lastKey;
+  }
+}

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -65,6 +66,7 @@ import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
  */
 public final class OMMetadataManagerTestUtils {
 
+  public static final String TEST_USER = "TestUser";
   private static OzoneConfiguration configuration;
   private OMMetadataManagerTestUtils() {
   }
@@ -86,7 +88,7 @@ public final class OMMetadataManagerTestUtils {
     OmVolumeArgs args =
         OmVolumeArgs.newBuilder()
             .setVolume("sampleVol")
-            .setAdminName("TestUser")
+            .setAdminName(TEST_USER)
             .setOwnerName("TestUser")
             .build();
     omMetadataManager.getVolumeTable().put(volumeKey, args);
@@ -262,6 +264,56 @@ public final class OMMetadataManagerTestUtils {
                     .setObjectID(objectId)
                     .setParentObjectID(parentObjectId)
                     .build());
+  }
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  private static String getKey(OMMetadataManager omMetadataManager, String key, String bucket, String volume,
+                               String fileName, long parentObjectId, long bucketObjectId, long volumeObjectId,
+                               BucketLayout bucketLayout) {
+    String omKey;
+    if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+      omKey = omMetadataManager.getOzonePathKey(volumeObjectId,
+          bucketObjectId, parentObjectId, fileName);
+    } else {
+      omKey = omMetadataManager.getOzoneKey(volume, bucket, key);
+    }
+    return omKey;
+  }
+
+  /**
+   * Write a key on OM instance.
+   * @throw IOException while writing.
+   */
+  @SuppressWarnings("checkstyle:parameternumber")
+  public static void writeKeyToOm(OMMetadataManager omMetadataManager,
+                                  String key,
+                                  String bucket,
+                                  String volume,
+                                  String fileName,
+                                  long objectID,
+                                  long parentObjectId,
+                                  long bucketObjectId,
+                                  long volumeObjectId,
+                                  long dataSize,
+                                  BucketLayout bucketLayout,
+                                  ReplicationConfig replicationConfig,
+                                  long creationTime, boolean isFile)
+      throws IOException {
+    String omKey =
+        getKey(omMetadataManager, key, bucket, volume, fileName, parentObjectId, bucketObjectId, volumeObjectId,
+            bucketLayout);
+    omMetadataManager.getKeyTable(bucketLayout).put(omKey,
+        new OmKeyInfo.Builder()
+            .setBucketName(bucket)
+            .setVolumeName(volume)
+            .setKeyName(key)
+            .setFile(isFile)
+            .setReplicationConfig(replicationConfig)
+            .setCreationTime(creationTime)
+            .setObjectID(objectID)
+            .setParentObjectID(parentObjectId)
+            .setDataSize(dataSize)
+            .build());
   }
 
   /**

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -81,6 +82,8 @@ public final class OMMetadataManagerTestUtils {
     OzoneConfiguration omConfiguration = new OzoneConfiguration();
     omConfiguration.set(OZONE_OM_DB_DIRS,
         omDbDir.getAbsolutePath());
+    omConfiguration.set(OMConfigKeys
+        .OZONE_OM_ENABLE_FILESYSTEM_PATHS, "true");
     OMMetadataManager omMetadataManager = new OmMetadataManagerImpl(
         omConfiguration, null);
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -102,10 +102,10 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private OMMetadataManager omMetadataManager;
   private ReconPipelineManager reconPipelineManager;
   private ReconOMMetadataManager reconOMMetadataManager;
-  private static ReconNamespaceSummaryManager reconNamespaceSummaryManager;
-  private static NSSummaryTaskWithLegacy nSSummaryTaskWithLegacy;
-  private static NSSummaryTaskWithOBS nsSummaryTaskWithOBS;
-  private static NSSummaryTaskWithFSO nsSummaryTaskWithFSO;
+  private ReconNamespaceSummaryManager reconNamespaceSummaryManager;
+  private NSSummaryTaskWithLegacy nSSummaryTaskWithLegacy;
+  private NSSummaryTaskWithOBS nsSummaryTaskWithOBS;
+  private NSSummaryTaskWithFSO nsSummaryTaskWithFSO;
   private OMDBInsightEndpoint omdbInsightEndpoint;
   private Pipeline pipeline;
   private Random random = new Random();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -1592,7 +1592,6 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     Response bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, EMPTY_OBS_BUCKET_PATH,
         "", 1000);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
-    // Since key7 doesn't exists in OM namespace, list keys on this will return zero keys.
     assertEquals(0, listKeysResponse.getKeys().size());
     assertEquals("", listKeysResponse.getLastKey());
   }
@@ -1611,10 +1610,9 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     Response bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, OBS_BUCKET_PATH +
             OM_KEY_PREFIX + NON_EXISTENT_KEY_SEVEN,
         "", 2);
-    ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
-    // Since key7 doesn't exists in OM namespace, list keys on this will return zero keys.
-    assertEquals(0, listKeysResponse.getKeys().size());
-    assertEquals("", listKeysResponse.getLastKey());
+    String entityResp = (String) bucketResponse.getEntity();
+    assertEquals("{\"message\": \"Unexpected runtime error while searching keys in OM DB: Not valid path: " +
+        "java.lang.UnsupportedOperationException: Object stores do not support directories.\"}", entityResp);
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -118,10 +118,16 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final String FSO_BUCKET = "fso-bucket";
   private static final String EMPTY_OBS_BUCKET = "empty-obs-bucket";
   private static final String EMPTY_FSO_BUCKET = "empty-fso-bucket";
+  private static final String LEGACY_BUCKET = "legacy-bucket";
 
   private static final String DIR_ONE = "dir1";
   private static final String DIR_TWO = "dir2";
   private static final String DIR_THREE = "dir3";
+
+  private static final String DIR_FOUR = "dir4";
+  private static final String DIR_FIVE = "dir5";
+  private static final String DIR_SIX = "dir6";
+  private static final String DIR_SEVEN = "dir7";
 
   private static final String TEST_FILE = "testfile";
   private static final String FILE_ONE = "file1";
@@ -134,6 +140,21 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final String KEY_SIX = "key6";
   private static final String NON_EXISTENT_KEY_SEVEN = "key7";
 
+  private static final String KEY_EIGHT = "key8";
+  private static final String KEY_NINE = "dir4/dir5/key9";
+  private static final String KEY_TEN = "dir4/dir6/key10";
+  private static final String KEY_ELEVEN = "key11";
+  private static final String KEY_TWELVE = "key12";
+  private static final String KEY_THIRTEEN = "dir4/dir7/key13";
+
+  private static final String FILE_EIGHT = "key8";
+  private static final String FILE_NINE = "key9";
+  private static final String FILE_TEN = "key10";
+  private static final String FILE_ELEVEN = "key11";
+  private static final String FILE_TWELVE = "key12";
+  private static final String FILE_THIRTEEN = "key13";
+
+  private static final long PARENT_OBJECT_ID_ZERO = 0L;
   private static final long VOLUME_ONE_OBJECT_ID = 1L;
 
   private static final long OBS_BUCKET_OBJECT_ID = 2L;
@@ -155,8 +176,19 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final long KEY_ELEVEN_OBJECT_ID = 18L;
   private static final long KEY_TWELVE_OBJECT_ID = 19L;
 
-  private static final long EMPTY_OBS_BUCKET_OBJECT_ID = 30L;
-  private static final long EMPTY_FSO_BUCKET_OBJECT_ID = 40L;
+  private static final long LEGACY_BUCKET_OBJECT_ID = 20L;
+  private static final long DIR_FOUR_OBJECT_ID = 21L;
+  private static final long DIR_FIVE_OBJECT_ID = 22L;
+  private static final long DIR_SIX_OBJECT_ID = 23L;
+  private static final long KEY_THIRTEEN_OBJECT_ID = 24L;
+  private static final long KEY_FOURTEEN_OBJECT_ID = 25L;
+  private static final long KEY_FIFTEEN_OBJECT_ID = 26L;
+  private static final long KEY_SIXTEEN_OBJECT_ID = 27L;
+  private static final long KEY_SEVENTEEN_OBJECT_ID = 28L;
+  private static final long KEY_EIGHTEEN_OBJECT_ID = 29L;
+
+  private static final long EMPTY_OBS_BUCKET_OBJECT_ID = 34L;
+  private static final long EMPTY_FSO_BUCKET_OBJECT_ID = 35L;
 
   private static final long KEY_ONE_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
   private static final long KEY_TWO_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
@@ -171,8 +203,11 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final long KEY_ELEVEN_SIZE = OzoneConsts.KB + 1; // bin 1
   private static final long KEY_TWELVE_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
 
+  private static final long KEY_THIRTEEN_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
+
   private static final String OBS_BUCKET_PATH = "/volume1/obs-bucket";
   private static final String FSO_BUCKET_PATH = "/volume1/fso-bucket";
+  private static final String LEGACY_BUCKET_PATH = "/volume1/legacy-bucket";
   private static final String EMPTY_OBS_BUCKET_PATH = "/volume1/empty-obs-bucket";
   private static final String EMPTY_FSO_BUCKET_PATH = "/volume1/empty-fso-bucket";
 
@@ -180,6 +215,12 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final String DIR_TWO_PATH = "/volume1/fso-bucket/dir1/dir2";
   private static final String DIR_THREE_PATH = "/volume1/fso-bucket/dir1/dir2/dir3";
   private static final String NON_EXISTENT_DIR_FOUR_PATH = "/volume1/fso-bucket/dir1/dir2/dir3/dir4";
+
+  private static final String DIR_FOUR_PATH = "/volume1/legacy-bucket/dir4";
+  private static final String DIR_FIVE_PATH = "/volume1/legacy-bucket/dir4";
+  private static final String DIR_SIX_PATH = "/volume1/legacy-bucket/dir4";
+  private static final String DIR_SEVEN_PATH = "/volume1/legacy-bucket/dir4";
+
 
   private static final long VOLUME_ONE_QUOTA = 2 * OzoneConsts.MB;
   private static final long OBS_BUCKET_QUOTA = OzoneConsts.MB;
@@ -392,6 +433,18 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
     reconOMMetadataManager.getBucketTable().put(emptyFSOBucketKey, emptyFSOBucketInfo);
 
+    OmBucketInfo legacyBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(VOLUME_ONE)
+        .setBucketName(LEGACY_BUCKET)
+        .setObjectID(LEGACY_BUCKET_OBJECT_ID)
+        .setQuotaInBytes(OzoneConsts.MB)
+        .setBucketLayout(BucketLayout.LEGACY)
+        .build();
+    String legacyBucketKey = reconOMMetadataManager.getBucketKey(
+        legacyBucketInfo.getVolumeName(), legacyBucketInfo.getBucketName());
+
+    reconOMMetadataManager.getBucketTable().put(legacyBucketKey, legacyBucketInfo);
+
     // Write FSO keys data - Start
     writeDirToOm(reconOMMetadataManager, DIR_ONE_OBJECT_ID,
         FSO_BUCKET_OBJECT_ID, FSO_BUCKET_OBJECT_ID,
@@ -566,6 +619,129 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         ratisOne,
         epochMillis2, true);
     // Write OBS Keys data - End
+
+    // Write LEGACY keys data - Start
+    writeDirToOm(reconOMMetadataManager,
+        (DIR_FOUR + OM_KEY_PREFIX),
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        DIR_FOUR,
+        DIR_FOUR_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        getBucketLayout());
+    writeDirToOm(reconOMMetadataManager,
+        (DIR_FOUR + OM_KEY_PREFIX + DIR_FIVE + OM_KEY_PREFIX),
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        DIR_FIVE,
+        DIR_FIVE_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        getBucketLayout());
+    writeDirToOm(reconOMMetadataManager,
+        (DIR_FOUR + OM_KEY_PREFIX + DIR_SIX + OM_KEY_PREFIX),
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        DIR_SIX,
+        DIR_SIX_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        getBucketLayout());
+    writeDirToOm(reconOMMetadataManager,
+        (DIR_FOUR + OM_KEY_PREFIX + DIR_SEVEN + OM_KEY_PREFIX),
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        DIR_FOUR,
+        DIR_FOUR_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        getBucketLayout());
+
+    // write all legacy bucket keys
+    writeKeyToOm(reconOMMetadataManager,
+        KEY_EIGHT,
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        FILE_EIGHT,
+        KEY_THIRTEEN_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_EIGHT_SIZE,
+        getBucketLayout(),
+        ratisOne,
+        epochMillis1, true);
+    writeKeyToOm(reconOMMetadataManager,
+        KEY_NINE,
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        FILE_NINE,
+        KEY_FOURTEEN_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_NINE_SIZE,
+        getBucketLayout(),
+        ratisOne,
+        epochMillis2, true);
+    writeKeyToOm(reconOMMetadataManager,
+        KEY_TEN,
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        FILE_TEN,
+        KEY_FIFTEEN_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_TEN_SIZE,
+        getBucketLayout(),
+        ratisOne,
+        epochMillis1, true);
+    writeKeyToOm(reconOMMetadataManager,
+        KEY_ELEVEN,
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        FILE_ELEVEN,
+        KEY_SIXTEEN_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_ELEVEN_SIZE,
+        getBucketLayout(),
+        ratisOne,
+        epochMillis2, true);
+    writeKeyToOm(reconOMMetadataManager,
+        KEY_TWELVE,
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        FILE_TWELVE,
+        KEY_SEVENTEEN_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_TWELVE_SIZE,
+        getBucketLayout(),
+        ratisOne,
+        epochMillis1, true);
+    writeKeyToOm(reconOMMetadataManager,
+        KEY_THIRTEEN,
+        LEGACY_BUCKET,
+        VOLUME_ONE,
+        FILE_THIRTEEN,
+        KEY_EIGHTEEN_OBJECT_ID,
+        PARENT_OBJECT_ID_ZERO,
+        LEGACY_BUCKET_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_THIRTEEN_SIZE,
+        getBucketLayout(),
+        ratisOne,
+        epochMillis1, true);
+    // Write LEGACY keys data - End
   }
 
   @Test
@@ -1446,6 +1622,46 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     Response bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, NON_EXISTENT_DIR_FOUR_PATH,
         "", 2);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
+    assertEquals(0, listKeysResponse.getKeys().size());
+    assertEquals("", listKeysResponse.getLastKey());
+  }
+
+  @Test
+  public void testListKeysLegacyBucketWithFSEnabled() {
+    Response bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, LEGACY_BUCKET_PATH,
+        "", 1000);
+    ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
+    assertEquals(6, listKeysResponse.getKeys().size());
+    assertEquals("/volume1/legacy-bucket/key8", listKeysResponse.getLastKey());
+  }
+
+  @Test
+  public void testListKeysLegacyBucketWithFSEnabledAndPagination() {
+    Response bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, LEGACY_BUCKET_PATH,
+        "", 2);
+    ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
+    assertEquals(2, listKeysResponse.getKeys().size());
+    assertEquals("/volume1/legacy-bucket/dir4/dir6/key10", listKeysResponse.getLastKey());
+
+    // Second page
+    bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, LEGACY_BUCKET_PATH,
+        listKeysResponse.getLastKey(), 2);
+    listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
+    assertEquals(2, listKeysResponse.getKeys().size());
+    assertEquals("/volume1/legacy-bucket/key11", listKeysResponse.getLastKey());
+
+    // Third page
+    bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, LEGACY_BUCKET_PATH,
+        listKeysResponse.getLastKey(), 2);
+    listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
+    assertEquals(2, listKeysResponse.getKeys().size());
+    assertEquals("/volume1/legacy-bucket/key8", listKeysResponse.getLastKey());
+
+    // Fourth page should not have any keys left as we have iterated
+    // all 6 keys in 3 pages with each page returns 2 keys.
+    bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, LEGACY_BUCKET_PATH,
+        listKeysResponse.getLastKey(), 2);
+    listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(0, listKeysResponse.getKeys().size());
     assertEquals("", listKeysResponse.getLastKey());
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -119,6 +119,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final String EMPTY_OBS_BUCKET = "empty-obs-bucket";
   private static final String EMPTY_FSO_BUCKET = "empty-fso-bucket";
   private static final String LEGACY_BUCKET = "legacy-bucket";
+  private static final String FSO_BUCKET_TWO = "fso-bucket2";
 
   private static final String DIR_ONE = "dir1";
   private static final String DIR_TWO = "dir2";
@@ -128,6 +129,10 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final String DIR_FIVE = "dir5";
   private static final String DIR_SIX = "dir6";
   private static final String DIR_SEVEN = "dir7";
+
+  private static final String DIR_EIGHT = "dir8";
+  private static final String DIR_NINE = "dir9";
+  private static final String DIR_TEN = "dir10";
 
   private static final String TEST_FILE = "testfile";
   private static final String FILE_ONE = "file1";
@@ -147,12 +152,26 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final String KEY_TWELVE = "key12";
   private static final String KEY_THIRTEEN = "dir4/dir7/key13";
 
+  private static final String KEY_FOURTEEN = "dir8/key14";
+  private static final String KEY_FIFTEEN = "dir8/key15";
+  private static final String KEY_SIXTEEN = "dir9/key16";
+  private static final String KEY_SEVENTEEN = "dir9/key17";
+  private static final String KEY_EIGHTEEN = "dir8/key18";
+  private static final String KEY_NINETEEN = "dir8/key19";
+
   private static final String FILE_EIGHT = "key8";
   private static final String FILE_NINE = "key9";
   private static final String FILE_TEN = "key10";
   private static final String FILE_ELEVEN = "key11";
   private static final String FILE_TWELVE = "key12";
   private static final String FILE_THIRTEEN = "key13";
+
+  private static final String FILE_FOURTEEN = "key14";
+  private static final String FILE_FIFTEEN = "key15";
+  private static final String FILE_SIXTEEN = "key16";
+  private static final String FILE_SEVENTEEN = "key17";
+  private static final String FILE_EIGHTEEN = "key18";
+  private static final String FILE_NINETEEN = "key19";
 
   private static final long PARENT_OBJECT_ID_ZERO = 0L;
   private static final long VOLUME_ONE_OBJECT_ID = 1L;
@@ -187,8 +206,19 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private static final long KEY_SEVENTEEN_OBJECT_ID = 28L;
   private static final long KEY_EIGHTEEN_OBJECT_ID = 29L;
 
-  private static final long EMPTY_OBS_BUCKET_OBJECT_ID = 34L;
-  private static final long EMPTY_FSO_BUCKET_OBJECT_ID = 35L;
+  private static final long FSO_BUCKET_TWO_OBJECT_ID = 30L;
+  private static final long DIR_EIGHT_OBJECT_ID = 31L;
+  private static final long DIR_NINE_OBJECT_ID = 32L;
+  private static final long DIR_TEN_OBJECT_ID = 33L;
+  private static final long KEY_NINETEEN_OBJECT_ID = 34L;
+  private static final long KEY_TWENTY_OBJECT_ID = 35L;
+  private static final long KEY_TWENTY_ONE_OBJECT_ID = 36L;
+  private static final long KEY_TWENTY_TWO_OBJECT_ID = 37L;
+  private static final long KEY_TWENTY_THREE_OBJECT_ID = 38L;
+  private static final long KEY_TWENTY_FOUR_OBJECT_ID = 39L;
+
+  private static final long EMPTY_OBS_BUCKET_OBJECT_ID = 40L;
+  private static final long EMPTY_FSO_BUCKET_OBJECT_ID = 41L;
 
   private static final long KEY_ONE_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
   private static final long KEY_TWO_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
@@ -205,22 +235,24 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
   private static final long KEY_THIRTEEN_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
 
+  private static final long KEY_FOURTEEN_SIZE = OzoneConsts.KB + 1; // bin 1
+  private static final long KEY_FIFTEEN_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
+  private static final long KEY_SIXTEEN_SIZE = OzoneConsts.KB + 1; // bin 1
+  private static final long KEY_SEVENTEEN_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
+  private static final long KEY_EIGHTEEN_SIZE = OzoneConsts.KB + 1; // bin 1
+  private static final long KEY_NINETEEN_SIZE = 2 * OzoneConsts.KB + 1; // bin 2
+
   private static final String OBS_BUCKET_PATH = "/volume1/obs-bucket";
   private static final String FSO_BUCKET_PATH = "/volume1/fso-bucket";
   private static final String LEGACY_BUCKET_PATH = "/volume1/legacy-bucket";
   private static final String EMPTY_OBS_BUCKET_PATH = "/volume1/empty-obs-bucket";
   private static final String EMPTY_FSO_BUCKET_PATH = "/volume1/empty-fso-bucket";
+  private static final String FSO_BUCKET_TWO_PATH = "/volume1/fso-bucket2";
 
   private static final String DIR_ONE_PATH = "/volume1/fso-bucket/dir1";
   private static final String DIR_TWO_PATH = "/volume1/fso-bucket/dir1/dir2";
   private static final String DIR_THREE_PATH = "/volume1/fso-bucket/dir1/dir2/dir3";
   private static final String NON_EXISTENT_DIR_FOUR_PATH = "/volume1/fso-bucket/dir1/dir2/dir3/dir4";
-
-  private static final String DIR_FOUR_PATH = "/volume1/legacy-bucket/dir4";
-  private static final String DIR_FIVE_PATH = "/volume1/legacy-bucket/dir4";
-  private static final String DIR_SIX_PATH = "/volume1/legacy-bucket/dir4";
-  private static final String DIR_SEVEN_PATH = "/volume1/legacy-bucket/dir4";
-
 
   private static final long VOLUME_ONE_QUOTA = 2 * OzoneConsts.MB;
   private static final long OBS_BUCKET_QUOTA = OzoneConsts.MB;
@@ -445,6 +477,18 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
     reconOMMetadataManager.getBucketTable().put(legacyBucketKey, legacyBucketInfo);
 
+    OmBucketInfo fsoBucketTwoInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(VOLUME_ONE)
+        .setBucketName(FSO_BUCKET_TWO)
+        .setObjectID(FSO_BUCKET_TWO_OBJECT_ID)
+        .setQuotaInBytes(OzoneConsts.MB)
+        .setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED)
+        .build();
+    String fsoBucketTwoKey = reconOMMetadataManager.getBucketKey(
+        fsoBucketTwoInfo.getVolumeName(), fsoBucketTwoInfo.getBucketName());
+
+    reconOMMetadataManager.getBucketTable().put(fsoBucketTwoKey, fsoBucketTwoInfo);
+
     // Write FSO keys data - Start
     writeDirToOm(reconOMMetadataManager, DIR_ONE_OBJECT_ID,
         FSO_BUCKET_OBJECT_ID, FSO_BUCKET_OBJECT_ID,
@@ -538,6 +582,99 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         ratisOne,
         epochMillis2, true);
     // Write FSO Keys data - End
+
+    // Write FSO bucket two keys - Start
+    writeDirToOm(reconOMMetadataManager, DIR_EIGHT_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID, FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID, DIR_EIGHT);
+    writeDirToOm(reconOMMetadataManager, DIR_NINE_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID, FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID, DIR_NINE);
+    writeDirToOm(reconOMMetadataManager, DIR_TEN_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID, FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID, DIR_TEN);
+
+    writeKeyToOm(reconOMMetadataManager,
+        TEST_FILE,
+        FSO_BUCKET_TWO,
+        VOLUME_ONE,
+        TEST_FILE,
+        KEY_NINETEEN_OBJECT_ID,
+        DIR_EIGHT_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_FOURTEEN_SIZE,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        ratisOne,
+        epochMillis1, true);
+    writeKeyToOm(reconOMMetadataManager,
+        FILE_ONE,
+        FSO_BUCKET_TWO,
+        VOLUME_ONE,
+        FILE_ONE,
+        KEY_TWENTY_OBJECT_ID,
+        DIR_EIGHT_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_FIFTEEN_SIZE,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        ratisOne,
+        epochMillis1, true);
+
+    writeKeyToOm(reconOMMetadataManager,
+        TEST_FILE,
+        FSO_BUCKET_TWO,
+        VOLUME_ONE,
+        TEST_FILE,
+        KEY_TWENTY_ONE_OBJECT_ID,
+        DIR_NINE_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_SIXTEEN_SIZE,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        ratisOne,
+        epochMillis1, true);
+    writeKeyToOm(reconOMMetadataManager,
+        FILE_ONE,
+        FSO_BUCKET_TWO,
+        VOLUME_ONE,
+        FILE_ONE,
+        KEY_TWENTY_TWO_OBJECT_ID,
+        DIR_NINE_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_SEVENTEEN_SIZE,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        ratisOne,
+        epochMillis1, true);
+
+    writeKeyToOm(reconOMMetadataManager,
+        TEST_FILE,
+        FSO_BUCKET_TWO,
+        VOLUME_ONE,
+        TEST_FILE,
+        KEY_TWENTY_THREE_OBJECT_ID,
+        DIR_TEN_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_EIGHTEEN_SIZE,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        ratisOne,
+        epochMillis1, true);
+    writeKeyToOm(reconOMMetadataManager,
+        FILE_ONE,
+        FSO_BUCKET_TWO,
+        VOLUME_ONE,
+        FILE_ONE,
+        KEY_TWENTY_FOUR_OBJECT_ID,
+        DIR_TEN_OBJECT_ID,
+        FSO_BUCKET_TWO_OBJECT_ID,
+        VOLUME_ONE_OBJECT_ID,
+        KEY_NINETEEN_SIZE,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        ratisOne,
+        epochMillis1, true);
+    // Write FSO bucket two keys - End
 
     // Write OBS Keys data - Start
     writeKeyToOm(reconOMMetadataManager,
@@ -1426,6 +1563,39 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   }
 
   @Test
+  public void testListKeysFSOBucketTwoPathWithLimitAcrossDirsAtBucketLevel() {
+    // bucket level keyList
+    // Total 3 pages , each page 2 records. If each page we will retrieve 2 items, as total 6 FSO keys,
+    // so till we get empty last key, we'll continue to fetch and empty last key signifies the last page.
+    // First Page
+    Response bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0, FSO_BUCKET_TWO_PATH,
+        "", 3);
+    ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
+    assertEquals(3, listKeysResponse.getKeys().size());
+    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    assertEquals("volume1/fso-bucket2/dir8/file1", keyEntityInfo.getPath());
+    assertEquals("/1/30/32/file1", listKeysResponse.getLastKey());
+    assertEquals("RATIS", keyEntityInfo.getReplicationConfig().getReplicationType().toString());
+
+    // Second page
+    bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0,
+        FSO_BUCKET_TWO_PATH, listKeysResponse.getLastKey(), 3);
+    listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
+    assertEquals(3, listKeysResponse.getKeys().size());
+    keyEntityInfo = listKeysResponse.getKeys().get(0);
+    assertEquals("volume1/fso-bucket2/dir9/testfile", keyEntityInfo.getPath());
+    assertEquals("/1/30/33/testfile", listKeysResponse.getLastKey());
+
+    // Try again if third page is available. Ideally there should not be any further records
+    // and lastKey should be empty as per design.
+    bucketResponse = omdbInsightEndpoint.listKeys("RATIS", "", 0,
+        FSO_BUCKET_TWO_PATH, listKeysResponse.getLastKey(), 3);
+    listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
+    assertEquals(0, listKeysResponse.getKeys().size());
+    assertEquals("", listKeysResponse.getLastKey());
+  }
+
+  @Test
   public void testListKeysFSOBucketDirTwoPathWithLimitAndPagination() {
     // bucket level keyList
     // Total 2 pages , each page 2 records. If each page we will retrieve 2 items, as total 4 FSO keys,
@@ -1622,6 +1792,21 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(0, listKeysResponse.getKeys().size());
     assertEquals("", listKeysResponse.getLastKey());
+  }
+
+  @Test
+  public void testListKeysForNullOrEmptyStartPrefixPath() {
+    Response nullStartPrefixResp = omdbInsightEndpoint.listKeys("RATIS", "", 0, null,
+        "", 2);
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), nullStartPrefixResp.getStatus());
+
+    Response emptyStartPrefixResp = omdbInsightEndpoint.listKeys("RATIS", "", 0, "",
+        "", 2);
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), emptyStartPrefixResp.getStatus());
+
+    Response invaliStartPrefixResp = omdbInsightEndpoint.listKeys("RATIS", "", 0, "null",
+        "", 2);
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), invaliStartPrefixResp.getStatus());
   }
 
   @Test


### PR DESCRIPTION
This PR adds a new API in Recon for listing keys for OBS buckets, Legacy buckets and FSO buckets with filters and recursively in a flat structure for OBS, LEGACY and FSO buckets.

New API:

api/v1/keys/listKeys?startPrefix=/volume1/obs-bucket/&limit=105

Default values of API parameters if not provided:

1.  `replicationType` - empty string and filter will not be applied, so list out all keys irrespective of replication type.
2. `creationTime` - empty string and filter will not be applied, so list out keys irrespective of age, else list out keys which got created on or after provided creationTime
3. `keySize` - 0 bytes, which means all keys greater than zero bytes will be listed, effectively all.
4. `startPrefix` - /
5.  `prevKey` - ""
6. `limit` - 1000
Behavior of API:
For OBS bucket - list out `limit` number of keys on the provided path.
This API will implement pagination support using `prevKey` and `limit` params.

Get List of All Keys:
GET /api/v1/keys/listKeys

 API params:
  1.  `replicationType` - Filter for RATIS or EC replication keys
  2. `creationDate` in "MM-dd-yyyy HH:mm:ss" string format.
  3. `startPrefix`
  4. `prevKey`
  5. `limit`
  6. `keySize`

Now lets consider, we have following OBS, LEGACY and FSO bucket key/files namespace tree structure

`For OBS Bucket`
- /volume1/obs-bucket/key1
- /volume1/obs-bucket/key1/key2
- /volume1/obs-bucket/key1/key2/key3
- /volume1/obs-bucket/key4
- /volume1/obs-bucket/key5
- /volume1/obs-bucket/key6

`For LEGACY Bucket`
- /volume1/legacy-bucket/key
- /volume1/legacy-bucket/key1/key2
- /volume1/legacy-bucket/key1/key2/key3
- /volume1/legacy-bucket/key4
- /volume1/legacy-bucket/key5
- /volume1/legacy-bucket/key6

`For FSO Bucket`
- /volume1/fso-bucket/dir1/dir2/dir3
- /volume1/fso-bucket/dir1/testfile
- /volume1/fso-bucket/dir1/file1
- /volume1/fso-bucket/dir1/dir2/testfile
- /volume1/fso-bucket/dir1/dir2/file1
- /volume1/fso-bucket/dir1/dir2/dir3/testfile
- /volume1/fso-bucket/dir1/dir2/dir3/file1

 **Input Request for OBS bucket:**

       `api/v1/keys/listKeys?startPrefix=/volume1/obs-bucket&limit=2&replicationType=RATIS`

 **Output Response:**

 ```
{
    "status": "OK",
    "path": "/volume1/obs-bucket",
    "replicatedDataSize": 20971520,
    "unReplicatedDataSize": 20971520,
    "keyCount": 2,
    "lastKey": "/volume1/obs-bucket/key1/key2",
    "keys": [
        {
            "key": "/volume1/obs-bucket/key1",
            "path": "key1",
            "inStateSince": 1715174266126,
            "size": 10485760,
            "replicatedSize": 10485760,
            "replicationInfo": {
                "replicationFactor": "ONE",
                "requiredNodes": 1,
                "replicationType": "RATIS"
            },
            "creationTime": 1715174266126,
            "modificationTime": 1715174267480,
            "isKey": true
        },
        {
            "key": "/volume1/obs-bucket/key1/key2",
            "path": "key1/key2",
            "inStateSince": 1715174269510,
            "size": 10485760,
            "replicatedSize": 10485760,
            "replicationInfo": {
                "replicationFactor": "ONE",
                "requiredNodes": 1,
                "replicationType": "RATIS"
            },
            "creationTime": 1715174269510,
            "modificationTime": 1715174270410,
            "isKey": true
        }
    ]
}
```
   **Input Request for FSO bucket:**

           `api/v1/keys/listKeys?startPrefix=/volume1/fso-bucket&limit=2&replicationType=RATIS`

  **Output Response:**

```
{
    "status": "OK",
    "path": "/volume1/fso-bucket",
    "replicatedDataSize": 62914560,
    "unReplicatedDataSize": 20971520,
    "keyCount": 2,
    "lastKey": "/-9223372036854775552/-9223372036854775040/-9223372036854774525/testfile",
    "keys": [
        {
            "key": "/-9223372036854775552/-9223372036854775040/-9223372036854774525/file1",
            "path": "file1",
            "inStateSince": 1715174237440,
            "size": 10485760,
            "replicatedSize": 31457280,
            "replicationInfo": {
                "replicationFactor": "THREE",
                "requiredNodes": 3,
                "replicationType": "RATIS"
            },
            "creationTime": 1715174237440,
            "modificationTime": 1715174238161,
            "isKey": true
        },
        {
            "key": "/-9223372036854775552/-9223372036854775040/-9223372036854774525/testfile",
            "path": "testfile",
            "inStateSince": 1715174234840,
            "size": 10485760,
            "replicatedSize": 31457280,
            "replicationInfo": {
                "replicationFactor": "THREE",
                "requiredNodes": 3,
                "replicationType": "RATIS"
            },
            "creationTime": 1715174234840,
            "modificationTime": 1715174235562,
            "isKey": true
        }
    ]
}
```
   **Input Request for Legacy bucket:**

           `api/v1/keys/listKeys?startPrefix=/volume1/legacy-bucket&limit=2&replicationType=RATIS`

  **Output Response:**

```
{
    "status": "OK",
    "path": "/volume1/legacy-bucket",
    "replicatedDataSize": 52428800,
    "unReplicatedDataSize": 52428800,
    "keyCount": 2,
    "lastKey": "/volume1/legacy-bucket/key1/key2",
    "keys": [
        {
            "key": "/volume1/legacy-bucket/key1",
            "path": "key1",
            "inStateSince": 1715174303702,
            "size": 10485760,
            "replicatedSize": 10485760,
            "replicationInfo": {
                "replicationFactor": "ONE",
                "requiredNodes": 1,
                "replicationType": "RATIS"
            },
            "creationTime": 1715174303702,
            "modificationTime": 1715174304619,
            "isKey": true
        },
        {
            "key": "/volume1/legacy-bucket/key1/key2",
            "path": "key1/key2",
            "inStateSince": 1715174306641,
            "size": 41943040,
            "replicatedSize": 41943040,
            "replicationInfo": {
                "replicationFactor": "ONE",
                "requiredNodes": 1,
                "replicationType": "RATIS"
            },
            "creationTime": 1715174306641,
            "modificationTime": 1715174307994,
            "isKey": true
        }
    ]
}
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10634

## How was this patch tested?
Added Junit test cases and tested various assertions.
