### PR TITLE
HDDS-10834. Revert snapshot diff output change added in HDDS-9360

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -101,16 +101,12 @@ public class SnapshotDiffReportOzone
         .append(" and snapshot: ")
         .append(getLaterSnapshotName())
         .append(LINE_SEPARATOR);
-    if (!getDiffList().isEmpty()) {
-      for (DiffReportEntry entry : getDiffList()) {
-        str.append(entry.toString()).append(LINE_SEPARATOR);
-      }
-      if (StringUtils.isNotEmpty(token)) {
-        str.append("Next token: ")
-            .append(token);
-      }
-    } else {
-      str.append("No diff or no more diff for the request parameters.");
+    for (DiffReportEntry entry : getDiffList()) {
+      str.append(entry.toString()).append(LINE_SEPARATOR);
+    }
+    if (StringUtils.isNotEmpty(token)) {
+      str.append("Next token: ")
+          .append(token);
     }
     return str.toString();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This [change](https://github.com/apache/ozone/pull/5697/files#diff-ba1235c3cb249eb15a22d8be137eca2b98f47edc1a1f4842da2e701d5204cc9cR104-R113) potentially breaks the backward compatibility of the snapshot diff CLI command if the output of the CLI is used directly. Because SnapDiff doesn't support JSON output format as of now, we are reverting this change.

In the future, we will add JSON output support for SnapDiff (Jira: HDDS-10833) so that this type of change can be done without any backward compatibility issues. More details about JSON backward compatibility support: https://lists.apache.org/thread/5gqnbstv1pznwmcvx7txspj1qrksy7gl

## What is the link to the Apache JIRA
HDDS-10834

## How was this patch tested?
Existing tests.
