### PR TITLE
HDDS-10891. Support Ozone to run ratis group-related command

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -267,6 +267,13 @@ public final class RatisHelper {
         ozoneConfiguration);
   }
 
+  public static RaftClient newRaftClient(RpcType rpcType, RaftPeer leader, RaftGroup group,
+                                         RetryPolicy retryPolicy, GrpcTlsConfig tlsConfig,
+                                         ConfigurationSource configuration) {
+    return newRaftClient(rpcType, leader.getId(), leader, group, retryPolicy, tlsConfig, configuration);
+  }
+
+
   @SuppressWarnings("checkstyle:ParameterNumber")
   private static RaftClient newRaftClient(RpcType rpcType, RaftPeerId leader,
       RaftPeer primary, RaftGroup group, RetryPolicy retryPolicy,

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -67,6 +67,16 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-hadoop-dependency-server</artifactId>
     </dependency>
+    <dependency>
+      <artifactId>ratis-common</artifactId>
+      <groupId>org.apache.ratis</groupId>
+      <version>${ratis.version}</version>
+    </dependency>
+    <dependency>
+      <artifactId>ratis-shell</artifactId>
+      <groupId>org.apache.ratis</groupId>
+      <version>${ratis.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/BaseRatisCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/BaseRatisCommand.java
@@ -49,7 +49,9 @@ import static org.apache.ratis.shell.cli.RaftUtils.buildRaftPeersFromStr;
 import static org.apache.ratis.shell.cli.RaftUtils.retrieveGroupInfoByGroupId;
 import static org.apache.ratis.shell.cli.RaftUtils.retrieveRemoteGroupId;
 
-
+/**
+ * The base class for all the ratis command.
+ */
 public class BaseRatisCommand {
   private RaftGroup raftGroup;
   private GroupInfoReply groupInfoReply;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/BaseRatisCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/BaseRatisCommand.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.ratis;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.ratis.RatisHelper;
+import org.apache.hadoop.hdds.scm.client.ClientTrustManager;
+import org.apache.hadoop.hdds.security.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.client.CACertificateProvider;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.grpc.GrpcTlsConfig;
+import org.apache.ratis.proto.RaftProtos.FollowerInfoProto;
+import org.apache.ratis.proto.RaftProtos.RaftPeerProto;
+import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
+import org.apache.ratis.proto.RaftProtos.RoleInfoProto;
+import org.apache.ratis.protocol.GroupInfoReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.rpc.SupportedRpcType;
+
+import java.util.List;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_GRPC_TLS_ENABLED_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
+import static org.apache.ratis.shell.cli.RaftUtils.buildRaftGroupIdFromStr;
+import static org.apache.ratis.shell.cli.RaftUtils.buildRaftPeersFromStr;
+import static org.apache.ratis.shell.cli.RaftUtils.retrieveGroupInfoByGroupId;
+import static org.apache.ratis.shell.cli.RaftUtils.retrieveRemoteGroupId;
+
+
+public class BaseRatisCommand {
+  private RaftGroup raftGroup;
+  private GroupInfoReply groupInfoReply;
+  private OzoneConfiguration config;
+  private String omServiceId;
+
+  public void run(String peers, String groupid, String omServiceId) throws Exception {
+    this.config = new OzoneConfiguration();
+    this.omServiceId = omServiceId;
+    List<RaftPeer> peerList = buildRaftPeersFromStr(peers);
+    RaftGroupId raftGroupIdFromConfig = buildRaftGroupIdFromStr(groupid);
+    raftGroup = RaftGroup.valueOf(raftGroupIdFromConfig, peerList);
+
+    try (RaftClient client = buildRaftClient(raftGroup)) {
+      RaftGroupId remoteGroupId = retrieveRemoteGroupId(raftGroupIdFromConfig, peerList, client, System.out);
+      groupInfoReply = retrieveGroupInfoByGroupId(remoteGroupId, peerList, client, System.out);
+      raftGroup = groupInfoReply.getGroup();
+    }
+
+  }
+
+  protected RaftClient buildRaftClient(RaftGroup raftGroup) throws Exception {
+    GrpcTlsConfig tlsConfig = null;
+    if (config.getBoolean(OZONE_SECURITY_ENABLED_KEY, OZONE_SECURITY_ENABLED_DEFAULT) &&
+        config.getBoolean(HDDS_GRPC_TLS_ENABLED, HDDS_GRPC_TLS_ENABLED_DEFAULT)) {
+      tlsConfig = createGrpcTlsConf(omServiceId);
+    }
+
+    return RatisHelper.newRaftClient(
+        SupportedRpcType.GRPC, null, raftGroup,
+        RatisHelper.createRetryPolicy(config), tlsConfig, config);
+  }
+
+  public RaftGroup getRaftGroup() {
+    return raftGroup;
+  }
+
+  public GroupInfoReply getGroupInfoReply() {
+    return groupInfoReply;
+  }
+
+  /**
+   * Get the leader id.
+   *
+   * @param roleInfo the role info
+   * @return the leader id
+   */
+  protected RaftPeerProto getLeader(RoleInfoProto roleInfo) {
+    if (roleInfo == null) {
+      return null;
+    }
+    if (roleInfo.getRole() == RaftPeerRole.LEADER) {
+      return roleInfo.getSelf();
+    }
+    FollowerInfoProto followerInfo = roleInfo.getFollowerInfo();
+    if (followerInfo == null) {
+      return null;
+    }
+    return followerInfo.getLeaderInfo().getId();
+  }
+
+  private GrpcTlsConfig createGrpcTlsConf(String omServiceId) throws Exception {
+    OzoneClient certClient = OzoneClientFactory.getRpcClient(omServiceId,
+        config);
+
+    ServiceInfoEx serviceInfoEx = certClient
+        .getObjectStore()
+        .getClientProxy()
+        .getOzoneManagerClient()
+        .getServiceInfo();
+
+    CACertificateProvider remoteCAProvider =
+        serviceInfoEx::provideCACerts;
+    ClientTrustManager trustManager = new ClientTrustManager(remoteCAProvider, serviceInfoEx);
+
+    return RatisHelper.createTlsClientConfig(new SecurityConfig(config), trustManager);
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/RatisAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/RatisAdmin.java
@@ -21,26 +21,12 @@ import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.cli.SubcommandWithParent;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ipc.ProtobufRpcEngine;
-import org.apache.hadoop.ipc.RPC;
-import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.admin.ratis.group.GroupCommand;
-import org.apache.hadoop.ozone.client.OzoneClientException;
-import org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory;
-import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
-import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
-import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
-import org.apache.ratis.protocol.ClientId;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
-import java.util.Collection;
-
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
 /**
  * Subcommand for ratis operations.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/RatisAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/RatisAdmin.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.admin.ratis;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.OzoneAdmin;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.admin.ratis.group.GroupCommand;
+import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory;
+import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
+import org.apache.ratis.protocol.ClientId;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+import java.util.Collection;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
+
+/**
+ * Subcommand for ratis operations.
+ */
+@CommandLine.Command(
+    name = "ratis",
+    description = "Ozone ratis operations",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+        GroupCommand.class
+    })
+@MetaInfServices(SubcommandWithParent.class)
+public class RatisAdmin extends GenericCli implements SubcommandWithParent {
+
+  @CommandLine.ParentCommand
+  private OzoneAdmin parent;
+
+  @Spec
+  private CommandSpec spec;
+
+  public OzoneAdmin getParent() {
+    return parent;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    GenericCli.missingSubcommand(spec);
+    return null;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return OzoneAdmin.class;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/GroupCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/GroupCommand.java
@@ -8,7 +8,7 @@ import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 
 /**
- * Subcommand for admin operations related to OM.
+ * Subcommand for ratis.
  */
 @CommandLine.Command(
     name = "group",

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/GroupCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/GroupCommand.java
@@ -1,0 +1,47 @@
+package org.apache.hadoop.ozone.admin.ratis.group;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.ozone.admin.ratis.RatisAdmin;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+/**
+ * Subcommand for admin operations related to OM.
+ */
+@CommandLine.Command(
+    name = "group",
+    description = "ratis group operations",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+        InfoCommand.class,
+        ListCommand.class
+    })
+@MetaInfServices(SubcommandWithParent.class)
+public class GroupCommand extends GenericCli implements SubcommandWithParent {
+
+  @CommandLine.ParentCommand
+  private RatisAdmin parent;
+
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
+  public RatisAdmin getParent() {
+    return parent;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    GenericCli.missingSubcommand(spec);
+    return null;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return RatisAdmin.class;
+  }
+
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/InfoCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/InfoCommand.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.ratis.group;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.ratis.RatisHelper;
+import org.apache.hadoop.hdds.scm.client.ClientTrustManager;
+import org.apache.hadoop.hdds.security.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.client.CACertificateProvider;
+import org.apache.hadoop.hdds.utils.HAUtils;
+import org.apache.hadoop.ozone.admin.ratis.BaseRatisCommand;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.grpc.GrpcTlsConfig;
+import org.apache.ratis.netty.NettyConfigKeys;
+import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.GroupInfoReply;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.exceptions.RaftException;
+import org.apache.ratis.util.function.CheckedFunction;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+/**
+ * Display the information of a specific raft group
+ */
+@CommandLine.Command(
+    name = "info",
+    description = "Display the information of a specific raft group",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class InfoCommand extends BaseRatisCommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  public GroupCommand parent;
+
+  @CommandLine.Option(names = {"-peers"},
+      description = "list of peers",
+      required = true)
+  private String peers;
+
+  @CommandLine.Option(names = { "-groupid" },
+      description = "groupid")
+  private String groupid;
+
+  @CommandLine.Option(names = {"-id", "--service-id"},
+      description = "OM Service ID",
+      required = true)
+  private String omServiceId;
+
+
+  @Override
+  public Void call() throws Exception {
+    super.run(peers, groupid, omServiceId);
+    System.out.println("group id: " + getRaftGroup().getGroupId().getUuid());
+    final GroupInfoReply reply = getGroupInfoReply();
+    RaftProtos.RaftPeerProto leader = getLeader(reply.getRoleInfoProto());
+    if (leader == null) {
+      System.out.println("leader not found");
+    } else {
+      System.out.printf("leader info: %s(%s)%n%n", leader.getId().toStringUtf8(), leader.getAddress());
+    }
+    System.out.println(reply.getCommitInfos());
+    return null;
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/InfoCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/InfoCommand.java
@@ -19,35 +19,12 @@
 package org.apache.hadoop.ozone.admin.ratis.group;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.ratis.RatisHelper;
-import org.apache.hadoop.hdds.scm.client.ClientTrustManager;
-import org.apache.hadoop.hdds.security.SecurityConfig;
-import org.apache.hadoop.hdds.security.x509.certificate.client.CACertificateProvider;
-import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.ozone.admin.ratis.BaseRatisCommand;
-import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
-import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.ratis.conf.Parameters;
-import org.apache.ratis.grpc.GrpcTlsConfig;
-import org.apache.ratis.netty.NettyConfigKeys;
 import org.apache.ratis.proto.RaftProtos;
-import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.GroupInfoReply;
-import org.apache.ratis.protocol.RaftClientReply;
-import org.apache.ratis.protocol.RaftGroup;
-import org.apache.ratis.protocol.exceptions.RaftException;
-import org.apache.ratis.util.function.CheckedFunction;
 import picocli.CommandLine;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.Collection;
-import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.function.Supplier;
 
 /**
  * Display the information of a specific raft group

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/ListCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/ratis/group/ListCommand.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.ratis.group;
+
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.ozone.admin.ratis.BaseRatisCommand;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.GroupListReply;
+import org.apache.ratis.protocol.RaftPeerId;
+import picocli.CommandLine;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.Callable;
+
+import static org.apache.ratis.shell.cli.RaftUtils.getPeerId;
+import static org.apache.ratis.shell.cli.RaftUtils.parseInetSocketAddress;
+import static org.apache.ratis.shell.cli.RaftUtils.processReply;
+
+
+/**
+ * Display the group information of a specific raft server
+ */
+@CommandLine.Command(
+    name = "list",
+    description = "Display the group information of a specific raft server",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class ListCommand extends BaseRatisCommand implements Callable<Void> {
+
+  public static final String SERVER_ADDRESS_OPTION_NAME = "serverAddress";
+  public static final String PEER_ID_OPTION_NAME = "peerId";
+
+
+  @picocli.CommandLine.ParentCommand
+  public GroupCommand parent;
+
+  @picocli.CommandLine.Option(names = {"-peers"},
+      description = "list of peers",
+      required = true)
+  private String peers;
+
+  @picocli.CommandLine.Option(names = {"-" + PEER_ID_OPTION_NAME},
+      description = "Id of peer")
+  private String peerIdStr;
+
+  @picocli.CommandLine.Option(names = { "-groupid" },
+      description = "groupid")
+  private String groupid;
+
+  @picocli.CommandLine.Option(names = { "-" + SERVER_ADDRESS_OPTION_NAME},
+      description = "serverAddress")
+  private String serverAddress;
+
+  @CommandLine.Option(names = {"-id", "--service-id"},
+      description = "OM Service ID",
+      required = true)
+  private String omServiceId;
+
+
+  @Override
+  public Void call() throws Exception {
+    super.run(peers, groupid, omServiceId);
+    final RaftPeerId peerId;
+    final String address;
+
+    if (StringUtils.isNotEmpty(peerIdStr)) {
+      peerId = RaftPeerId.getRaftPeerId(peerIdStr);
+      address = getRaftGroup().getPeer(peerId).getAddress();
+    } else if (StringUtils.isNotEmpty(serverAddress)) {
+      address = serverAddress;
+      final InetSocketAddress serverAddress = parseInetSocketAddress(address);
+      peerId = RaftUtils.getPeerId(serverAddress);
+    } else {
+      throw new IllegalArgumentException(
+          "Both " + PEER_ID_OPTION_NAME + " and " + SERVER_ADDRESS_OPTION_NAME
+              + " options are missing.");
+    }
+
+    try(final RaftClient raftClient = buildRaftClient(getRaftGroup())) {
+      GroupListReply reply = raftClient.getGroupManagementApi(peerId).list();
+      processReply(reply,
+          System.out, String.format("Failed to get group information of peerId %s (server %s)", peerId, address));
+      System.out.println(String.format("The peerId %s (server %s) is in %d groups, and the groupIds is: %s",
+          peerId, address, reply.getGroupIds().size(), reply.getGroupIds()));
+    }
+    return null;
+  }
+
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support Ozone to run ratis group-related command

(I currently put this PR as draft because this is pending on another [PR for RATIS-2095](https://github.com/apache/ratis/pull/1098). (Move common logic of ratis-shell to RaftUtils so that Ozone shell could share and use common logic) to be merged first. Then new methods created in RATIS-2095 would be used here.)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10891

## How was this patch tested?
unit test