### PR TITLE
HDDS-11022. Set default test exclusion

### DIFF
--- a/hadoop-ozone/dev-support/checks/native.sh
+++ b/hadoop-ozone/dev-support/checks/native.sh
@@ -19,5 +19,5 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CHECK=native
 
-source "${DIR}/junit.sh" -Pnative -Drocks_tools_native -DexcludedGroups="unhealthy" \
+source "${DIR}/junit.sh" -Pnative -Drocks_tools_native \
   "$@"

--- a/hadoop-ozone/dev-support/checks/unit.sh
+++ b/hadoop-ozone/dev-support/checks/unit.sh
@@ -18,5 +18,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CHECK=unit
 source "${DIR}/junit.sh" \
   -pl \!:ozone-integration-test,\!:mini-chaos-tests \
-  -DexcludedGroups="native | unhealthy" \
   "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
     <maven-surefire-plugin.argLineAccessArgs></maven-surefire-plugin.argLineAccessArgs>
-    <unstable-test-groups>flaky | native | slow | unhealthy</unstable-test-groups>
+    <excluded-test-groups>native | unhealthy</excluded-test-groups> <!-- test groups excluded by default (without any manual profile activation -->
+    <unstable-test-groups>flaky | native | slow | unhealthy</unstable-test-groups> <!-- test groups excluded in CI (except in dedicated profiles for flaky and native) -->
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
 
@@ -1714,6 +1715,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <includes>
             <include>**/Test*.java</include>
           </includes>
+          <excludedGroups>${excluded-test-groups}</excludedGroups>
         </configuration>
       </plugin>
       <plugin>
@@ -1969,6 +1971,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </properties>
     </profile>
     <profile>
+      <!-- @Native tests are excluded by default.  This profile removes the exclusion if native build is enabled. -->
+      <id>rocks-native-tests</id>
+      <activation>
+        <property>
+          <name>rocks_tools_native</name>
+        </property>
+      </activation>
+      <properties>
+        <excluded-test-groups>unhealthy</excluded-test-groups>
+      </properties>
+    </profile>
+    <!-- The following profiles define test splits for CI -->
+    <profile>
       <id>client</id>
       <build>
         <plugins>
@@ -2155,6 +2170,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </build>
     </profile>
     <profile>
+      <!-- Test split dedicated for running @Flaky tests -->
       <id>flaky</id>
       <build>
         <plugins>
@@ -2170,6 +2186,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </build>
     </profile>
     <profile>
+      <!-- Test split dedicated for running @Native tests -->
       <id>native</id>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
     <maven-surefire-plugin.argLineAccessArgs></maven-surefire-plugin.argLineAccessArgs>
-    <excluded-test-groups>native | unhealthy</excluded-test-groups> <!-- test groups excluded by default (without any manual profile activation -->
+    <excluded-test-groups>native | unhealthy</excluded-test-groups> <!-- test groups excluded by default (without any manual profile activation) -->
     <unstable-test-groups>flaky | native | slow | unhealthy</unstable-test-groups> <!-- test groups excluded in CI (except in dedicated profiles for flaky and native) -->
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

When running `integration.sh` without any arguments, some undesired tests are executed:
- tests marked as `@Native` (which require native bits from `hdds-rocks-native`)
- tests marked as `@Unhealthy` (which are expected to fail)

Changes in this PR:
- Add exclusion of `@Native` and `@Unhealthy` tests to Ozone's default configuration of Maven Surefire plugin.
- Add a new profile to not skip `@Native` tests when native bits are compiled.  The profile is activated by presence of `rocks_tools_native` property, which also triggers compilation of native bits.
- Remove `excludedGroups` from `native.sh`, since it was overriding the exclusion defined in the profile.
- Remove `excludedGroups` from `unit.sh`, since now it matches the default exclusion.

https://issues.apache.org/jira/browse/HDDS-11022

## How was this patch tested?

Generated and compared the effective POM (`mvn -B help:effective-pom -Doutput=<output.xml>`) for various arguments.  Verified that test inclusion/exclusion filters are as expected.

- no arguments: skip native and unhealthy
  ```
  <excludedGroups>native | unhealthy</excludedGroups>
  ```
- enable native build (`-Drocks_tools_native`): skip only unhealthy
  ```
  <excludedGroups>unhealthy</excludedGroups>
  ```
- arguments from `native.sh` (`-Pnative -Drocks_tools_native`): only run native, skip slow and unhealthy
  ```
  <groups>native</groups>
  <excludedGroups>slow | unhealthy</excludedGroups>
  ```
- arguments from one of the "normal" splits of integration CI check: (`-Pclient`): unchanged from `master`
  ```
  <includes>
    <include>org.apache.hadoop.ozone.client.**</include>
  </includes>
  <excludedGroups>flaky | native | slow | unhealthy</excludedGroups>
  ```
- arguments from `flaky` split: (`-Pflaky`): unchanged from `master`
  ```
  <groups>flaky</groups>
  <excludedGroups>native | slow | unhealthy</excludedGroups>
  ```

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/9561202938