### PR TITLE
HDDS-10840. Do not pass owner in keyargs when rewriting a key

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1421,7 +1421,6 @@ public class RpcClient implements ClientProtocol {
     }
 
     createKeyPreChecks(volumeName, bucketName, keyName, replicationConfig);
-    String ownerName = getRealUserInfo().getShortUserName();
 
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
@@ -1431,7 +1430,6 @@ public class RpcClient implements ClientProtocol {
         .setReplicationConfig(replicationConfig)
         .addAllMetadataGdpr(metadata)
         .setLatestVersionLocation(getLatestVersionLocation)
-        .setOwnerName(ownerName)
         .setExpectedDataGeneration(existingKeyGeneration);
 
     OpenKeySession openKey = ozoneManagerClient.openKey(builder.build());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -686,8 +686,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     KeyArgs.Builder keyArgs = KeyArgs.newBuilder()
         .setVolumeName(args.getVolumeName())
         .setBucketName(args.getBucketName())
-        .setKeyName(args.getKeyName())
-        .setOwnerName(args.getOwner());
+        .setKeyName(args.getKeyName());
+
+    // When rewriting a key, the owner does not need to be passed, as it is inherited
+    // from the existing key. Hence it can be null.
+    if (args.getOwner() != null) {
+      keyArgs.setOwnerName(args.getOwner());
+    }
 
     if (args.getAcls() != null) {
       keyArgs.addAllAcls(args.getAcls().stream().distinct().map(a ->

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1133,6 +1133,8 @@ public abstract class TestOzoneRpcClientAbstract {
       is.read(fileContent);
       assertEquals(rewriteValue, new String(fileContent, UTF_8));
     }
+    OzoneKeyDetails rewrittenKeyDetails = bucket.getKey(keyName);
+    assertEquals(keyDetails.getOwner(), rewrittenKeyDetails.getOwner());
 
     // Delete the key
     bucket.deleteKey(keyName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The "owner" field is only set at the OM server side when a new key is created. In the case a key is overwritten, the owner is never retrieved from the keyargs and hence overwriting the owner when overwriting a key is not possible. This is the case, both prior to the atomic key overwrite feature and when the traditional key overwrite where a new version is allocated.

Therefore this change should simply remove the owner details from being passed in the rewrite key and the owner will continue to be inherited as it is now.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10840

## How was this patch tested?

Existing test modified to check the owner before and after are the same.
