### PR TITLE
HDDS-11019. Remove unused variable release-year from root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
     <shell-executable>bash</shell-executable>
 
-    <!-- Set the Release year during release -->
-    <release-year>2019</release-year>
-
     <failIfNoTests>false</failIfNoTests>
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove unused variable `release-year` from root POM.

`release-year` was used in Hadoop to show the release year in HDFS Web UI footer. Such footer is not present in Ozone Web UI and thus it is not used by Ozone anywhere.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11019

## How was this patch tested?

- n/a