### PR TITLE
HDDS-10872. Rewrite single key via CLI

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
@@ -44,6 +44,7 @@ import picocli.CommandLine.ParentCommand;
         CatKeyHandler.class,
         PutKeyHandler.class,
         RenameKeyHandler.class,
+        RewriteKeyHandler.class,
         CopyKeyHandler.class,
         DeleteKeyHandler.class,
         AddAclKeyHandler.class,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/RewriteKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/RewriteKeyHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.shell.keys;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.ShellReplicationOptions;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.apache.hadoop.ozone.OzoneConsts.MB;
+
+/**
+ * Rewrite a key with different replication.
+ */
+@CommandLine.Command(name = "rewrite",
+    description = "Rewrites the key with different replication")
+public class RewriteKeyHandler extends KeyHandler {
+
+  @CommandLine.Mixin
+  private ShellReplicationOptions replication;
+
+  @Override
+  protected void execute(OzoneClient client, OzoneAddress address) throws IOException, OzoneClientException {
+    String volumeName = address.getVolumeName();
+    String bucketName = address.getBucketName();
+    String keyName = address.getKeyName();
+
+    OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
+    OzoneBucket bucket = vol.getBucket(bucketName);
+    OzoneKeyDetails key = bucket.getKey(keyName);
+
+    ReplicationConfig newReplication = replication.fromParamsOrConfig(getConf());
+    if (newReplication == null) {
+      newReplication = key.getReplicationConfig().getReplicationType() == HddsProtos.ReplicationType.RATIS
+          ? new ECReplicationConfig(3, 2)
+          : RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
+    } else if (newReplication.equals(key.getReplicationConfig())) {
+      System.err.println("Replication unchanged: " + key.getReplicationConfig());
+      return;
+    }
+
+    try (
+        InputStream input = bucket.readKey(keyName);
+        OutputStream output = bucket.rewriteKey(keyName, key.getDataSize(), key.getGeneration(),
+            newReplication, key.getMetadata())) {
+      IOUtils.copyBytes(input, output, (int) Math.min(MB, key.getDataSize()));
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow rewriting a key via CLI:

1. with new content via `ozone sh key put --expectedGeneration ...` command.  Generation value needs to be supplied manually.
2. with existing content via `ozone sh key rewrite` command.  Generation is used from current version of the key.  Replication can be specified via usual options.  If omitted, replication is toggled between RATIS/3 and EC/3,2 (this is intended as a temporary behavior for easier testing.)

https://issues.apache.org/jira/browse/HDDS-10872

## How was this patch tested?

```
$ ozone sh volume create /vol1
$ ozone sh bucket create --layout OBJECT_STORE /vol1/obs
$ k=/vol1/obs/key
$ ozone sh key put $k share/ozone/lib/rocksdbjni-7.7.3.jar

$ ozone sh key put --expectedGeneration 555 $k share/ozone/lib/rocksdbjni-7.7.3.jar
KEY_NOT_FOUND Generation mismatch during expected rewrite

$ ozone sh key put --expectedGeneration $(ozone sh key info $k | jq -r '.generation') $k /etc/passwd
$ ozone sh key info $k | jq -r '.generation'
15

$ ozone sh key put --expectedGeneration $(ozone sh key info $k | jq -r '.generation') $k share/ozone/lib/rocksdbjni-7.7.3.jar
$ ozone sh key info $k | jq -r '.generation'
21

$ ozone sh key put --expectedGeneration $(ozone sh key info $k | jq -r '.generation') $k /etc/passwd
$ ozone sh key info $k | jq -r '.generation'
25

$ ozone sh key rewrite $k 
$ ozone sh key info $k | jq -r '.generation'
29

$ ozone sh key rewrite $k 
$ ozone sh key info $k | jq -r '.generation'
33

$ ozone sh key rewrite --type EC --replication rs-3-2-1024k $k 
$ ozone sh key rewrite --type EC --replication rs-3-2-1024k $k 
Replication unchanged: EC{rs-3-2-1024k}

$ ozone sh key put --expectedGeneration 555 /vol1/obs/no-such-key share/ozone/lib/rocksdbjni-7.7.3.jar
KEY_NOT_FOUND Key not found during expected rewrite
```