### PR TITLE
HDDS-6116. Remove flaky tag from TestSCMInstallSnapshot

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.ozone.test.tag.Flaky;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -126,7 +125,6 @@ public class TestSCMInstallSnapshot {
   }
 
   @Test
-  @Flaky("HDDS-6116")
   public void testInstallCheckPoint() throws Exception {
     DBCheckpoint checkpoint = downloadSnapshot();
     StorageContainerManager scm = cluster.getStorageContainerManager();


### PR DESCRIPTION
## What changes were proposed in this pull request?

No intermittent failures in testInstallCheckPoint method of TestSCMInstallSnapshot, so removed `@Flaky` tag.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6116

## How was this patch tested?

https://github.com/muskan1012/ozone/actions/runs/9093526472