### PR TITLE
HDDS-10835. Show overwritten hsync keys in ListOpenFile CLI

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -899,7 +899,6 @@ public class TestOzoneShellHA {
       OpenKeyCleanupService openKeyCleanupService =
           (OpenKeyCleanupService) cluster.getOzoneManager().getKeyManager().getOpenKeyCleanupService();
       openKeyCleanupService.suspend();
-      OzoneFsShell shell = new OzoneFsShell(clientConf);
       // overwrite last key
       try (FSDataOutputStream os = fs.create(new Path(keys[numKeys - 1]))) {
         os.write(2);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -876,13 +876,13 @@ public class TestOzoneShellHA {
       String cmdRes = getStdOut();
 
       // Verify that key is hsync'ed
-      assertTrue(cmdRes.contains("\tYes\t\tNo\t\t\tNo"), "key should be hsync'ed and not deleted, not overwritten");
+      assertTrue(cmdRes.contains("\tYes\t\tNo\t\tNo"), "key should be hsync'ed and not deleted, not overwritten");
 
       execute(ozoneAdminShell, new String[] {"om", "lof", "--service-id",
           omServiceId, "--show-overwritten", "-p", pathToBucket});
       cmdRes = getStdOut();
       // Verify that key is hsync'ed
-      assertTrue(cmdRes.contains("\tYes\t\t\tNo"), "key should be hsync'ed and not overwritten");
+      assertTrue(cmdRes.contains("\tYes\t\tNo"), "key should be hsync'ed and not overwritten");
 
       // Verify json output
       String[] args1 = new String[] {"om", "lof", "--service-id", omServiceId, "--show-deleted", "--show-overwritten",
@@ -911,7 +911,7 @@ public class TestOzoneShellHA {
           String cmdRes1 = getStdOut();
           // When hsync file is overwritten, it should add OVERWRITTEN_HSYNC_KEY metadata in hsync openKey
           // And list open key should show as overwritten
-          return cmdRes1.contains("\tYes\t\tNo\t\t\tYes");
+          return cmdRes1.contains("\tYes\t\tNo\t\tYes");
         } catch (Throwable t) {
           LOG.warn("Failed to list open key", t);
           return false;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -106,7 +106,7 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
   public Void call() throws Exception {
 
     if (StringUtils.isEmpty(omServiceId) && StringUtils.isEmpty(omHost)) {
-      System.err.println("Error: Please specify -id or -host");
+      System.err.println("Error: Please specify --service-id or --service-host");
       return null;
     }
 
@@ -149,9 +149,9 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
     if (startItem != null && !startItem.isEmpty()) {
       msg += "\nafter continuation token:\n  " + startItem;
     }
-    msg += "\n\nClient ID\t\t\tCreation time\t\t\tHsync'ed\t";
+    msg += "\n\nClient ID\t\t\tCreation time\t\tHsync'ed\t";
     msg += showDeleted ? "Deleted\t" : "";
-    msg += showOverwritten? "Overwritten\t" : "";
+    msg += showOverwritten ? "Overwritten\t" : "";
     msg += "Open File Path";
     System.out.println(msg);
 
@@ -181,14 +181,14 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
         }
         if (showOverwritten) {
           if (omKeyInfo.getMetadata().containsKey(OzoneConsts.OVERWRITTEN_HSYNC_KEY)) {
-            line += "\tYes\t\t";
+            line += "Yes\t";
           } else {
-            line += "\tNo\t\t";
+            line += "No\t";
           }
         }
       } else {
         line += showDeleted ? "No\t\tNo\t\t" : "No\t\t";
-        line += showOverwritten ? "\tNo\t\t" : "";
+        line += showOverwritten ? "No\t" : "";
       }
 
       line += getFullPathFromKeyInfo(omKeyInfo);


### PR DESCRIPTION
## What changes were proposed in this pull request?
When a hsync key is overwritten, it will have the overwrittenHsyncKey metadata. This task will support to show or hide this metadata in ListOpenFile CLI.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10835

## How was this patch tested?

new Unit test
