### PR TITLE
HDDS-11005. TestEndPoint#testRegisterRpcTimeout fails when run in itself

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -405,14 +405,8 @@ public class TestEndPoint {
         null);
   }
 
-  private EndpointStateMachine registerTaskHelper(InetSocketAddress scmAddress,
-      int rpcTimeout, boolean clearDatanodeDetails
-  ) throws Exception {
-    OzoneConfiguration conf = SCMTestUtils.getConf(tempDir);
-    EndpointStateMachine rpcEndPoint =
-        createEndpoint(conf,
-            scmAddress, rpcTimeout);
-    rpcEndPoint.setState(EndpointStateMachine.EndPointStates.REGISTER);
+  private RegisterEndpointTask getRegisterEndpointTask(boolean clearDatanodeDetails, OzoneConfiguration conf,
+                                                       EndpointStateMachine rpcEndPoint) throws Exception {
     OzoneContainer ozoneContainer = mock(OzoneContainer.class);
     UUID datanodeID = UUID.randomUUID();
     when(ozoneContainer.getNodeReport()).thenReturn(HddsTestUtils
@@ -437,6 +431,16 @@ public class TestEndPoint {
       DatanodeDetails datanodeDetails = randomDatanodeDetails();
       endpointTask.setDatanodeDetails(datanodeDetails);
     }
+    return endpointTask;
+  }
+
+  private EndpointStateMachine registerTaskHelper(InetSocketAddress scmAddress,
+      int rpcTimeout, boolean clearDatanodeDetails
+  ) throws Exception {
+    OzoneConfiguration conf = SCMTestUtils.getConf(tempDir);
+    EndpointStateMachine rpcEndPoint = createEndpoint(conf, scmAddress, rpcTimeout);
+    rpcEndPoint.setState(EndpointStateMachine.EndPointStates.REGISTER);
+    RegisterEndpointTask endpointTask = getRegisterEndpointTask(clearDatanodeDetails, conf, rpcEndPoint);
     endpointTask.call();
     return rpcEndPoint;
   }
@@ -472,14 +476,23 @@ public class TestEndPoint {
 
   @Test
   public void testRegisterRpcTimeout() throws Exception {
-    final long rpcTimeout = 1000;
-    final long tolerance = 900;
-    scmServerImpl.setRpcResponseDelay(2500);
-    long start = Time.monotonicNow();
-    registerTaskHelper(serverAddress, (int) rpcTimeout, false).close();
-    long end = Time.monotonicNow();
-    scmServerImpl.setRpcResponseDelay(0);
-    assertThat(end - start).isLessThanOrEqualTo(rpcTimeout + tolerance);
+    final int rpcTimeout = 1000;
+    final int tolerance = 200;
+    scmServerImpl.setRpcResponseDelay(rpcTimeout + tolerance * 2);
+    OzoneConfiguration conf = SCMTestUtils.getConf(tempDir);
+
+    try (EndpointStateMachine rpcEndPoint = createEndpoint(conf, serverAddress, rpcTimeout)) {
+      rpcEndPoint.setState(EndpointStateMachine.EndPointStates.REGISTER);
+      RegisterEndpointTask endpointTask = getRegisterEndpointTask(false, conf, rpcEndPoint);
+      long start = Time.monotonicNow();
+      endpointTask.call();
+      long end = Time.monotonicNow();
+      assertThat(end - start)
+          .isGreaterThanOrEqualTo(rpcTimeout)
+          .isLessThanOrEqualTo(rpcTimeout + tolerance);
+    } finally {
+      scmServerImpl.setRpcResponseDelay(0);
+    }
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -473,8 +473,8 @@ public class TestEndPoint {
   @Test
   public void testRegisterRpcTimeout() throws Exception {
     final long rpcTimeout = 1000;
-    final long tolerance = 200;
-    scmServerImpl.setRpcResponseDelay(1500);
+    final long tolerance = 900;
+    scmServerImpl.setRpcResponseDelay(2500);
     long start = Time.monotonicNow();
     registerTaskHelper(serverAddress, 1000, false).close();
     long end = Time.monotonicNow();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -476,7 +476,7 @@ public class TestEndPoint {
     final long tolerance = 900;
     scmServerImpl.setRpcResponseDelay(2500);
     long start = Time.monotonicNow();
-    registerTaskHelper(serverAddress, 1000, false).close();
+    registerTaskHelper(serverAddress, (int) rpcTimeout, false).close();
     long end = Time.monotonicNow();
     scmServerImpl.setRpcResponseDelay(0);
     assertThat(end - start).isLessThanOrEqualTo(rpcTimeout + tolerance);


### PR DESCRIPTION
## What changes were proposed in this pull request?

After running the testRegisterRpcTimeout through the flaky workflow: https://github.com/Tejaskriya/ozone/actions/runs/9476838761 , the test seems to fail each time.
Even when the single test case is run multiple times locally, failures are observed on the first run, and the remaining runs are successful. 
By seeing the logs, It seems like the steps after timeout interruption takes place could take 700-800ms when the test is run individually.
In this PR, the test is refactored to measure only the required latency of endpointTask.call(), and not the remaining steps.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11005

## How was this patch tested?

Tested flaky workflow: https://github.com/Tejaskriya/ozone/actions/runs/9494208563