### PR TITLE
HDDS-10696. Fix test failure caused by empty snapshot installation

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.grpc.server.GrpcLogAppender;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -184,7 +183,6 @@ public class TestAddRemoveOzoneManager {
    * OM.
    */
   @Test
-  @Flaky("HDDS-7880")
   public void testBootstrap() throws Exception {
     setupCluster(1);
     OzoneManager oldOM = cluster.getOzoneManager();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -318,7 +318,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
     // Get the snapshot files.
     Set<Path> snapshotPaths = waitForSnapshotDirs(checkpoint);
-    Path snapshotDir = Paths.get(getSnapshotsParentDir()).getParent();
+    Path snapshotDir = getSnapshotDir();
     if (!processDir(snapshotDir, copyFiles, hardLinkFiles, sstFilesToExclude,
         snapshotPaths, excluded, copySize, null)) {
       return false;
@@ -635,10 +635,13 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         .getConfiguration();
   }
 
-  private String getSnapshotsParentDir() {
+  private Path getSnapshotDir() {
     OzoneManager om = (OzoneManager) getServletContext().getAttribute(OzoneConsts.OM_CONTEXT_ATTRIBUTE);
     RDBStore store = (RDBStore) om.getMetadataManager().getStore();
-    return store.getSnapshotsParentDir();
+    // store.getSnapshotsParentDir() returns path to checkpointState (e.g. <om-data-dir>/db.snapshots/checkpointState)
+    // But we need to return path till db.snapshots which contains checkpointState and diffState.
+    // So that whole snapshots and compaction information can be transferred to follower.
+    return Paths.get(store.getSnapshotsParentDir()).getParent();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.recon.ReconConfig;
 import org.apache.hadoop.hdds.utils.DBCheckpointServlet;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RDBCheckpointUtils;
+import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -317,8 +318,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
     // Get the snapshot files.
     Set<Path> snapshotPaths = waitForSnapshotDirs(checkpoint);
-    Path snapshotDir = Paths.get(OMStorage.getOmDbDir(getConf()).toString(),
-        OM_SNAPSHOT_DIR);
+    Path snapshotDir = Paths.get(getSnapshotsParentDir()).getParent();
     if (!processDir(snapshotDir, copyFiles, hardLinkFiles, sstFilesToExclude,
         snapshotPaths, excluded, copySize, null)) {
       return false;
@@ -633,6 +633,12 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     return ((OzoneManager) getServletContext()
         .getAttribute(OzoneConsts.OM_CONTEXT_ATTRIBUTE))
         .getConfiguration();
+  }
+
+  private String getSnapshotsParentDir() {
+    OzoneManager om = (OzoneManager) getServletContext().getAttribute(OzoneConsts.OM_CONTEXT_ATTRIBUTE);
+    RDBStore store = (RDBStore) om.getMetadataManager().getStore();
+    return store.getSnapshotsParentDir();
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
After applying RATIS-2045, we saw lots of integration test failures as described in the HDDS-10696.

It is because of how MiniOzoneHACluster is set up. It doesn't set value for config `ozone.om.db.dirs` which OMDBCheckpointServlet is trying to access [here](https://github.com/apache/ozone/blob/ff78dc83a7640bf1dbed409bc6e79b3a0f231483/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java#L320).
So when `ozone.om.db.dirs` is not set, [ServerUtils#getDBPath](https://github.com/apache/ozone/blob/ff78dc83a7640bf1dbed409bc6e79b3a0f231483/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java#L292) returns `ozone.metadata.dirs`. Because of that **snapshotDir path**: is getting evaluated to`/Users/iamgroot/ozone-ws/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-e919072d-914a-4de6-9bfc-5b610697b58a/ozone-meta/db.snapshots`, and the test is trying to access that doesn't exist causing `NoSuchFileException`.
In the actual **snapshotDir path** is `/Users/iamgroot/ozone-ws/ozone/hadoop-ozone/integration-test/target/test-dir/MiniOzoneClusterImpl-1146c9db-bf52-4c4b-94c9-131053141484/omNode-1/db.snapshots` which is inside the ozone data directory.

To fix the issue, I changed the way we are trying to get the `snapshotDir`. So rather than creating one, it will get from RDBStore after the change dir should exist by default after snapshot feature.

Also removed `Flaky` annotation from the test because jira: HDDS-7880 has been resolved after RATIS-1960.

## What is the link to the Apache JIRA
HDDS-10696

## How was this patch tested?
Applied the [patch](https://github.com/hemantk-12/ozone/commit/900ac073c49e8a05c8afe1feae98498c76955906) on top of [the changes where we saw the failure](https://github.com/duongkame/ozone/commit/826340e8cf35e678380e893b508ec94fff3416bf). And verify by running the full [workflow](https://github.com/hemantk-12/ozone/actions/runs/8996903031) and [flaky-test-workflow](https://github.com/hemantk-12/ozone/actions/runs/8996914220) 5x5 time.
