### PR TITLE
HDDS-10632. Handle inconsistent read issue for hsync keys after lease recovery.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/LeaseKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/LeaseKeyInfo.java
@@ -22,19 +22,15 @@ package org.apache.hadoop.ozone.om.helpers;
  */
 public class LeaseKeyInfo {
   private final OmKeyInfo keyInfo;
-  /**
-   * isKeyInfo = true indicates keyInfo is from keyTable.
-   * isKeyInfo = false indicates keyInfo is from openKeyTable.
-   */
-  private boolean isKeyInfo;
+  private final OmKeyInfo openKeyInfo;
 
-  public LeaseKeyInfo(OmKeyInfo info, boolean isKeyInfo) {
-    this.keyInfo = info;
-    this.isKeyInfo = isKeyInfo;
+  public LeaseKeyInfo(OmKeyInfo keyInfo, OmKeyInfo openKeyInfo) {
+    this.keyInfo = keyInfo;
+    this.openKeyInfo = openKeyInfo;
   }
 
-  public boolean getIsKeyInfo() {
-    return this.isKeyInfo;
+  public OmKeyInfo getOpenKeyInfo() {
+    return openKeyInfo;
   }
 
   public OmKeyInfo getKeyInfo() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2562,7 +2562,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         handleError(submitRequest(omRequest)).getRecoverLeaseResponse();
 
     return new LeaseKeyInfo(OmKeyInfo.getFromProtobuf(recoverLeaseResponse.getKeyInfo()),
-        recoverLeaseResponse.getIsKeyInfo());
+        OmKeyInfo.getFromProtobuf(recoverLeaseResponse.getOpenKeyInfo()));
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -508,6 +508,56 @@ public class TestLeaseRecovery {
     }
   }
 
+  @Test
+  public void testRecoveryWithPartialFilledHsyncBlock() throws Exception {
+    RootedOzoneFileSystem fs = (RootedOzoneFileSystem)FileSystem.get(conf);
+    int blockSize = (int) cluster.getOzoneManager().getConfiguration().getStorageSize(
+        OZONE_SCM_BLOCK_SIZE, OZONE_SCM_BLOCK_SIZE_DEFAULT, StorageUnit.BYTES);
+    final byte[] data = getData(blockSize - 1);
+
+    final FSDataOutputStream stream = fs.create(file, true);
+    try {
+      // Write data into 1st block with total length = blockSize - 1
+      stream.write(data);
+      stream.hsync();
+
+      StorageContainerManager scm = cluster.getStorageContainerManager();
+      ContainerInfo container = scm.getContainerManager().getContainers().get(0);
+      // Close container so that new data won't be written into the same block
+      // block1 is partially filled
+      OzoneTestUtils.closeContainer(scm, container);
+      GenericTestUtils.waitFor(() -> {
+        try {
+          return scm.getPipelineManager().getPipeline(container.getPipelineID()).isClosed();
+        } catch (PipelineNotFoundException e) {
+          throw new RuntimeException(e);
+        }
+      }, 200, 30000);
+
+      assertFalse(fs.isFileClosed(file));
+
+      // write data, this data will completely go into block2 even though block1 had 1 space left
+      stream.write(data);
+      stream.flush();
+      // At this point both block1 and block2 has (blockSize - 1) length data
+
+      int count = 0;
+      while (count++ < 15 && !fs.recoverLease(file)) {
+        Thread.sleep(1000);
+      }
+      // The lease should have been recovered.
+      assertTrue(fs.isFileClosed(file), "File should be closed");
+
+      // A second call to recoverLease should succeed too.
+      assertTrue(fs.recoverLease(file));
+    } finally {
+      closeIgnoringKeyNotFound(stream);
+    }
+
+    // open it again, make sure the data is correct
+    verifyData(data, (blockSize - 1) * 2, file, fs);
+  }
+
   private void verifyData(byte[] data, int dataSize, Path filePath, RootedOzoneFileSystem fs) throws IOException {
     try (FSDataInputStream fdis = fs.open(filePath)) {
       int bufferSize = dataSize > data.length ? dataSize / 2 : dataSize;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestLeaseRecovery.java
@@ -162,7 +162,7 @@ public class TestLeaseRecovery {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {1 << 20, (1 << 20) + 1, (1 << 20) - 1})
+  @ValueSource(ints = {1 << 17, (1 << 17) + 1, (1 << 17) - 1})
   public void testRecovery(int dataSize) throws Exception {
     RootedOzoneFileSystem fs = (RootedOzoneFileSystem)FileSystem.get(conf);
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -2144,7 +2144,7 @@ message RecoverLeaseRequest {
 message RecoverLeaseResponse {
   optional bool response = 1 [deprecated=true];
   optional KeyInfo keyInfo = 2;
-  optional bool isKeyInfo = 3 [default = true];
+  optional KeyInfo openKeyInfo = 3;
 }
 
 message SetTimesRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -225,7 +225,6 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
       throw new OMException("Open Key " + keyName + " is already deleted",
           KEY_NOT_FOUND);
     }
-    long openKeyModificationTime = openKeyInfo.getModificationTime();
     if (openKeyInfo.getMetadata().containsKey(OzoneConsts.LEASE_RECOVERY)) {
       LOG.debug("Key: " + keyName + " is already under recovery");
     } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -251,28 +251,19 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
     OmKeyLocationInfoGroup openKeyLatestVersionLocations = openKeyInfo.getLatestVersionLocations();
     List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
 
-    OmKeyLocationInfo finalBlock = null;
-    OmKeyLocationInfo penultimateBlock = null;
-    boolean returnKeyInfo = true;
-    if (openKeyLocationInfoList.size() > keyLocationInfoList.size() &&
-        openKeyModificationTime > keyInfo.getModificationTime() &&
-        openKeyLocationInfoList.size() > 0) {
-      finalBlock = openKeyLocationInfoList.get(openKeyLocationInfoList.size() - 1);
-      if (openKeyLocationInfoList.size() > 1) {
-        penultimateBlock = openKeyLocationInfoList.get(openKeyLocationInfoList.size() - 2);
-      }
-      returnKeyInfo = false;
-    } else if (keyLocationInfoList.size() > 0) {
-      finalBlock = keyLocationInfoList.get(keyLocationInfoList.size() - 1);
+    if (keyLocationInfoList.size() > 0) {
+      updateBlockInfo(ozoneManager, keyLocationInfoList.get(keyLocationInfoList.size() - 1));
     }
-    updateBlockInfo(ozoneManager, finalBlock);
-    updateBlockInfo(ozoneManager, penultimateBlock);
+    if (openKeyLocationInfoList.size() > 1) {
+      updateBlockInfo(ozoneManager, openKeyLocationInfoList.get(openKeyLocationInfoList.size() - 1));
+      updateBlockInfo(ozoneManager, openKeyLocationInfoList.get(openKeyLocationInfoList.size() - 2));
+    } else if (openKeyLocationInfoList.size() > 0) {
+      updateBlockInfo(ozoneManager, openKeyLocationInfoList.get(0));
+    }
 
     RecoverLeaseResponse.Builder rb = RecoverLeaseResponse.newBuilder();
-    rb.setKeyInfo(returnKeyInfo ? keyInfo.getNetworkProtobuf(getOmRequest().getVersion(), true) :
-        openKeyInfo.getNetworkProtobuf(getOmRequest().getVersion(), true));
-    rb.setIsKeyInfo(returnKeyInfo);
-
+    rb.setKeyInfo(keyInfo.getNetworkProtobuf(getOmRequest().getVersion(), true));
+    rb.setOpenKeyInfo(openKeyInfo.getNetworkProtobuf(getOmRequest().getVersion(), true));
     return rb.build();
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/LeaseRecoveryClientDNHandler.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/LeaseRecoveryClientDNHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.hadoop.fs.ozone;
 
 import jakarta.annotation.Nonnull;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/LeaseRecoveryClientDNHandler.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/LeaseRecoveryClientDNHandler.java
@@ -1,0 +1,105 @@
+package org.apache.hadoop.fs.ozone;
+
+import jakarta.annotation.Nonnull;
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
+import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
+
+/**
+ * Handles lease recovery call between client and DN.
+ */
+public final class LeaseRecoveryClientDNHandler {
+  static final Logger LOG = LoggerFactory.getLogger(LeaseRecoveryClientDNHandler.class);
+
+  private LeaseRecoveryClientDNHandler() {
+      // Not required.
+  }
+
+  /**
+   * Get actual block length from DN for the last/penultimate block and update in KeyLocationInfo.
+   * @param leaseKeyInfo keyInfo received from OM
+   * @param adapter client adapter
+   * @param forceRecovery whether to do force recovery
+   * @return List<OmKeyLocationInfo>
+   */
+  @Nonnull
+  public static List<OmKeyLocationInfo> getOmKeyLocationInfos(LeaseKeyInfo leaseKeyInfo,
+      OzoneClientAdapter adapter, boolean forceRecovery) throws IOException {
+    OmKeyLocationInfoGroup keyLatestVersionLocations = leaseKeyInfo.getKeyInfo().getLatestVersionLocations();
+    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.getLocationList();
+    OmKeyLocationInfoGroup openKeyLatestVersionLocations = leaseKeyInfo.getOpenKeyInfo().getLatestVersionLocations();
+    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
+
+    int openKeyLocationSize = openKeyLocationInfoList.size();
+    int keyLocationSize = keyLocationInfoList.size();
+    OmKeyLocationInfo openKeyFinalBlock = null;
+    OmKeyLocationInfo openKeyPenultimateBlock = null;
+    OmKeyLocationInfo keyFinalBlock;
+
+    if (keyLocationSize > 0) {
+      // Block info from fileTable
+      keyFinalBlock = keyLocationInfoList.get(keyLocationSize - 1);
+      // Block info from openFileTable
+      if (openKeyLocationSize > 1) {
+        openKeyFinalBlock = openKeyLocationInfoList.get(openKeyLocationSize - 1);
+        openKeyPenultimateBlock = openKeyLocationInfoList.get(openKeyLocationSize - 2);
+      } else if (openKeyLocationSize > 0) {
+        openKeyFinalBlock = openKeyLocationInfoList.get(0);
+      }
+      // Finalize the final block and get block length
+      try {
+        // CASE 1: When openFileTable has more block than fileTable
+        // Try to finalize last block of openFileTable
+        // Add that block into fileTable locationInfo
+        if (openKeyLocationSize > keyLocationSize) {
+          openKeyFinalBlock.setLength(adapter.finalizeBlock(openKeyFinalBlock));
+          keyLocationInfoList.add(openKeyFinalBlock);
+        }
+        // CASE 2: When openFileTable penultimate block length is not equal to fileTable block length of last block
+        // Finalize and get the actual block length and update in fileTable last block
+        if ((openKeyPenultimateBlock != null && keyFinalBlock != null) &&
+            openKeyPenultimateBlock.getLength() != keyFinalBlock.getLength() &&
+            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
+          keyFinalBlock.setLength(adapter.finalizeBlock(keyFinalBlock));
+        }
+        // CASE 3: When openFileTable has same number of blocks as fileTable
+        // Finalize and get actual length of fileTable final block
+        if (keyLocationInfoList.size() == openKeyLocationInfoList.size() && keyFinalBlock != null) {
+          keyFinalBlock.setLength(adapter.finalizeBlock(keyFinalBlock));
+        }
+      } catch (Throwable e) {
+        if (e instanceof StorageContainerException &&
+            (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
+            || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
+            && openKeyPenultimateBlock != null && keyFinalBlock != null &&
+            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
+          try {
+            keyFinalBlock.setLength(adapter.finalizeBlock(keyFinalBlock));
+          } catch (Throwable exp) {
+            if (!forceRecovery) {
+              throw exp;
+            }
+            LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+                FORCE_LEASE_RECOVERY_ENV, exp);
+          }
+        } else if (!forceRecovery) {
+          throw e;
+        } else {
+          LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
+              FORCE_LEASE_RECOVERY_ENV, e);
+        }
+      }
+    }
+    return keyLocationInfoList;
+  }
+}

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -35,16 +35,12 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
 /**
@@ -157,71 +153,9 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
       throw e;
     }
 
-    OmKeyLocationInfoGroup keyLatestVersionLocations = leaseKeyInfo.getKeyInfo().getLatestVersionLocations();
-    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.getLocationList();
-    OmKeyLocationInfoGroup openKeyLatestVersionLocations = leaseKeyInfo.getOpenKeyInfo().getLatestVersionLocations();
-    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
-
-    int openKeyLocationSize = openKeyLocationInfoList.size();
-    int keyLocationSize = keyLocationInfoList.size();
-    OmKeyLocationInfo openKeyFinalBlock = null;
-    OmKeyLocationInfo openKeyPenultimateBlock = null;
-    OmKeyLocationInfo keyFinalBlock;
-
-    if (keyLocationSize > 0) {
-      // Block info from fileTable
-      keyFinalBlock = keyLocationInfoList.get(keyLocationSize - 1);
-      // Block info from openFileTable
-      if (openKeyLocationSize > 1) {
-        openKeyFinalBlock = openKeyLocationInfoList.get(openKeyLocationSize - 1);
-        openKeyPenultimateBlock = openKeyLocationInfoList.get(openKeyLocationSize - 2);
-      } else if (openKeyLocationSize > 0) {
-        openKeyFinalBlock = openKeyLocationInfoList.get(0);
-      }
-      // Finalize the final block and get block length
-      try {
-        // CASE 1: When openFileTable has more block than fileTable
-        // Try to finalize last block of openFileTable
-        // Add that block into fileTable locationInfo
-        if (openKeyLocationSize > keyLocationSize) {
-          openKeyFinalBlock.setLength(getAdapter().finalizeBlock(openKeyFinalBlock));
-          keyLocationInfoList.add(openKeyFinalBlock);
-        }
-        // CASE 2: When openFileTable penultimate block length is not equal to fileTable block length of last block
-        // Finalize and get the actual block length and update in fileTable last block
-        if ((openKeyPenultimateBlock != null && keyFinalBlock != null) &&
-            openKeyPenultimateBlock.getLength() != keyFinalBlock.getLength() &&
-            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
-          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-        }
-        // CASE 3: When openFileTable has same number of blocks as fileTable
-        // Finalize and get actual length of fileTable final block
-        if (keyLocationInfoList.size() == openKeyLocationInfoList.size() && keyFinalBlock != null) {
-          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-        }
-      } catch (Throwable e) {
-        if (e instanceof StorageContainerException && (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
-            || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
-            && openKeyPenultimateBlock != null && keyFinalBlock != null &&
-            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
-          try {
-            keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-          } catch (Throwable exp) {
-            if (!forceRecovery) {
-              throw exp;
-            }
-            LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-                FORCE_LEASE_RECOVERY_ENV, exp);
-          }
-        } else if (!forceRecovery) {
-          throw e;
-        } else {
-          LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-              FORCE_LEASE_RECOVERY_ENV, e);
-        }
-      }
-    }
-
+    // Get keyLocationInfo
+    List<OmKeyLocationInfo> keyLocationInfoList = LeaseRecoveryClientDNHandler.getOmKeyLocationInfos(
+        leaseKeyInfo, getAdapter(), forceRecovery);
     // recover and commit file
     long keyLength = keyLocationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(leaseKeyInfo.getKeyInfo().getVolumeName())

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
 import java.io.IOException;
@@ -160,21 +161,55 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
       throw e;
     }
 
-    // finalize the final block and get block length
-    List<OmKeyLocationInfo> locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList();
-    if (!locationInfoList.isEmpty()) {
-      OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
+    OmKeyLocationInfoGroup keyLatestVersionLocations = leaseKeyInfo.getKeyInfo().getLatestVersionLocations();
+    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.getLocationList();
+    OmKeyLocationInfoGroup openKeyLatestVersionLocations = leaseKeyInfo.getOpenKeyInfo().getLatestVersionLocations();
+    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
+
+    int openKeyLocationSize = openKeyLocationInfoList.size();
+    int keyLocationSize = keyLocationInfoList.size();
+    OmKeyLocationInfo openKeyFinalBlock = null;
+    OmKeyLocationInfo openKeyPenultimateBlock = null;
+    OmKeyLocationInfo keyFinalBlock;
+
+    if (keyLocationSize > 0) {
+      // Block info from fileTable
+      keyFinalBlock = keyLocationInfoList.get(keyLocationSize - 1);
+      // Block info from openFileTable
+      if (openKeyLocationSize > 1) {
+        openKeyFinalBlock = openKeyLocationInfoList.get(openKeyLocationSize - 1);
+        openKeyPenultimateBlock = openKeyLocationInfoList.get(openKeyLocationSize - 2);
+      } else if (openKeyLocationSize > 0) {
+        openKeyFinalBlock = openKeyLocationInfoList.get(0);
+      }
+      // Finalize the final block and get block length
       try {
-        block.setLength(getAdapter().finalizeBlock(block));
+        // CASE 1: When openFileTable has more block than fileTable
+        // Try to finalize last block of openFileTable
+        // Add that block into fileTable locationInfo
+        if (openKeyLocationSize > keyLocationSize) {
+          openKeyFinalBlock.setLength(getAdapter().finalizeBlock(openKeyFinalBlock));
+          keyLocationInfoList.add(openKeyFinalBlock);
+        }
+        // CASE 2: When openFileTable penultimate block length is not equal to fileTable block length of last block
+        // Finalize and get the actual block length and update in fileTable last block
+        if ((openKeyPenultimateBlock != null && keyFinalBlock != null) &&
+            openKeyPenultimateBlock.getLength() != keyFinalBlock.getLength() &&
+            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
+          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
+        }
+        // CASE 3: When openFileTable has same number of blocks as fileTable
+        // Finalize and get actual length of fileTable final block
+        if (keyLocationInfoList.size() == openKeyLocationInfoList.size() && keyFinalBlock != null) {
+          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
+        }
       } catch (Throwable e) {
         if (e instanceof StorageContainerException && (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
             || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
-            && !leaseKeyInfo.getIsKeyInfo() && locationInfoList.size() > 1) {
-          locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList().subList(0,
-              locationInfoList.size() - 1);
-          block = locationInfoList.get(locationInfoList.size() - 1);
+            && openKeyPenultimateBlock != null && keyFinalBlock != null &&
+            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
           try {
-            block.setLength(getAdapter().finalizeBlock(block));
+            keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
           } catch (Throwable exp) {
             if (!forceRecovery) {
               throw exp;
@@ -192,11 +227,11 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     }
 
     // recover and commit file
-    long keyLength = locationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
+    long keyLength = keyLocationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(leaseKeyInfo.getKeyInfo().getVolumeName())
         .setBucketName(leaseKeyInfo.getKeyInfo().getBucketName()).setKeyName(leaseKeyInfo.getKeyInfo().getKeyName())
         .setReplicationConfig(leaseKeyInfo.getKeyInfo().getReplicationConfig()).setDataSize(keyLength)
-        .setLocationInfoList(locationInfoList)
+        .setLocationInfoList(keyLocationInfoList)
         .build();
     getAdapter().recoverFile(keyArgs);
     return true;

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -30,12 +30,10 @@ import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.StorageStatistics;
-import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
 import java.io.IOException;
@@ -43,8 +41,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
 /**
@@ -161,71 +157,9 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
       throw e;
     }
 
-    OmKeyLocationInfoGroup keyLatestVersionLocations = leaseKeyInfo.getKeyInfo().getLatestVersionLocations();
-    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.getLocationList();
-    OmKeyLocationInfoGroup openKeyLatestVersionLocations = leaseKeyInfo.getOpenKeyInfo().getLatestVersionLocations();
-    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
-
-    int openKeyLocationSize = openKeyLocationInfoList.size();
-    int keyLocationSize = keyLocationInfoList.size();
-    OmKeyLocationInfo openKeyFinalBlock = null;
-    OmKeyLocationInfo openKeyPenultimateBlock = null;
-    OmKeyLocationInfo keyFinalBlock;
-
-    if (keyLocationSize > 0) {
-      // Block info from fileTable
-      keyFinalBlock = keyLocationInfoList.get(keyLocationSize - 1);
-      // Block info from openFileTable
-      if (openKeyLocationSize > 1) {
-        openKeyFinalBlock = openKeyLocationInfoList.get(openKeyLocationSize - 1);
-        openKeyPenultimateBlock = openKeyLocationInfoList.get(openKeyLocationSize - 2);
-      } else if (openKeyLocationSize > 0) {
-        openKeyFinalBlock = openKeyLocationInfoList.get(0);
-      }
-      // Finalize the final block and get block length
-      try {
-        // CASE 1: When openFileTable has more block than fileTable
-        // Try to finalize last block of openFileTable
-        // Add that block into fileTable locationInfo
-        if (openKeyLocationSize > keyLocationSize) {
-          openKeyFinalBlock.setLength(getAdapter().finalizeBlock(openKeyFinalBlock));
-          keyLocationInfoList.add(openKeyFinalBlock);
-        }
-        // CASE 2: When openFileTable penultimate block length is not equal to fileTable block length of last block
-        // Finalize and get the actual block length and update in fileTable last block
-        if ((openKeyPenultimateBlock != null && keyFinalBlock != null) &&
-            openKeyPenultimateBlock.getLength() != keyFinalBlock.getLength() &&
-            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
-          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-        }
-        // CASE 3: When openFileTable has same number of blocks as fileTable
-        // Finalize and get actual length of fileTable final block
-        if (keyLocationInfoList.size() == openKeyLocationInfoList.size() && keyFinalBlock != null) {
-          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-        }
-      } catch (Throwable e) {
-        if (e instanceof StorageContainerException && (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
-            || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
-            && openKeyPenultimateBlock != null && keyFinalBlock != null &&
-            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
-          try {
-            keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-          } catch (Throwable exp) {
-            if (!forceRecovery) {
-              throw exp;
-            }
-            LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-                FORCE_LEASE_RECOVERY_ENV, exp);
-          }
-        } else if (!forceRecovery) {
-          throw e;
-        } else {
-          LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-              FORCE_LEASE_RECOVERY_ENV, e);
-        }
-      }
-    }
-
+    // Get keyLocationInfo
+    List<OmKeyLocationInfo> keyLocationInfoList = LeaseRecoveryClientDNHandler.getOmKeyLocationInfos(
+        leaseKeyInfo, getAdapter(), forceRecovery);
     // recover and commit file
     long keyLength = keyLocationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(leaseKeyInfo.getKeyInfo().getVolumeName())

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -35,16 +35,12 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_NOT_FOUND;
-import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.ozone.OzoneConsts.FORCE_LEASE_RECOVERY_ENV;
 
 /**
@@ -157,71 +153,9 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
       throw e;
     }
 
-    OmKeyLocationInfoGroup keyLatestVersionLocations = leaseKeyInfo.getKeyInfo().getLatestVersionLocations();
-    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.getLocationList();
-    OmKeyLocationInfoGroup openKeyLatestVersionLocations = leaseKeyInfo.getOpenKeyInfo().getLatestVersionLocations();
-    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
-
-    int openKeyLocationSize = openKeyLocationInfoList.size();
-    int keyLocationSize = keyLocationInfoList.size();
-    OmKeyLocationInfo openKeyFinalBlock = null;
-    OmKeyLocationInfo openKeyPenultimateBlock = null;
-    OmKeyLocationInfo keyFinalBlock;
-
-    if (keyLocationSize > 0) {
-      // Block info from fileTable
-      keyFinalBlock = keyLocationInfoList.get(keyLocationSize - 1);
-      // Block info from openFileTable
-      if (openKeyLocationSize > 1) {
-        openKeyFinalBlock = openKeyLocationInfoList.get(openKeyLocationSize - 1);
-        openKeyPenultimateBlock = openKeyLocationInfoList.get(openKeyLocationSize - 2);
-      } else if (openKeyLocationSize > 0) {
-        openKeyFinalBlock = openKeyLocationInfoList.get(0);
-      }
-      // Finalize the final block and get block length
-      try {
-        // CASE 1: When openFileTable has more block than fileTable
-        // Try to finalize last block of openFileTable
-        // Add that block into fileTable locationInfo
-        if (openKeyLocationSize > keyLocationSize) {
-          openKeyFinalBlock.setLength(getAdapter().finalizeBlock(openKeyFinalBlock));
-          keyLocationInfoList.add(openKeyFinalBlock);
-        }
-        // CASE 2: When openFileTable penultimate block length is not equal to fileTable block length of last block
-        // Finalize and get the actual block length and update in fileTable last block
-        if ((openKeyPenultimateBlock != null && keyFinalBlock != null) &&
-            openKeyPenultimateBlock.getLength() != keyFinalBlock.getLength() &&
-            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
-          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-        }
-        // CASE 3: When openFileTable has same number of blocks as fileTable
-        // Finalize and get actual length of fileTable final block
-        if (keyLocationInfoList.size() == openKeyLocationInfoList.size() && keyFinalBlock != null) {
-          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-        }
-      } catch (Throwable e) {
-        if (e instanceof StorageContainerException && (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
-            || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
-            && openKeyPenultimateBlock != null && keyFinalBlock != null &&
-            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
-          try {
-            keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
-          } catch (Throwable exp) {
-            if (!forceRecovery) {
-              throw exp;
-            }
-            LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-                FORCE_LEASE_RECOVERY_ENV, exp);
-          }
-        } else if (!forceRecovery) {
-          throw e;
-        } else {
-          LOG.warn("Failed to finalize block. Continue to recover the file since {} is enabled.",
-              FORCE_LEASE_RECOVERY_ENV, e);
-        }
-      }
-    }
-
+    // Get keyLocationInfo
+    List<OmKeyLocationInfo> keyLocationInfoList = LeaseRecoveryClientDNHandler.getOmKeyLocationInfos(
+        leaseKeyInfo, getAdapter(), forceRecovery);
     // recover and commit file
     long keyLength = keyLocationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(leaseKeyInfo.getKeyInfo().getVolumeName())

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.LeaseKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
 import java.io.IOException;
@@ -160,21 +161,55 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
       throw e;
     }
 
-    // finalize the final block and get block length
-    List<OmKeyLocationInfo> locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList();
-    if (!locationInfoList.isEmpty()) {
-      OmKeyLocationInfo block = locationInfoList.get(locationInfoList.size() - 1);
+    OmKeyLocationInfoGroup keyLatestVersionLocations = leaseKeyInfo.getKeyInfo().getLatestVersionLocations();
+    List<OmKeyLocationInfo> keyLocationInfoList = keyLatestVersionLocations.getLocationList();
+    OmKeyLocationInfoGroup openKeyLatestVersionLocations = leaseKeyInfo.getOpenKeyInfo().getLatestVersionLocations();
+    List<OmKeyLocationInfo> openKeyLocationInfoList = openKeyLatestVersionLocations.getLocationList();
+
+    int openKeyLocationSize = openKeyLocationInfoList.size();
+    int keyLocationSize = keyLocationInfoList.size();
+    OmKeyLocationInfo openKeyFinalBlock = null;
+    OmKeyLocationInfo openKeyPenultimateBlock = null;
+    OmKeyLocationInfo keyFinalBlock;
+
+    if (keyLocationSize > 0) {
+      // Block info from fileTable
+      keyFinalBlock = keyLocationInfoList.get(keyLocationSize - 1);
+      // Block info from openFileTable
+      if (openKeyLocationSize > 1) {
+        openKeyFinalBlock = openKeyLocationInfoList.get(openKeyLocationSize - 1);
+        openKeyPenultimateBlock = openKeyLocationInfoList.get(openKeyLocationSize - 2);
+      } else if (openKeyLocationSize > 0) {
+        openKeyFinalBlock = openKeyLocationInfoList.get(0);
+      }
+      // Finalize the final block and get block length
       try {
-        block.setLength(getAdapter().finalizeBlock(block));
+        // CASE 1: When openFileTable has more block than fileTable
+        // Try to finalize last block of openFileTable
+        // Add that block into fileTable locationInfo
+        if (openKeyLocationSize > keyLocationSize) {
+          openKeyFinalBlock.setLength(getAdapter().finalizeBlock(openKeyFinalBlock));
+          keyLocationInfoList.add(openKeyFinalBlock);
+        }
+        // CASE 2: When openFileTable penultimate block length is not equal to fileTable block length of last block
+        // Finalize and get the actual block length and update in fileTable last block
+        if ((openKeyPenultimateBlock != null && keyFinalBlock != null) &&
+            openKeyPenultimateBlock.getLength() != keyFinalBlock.getLength() &&
+            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
+          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
+        }
+        // CASE 3: When openFileTable has same number of blocks as fileTable
+        // Finalize and get actual length of fileTable final block
+        if (keyLocationInfoList.size() == openKeyLocationInfoList.size() && keyFinalBlock != null) {
+          keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
+        }
       } catch (Throwable e) {
         if (e instanceof StorageContainerException && (((StorageContainerException) e).getResult().equals(NO_SUCH_BLOCK)
             || ((StorageContainerException) e).getResult().equals(CONTAINER_NOT_FOUND))
-            && !leaseKeyInfo.getIsKeyInfo() && locationInfoList.size() > 1) {
-          locationInfoList = leaseKeyInfo.getKeyInfo().getLatestVersionLocations().getLocationList().subList(0,
-              locationInfoList.size() - 1);
-          block = locationInfoList.get(locationInfoList.size() - 1);
+            && openKeyPenultimateBlock != null && keyFinalBlock != null &&
+            openKeyPenultimateBlock.getBlockID().getLocalID() == keyFinalBlock.getBlockID().getLocalID()) {
           try {
-            block.setLength(getAdapter().finalizeBlock(block));
+            keyFinalBlock.setLength(getAdapter().finalizeBlock(keyFinalBlock));
           } catch (Throwable exp) {
             if (!forceRecovery) {
               throw exp;
@@ -192,11 +227,11 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     }
 
     // recover and commit file
-    long keyLength = locationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
+    long keyLength = keyLocationInfoList.stream().mapToLong(OmKeyLocationInfo::getLength).sum();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(leaseKeyInfo.getKeyInfo().getVolumeName())
         .setBucketName(leaseKeyInfo.getKeyInfo().getBucketName()).setKeyName(leaseKeyInfo.getKeyInfo().getKeyName())
         .setReplicationConfig(leaseKeyInfo.getKeyInfo().getReplicationConfig()).setDataSize(keyLength)
-        .setLocationInfoList(locationInfoList)
+        .setLocationInfoList(keyLocationInfoList)
         .build();
     getAdapter().recoverFile(keyArgs);
     return true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this PR, In some cases we are considering last two block to get the actual length from DN and update OM fileTable during lease recovery.
This is done as there may be some corner case when hsync is not called on last block and lease recover is called and also penultimate block is not completely filled because of various reason like CLOSE container. In this case penultimate block length is not correct in openFileTable as well as fileTable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10632

## How was this patch tested?

New integration test
