### PR TITLE
HDDS-10898. Validate OZONE_CONF_DIR by presence of ozone-site.xml, not log4.properties

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -687,9 +687,8 @@ function ozone_find_confdir
 ## @return       will exit on failure conditions
 function ozone_verify_confdir
 {
-  # Check only log4j.properties by default.
-  # --loglevel does not work without logger settings in log4j.properties.
-  [[ -f "${1:?ozone_verify_confir requires parameter}/log4j.properties" ]]
+  # Check ozone-site.xml by default.
+  [[ -f "${1:?ozone_verify_confir requires parameter}/ozone-site.xml" ]]
 }
 
 ## @description  Import the ozone-env.sh settings


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ozone's services startup scripts (e.g. ozone-functions.sh) require the log4j.properties config file to be in $OZONE_CONF_DIR. If the config file isn't there the **OZONE_CONF_DIR** env variable will be overridden as $OZONE_HOME/etc/hadoop (but all of the required and properly filled configuration files are in the previous location).

The PR suggests changing the requirement from **log4j.properties** to **ozone-site.xml** configuration file (at least SCM can't start without some mandatory conf properties inside, but all of the ozone's services can work without logger config (we won't see any log message, but the service will work anyway)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10898

## How was this patch tested?
manually (mvn build and docker-compose up, + number of commands to deal with ozone cluster: create bucket, put key, get key), a green build is here - https://github.com/vtutrinov/ozone/actions/runs/9188563850
