### PR TITLE
HDDS-8875. Reduce duplicate delete transactions write to the DB

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -203,6 +203,21 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
       BLOCK_DELETE_COMMAND_WORKER_INTERVAL_DEFAULT;
 
   /**
+   * The maximum count of recent transactions cached in memory. This cache
+   * prevents duplicate transactions from being written to the database.
+   * By default, the value is set to the same as
+   * {@link org.apache.hadoop.hdds.scm.ScmConfig#blockDeletionLimit}.
+   */
+  @Config(key = "max.cached.recent.committed.transactions.count",
+      type = ConfigType.INT,
+      defaultValue = "5000",
+      tags = {DATANODE},
+      description = "The maximum count of recently committed transaction" +
+          " IDs that can be cached in memory."
+  )
+  private int maxCachedRecentCommittedTransactionsCount = 5000;
+
+  /**
    * The maximum number of commands in queued list.
    * if the commands limit crosses limit, then command will be ignored.
    */
@@ -805,6 +820,14 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
   public void setBlockDeleteCommandWorkerInterval(
       Duration blockDeleteCommandWorkerInterval) {
     this.blockDeleteCommandWorkerInterval = blockDeleteCommandWorkerInterval;
+  }
+
+  public int getMaxCachedRecentCommittedTransactionsCount() {
+    return maxCachedRecentCommittedTransactionsCount;
+  }
+
+  public void setMaxCachedRecentCommittedTransactionsCount(int count) {
+    maxCachedRecentCommittedTransactionsCount = count;
   }
 
   public int getCommandQueueLimit() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
`DeleteBlockCommands` can be sent out of order, so even `DeleteBlockCommand's` transaction is smaller than container's deleteTransactionId, we cannot tell it's duplicate or not. we must put this may be committed transaction to the RocksDB.

However, if we know that transaction has been executed successfully, we can skip these duplicate transactions. This PR caches the most recently executed transactions in memory. Through this cache, we can avoid duplicate transactions from being submitted, which can effectively reduce the waste of system resources.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-8875

## How was this patch tested?
unit tests
