### PR TITLE
HDDS-10857. Rename rewriteGeneration to expectedDataGeneration in the protobuf and builders

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1432,7 +1432,7 @@ public class RpcClient implements ClientProtocol {
         .addAllMetadataGdpr(metadata)
         .setLatestVersionLocation(getLatestVersionLocation)
         .setOwnerName(ownerName)
-        .setRewriteGeneration(existingKeyGeneration);
+        .setExpectedDataGeneration(existingKeyGeneration);
 
     OpenKeySession openKey = ozoneManagerClient.openKey(builder.build());
     // For bucket with layout OBJECT_STORE, when create an empty file (size=0),

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -53,13 +53,13 @@ public final class OmKeyArgs implements Auditable {
   private final boolean recursive;
   private final boolean headOp;
   private final boolean forceUpdateContainerCacheFromSCM;
-  // RewriteGeneration, when used in key creation indicates that a
+  // expectedDataGeneration, when used in key creation indicates that a
   // key with the same keyName should exist with the given generation.
   // For a key commit to succeed, the original key should still be present with the
   // generation unchanged.
   // This allows a key to be created an committed atomically if the original has not
   // been modified.
-  private Long rewriteGeneration = null;
+  private Long expectedDataGeneration = null;
 
   private OmKeyArgs(Builder b) {
     this.volumeName = b.volumeName;
@@ -79,7 +79,7 @@ public final class OmKeyArgs implements Auditable {
     this.headOp = b.headOp;
     this.forceUpdateContainerCacheFromSCM = b.forceUpdateContainerCacheFromSCM;
     this.ownerName = b.ownerName;
-    this.rewriteGeneration = b.rewriteGeneration;
+    this.expectedDataGeneration = b.expectedDataGeneration;
   }
 
   public boolean getIsMultipartKey() {
@@ -158,8 +158,8 @@ public final class OmKeyArgs implements Auditable {
     return forceUpdateContainerCacheFromSCM;
   }
 
-  public Long getRewriteGeneration() {
-    return rewriteGeneration;
+  public Long getExpectedDataGeneration() {
+    return expectedDataGeneration;
   }
 
   @Override
@@ -203,8 +203,8 @@ public final class OmKeyArgs implements Auditable {
         .setAcls(acls)
         .setForceUpdateContainerCacheFromSCM(forceUpdateContainerCacheFromSCM);
 
-    if (rewriteGeneration != null) {
-      builder.setRewriteGeneration(rewriteGeneration);
+    if (expectedDataGeneration != null) {
+      builder.setExpectedDataGeneration(expectedDataGeneration);
     }
     return builder;
   }
@@ -221,8 +221,8 @@ public final class OmKeyArgs implements Auditable {
         .setHeadOp(isHeadOp())
         .setForceUpdateContainerCacheFromSCM(
             isForceUpdateContainerCacheFromSCM());
-    if (rewriteGeneration != null) {
-      builder.setRewriteGeneration(rewriteGeneration);
+    if (expectedDataGeneration != null) {
+      builder.setExpectedDataGeneration(expectedDataGeneration);
     }
     return builder.build();
   }
@@ -248,7 +248,7 @@ public final class OmKeyArgs implements Auditable {
     private boolean recursive;
     private boolean headOp;
     private boolean forceUpdateContainerCacheFromSCM;
-    private Long rewriteGeneration = null;
+    private Long expectedDataGeneration = null;
 
     public Builder setVolumeName(String volume) {
       this.volumeName = volume;
@@ -348,8 +348,8 @@ public final class OmKeyArgs implements Auditable {
       return this;
     }
 
-    public Builder setRewriteGeneration(long generation) {
-      this.rewriteGeneration = generation;
+    public Builder setExpectedDataGeneration(long generation) {
+      this.expectedDataGeneration = generation;
       return this;
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -102,13 +102,13 @@ public final class OmKeyInfo extends WithParentObjectId
    */
   private final CopyOnWriteArrayList<OzoneAcl> acls;
 
-  // rewriteGeneration, when used in key creation indicates that a
+  // expectedDataGeneration, when used in key creation indicates that a
   // key with the same keyName should exist with the given generation.
   // For a key commit to succeed, the original key should still be present with the
   // generation unchanged.
   // This allows a key to be created an committed atomically if the original has not
   // been modified.
-  private Long rewriteGeneration = null;
+  private Long expectedDataGeneration = null;
 
   private OmKeyInfo(Builder b) {
     super(b);
@@ -126,7 +126,7 @@ public final class OmKeyInfo extends WithParentObjectId
     this.fileName = b.fileName;
     this.isFile = b.isFile;
     this.ownerName = b.ownerName;
-    this.rewriteGeneration = b.rewriteGeneration;
+    this.expectedDataGeneration = b.expectedDataGeneration;
   }
 
   public String getVolumeName() {
@@ -169,12 +169,12 @@ public final class OmKeyInfo extends WithParentObjectId
     return fileName;
   }
 
-  public void setRewriteGeneration(Long generation) {
-    this.rewriteGeneration = generation;
+  public void setExpectedDataGeneration(Long generation) {
+    this.expectedDataGeneration = generation;
   }
 
-  public Long getRewriteGeneration() {
-    return rewriteGeneration;
+  public Long getExpectedDataGeneration() {
+    return expectedDataGeneration;
   }
 
   public String getOwnerName() {
@@ -460,7 +460,7 @@ public final class OmKeyInfo extends WithParentObjectId
     private FileChecksum fileChecksum;
 
     private boolean isFile;
-    private Long rewriteGeneration = null;
+    private Long expectedDataGeneration = null;
 
     public Builder() {
     }
@@ -589,8 +589,8 @@ public final class OmKeyInfo extends WithParentObjectId
       return this;
     }
 
-    public Builder setRewriteGeneration(Long existingGeneration) {
-      this.rewriteGeneration = existingGeneration;
+    public Builder setExpectedDataGeneration(Long existingGeneration) {
+      this.expectedDataGeneration = existingGeneration;
       return this;
     }
 
@@ -698,8 +698,8 @@ public final class OmKeyInfo extends WithParentObjectId
       kb.setFileEncryptionInfo(OMPBHelper.convert(encInfo));
     }
     kb.setIsFile(isFile);
-    if (rewriteGeneration != null) {
-      kb.setRewriteGeneration(rewriteGeneration);
+    if (expectedDataGeneration != null) {
+      kb.setExpectedDataGeneration(expectedDataGeneration);
     }
     if (ownerName != null) {
       kb.setOwnerName(ownerName);
@@ -750,8 +750,8 @@ public final class OmKeyInfo extends WithParentObjectId
     if (keyInfo.hasIsFile()) {
       builder.setFile(keyInfo.getIsFile());
     }
-    if (keyInfo.hasRewriteGeneration()) {
-      builder.setRewriteGeneration(keyInfo.getRewriteGeneration());
+    if (keyInfo.hasExpectedDataGeneration()) {
+      builder.setExpectedDataGeneration(keyInfo.getExpectedDataGeneration());
     }
 
     if (keyInfo.hasOwnerName()) {
@@ -867,8 +867,8 @@ public final class OmKeyInfo extends WithParentObjectId
     if (fileChecksum != null) {
       builder.setFileChecksum(fileChecksum);
     }
-    if (rewriteGeneration != null) {
-      builder.setRewriteGeneration(rewriteGeneration);
+    if (expectedDataGeneration != null) {
+      builder.setExpectedDataGeneration(expectedDataGeneration);
     }
 
     return builder.build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -726,8 +726,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     keyArgs.setSortDatanodes(args.getSortDatanodes());
 
-    if (args.getRewriteGeneration() != null) {
-      keyArgs.setRewriteGeneration(args.getRewriteGeneration());
+    if (args.getExpectedDataGeneration() != null) {
+      keyArgs.setExpectedDataGeneration(args.getExpectedDataGeneration());
     }
 
     req.setKeyArgs(keyArgs.build());

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -67,7 +67,7 @@ public class TestOmKeyInfo {
     assertFalse(key.isHsync());
     key.getMetadata().put(OzoneConsts.HSYNC_CLIENT_ID, "clientid");
     assertTrue(key.isHsync());
-    assertEquals(5678L, key.getRewriteGeneration());
+    assertEquals(5678L, key.getExpectedDataGeneration());
   }
 
   @Test
@@ -124,7 +124,7 @@ public class TestOmKeyInfo {
         .setReplicationConfig(replicationConfig)
         .addMetadata("key1", "value1")
         .addMetadata("key2", "value2")
-        .setRewriteGeneration(5678L)
+        .setExpectedDataGeneration(5678L)
         .build();
   }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1026,13 +1026,13 @@ message KeyArgs {
     // Force OM to update container cache location from SCL
     optional bool forceUpdateContainerCacheFromSCM = 20;
     optional string ownerName = 21;
-    // rewriteGeneration, when used in key creation indicates that a
+    // expectedDataGeneration, when used in key creation indicates that a
     // key with the same keyName should exist with the given generation.
     // For a key commit to succeed, the original key should still be present with the
     // generation unchanged.
     // This allows a key to be created an committed atomically if the original has not
     // been modified.
-    optional uint64 rewriteGeneration = 22;
+    optional uint64 expectedDataGeneration = 22;
 }
 
 message KeyLocation {
@@ -1116,13 +1116,13 @@ message KeyInfo {
     optional FileChecksumProto fileChecksum = 18;
     optional bool isFile = 19;
     optional string ownerName = 20;
-  // rewriteGeneration, when used in key creation indicates that a
+  // expectedDataGeneration, when used in key creation indicates that a
   // key with the same keyName should exist with the given generation.
   // For a key commit to succeed, the original key should still be present with the
   // generation unchanged.
   // This allows a key to be created an committed atomically if the original has not
   // been modified.
-    optional uint64 rewriteGeneration = 21;
+    optional uint64 expectedDataGeneration = 21;
 }
 
 message BasicKeyInfo {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -82,9 +82,9 @@ public interface RequestAuditor {
         auditMap.put(OzoneConsts.REPLICATION_CONFIG,
             ECReplicationConfig.toString(keyArgs.getEcReplicationConfig()));
       }
-      if (keyArgs.hasRewriteGeneration()) {
+      if (keyArgs.hasExpectedDataGeneration()) {
         auditMap.put(OzoneConsts.REWRITE_GENERATION,
-            String.valueOf(keyArgs.getRewriteGeneration()));
+            String.valueOf(keyArgs.getExpectedDataGeneration()));
       }
       for (HddsProtos.KeyValue item : keyArgs.getMetadataList()) {
         if (ETAG.equals(item.getKey())) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -244,7 +244,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       validateAtomicRewrite(keyToDelete, omKeyInfo, auditMap);
       // Optimistic locking validation has passed. Now set the rewrite fields to null so they are
       // not persisted in the key table.
-      omKeyInfo.setRewriteGeneration(null);
+      omKeyInfo.setExpectedDataGeneration(null);
 
       omKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
           commitKeyArgs.getMetadataList()));
@@ -506,16 +506,16 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
   private void validateAtomicRewrite(OmKeyInfo existing, OmKeyInfo toCommit, Map<String, String> auditMap)
       throws OMException {
-    if (toCommit.getRewriteGeneration() != null) {
+    if (toCommit.getExpectedDataGeneration() != null) {
       // These values are not passed in the request keyArgs, so add them into the auditMap if they are present
       // in the open key entry.
-      auditMap.put(OzoneConsts.REWRITE_GENERATION, String.valueOf(toCommit.getRewriteGeneration()));
+      auditMap.put(OzoneConsts.REWRITE_GENERATION, String.valueOf(toCommit.getExpectedDataGeneration()));
       if (existing == null) {
         throw new OMException("Atomic rewrite is not allowed for a new key", KEY_NOT_FOUND);
       }
-      if (!toCommit.getRewriteGeneration().equals(existing.getUpdateID())) {
+      if (!toCommit.getExpectedDataGeneration().equals(existing.getUpdateID())) {
         throw new OMException("Cannot commit as current generation (" + existing.getUpdateID() +
-            ") does not match with the rewrite generation (" + toCommit.getRewriteGeneration() + ")",
+            ") does not match with the rewrite generation (" + toCommit.getExpectedDataGeneration() + ")",
             KEY_NOT_FOUND);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -444,12 +444,12 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
   private void validateAtomicRewrite(OmKeyInfo dbKeyInfo, KeyArgs keyArgs)
       throws OMException {
-    if (keyArgs.hasRewriteGeneration()) {
+    if (keyArgs.hasExpectedDataGeneration()) {
       // If a key does not exist, or if it exists but the updateID do not match, then fail this request.
       if (dbKeyInfo == null) {
         throw new OMException("Key not found during expected rewrite", OMException.ResultCodes.KEY_NOT_FOUND);
       }
-      if (dbKeyInfo.getUpdateID() != keyArgs.getRewriteGeneration()) {
+      if (dbKeyInfo.getUpdateID() != keyArgs.getExpectedDataGeneration()) {
         throw new OMException("Generation mismatch during expected rewrite", OMException.ResultCodes.KEY_NOT_FOUND);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -779,8 +779,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
       dbKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
           keyArgs.getMetadataList()));
 
-      if (keyArgs.hasRewriteGeneration()) {
-        dbKeyInfo.setRewriteGeneration(keyArgs.getRewriteGeneration());
+      if (keyArgs.hasExpectedDataGeneration()) {
+        dbKeyInfo.setExpectedDataGeneration(keyArgs.getExpectedDataGeneration());
       }
       dbKeyInfo.setFileEncryptionInfo(encInfo);
       return dbKeyInfo;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -249,7 +249,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     OmKeyInfo.Builder omKeyInfoBuilder = OMRequestTestUtils.createOmKeyInfo(
         volumeName, bucketName, keyName, replicationConfig, new OmKeyLocationInfoGroup(version, new ArrayList<>()));
-    omKeyInfoBuilder.setRewriteGeneration(1L);
+    omKeyInfoBuilder.setExpectedDataGeneration(1L);
     OmKeyInfo omKeyInfo = omKeyInfoBuilder.build();
     omKeyInfo.appendNewBlocks(allocatedLocationList, false);
     List<OzoneAcl> acls = Collections.singletonList(OzoneAcl.parseAcl("user:foo:rw"));
@@ -268,7 +268,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     assertEquals(KEY_NOT_FOUND, omClientResponse.getOMResponse().getStatus());
 
     // Now add the key to the key table, and try again, but with different generation
-    omKeyInfoBuilder.setRewriteGeneration(null);
+    omKeyInfoBuilder.setExpectedDataGeneration(null);
     omKeyInfoBuilder.setUpdateID(0L);
     OmKeyInfo invalidKeyInfo = omKeyInfoBuilder.build();
     closedKeyTable.put(getOzonePathKey(), invalidKeyInfo);
@@ -287,7 +287,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     assertEquals(OK, omClientResponse.getOMResponse().getStatus());
 
     OmKeyInfo committedKey = closedKeyTable.get(getOzonePathKey());
-    assertNull(committedKey.getRewriteGeneration());
+    assertNull(committedKey.getExpectedDataGeneration());
     // Generation should be changed
     assertNotEquals(closedKeyInfo.getGeneration(), committedKey.getGeneration());
     assertEquals(acls, committedKey.getAcls());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -706,14 +706,14 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
   private OMRequest createKeyRequest(
       boolean isMultipartKey, int partNumber, long keyLength,
-      ReplicationConfig repConfig, Long rewriteGeneration) {
+      ReplicationConfig repConfig, Long expectedDataGeneration) {
     return createKeyRequest(isMultipartKey, partNumber, keyLength, repConfig,
-        rewriteGeneration, null);
+        expectedDataGeneration, null);
   }
 
   private OMRequest createKeyRequest(
       boolean isMultipartKey, int partNumber, long keyLength,
-      ReplicationConfig repConfig, Long rewriteGeneration, Map<String, String> metaData) {
+      ReplicationConfig repConfig, Long expectedDataGeneration, Map<String, String> metaData) {
 
     KeyArgs.Builder keyArgs = KeyArgs.newBuilder()
         .setVolumeName(volumeName).setBucketName(bucketName)
@@ -732,8 +732,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     if (isMultipartKey) {
       keyArgs.setMultipartNumber(partNumber);
     }
-    if (rewriteGeneration != null) {
-      keyArgs.setRewriteGeneration(rewriteGeneration);
+    if (expectedDataGeneration != null) {
+      keyArgs.setExpectedDataGeneration(expectedDataGeneration);
     }
     if (metaData != null) {
       metaData.forEach((key, value) -> keyArgs.addMetadata(KeyValue.newBuilder()
@@ -981,12 +981,12 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     response = omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 105L);
     assertEquals(OK, response.getOMResponse().getStatus());
 
-    // Ensure the rewriteGeneration is persisted in the open key table
+    // Ensure the expectedDataGeneration is persisted in the open key table
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, omRequest.getCreateKeyRequest().getClientID());
     OmKeyInfo openKeyInfo = omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout()).get(openKey);
 
-    assertEquals(existingKeyInfo.getGeneration(), openKeyInfo.getRewriteGeneration());
+    assertEquals(existingKeyInfo.getGeneration(), openKeyInfo.getExpectedDataGeneration());
     // Creation time should remain the same on rewrite.
     assertEquals(existingKeyInfo.getCreationTime(), openKeyInfo.getCreationTime());
     // Update ID should change


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename rewriteGeneration to expectedDataGeneration.

This future proofs the name, so we can potentially have expectedMetaGeneration in the future.

It also better describes what the field is for - when passed, it indicates the existing key is "expected" to have a Data Generation of the given value, whether it is for read, write (potential future use cases) or re-write (the current use case).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10857

## How was this patch tested?

Just a name change so existing tests cover this.
