### PR TITLE
HDDS-10969. support set a customized source config directory for startup in docker image apache/ozone

### DIFF
--- a/hadoop-ozone/dist/src/main/dockerlibexec/entrypoint.sh
+++ b/hadoop-ozone/dist/src/main/dockerlibexec/entrypoint.sh
@@ -99,9 +99,15 @@ fi
 
 CONF_DESTINATION_DIR="${OZONE_CONF_DIR:-/opt/hadoop/etc/hadoop}"
 
+# If custom define config at local, you can set the CUSTOMIZED_CONFIG_DIR
+# eg: CUSTOMIZED_CONFIG_DIR=$DIR/../etc/hadoop, this is an environment variable.
+
 #Try to copy the defaults
 set +e
-if [[ -d "/opt/ozone/etc/hadoop" ]]; then
+if [[ -d "$CUSTOMIZED_CONFIG_DIR" ]]; then
+   CONF_DESTINATION_DIR=$CUSTOMIZED_CONFIG_DIR
+   OZONE_CONF_DIR=$CUSTOMIZED_CONFIG_DIR
+elif [[ -d "/opt/ozone/etc/hadoop" ]]; then
    cp /opt/ozone/etc/hadoop/* "$CONF_DESTINATION_DIR/" > /dev/null 2>&1
 elif [[ -d "/opt/hadoop/etc/hadoop" ]]; then
    cp /opt/hadoop/etc/hadoop/* "$CONF_DESTINATION_DIR/" > /dev/null 2>&1


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support set a customized source config directory for startup in docker image apache/ozone.

In my scenario, I use apache/ozone to start a simple ozone cluster. But it only has 1 datanode. I want to make this simple cluster multi datanodes, so I generate some config files(ozone-site.xml  it is distinguished by ports), and use this config start new datanodes. 

I specified this config directory by a environment.

OZONE_CONF_DIR=/opt/ozone/dn$i/config OZONE_PID_DIR=/opt/ozone/dn$i sh -x /opt/ozone/dn$i/libexec/entrypoint.sh /opt/ozone/dn$i/bin/ozone datanode &> /opt/ozone/dn$i/log/datanode.log &

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10969


## How was this patch tested?
I test it using a local environment startup by apache/ozone.
![image](https://github.com/apache/ozone/assets/6360122/81e3e8d1-79b7-478a-b310-33d81f659a68)

