### PR TITLE
HDDS-10874. Freon tool DNRPCLoadGenerator should not cache client objects.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientFactory.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientFactory.java
@@ -42,4 +42,6 @@ public interface XceiverClientFactory extends AutoCloseable {
   void releaseClient(XceiverClientSpi xceiverClient, boolean invalidateClient,
                      boolean topologyAware);
 
+  XceiverClientSpi acquireClientUncached(Pipeline pipeline, boolean topologyAware)
+      throws Exception;
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hdds.scm;
 
 import java.io.IOException;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.conf.Config;

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientFactory.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientFactory.java
@@ -122,6 +122,12 @@ public class MockXceiverClientFactory
   }
 
   @Override
+  public XceiverClientSpi acquireClientUncached(Pipeline pipeline,
+      boolean topologyAware) throws IOException {
+    return acquireClient(pipeline, topologyAware);
+  }
+
+  @Override
   public void releaseClient(XceiverClientSpi xceiverClient,
                             boolean invalidateClient, boolean topologyAware) {
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DNRPCLoadGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DNRPCLoadGenerator.java
@@ -160,7 +160,7 @@ public class DNRPCLoadGenerator extends BaseFreonGenerator
     }
     clients = new ArrayList<>(numClients);
     for (int i = 0; i < numClients; i++) {
-      clients.add(xceiverClientManager.acquireClient(pipeline));
+      clients.add(xceiverClientManager.acquireClientUncached(pipeline, true));
     }
 
     init();
@@ -171,7 +171,7 @@ public class DNRPCLoadGenerator extends BaseFreonGenerator
       runTests(this::sendRPCReq);
     } finally {
       for (XceiverClientSpi client : clients) {
-        xceiverClientManager.releaseClient(client, false);
+        client.close();
       }
       xceiverClientManager.close();
       scmClient.close();


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10874. Freon tool DNRPCLoadGenerator should not cache client objects.

The original XceiverClientSpi API always caches client objects to a specific pipeline. But in this freon tool we wanted to have multiple clients to parallelize throughput.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10874

## How was this patch tested?

Ran on a real cluster. Other than that it leverages the existing tests.

After this change:

ozone freon dne --clients=32 --container-id=1 -t 32 -n 1000000 --ratis --read-only
rpc-payload
         mean rate = 38794.07 calls/second

ozone freon dne --clients=1 --container-id=1 -t 32 -n 1000000 --ratis --read-only
             count = 1000000
         mean rate = 9987.42 calls/second

But number of clients has no impact for Ratis in write mode and GRPC.