### PR TITLE
HDDS-10640. Support x-amz-mp-parts-count for MPU key

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -150,10 +150,12 @@ Test Multipart Upload Complete
 
 #check whether parts count is retrieved through get and head object
     ${result}                   Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --part-number 1 /tmp/${PREFIX}-multipartKey1-part1.result
-                                Should contain             ${result}        PartsCount
+    ${partsCount}               Execute and checkrc        echo '${result}' | jq -r '.PartsCount'    0
+                                Should Be Equal            ${partsCount}    2
 
     ${result}                   Execute AWSS3ApiCli        head-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1
-                                Should contain             ${result}        PartsCount
+    ${partsCount}               Execute and checkrc        echo '${result}' | jq -r '.PartsCount'    0
+                                Should Be Equal            ${partsCount}    2
 
 Test Multipart Upload with user defined metadata size larger than 2 KB
     ${custom_metadata_value} =  Execute                               printf 'v%.0s' {1..3000}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -148,6 +148,13 @@ Test Multipart Upload Complete
     ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --part-number 2 /tmp/${PREFIX}-multipartKey1-part2.result
     Compare files               /tmp/part2        /tmp/${PREFIX}-multipartKey1-part2.result
 
+#check whether parts count is retrieved through get and head object
+    ${result}                   Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --part-number 1 /tmp/${PREFIX}-multipartKey1-part1.result
+                                Should contain             ${result}        PartsCount
+
+    ${result}                   Execute AWSS3ApiCli        head-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1
+                                Should contain             ${result}        PartsCount
+
 Test Multipart Upload with user defined metadata size larger than 2 KB
     ${custom_metadata_value} =  Execute                               printf 'v%.0s' {1..3000}
     ${result} =                 Execute AWSS3APICli and checkrc       create-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpuWithLargeMetadata --metadata="custom-key1=${custom_metadata_value}"    255

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -170,6 +170,7 @@ public class TestMultipartObjectGet {
         REST.get(BUCKET, KEY, partNumber, null, 100, null);
     assertEquals(200, response.getStatus());
     assertEquals(bytes, response.getLength());
+    assertEquals("3", response.getHeaderString("x-amz-mp-parts-count"));
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -48,6 +48,7 @@ import java.util.Base64;
 import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.MP_PARTS_COUNT;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -170,7 +171,13 @@ public class TestMultipartObjectGet {
         REST.get(BUCKET, KEY, partNumber, null, 100, null);
     assertEquals(200, response.getStatus());
     assertEquals(bytes, response.getLength());
-    assertEquals("3", response.getHeaderString("x-amz-mp-parts-count"));
+    assertEquals("3", response.getHeaderString(MP_PARTS_COUNT));
+  }
+
+  private void headObjectMultipart() throws IOException, OS3Exception {
+    Response response = REST.head(BUCKET, KEY);
+    assertEquals(200, response.getStatus());
+    assertEquals("3", response.getHeaderString(MP_PARTS_COUNT));
   }
 
   @Test
@@ -200,6 +207,8 @@ public class TestMultipartObjectGet {
         CompleteMultipartUploadRequest();
     completeMultipartUploadRequest.setPartList(partsList);
     completeMultipartUpload(completeMultipartUploadRequest, uploadID);
+
+    headObjectMultipart();
 
     getObjectMultipart(0,
         (content1 + content2 + content3).getBytes(UTF_8).length);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -123,7 +123,21 @@ import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_UPLOAD;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
-import static org.apache.hadoop.ozone.s3.util.S3Consts.*;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.ACCEPT_RANGE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.CUSTOM_METADATA_COPY_DIRECTIVE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.DECODED_CONTENT_LENGTH_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.CONTENT_RANGE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER_RANGE;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_IF_MODIFIED_SINCE;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_IF_UNMODIFIED_SINCE;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_HEADER_SUPPORTED_UNIT;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.STORAGE_CLASS_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.CopyDirective;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_COUNT_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.TAG_DIRECTIVE_HEADER;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.MP_PARTS_COUNT;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.urlDecode;
 
 /**

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -493,8 +493,9 @@ public class ObjectEndpoint extends EndpointBase {
       String eTag = keyDetails.getMetadata().get(ETAG);
       if (eTag != null) {
         responseBuilder.header(ETAG, wrapInQuotes(eTag));
-        if (eTag.contains("-")) {
-          responseBuilder.header(MP_PARTS_COUNT, extractPartsCount(eTag));
+        String partsCount = extractPartsCount(eTag);
+        if (partsCount != null) {
+          responseBuilder.header(MP_PARTS_COUNT, partsCount);
         }
       }
 
@@ -624,8 +625,9 @@ public class ObjectEndpoint extends EndpointBase {
       // doing so will result in "null" string being returned instead
       // which breaks some AWS SDK implementation
       response.header(ETAG, wrapInQuotes(eTag));
-      if (eTag.contains("-")) {
-        response.header(MP_PARTS_COUNT, extractPartsCount(eTag));
+      String partsCount = extractPartsCount(eTag);
+      if (partsCount != null) {
+        response.header(MP_PARTS_COUNT, partsCount);
       }
     }
 
@@ -1399,7 +1401,11 @@ public class ObjectEndpoint extends EndpointBase {
   }
 
   private String extractPartsCount(String eTag) {
-    String[] parts = eTag.replace("\"", "").split("-");
-    return  parts[parts.length - 1];
+    if (eTag.contains("-")) {
+      String[] parts = eTag.replace("\"", "").split("-");
+      String lastPart = parts[parts.length - 1];
+      return lastPart.matches("\\d+") ? lastPart : null;
+    }
+    return null;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
@@ -81,6 +81,8 @@ public final class S3Consts {
   // See https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_S3Tag.html
   // Also see https://docs.aws.amazon.com/directoryservice/latest/devguide/API_Tag.html for Java regex equivalent
   public static final Pattern TAG_REGEX_PATTERN = Pattern.compile("^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-]*)$");
+  public static final String MP_PARTS_COUNT = "x-amz-mp-parts-count";
+
 
   /**
    * Copy directive for metadata and tags.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support the `x-amz-mp-parts-count` for MPU key. This value is returned if the object is uploaded as a multipart upload. The response is displayed in the get and head object aws commands as `PartsCount`.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10640

## How was this patch tested?
Tested the patch locally on a docker cluster and verified the output.
sarvekshayr@Sarvekshas-MacBook-Pro ozonesecure % aws s3api head-object --bucket multipart-30oct-rat --endpoint http://localhost:9878 --key my_1GB_file
```
{
    "LastModified": "2024-06-10T05:07:19+00:00",
    "ContentLength": 1048576000,
    "ETag": "\"9866ed9e49f7808c22243d26910dd99d-2\"",
    "CacheControl": "no-cache",
    "ContentType": "binary/octet-stream",
    "Expires": "2024-06-10T05:07:37+00:00",
    "Metadata": {},
    "PartsCount": 2
}
```

sarvekshayr@Sarvekshas-MacBook-Pro ozonesecure % aws s3api get-object --bucket multipart-30oct-rat --endpoint http://localhost:9878 --key my_1GB_file outfile
```
{
    "AcceptRanges": "bytes",
    "LastModified": "2024-06-10T05:07:19+00:00",
    "ContentLength": 1048576000,
    "ETag": "\"9866ed9e49f7808c22243d26910dd99d-2\"",
    "CacheControl": "no-cache",
    "ContentType": "application/octet-stream",
    "Expires": "2024-06-10T05:08:45+00:00",
    "Metadata": {},
    "PartsCount": 2
}
```
