### PR TITLE
HDDS-10972. Reduce the default watch timeout configuration in DatanodeRatisServerConfig

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
@@ -86,7 +86,9 @@ public class RatisClientConfig {
         description =
         "The timeout duration for ratis client watch request. "
             + "Timeout for the watch API in Ratis client to acknowledge a "
-            + "particular request getting replayed to all servers.")
+            + "particular request getting replayed to all servers. "
+            + "It is highly recommended for the timeout duration to be strictly longer than "
+            + "Ratis server watch timeout (hdds.ratis.raft.server.watch.timeout)")
     private Duration rpcWatchRequestTimeout = Duration.ofSeconds(180);
 
     public Duration getRpcWatchRequestTimeout() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
@@ -54,14 +54,16 @@ public class DatanodeRatisServerConfig {
   }
 
   @Config(key = "watch.timeout",
-      defaultValue = "180s",
+      defaultValue = "10s",
       type = ConfigType.TIME,
       tags = {OZONE, DATANODE, RATIS},
       description = "The timeout duration for watch request on Ratis Server. " +
           "Timeout for the watch request in Ratis server to acknowledge a " +
-          "particular request is replayed to all servers."
+          "particular request is replayed to all servers. It is highly recommended " +
+          "for the timeout duration to be strictly shorter than Ratis client watch timeout " +
+          "(hdds.ratis.raft.client.rpc.watch.request.timeout)."
   )
-  private long watchTimeOut = Duration.ofSeconds(180).toMillis();
+  private long watchTimeOut = Duration.ofSeconds(10).toMillis();
 
   public long getWatchTimeOut() {
     return watchTimeOut;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
@@ -54,7 +54,7 @@ public class DatanodeRatisServerConfig {
   }
 
   @Config(key = "watch.timeout",
-      defaultValue = "10s",
+      defaultValue = "30s",
       type = ConfigType.TIME,
       tags = {OZONE, DATANODE, RATIS},
       description = "The timeout duration for watch request on Ratis Server. " +
@@ -63,7 +63,7 @@ public class DatanodeRatisServerConfig {
           "for the timeout duration to be strictly shorter than Ratis client watch timeout " +
           "(hdds.ratis.raft.client.rpc.watch.request.timeout)."
   )
-  private long watchTimeOut = Duration.ofSeconds(10).toMillis();
+  private long watchTimeOut = Duration.ofSeconds(30).toMillis();
 
   public long getWatchTimeOut() {
     return watchTimeOut;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce the default duration of Ratis server watch timeout hdds.ratis.raft.server.watch.timeout to reduce the amount of time client needs to wait during two-way commit (i.e. one DN is not reachable).

The watch timeout configuration affects the upper bound of how long the watch request will wait during a block write, let's set it to 10s as a good starting point.

See the related tickets for context.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10972

## How was this patch tested?

Existing tests (thanks for @smengcl for validating the CI earlier). Clean CI: https://github.com/ivandika3/ozone/actions/runs/9365515025

Tested with ozone-ha docker-compose environment with one DN down (using "docker container pause")

Without watch timeout configuration change -> client needs to wait for 3 minutes (the default hdds.ratis.raft.server.watch.timeout configuration)

```
time ozone sh key put /vol1/bucket1/key1 ~/LICENSE.txt --type RATIS -r THREE
real 3m3.037s
user 0m9.957s
sys 0m1.106s 
```

hdds.ratis.raft.server.watch.timeout=30s -> client needs to wait for around 30s

```
time ozone sh key put /vol1/bucket1/key1 ~/LICENSE.txt --type RATIS -r THREE
real 0m33.897s
user 0m9.990s
sys 0m1.346s 
```

hdds.ratis.raft.server.watch.timeout=10s -> client needs to wait for around 10s

```
time ozone sh key put /vol1/bucket1/key1 ~/LICENSE.txt --type RATIS -r THREE
real	0m13.319s
user	0m9.966s
sys	0m1.102s
```


