### PR TITLE
HDDS-9679. Added Multipart Upload ID to S3MultiPart audit logs.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3ExpiredMultipartUploadsAbortRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -158,6 +159,8 @@ public class S3ExpiredMultipartUploadsAbortRequest extends OMKeyRequest {
                 .getUploadID())
             .build();
         Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgsForAudit);
+        auditMap.put(OzoneConsts.UPLOAD_ID, abortInfo.getOmMultipartKeyInfo()
+            .getUploadID());
         auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
             OMAction.ABORT_EXPIRED_MULTIPART_UPLOAD, auditMap,
             null, getOmRequest().getUserInfo()));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.audit.OMAction;
@@ -121,6 +122,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
     Preconditions.checkNotNull(keyArgs.getMultipartUploadID());
 
     Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+    auditMap.put(OzoneConsts.UPLOAD_ID, keyArgs.getMultipartUploadID());
 
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -79,6 +80,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
     Preconditions.checkNotNull(keyArgs.getMultipartUploadID());
 
     Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+    auditMap.put(OzoneConsts.UPLOAD_ID, keyArgs.getMultipartUploadID());
 
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.Map;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -107,6 +108,7 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
     OzoneManagerProtocolProtos.KeyArgs keyArgs = multipartUploadAbortRequest
         .getKeyArgs();
     Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+    auditMap.put(OzoneConsts.UPLOAD_ID, keyArgs.getMultipartUploadID());
 
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -112,6 +112,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
 
     KeyArgs keyArgs = multipartCommitUploadPartRequest.getKeyArgs();
     Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+    auditMap.put(OzoneConsts.UPLOAD_ID, keyArgs.getMultipartUploadID());
 
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -151,6 +151,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     List<OzoneManagerProtocolProtos.Part> partsList =
         multipartUploadCompleteRequest.getPartsListList();
     Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+    auditMap.put(OzoneConsts.UPLOAD_ID, keyArgs.getMultipartUploadID());
 
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Multipart UploadID is not written to S3 MPU requests. Since, the same multipart key can be created with multiple uploadIDs added the multipart UploadID info to the audits.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9679

## How was this patch tested?

Manually tested multipart commands using `aws s3api`

```
2024-05-14 00:33:50,810 | INFO  | S3GAudit | user=unsecure | ip=172.19.0.3 | op=INIT_MULTIPART_UPLOAD {bucket=[testbucket], path=[large_test_file1], uploads=[]} | ret=SUCCESS |  
2024-05-14 00:34:36,473 | INFO  | S3GAudit | user=unsecure | ip=172.19.0.3 | op=CREATE_MULTIPART_KEY {bucket=[testbucket], path=[large_test_file1], uploadId=[57bc370c-e8c5-4a24-b7ec-2a1e4b3a240f-112436630703439875], partNumber=[1]} | ret=SUCCESS | perf={streamMode=true, metaLatencyMs=29, sizeByte=5242880, opLatencyMs=793} |  
2024-05-14 00:34:49,372 | INFO  | S3GAudit | user=unsecure | ip=172.19.0.3 | op=CREATE_MULTIPART_KEY {bucket=[testbucket], path=[large_test_file1], uploadId=[57bc370c-e8c5-4a24-b7ec-2a1e4b3a240f-112436630703439875], partNumber=[2]} | ret=SUCCESS | perf={streamMode=true, metaLatencyMs=9, sizeByte=5242880, opLatencyMs=376} |  
2024-05-14 00:36:03,031 | INFO  | S3GAudit | user=unsecure | ip=172.19.0.3 | op=LIST_PARTS {bucket=[testbucket], path=[large_test_file1], uploadId=[57bc370c-e8c5-4a24-b7ec-2a1e4b3a240f-112436630703439875]} | ret=SUCCESS | perf={count=2, opLatencyMs=19} |  
2024-05-14 00:37:09,408 | INFO  | S3GAudit | user=unsecure | ip=172.19.0.3 | op=COMPLETE_MULTIPART_UPLOAD {bucket=[testbucket], path=[large_test_file1], uploadId=[57bc370c-e8c5-4a24-b7ec-2a1e4b3a240f-112436630703439875]} | ret=SUCCESS | 
```
