### PR TITLE
HDDS-10905. Override getHomeDirectory() in Ozone FileSystem implementations

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -269,7 +269,8 @@ abstract class AbstractOzoneFileSystemTest {
 
   @Test
   void testUserHomeDirectory() {
-    assertEquals(new Path("/user/" + USER1), userO3fs.getHomeDirectory());
+    assertEquals(new Path(fsRoot + "user/" + USER1),
+        userO3fs.getHomeDirectory());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -83,6 +83,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.security.PrivilegedExceptionAction;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -172,6 +173,10 @@ abstract class AbstractOzoneFileSystemTest {
   private String bucketName;
   private Trash trash;
   private OMMetrics omMetrics;
+  private static final String USER1 = "regularuser1";
+  private static final UserGroupInformation UGI_USER1 = UserGroupInformation
+      .createUserForTesting(USER1,  new String[] {"usergroup"});
+  private OzoneFileSystem userO3fs;
 
   @BeforeAll
   void init() throws Exception {
@@ -217,6 +222,10 @@ abstract class AbstractOzoneFileSystemTest {
     statistics = (OzoneFSStorageStatistics) o3fs.getOzoneFSOpsCountStatistics();
     assertEquals(OzoneConsts.OZONE_URI_SCHEME, fs.getUri().getScheme());
     assertEquals(OzoneConsts.OZONE_URI_SCHEME, statistics.getScheme());
+
+    userO3fs = UGI_USER1.doAs(
+        (PrivilegedExceptionAction<OzoneFileSystem>)()
+            -> (OzoneFileSystem) FileSystem.get(conf));
   }
 
   @AfterAll
@@ -256,6 +265,11 @@ abstract class AbstractOzoneFileSystemTest {
 
   public BucketLayout getBucketLayout() {
     return bucketLayout;
+  }
+
+  @Test
+  void testUserHomeDirectory() {
+    assertEquals(new Path("/user/" + USER1), userO3fs.getHomeDirectory());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -305,8 +305,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
   @Test
   void testUserHomeDirectory() {
-    assertEquals("/user/" + USER1, userOfs.getHomeDirectory());
-    assertEquals("/user/" + USER1, userO3fs.getHomeDirectory());
+    assertEquals(new Path("/user/" + USER1), userOfs.getHomeDirectory());
+    assertEquals(new Path("/user/" + USER1), userO3fs.getHomeDirectory());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -301,7 +301,8 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
   @Test
   void testUserHomeDirectory() {
-    assertEquals(new Path("/user/" + USER1), userOfs.getHomeDirectory());
+    assertEquals(new Path(rootPath + "user/" + USER1),
+        userOfs.getHomeDirectory());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -229,7 +229,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
       .createUserForTesting(USER1,  new String[] {"usergroup"});
   // Non-privileged OFS instance
   private RootedOzoneFileSystem userOfs;
-  private OzoneFileSystem userO3fs;
 
   @BeforeAll
   void initClusterAndEnv() throws IOException, InterruptedException, TimeoutException {
@@ -280,9 +279,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
     userOfs = UGI_USER1.doAs(
         (PrivilegedExceptionAction<RootedOzoneFileSystem>)()
             -> (RootedOzoneFileSystem) FileSystem.get(conf));
-    userO3fs = UGI_USER1.doAs(
-        (PrivilegedExceptionAction<OzoneFileSystem>)()
-            -> (OzoneFileSystem) FileSystem.get(conf));
 
     if (useOnlyCache) {
       cluster.getOzoneManager().getOmServerProtocol().setShouldFlushCache(omRatisEnabled);
@@ -306,7 +302,6 @@ abstract class AbstractRootedOzoneFileSystemTest {
   @Test
   void testUserHomeDirectory() {
     assertEquals(new Path("/user/" + USER1), userOfs.getHomeDirectory());
-    assertEquals(new Path("/user/" + USER1), userO3fs.getHomeDirectory());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -229,6 +229,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
       .createUserForTesting(USER1,  new String[] {"usergroup"});
   // Non-privileged OFS instance
   private RootedOzoneFileSystem userOfs;
+  private OzoneFileSystem userO3fs;
 
   @BeforeAll
   void initClusterAndEnv() throws IOException, InterruptedException, TimeoutException {
@@ -279,6 +280,9 @@ abstract class AbstractRootedOzoneFileSystemTest {
     userOfs = UGI_USER1.doAs(
         (PrivilegedExceptionAction<RootedOzoneFileSystem>)()
             -> (RootedOzoneFileSystem) FileSystem.get(conf));
+    userO3fs = UGI_USER1.doAs(
+        (PrivilegedExceptionAction<OzoneFileSystem>)()
+            -> (OzoneFileSystem) FileSystem.get(conf));
 
     if (useOnlyCache) {
       cluster.getOzoneManager().getOmServerProtocol().setShouldFlushCache(omRatisEnabled);
@@ -297,6 +301,12 @@ abstract class AbstractRootedOzoneFileSystemTest {
     // fs.ofs.impl should be loaded from META-INF, no need to explicitly set it
     assertEquals(FileSystem.getFileSystemClass(
         OzoneConsts.OZONE_OFS_URI_SCHEME, confTestLoader), RootedOzoneFileSystem.class);
+  }
+
+  @Test
+  void testUserHomeDirectory() {
+    assertEquals("/user/" + USER1, userOfs.getHomeDirectory());
+    assertEquals("/user/" + USER1, userO3fs.getHomeDirectory());
   }
 
   @Test

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -722,6 +722,12 @@ public class BasicOzoneFileSystem extends FileSystem {
   }
 
   @Override
+  public Path getHomeDirectory() {
+    return makeQualified(new Path(OZONE_USER_DIR + "/"
+        + this.userName));
+  }
+
+  @Override
   public Token<?> getDelegationToken(String renewer) throws IOException {
     return adapter.getDelegationToken(renewer);
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -971,6 +971,12 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   }
 
   @Override
+  public Path getHomeDirectory() {
+    return makeQualified(new Path(OZONE_USER_DIR + "/"
+        + this.userName));
+  }
+
+  @Override
   public Token<?> getDelegationToken(String renewer) throws IOException {
     return TracingUtil.executeInNewSpan("ofs getDelegationToken",
         () -> adapter.getDelegationToken(renewer));


### PR DESCRIPTION
## What changes were proposed in this pull request?
FileSystem.getHomeDirectory() sometimes returns the current process' user name even if the process has securely impersonated another use using [UserGroupInformation.doAs()](https://hadoop.apache.org/docs/r1.2.1/Secure_Impersonation.html).

Implementation getHomeDirectory() in BasicRootedOzoneFileSystem and BasicOzoneFileSystem to return the securely impersonated user's home directory like in other FileSystem implementations like HDFS. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10905

## How was this patch tested?

Added an integration test and tested manually with Oozie workflows
