### PR TITLE
HDDS-10975. Recon Show SCM and OM services IDs in overview page

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.api;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
@@ -46,6 +47,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SERVICE_IDS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_DIR_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
@@ -68,14 +71,17 @@ public class ClusterStateEndpoint {
   private ReconPipelineManager pipelineManager;
   private ReconContainerManager containerManager;
   private GlobalStatsDao globalStatsDao;
-
+  private OzoneConfiguration ozoneConfiguration;
   private final ContainerHealthSchemaManager containerHealthSchemaManager;
+
+
 
   @Inject
   ClusterStateEndpoint(OzoneStorageContainerManager reconSCM,
                        GlobalStatsDao globalStatsDao,
                        ContainerHealthSchemaManager
-                           containerHealthSchemaManager) {
+                           containerHealthSchemaManager,
+                       OzoneConfiguration ozoneConfiguration) {
     this.nodeManager =
         (ReconNodeManager) reconSCM.getScmNodeManager();
     this.pipelineManager = (ReconPipelineManager) reconSCM.getPipelineManager();
@@ -83,6 +89,7 @@ public class ClusterStateEndpoint {
         (ReconContainerManager) reconSCM.getContainerManager();
     this.globalStatsDao = globalStatsDao;
     this.containerHealthSchemaManager = containerHealthSchemaManager;
+    this.ozoneConfiguration = ozoneConfiguration;
   }
 
   /**
@@ -182,6 +189,8 @@ public class ClusterStateEndpoint {
         .setHealthyDatanodes(healthyDatanodes)
         .setOpenContainers(containerStateCounts.getOpenContainersCount())
         .setDeletedContainers(containerStateCounts.getDeletedContainersCount())
+        .setScmServiceId(ozoneConfiguration.get(OZONE_SCM_SERVICE_IDS_KEY))
+        .setOmServiceId(ozoneConfiguration.get(OZONE_OM_SERVICE_IDS_KEY))
         .build();
     return Response.ok(response).build();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
@@ -102,10 +102,10 @@ public final class ClusterStateResponse {
   @JsonProperty
   private long deletedDirs;
 
-  @JsonProperty
+  @JsonProperty("scmServiceId")
   private String scmServiceId;
 
-  @JsonProperty
+  @JsonProperty("omServiceId")
   private String omServiceId;
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
@@ -102,6 +102,12 @@ public final class ClusterStateResponse {
   @JsonProperty
   private long deletedDirs;
 
+  @JsonProperty
+  private String scmServiceId;
+
+  @JsonProperty
+  private String omServiceId;
+
   /**
    * Returns new builder class that builds a ClusterStateResponse.
    *
@@ -125,6 +131,8 @@ public final class ClusterStateResponse {
     this.keysPendingDeletion = b.keysPendingDeletion;
     this.deletedDirs = b.deletedDirs;
     this.deletedContainers = b.deletedContainers;
+    this.scmServiceId = b.scmServiceId;
+    this.omServiceId = b.omServiceId;
   }
 
   /**
@@ -145,6 +153,8 @@ public final class ClusterStateResponse {
     private long keys;
     private long keysPendingDeletion;
     private long deletedDirs;
+    private String scmServiceId;
+    private String omServiceId;
 
     public Builder() {
       // Default values
@@ -225,6 +235,16 @@ public final class ClusterStateResponse {
       return this;
     }
 
+    public Builder setScmServiceId(String scmServiceId) {
+      this.scmServiceId = scmServiceId;
+      return this;
+    }
+
+    public Builder setOmServiceId(String omServiceId) {
+      this.omServiceId = omServiceId;
+      return this;
+    }
+
     public ClusterStateResponse build() {
       Preconditions.checkNotNull(this.storageReport);
 
@@ -283,4 +303,13 @@ public final class ClusterStateResponse {
   public long getDeletedDirs() {
     return deletedDirs;
   }
+
+  public String getScmServiceId() {
+    return scmServiceId;
+  }
+
+  public String getOmServiceId() {
+    return omServiceId;
+  }
+
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -16,7 +16,7 @@
     "buckets": 156,
     "keys": 253000,
     "keysPendingDeletion": 1000,
-    "scmServiceId": "scmservice,",
+    "scmServiceId": "scmservice",
     "omServiceId": "omservice"
   },
   "datanodes": {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -15,7 +15,9 @@
     "volumes": 5,
     "buckets": 156,
     "keys": 253000,
-    "keysPendingDeletion": 1000
+    "keysPendingDeletion": 1000,
+    "scmServiceId": "scmservice,",
+    "omServiceId": "omservice"
   },
   "datanodes": {
     "totalCount": 12,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
@@ -62,6 +62,11 @@ class OverviewCardWrapper extends React.Component<IOverviewCardWrapperProps> {
         active: '3'
       }
     }
+    else if (title === "Ozone Manager") {
+      return {
+        active: '4'
+      }
+    }
   };
 
   render() {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
@@ -62,7 +62,7 @@ class OverviewCardWrapper extends React.Component<IOverviewCardWrapperProps> {
         active: '3'
       }
     }
-    else if (title === "Ozone Manager") {
+    else if (title === "OM Service") {
       return {
         active: '4'
       }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -44,6 +44,8 @@ interface IClusterStateResponse {
   openContainers: number;
   deletedContainers: number;
   keysPendingDeletion: number;
+  scmServiceId: string;
+  omServiceId: string;
 }
 
 interface IOverviewState {
@@ -68,6 +70,8 @@ interface IOverviewState {
   deletePendingSummarytotalUnrepSize: number,
   deletePendingSummarytotalRepSize: number,
   deletePendingSummarytotalDeletedKeys: number,
+  scmServiceId: string;
+  omServiceId: string;
 }
 
 let cancelOverviewSignal: AbortController;
@@ -156,7 +160,9 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         openSummarytotalOpenKeys: openResponse.data && openResponse.data.totalOpenKeys,
         deletePendingSummarytotalUnrepSize: deletePendingResponse.data && deletePendingResponse.data.totalUnreplicatedDataSize,
         deletePendingSummarytotalRepSize: deletePendingResponse.data && deletePendingResponse.data.totalReplicatedDataSize,
-        deletePendingSummarytotalDeletedKeys: deletePendingResponse.data && deletePendingResponse.data.totalDeletedKeys
+        deletePendingSummarytotalDeletedKeys: deletePendingResponse.data && deletePendingResponse.data.totalDeletedKeys,
+        scmServiceId: clusterState.scmServiceId,
+        omServiceId: clusterState.omServiceId
       });
     })).catch(error => {
       this.setState({
@@ -209,7 +215,8 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
   render() {
     const {loading, datanodes, pipelines, storageReport, containers, volumes, buckets, openSummarytotalUnrepSize, openSummarytotalRepSize, openSummarytotalOpenKeys,
       deletePendingSummarytotalUnrepSize,deletePendingSummarytotalRepSize,deletePendingSummarytotalDeletedKeys,
-      keys, missingContainersCount, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull, omStatus, openContainers, deletedContainers } = this.state;
+      keys, missingContainersCount, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull,
+      omStatus, openContainers, deletedContainers, scmServiceId, omServiceId } = this.state;
       
     const datanodesElement = (
       <span>
@@ -230,6 +237,12 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         {deletePendingSummarytotalDeletedKeys !== undefined ? deletePendingSummarytotalDeletedKeys: '0'}  <span className='ant-card-meta-description meta'>Total Pending Delete Keys</span>
       </div>
   );
+    const scmAndOmServicesData = (
+        <div>
+          SCM Service Id: <span className="ant-card-meta-description meta">{scmServiceId}</span><br />
+          OM Service Id: <span className="ant-card-meta-description meta">{omServiceId}</span>
+        </div>
+    );
     const containersTooltip = missingContainersCount === 1 ? 'container is missing' : 'containers are missing';
     const containersLink = missingContainersCount > 0 ? '/MissingContainers' : '/Containers';
     const volumesLink = '/Volumes';
@@ -249,6 +262,8 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         </Tooltip>
       </div>
     const clusterCapacity = `${size(storageReport.capacity - storageReport.remaining)}/${size(storageReport.capacity)}`;
+    const clusterIsInHaMode = scmServiceId !== null && scmServiceId !== undefined && scmServiceId !== '' && omServiceId !== null
+        && omServiceId !== undefined && omServiceId !== '';
     return (
       <div className='overview-content'>
         <div className='page-header'>
@@ -302,6 +317,11 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
           <Col xs={24} sm={18} md={12} lg={12} xl={6} className='summary-font'>
             <OverviewCard loading={loading} title='Pending Deleted Keys Summary' data={deletePendingSummaryData} icon='delete' linkToUrl='/Om'/>
           </Col>
+          {clusterIsInHaMode &&
+            <Col xs={24} sm={18} md={12} lg={12} xl={6}>
+              <OverviewCard loading={loading} data={scmAndOmServicesData}/>
+            </Col>
+          }
         </Row>
       </div>
     );

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -237,10 +237,14 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         {deletePendingSummarytotalDeletedKeys !== undefined ? deletePendingSummarytotalDeletedKeys: '0'}  <span className='ant-card-meta-description meta'>Total Pending Delete Keys</span>
       </div>
   );
-    const scmAndOmServicesData = (
+    const scmServiceData = (
         <div>
-          SCM Service Id: <span className="ant-card-meta-description meta">{scmServiceId}</span><br />
-          OM Service Id: <span className="ant-card-meta-description meta">{omServiceId}</span>
+          Service Id: <span className="ant-card-meta-description meta" style={{fontSize: "17px"}}>{scmServiceId}</span><br />
+        </div>
+    );
+    const omServiceData = (
+        <div>
+          Service Id: <span className="ant-card-meta-description meta" style={{fontSize: "17px"}}>{omServiceId}</span>
         </div>
     );
     const containersTooltip = missingContainersCount === 1 ? 'container is missing' : 'containers are missing';
@@ -262,8 +266,6 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         </Tooltip>
       </div>
     const clusterCapacity = `${size(storageReport.capacity - storageReport.remaining)}/${size(storageReport.capacity)}`;
-    const clusterIsInHaMode = scmServiceId !== null && scmServiceId !== undefined && scmServiceId !== '' && omServiceId !== null
-        && omServiceId !== undefined && omServiceId !== '';
     return (
       <div className='overview-content'>
         <div className='page-header'>
@@ -317,10 +319,15 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
           <Col xs={24} sm={18} md={12} lg={12} xl={6} className='summary-font'>
             <OverviewCard loading={loading} title='Pending Deleted Keys Summary' data={deletePendingSummaryData} icon='delete' linkToUrl='/Om'/>
           </Col>
-          {clusterIsInHaMode &&
-            <Col xs={24} sm={18} md={12} lg={12} xl={6}>
-              <OverviewCard loading={loading} data={scmAndOmServicesData}/>
-            </Col>
+          {scmServiceId &&
+              <Col xs={24} sm={18} md={12} lg={12} xl={6} className='summary-font'>
+                <OverviewCard title="Storage Container Manager" loading={loading} data={scmServiceData} icon='file-text'/>
+              </Col>
+          }
+          {omServiceId &&
+              <Col xs={24} sm={18} md={12} lg={12} xl={6} className='summary-font'>
+                <OverviewCard title="Ozone Manager" loading={loading} data={omServiceData} icon='file-text' linkToUrl='/Om' />
+              </Col>
           }
         </Row>
       </div>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -236,16 +236,6 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         {deletePendingSummarytotalUnrepSize!== undefined ? byteToSize(deletePendingSummarytotalUnrepSize,1): '0'}  <span className='ant-card-meta-description meta'>Total UnReplicated Data Size</span><br />
         {deletePendingSummarytotalDeletedKeys !== undefined ? deletePendingSummarytotalDeletedKeys: '0'}  <span className='ant-card-meta-description meta'>Total Pending Delete Keys</span>
       </div>
-  );
-    const scmServiceData = (
-        <div>
-          Service Id: <span className="ant-card-meta-description meta" style={{fontSize: "17px"}}>{scmServiceId}</span><br />
-        </div>
-    );
-    const omServiceData = (
-        <div>
-          Service Id: <span className="ant-card-meta-description meta" style={{fontSize: "17px"}}>{omServiceId}</span>
-        </div>
     );
     const containersTooltip = missingContainersCount === 1 ? 'container is missing' : 'containers are missing';
     const containersLink = missingContainersCount > 0 ? '/MissingContainers' : '/Containers';
@@ -320,13 +310,13 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
             <OverviewCard loading={loading} title='Pending Deleted Keys Summary' data={deletePendingSummaryData} icon='delete' linkToUrl='/Om'/>
           </Col>
           {scmServiceId &&
-              <Col xs={24} sm={18} md={12} lg={12} xl={6} className='summary-font'>
-                <OverviewCard title="Storage Container Manager" loading={loading} data={scmServiceData} icon='file-text'/>
+              <Col xs={24} sm={18} md={12} lg={12} xl={6}>
+                <OverviewCard title="SCM Service" loading={loading} data={scmServiceId} icon='file-text'/>
               </Col>
           }
           {omServiceId &&
-              <Col xs={24} sm={18} md={12} lg={12} xl={6} className='summary-font'>
-                <OverviewCard title="Ozone Manager" loading={loading} data={omServiceData} icon='file-text' linkToUrl='/Om' />
+              <Col xs={24} sm={18} md={12} lg={12} xl={6}>
+                <OverviewCard title="OM Service" loading={loading} data={omServiceId} icon='file-text' linkToUrl='/Om' />
               </Col>
           }
         </Row>

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -319,7 +319,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
         reconTestInjector.getInstance(ContainerHealthSchemaManager.class);
     clusterStateEndpoint =
         new ClusterStateEndpoint(reconScm, globalStatsDao,
-            containerHealthSchemaManager);
+            containerHealthSchemaManager, mock(OzoneConfiguration.class));
     containerSizeCountTask = reconScm.getContainerSizeCountTask();
     MetricsServiceProviderFactory metricsServiceProviderFactory =
         reconTestInjector.getInstance(MetricsServiceProviderFactory.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a data block with SCM and OM service IDs if the cluster is in HA mode

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10975

## How was this patch tested?

A new unit-test to check required field values in a response of cluster state endpoint, manually check the Recon UI Overview page
![2024-06-06-142448_3845x1168_scrot](https://github.com/apache/ozone/assets/1343632/47eab60c-d5ee-4b37-a0c3-a064e892c51d)
