### PR TITLE
HDDS-9918. [hsync] Remove block token from Ratis log once verified.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -422,39 +422,26 @@ public class ContainerStateMachine extends BaseStateMachine {
       }
       return builder.build().setException(ioe);
     }
+
+    // once the token is verified, clear it from the proto
+    final ContainerCommandRequestProto.Builder protoBuilder = ContainerCommandRequestProto.newBuilder(proto)
+        .clearEncodedToken();
     if (proto.getCmdType() == Type.WriteChunk) {
       final WriteChunkRequestProto write = proto.getWriteChunk();
-      // create the log entry proto
-      final WriteChunkRequestProto commitWriteChunkProto =
-          WriteChunkRequestProto.newBuilder()
-              .setBlockID(write.getBlockID())
-              .setChunkData(write.getChunkData())
-              // skipping the data field as it is
-              // already set in statemachine data proto
-              .build();
-      ContainerCommandRequestProto commitContainerCommandProto =
-          ContainerCommandRequestProto
-              .newBuilder(proto)
-              .setPipelineID(gid.getUuid().toString())
-              .setWriteChunk(commitWriteChunkProto)
-              .setTraceID(proto.getTraceID())
-              .build();
       Preconditions.checkArgument(write.hasData());
       Preconditions.checkArgument(!write.getData().isEmpty());
+      // skipping the data field as it is already set in statemachine data proto
+      final WriteChunkRequestProto.Builder commitWriteChunkProto = WriteChunkRequestProto.newBuilder(write)
+          .clearData();
+      protoBuilder.setWriteChunk(commitWriteChunkProto)
+          .setPipelineID(gid.getUuid().toString())
+          .setTraceID(proto.getTraceID());
 
-      final Context context = new Context(proto, commitContainerCommandProto);
-      return builder
-          .setStateMachineContext(context)
-          .setStateMachineData(write.getData())
-          .setLogData(commitContainerCommandProto.toByteString())
-          .build();
-    } else {
-      final Context context = new Context(proto, proto);
-      return builder
-          .setStateMachineContext(context)
-          .setLogData(proto.toByteString())
-          .build();
+      builder.setStateMachineData(write.getData());
     }
+    return builder.setStateMachineContext(new Context(proto, protoBuilder.build()))
+        .setLogData(proto.toByteString())
+        .build();
 
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -439,10 +439,10 @@ public class ContainerStateMachine extends BaseStateMachine {
 
       builder.setStateMachineData(write.getData());
     }
-    return builder.setStateMachineContext(new Context(proto, protoBuilder.build()))
-        .setLogData(proto.toByteString())
+    final ContainerCommandRequestProto containerCommandRequestProto = protoBuilder.build();
+    return builder.setStateMachineContext(new Context(proto, containerCommandRequestProto))
+        .setLogData(containerCommandRequestProto.toByteString())
         .build();
-
   }
 
   private static ContainerCommandRequestProto getContainerCommandRequestProto(


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-9918. [hsync] Remove block token from Ratis log once verified

After [HDDS-9697](https://issues.apache.org/jira/browse/HDDS-9697), block token is not useful after leader DN verifies it, and does not need to be recorded in Ratis log.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9918

## How was this patch tested?

Stand up a docker compose cluster, verified that secure DataNode does not preserve encodedToken in Ratis log.
Unit tests passed