### PR TITLE
HDDS-10855. Handle Null ParentKeyInfo Error in Recon Namespace Summary Task.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
@@ -155,7 +155,8 @@ public class NSSummaryTaskDbEventHandler {
   protected void handleDeleteKeyEvent(OmKeyInfo keyInfo,
                                       Map<Long, NSSummary> nsSummaryMap)
       throws IOException {
-    long parentObjectId = keyInfo.getParentObjectID();
+    NSSummary currentNSSummary = nsSummaryMap.get(keyInfo.getObjectID());
+    long parentObjectId = currentNSSummary.getParentId();
     // Try to get the NSSummary from our local map that maps NSSummaries to IDs
     NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
     if (nsSummary == null) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskDbEventHandler.java
@@ -155,8 +155,7 @@ public class NSSummaryTaskDbEventHandler {
   protected void handleDeleteKeyEvent(OmKeyInfo keyInfo,
                                       Map<Long, NSSummary> nsSummaryMap)
       throws IOException {
-    NSSummary currentNSSummary = nsSummaryMap.get(keyInfo.getObjectID());
-    long parentObjectId = currentNSSummary.getParentId();
+    long parentObjectId = keyInfo.getParentObjectID();
     // Try to get the NSSummary from our local map that maps NSSummaries to IDs
     NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
     if (nsSummary == null) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -294,7 +294,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
     if (!flushAndCommitNSToDB(nsSummaryMap)) {
       return false;
     }
-    LOG.debug("Completed a reprocess run of NSSummaryTaskWithLegacy");
+    LOG.info("Completed a reprocess run of NSSummaryTaskWithLegacy");
     return true;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -326,8 +326,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
       if (parentKeyInfo != null) {
         keyInfo.setParentObjectID(parentKeyInfo.getObjectID());
       } else {
-        LOG.error(
-            "ParentKeyInfo is null for key: {} in volume: {}, bucket: {}. Full Parent Key: {}",
+        LOG.warn("ParentKeyInfo is null for key: {} in volume: {}, bucket: {}. Full Parent Key: {}",
             keyInfo.getKeyName(), keyInfo.getVolumeName(), keyInfo.getBucketName(), fullParentKeyName);
         throw new IOException("ParentKeyInfo for NSSummaryTaskWithLegacy is null for key: " +
                 keyInfo.getKeyName());
@@ -352,8 +351,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
     if (parentBucketInfo != null) {
       keyInfo.setParentObjectID(parentBucketInfo.getObjectID());
     } else {
-      LOG.error(
-          "ParentBucketInfo is null for key: {} in volume: {}, bucket: {}",
+      LOG.warn("ParentBucketInfo is null for key: {} in volume: {}, bucket: {}",
           keyInfo.getKeyName(), keyInfo.getVolumeName(), keyInfo.getBucketName());
       throw new IOException("ParentBucketInfo for NSSummaryTaskWithLegacy is null for key: " +
               keyInfo.getKeyName());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithOBS.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithOBS.java
@@ -228,6 +228,8 @@ public class NSSummaryTaskWithOBS extends NSSummaryTaskDbEventHandler {
     if (parentBucketInfo != null) {
       keyInfo.setParentObjectID(parentBucketInfo.getObjectID());
     } else {
+      LOG.warn("ParentBucketInfo is null for key: %s in volume: %s, bucket: %s",
+          keyInfo.getKeyName(), keyInfo.getVolumeName(), keyInfo.getBucketName());
       throw new IOException("ParentKeyInfo for " +
           "NSSummaryTaskWithOBS is null");
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the `NSSummaryTaskWithLegacy` class, a common issue arises when the ParentKeyInfo is null. ParentKeyInfo might be null due to deleted parents, yet-to-be-added parents, concurrency problems, or orphaned keys. Proper logging and error handling are essential to diagnose and address these issues effectively.

### Current Behaviour
When ParentKeyInfo is null:

1. An IOException is thrown.
2. The error is logged with a few details.
3. The task fails, and the system attempts `to retry or reprocess the task.`

This behaviour ensures that the system does not silently ignore critical metadata inconsistencies, which could lead to larger issues later.

### Desired Functionality
The desired functionality in handling the Null ParentKeyInfo error is to leave the current behaviour as is because:

Throwing exceptions on critical errors like missing ParentKeyInfo is necessary to maintain the integrity of the metadata.
Improved logging can help in identifying and debugging the specific issues without altering the fundamental behaviour.
### Approach:

- Added detailed logging when the parent key info is missing.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10855

## How was this patch tested?


