### PR TITLE
HDDS-11022. Activate native profile only if -Drocks_tools_native is set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2171,6 +2171,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     </profile>
     <profile>
       <id>native</id>
+      <activation>
+        <property>
+          <name>rocks_tools_native</name>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently when integration.sh script also triggers native tests which should be only triggered by native.sh. This happens because native maven profile gets activated by default if no profile is set. The test fails since native lib has not been built.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11022

## How was this patch tested?
Local running of integration.sh script without explicitly activating any maven profile.
