### PR TITLE
HDDS-9317. Provide an option for displaying Ozone snapshot diff output as JSON

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/CancelSnapshotDiffResponse.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/CancelSnapshotDiffResponse.java
@@ -34,7 +34,7 @@ public class CancelSnapshotDiffResponse {
 
   @Override
   public String toString() {
-    return message + "\n";
+    return message;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -89,6 +89,14 @@ public class SnapshotDiffReportOzone
     return super.getDiffList();
   }
 
+  public String getVolumeName() {
+    return volumeName;
+  }
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
   public String getToken() {
     return token;
   }

--- a/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-sh.robot
@@ -53,6 +53,16 @@ Snapshot Diff
                     Should contain      ${result}       +    ${KEY_TWO}
                     Should contain      ${result}       +    ${KEY_THREE}
 
+Snapshot Diff as JSON
+    ${result} =     Execute             ozone sh snapshot diff --json /${VOLUME}/${BUCKET} ${SNAPSHOT_ONE} ${SNAPSHOT_TWO}
+                    Should contain      echo '${result}' | jq '.jobStatus'   DONE
+                    Should contain      echo '${result}' | jq '.snapshotDiffReport.volumeName'    ${VOLUME}
+                    Should contain      echo '${result}' | jq '.snapshotDiffReport.bucketName'    ${BUCKET}
+                    Should contain      echo '${result}' | jq '.snapshotDiffReport.fromSnapshot'  ${SNAPSHOT_ONE}
+                    Should contain      echo '${result}' | jq '.snapshotDiffReport.toSnapshot'    ${SNAPSHOT_TWO}
+                    Should contain      echo '${result}' | jq '.snapshotDiffReport.diffList | .[].sourcePath'    ${KEY_TWO}
+                    Should contain      echo '${result}' | jq '.snapshotDiffReport.diffList | .[].sourcePath'    ${KEY_THREE}
+
 List Snapshot Diff Jobs
     ${result} =     Execute             ozone sh snapshot listDiff /${VOLUME}/${BUCKET} --all
                     Should contain      ${result}        ${VOLUME}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -17,16 +17,27 @@
  */
 package org.apache.hadoop.ozone.shell.snapshot;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.server.JsonUtils;
+import org.apache.hadoop.hdfs.DFSUtilClient;
+import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.shell.Handler;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.bucket.BucketUri;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffReportOzone;
+import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
 import picocli.CommandLine;
 
 import java.io.IOException;
 import java.io.PrintStream;
+
+import static org.apache.hadoop.hdds.server.JsonUtils.toJsonStringWithDefaultPrettyPrinter;
 
 /**
  * ozone sh snapshot diff.
@@ -74,6 +85,11 @@ public class SnapshotDiffHandler extends Handler {
       hidden = true)
   private boolean diffDisableNativeLibs;
 
+  @CommandLine.Option(names = { "--json" },
+      defaultValue = "false",
+      description = "Format output as JSON")
+  private boolean json;
+
   @Override
   protected OzoneAddress getAddress() {
     return snapshotPath.getValue();
@@ -97,17 +113,71 @@ public class SnapshotDiffHandler extends Handler {
 
   private void getSnapshotDiff(ObjectStore store, String volumeName,
                                String bucketName) throws IOException {
+    SnapshotDiffResponse diffResponse = store.snapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot,
+        token, pageSize, forceFullDiff, diffDisableNativeLibs);
     try (PrintStream stream = out()) {
-      stream.println(store.snapshotDiff(volumeName, bucketName, fromSnapshot,
-          toSnapshot, token, pageSize, forceFullDiff, diffDisableNativeLibs));
+      if (json) {
+        stream.println(toJsonStringWithDefaultPrettyPrinter(getJsonObject(diffResponse)));
+      } else {
+        stream.println(diffResponse);
+      }
     }
   }
 
   private void cancelSnapshotDiff(ObjectStore store, String volumeName,
                                   String bucketName) throws IOException {
     try (PrintStream stream = out()) {
-      stream.print(store.cancelSnapshotDiff(volumeName, bucketName,
-          fromSnapshot, toSnapshot));
+      stream.println(store.cancelSnapshotDiff(volumeName, bucketName, fromSnapshot, toSnapshot));
+    }
+  }
+
+  private ObjectNode getJsonObject(SnapshotDiffResponse diffResponse) {
+    ObjectNode diffResponseNode = JsonUtils.createObjectNode(null);
+    diffResponseNode.set("snapshotDiffReport", getJsonObject(diffResponse.getSnapshotDiffReport()));
+    diffResponseNode.put("jobStatus", diffResponse.getJobStatus().name());
+    if (diffResponse.getWaitTimeInMs() != 0) {
+      diffResponseNode.put("waitTimeInMs", diffResponse.getWaitTimeInMs());
+    }
+    if (StringUtils.isNotEmpty(diffResponse.getReason())) {
+      diffResponseNode.put("reason", diffResponse.getReason());
+    }
+    return diffResponseNode;
+  }
+
+  private ObjectNode getJsonObject(SnapshotDiffReportOzone diffReportOzone) {
+    ObjectNode diffReportNode = JsonUtils.createObjectNode(null);
+    diffReportNode.put("volumeName", diffReportOzone.getVolumeName());
+    diffReportNode.put("bucketName", diffReportOzone.getBucketName());
+    diffReportNode.put("fromSnapshot", diffReportOzone.getFromSnapshot());
+    diffReportNode.put("toSnapshot", diffReportOzone.getLaterSnapshotName());
+    ArrayNode resArray = JsonUtils.createArrayNode();
+    diffReportOzone.getDiffList()
+        .forEach(diffReportEntry -> resArray.add(getJsonObject(diffReportEntry)));
+    diffReportNode.set("diffList", resArray);
+
+    if (StringUtils.isNotEmpty(diffReportOzone.getToken())) {
+      diffReportNode.put("nextToken", diffReportOzone.getToken());
+    }
+    return diffReportNode;
+  }
+
+
+  private ObjectNode getJsonObject(SnapshotDiffReport.DiffReportEntry diffReportEntry) {
+    ObjectNode diffReportNode = JsonUtils.createObjectNode(null);
+    diffReportNode.put("diffType", diffReportEntry.getType().getLabel());
+    diffReportNode.put("sourcePath", getPathString(diffReportEntry.getSourcePath()));
+    if (diffReportEntry.getTargetPath() != null) {
+      diffReportNode.put("targetPath", getPathString(diffReportEntry.getTargetPath()));
+    }
+    return diffReportNode;
+  }
+
+  private String getPathString(byte[] path) {
+    String pathStr = DFSUtilClient.bytes2String(path);
+    if (pathStr.isEmpty()) {
+      return Path.CUR_DIR;
+    } else {
+      return Path.CUR_DIR + Path.SEPARATOR + pathStr;
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
As per HDDS-6637 and [discussion](https://lists.apache.org/thread/5gqnbstv1pznwmcvx7txspj1qrksy7gl), Ozone CLI is supposed to support JSON output format. And currently, SnapshotDiff CLI doesn't support that.
This change is to add the support of JSON format along with the existing format so that issues like HDDS-10834 can be avoided.

## What is the link to the Apache JIRA
HDDS-9317

## How was this patch tested?
Locally on docker.