### PR TITLE
HDDS-2887. Add config to tune replication level of watch requests in Ozone client

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -153,7 +153,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
 
   public long updateCommitInfosMap(
       Collection<RaftProtos.CommitInfoProto> commitInfoProtos) {
-    return updateCommitInfosMap(commitInfoProtos, ReplicationLevel.ALL_COMMITTED);
+    return updateCommitInfosMap(commitInfoProtos, watchType);
   }
 
   public long updateCommitInfosMap(
@@ -304,10 +304,6 @@ public final class XceiverClientRatis extends XceiverClientSpi {
     try {
       CompletableFuture<RaftClientReply> replyFuture = getClient().async().watch(index, watchType);
       final RaftClientReply reply = replyFuture.get();
-      if (!reply.isSuccess()) {
-        LOG.error("{} way commit failed", watchType, reply.getException());
-        throw reply.getException();
-      }
       final long updated = updateCommitInfosMap(reply, watchType);
       Preconditions.checkState(updated >= index, "Returned index " + updated + " is smaller than expected " + index);
       return newWatchReply(index, watchType, updated);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -42,6 +43,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerC
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.ContainerCommandRequestMessage;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
+import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.client.ClientTrustManager;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -105,6 +107,8 @@ public final class XceiverClientRatis extends XceiverClientSpi {
 
   private final XceiverClientMetrics metrics
       = XceiverClientManager.getXceiverClientMetrics();
+  private final RaftProtos.ReplicationLevel watchType;
+  private final int majority;
 
   /**
    * Constructs a client.
@@ -114,28 +118,46 @@ public final class XceiverClientRatis extends XceiverClientSpi {
       ConfigurationSource configuration) {
     super();
     this.pipeline = pipeline;
+    this.majority = (pipeline.getReplicationConfig().getRequiredNodes() / 2) + 1;
     this.rpcType = rpcType;
     this.retryPolicy = retryPolicy;
     commitInfoMap = new ConcurrentHashMap<>();
     this.tlsConfig = tlsConfig;
     this.ozoneConfiguration = configuration;
+    try {
+      this.watchType = RaftProtos.ReplicationLevel.valueOf(
+          configuration.getObject(RatisClientConfig.class).getWatchType());
+    } catch (Exception e) {
+      throw new IllegalArgumentException(configuration.getObject(RatisClientConfig.class).getWatchType() +
+          " is not supported. Currently only ALL_COMMITTED or MAJORITY_COMMITTED are supported");
+    }
 
+    if (watchType != ReplicationLevel.ALL_COMMITTED && watchType != ReplicationLevel.MAJORITY_COMMITTED) {
+      throw new IllegalArgumentException(watchType + " is not supported. " +
+          "Currently only ALL_COMMITTED or MAJORITY_COMMITTED are supported");
+    }
+    LOG.info("WatchType {}. Majority {}, ", this.watchType, this.majority);
     if (LOG.isTraceEnabled()) {
       LOG.trace("new XceiverClientRatis for pipeline " + pipeline.getId(),
           new Throwable("TRACE"));
     }
   }
 
-  private long updateCommitInfosMap(RaftClientReply reply) {
+  private long updateCommitInfosMap(RaftClientReply reply, RaftProtos.ReplicationLevel level) {
     return Optional.ofNullable(reply)
         .filter(RaftClientReply::isSuccess)
         .map(RaftClientReply::getCommitInfos)
-        .map(this::updateCommitInfosMap)
+        .map(v -> updateCommitInfosMap(v, level))
         .orElse(0L);
   }
 
   public long updateCommitInfosMap(
       Collection<RaftProtos.CommitInfoProto> commitInfoProtos) {
+    return updateCommitInfosMap(commitInfoProtos, ReplicationLevel.ALL_COMMITTED);
+  }
+
+  public long updateCommitInfosMap(
+      Collection<RaftProtos.CommitInfoProto> commitInfoProtos, RaftProtos.ReplicationLevel level) {
     // if the commitInfo map is empty, just update the commit indexes for each
     // of the servers
     final Stream<Long> stream;
@@ -152,7 +174,12 @@ public final class XceiverClientRatis extends XceiverClientSpi {
               (address, index) -> proto.getCommitIndex()))
           .filter(Objects::nonNull);
     }
-    return stream.mapToLong(Long::longValue).min().orElse(0);
+    if (level == ReplicationLevel.ALL_COMMITTED) {
+      return stream.mapToLong(Long::longValue).min().orElse(0);
+    } else {
+      // if majority committed, then find the second large index
+      return stream.sorted(Comparator.reverseOrder()).limit(majority).skip(majority - 1).findFirst().orElse(0L);
+    }
   }
 
   private long putCommitInfo(RaftProtos.CommitInfoProto proto) {
@@ -275,39 +302,45 @@ public final class XceiverClientRatis extends XceiverClientSpi {
     }
 
     try {
-      CompletableFuture<RaftClientReply> replyFuture = getClient().async()
-          .watch(index, RaftProtos.ReplicationLevel.ALL_COMMITTED);
+      CompletableFuture<RaftClientReply> replyFuture = getClient().async().watch(index, watchType);
       final RaftClientReply reply = replyFuture.get();
-      final long updated = updateCommitInfosMap(reply);
-      Preconditions.checkState(updated >= index);
-      return newWatchReply(index, ReplicationLevel.ALL_COMMITTED, updated);
+      if (!reply.isSuccess()) {
+        LOG.error("{} way commit failed", watchType, reply.getException());
+        throw reply.getException();
+      }
+      final long updated = updateCommitInfosMap(reply, watchType);
+      Preconditions.checkState(updated >= index, "Returned index " + updated + " is smaller than expected " + index);
+      return newWatchReply(index, watchType, updated);
     } catch (Exception e) {
-      LOG.warn("3 way commit failed on pipeline {}", pipeline, e);
+      LOG.warn("{} way commit failed on pipeline {}", watchType, pipeline, e);
       Throwable t =
           HddsClientUtils.containsException(e, GroupMismatchException.class);
       if (t != null) {
         throw e;
       }
-      final RaftClientReply reply = getClient().async()
-          .watch(index, RaftProtos.ReplicationLevel.MAJORITY_COMMITTED)
-          .get();
-      final XceiverClientReply clientReply = newWatchReply(
-          index, ReplicationLevel.MAJORITY_COMMITTED, index);
-      reply.getCommitInfos().stream()
-          .filter(i -> i.getCommitIndex() < index)
-          .forEach(proto -> {
-            UUID address = RatisHelper.toDatanodeId(proto.getServer());
-            addDatanodetoReply(address, clientReply);
-            // since 3 way commit has failed, the updated map from now on  will
-            // only store entries for those datanodes which have had successful
-            // replication.
-            commitInfoMap.remove(address);
-            LOG.info(
-                "Could not commit index {} on pipeline {} to all the nodes. " +
-                "Server {} has failed. Committed by majority.",
-                index, pipeline, address);
-          });
-      return clientReply;
+      if (watchType == ReplicationLevel.ALL_COMMITTED) {
+        final RaftClientReply reply = getClient().async()
+            .watch(index, RaftProtos.ReplicationLevel.MAJORITY_COMMITTED)
+            .get();
+        final XceiverClientReply clientReply = newWatchReply(
+            index, ReplicationLevel.MAJORITY_COMMITTED, index);
+        reply.getCommitInfos().stream()
+            .filter(i -> i.getCommitIndex() < index)
+            .forEach(proto -> {
+              UUID address = RatisHelper.toDatanodeId(proto.getServer());
+              addDatanodetoReply(address, clientReply);
+              // since 3 way commit has failed, the updated map from now on will
+              // only store entries for those datanodes which have had successful
+              // replication.
+              commitInfoMap.remove(address);
+              LOG.info(
+                  "Could not commit index {} on pipeline {} to all the nodes. " +
+                      "Server {} has failed. Committed by majority.",
+                  index, pipeline, address);
+            });
+        return clientReply;
+      }
+      throw e;
     }
   }
 
@@ -360,7 +393,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
                     .parseFrom(reply.getMessage().getContent());
             UUID serverId = RatisHelper.toDatanodeId(reply.getReplierId());
             if (response.getResult() == ContainerProtos.Result.SUCCESS) {
-              updateCommitInfosMap(reply.getCommitInfos());
+              updateCommitInfosMap(reply.getCommitInfos(), watchType);
             }
             asyncReply.setLogIndex(reply.getLogIndex());
             addDatanodetoReply(serverId, asyncReply);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
@@ -98,6 +98,21 @@ public class RatisClientConfig {
     }
   }
 
+  @Config(key = "client.request.watch.type",
+      defaultValue = "ALL_COMMITTED",
+      type = ConfigType.STRING,
+      tags = { OZONE, CLIENT, PERFORMANCE },
+      description = "The RATIS watch commit type, ALL_COMMITTED or MAJORITY_COMMITTED.")
+  private String watchType;
+
+  public String getWatchType() {
+    return watchType;
+  }
+
+  public void setWatchType(String type) {
+    watchType = type;
+  }
+
   @Config(key = "client.request.write.timeout",
       defaultValue = "5m",
       type = ConfigType.TIME,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
@@ -102,7 +102,10 @@ public class RatisClientConfig {
       defaultValue = "ALL_COMMITTED",
       type = ConfigType.STRING,
       tags = { OZONE, CLIENT, PERFORMANCE },
-      description = "The RATIS watch commit type, ALL_COMMITTED or MAJORITY_COMMITTED.")
+      description = "Desired replication level when Ozone client's Raft client calls watch(), " +
+          "ALL_COMMITTED or MAJORITY_COMMITTED. MAJORITY_COMMITTED increases write performance by reducing watch() " +
+          "latency when an Ozone datanode is slow in a pipeline, at the cost of potential read latency increasing " +
+          "due to read retries to different datanodes.")
   private String watchType;
 
   public String getWatchType() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
@@ -175,7 +175,7 @@ public class Test2WayCommitInRatis {
     // commitInfo Map will be reduced to 2 here
     assertEquals(2, ratisClient.getCommitInfoMap().size());
     clientManager.releaseClient(xceiverClient, false);
-    assertThat(logCapturer.getOutput()).contains("3 way commit failed");
+    assertThat(logCapturer.getOutput()).contains("ALL_COMMITTED way commit failed");
     assertThat(logCapturer.getOutput()).contains("Committed by majority");
     logCapturer.stopCapturing();
     shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitInRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitInRatis.java
@@ -45,7 +45,6 @@ import org.apache.ratis.proto.RaftProtos;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -74,6 +74,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests Exception handling by Ozone Client.
@@ -90,6 +92,7 @@ public class TestFailureHandlingByClient {
   private String volumeName;
   private String bucketName;
   private String keyString;
+  private String watchType;
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -108,6 +111,7 @@ public class TestFailureHandlingByClient {
         conf.getObject(RatisClientConfig.class);
     ratisClientConfig.setWriteRequestTimeout(Duration.ofSeconds(30));
     ratisClientConfig.setWatchRequestTimeout(Duration.ofSeconds(30));
+    ratisClientConfig.setWatchType(watchType);
     conf.setFromObject(ratisClientConfig);
 
     conf.setTimeDuration(
@@ -411,8 +415,10 @@ public class TestFailureHandlingByClient {
     validateData(keyName, data.concat(data).getBytes(UTF_8));
   }
 
-  @Test
-  public void testDatanodeExclusionWithMajorityCommit() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {"ALL_COMMITTED", "MAJORITY_COMMITTED"})
+  public void testDatanodeExclusionWithMajorityCommit(String type) throws Exception {
+    this.watchType = type;
     startCluster();
     String keyName = UUID.randomUUID().toString();
     OzoneOutputStream key =
@@ -448,8 +454,10 @@ public class TestFailureHandlingByClient {
     key.write(data.getBytes(UTF_8));
     key.flush();
 
-    assertThat(keyOutputStream.getExcludeList().getDatanodes())
-        .contains(datanodes.get(0));
+    if (type.equals("ALL_COMMITTED")) {
+      assertThat(keyOutputStream.getExcludeList().getDatanodes())
+          .contains(datanodes.get(0));
+    }
     assertThat(keyOutputStream.getExcludeList().getContainerIds()).isEmpty();
     assertThat(keyOutputStream.getExcludeList().getPipelineIds()).isEmpty();
     // The close will just write to the buffer

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -77,7 +77,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests Exception handling by Ozone Client.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -345,7 +345,7 @@ public class TestWatchForCommit {
         clientManager.releaseClient(xceiverClient, false);
       }
       String output = logCapturer.getOutput();
-      assertThat(output).contains("3 way commit failed");
+      assertThat(output).contains("ALL_COMMITTED way commit failed");
       assertThat(output).contains("TimeoutException");
       assertThat(output).contains("Committed by majority");
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -79,7 +79,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * This class verifies the watchForCommit Handling by xceiverClient.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, while sending watch requests in ozone client, it sends watch requests with ratis replication level set to ALL_COMMITTED and in case it fails, it sends the request  with MAJORITY_COMMITTED semantics. The idea is to configure the replication level for watch requests so that MAJORITY_COMMITTED can be used if write performance is favored.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2887


## How was this patch tested?

Existing UT.  This CI will test ALL_COMMITTED case.

This CI https://github.com/ChenSammi/ozone/actions/runs/9367491573  tested MAJORITY_COMMITTED case. 