### PR TITLE
HDDS-10899. Refactor Lease callbacks

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/Lease.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/Lease.java
@@ -19,9 +19,6 @@ package org.apache.hadoop.ozone.lease;
 
 import org.apache.hadoop.util.Time;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
@@ -49,9 +46,9 @@ public class Lease<T> {
   private boolean expired;
 
   /**
-   * Functions to be called in case of timeout.
+   * Function to be called in case of timeout.
    */
-  private List<Callable<Void>> callbacks;
+  private Callable<Void> callback;
 
 
   /**
@@ -63,11 +60,7 @@ public class Lease<T> {
    *        Lease lifetime in milliseconds
    */
   public Lease(T resource, long timeout) {
-    this.resource = resource;
-    this.leaseTimeout = new AtomicLong(timeout);
-    this.callbacks = Collections.synchronizedList(new ArrayList<>());
-    this.creationTime = Time.monotonicNow();
-    this.expired = false;
+    this(resource, timeout, null);
   }
 
   /**
@@ -81,8 +74,11 @@ public class Lease<T> {
    *        Callback registered to be triggered when lease expire
    */
   public Lease(T resource, long timeout, Callable<Void> callback) {
-    this(resource, timeout);
-    callbacks.add(callback);
+    this.resource = resource;
+    this.leaseTimeout = new AtomicLong(timeout);
+    this.callback = callback;
+    this.creationTime = Time.monotonicNow();
+    this.expired = false;
   }
 
   /**
@@ -176,15 +172,15 @@ public class Lease<T> {
    *
    * @return callbacks to be executed
    */
-  List<Callable<Void>> getCallbacks() {
-    return callbacks;
+  Callable<Void> getCallback() {
+    return callback;
   }
 
   /**
    * Expires/Invalidates the lease.
    */
   void invalidate() {
-    callbacks = null;
+    callback = null;
     expired = true;
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseCallbackExecutor.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseCallbackExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.lease;
 
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,7 @@ public class LeaseCallbackExecutor<T> implements Runnable {
    */
   public LeaseCallbackExecutor(T resource, List<Callable<Void>> callbacks) {
     this.resource = resource;
-    this.callbacks = callbacks;
+    this.callbacks = callbacks == null ? ImmutableList.of() : ImmutableList.copyOf(callbacks);
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseCallbackExecutor.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseCallbackExecutor.java
@@ -17,11 +17,9 @@
 
 package org.apache.hadoop.ozone.lease;
 
-import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
@@ -34,19 +32,19 @@ public class LeaseCallbackExecutor<T> implements Runnable {
       LoggerFactory.getLogger(LeaseCallbackExecutor.class);
 
   private final T resource;
-  private final List<Callable<Void>> callbacks;
+  private final Callable<Void> callback;
 
   /**
    * Constructs LeaseCallbackExecutor instance with list of callbacks.
    *
    * @param resource
    *        The resource for which the callbacks are executed
-   * @param callbacks
-   *        Callbacks to be executed by this executor
+   * @param callback
+   *        Callback to be executed by this executor
    */
-  public LeaseCallbackExecutor(T resource, List<Callable<Void>> callbacks) {
+  public LeaseCallbackExecutor(T resource, Callable<Void> callback) {
     this.resource = resource;
-    this.callbacks = callbacks == null ? ImmutableList.of() : ImmutableList.copyOf(callbacks);
+    this.callback = callback;
   }
 
   @Override
@@ -54,7 +52,7 @@ public class LeaseCallbackExecutor<T> implements Runnable {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Executing callbacks for lease on {}", resource);
     }
-    for (Callable<Void> callback : callbacks) {
+    if (callback != null) {
       try {
         callback.call();
       } catch (Exception e) {
@@ -63,5 +61,4 @@ public class LeaseCallbackExecutor<T> implements Runnable {
       }
     }
   }
-
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
@@ -267,9 +267,10 @@ public class LeaseManager<T> {
             long remainingTime = lease.getRemainingTime();
             if (remainingTime <= 0) {
               //Lease has timed out
+              Callable<Void> leaseCallback = lease.getCallback();
               release(resource);
               executorService.execute(
-                  new LeaseCallbackExecutor<>(resource, lease.getCallback()));
+                  new LeaseCallbackExecutor<>(resource, leaseCallback));
             } else {
               sleepTime = Math.min(remainingTime, sleepTime);
             }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
@@ -268,10 +268,9 @@ public class LeaseManager<T> {
             long remainingTime = lease.getRemainingTime();
             if (remainingTime <= 0) {
               //Lease has timed out
-              List<Callable<Void>> leaseCallbacks = lease.getCallbacks();
               release(resource);
               executorService.execute(
-                  new LeaseCallbackExecutor<>(resource, leaseCallbacks));
+                  new LeaseCallbackExecutor<>(resource, lease.getCallback()));
             } else {
               sleepTime = Math.min(remainingTime, sleepTime);
             }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lease/LeaseManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.lease;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not expose mutable `Lease#callbacks`.  Also, normally [only zero or one callbacks are present](https://github.com/apache/ozone/pull/6351#discussion_r1605881549), so we can avoid using `List`.

Extracted from #6351.  Most of this change is from review suggestion by @szetszwo.

https://issues.apache.org/jira/browse/HDDS-10899

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/9190676417