### PR TITLE
HDDS-10915. Remove unused org.glassfish:javax.servlet dependency declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jsch.version>0.1.55</jsch.version>
     <cdi-api.version>2.0</cdi-api.version>
     <servlet-api.version>3.1.0</servlet-api.version>
-    <glassfish-servlet.version>3.1</glassfish-servlet.version>
     <jsp-api.version>2.1</jsp-api.version>
     <jsr311-api.version>1.1.1</jsr311-api.version>
 
@@ -552,11 +551,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>javax.servlet.jsp</groupId>
         <artifactId>jsp-api</artifactId>
         <version>${jsp-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish</groupId>
-        <artifactId>javax.servlet</artifactId>
-        <version>${glassfish-servlet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.hk2</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dependency declaration for `org.glassfish:javax.servlet` is unused, can be removed.

https://issues.apache.org/jira/browse/HDDS-10915

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/9235851651