### PR TITLE
HDDS-10988. Let zero OzoneQuota use byte as unit

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -77,9 +77,11 @@ public final class OzoneQuota {
     PARSE_ORDER = Collections.unmodifiableList(reversed);
   }
 
+  private static final RawQuotaInBytes ZERO_BYTES = new RawQuotaInBytes(Units.B, 0);
+
   // Quota to decide how many buckets can be created.
   private long quotaInNamespace;
-  // Quota to decide how many storage space will be used in bytes.
+  // Quota to decide how much storage space will be used in bytes.
   private final long quotaInBytes;
   private final RawQuotaInBytes rawQuotaInBytes;
 
@@ -89,6 +91,9 @@ public final class OzoneQuota {
   private static class RawQuotaInBytes {
     static RawQuotaInBytes valueOf(long quotaInBytes) {
       Preconditions.assertTrue(quotaInBytes >= 0, () -> "quotaInBytes = " + quotaInBytes + " must be >= 0");
+      if (quotaInBytes == 0) {
+        return ZERO_BYTES;
+      }
       final int i = Long.numberOfTrailingZeros(quotaInBytes) / 10;
       final Units unit = Units.values()[i];
       final RawQuotaInBytes b = unit.getRawQuotaInBytes(quotaInBytes >> (i * 10));

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestOzoneQuota.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestOzoneQuota.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link OzoneQuota}. */
+class TestOzoneQuota {
+  @Test
+  void zeroBytes() {
+    OzoneQuota actual = OzoneQuota.getOzoneQuota(0, 1);
+    assertEquals(0, actual.getQuotaInBytes());
+    assertEquals(0, actual.getRawSize());
+    assertEquals(OzoneQuota.Units.B, actual.getUnit());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RawQuotaInBytes.valueOf(0)` creates an object with unit of `EB`.  This PR changes that to use `B` (byte) as unit.

https://issues.apache.org/jira/browse/HDDS-10988

## How was this patch tested?

Added unit test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/9420841951