### PR TITLE
HDDS-10896. Refactor PerformanceMetrics creation

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.util.PerformanceMetrics;
-import org.apache.hadoop.util.PerformanceMetricsInitializer;
 
 /**
  * The client metrics for the Storage Container protocol.
@@ -76,7 +75,7 @@ public class XceiverClientMetrics implements MetricsSource {
               "number of" + ContainerProtos.Type.forNumber(i + 1) + " ops",
               (long) 0);
       containerOpsLatency[i] =
-          PerformanceMetricsInitializer.getMetrics(registry,
+          new PerformanceMetrics(registry,
               ContainerProtos.Type.forNumber(i + 1) + "Latency",
               "latency of " + ContainerProtos.Type.forNumber(i + 1),
               "Ops", "Time", intervals);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/PerformanceMetrics.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/PerformanceMetrics.java
@@ -56,18 +56,21 @@ public class PerformanceMetrics {
   }
 
   /**
-   * Construct an instance of PerformanceMetrics with the specified MutableStat,
-   * MutableQuantiles, and MutableMinMax.
+   * Helper method to create PerformanceMetrics.
    *
-   * @param stat the stat metric
-   * @param quantiles the quantiles metrics
-   * @param minMax the min/max tracker
+   * @param registry the metrics registry
+   * @param name metric name
+   * @param description metric description
+   * @param sampleName sample name
+   * @param valueName value name
+   * @param intervals intervals for quantiles
    */
-  public PerformanceMetrics(MutableStat stat,
-      List<MutableQuantiles> quantiles, MutableMinMax minMax) {
-    this.stat = stat;
-    this.quantiles = quantiles;
-    this.minMax = minMax;
+  public PerformanceMetrics(
+      MetricsRegistry registry, String name, String description,
+      String sampleName, String valueName, int[] intervals) {
+    stat = registry.newStat(name, description, sampleName, valueName, false);
+    quantiles = MetricUtil.createQuantiles(registry, name, description, sampleName, valueName, intervals);
+    minMax = new MutableMinMax(registry, name, description, valueName);
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/PerformanceMetricsInitializer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/util/PerformanceMetricsInitializer.java
@@ -50,34 +50,12 @@ public final class PerformanceMetricsInitializer {
           String description = annotation.about();
           String name = field.getName();
           PerformanceMetrics performanceMetrics =
-              getMetrics(registry, name, description,
+              new PerformanceMetrics(registry, name, description,
                   sampleName, valueName, intervals);
           field.setAccessible(true);
           field.set(source, performanceMetrics);
         }
       }
     }
-  }
-
-  /**
-   * Helper method to create PerformanceMetrics.
-   *
-   * @param registry the metrics registry
-   * @param name metric name
-   * @param description metric description
-   * @param sampleName sample name
-   * @param valueName value name
-   * @param intervals intervals for quantiles
-   * @return an instance of PerformanceMetrics
-   */
-  public static PerformanceMetrics getMetrics(
-      MetricsRegistry registry, String name, String description,
-      String sampleName, String valueName, int[] intervals) {
-    return new PerformanceMetrics(
-        registry.newStat(
-            name, description, sampleName, valueName, false),
-        MetricUtil.createQuantiles(
-            registry, name, description, sampleName, valueName, intervals),
-        new MutableMinMax(registry, name, description, valueName));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move creation of mutable metrics objects to `PerformanceMetrics`.  Extracted from #6351.

https://issues.apache.org/jira/browse/HDDS-10896

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/9188822100