### PR TITLE
HDDS-11001. Speed up some tests that restart datanode

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -167,6 +167,7 @@ public class TestContainerCommandsEC {
   public static void init() throws Exception {
     config = new OzoneConfiguration();
     config.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
+    config.setTimeDuration(ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     config.setBoolean(OzoneConfigKeys.OZONE_ACL_ENABLED, true);
     config.set(OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneContainerUpgradeShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneContainerUpgradeShell.java
@@ -69,6 +69,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERV
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.CONTAINER_SCHEMA_V3_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,6 +100,7 @@ public class TestOzoneContainerUpgradeShell {
     conf.set(OZONE_ADMINISTRATORS, "*");
     conf.setTimeDuration(OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL, 100,
         TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 1, SECONDS);
     conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1, SECONDS);
     conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 1, SECONDS);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.ReconfigurableBase;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.Timeout;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -66,6 +68,7 @@ public class TestReconfigShell {
   @BeforeAll
   public static void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
     String omServiceId = UUID.randomUUID().toString();
     cluster = MiniOzoneCluster.newHABuilder(conf)
         .setOMServiceId(omServiceId)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Restarting datanode in integration test with `waitForDatanode=true` waits for the node to become stale.  Reducing stale node period (like most other tests already do) can improve test execution time.

https://issues.apache.org/jira/browse/HDDS-11001

## How was this patch tested?

Before:

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 129.058 s - in org.apache.hadoop.ozone.shell.TestReconfigShell
[INFO] org.apache.hadoop.ozone.shell.TestReconfigShell.testStorageContainerManagerGetReconfigurationProperties  Time elapsed: 0.097 s
[INFO] org.apache.hadoop.ozone.shell.TestReconfigShell.testDataNodeGetReconfigurableProperties  Time elapsed: 0.076 s
[INFO] org.apache.hadoop.ozone.shell.TestReconfigShell.testDatanodeBulkReconfig  Time elapsed: 107.224 s
[INFO] org.apache.hadoop.ozone.shell.TestReconfigShell.testOzoneManagerGetReconfigurationProperties  Time elapsed: 0.022 s
[INFO] Running org.apache.hadoop.ozone.shell.TestOzoneContainerUpgradeShell
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 133.043 s - in org.apache.hadoop.ozone.shell.TestOzoneContainerUpgradeShell
[INFO] org.apache.hadoop.ozone.shell.TestOzoneContainerUpgradeShell.testNormalContainerUpgrade  Time elapsed: 115.725 s
[INFO] Running org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 170.121 s - in org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorShouldCleanupContainersOnFailure  Time elapsed: 30.298 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithFullAndPartialStripe(List)[1]  Time elapsed: 0.292 s
...
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithFullAndPartialStripe(List)[9]  Time elapsed: 0.185 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testCreateRecoveryContainer  Time elapsed: 0.024 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testCreateRecoveryContainerAfterDNRestart  Time elapsed: 108.108 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithPartialStripe(List)[1]  Time elapsed: 0.15 s
...
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithPartialStripe(List)[9]  Time elapsed: 0.115 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testListBlock  Time elapsed: 0.048 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithMissingIndexes135  Time elapsed: 0.105 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWith(List)[1]  Time elapsed: 0.1 s
...
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWith(List)[9]  Time elapsed: 0.118 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testOrphanBlock  Time elapsed: 6.578 s
```

After:

```
[INFO] Running org.apache.hadoop.ozone.shell.TestReconfigShell
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.261 s - in org.apache.hadoop.ozone.shell.TestReconfigShell
[INFO] org.apache.hadoop.ozone.shell.TestReconfigShell.testStorageContainerManagerGetReconfigurationProperties  Time elapsed: 0.095 s
[INFO] org.apache.hadoop.ozone.shell.TestReconfigShell.testDataNodeGetReconfigurableProperties  Time elapsed: 0.074 s
[INFO] org.apache.hadoop.ozone.shell.TestReconfigShell.testDatanodeBulkReconfig  Time elapsed: 10.145 s
[INFO] org.apache.hadoop.ozone.shell.TestReconfigShell.testOzoneManagerGetReconfigurationProperties  Time elapsed: 0.024 s
[INFO] Running org.apache.hadoop.ozone.shell.TestOzoneContainerUpgradeShell
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.499 s - in org.apache.hadoop.ozone.shell.TestOzoneContainerUpgradeShell
[INFO] org.apache.hadoop.ozone.shell.TestOzoneContainerUpgradeShell.testNormalContainerUpgrade  Time elapsed: 19.96 s
[INFO] Running org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 72.319 s - in org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorShouldCleanupContainersOnFailure  Time elapsed: 30.309 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithFullAndPartialStripe(List)[1]  Time elapsed: 0.308 s
...
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithFullAndPartialStripe(List)[9]  Time elapsed: 0.189 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testCreateRecoveryContainer  Time elapsed: 0.022 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testCreateRecoveryContainerAfterDNRestart  Time elapsed: 10.926 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithPartialStripe(List)[1]  Time elapsed: 0.138 s
...
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithPartialStripe(List)[9]  Time elapsed: 0.12 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testListBlock  Time elapsed: 0.078 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWithMissingIndexes135  Time elapsed: 0.115 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWith(List)[1]  Time elapsed: 0.095 s
...
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testECReconstructionCoordinatorWith(List)[9]  Time elapsed: 0.115 s
[INFO] org.apache.hadoop.hdds.scm.storage.TestContainerCommandsEC.testOrphanBlock  Time elapsed: 5.569 s
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/9463724905