### PR TITLE
HDDS-11002. Speed up TestPipelineClose

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -45,9 +45,11 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverSe
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.RaftGroupId;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
@@ -70,6 +72,7 @@ import static org.mockito.Mockito.verify;
 /**
  * Tests for Pipeline Closing.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(300)
 public class TestPipelineClose {
 
@@ -86,7 +89,7 @@ public class TestPipelineClose {
    *
    * @throws IOException
    */
-  @BeforeEach
+  @BeforeAll
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
@@ -102,12 +105,15 @@ public class TestPipelineClose {
     scm = cluster.getStorageContainerManager();
     containerManager = scm.getContainerManager();
     pipelineManager = scm.getPipelineManager();
+  }
+
+  @BeforeEach
+  void createContainer() throws IOException {
     ContainerInfo containerInfo = containerManager
         .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "testOwner");
     ratisContainer = new ContainerWithPipeline(containerInfo,
         pipelineManager.getPipeline(containerInfo.getPipelineID()));
-    pipelineManager = scm.getPipelineManager();
     // At this stage, there should be 2 pipeline one with 1 open container each.
     // Try closing the both the pipelines, one with a closed container and
     // the other with an open container.
@@ -116,7 +122,7 @@ public class TestPipelineClose {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterEach
+  @AfterAll
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Speed up `TestPipelineClose` by reusing the same cluster for all test cases.

https://issues.apache.org/jira/browse/HDDS-11002

## How was this patch tested?

Before:

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 78.613 s - in org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose
[INFO] org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose.testPipelineCloseWithPipelineAction  Time elapsed: 26.663 s
[INFO] org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose.testPipelineCloseWithOpenContainer  Time elapsed: 17.085 s
[INFO] org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose.testPipelineCloseWithClosedContainer  Time elapsed: 16.943 s
[INFO] org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose.testPipelineCloseWithLogFailure  Time elapsed: 17.901 s
```

After:

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.547 s - in org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose
[INFO] org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose.testPipelineCloseWithPipelineAction  Time elapsed: 5.53 s
[INFO] org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose.testPipelineCloseWithOpenContainer  Time elapsed: 0.003 s
[INFO] org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose.testPipelineCloseWithClosedContainer  Time elapsed: 6.646 s
[INFO] org.apache.hadoop.hdds.scm.pipeline.TestPipelineClose.testPipelineCloseWithLogFailure  Time elapsed: 8.711 s
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/9471526718