### PR TITLE
HDDS-10999. Remove dependency on ratis-server from Ozone Client

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -96,18 +96,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
-      <artifactId>ratis-server</artifactId>
+      <artifactId>ratis-server-api</artifactId>
       <groupId>org.apache.ratis</groupId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-reload4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk18on</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <artifactId>ratis-metrics-dropwizard3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -688,8 +688,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>${ratis.version}</version>
       </dependency>
       <dependency>
-        <artifactId>ratis-client</artifactId>
         <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-client</artifactId>
+        <version>${ratis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-server-api</artifactId>
         <version>${ratis.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS/Ozone Client depends (via `hdds-common`) on Ratis Server, which is unnecessary after the separation of Ratis Server API.

https://issues.apache.org/jira/browse/HDDS-10999

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/9450260526