### PR TITLE
HDDS-10881. Recursive delete on special volume /tmp fails

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OFSPath.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OFSPath.java
@@ -309,7 +309,7 @@ public class OFSPath {
     return !this.getKeyName().isEmpty();
   }
 
-  private static String md5Hex(String input) {
+  public static String md5Hex(String input) {
     try {
       MessageDigest md = MessageDigest.getInstance("MD5");
       byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/DeleteVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/DeleteVolumeHandler.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.PATH_SEPARATOR_STR;
+import static org.apache.hadoop.ozone.OFSPath.OFS_MOUNT_TMP_VOLUMENAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.helpers.BucketLayout.FILE_SYSTEM_OPTIMIZED;
 import static org.apache.hadoop.ozone.om.helpers.BucketLayout.LEGACY;
@@ -83,7 +84,7 @@ public class DeleteVolumeHandler extends VolumeHandler {
       throws IOException {
 
     String volumeName = address.getVolumeName();
-    boolean success = false;
+    boolean success = true;
     omServiceId = address.getOmServiceId(getConf());
     try {
       if (bRecursive) {
@@ -141,7 +142,8 @@ public class DeleteVolumeHandler extends VolumeHandler {
 
     while (bucketIterator.hasNext()) {
       OzoneBucket bucket = bucketIterator.next();
-      if ((bucket.getBucketLayout() == FILE_SYSTEM_OPTIMIZED || bucket.getBucketLayout() == LEGACY) &&
+      if (vol.getName().equals(OFS_MOUNT_TMP_VOLUMENAME) &&
+          (bucket.getBucketLayout() == FILE_SYSTEM_OPTIMIZED || bucket.getBucketLayout() == LEGACY) &&
           handleSpecialVolumeTmp(bucket)) {
         return false;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recursive delete on the /tmp special volume, as well as its FSO/LEGACY buckets, fails using the ozone shell delete -r -y command with "java.lang.RuntimeException: Failed to clean bucket."

With this patch, we specifically check if the hashed bucket (bucket name based on the MD5 hash of the bucket's username) is present. If it is, we do not call delete on it. If the bucket doesn't exist, we may simply ignore the delete. This should be a cosmetic change.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10881

## How was this patch tested?

Tested on a local docker-compose cluster.

Volume creation using ozone sh:

```
bash-4.2$ ozone sh volume create tmp 
bash-4.2$ ozone sh bucket create tmp/dir1
bash-4.2$ ozone sh bucket info tmp/dir1
{
  "metadata" : { },
  "volumeName" : "tmp",
  "name" : "dir1",
  "storageType" : "DISK",
  "versioning" : false,
  "listCacheSize" : 1000,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2024-06-03T11:58:22.160Z",
  "modificationTime" : "2024-06-03T11:58:22.160Z",
  "sourcePathExist" : true,
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "owner" : "om",
  "link" : false
}
```

Before Changes:
```
bash-4.2$ ozone sh bucket delete -r -y tmp/dir1
Could not delete bucket dir1.
```

After Changes:
```
bash-4.2$ ozone sh bucket delete -r -y tmp/dir1
bash-4.2$ 

bash-4.2$ ozone sh bucket info tmp/dir1
{
  "metadata" : { },
  "volumeName" : "tmp",
  "name" : "dir1",
  "storageType" : "DISK",
  "versioning" : false,
  "listCacheSize" : 1000,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2024-06-03T11:58:22.160Z",
  "modificationTime" : "2024-06-03T11:58:22.160Z",
  "sourcePathExist" : true,
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "owner" : "om",
  "link" : false
}
```

Before Changes:
```
bash-4.2$ ozone sh volume delete -r -y tmp
Exception in thread "pool-2-thread-1" java.lang.RuntimeException: Failed to clean bucket
        at org.apache.hadoop.ozone.shell.volume.DeleteVolumeHandler$BucketCleaner.run(DeleteVolumeHandler.java:202)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
VOLUME_NOT_EMPTY 
```

After Changes:
```
bash-4.2$ ozone sh volume delete -r -y tmp  
bash-4.2$ 

bash-4.2$ ozone sh volume info tmp
{
  "metadata" : { },
  "name" : "tmp",
  "admin" : "om",
  "owner" : "om",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "usedNamespace" : 1,
  "creationTime" : "2024-06-03T11:58:02.705Z",
  "modificationTime" : "2024-06-03T11:58:02.705Z",
  "acls" : [ {
    "type" : "USER",
    "name" : "om",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  }, {
    "type" : "GROUP",
    "name" : "om",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  } ],
  "refCount" : 0
}
```

Volume creation using ozone fs:
```
bash-4.2$ ozone fs -mkdir ofs://omservice/tmp/
bash-4.2$ ozone sh volume info tmp
{
  "metadata" : { },
  "name" : "tmp",
  "admin" : "om",
  "owner" : "om",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "usedNamespace" : 1,
  "creationTime" : "2024-06-03T12:31:24.334Z",
  "modificationTime" : "2024-06-03T12:31:24.334Z",
  "acls" : [ {
    "type" : "USER",
    "name" : "om",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  }, {
    "type" : "GROUP",
    "name" : "om",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  } ],
  "refCount" : 0
}

bash-4.2$ ozone sh bucket list tmp
[ {
  "metadata" : { },
  "volumeName" : "tmp",
  "name" : "d58da82289939d8c4ec4f40689c2847e",
  "storageType" : "DISK",
  "versioning" : false,
  "listCacheSize" : 1000,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2024-06-03T12:31:24.416Z",
  "modificationTime" : "2024-06-03T12:31:24.416Z",
  "sourcePathExist" : true,
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "owner" : "om",
  "link" : false
} ]

bash-4.2$ ozone fs -touch ofs://omservice/tmp/sample.txt
bash-4.2$ ozone fs -ls ofs://omservice/tmp/
Found 1 items
-rw-rw-rw-   3 om om          0 2024-06-03 12:33 ofs://omservice/tmp/sample.txt
```

Before Changes:
```
bash-4.2$ ozone sh volume delete -r -y o3://omservice/tmp/
Exception in thread "pool-2-thread-1" java.lang.RuntimeException: Failed to clean bucket
        at org.apache.hadoop.ozone.shell.volume.DeleteVolumeHandler$BucketCleaner.run(DeleteVolumeHandler.java:202)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
VOLUME_NOT_EMPTY 
```

After Changes:
```
bash-4.2$ ozone sh volume delete -r -y o3://omservice/tmp/
bash-4.2$ 

bash-4.2$ ozone fs -ls ofs://omservice/
Found 2 items
drwxrwxrwx   - om om          0 2024-06-03 12:30 ofs://omservice/s3v
drwxrwxrwx   - om om          0 2024-06-03 12:31 ofs://omservice/tmp

bash-4.2$ ozone fs -ls ofs://omservice/tmp
Found 1 items
-rw-rw-rw-   3 om om          0 2024-06-03 12:33 ofs://omservice/tmp/sample.txt
```
