### PR TITLE
HDDS-2643. TestOzoneDelegationTokenSecretManager#testRenewTokenFailureRenewalTime fails intermittently

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -323,7 +323,7 @@ public class TestOzoneDelegationTokenSecretManager {
             () -> secretManager.renewToken(token, TEST_USER.toString()));
     String errorMessage = ioException.getMessage();
     assertTrue(errorMessage.contains("is expired") || errorMessage.contains("can't be found in cache"),
-        "\nExpecting:\n"+errorMessage+"\n to contain \"is expired\" or \"can't be found in cache\"");
+        "\nExpecting:\n" + errorMessage + "\n to contain \"is expired\" or \"can't be found in cache\"");
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -321,7 +321,9 @@ public class TestOzoneDelegationTokenSecretManager {
     IOException ioException =
         assertThrows(IOException.class,
             () -> secretManager.renewToken(token, TEST_USER.toString()));
-    assertThat(ioException.getMessage()).contains("is expired");
+    String errorMessage = ioException.getMessage();
+    assertTrue(errorMessage.contains("is expired") || errorMessage.contains("can't be found in cache"),
+        "\nExpecting:\n"+errorMessage+"\n to contain \"is expired\" or \"can't be found in cache\"");
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
TestOzoneDelegationTokenSecretManager#testRenewTokenFailureRenewalTime fails intermittently

There is 'OzoneDelegationTokenSecretManager.run()' check every five seconds(or lesser if value is configured) for the expired tokens to be removed from the cache and in rare scenario if our thread doesn't get control before it, the expired token may get out of cache and hence will have to consider this as a valid scenario. I have modified the code to accommodate that condition. We are testing the exceptions to be thrown as part of this test method.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2643

## How was this patch tested?
Tested the modified code with 500 runs having 25 splits and 20 iterations, it is working 100% fine https://github.com/raju-balpande/apache_ozone/actions/runs/9114752214
