### PR TITLE
HDDS-11004. Keep logs only for failed iterations in `flaky-test-check`

### DIFF
--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -83,6 +83,10 @@ for i in $(seq 1 ${ITERATIONS}); do
       FAIL_FAST=true
     fi
 
+    if [[ ${irc} == 0 ]]; then
+      rm -fr "${REPORT_DIR}"
+    fi
+
     REPORT_DIR="${original_report_dir}"
     echo "Iteration ${i} exit code: ${irc}" | tee -a "${REPORT_FILE}"
   fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Keep logs only for failed iterations in `flaky-test-check`.

https://issues.apache.org/jira/browse/HDDS-11004

## How was this patch tested?

https://github.com/adoroszlai/ozone/actions/runs/9478551418

```
$ unzip -t result-243-9478551418-split-2.zip 
Archive:  result-243-9478551418-split-2.zip
    testing: iteration1/failures      OK
    testing: iteration1/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.om.TestOzoneManagerPrepare.xml   OK
    testing: iteration1/hadoop-ozone/integration-test/org.apache.hadoop.ozone.om.TestOzoneManagerPrepare-output.txt   OK
    testing: iteration1/hadoop-ozone/integration-test/org.apache.hadoop.ozone.om.TestOzoneManagerPrepare.txt   OK
    testing: iteration1/output.log    OK
    testing: iteration1/summary.md    OK
    testing: iteration1/summary.txt   OK
    testing: summary.txt              OK
No errors detected in compressed data of result-243-9478551418-split-2.zip.

$ unzip -t result-243-9478551418-split-3.zip
Archive:  result-243-9478551418-split-3.zip
    testing: iteration9/failures      OK
    testing: iteration9/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.om.TestOzoneManagerPrepare.xml   OK
    testing: iteration9/hadoop-ozone/integration-test/org.apache.hadoop.ozone.om.TestOzoneManagerPrepare-output.txt   OK
    testing: iteration9/hadoop-ozone/integration-test/org.apache.hadoop.ozone.om.TestOzoneManagerPrepare.txt   OK
    testing: iteration9/output.log    OK
    testing: iteration9/summary.md    OK
    testing: iteration9/summary.txt   OK
    testing: summary.txt              OK
No errors detected in compressed data of result-243-9478551418-split-3.zip.
```