### PR TITLE
HDDS-10936. Create hdds-crypto-default module.

### DIFF
--- a/hadoop-hdds/crypto-default/pom.xml
+++ b/hadoop-hdds/crypto-default/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hdds-crypto-default</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
+    <description>Default implementation of Apache Ozone Distributed Data Store's cryptographic functions</description>
+    <name>Apache Ozone HDDS Crypto - Default</name>
+
+    <dependencies>
+
+    </dependencies>
+</project>
+

--- a/hadoop-hdds/crypto-default/pom.xml
+++ b/hadoop-hdds/crypto-default/pom.xml
@@ -27,6 +27,10 @@
     <description>Default implementation of Apache Ozone Distributed Data Store's cryptographic functions</description>
     <name>Apache Ozone HDDS Crypto - Default</name>
 
+    <properties>
+        <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+    </properties>
+
     <dependencies>
 
     </dependencies>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -39,6 +39,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <module>interface-server</module>
     <module>client</module>
     <module>common</module>
+    <module>crypto-default</module>
     <module>framework</module>
     <module>managed-rocksdb</module>
     <module>rocksdb-checkpoint-differ</module>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds the crypto-default module, that will serve as the home of the default (unrestricted) crypto implementation code, that does not have any compliance restrictions, and serves as the default used implementation in our codebase.

On the naming let me add some reasoning.
The `hdds.crypto.compliance.mode` configuration property has a default value of "unrestricted" which may possibly implies that this module should be called hdds-crypto-unrestricted, but as I learned unrestricted may be a confusing term.
As a configuration option, it sounds reasonable, as it marks that the crypto compliance mode is not restricted by any law or ruleset by default. When it comes to module naming though, I think it is much more reasonable to express that this module contains the default implementation, instead of trying to express the intension and some implementation property of the code within, that is why I propose to name this module as hdds-crypto-default.

This PR is related to #6770 in a sense that this one intends to contain an implementation for the generic module, and also this PR is part of the effort defined in the related design under (#6685)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10936

## How was this patch tested?

A local build succeeded with the provided pom.xml, no further test beyond that is required.