### PR TITLE
HDDS-10990. Fix memory leak in native lib

### DIFF
--- a/hadoop-hdds/rocks-native/src/main/patches/rocks-native.patch
+++ b/hadoop-hdds/rocks-native/src/main/patches/rocks-native.patch
@@ -217,10 +217,10 @@ index 000000000..3051637a3
 +#endif  // ROCKSDB_LITE
 diff --git a/tools/raw_sst_file_iterator.h b/tools/raw_sst_file_iterator.h
 new file mode 100644
-index 000000000..58e34b260
+index 000000000..eedb848b5
 --- /dev/null
 +++ b/tools/raw_sst_file_iterator.h
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,46 @@
 +//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
 +//  This source code is licensed under both the GPLv2 (found in the
 +//  COPYING file in the root directory) and Apache 2.0 License
@@ -253,6 +253,7 @@ index 000000000..58e34b260
 +
 +  ~RawSstFileIterator(){
 +    delete iter_;
++    delete ikey;
 +  }
 +
 + private:


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changing the patch file in native lib to clear ParsedInternalKey object.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10990