### PR TITLE
HDDS-10845. BaseFreonGenerator allows an empty prefix

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -285,7 +285,7 @@ public class BaseFreonGenerator {
     attemptCounter = new AtomicLong(0);
 
     if (prefix.length() == 0) {
-      prefix = randomPrefix() ? RandomStringUtils.randomAlphanumeric(10).toLowerCase() : "";
+      prefix = !allowEmptyPrefix() ? RandomStringUtils.randomAlphanumeric(10).toLowerCase() : "";
     } else {
       //replace environment variables to support multi-node execution
       prefix = resolvePrefix(prefix);
@@ -542,10 +542,12 @@ public class BaseFreonGenerator {
   }
 
   /**
-   * Whether using a random prefix when the prefix is empty.
+   * When no prefix is specified,
+   * if allowEmptyPrefix is false, a random prefix will be used;
+   * if allowEmptyPrefix is true, an empty prefix will be used.
    */
-  public boolean randomPrefix() {
-    return true;
+  public boolean allowEmptyPrefix() {
+    return false;
   }
 
   public String getPrefix() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -285,7 +285,7 @@ public class BaseFreonGenerator {
     attemptCounter = new AtomicLong(0);
 
     if (prefix.length() == 0) {
-      prefix = RandomStringUtils.randomAlphanumeric(10).toLowerCase();
+      prefix = randomPrefix() ? RandomStringUtils.randomAlphanumeric(10).toLowerCase() : "";
     } else {
       //replace environment variables to support multi-node execution
       prefix = resolvePrefix(prefix);
@@ -306,8 +306,8 @@ public class BaseFreonGenerator {
               "Invalid command, "
                       + "the testNo must be a positive integer");
     }
-    LOG.info("Executing test with prefix {} " +
-        "and number-of-tests {}", prefix, testNo);
+    LOG.info("Executing test with prefix {} and number-of-tests {}",
+        prefix.isEmpty() ? "''" : prefix, testNo);
 
     pathSchema = new PathSchema(prefix);
 
@@ -539,6 +539,13 @@ public class BaseFreonGenerator {
     DigestUtils dig = new DigestUtils(DIGEST_ALGORITHM);
     dig.getMessageDigest().reset();
     return dig.digest(stream);
+  }
+
+  /**
+   * Whether using a random prefix when the prefix is empty.
+   */
+  public boolean randomPrefix() {
+    return true;
   }
 
   public String getPrefix() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
@@ -461,4 +461,7 @@ public class OmMetadataGenerator extends BaseFreonGenerator
     }
   }
 
+  public boolean randomPrefix() {
+    return false;
+  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
@@ -461,7 +461,8 @@ public class OmMetadataGenerator extends BaseFreonGenerator
     }
   }
 
-  public boolean randomPrefix() {
-    return false;
+  @Override
+  public boolean allowEmptyPrefix() {
+    return true;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
@@ -272,7 +272,8 @@ public class OzoneClientKeyReadWriteListOps extends BaseFreonGenerator
     return keyNameSb.toString();
   }
 
-  public boolean randomPrefix() {
-    return false;
+  @Override
+  public boolean allowEmptyPrefix() {
+    return true;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyReadWriteListOps.java
@@ -271,4 +271,8 @@ public class OzoneClientKeyReadWriteListOps extends BaseFreonGenerator
     }
     return keyNameSb.toString();
   }
+
+  public boolean randomPrefix() {
+    return false;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

BaseFreonGenerator allows an empty prefix instead of enforcing a random prefix when no prefix is specified.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10845

## How was this patch tested?

manual tests.

### case1:
without pr:
```java
# note: write first and then exe related read op
$ ozone freon ockrw -r 1000 -t 10 --linear --contiguous --percentage-read 50 -m=true --size=0 --duration 10s -v vol1 -b freon2
2024-05-12 16:54:45,789 [pool-2-thread-9] ERROR freon.OzoneClientKeyReadWriteListOps: Key:o7h00eovbs/9 not found
2024-05-12 16:54:45,789 [pool-2-thread-2] ERROR freon.OzoneClientKeyReadWriteListOps: Key:o7h00eovbs/5 not found
2024-05-12 16:54:45,789 [pool-2-thread-1] ERROR freon.OzoneClientKeyReadWriteListOps: Key:o7h00eovbs/7 not found
2024-05-12 16:54:45,789 [pool-2-thread-5] ERROR freon.OzoneClientKeyReadWriteListOps: Key:o7h00eovbs/0 not found
2024-05-12 16:54:45,791 [pool-2-thread-6] ERROR freon.BaseFreonGenerator: Error on executing task 5
java.lang.RuntimeException: Key:o7h00eovbs/6 not found
    at org.apache.hadoop.ozone.freon.OzoneClientKeyReadWriteListOps.lambda$readWriteListKeys$0(OzoneClientKeyReadWriteListOps.java:212)
    at com.codahale.metrics.Timer.time(Timer.java:116)
    at org.apache.hadoop.ozone.freon.OzoneClientKeyReadWriteListOps.readWriteListKeys(OzoneClientKeyReadWriteListOps.java:192)
    at org.apache.hadoop.ozone.freon.BaseFreonGenerator.tryNextTask(BaseFreonGenerator.java:220)
    at org.apache.hadoop.ozone.freon.BaseFreonGenerator.taskLoop(BaseFreonGenerator.java:200)
    at org.apache.hadoop.ozone.freon.BaseFreonGenerator.lambda$startTaskRunners$0(BaseFreonGenerator.java:174)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748) 
```
with pr, no err:
```
$ ozone freon ockrw -r 1000 -t 10 --linear --contiguous --percentage-read 50 -m=true --size=0 --duration 10s -v vol1 -b freon2
2024-05-12 17:42:51,677 [main] INFO freon.BaseFreonGenerator: Executing test with prefix '' and number-of-tests 1000

 100.00% |█████████████████████████████████████████████████████████████████████████████████████████████████████|  10/10 Time: 0:00:10|
24-5-12 17:43:02 ===============================================================

-- Timers ----------------------------------------------------------------------
key-read-write-list
             count = 6073
         mean rate = 671.91 calls/second
     1-minute rate = 630.00 calls/second
     5-minute rate = 630.00 calls/second
    15-minute rate = 630.00 calls/second
               min = 0.29 milliseconds
               max = 223.48 milliseconds
              mean = 12.61 milliseconds
            stddev = 30.34 milliseconds
            median = 1.82 milliseconds
              75% <= 2.95 milliseconds
              95% <= 90.20 milliseconds
              98% <= 93.20 milliseconds
              99% <= 94.80 milliseconds
            99.9% <= 223.33 milliseconds


Total execution time (sec): 10
Failures: 0
Successful executions: 6073
```
### case 2:
without pr:
```bash
ozone freon ommg --operation CREATE_KEY -n 25000 --duration 10 -v vol1 -b freon2
2024-05-12 15:22:35,976 [main] INFO freon.BaseFreonGenerator: Executing test with prefix hrjrsaohi9 and number-of-tests 25000
```
"prefix hrjrsaohi9" should be prefix ''.
with pr:
```bash
2024-05-12 17:45:36,898 [main] INFO freon.BaseFreonGenerator: Executing test with prefix '' and number-of-tests 25000
```


