### PR TITLE
HDDS-10859. Improve error messages when decommission and maintenance fail-early

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -327,7 +327,6 @@ public class NodeDecommissionManager {
       boolean decommissionPossible = checkIfDecommissionPossible(dns, errors);
       if (!decommissionPossible) {
         LOG.error("Cannot decommission nodes as sufficient node are not available.");
-        errors.add(new DatanodeAdminError("AllHosts", "Sufficient nodes are not available."));
         return errors;
       }
     } else {
@@ -436,10 +435,11 @@ public class NodeDecommissionManager {
           }
           int reqNodes = cif.getReplicationConfig().getRequiredNodes();
           if ((inServiceTotal - numDecom) < reqNodes) {
-            LOG.info("Cannot decommission nodes. Tried to decommission {} nodes of which valid nodes = {}. " +
-                    "Cluster state: In-service nodes = {}, nodes required for replication = {}. " +
-                    "Failing due to datanode : {}, container : {}",
-                dns.size(), numDecom, inServiceTotal, reqNodes, dn, cid);
+            String errorMsg = "Insufficient nodes. Tried to decommission " + dns.size() +
+                " nodes of which " + numDecom + " nodes were valid. Cluster has " + inServiceTotal +
+                " IN-SERVICE nodes, " + reqNodes + " of which are required for minimum replication. ";
+            LOG.info(errorMsg + "Failing due to datanode : {}, container : {}", dn, cid);
+            errors.add(new DatanodeAdminError("AllHosts", errorMsg));
             return false;
           }
         }
@@ -495,7 +495,6 @@ public class NodeDecommissionManager {
       boolean maintenancePossible = checkIfMaintenancePossible(dns, errors);
       if (!maintenancePossible) {
         LOG.error("Cannot put nodes to maintenance as sufficient node are not available.");
-        errors.add(new DatanodeAdminError("AllHosts", "Sufficient nodes are not available."));
         return errors;
       }
     } else {
@@ -600,11 +599,11 @@ public class NodeDecommissionManager {
             minInService = maintenanceReplicaMinimum;
           }
           if ((inServiceTotal - numMaintenance) < minInService) {
-            LOG.info("Cannot enter nodes into maintenance. Tried to start maintenance for {} nodes " +
-                    "of which valid nodes = {}. " +
-                    "Cluster state: In-service nodes = {}, nodes required for replication = {}. " +
-                    "Failing due to datanode : {}, container : {}",
-                dns.size(), numMaintenance, inServiceTotal, minInService, dn, cid);
+            String errorMsg = "Insufficient nodes. Tried to start maintenance for " + dns.size() +
+                " nodes of which " + numMaintenance + " nodes were valid. Cluster has " + inServiceTotal +
+                " IN-SERVICE nodes, " + minInService + " of which are required for minimum replication. ";
+            LOG.info(errorMsg + "Failing due to datanode : {}, container : {}", dn, cid);
+            errors.add(new DatanodeAdminError("AllHosts", errorMsg));
             return false;
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current error message if decommission or maintenance fails early is not detailed enough:
`Error: AllHosts: Sufficient nodes are not available.`
The message must be self-explanatory and mention the reason of failure.
In this PR, the error messages have been changed to show the number of nodes trying to be decommissioned/put into maintenance and how many nodes are needed to maintain required replication.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10859

## How was this patch tested?

Tested locally in docker cluster with 5 nodes, max replication factor of keys was RATIS-THREE:
```
bash-4.2$ ozone admin datanode decommission ozone-datanode-1 ozone-datanode-2 ozone-datanode-3
Started decommissioning datanode(s):
ozone-datanode-1
ozone-datanode-2
ozone-datanode-3
Error: AllHosts: Insufficient nodes. Tried to decommission 3 nodes of which 3 nodes were valid. Cluster has 5 IN-SERVICE nodes, 3 of which are required for minimum replication. 
Some nodes could not enter the decommission workflow
bash-4.2$ 
bash-4.2$ ozone admin datanode maintenance ozone-datanode-1 ozone-datanode-2 ozone-datanode-3 ozone-datanode-4
Entering maintenance mode on datanode(s):
ozone-datanode-1
ozone-datanode-2
ozone-datanode-3
ozone-datanode-4
Error: AllHosts: Insufficient nodes. Tried to start maintenance for 4 nodes of which 4 nodes were valid. Cluster has 5 IN-SERVICE nodes, 2 of which are required for minimum replication. 
Some nodes could not start the maintenance workflow
```
