### PR TITLE
HDDS-10843. Enhance rewrite test to cover all key attributes

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1124,7 +1124,6 @@ public abstract class TestOzoneRpcClientAbstract extends OzoneTestBase {
   void overwriteAfterRewrite(BucketLayout layout) throws IOException {
     OzoneBucket bucket = createBucket(layout);
     OzoneKeyDetails keyDetails = createTestKey(bucket);
-    OmKeyArgs keyArgs = toOmKeyArgs(keyDetails);
     rewriteKey(bucket, keyDetails, "rewrite".getBytes(UTF_8));
 
     final byte[] overwriteContent = "overwrite".getBytes(UTF_8);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -134,6 +134,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+
+import static java.util.Collections.singletonMap;
 import static org.apache.hadoop.hdds.StringUtils.string2Bytes;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.THREE;
@@ -1124,15 +1126,12 @@ public abstract class TestOzoneRpcClientAbstract extends OzoneTestBase {
     OzoneKeyDetails keyDetails = createTestKey(bucket);
     OmKeyArgs keyArgs = toOmKeyArgs(keyDetails);
     rewriteKey(bucket, keyDetails, "rewrite".getBytes(UTF_8));
-    OmKeyInfo keyInfo = ozoneManager.lookupKey(keyArgs);
 
     final byte[] overwriteContent = "overwrite".getBytes(UTF_8);
     OzoneKeyDetails overwriteDetails = createTestKey(bucket, keyDetails.getName(), overwriteContent);
 
     OzoneKeyDetails actualKeyDetails = assertKeyContent(bucket, keyDetails.getName(), overwriteContent);
     assertEquals(overwriteDetails.getGeneration(), actualKeyDetails.getGeneration());
-    assertMetadataUnchanged(keyDetails, actualKeyDetails);
-    assertMetadataAfterRewrite(keyInfo, ozoneManager.lookupKey(keyArgs));
   }
 
   @ParameterizedTest
@@ -4075,7 +4074,8 @@ public abstract class TestOzoneRpcClientAbstract extends OzoneTestBase {
       OzoneBucket bucket, String keyName, byte[] bytes
   ) throws IOException {
     RatisReplicationConfig replication = RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE);
-    try (OzoneOutputStream out = bucket.createKey(keyName, bytes.length, replication, new HashMap<>())) {
+    Map<String, String> metadata = singletonMap("key", RandomStringUtils.randomAscii(10));
+    try (OzoneOutputStream out = bucket.createKey(keyName, bytes.length, replication, metadata)) {
       out.write(bytes);
     }
     OzoneKeyDetails key = bucket.getKey(keyName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add assertions about `OmKeyInfo` and `OzoneKey` attributes for tests covering rewrite.

https://issues.apache.org/jira/browse/HDDS-10843

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/9448431396