### PR TITLE
HDDS-10788. Intermittent failure in testWatchForCommitForRetryfailure

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -272,7 +272,7 @@ public class TestWatchForCommit {
                 xceiverClient.getPipeline()));
         reply.getResponse().get();
         long index = reply.getLogIndex();
-        for (int i=0; i < pipeline.getNodes().size(); i++) {
+        for (int i = 0; i < pipeline.getNodes().size(); i++) {
           cluster.shutdownHddsDatanode(pipeline.getNodes().get(i));
         }
         // emulate closing pipeline when SCM detects DEAD datanodes

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -272,7 +272,7 @@ public class TestWatchForCommit {
                 xceiverClient.getPipeline()));
         reply.getResponse().get();
         long index = reply.getLogIndex();
-        for (int i; i < pipeline.getNodes(); i++) {
+        for (int i; i < pipeline.getNodes().size(); i++) {
           cluster.shutdownHddsDatanode(pipeline.getNodes().get(i));
         }
         // emulate closing pipeline when SCM detects DEAD datanodes

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -273,8 +273,9 @@ public class TestWatchForCommit {
                 xceiverClient.getPipeline()));
         reply.getResponse().get();
         long index = reply.getLogIndex();
-        for (int i; i < pipeline.getNodes(); i++)
+        for (int i; i < pipeline.getNodes(); i++) {
           cluster.shutdownHddsDatanode(pipeline.getNodes().get(i));
+        }
         // emulate closing pipeline when SCM detects DEAD datanodes
         cluster.getStorageContainerManager()
             .getPipelineManager().closePipeline(pipeline, false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -272,7 +272,7 @@ public class TestWatchForCommit {
                 xceiverClient.getPipeline()));
         reply.getResponse().get();
         long index = reply.getLogIndex();
-        for (int i; i < pipeline.getNodes().size(); i++) {
+        for (int i=0; i < pipeline.getNodes().size(); i++) {
           cluster.shutdownHddsDatanode(pipeline.getNodes().get(i));
         }
         // emulate closing pipeline when SCM detects DEAD datanodes

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -309,12 +309,12 @@ public class TestWatchForCommit {
         XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
 //        GenericTestUtils.waitFor(() ->
 //            cluster.getStorageContainerManager().checkLeader(), 1000, 20000);
-        Thread.sleep(6000);
+//        Thread.sleep(6000);
         XceiverClientReply reply = xceiverClient.sendCommandAsync(
             ContainerTestHelper.getCreateContainerRequest(
                 container1.getContainerInfo().getContainerID(),
                 xceiverClient.getPipeline()));
-//        Thread.sleep(5000);
+        Thread.sleep(7000);
         reply.getResponse().get();
         assertEquals(3, ratisClient.getCommitInfoMap().size());
         List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -307,12 +307,12 @@ public class TestWatchForCommit {
         Pipeline pipeline = xceiverClient.getPipeline();
         TestHelper.createPipelineOnDatanode(pipeline, cluster);
         XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
+        GenericTestUtils.waitFor(() ->
+            cluster.getStorageContainerManager().checkLeader(), 1000, 20000);
         XceiverClientReply reply = xceiverClient.sendCommandAsync(
             ContainerTestHelper.getCreateContainerRequest(
                 container1.getContainerInfo().getContainerID(),
                 xceiverClient.getPipeline()));
-        GenericTestUtils.waitFor(() ->
-            cluster.getStorageContainerManager().checkLeader(), 1000, 10000);
         reply.getResponse().get();
         assertEquals(3, ratisClient.getCommitInfoMap().size());
         List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -311,6 +311,8 @@ public class TestWatchForCommit {
             ContainerTestHelper.getCreateContainerRequest(
                 container1.getContainerInfo().getContainerID(),
                 xceiverClient.getPipeline()));
+        GenericTestUtils.waitFor(() ->
+            cluster.getStorageContainerManager().checkLeader(), 1000, 10000);
         reply.getResponse().get();
         assertEquals(3, ratisClient.getCommitInfoMap().size());
         List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -309,12 +309,12 @@ public class TestWatchForCommit {
         XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
 //        GenericTestUtils.waitFor(() ->
 //            cluster.getStorageContainerManager().checkLeader(), 1000, 20000);
-        Thread.sleep(3000);
+        Thread.sleep(5000);
         XceiverClientReply reply = xceiverClient.sendCommandAsync(
             ContainerTestHelper.getCreateContainerRequest(
                 container1.getContainerInfo().getContainerID(),
                 xceiverClient.getPipeline()));
-        Thread.sleep(3000);
+        Thread.sleep(5000);
         reply.getResponse().get();
         assertEquals(3, ratisClient.getCommitInfoMap().size());
         List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -80,7 +80,6 @@ import org.junit.jupiter.api.Test;
 /**
  * This class verifies the watchForCommit Handling by xceiverClient.
  */
-@Flaky("HDDS-5818")
 public class TestWatchForCommit {
 
   private MiniOzoneCluster cluster;
@@ -274,8 +273,8 @@ public class TestWatchForCommit {
                 xceiverClient.getPipeline()));
         reply.getResponse().get();
         long index = reply.getLogIndex();
-        cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
-        cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
+        for (int i; i < pipeline.getNodes(); i++)
+          cluster.shutdownHddsDatanode(pipeline.getNodes().get(i));
         // emulate closing pipeline when SCM detects DEAD datanodes
         cluster.getStorageContainerManager()
             .getPipelineManager().closePipeline(pipeline, false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -62,7 +62,6 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -309,12 +309,12 @@ public class TestWatchForCommit {
         XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
 //        GenericTestUtils.waitFor(() ->
 //            cluster.getStorageContainerManager().checkLeader(), 1000, 20000);
-        Thread.sleep(5000);
+        Thread.sleep(6000);
         XceiverClientReply reply = xceiverClient.sendCommandAsync(
             ContainerTestHelper.getCreateContainerRequest(
                 container1.getContainerInfo().getContainerID(),
                 xceiverClient.getPipeline()));
-        Thread.sleep(5000);
+//        Thread.sleep(5000);
         reply.getResponse().get();
         assertEquals(3, ratisClient.getCommitInfoMap().size());
         List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -307,12 +307,14 @@ public class TestWatchForCommit {
         Pipeline pipeline = xceiverClient.getPipeline();
         TestHelper.createPipelineOnDatanode(pipeline, cluster);
         XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
-        GenericTestUtils.waitFor(() ->
-            cluster.getStorageContainerManager().checkLeader(), 1000, 20000);
+//        GenericTestUtils.waitFor(() ->
+//            cluster.getStorageContainerManager().checkLeader(), 1000, 20000);
+        Thread.sleep(3000);
         XceiverClientReply reply = xceiverClient.sendCommandAsync(
             ContainerTestHelper.getCreateContainerRequest(
                 container1.getContainerInfo().getContainerID(),
                 xceiverClient.getPipeline()));
+        Thread.sleep(3000);
         reply.getResponse().get();
         assertEquals(3, ratisClient.getCommitInfoMap().size());
         List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();


### PR DESCRIPTION
## What changes were proposed in this pull request?
The intermittent failure in TestWatchForCommit.testWatchForCommitForRetryfailure
Fixed the changes and tested it for 1000 runs.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10788

## How was this patch tested?
Reproduced and tested the scenario in local system. Tested it in CI build. Earlier there were 4.5% failure ratio for 1000 runs https://github.com/raju-balpande/apache_ozone/actions/runs/9398762434 
Now it succeed completely here https://github.com/raju-balpande/apache_ozone/actions/runs/9427808268 
