### PR TITLE
HDDS-10373. Add merkle tree persistence and metrics.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/merkletree/ContainerMerkleTreeMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/merkletree/ContainerMerkleTreeMetrics.java
@@ -1,0 +1,40 @@
+package org.apache.hadoop.ozone.container.merkletree;
+
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MutableRate;
+
+import java.util.function.Consumer;
+
+public class ContainerMerkleTreeMetrics {
+    private static final String METRICS_SOURCE_NAME = ContainerMerkleTreeMetrics.class.getSimpleName();
+    public void updateMerkleTreeMetrics() {
+        MetricsSystem ms = DefaultMetricsSystem.instance();
+        ms.register(METRICS_SOURCE_NAME, "Container Merkle Tree Metrics", this);
+
+    }
+
+    public void unregister() {
+        MetricsSystem ms = DefaultMetricsSystem.instance();
+        ms.unregisterSource(METRICS_SOURCE_NAME);
+    }
+
+    public void incrementMerkleTreeWriteFailures() {
+
+    }
+
+    public MutableRate getWriteContainerMerkleTreeLatencyNS() {
+        return null;
+    }
+
+    public void incrementMerkleTreeReadFailures() {
+    }
+
+    public MutableRate  getReadContainerMerkleTreeLatencyNS() {
+        return null;
+    }
+
+    public void incrementMerkleTreeParseFailures() {
+
+    }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/merkletree/ContainerMerkleTreePersistence.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/merkletree/ContainerMerkleTreePersistence.java
@@ -1,0 +1,51 @@
+package org.apache.hadoop.ozone.container.merkletree;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerMerkleTree;
+import org.apache.hadoop.ozone.container.common.impl.ContainerData;
+import org.apache.hadoop.util.MetricUtil;
+import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ContainerMerkleTreePersistence {
+    public static String CONTAINER_MERKLE_TREE_FILE = "container.merkletree.proto";
+
+    public static void writeMerkleTreeToDisk(ContainerData containerData,
+                                             ContainerMerkleTree containerMerkleTree,
+                                             ContainerMerkleTreeMetrics metrics) throws IOException {
+        // Write the container Merkle Tree to disk.
+        byte[] data = containerMerkleTree.toByteArray();
+        // write the data to the file.
+        try {
+            MetricUtil.captureLatencyNs(metrics.getWriteContainerMerkleTreeLatencyNS(), () -> {
+                Files.write(getFileNameForMerkleTree(containerData.getContainerPath()), data);
+            });
+        } catch (IOException ex) {
+            metrics.incrementMerkleTreeWriteFailures();
+            throw ex;
+        }
+    }
+
+    private static Path getFileNameForMerkleTree(String path) {
+        return Paths.get(path, CONTAINER_MERKLE_TREE_FILE);
+    }
+
+    public static ContainerMerkleTree readMerkleTreeFromDisk(ContainerData containerData,
+                                                             ContainerMerkleTreeMetrics metrics) throws IOException {
+        try {
+            byte[] data = MetricUtil.captureLatencyNs(metrics.getReadContainerMerkleTreeLatencyNS(), () -> {
+                return Files.readAllBytes(getFileNameForMerkleTree(containerData.getContainerPath()));
+            });
+            return ContainerMerkleTree.parseFrom(data);
+        } catch (InvalidProtocolBufferException e) {
+            metrics.incrementMerkleTreeParseFailures();
+            throw new RuntimeException(e);
+        } catch (IOException ex) {
+            metrics.incrementMerkleTreeReadFailures();
+            throw ex;
+        }
+    }
+}

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -395,6 +395,7 @@ message ChunkInfo {
   repeated KeyValue metadata = 4;
   required ChecksumData checksumData =5;
   optional bytes stripeChecksum = 6;
+  optional bool healthy = 7;
 }
 
 message ChunkInfoList {
@@ -524,6 +525,25 @@ message SendContainerRequest {
 }
 
 message SendContainerResponse {
+}
+
+message ChunkInfoListMerkleTree {
+  repeated ChunkInfo chunks = 1; // List of chunks, a chunk has multiple hashes within it.
+}
+
+message BlockMerkleTree {
+  optional DatanodeBlockID blockID = 1;
+  optional int64 checksum = 2;
+  optional ChunkInfoListMerkleTree chunkInfo = 3;
+  optional bool deleted = 4;
+  optional bool healthy = 5;
+}
+
+message ContainerMerkleTree {
+  optional int64 containerID = 1;
+  optional int64 checksum = 2;
+  optional int64 deleteChecksum = 3;
+  repeated BlockMerkleTree blockMerkleTree = 4;
 }
 
 service XceiverClientProtocolService {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a basic reconciliation manager that will be a singleton class in Datanode to read write and update container merkle tree across all drives for all containers. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10373

## How was this patch tested?

ToDo
