### PR TITLE
HDDS-10867. Clean Up Unnecessary Logs in Recon.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -137,7 +137,7 @@ public class ContainerHealthTask extends ReconScmTask {
       long currentTime = System.currentTimeMillis();
       long existingCount = processExistingDBRecords(currentTime,
           unhealthyContainerStateStatsMap);
-      LOG.info("Container Health task thread took {} milliseconds to" +
+      LOG.debug("Container Health task thread took {} milliseconds to" +
               " process {} existing database records.",
           Time.monotonicNow() - start, existingCount);
 
@@ -163,7 +163,7 @@ public class ContainerHealthTask extends ReconScmTask {
           .forEach(c -> processContainer(c, currentTime,
               unhealthyContainerStateStatsMap));
       recordSingleRunCompletion();
-      LOG.info("Container Health task thread took {} milliseconds for" +
+      LOG.debug("Container Health task thread took {} milliseconds for" +
               " processing {} containers.", Time.monotonicNow() - start,
           containers.size());
       logUnhealthyContainerStats(unhealthyContainerStateStatsMap);
@@ -492,11 +492,11 @@ public class ContainerHealthTask extends ReconScmTask {
           populateContainerStats(container, UnHealthyContainerStates.MISSING,
               unhealthyContainerStateStatsMap);
         } else {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Empty container {} is missing. Kindly check the " +
-                "consolidated container stats per UNHEALTHY state logged as " +
-                "starting with **Container State Stats:**");
-          }
+
+          LOG.debug("Empty container {} is missing. Kindly check the " +
+              "consolidated container stats per UNHEALTHY state logged as " +
+              "starting with **Container State Stats:**");
+
           records.add(
               recordForState(container, EMPTY_MISSING,
                   time));

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
@@ -91,7 +91,7 @@ public class PipelineSyncTask extends ReconScmTask {
       List<Pipeline> pipelinesFromScm = scmClient.getPipelines();
       reconPipelineManager.initializePipelines(pipelinesFromScm);
       syncOperationalStateOnDeadNodes();
-      LOG.info("Pipeline sync Thread took {} milliseconds.",
+      LOG.debug("Pipeline sync Thread took {} milliseconds.",
           Time.monotonicNow() - start);
       recordSingleRunCompletion();
     } finally {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
@@ -94,7 +94,7 @@ public class ContainerKeyMapperTask implements ReconOmTask {
     // containerId -> key count
     Map<Long, Long> containerKeyCountMap = new HashMap<>();
     try {
-      LOG.info("Starting a 'reprocess' run of ContainerKeyMapperTask.");
+      LOG.debug("Starting a 'reprocess' run of ContainerKeyMapperTask.");
       Instant start = Instant.now();
 
       // initialize new container DB
@@ -137,10 +137,10 @@ public class ContainerKeyMapperTask implements ReconOmTask {
         return new ImmutablePair<>(getTaskName(), false);
       }
 
-      LOG.info("Completed 'reprocess' of ContainerKeyMapperTask.");
+      LOG.debug("Completed 'reprocess' of ContainerKeyMapperTask.");
       Instant end = Instant.now();
       long duration = Duration.between(start, end).toMillis();
-      LOG.info("It took me {} seconds to process {} keys.",
+      LOG.debug("It took me {} seconds to process {} keys.",
           (double) duration / 1000.0, omKeyCount);
     } catch (IOException ioEx) {
       LOG.error("Unable to populate Container Key data in Recon DB. ",
@@ -258,7 +258,7 @@ public class ContainerKeyMapperTask implements ReconOmTask {
       LOG.error("Unable to write Container Key Prefix data in Recon DB.", e);
       return new ImmutablePair<>(getTaskName(), false);
     }
-    LOG.info("{} successfully processed {} OM DB update event(s).",
+    LOG.debug("{} successfully processed {} OM DB update event(s).",
         getTaskName(), eventCount);
     return new ImmutablePair<>(getTaskName(), true);
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerSizeCountTask.java
@@ -98,7 +98,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
           try {
             int execute =
                 dslContext.truncate(CONTAINER_COUNT_BY_SIZE).execute();
-            LOG.info("Deleted {} records from {}", execute,
+            LOG.debug("Deleted {} records from {}", execute,
                 CONTAINER_COUNT_BY_SIZE);
           } catch (Exception e) {
             LOG.error("An error occurred while truncating the table {}: {}",
@@ -111,7 +111,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
         endTime = System.nanoTime();
         duration = endTime - startTime;
         durationMilliseconds = duration / 1_000_000;
-        LOG.info("Elapsed Time in milliseconds for Process() execution: {}",
+        LOG.debug("Elapsed Time in milliseconds for Process() execution: {}",
             durationMilliseconds);
       }
     } catch (Throwable t) {
@@ -197,7 +197,7 @@ public class ContainerSizeCountTask extends ReconScmTask {
       // Write to the database
       writeCountsToDB(false, containerSizeCountMap);
       containerSizeCountMap.clear();
-      LOG.info("Completed a 'process' run of ContainerSizeCountTask.");
+      LOG.debug("Completed a 'process' run of ContainerSizeCountTask.");
     } finally {
       lock.writeLock().unlock();
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -81,7 +81,7 @@ public class FileSizeCountTask implements ReconOmTask {
 
     // Delete all records from FILE_COUNT_BY_SIZE table
     int execute = dslContext.delete(FILE_COUNT_BY_SIZE).execute();
-    LOG.info("Deleted {} records from {}", execute, FILE_COUNT_BY_SIZE);
+    LOG.debug("Deleted {} records from {}", execute, FILE_COUNT_BY_SIZE);
 
     // Call reprocessBucket method for FILE_SYSTEM_OPTIMIZED bucket layout
     boolean statusFSO =
@@ -96,7 +96,7 @@ public class FileSizeCountTask implements ReconOmTask {
       return new ImmutablePair<>(getTaskName(), false);
     }
     writeCountsToDB(true, fileSizeCountMap);
-    LOG.info("Completed a 'reprocess' run of FileSizeCountTask.");
+    LOG.debug("Completed a 'reprocess' run of FileSizeCountTask.");
     return new ImmutablePair<>(getTaskName(), true);
   }
 
@@ -198,7 +198,7 @@ public class FileSizeCountTask implements ReconOmTask {
       }
     }
     writeCountsToDB(false, fileSizeCountMap);
-    LOG.info("Completed a 'process' run of FileSizeCountTask.");
+    LOG.debug("Completed a 'process' run of FileSizeCountTask.");
     return new ImmutablePair<>(getTaskName(), true);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -166,7 +166,7 @@ public class NSSummaryTask implements ReconOmTask {
           TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
 
       // Log performance metrics
-      LOG.info("Task execution time: {} milliseconds", durationInMillis);
+      LOG.debug("Task execution time: {} milliseconds", durationInMillis);
     }
 
     return new ImmutablePair<>(getTaskName(), true);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithFSO.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithFSO.java
@@ -162,7 +162,7 @@ public class NSSummaryTaskWithFSO extends NSSummaryTaskDbEventHandler {
       return false;
     }
 
-    LOG.info("Completed a process run of NSSummaryTaskWithFSO");
+    LOG.debug("Completed a process run of NSSummaryTaskWithFSO");
     return true;
   }
 
@@ -210,7 +210,7 @@ public class NSSummaryTaskWithFSO extends NSSummaryTaskDbEventHandler {
     if (!flushAndCommitNSToDB(nsSummaryMap)) {
       return false;
     }
-    LOG.info("Completed a reprocess run of NSSummaryTaskWithFSO");
+    LOG.debug("Completed a reprocess run of NSSummaryTaskWithFSO");
     return true;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithLegacy.java
@@ -127,7 +127,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
       return false;
     }
 
-    LOG.info("Completed a process run of NSSummaryTaskWithLegacy");
+    LOG.debug("Completed a process run of NSSummaryTaskWithLegacy");
     return true;
   }
 
@@ -294,7 +294,7 @@ public class NSSummaryTaskWithLegacy extends NSSummaryTaskDbEventHandler {
     if (!flushAndCommitNSToDB(nsSummaryMap)) {
       return false;
     }
-    LOG.info("Completed a reprocess run of NSSummaryTaskWithLegacy");
+    LOG.debug("Completed a reprocess run of NSSummaryTaskWithLegacy");
     return true;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithOBS.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTaskWithOBS.java
@@ -107,7 +107,7 @@ public class NSSummaryTaskWithOBS extends NSSummaryTaskDbEventHandler {
     if (!flushAndCommitNSToDB(nsSummaryMap)) {
       return false;
     }
-    LOG.info("Completed a reprocess run of NSSummaryTaskWithOBS");
+    LOG.debug("Completed a reprocess run of NSSummaryTaskWithOBS");
     return true;
   }
 
@@ -203,7 +203,7 @@ public class NSSummaryTaskWithOBS extends NSSummaryTaskDbEventHandler {
       return false;
     }
 
-    LOG.info("Completed a process run of NSSummaryTaskWithOBS");
+    LOG.debug("Completed a process run of NSSummaryTaskWithOBS");
     return true;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -134,7 +134,7 @@ public class OmTableInsightTask implements ReconOmTask {
       writeDataToDB(replicatedSizeMap);
     }
 
-    LOG.info("Completed a 'reprocess' run of OmTableInsightTask.");
+    LOG.debug("Completed a 'reprocess' run of OmTableInsightTask.");
     return new ImmutablePair<>(getTaskName(), true);
   }
 
@@ -208,7 +208,7 @@ public class OmTableInsightTask implements ReconOmTask {
     if (!replicatedSizeMap.isEmpty()) {
       writeDataToDB(replicatedSizeMap);
     }
-    LOG.info("Completed a 'process' run of OmTableInsightTask.");
+    LOG.debug("Completed a 'process' run of OmTableInsightTask.");
     return new ImmutablePair<>(getTaskName(), true);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Set the log levels of various background tasks in Recon to debug. These tasks were previously filling the Recon logs unnecessarily, as they are only needed for debugging in rare cases. Now, they will not flood the Recon logs after every delta update sync as they did before.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10867

## How was this patch tested?
Verified the logs manually.