### PR TITLE
HDDS-10890. [hsync] Increase default value for hdds.container.ratis.log.appender.queue.num-elements.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -100,7 +100,7 @@ public final class ScmConfigKeys {
       HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS =
       "hdds.container.ratis.log.appender.queue.num-elements";
   public static final int
-      HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS_DEFAULT = 1;
+      HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS_DEFAULT = 1024;
   public static final String HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT =
       "hdds.container.ratis.log.appender.queue.byte-limit";
   public static final String

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -126,9 +126,8 @@
     </description>
   </property>
   <property>
-    <name>hdds.container.ratis.log.appender.queue.num-elements
-</name>
-    <value>1</value>
+    <name>hdds.container.ratis.log.appender.queue.num-elements</name>
+    <value>1024</value>
     <tag>OZONE, DEBUG, CONTAINER, RATIS</tag>
     <description>Limit for number of append entries in ratis leader's
       log appender queue.


### PR DESCRIPTION

## What changes were proposed in this pull request?
HDDS-10890. [hsync] Increase default value for hdds.container.ratis.log.appender.queue.num-elements.

Please describe your PR in detail:
Using Freon DN Echo tool, I found that increasing hdds.container.ratis.log.appender.queue.num-elements value drastically improve DN Echo throughput and latency.

Set it to 1024 to be consistent with OM and SCM.
ozone.om.ratis.log.appender.queue.num-elements
ozone.scm.ha.ratis.log.appender.queue.num-elements

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10890

## How was this patch tested?
Benchmarked on a real cluster