### PR TITLE
HDDS-8942. Intermittent failure in ITestOzoneContractCreate#testSyncable

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -358,13 +358,19 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     DatanodeBlockID blockID = null;
     if (request.getCmdType() == ContainerProtos.Type.GetBlock) {
       blockID = request.getGetBlock().getBlockID();
+      datanodeList = pipeline.getNodes();
+      int getBlockDNLeaderIndex = datanodeList.indexOf(pipeline.getLeaderNode());
+      if (getBlockDNLeaderIndex > 0) {
+        // Pull the Cached DN to the top of the DN list
+        Collections.swap(datanodeList, 0, getBlockDNLeaderIndex);
+      }
     } else if  (request.getCmdType() == ContainerProtos.Type.ReadChunk) {
       blockID = request.getReadChunk().getBlockID();
     } else if (request.getCmdType() == ContainerProtos.Type.GetSmallFile) {
       blockID = request.getGetSmallFile().getBlock().getBlockID();
     }
 
-    if (blockID != null) {
+    if (blockID != null && datanodeList == null) {
       // Check if the DN to which the GetBlock command was sent has been cached.
       DatanodeDetails cachedDN = getBlockDNcache.get(blockID);
       if (cachedDN != null) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestXceiverClientGrpc.java
@@ -88,27 +88,27 @@ public class TestXceiverClientGrpc {
 
   @Test
   @Timeout(5)
-  public void testRandomFirstNodeIsCommandTarget() throws IOException {
-    final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
+  public void testLeaderNodeIsCommandTarget() throws IOException {
+    final Set<DatanodeDetails> seenDN = new HashSet<>();
     conf.setBoolean(
             OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY, false);
-    // Using a new Xceiver Client, call it repeatedly until all DNs in the
-    // pipeline have been the target of the command, indicating it is shuffling
-    // the DNs on each call with a new client. This test will timeout if this
-    // is not happening.
-    while (allDNs.size() > 0) {
+    // Using a new Xceiver Client, make 100 calls and ensure leader node is used
+    // each time. The logic should always use the leader node, so we can check
+    // only a single DN is ever seen after 100 calls.
+    for (int i = 0; i < 100; i++) {
       try (XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
         @Override
         public XceiverClientReply sendCommandAsync(
             ContainerProtos.ContainerCommandRequestProto request,
             DatanodeDetails dn) {
-          allDNs.remove(dn);
+          seenDN.add(dn);
           return buildValidResponse();
         }
       }) {
         invokeXceiverClientGetBlock(client);
       }
     }
+    assertEquals(1, seenDN.size());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reading data before the follower state machine hasn't finished applying log gets wrong `BlockData`.
The BlockInputStream reads data from one of the datanodes in the pipeline. If the BlockInputStream read data from follower before the statemachine finished updating, the data may be incorrect.
Therefore, I make the BlockInputStream read data from leader first.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-8942

## How was this patch tested?

Run `TestHSync` for 20*10 times:
https://github.com/chungen0126/ozone/actions/runs/9532695490
