### PR TITLE
HDDS-10880. Duplicate Pipeline ID Detected in ReconContainerManager.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -229,11 +229,9 @@ public class ReconContainerManager extends ContainerManagerImpl {
     try {
       if (containerInfo.getState().equals(HddsProtos.LifeCycleState.OPEN)) {
         PipelineID pipelineID = containerWithPipeline.getPipeline().getId();
-        // Check if the pipeline is present in Recon
-        if (!pipelineManager.containsPipeline(pipelineID)) {
-          // Pipeline is not present, add it first.
-          LOG.info("Adding new pipeline {} from SCM.", pipelineID);
-          reconPipelineManager.addPipeline(containerWithPipeline.getPipeline());
+        // Check if the pipeline is present in Recon if not add it.
+        if (reconPipelineManager.addPipeline(containerWithPipeline.getPipeline())) {
+          LOG.info("Added new pipeline {} to Recon pipeline metadata.", pipelineID);
         }
 
         getContainerStateManager().addContainer(containerInfo.getProtobuf());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -231,7 +231,7 @@ public class ReconContainerManager extends ContainerManagerImpl {
         PipelineID pipelineID = containerWithPipeline.getPipeline().getId();
         // Check if the pipeline is present in Recon if not add it.
         if (reconPipelineManager.addPipeline(containerWithPipeline.getPipeline())) {
-          LOG.info("Added new pipeline {} to Recon pipeline metadata.", pipelineID);
+          LOG.info("Added new pipeline {} to Recon pipeline metadata from SCM.", pipelineID);
         }
 
         getContainerStateManager().addContainer(containerInfo.getProtobuf());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
@@ -166,10 +166,14 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
    * @throws IOException
    */
   @VisibleForTesting
-  public void addPipeline(Pipeline pipeline)
-      throws IOException {
+  public void addPipeline(Pipeline pipeline) throws IOException {
     acquireWriteLock();
     try {
+      // Check if the pipeline already exists
+      if (containsPipeline(pipeline.getId())) {
+        LOG.warn("Duplicate pipeline ID {} detected, skipping addition.", pipeline.getId());
+        return;
+      }
       getStateManager().addPipeline(
           pipeline.getProtobufMessage(ClientVersion.CURRENT_VERSION));
     } finally {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineReportHandler.java
@@ -83,8 +83,6 @@ public class ReconPipelineReportHandler extends PipelineReportHandler {
         throw ex;
       }
 
-      LOG.info("Adding new pipeline {} to Recon pipeline metadata.",
-          pipelineFromScm);
       if (reconPipelineManager.addPipeline(pipelineFromScm)) {
         LOG.info("Pipeline {} added to Recon pipeline metadata.", pipelineFromScm);
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineReportHandler.java
@@ -84,7 +84,8 @@ public class ReconPipelineReportHandler extends PipelineReportHandler {
       }
 
       if (reconPipelineManager.addPipeline(pipelineFromScm)) {
-        LOG.info("Pipeline {} added to Recon pipeline metadata.", pipelineFromScm);
+        LOG.info("Pipeline {} verified from SCM and added to Recon pipeline metadata.",
+            pipelineFromScm);
       }
     }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineReportHandler.java
@@ -85,7 +85,9 @@ public class ReconPipelineReportHandler extends PipelineReportHandler {
 
       LOG.info("Adding new pipeline {} to Recon pipeline metadata.",
           pipelineFromScm);
-      reconPipelineManager.addPipeline(pipelineFromScm);
+      if (reconPipelineManager.addPipeline(pipelineFromScm)) {
+        LOG.info("Pipeline {} added to Recon pipeline metadata.", pipelineFromScm);
+      }
     }
 
     Pipeline pipeline;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -209,6 +209,40 @@ public class TestReconPipelineManager {
   }
 
   @Test
+  public void testDuplicatePipelineHandling() throws IOException {
+    Pipeline pipeline = getRandomPipeline();
+    NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
+    EventQueue eventQueue = new EventQueue();
+    this.versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion()).thenReturn(
+        maxLayoutVersion());
+    when(versionManager.getSoftwareLayoutVersion()).thenReturn(
+        maxLayoutVersion());
+    NodeManager nodeManager =
+        new SCMNodeManager(conf, scmStorageConfig, eventQueue, clusterMap,
+            SCMContext.emptyContext(), versionManager);
+
+    ReconPipelineManager reconPipelineManager =
+        ReconPipelineManager.newReconPipelineManager(conf, nodeManager,
+            ReconSCMDBDefinition.PIPELINES.getTable(store), eventQueue,
+            scmhaManager, scmContext);
+
+    try {
+      reconPipelineManager.addPipeline(pipeline);
+      reconPipelineManager.addPipeline(
+          pipeline); // Adding the same pipeline again to check for duplicates
+    } catch (Exception e) {
+      // Fail the test if an exception is thrown
+      assertTrue(false,
+          "Exception was thrown when adding a duplicate pipeline: " +
+              e.getMessage());
+    }
+
+    // If no exception was thrown, the test is successful
+    assertTrue(true);
+  }
+
+  @Test
   public void testStubbedReconPipelineFactory() throws IOException {
 
     NodeManager nodeManagerMock = mock(NodeManager.class);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -58,16 +58,13 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -213,11 +210,9 @@ public class TestReconPipelineManager {
     Pipeline pipeline = getRandomPipeline();
     NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
     EventQueue eventQueue = new EventQueue();
-    this.versionManager = mock(HDDSLayoutVersionManager.class);
-    when(versionManager.getMetadataLayoutVersion()).thenReturn(
-        maxLayoutVersion());
-    when(versionManager.getSoftwareLayoutVersion()).thenReturn(
-        maxLayoutVersion());
+    versionManager = mock(HDDSLayoutVersionManager.class);
+    when(versionManager.getMetadataLayoutVersion()).thenReturn(maxLayoutVersion());
+    when(versionManager.getSoftwareLayoutVersion()).thenReturn(maxLayoutVersion());
     NodeManager nodeManager =
         new SCMNodeManager(conf, scmStorageConfig, eventQueue, clusterMap,
             SCMContext.emptyContext(), versionManager);
@@ -227,20 +222,15 @@ public class TestReconPipelineManager {
             ReconSCMDBDefinition.PIPELINES.getTable(store), eventQueue,
             scmhaManager, scmContext);
 
-    try {
-      reconPipelineManager.addPipeline(pipeline);
-      reconPipelineManager.addPipeline(
-          pipeline); // Adding the same pipeline again to check for duplicates
-    } catch (Exception e) {
-      // Fail the test if an exception is thrown
-      assertTrue(false,
-          "Exception was thrown when adding a duplicate pipeline: " +
-              e.getMessage());
-    }
+    // Add the pipeline for the first time
+    reconPipelineManager.addPipeline(pipeline);
 
-    // If no exception was thrown, the test is successful
-    assertTrue(true);
+    // Attempt to add the same pipeline again and ensure no exception is thrown
+    assertDoesNotThrow(() -> {
+      reconPipelineManager.addPipeline(pipeline);
+    }, "Exception was thrown when adding a duplicate pipeline.");
   }
+
 
   @Test
   public void testStubbedReconPipelineFactory() throws IOException {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -64,7 +64,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Description:
This pull request proposes changes to handle the scenario where a duplicate pipeline ID is detected in Recon. The modifications ensure that when a pipeline with a duplicate ID is encountered, the system logs a warning and skips the addition, instead of throwing an exception.

### Proposed Changes:
1. Modified the `addPipeline` method in the `ReconPipelineManager` class to check if the pipeline already exists before attempting to add it.
2. If a duplicate pipeline ID is detected, the system logs a warning and skips the addition.
3. Implemented a test case to verify that no exception is thrown when attempting to add a duplicate pipeline.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10880
## How was this patch tested?
A new test case was added to `TestReconPipelineManager` to verify that no exception is thrown when a duplicate pipeline is added. The test case involves: