### PR TITLE
HDDS-9644. Fixed incorrect validation of path with namespace du commands.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -115,7 +115,25 @@ public class TestNSSummaryAdmin extends StandardOutputTestBase {
     String path = "/";
     executeAdminCommands(path);
     // Should throw warning - only buckets can have bucket layout.
-    assertThat(getOutContentString()).contains("[Warning] Namespace CLI is not designed for OBS bucket layout.");
+    assertThat(getOutContentString()).doesNotContain("INVALID_VOLUME_NAME");
+    assertThat(getOutContentString()).doesNotContain(
+        "[Warning] Namespace CLI is not designed for OBS bucket layout.");
+    assertThat(getOutContentString()).contains("Put more files into it to visualize DU");
+    assertThat(getOutContentString()).contains("Put more files into it to visualize file size distribution");
+  }
+
+  /**
+   * Test NSSummaryCLI on volume.
+   */
+  @Test
+  public void testNSSummaryCLIVolume() throws UnsupportedEncodingException {
+    // Running on root path.
+    String path = "/" + volumeName;
+    executeAdminCommands(path);
+    // Should throw warning - only buckets can have bucket layout.
+    assertThat(getOutContentString()).doesNotContain("INVALID_BUCKET_NAME");
+    assertThat(getOutContentString()).doesNotContain(
+        "[Warning] Namespace CLI is not designed for OBS bucket layout.");
     assertThat(getOutContentString()).contains("Put more files into it to visualize DU");
     assertThat(getOutContentString()).contains("Put more files into it to visualize file size distribution");
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -114,7 +114,6 @@ public class TestNSSummaryAdmin extends StandardOutputTestBase {
     // Running on root path.
     String path = "/";
     executeAdminCommands(path);
-    // Should throw warning - only buckets can have bucket layout.
     assertThat(getOutContentString()).doesNotContain("INVALID_VOLUME_NAME");
     assertThat(getOutContentString()).doesNotContain(
         "[Warning] Namespace CLI is not designed for OBS bucket layout.");
@@ -127,10 +126,9 @@ public class TestNSSummaryAdmin extends StandardOutputTestBase {
    */
   @Test
   public void testNSSummaryCLIVolume() throws UnsupportedEncodingException {
-    // Running on root path.
+    // Running on /volume path.
     String path = "/" + volumeName;
     executeAdminCommands(path);
-    // Should throw warning - only buckets can have bucket layout.
     assertThat(getOutContentString()).doesNotContain("INVALID_BUCKET_NAME");
     assertThat(getOutContentString()).doesNotContain(
         "[Warning] Namespace CLI is not designed for OBS bucket layout.");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -30,7 +30,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.parseInputPath;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
-import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printBucketReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printKVSeparator;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
@@ -104,9 +103,6 @@ public class DiskUsageSubCommand implements Callable {
     if ("PATH_NOT_FOUND".equals(duResponse.path("status").asText(""))) {
       printPathNotFound();
     } else {
-      if (parent.isNotValidBucketOrOBSBucket(path)) {
-        printBucketReminder();
-      }
 
       long totalSize = duResponse.path("size").asLong(-1);
       if (!noHeader) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -115,7 +115,8 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
         OzoneConfiguration.of(getOzoneConfig()));
     try (OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(getOzoneConfig())) {
       ObjectStore objectStore = ozoneClient.getObjectStore();
-      // Return false if path is root, just a volume
+      // Return false if path is root "/" or
+      // contains just the volume and no bucket like "/volume"
       if (ofsPath.getVolumeName().isEmpty() ||
           ofsPath.getBucketName().isEmpty()) {
         return false;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -115,6 +115,11 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
         OzoneConfiguration.of(getOzoneConfig()));
     try (OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(getOzoneConfig())) {
       ObjectStore objectStore = ozoneClient.getObjectStore();
+      // Return false if path is root, just a volume
+      if (ofsPath.getVolumeName().isEmpty() ||
+          ofsPath.getBucketName().isEmpty()) {
+        return false;
+      }
       // Checks if the bucket is part of the path.
       OzoneBucket bucket = objectStore.getVolume(ofsPath.getVolumeName())
           .getBucket(ofsPath.getBucketName());


### PR DESCRIPTION
## What changes were proposed in this pull request?
When running `namespace du` command with root `/` or volume name `/volume` ofs paths, ofs path validation errors `INVALID_VOLUME_NAME` and `INVALID_BUCKET_NAME` are like below printed on the output. This is invalid because both `/` and `/volume` are valid paths.

Fixed the path validation code to skip printing errors if paths are valid.

```
ozone admin namespace du /
Connecting to Recon: https://xxx:9889/api/v1/namespace/du?path=/ ...

Bucket layout couldn't be verified for path: . Exception: INVALID_VOLUME_NAME org.apache.hadoop.ozone.om.exceptions.OMException: Bucket or Volume length is illegal, valid length is 3-63 characters
Bucket layout couldn't be verified for path: . Exception: INVALID_VOLUME_NAME org.apache.hadoop.ozone.om.exceptions.OMException: Bucket or Volume length is illegal, valid length is 3-63 characters

[Warning] Namespace CLI is not designed for OBS bucket layout.
Bucket being accessed must be of type FILE_SYSTEM_OPTIMIZED bucket layout or 
LEGACY bucket layout with 'ozone.om.enable.filesystem.paths' set to true.

Path : /
Total Size : 0 bytes

DU
  Size      Path Name
  0 bytes   /s3v/

```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9644

## How was this patch tested?

Integration tests added.
Manual test performed
```
bash-4.2$ ozone admin namespace du /
Connecting to Recon: http://recon:9888/api/v1/namespace/du?path=/ ...

Path : /
Total Size : 22 KB

DU
  Size      Path Name
  22 KB     /s3v/

bash-4.2$ ozone admin namespace du /s3v
Connecting to Recon: http://recon:9888/api/v1/namespace/du?path=/s3v ...

Path : /s3v
Total Size : 22 KB

DU
  Size      Path Name
  11 KB     /s3v/fso/
  11 KB     /s3v/obs/
```
