### PR TITLE
HDDS-10875. XceiverRatisServer#getRaftPeersInPipeline should be called before XceiverRatisServer#removeGroup

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -61,6 +61,7 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.RoutingTable;
+import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.rpc.SupportedRpcType;
@@ -242,6 +243,12 @@ public final class RatisHelper {
       ConfigurationSource conf) {
     return (leader, tlsConfig) -> newRaftClient(getRpcType(conf), leader,
         RatisHelper.createRetryPolicy(conf), tlsConfig, conf);
+  }
+
+  public static BiFunction<RaftPeer, GrpcTlsConfig, RaftClient> newRaftClientNoRetry(
+      ConfigurationSource conf) {
+    return (leader, tlsConfig) -> newRaftClient(getRpcType(conf), leader,
+        RetryPolicies.noRetry(), tlsConfig, conf);
   }
 
   public static RaftClient newRaftClient(RpcType rpcType, RaftPeer leader,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 
-import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -69,7 +69,7 @@ public class ClosePipelineCommandHandler implements CommandHandler {
    */
   public ClosePipelineCommandHandler(ConfigurationSource conf,
                                      Executor executor) {
-    this(RatisHelper.newRaftClient(conf), executor);
+    this(RatisHelper.newRaftClientNoRetry(conf), executor);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -124,8 +124,12 @@ public class ClosePipelineCommandHandler implements CommandHandler {
                   } catch (GroupMismatchException ae) {
                     // ignore silently since this means that the group has been closed by earlier close pipeline
                     // command in another datanode
+                    LOG.debug("Failed to remove group {} for pipeline {} on peer {} since the group has " +
+                        "been removed by earlier close pipeline command handled in another datanode", raftGroupId,
+                        pipelineID, peer.getId());
                   } catch (IOException ioe) {
-                    LOG.warn("Failed to remove group {} for peer {}", raftGroupId, peer.getId(), ioe);
+                    LOG.warn("Failed to remove group {} of pipeline {} on peer {}",
+                        raftGroupId, pipelineID, peer.getId(), ioe);
                   }
                 });
           }
@@ -135,14 +139,14 @@ public class ClosePipelineCommandHandler implements CommandHandler {
           LOG.info("Close Pipeline {} command on datanode {}.", pipelineID,
               dn.getUuidString());
         } else {
-          LOG.debug("Ignoring close pipeline command for pipeline {} " +
-              "as it does not exist", pipelineID);
+          LOG.debug("Ignoring close pipeline command for pipeline {} on datanode {} " +
+              "as it does not exist", pipelineID, dn.getUuidString());
         }
       } catch (GroupMismatchException gme) {
         // ignore silently since this means that the group has been closed by earlier close pipeline
         // command in another datanode
-        LOG.debug("The Ratis group for the pipeline {} has been removed by earlier close pipeline command from " +
-            "other datanodes", pipelineID.getId());
+        LOG.debug("The group for pipeline {} on datanode {} has been removed by earlier close " +
+            "pipeline command handled in another datanode", pipelineID, dn.getUuidString());
       } catch (IOException e) {
         LOG.error("Can't close pipeline {}", pipelineID, e);
       } finally {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -135,8 +135,8 @@ public class ClosePipelineCommandHandler implements CommandHandler {
             } catch (GroupMismatchException gme) {
               // ignore silently since this means that the group has been closed by earlier close pipeline
               // command in another datanode
-              LOG.debug("The Ratis group for the pipeline has been removed by earlier close pipeline command from " +
-                  "other datanodes, ignoring");
+              LOG.debug("The Ratis group for the pipeline {} has been removed by earlier close pipeline command from " +
+                  "other datanodes", pipelineID.getId());
             }
           } else {
             // Although the default implementation is a no-op operation, calls it anyway

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -143,14 +143,11 @@ public class ClosePipelineCommandHandler implements CommandHandler {
           LOG.debug("Ignoring close pipeline command for pipeline {} on datanode {} " +
               "as it does not exist", pipelineID, dn.getUuidString());
         }
-      } catch (GroupMismatchException gme) {
-        // ignore silently since this means that the group has been closed by earlier close pipeline
-        // command in another datanode
-        LOG.debug("The group for pipeline {} on datanode {} has been removed by earlier close " +
-            "pipeline command handled in another datanode", pipelineID, dn.getUuidString());
       } catch (IOException e) {
         Throwable gme = HddsClientUtils.containsException(e, GroupMismatchException.class);
         if (gme != null) {
+          // ignore silently since this means that the group has been closed by earlier close pipeline
+          // command in another datanode
           LOG.debug("The group for pipeline {} on datanode {} has been removed by earlier close " +
               "pipeline command handled in another datanode", pipelineID, dn.getUuidString());
         } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

From the https://issues.apache.org/jira/browse/HDDS-10750?focusedCommentId=17847435&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17847435 in [HDDS-10750](https://issues.apache.org/jira/browse/HDDS-10750), it's found `GroupMismatchException` are thrown during the `ClosePipelineCommandHandler`.

This is because `XceiverRatisServer#removeGroup` is called before `XceiverRatisServer#getRaftPeersInPipeline`, which causes `XceiverRatisServer#getRaftPeersInPipeline` to throw `GroupMismatchException` when it's trying to get the `RaftServerProxy#getDivision` since the group has been removed.

Therefore, we need to first call the `XceiverRatisServer#getRaftPeersInPipeline` before calling `XceiverRatisServer#removeGroup`. 

This patch also catch the `GroupMismatchException` in case the group has been removed by earlier `ClosePipelineCommandHandler` in other datanode for the same pipeline. The datanode will also try to remove the Ratis group from the other datanodes (ignoring the GroupMismatchException) before removing its own Ratis group.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10875

## How was this patch tested?

Clean CI: https://github.com/ivandika3/ozone/actions/runs/9145754999