### PR TITLE
HDDS-10938. flaky-test-check does not list failed iterations

### DIFF
--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -211,7 +211,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: result-${{ github.run_id }}-${{ github.run_number }}-${{ matrix.split }}
+          name: result-${{ github.run_number }}-${{ github.run_id }}-split-${{ matrix.split }}
           path: target/unit
   count-failures:
     if: ${{ always() }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the bug that `flaky-test-check`'s `count-failures` job does not list failed iterations:

```
Total failures: 5

Failed runs:

Error: Process completed with exit code 1.
```

This was caused by HDDS-10264, which removed `split` from the artifact name.

Also swap `run_id` and `run_number` in the artifact name, because `run_number` is a smaller number.  This makes it easier to extract a specific artifact zip after downloading several of them.

https://issues.apache.org/jira/browse/HDDS-10938

## How was this patch tested?

Triggered run for `TestOzoneManagerPrepare`, verified failures are [listed](https://github.com/adoroszlai/ozone/actions/runs/9285132172/job/25550868993#step:3:21):

```
Total failures: 7

Failed runs:
split 1 Iteration 10
split 3 Iteration 8
split 3 Iteration 10
split 9 Iteration 3
split 9 Iteration 5
split 9 Iteration 9
split 10 Iteration 7

Error: Process completed with exit code 1.
```