### PR TITLE
HDDS-10860. Fix Intermittent failure in TestLeaseRecovery.testFinalizeBlockFailure

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1469,20 +1469,22 @@ public class KeyValueHandler extends Handler {
   }
 
   private ContainerCommandResponseProto checkFaultInjector(ContainerCommandRequestProto request) {
-    if (injector != null && (request.getCmdType().equals(injector.getType()) || injector.getType() == null)) {
+    if (injector != null) {
       synchronized (injector) {
-        Throwable ex = injector.getException();
         ContainerProtos.Type type = injector.getType();
-        if (ex != null) {
-          if (type == null) {
-            injector = null;
+        if (request.getCmdType().equals(type) || type == null) {
+          Throwable ex = injector.getException();
+          if (ex != null) {
+            if (type == null) {
+              injector = null;
+            }
+            return ContainerUtils.logAndReturnError(LOG, (StorageContainerException) ex, request);
           }
-          return ContainerUtils.logAndReturnError(LOG, (StorageContainerException) ex, request);
-        }
-        try {
-          injector.pause();
-        } catch (IOException e) {
-          // do nothing
+          try {
+            injector.pause();
+          } catch (IOException e) {
+            // do nothing
+          }
         }
       }
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1472,8 +1472,9 @@ public class KeyValueHandler extends Handler {
     if (injector != null && (request.getCmdType().equals(injector.getType()) || injector.getType() == null)) {
       synchronized (injector) {
         Throwable ex = injector.getException();
+        ContainerProtos.Type type = injector.getType();
         if (ex != null) {
-          if (injector.getType() == null) {
+          if (type == null) {
             injector = null;
           }
           return ContainerUtils.logAndReturnError(LOG, (StorageContainerException) ex, request);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/FaultInjector.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/FaultInjector.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.hdds.utils;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 
 import java.io.IOException;
 
@@ -47,6 +48,15 @@ public abstract class FaultInjector {
 
   @VisibleForTesting
   public Throwable getException() {
+    return null;
+  }
+
+  @VisibleForTesting
+  public void setType(ContainerProtos.Type type) {
+  }
+
+  @VisibleForTesting
+  public ContainerProtos.Type getType() {
     return null;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -265,6 +265,7 @@ public class TestLeaseRecovery {
       stream.flush();
 
       FaultInjectorImpl injector = new FaultInjectorImpl();
+      injector.setType(ContainerProtos.Type.FinalizeBlock);
       KeyValueHandler.setInjector(injector);
       StorageContainerException sce = new StorageContainerException(
           "Requested operation not allowed as ContainerState is CLOSED",
@@ -357,6 +358,7 @@ public class TestLeaseRecovery {
       OzoneTestUtils.closeContainer(cluster.getStorageContainerManager(), container);
       // pause getCommittedBlockLength handling on all DNs to make sure all getCommittedBlockLength will time out
       FaultInjectorImpl injector = new FaultInjectorImpl();
+      injector.setType(ContainerProtos.Type.GetCommittedBlockLength);
       KeyValueHandler.setInjector(injector);
       GenericTestUtils.LogCapturer logs =
           GenericTestUtils.LogCapturer.captureLogs(XceiverClientGrpc.getLogger());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/utils/FaultInjectorImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/utils/FaultInjectorImpl.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.utils;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.utils.FaultInjector;
 import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.Assertions;
@@ -32,6 +33,7 @@ public class FaultInjectorImpl extends FaultInjector {
   private CountDownLatch ready;
   private CountDownLatch wait;
   private Throwable ex;
+  private ContainerProtos.Type type = null;
 
   public FaultInjectorImpl() {
     init();
@@ -78,6 +80,16 @@ public class FaultInjectorImpl extends FaultInjector {
   @VisibleForTesting
   public Throwable getException() {
     return ex;
+  }
+
+  @VisibleForTesting
+  public void setType(ContainerProtos.Type type) {
+    this.type = type;
+  }
+
+  @VisibleForTesting
+  public ContainerProtos.Type getType() {
+    return type;
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fault injector is been updated by different thread call which leads to intermittent behaviour. In this PR we are protecting injector to get updated correctly and used by different threads.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10860

## How was this patch tested?

Flaky test run 10X10
https://github.com/ashishkumar50/ozone/actions/runs/9124256970/workflow
