### PR TITLE
HDDS-10919. Change ozone.security.crypto.compliance.mode default value in ozone-default.xml

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1933,7 +1933,7 @@
   </property>
   <property>
     <name>ozone.security.crypto.compliance.mode</name>
-    <value>none</value>
+    <value>unrestricted</value>
     <tag>OZONE, SECURITY, HDDS, CRYPTO_COMPLIANCE</tag>
     <description>Based on this property the security compliance mode
       is loaded and enables filtering cryptographic configuration options


### PR DESCRIPTION
## What changes were proposed in this pull request?
I changed the `ozone.security.crypto.compliance.mode` configuration default value to `unrestricted`. Its default value is already "unrestricted" in the OzoneConfigKeys class.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10919

## How was this patch tested?

No testing needed.
