### PR TITLE
HDDS-9522. Add percentile for ProtocolMessageMetrics

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -196,6 +196,9 @@ public final class OzoneConfigKeys {
   public static final int OZONE_CLIENT_EC_GRPC_RETRIES_MAX_DEFAULT = 3;
   public static final String OZONE_GPRC_METRICS_PERCENTILES_INTERVALS_KEY
       = "ozone.grpc.metrics.percentiles.intervals";
+  public static final String
+      OZONE_PROTOCOL_MESSAGE_METRICS_PERCENTILES_INTERVALS
+      = "ozone.protocol.message.metrics.percentiles.intervals";
 
   public static final String OZONE_CLIENT_EC_GRPC_WRITE_TIMEOUT =
       "ozone.client.ec.grpc.write.timeout";

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -139,10 +139,11 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     this.slowOpThresholdNs = getSlowOpThresholdMs(conf) * 1000000;
 
     protocolMetrics =
-        new ProtocolMessageMetrics<>(
+        ProtocolMessageMetrics.create(
             "HddsDispatcher",
             "HDDS dispatcher metrics",
-            Type.values());
+            Type.values(),
+            conf);
 
     this.dispatcher =
         new OzoneProtocolMessageDispatcher<>("DatanodeClient",

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ProtocolMessageMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/ProtocolMessageMetrics.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableQuantiles;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.util.MetricUtil;
 import org.apache.ratis.util.UncheckedAutoCloseable;
 
 /**
@@ -125,6 +126,7 @@ public final class ProtocolMessageMetrics<KEY> implements MetricsSource {
 
   public void unregister() {
     DefaultMetricsSystem.instance().unregisterSource(name);
+    quantiles.values().forEach(q -> MetricUtil.stop(q));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -129,7 +129,8 @@ public class SCMBlockProtocolServer implements
         ProtocolMessageMetrics.create(
             "ScmBlockLocationProtocol",
             "SCM Block location protocol counters",
-            ScmBlockLocationProtocolProtos.Type.values());
+            ScmBlockLocationProtocolProtos.Type.values(),
+            conf);
 
     // SCM Block Service RPC.
     BlockingService blockProtoPbService =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -160,7 +160,8 @@ public class SCMClientProtocolServer implements
     protocolMetrics = ProtocolMessageMetrics
         .create("ScmContainerLocationProtocol",
             "SCM ContainerLocation protocol metrics",
-            StorageContainerLocationProtocolProtos.Type.values());
+            StorageContainerLocationProtocolProtos.Type.values(),
+            conf);
 
     // SCM Container Service RPC
     BlockingService storageProtoPbService =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -30,6 +30,7 @@ import java.util.OptionalLong;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -159,7 +160,7 @@ public class SCMDatanodeProtocolServer implements
     InetSocketAddress datanodeRpcAddr = getDataNodeBindAddress(
         conf, scm.getScmNodeDetails());
 
-    protocolMessageMetrics = getProtocolMessageMetrics();
+    protocolMessageMetrics = getProtocolMessageMetrics(conf);
     final int handlerCount = conf.getInt(OZONE_SCM_DATANODE_HANDLER_COUNT_KEY,
         OZONE_SCM_HANDLER_COUNT_KEY, OZONE_SCM_HANDLER_COUNT_DEFAULT,
             LOG::info);
@@ -475,10 +476,10 @@ public class SCMDatanodeProtocolServer implements
    * @return ProtocolMessageMetrics
    */
   protected ProtocolMessageMetrics<ProtocolMessageEnum>
-        getProtocolMessageMetrics() {
+        getProtocolMessageMetrics(ConfigurationSource conf) {
     return ProtocolMessageMetrics
         .create("SCMDatanodeProtocol", "SCM Datanode protocol",
-            StorageContainerDatanodeProtocolProtos.Type.values());
+            StorageContainerDatanodeProtocolProtos.Type.values(), conf);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -136,12 +136,14 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
     // SCM security service RPC service.
     RPC.setProtocolEngine(conf, SCMSecurityProtocolPB.class,
         ProtobufRpcEngine.class);
-    metrics = new ProtocolMessageMetrics("ScmSecurityProtocol",
+    metrics = ProtocolMessageMetrics.create("ScmSecurityProtocol",
         "SCM Security protocol metrics",
-        SCMSecurityProtocolProtos.Type.values());
-    secretKeyMetrics = new ProtocolMessageMetrics("ScmSecretKeyProtocol",
+        SCMSecurityProtocolProtos.Type.values(),
+        conf);
+    secretKeyMetrics = ProtocolMessageMetrics.create("ScmSecretKeyProtocol",
         "SCM SecretKey protocol metrics",
-        SCMSecretKeyProtocolProtos.Type.values());
+        SCMSecretKeyProtocolProtos.Type.values(),
+        conf);
     BlockingService secureProtoPbService =
         SCMSecurityProtocolProtos.SCMSecurityProtocolService
             .newReflectiveBlockingService(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -100,6 +100,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OzoneConfigKeys.OZONE_RECOVERING_CONTAINER_SCRUBBING_SERVICE_TIMEOUT,
         OzoneConfigKeys.OZONE_RECOVERING_CONTAINER_TIMEOUT,
         OzoneConfigKeys.OZONE_GPRC_METRICS_PERCENTILES_INTERVALS_KEY,
+        OzoneConfigKeys.OZONE_PROTOCOL_MESSAGE_METRICS_PERCENTILES_INTERVALS,
         ReconConfigKeys.RECON_SCM_CONFIG_PREFIX,
         ReconConfigKeys.OZONE_RECON_ADDRESS_KEY,
         ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -714,7 +714,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     omClientProtocolMetrics = ProtocolMessageMetrics
         .create("OmClientProtocol", "Ozone Manager RPC endpoint",
-            OzoneManagerProtocolProtos.Type.values());
+            OzoneManagerProtocolProtos.Type.values(), conf);
 
     // Start Om Rpc Server.
     omRpcServer = getRpcServer(configuration);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.recon.scm;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
@@ -51,10 +52,10 @@ public class ReconDatanodeProtocolServer extends SCMDatanodeProtocolServer
 
   @Override
   public ProtocolMessageMetrics<ProtocolMessageEnum>
-      getProtocolMessageMetrics() {
+      getProtocolMessageMetrics(ConfigurationSource conf) {
     return ProtocolMessageMetrics
         .create("ReconDatanodeProtocol", "Recon Datanode protocol",
-            StorageContainerDatanodeProtocolProtos.Type.values());
+            StorageContainerDatanodeProtocolProtos.Type.values(), conf);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to add percentile for ProtocolMessageMetrics.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9522

## How was this patch tested?

Tested in my own cluster.

When we have config:
```
<property>
  <name>ozone.protocol.message.metrics.percentiles.intervals</name>
  <value>127</value>
</property>
``` 

OM:
<img width="543" alt="om" src="https://github.com/apache/ozone/assets/48795318/76c4336f-029e-4fd8-bf08-cabc27c742a2">

SCM:
<img width="658" alt="scm1" src="https://github.com/apache/ozone/assets/48795318/64f0f979-b381-42c9-8ccb-045686c05d08">
<img width="644" alt="scm2" src="https://github.com/apache/ozone/assets/48795318/69215364-c6c7-432b-88e6-91211ae598f0">
<img width="667" alt="scm3" src="https://github.com/apache/ozone/assets/48795318/e6e3ca62-f9fa-4537-8b5c-451abc94ab6e">

DN:
<img width="497" alt="dn1" src="https://github.com/apache/ozone/assets/48795318/54ba26a4-8774-40ac-8f28-58db9455a796">

The previous review record is as follows: 
https://github.com/apache/ozone/pull/5479