### PR TITLE
HDDS-10921. Enable Atomic Rewrite in FSO buckets

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1101,7 +1101,7 @@ public abstract class TestOzoneRpcClientAbstract extends OzoneTestBase {
   }
 
   @ParameterizedTest
-  @EnumSource(names = { "OBJECT_STORE" }) // TODO - only works on object store layout for now.
+  @EnumSource
   void rewriteKey(BucketLayout layout) throws IOException {
     OzoneBucket bucket = createBucket(layout);
     OzoneKeyDetails keyDetails = createTestKey(bucket);
@@ -1115,7 +1115,7 @@ public abstract class TestOzoneRpcClientAbstract extends OzoneTestBase {
   }
 
   @ParameterizedTest
-  @EnumSource(names = { "OBJECT_STORE" }) // TODO - only works on object store layout for now.
+  @EnumSource
   void overwriteAfterRewrite(BucketLayout layout) throws IOException {
     OzoneBucket bucket = createBucket(layout);
     OzoneKeyDetails keyDetails = createTestKey(bucket);
@@ -1130,7 +1130,7 @@ public abstract class TestOzoneRpcClientAbstract extends OzoneTestBase {
   }
 
   @ParameterizedTest
-  @EnumSource(names = { "OBJECT_STORE" }) // TODO - only works on object store layout for now.
+  @EnumSource
   void rewriteFailsDueToOutdatedGeneration(BucketLayout layout) throws IOException {
     OzoneBucket bucket = createBucket(layout);
     OzoneKeyDetails keyDetails = createTestKey(bucket);
@@ -1147,7 +1147,7 @@ public abstract class TestOzoneRpcClientAbstract extends OzoneTestBase {
   }
 
   @ParameterizedTest
-  @EnumSource(names = { "OBJECT_STORE" }) // TODO - only works on object store layout for now.
+  @EnumSource
   void rewriteFailsDueToOutdatedGenerationAtCommit(BucketLayout layout) throws IOException {
     OzoneBucket bucket = createBucket(layout);
     OzoneKeyDetails keyDetails = createTestKey(bucket);
@@ -1177,7 +1177,7 @@ public abstract class TestOzoneRpcClientAbstract extends OzoneTestBase {
   }
 
   @ParameterizedTest
-  @EnumSource(names = { "OBJECT_STORE" }) // TODO - only works on object store layout for now.
+  @EnumSource
   void cannotRewriteDeletedKey(BucketLayout layout) throws IOException {
     OzoneBucket bucket = createBucket(layout);
     OzoneKeyDetails keyDetails = createTestKey(bucket);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -504,7 +504,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     return req;
   }
 
-  private void validateAtomicRewrite(OmKeyInfo existing, OmKeyInfo toCommit, Map<String, String> auditMap)
+  protected void validateAtomicRewrite(OmKeyInfo existing, OmKeyInfo toCommit, Map<String, String> auditMap)
       throws OMException {
     if (toCommit.getExpectedDataGeneration() != null) {
       // These values are not passed in the request keyArgs, so add them into the auditMap if they are present

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -148,7 +148,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
           action = "hsync";
         }
         throw new OMException("Failed to " + action + " key, as " +
-                dbOpenFileKey + "entry is not found in the OpenKey table",
+                dbOpenFileKey + " entry is not found in the OpenKey table",
                 KEY_NOT_FOUND);
       }
       omKeyInfo.getMetadata().putAll(KeyValueUtil.getFromProtobuf(
@@ -176,6 +176,12 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       Map<String, RepeatedOmKeyInfo> oldKeyVersionsToDeleteMap = null;
       OmKeyInfo keyToDelete =
           omMetadataManager.getKeyTable(getBucketLayout()).get(dbFileKey);
+
+      validateAtomicRewrite(keyToDelete, omKeyInfo, auditMap);
+      // Optimistic locking validation has passed. Now set the rewrite fields to null so they are
+      // not persisted in the key table.
+      omKeyInfo.setExpectedDataGeneration(null);
+
       if (null != keyToDelete) {
         final String clientIdString
             = String.valueOf(commitKeyRequest.getClientID());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -442,7 +442,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
     return req;
   }
 
-  private void validateAtomicRewrite(OmKeyInfo dbKeyInfo, KeyArgs keyArgs)
+  protected void validateAtomicRewrite(OmKeyInfo dbKeyInfo, KeyArgs keyArgs)
       throws OMException {
     if (keyArgs.hasExpectedDataGeneration()) {
       // If a key does not exist, or if it exists but the updateID do not match, then fail this request.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -120,6 +120,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
         dbFileInfo = OMFileRequest.getOmKeyInfoFromFileTable(false,
                 omMetadataManager, dbFileKey, keyName);
       }
+      validateAtomicRewrite(dbFileInfo, keyArgs);
 
       // Check if a file or directory exists with same key name.
       if (pathInfoFSO.getDirectoryResult() == DIRECTORY_EXISTS) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -226,11 +226,6 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
   @Test
   public void testAtomicRewrite() throws Exception {
-    if (getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {
-     // TODO - does not work with in FSO for now
-      return;
-    }
-
     Table<String, OmKeyInfo> openKeyTable = omMetadataManager.getOpenKeyTable(getBucketLayout());
     Table<String, OmKeyInfo> closedKeyTable = omMetadataManager.getKeyTable(getBucketLayout());
 
@@ -255,9 +250,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     List<OzoneAcl> acls = Collections.singletonList(OzoneAcl.parseAcl("user:foo:rw"));
     omKeyInfo.addAcl(acls.get(0));
 
-    String openKey = getOzonePathKey() + "/" + modifiedOmRequest.getCommitKeyRequest().getClientID();
-
-    openKeyTable.put(openKey, omKeyInfo);
+    String openKey = addKeyToOpenKeyTable(allocatedLocationList, omKeyInfo);
     OmKeyInfo openKeyInfo = openKeyTable.get(openKey);
     assertNotNull(openKeyInfo);
     assertEquals(acls, openKeyInfo.getAcls());
@@ -825,6 +818,14 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     return omMetadataManager.getOpenKey(volumeName, bucketName,
               keyName, clientID);
+  }
+
+  @Nonnull
+  protected String addKeyToOpenKeyTable(List<OmKeyLocationInfo> locationList, OmKeyInfo keyInfo) throws Exception {
+    OMRequestTestUtils.addKeyToTable(true, false, keyInfo, clientID, 0, omMetadataManager);
+
+    return omMetadataManager.getOpenKey(volumeName, bucketName,
+        keyName, clientID);
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
@@ -69,30 +69,36 @@ public class TestOMKeyCommitRequestWithFSO extends TestOMKeyCommitRequest {
   }
 
   @Override
-  protected String addKeyToOpenKeyTable(List<OmKeyLocationInfo> locationList)
+  protected String addKeyToOpenKeyTable(List<OmKeyLocationInfo> locationList, OmKeyInfo keyInfo)
       throws Exception {
     // need to initialize parentID
     if (getParentDir() == null) {
       parentID = getBucketID();
     } else {
       parentID = OMRequestTestUtils.addParentsToDirTable(volumeName,
-              bucketName, getParentDir(), omMetadataManager);
+          bucketName, getParentDir(), omMetadataManager);
     }
+    keyInfo.setParentObjectID(parentID);
+    keyInfo.appendNewBlocks(locationList, false);
+
+    String fileName = OzoneFSUtils.getFileName(keyName);
+    return OMRequestTestUtils.addFileToKeyTable(true, false,
+        fileName, keyInfo, clientID, txnLogId, omMetadataManager);
+
+  }
+
+  @Override
+  protected String addKeyToOpenKeyTable(List<OmKeyLocationInfo> locationList)
+      throws Exception {
     long objectId = 100;
 
     OmKeyInfo omKeyInfoFSO =
         OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
                 RatisReplicationConfig.getInstance(ONE), new OmKeyLocationInfoGroup(version, new ArrayList<>(), false))
             .setObjectID(objectId)
-            .setParentObjectID(parentID)
             .setUpdateID(100L)
             .build();
-    omKeyInfoFSO.appendNewBlocks(locationList, false);
-
-    String fileName = OzoneFSUtils.getFileName(keyName);
-    return OMRequestTestUtils.addFileToKeyTable(true, false,
-            fileName, omKeyInfoFSO, clientID, txnLogId, omMetadataManager);
-
+    return addKeyToOpenKeyTable(locationList, omKeyInfoFSO);
   }
 
   @Nonnull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -153,6 +153,11 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     long lastKnownParentId = omBucketInfo.getObjectID();
     final long volumeId = omMetadataManager.getVolumeId(volumeName);
 
+    if (keyPath == null) {
+      // The file is at the root of the bucket, so it has no parent folder. The parent is
+      // the bucket itself.
+      return lastKnownParentId;
+    }
     Iterator<Path> elements = keyPath.iterator();
     StringBuilder fullKeyPath = new StringBuilder(bucketKey);
     while (elements.hasNext()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extend the atomic commit support to FSO buckets. This will follow the same pattern for OBS buckets, ensuring that a key exists at the given path, and still existings upon commit with the same expected generation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10921

## How was this patch tested?

The tests added for OBS buckets have been enabled for FSO buckets too. Previously they were disabled for FSO, as the feature was not implemented there. Some changes were needed to the tests to handle FSO buckets.
