### PR TITLE
HDDS-10986. Publish SBOM artifacts

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -113,6 +113,9 @@ run cp  -r "${ROOT}/hadoop-ozone/fault-injection-test/network-tests/src/test/blo
 # Optional documentation, could be missing
 cp -r "${ROOT}/hadoop-hdds/docs/target/classes/docs" ./
 
+# BOM is created only when using 'dist' profile
+cp -p "${ROOT}"/target/bom.* ./
+
 #copy byteman helpers
 run cp -r "${ROOT}/dev-support/byteman" "share/ozone/"
 

--- a/pom.xml
+++ b/pom.xml
@@ -1848,9 +1848,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 </goals>
               </execution>
             </executions>
-            <configuration>
-              <outputFormat>xml</outputFormat>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <derby.version>10.14.2.0</derby.version>
     <codahale-metrics.version>3.0.2</codahale-metrics.version>
-    <cyclonedx.version>2.7.10</cyclonedx.version>
+    <cyclonedx.version>2.8.0</cyclonedx.version>
     <dropwizard-metrics.version>3.2.6</dropwizard-metrics.version>
     <jacoco.version>0.8.12</jacoco.version>
     <javassist.version>3.30.2-GA</javassist.version>
@@ -1844,7 +1844,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <execution>
                 <phase>package</phase>
                 <goals>
-                  <goal>makeBom</goal>
+                  <goal>makeAggregateBom</goal>
                 </goals>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <derby.version>10.14.2.0</derby.version>
     <codahale-metrics.version>3.0.2</codahale-metrics.version>
+    <cyclonedx.version>2.7.10</cyclonedx.version>
     <dropwizard-metrics.version>3.2.6</dropwizard-metrics.version>
     <jacoco.version>0.8.12</jacoco.version>
     <javassist.version>3.30.2-GA</javassist.version>
@@ -1574,6 +1575,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <artifactId>download-maven-plugin</artifactId>
           <version>${download-maven-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${cyclonedx.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -1830,6 +1836,21 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>makeBom</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <outputFormat>xml</outputFormat>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create and publish Software Bill of Materials (SBOM) for Ozone.

https://cwiki.apache.org/confluence/display/SECURITY/Software+Bill+of+Materials+SBOM

SBOM is created using `cyclonedx-maven-plugin` at build time, when using `dist` profile.

Both aggregate and module-level BOM is created.  Aggregate SBOM is included in the binary tarball, submodule BOMs are attached to JARs published to Maven repo.

https://issues.apache.org/jira/browse/HDDS-10986

## How was this patch tested?

```
$ mvn -DskipShade -DskipTests -Pdist clean install
...

$ ls -1hs hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/bom*
640K hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/bom.json
572K hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/bom.xml
...

$ ls ~/.m2/repository/org/apache/ozone/hdds-config/1.5.0-SNAPSHOT/*cyclonedx.*
~/.m2/repository/org/apache/ozone/hdds-config/1.5.0-SNAPSHOT/hdds-config-1.5.0-SNAPSHOT-cyclonedx.json
~/.m2/repository/org/apache/ozone/hdds-config/1.5.0-SNAPSHOT/hdds-config-1.5.0-SNAPSHOT-cyclonedx.xml
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/9417663961