### PR TITLE
HDDS-10968. Add "hdds.datanode.replication.port" to ozone-default.xml

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -453,7 +453,8 @@ public final class OzoneConfigKeys {
 
   public static final String OZONE_CONTAINER_COPY_WORKDIR =
       "hdds.datanode.replication.work.dir";
-
+  public static final String OZONE_CONTAINER_REPLICATION_PORT =
+      "hdds.datanode.replication.port";
 
   public static final int OZONE_CLIENT_BYTES_PER_CHECKSUM_MIN_SIZE = 8 * 1024;
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1680,6 +1680,14 @@
       datanodes to save the downloaded container(in compressed format).
     </description>
   </property>
+  <property>
+    <name>hdds.datanode.replication.port</name>
+    <value>9886</value>
+    <tag>DATANODE, MANAGEMENT</tag>
+    <description>Port used for the server2server replication server. Mainly used for replication of containers
+      between datanodes.
+    </description>
+  </property>
 
   <property>
     <name>hdds.scm.safemode.pipeline.creation</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Just add a default config item into ozone-default.xml. In fact, this config item has supported, but it is not in the ozone-default.xml, maybe some situation may change it.

Examples of well-written pull requests:

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10968


## How was this patch tested?
This is a config. no test.
