### PR TITLE
HDDS-10941. Add a few interesting ContainerStateMachine metrics in CSMMetrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -57,6 +57,7 @@ public class ContainerMetrics {
   @Metric private MutableCounterLong numReadStateMachine;
   @Metric private MutableCounterLong bytesReadStateMachine;
 
+
   private final EnumMap<ContainerProtos.Type, MutableCounterLong> numOpsArray;
   private final EnumMap<ContainerProtos.Type, MutableCounterLong> opsBytesArray;
   private final EnumMap<ContainerProtos.Type, MutableRate> opsLatency;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -57,7 +57,6 @@ public class ContainerMetrics {
   @Metric private MutableCounterLong numReadStateMachine;
   @Metric private MutableCounterLong bytesReadStateMachine;
 
-
   private final EnumMap<ContainerProtos.Type, MutableCounterLong> numOpsArray;
   private final EnumMap<ContainerProtos.Type, MutableCounterLong> opsBytesArray;
   private final EnumMap<ContainerProtos.Type, MutableRate> opsLatency;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -64,6 +64,7 @@ public class CSMMetrics {
   private @Metric MutableCounterLong numDataCacheMiss;
   private @Metric MutableCounterLong numDataCacheHit;
   private @Metric MutableCounterLong numEvictedCacheCount;
+  private @Metric MutableCounterLong pendingApplyTransactions;
 
   private @Metric MutableRate applyTransactionNs;
   private @Metric MutableRate writeStateMachineDataNs;
@@ -214,6 +215,14 @@ public class CSMMetrics {
   }
   public void incNumEvictedCacheCount() {
     numEvictedCacheCount.incr();
+  }
+
+  public void incPendingApplyTransactions() {
+    pendingApplyTransactions.incr();
+  }
+
+  public void decPendingApplyTransactions() {
+    pendingApplyTransactions.incr(-1);
   }
 
   public void unRegister() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -70,7 +70,6 @@ public class CSMMetrics {
 
   private @Metric MutableRate applyTransactionNs;
   private @Metric MutableRate writeStateMachineDataNs;
-  private @Metric MutableRate writeChunkCommitNs;
   private @Metric MutableRate untilApplyTransactionNs;
   private @Metric MutableRate startTransactionCompleteNs;
 
@@ -222,10 +221,6 @@ public class CSMMetrics {
 
   public void recordWriteStateMachineCompletionNs(long latencyNanos) {
     writeStateMachineDataNs.add(latencyNanos);
-  }
-
-  public void recordWriteChunkCommitNs(long latencyNanos) {
-    writeChunkCommitNs.add(latencyNanos);
   }
 
   public void recordUntilApplyTransactionNs(long latencyNanos) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -70,6 +70,7 @@ public class CSMMetrics {
 
   private @Metric MutableRate applyTransactionNs;
   private @Metric MutableRate writeStateMachineDataNs;
+  private @Metric MutableRate writeStateMachineQueueingLatencyNs;
   private @Metric MutableRate untilApplyTransactionNs;
   private @Metric MutableRate startTransactionCompleteNs;
 
@@ -223,6 +224,11 @@ public class CSMMetrics {
     writeStateMachineDataNs.add(latencyNanos);
   }
 
+
+  public void recordWriteStateMachineQueueingLatencyNs(long latencyNanos) {
+    writeStateMachineQueueingLatencyNs.add(latencyNanos);
+  }
+
   public void recordUntilApplyTransactionNs(long latencyNanos) {
     untilApplyTransactionNs.add(latencyNanos);
   }
@@ -252,6 +258,6 @@ public class CSMMetrics {
 
   public void unRegister() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    ms.unregisterSource(SOURCE_NAME);
+    ms.unregisterSource(SOURCE_NAME + gid.toString());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -39,6 +39,7 @@ import java.util.EnumMap;
 public class CSMMetrics {
   public static final String SOURCE_NAME =
       CSMMetrics.class.getSimpleName();
+  private RaftGroupId gid;
 
   // ratis op metrics metrics
   private @Metric MutableCounterLong numWriteStateMachineOps;
@@ -69,7 +70,8 @@ public class CSMMetrics {
   private @Metric MutableRate applyTransactionNs;
   private @Metric MutableRate writeStateMachineDataNs;
 
-  public CSMMetrics() {
+  public CSMMetrics(RaftGroupId gid) {
+    this.gid = gid;
     this.opsLatencyMs = new EnumMap<>(ContainerProtos.Type.class);
     this.registry = new MetricsRegistry(CSMMetrics.class.getSimpleName());
     for (ContainerProtos.Type type : ContainerProtos.Type.values()) {
@@ -81,7 +83,12 @@ public class CSMMetrics {
     MetricsSystem ms = DefaultMetricsSystem.instance();
     return ms.register(SOURCE_NAME + gid.toString(),
         "Container State Machine",
-        new CSMMetrics());
+        new CSMMetrics(gid));
+  }
+
+  @Metric
+  public String getRaftGroupId() {
+    return gid.toString();
   }
 
   public void incNumWriteStateMachineOps() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -526,6 +526,8 @@ public class ContainerStateMachine extends BaseStateMachine {
     CompletableFuture<ContainerCommandResponseProto> writeChunkFuture =
         CompletableFuture.supplyAsync(() -> {
           try {
+            metrics.recordWriteStateMachineQueueingLatencyNs(
+                Time.monotonicNowNanos() - startTime);
             return dispatchCommand(requestProto, context);
           } catch (Exception e) {
             LOG.error("{}: writeChunk writeStateMachineData failed: blockId" +

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -895,8 +895,6 @@ public class ContainerStateMachine extends BaseStateMachine {
             // TODO: add a counter to track number of executing applyTransaction
             // and queue size
             ContainerCommandResponseProto proto =  dispatchCommand(request, context);
-            metrics.recordWriteChunkCommitNs(
-                Time.monotonicNowNanos() - timeNow);
             return proto;
           } catch (Exception e) {
             exceptionHandler.accept(e);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -894,8 +894,7 @@ public class ContainerStateMachine extends BaseStateMachine {
             metrics.recordQueueingDelay(request.getCmdType(), queueingDelay);
             // TODO: add a counter to track number of executing applyTransaction
             // and queue size
-            ContainerCommandResponseProto proto =  dispatchCommand(request, context);
-            return proto;
+            return dispatchCommand(request, context);
           } catch (Exception e) {
             exceptionHandler.accept(e);
             throw e;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/DispatcherContext.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.common.transport.server.ratis;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.util.Time;
 import org.apache.ratis.server.protocol.TermIndex;
 
 import java.util.Map;
@@ -118,12 +119,15 @@ public final class DispatcherContext {
 
   private final Map<Long, Long> container2BCSIDMap;
 
+  private long startTime;
+
   private DispatcherContext(Builder b) {
     this.op = Objects.requireNonNull(b.op, "op == null");
     this.term = b.term;
     this.logIndex = b.logIndex;
     this.stage = b.stage;
     this.container2BCSIDMap = b.container2BCSIDMap;
+    this.startTime = Time.monotonicNowNanos();
   }
 
   /** Use {@link DispatcherContext#op(DispatcherContext)} for handling null. */
@@ -145,6 +149,10 @@ public final class DispatcherContext {
 
   public Map<Long, Long> getContainer2BCSIDMap() {
     return container2BCSIDMap;
+  }
+
+  public long getStartTime() {
+    return startTime;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10941. CSMMetrics to record number of started transactions

(1) 
Add a label RaftGroupId so that Prometheus can identify different CSM instances by pipeline id. Previously, only one Container State Machine metrics instance is exported, which is confusing.

Add a few metrics for ContainerStateMachine operations.
* opsQueueingDelay -- the queueing latency of ContainerOp thread pool.
* pendingApplyTransactions -- count the number of transactions between startTransaction and applyTransaction
* untilApplyTransactionNs -- measures the latency between startTransaction and applyTransaction
* startTransactionCompleteNs -- measures the time spent in startTransaction callback method.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10941

## How was this patch tested?

Existing unit tests passed. https://github.com/jojochuang/ozone/actions/runs/9409277999/job/25918878051
Deployed a version of this PR on a real cluster and observed the metrics were exported properly.