### PR TITLE
HDDS-10924. TestSCMHAManagerImpl#testAddSCM fails on ratis master

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -233,8 +233,8 @@ public class SCMStateMachine extends BaseStateMachine {
     String leaderAddress = roleInfoProto.getFollowerInfo()
         .getLeaderInfo().getId().getAddress();
     Optional<SCMNodeDetails> leaderDetails =
-        scm.getSCMHANodeDetails().getPeerNodeDetails().stream().filter(
-            p -> p.getRatisHostPortStr().equals(leaderAddress))
+        scm.getSCMHANodeDetails().getPeerNodeDetails().stream()
+            .filter(p -> p.getRatisHostPortStr().equals(leaderAddress))
             .findFirst();
     Preconditions.checkState(leaderDetails.isPresent());
     final String leaderNodeId = leaderDetails.get().getNodeId();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tweak `TestSCMHAManagerImpl` to let it pass with Ratis 3.1.0.

https://issues.apache.org/jira/browse/HDDS-10924

## How was this patch tested?

Ozone CI with Ratis 3.1.0 RC0:
https://github.com/adoroszlai/ozone/actions/runs/9306740993

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/9306735813