### PR TITLE
HDDS-11006. Selective checks: integration skipped when build not required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,6 @@ jobs:
   integration:
     needs:
       - build-info
-      - build
       - basic
     runs-on: ubuntu-20.04
     timeout-minutes: 150


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changing only `junit.sh` should trigger `integration` check (which uses this script).  Output of `build-info` is correct ([`needs-integration-tests=true`](https://github.com/apache/ozone/actions/runs/9479546581/job/26118309123?pr=6807#step:4:777)), but `integration` is [skipped](https://github.com/apache/ozone/actions/runs/9479546581/job/26118347341?pr=6807) because `build` is [skipped](https://github.com/apache/ozone/actions/runs/9479546581/job/26118319979?pr=6807).  Since `integration` no longer uses artifacts from `build`, I propose to fix this by removing this dependency.

https://issues.apache.org/jira/browse/HDDS-11006

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/9480041261