### PR TITLE
HDDS-10937. Ozone Recon - Handle startup failure and log reasons as error due to SCM non-HA scenario

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmNonHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmNonHASnapshot.java
@@ -20,10 +20,9 @@ package org.apache.hadoop.ozone.recon;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY;
@@ -32,14 +31,14 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY;
  * Test Recon SCM HA Snapshot Download implementation.
  */
 @Timeout(300)
-public class TestReconScmHASnapshot {
+public class TestReconScmNonHASnapshot {
   private OzoneConfiguration conf;
   private MiniOzoneCluster ozoneCluster = null;
 
   @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
-    conf.setBoolean(OZONE_SCM_HA_ENABLE_KEY, true);
+    conf.setBoolean(OZONE_SCM_HA_ENABLE_KEY, false);
     conf.setBoolean(
         ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_ENABLED, true);
     conf.setInt(ReconServerConfigKeys.OZONE_RECON_SCM_CONTAINER_THRESHOLD, 0);
@@ -52,7 +51,8 @@ public class TestReconScmHASnapshot {
   }
 
   @Test
-  public void testScmHASnapshot() throws Exception {
+  public void testScmNonHASnapshot() throws Exception {
+    //ozoneCluster.getReconServer().getStorageContainerServiceProvider().
     TestReconScmSnapshot.testSnapshot(ozoneCluster);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmNonHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmNonHASnapshot.java
@@ -52,7 +52,6 @@ public class TestReconScmNonHASnapshot {
 
   @Test
   public void testScmNonHASnapshot() throws Exception {
-    //ozoneCluster.getReconServer().getStorageContainerServiceProvider().
     TestReconScmSnapshot.testSnapshot(ozoneCluster);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconContext.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconContext.java
@@ -125,7 +125,10 @@ public final class ReconContext {
         Arrays.asList("Recon health")),
     GET_OM_DB_SNAPSHOT_FAILED(
         "OM DB Snapshot sync failed !!!",
-        Arrays.asList("Overview (OM Data)", "OM DB Insights"));
+        Arrays.asList("Overview (OM Data)", "OM DB Insights")),
+    GET_SCM_DB_SNAPSHOT_FAILED(
+        "SCM DB Snapshot sync failed !!!",
+        Arrays.asList("Containers", "Pipelines"));
 
     private final String message;
     private final List<String> impacts;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.ozone.recon.api.types.FeatureProvider;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.security.ReconCertificateClient;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
@@ -55,6 +56,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.hdds.ratis.RatisHelper.newJvmPauseMonitor;
 import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY;
@@ -139,6 +141,7 @@ public class ReconServer extends GenericCli {
           injector.getInstance(ReconSchemaManager.class);
       LOG.info("Creating Recon Schema.");
       reconSchemaManager.createReconSchema();
+      LOG.debug("Recon schema creation done.");
 
       this.reconSafeModeMgr = injector.getInstance(ReconSafeModeManager.class);
       this.reconSafeModeMgr.setInSafeMode(true);
@@ -153,13 +156,21 @@ public class ReconServer extends GenericCli {
 
       LOG.info("Initializing support of Recon Features...");
       FeatureProvider.initFeatureSupport(configuration);
+
+      LOG.debug("Now starting all services of Recon...");
+      // Start all services
+      start();
+      isStarted = true;
+      LOG.debug("Start of all services of Recon completed successfully !!!");
       LOG.info("Recon server initialized successfully!");
     } catch (Exception e) {
+      ReconStorageContainerManagerFacade reconStorageContainerManagerFacade =
+          (ReconStorageContainerManagerFacade) this.getReconStorageContainerManager();
+      ReconContext reconContext = reconStorageContainerManagerFacade.getReconContext();
+      reconContext.updateHealthStatus(new AtomicBoolean(false));
+      reconContext.getErrors().add(ReconContext.ErrorCode.INTERNAL_ERROR);
       LOG.error("Error during initializing Recon server.", e);
     }
-    // Start all services
-    start();
-    isStarted = true;
 
     ShutdownHookManager.get().addShutdownHook(() -> {
       try {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -161,7 +161,6 @@ public class ReconServer extends GenericCli {
       // Start all services
       start();
       isStarted = true;
-      LOG.debug("Start of all services of Recon completed successfully !!!");
       LOG.info("Recon server initialized successfully!");
     } catch (Exception e) {
       ReconStorageContainerManagerFacade reconStorageContainerManagerFacade =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -745,4 +745,8 @@ public class ReconStorageContainerManagerFacade
   public ContainerCountBySizeDao getContainerCountBySizeDao() {
     return containerCountBySizeDao;
   }
+
+  public ReconContext getReconContext() {
+    return reconContext;
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -225,8 +225,8 @@ public class StorageContainerServiceProviderImpl
               }
             }
           }
-        } catch (Exception exception) {
-          LOG.error("Unexpected runtime error while downloading SCM Rocks DB snapshot/checkpoint : {}", exception);
+        } catch (Throwable throwable) {
+          LOG.error("Unexpected runtime error while downloading SCM Rocks DB snapshot/checkpoint : {}", throwable);
           throw exception;
         }
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -231,7 +231,7 @@ public class StorageContainerServiceProviderImpl
         }
       }
       return getRocksDBCheckpoint(snapshotFileName, targetFile);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       reconContext.updateHealthStatus(new AtomicBoolean(false));
       reconContext.getErrors().add(ReconContext.ErrorCode.GET_SCM_DB_SNAPSHOT_FAILED);
       LOG.error("Unable to obtain SCM DB Snapshot: {} ", e);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -227,7 +227,7 @@ public class StorageContainerServiceProviderImpl
           }
         } catch (Throwable throwable) {
           LOG.error("Unexpected runtime error while downloading SCM Rocks DB snapshot/checkpoint : {}", throwable);
-          throw exception;
+          throw throwable;
         }
       }
       return getRocksDBCheckpoint(snapshotFileName, targetFile);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -65,7 +66,6 @@ import org.apache.hadoop.ozone.recon.security.ReconCertificateClient;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.ratis.proto.RaftProtos;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR handles Recon startup failure due to unexpected runtime error and shuts down silently without logging the actual cause of error.

Ozone Recon - Handle startup failure and log reasons as error due to SCM non-HA scenario

While ReconServer.start() method is called, if any runtime errors being thrown, those are not being logged and Recon startup fails silently without logging any reason of failure. E.g. In case of non-HA SCM case, few configurations made Recon fails to start. This scenario or any runtime exception  needs to be handled for proper logging.
In non-HA SCM case, while trying to fetch SCM DB snapshot, SCM peer roles are not being returned correctly, so the logic needs to handle.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10937

## How was this patch tested?
Tested manually and added additional integration tests in Recon for non HA SCM case.
