### PR TITLE
HDDS-10273. Intermittent build failure while downloading nodejs

### DIFF
--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -28,6 +28,7 @@ on:
       - '.github/workflows/populate-cache.yml'
   schedule:
     - cron: '20 3 * * *'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -45,27 +46,40 @@ jobs:
             !~/.m2/repository/org/apache/ozone
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
 
+      - name: Check for partial cache
+        id: verify-cache
+        run: |
+          cache_ok='true'
+          if [[ '${{ steps.restore-cache.outputs.cache-hit }}' != 'true' ]]; then
+            cache_ok='false'
+          elif [[ -e ~/.m2/repository/.cache/org-apache-ozone/partial-cache ]]; then
+            cache_ok='false'
+          fi
+          echo "cache-ok=$cache_ok" >> $GITHUB_OUTPUT
+
       - name: Setup Java
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.verify-cache.outputs.cache-ok != 'true'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
 
       - name: Fetch dependencies
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: mvn --batch-mode --fail-never --no-transfer-progress --show-version -Pgo-offline -Pdist clean verify
+        if: steps.verify-cache.outputs.cache-ok != 'true'
+        run: |
+          mkdir -p ~/.m2/repository
+          dev-support/ci/populate-cache.sh
+        continue-on-error: true
 
       - name: Delete Ozone jars from repo
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.verify-cache.outputs.cache-ok != 'true'
         run: rm -fr ~/.m2/repository/org/apache/ozone
 
       - name: List repo contents
-        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: find ~/.m2/repository -type f | sort | xargs ls -lh
 
       - name: Save cache for Maven dependencies
-        if: steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.verify-cache.outputs.cache-ok != 'true'
         uses: actions/cache/save@v4
         with:
           path: |

--- a/dev-support/ci/populate-cache.sh
+++ b/dev-support/ci/populate-cache.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# This script gets a list of the changed files from git, and matches
+# that list against a set of regexes, each of which corresponds to a
+# test group.  For each set of matches, a flag is set to let github
+# actions know to run that test group.
+
+# Populates local Maven repository (similar to go-offline, but using actual build).
+# Downloads Node.js for multiple platforms (Linux, Mac)
+
+set -u -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${DIR}/../.." || exit 1
+
+: ${REPO_DIR:="${HOME}/.m2/repository"}
+: ${MARKER_FILE:="${REPO_DIR}/.cache/org-apache-ozone/partial-cache"}
+
+declare -i rc=0
+
+if [[ ! -d "${REPO_DIR}" ]]; then
+  echo "Error: repository dir ${REPO_DIR} does not exist"
+  exit 1
+fi
+
+# Download Node.js manually
+NODEJS_VERSION=$(mvn help:evaluate -Dexpression=nodejs.version -q -DforceStdout)
+if [[ -n "${NODEJS_VERSION}" ]]; then
+  for platform in darwin-x64 linux-x64; do
+    output="${REPO_DIR}/com/github/eirslett/node/${NODEJS_VERSION}/node-${NODEJS_VERSION}-${platform}.tar.gz"
+    url="https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-${platform}.tar.gz"
+    mkdir -pv "$(dirname "${output}")"
+    curl --retry 3 --location --continue-at - -o "${output}" "${url}"
+    irc=$?
+
+    if [[ ${rc} -eq 0 ]]; then
+      rc=${irc}
+    fi
+  done
+fi
+
+MAVEN_OPTIONS="--batch-mode --fail-at-end --no-transfer-progress --show-version -Pgo-offline -Pdist"
+if ! mvn ${MAVEN_OPTIONS} clean verify; then
+  rc=1
+fi
+
+if [[ ${rc} -eq 0 ]]; then
+  rm -fv "${MARKER_FILE}"
+else
+  # Create Marker file if build fails to indicate cache is partial, needs to be rebuilt next time
+  mkdir -pv "$(dirname "${MARKER_FILE}")"
+  touch "${MARKER_FILE}"
+fi
+
+exit ${rc}

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -103,7 +103,7 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v16.14.2</nodeVersion>
+              <nodeVersion>v${nodejs.version}</nodeVersion>
             </configuration>
           </execution>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <spring.version>5.3.34</spring.version>
     <jooq.version>3.11.10</jooq.version>
 
+    <!-- Node.js version number (without the v prefix required by frontend-maven-plugin) -->
+    <nodejs.version>16.14.2</nodejs.version>
+
     <vault.driver.version>5.1.0</vault.driver.version>
     <native.lib.tmp.dir></native.lib.tmp.dir>
     <properties.maven.plugin.version>1.2.1</properties.maven.plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Download from `nodejs.org` seems to be unreliable.

This PR fixes intermittent failures in:
- `compile (8, macos-12)`, which previously had to download Node.js for each run, since the binary tarball is platform-specific, and we only cached the one for Linux
- various [checks](https://github.com/apache/ozone/actions/runs/9013830936) in the rare case that `populate-cache` runs into [download problem](https://github.com/apache/ozone/actions/runs/8968724893/job/24628735903#step:5:3429)

Changes:

1. Download both Linux and Mac versions of Node.js.  Use `curl`, with retry enabled.
2. Indicate partially built cache by creating a marker file, which is deleted if all downloads succeed.
3. Log cache contents even in case of cache hit, making it easier to check contents.
4. Allow triggering `populate-cache` workflow manually for easier testing.

https://issues.apache.org/jira/browse/HDDS-10273

## How was this patch tested?

Triggered the workflow manually in my fork:
https://github.com/adoroszlai/ozone/actions/workflows/populate-cache.yml

Node.js tarballs from latest run:
https://github.com/adoroszlai/ozone/actions/runs/9018931552/job/24780630992#step:8:300