### PR TITLE
HDDS-10943. Freon DN Echo should skip writing payload to ratis log

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Container2BCSIDMapProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.EchoRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadChunkRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadChunkResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
@@ -455,6 +456,10 @@ public class ContainerStateMachine extends BaseStateMachine {
     } else if (proto.getCmdType() == Type.FinalizeBlock) {
       containerController.addFinalizedBlock(proto.getContainerID(),
           proto.getFinalizeBlock().getBlockID().getLocalID());
+    } else if (proto.getCmdType() == Type.Echo) {
+      final EchoRequestProto echo = proto.getEcho();
+      // skipping the payload field so it doesn't get written to the ratis log
+      protoBuilder.setEcho(EchoRequestProto.newBuilder(echo).clearPayload()).build();
     }
 
     if (blockAlreadyFinalized) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10943. Freon DN Echo should skip writing payload to ratis log

Please describe your PR in detail:
Echo request transaction payload is saved into ratis log. The payload isn't used and causes rapid ratis log rotation

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10943

## How was this patch tested?

This is an optimization; no functional change. Plus, it doesn't look easy to write a unit test around ContainerStateMachine within the current framework.