### PR TITLE
HDDS-10997. Avoid publishing build scan for helper Maven commands

### DIFF
--- a/.github/workflows/build-ratis.yml
+++ b/.github/workflows/build-ratis.yml
@@ -84,15 +84,15 @@ jobs:
       - name: Get component versions
         id: versions
         run: |
-          thirdparty_version="$(mvn help:evaluate -N -q -DforceStdout -Dexpression=ratis.thirdparty.version)"
+          thirdparty_version="$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=ratis.thirdparty.version)"
           echo "thirdparty=${thirdparty_version}" >> $GITHUB_OUTPUT
 
           ratis_sha=$(git rev-parse --short HEAD)
-          ratis_version="$(mvn help:evaluate -N -q -DforceStdout -Dexpression=project.version | sed -e "s/-SNAPSHOT/-${ratis_sha}-SNAPSHOT/")"
+          ratis_version="$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=project.version | sed -e "s/-SNAPSHOT/-${ratis_sha}-SNAPSHOT/")"
           echo "ratis=${ratis_version}" >> $GITHUB_OUTPUT
       - name: Run a full build
         run: |
-          mvn versions:set -DnewVersion=${{ steps.versions.outputs.ratis }}
+          mvn versions:set -DnewVersion=${{ steps.versions.outputs.ratis }} -Dscan=false
           dev-support/checks/build.sh
       - name: Store Maven repo for tests
         uses: actions/upload-artifact@v4
@@ -119,9 +119,9 @@ jobs:
       - name: Get component versions
         id: versions
         run: |
-          echo "grpc=$(mvn help:evaluate -N -q -DforceStdout -Dexpression=shaded.grpc.version)" >> $GITHUB_OUTPUT
-          echo "netty=$(mvn help:evaluate -N -q -DforceStdout -Dexpression=shaded.netty.version)" >> $GITHUB_OUTPUT
-          echo "protobuf=$(mvn help:evaluate -N -q -DforceStdout -Dexpression=shaded.protobuf.version)" >> $GITHUB_OUTPUT
+          echo "grpc=$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=shaded.grpc.version)" >> $GITHUB_OUTPUT
+          echo "netty=$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=shaded.netty.version)" >> $GITHUB_OUTPUT
+          echo "protobuf=$(mvn help:evaluate -N -q -DforceStdout -Dscan=false -Dexpression=shaded.protobuf.version)" >> $GITHUB_OUTPUT
   debug:
     runs-on: ubuntu-20.04
     needs:

--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Get NodeJS version
         id: nodejs-version
         if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: echo "nodejs-version=$(mvn help:evaluate -Dexpression=nodejs.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+        run: echo "nodejs-version=$(mvn help:evaluate -Dexpression=nodejs.version -q -DforceStdout -Dscan=false)" >> $GITHUB_OUTPUT
 
       - name: Restore NodeJS tarballs
         id: restore-nodejs

--- a/dev-support/ci/download-nodejs.sh
+++ b/dev-support/ci/download-nodejs.sh
@@ -34,7 +34,7 @@ mkdir -p "${REPO_DIR}"
 declare -i rc=1
 
 if [[ -z "${NODEJS_VERSION:-}" ]]; then
-  NODEJS_VERSION=$(mvn help:evaluate -Dexpression=nodejs.version -q -DforceStdout)
+  NODEJS_VERSION=$(mvn help:evaluate -Dexpression=nodejs.version -q -DforceStdout -Dscan=false)
 fi
 
 if [[ -n "${NODEJS_VERSION}" ]]; then

--- a/hadoop-hdds/docs/dev-support/bin/generate-site.sh
+++ b/hadoop-hdds/docs/dev-support/bin/generate-site.sh
@@ -24,7 +24,7 @@ if [ ! "$(which hugo)" ]; then
    exit 0
 fi
 
-export OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout)
+export OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout -Dscan=false)
 
 ENABLE_GIT_INFO=
 if git -C $(pwd) status >& /dev/null; then

--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -31,7 +31,7 @@ source "${DIR}/_lib.sh"
 
 REPORT_DIR=${OUTPUT_DIR:-"${OZONE_ROOT}/target/acceptance"}
 
-OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout)
+OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout -Dscan=false)
 DIST_DIR="${OZONE_ROOT}/hadoop-ozone/dist/target/ozone-$OZONE_VERSION"
 
 if [ ! -d "$DIST_DIR" ]; then
@@ -45,7 +45,7 @@ if [[ "${OZONE_ACCEPTANCE_SUITE}" == "s3a" ]]; then
   OZONE_ACCEPTANCE_TEST_TYPE="maven"
 
   if [[ -z "${HADOOP_AWS_DIR}" ]]; then
-    HADOOP_VERSION=$(mvn help:evaluate -Dexpression=hadoop.version -q -DforceStdout)
+    HADOOP_VERSION=$(mvn help:evaluate -Dexpression=hadoop.version -q -DforceStdout -Dscan=false)
     export HADOOP_AWS_DIR=${OZONE_ROOT}/target/hadoop-src
   fi
 

--- a/hadoop-ozone/dev-support/checks/blockade.sh
+++ b/hadoop-ozone/dev-support/checks/blockade.sh
@@ -17,7 +17,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
-OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout)
+OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout -Dscan=false)
 cd "$DIR/../../dist/target/ozone-$OZONE_VERSION/tests" || exit 1
 
 source ${DIR}/../../dist/target/ozone-${OZONE_VERSION}/compose/ozoneblockade/.env

--- a/hadoop-ozone/dev-support/checks/coverage.sh
+++ b/hadoop-ozone/dev-support/checks/coverage.sh
@@ -26,10 +26,10 @@ REPORT_DIR="$DIR/../../../target/coverage"
 
 mkdir -p "$REPORT_DIR"
 
-JACOCO_VERSION=$(mvn help:evaluate -Dexpression=jacoco.version -q -DforceStdout)
+JACOCO_VERSION=$(mvn help:evaluate -Dexpression=jacoco.version -q -DforceStdout -Dscan=false)
 
 #Install jacoco cli
-mvn --non-recursive --no-transfer-progress \
+mvn --non-recursive --no-transfer-progress -Dscan=false \
   org.apache.maven.plugins:maven-dependency-plugin:copy \
   -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps
 

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -103,7 +103,7 @@ fi
 
 if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
   #Archive combined jacoco records
-  mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
+  mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec -Dscan=false
 fi
 
 exit ${rc}

--- a/hadoop-ozone/dev-support/checks/kubernetes.sh
+++ b/hadoop-ozone/dev-support/checks/kubernetes.sh
@@ -36,7 +36,7 @@ fi
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/kubernetes"}
 
-OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout)
+OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout -Dscan=false)
 DIST_DIR="$DIR/../../dist/target/ozone-$OZONE_VERSION"
 
 if [ ! -d "$DIST_DIR" ]; then

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -129,7 +129,7 @@ regenerate_resources() {
   if [ $(basename $PARENT_OF_PARENT) == "k8s" ]; then
     #running from src dir
     local version
-    version=$(cd ../../../../.. && mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout)
+    version=$(cd ../../../../.. && mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout -Dscan=false)
     OZONE_ROOT=$(realpath ../../../../../target/ozone-${version})
   else
     #running from dist

--- a/hadoop-ozone/dist/src/main/keytabs/update-keytabs.sh
+++ b/hadoop-ozone/dist/src/main/keytabs/update-keytabs.sh
@@ -91,7 +91,7 @@ if [ "$1" == "internal" ]; then
    exit 0
 fi
 
-TESTKRB5_IMAGE=$(mvn -f "$SCRIPT_DIR"/../../../pom.xml help:evaluate -Dexpression=docker.ozone-testkr5b.image -q -DforceStdout)
+TESTKRB5_IMAGE=$(mvn -f "$SCRIPT_DIR"/../../../pom.xml help:evaluate -Dexpression=docker.ozone-testkr5b.image -q -DforceStdout -Dscan=false)
 
 docker run -it --entrypoint=/etc/security/keytabs/update-keytabs.sh -v "$SCRIPT_DIR":/etc/security/keytabs $TESTKRB5_IMAGE internal
 

--- a/hadoop-ozone/dist/src/main/license/update-jar-report.sh
+++ b/hadoop-ozone/dist/src/main/license/update-jar-report.sh
@@ -22,7 +22,7 @@ REPORT_NAME=${1:-current.txt}
 
 cd "$SCRIPTDIR/../../.." || exit 1
 
-OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout)
+OZONE_VERSION=$(mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout -Dscan=false)
 DIST_DIR="$SCRIPTDIR/../../../target/ozone-$OZONE_VERSION"
 : ${OZONE_DIST_DIR:=$DIST_DIR}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Skip publication of build scans for helper Maven commands:
* read dependency versions (`help:evaluate`)
* merge Jacoco files (`jacoco:merge`)
* set version in POMs (`versions:set`)

to reduce noise in Develocity.

https://issues.apache.org/jira/browse/HDDS-10997

## How was this patch tested?

CI run in `apache/ozone`:
https://github.com/apache/ozone/actions/runs/9429335669

Verified that the run published no scans for helper tasks:
https://ge.apache.org/scans?search.rootProjectNames=Apache%20Ozone%20Main&search.startTimeMax=1717883999999&search.startTimeMin=1717855200000&search.tags=HDDS-10997&search.timeZoneId=Europe%2FVienna