### PR TITLE
HDDS-10865. Check OM version before making rewrite key request

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -40,6 +40,8 @@ public enum OzoneManagerVersion implements ComponentVersion {
   LIGHTWEIGHT_LIST_KEYS(4, "OzoneManager version that supports lightweight"
       + " listKeys API."),
 
+  ATOMIC_REWRITE_KEY(5, "OzoneManager version that supports rewriting key as atomic operation"),
+
   FUTURE_VERSION(-1, "Used internally in the client when the server side is "
       + " newer and an unknown server version has arrived to the client.");
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1416,6 +1416,10 @@ public class RpcClient implements ClientProtocol {
   public OzoneOutputStream rewriteKey(String volumeName, String bucketName, String keyName,
       long size, long existingKeyGeneration, ReplicationConfig replicationConfig,
       Map<String, String> metadata) throws IOException {
+    if (omVersion.compareTo(OzoneManagerVersion.ATOMIC_REWRITE_KEY) < 0) {
+      throw new IOException("OzoneManager does not support atomic key rewrite.");
+    }
+
     createKeyPreChecks(volumeName, bucketName, keyName, replicationConfig);
     String ownerName = getRealUserInfo().getShortUserName();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reject `rewriteKey` call at client if OM does not support it.

https://issues.apache.org/jira/browse/HDDS-10865

## How was this patch tested?

Created command `ozone sh key rewrite` to call the new API, toggling replication between RATIS/3 and EC/3,2.

Tested the command in `ozone` environment to verify it works:

```
$ cd hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose/ozone
$ OZONE_DATANODES=5 ./run.sh -d
$ docker-compose exec scm bash
bash-4.2$ ozone freon ockg -n1 -t1 # create volume and bucket
...
bash-4.2$ ozone sh key put /vol1/bucket1/rocksdbjni-7.7.3.jar share/ozone/lib/rocksdbjni-7.7.3.jar
bash-4.2$ ozone sh key list /vol1/bucket1 -p=rocksdbjni-7.7.3.jar 
[ {
  "creationTime" : "2024-05-16T18:33:10.860Z",
  "modificationTime" : "2024-05-16T18:33:12.277Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  ...
} ]
bash-4.2$ ozone sh key rewrite /vol1/bucket1/rocksdbjni-7.7.3.jar 
bash-4.2$ ozone sh key list /vol1/bucket1 -p=rocksdbjni-7.7.3.jar 
[ {
  "creationTime" : "2024-05-16T18:33:10.860Z",
  "modificationTime" : "2024-05-16T18:33:48.322Z",
  "replicationConfig" : {
    "data" : 3,
    "parity" : 2,
    "ecChunkSize" : 1048576,
    "codec" : "RS",
    "requiredNodes" : 5,
    "replicationType" : "EC"
  },
  ...
} ]
bash-4.2$ ozone sh key rewrite /vol1/bucket1/rocksdbjni-7.7.3.jar 
bash-4.2$ ozone sh key list /vol1/bucket1 -p=rocksdbjni-7.7.3.jar 
[ {
  "creationTime" : "2024-05-16T18:33:10.860Z",
  "modificationTime" : "2024-05-16T18:33:55.015Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  ...
} ]
```

Tested the command in `xcompat` environment with old cluster and new client to verify the change in this PR:

```
$ cd hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose/xcompat
$ OZONE_VERSION=1.4.0 COMPOSE_FILE=old-cluster.yaml:clients.yaml docker-compose up -d --scale datanode=5
$ OZONE_VERSION=1.4.0 COMPOSE_FILE=old-cluster.yaml:clients.yaml docker-compose exec new_client bash
bash-4.2$ ozone freon ockg -n1 -t1 # create volume and bucket
...
bash-4.2$ ozone sh key put /vol1/bucket1/rocksdbjni-7.7.3.jar share/ozone/lib/rocksdbjni-7.7.3.jar
bash-4.2$ ozone sh key rewrite /vol1/bucket1/rocksdbjni-7.7.3.jar 
OzoneManager does not support atomic key rewrite.
```

The new command is not part of the PR, but can be added if you think it's useful.

CI:
https://github.com/adoroszlai/ozone/actions/runs/9114412166