### PR TITLE
HDDS-11035. Implement initial version of the Helm chart

### DIFF
--- a/charts/ozone/Chart.yaml
+++ b/charts/ozone/Chart.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: ozone
+description: The official Helm chart for Apache Ozone
+type: application
+version: 0.1.0
+appVersion: "1.4.0"
+home: https://ozone.apache.org
+icon: https://ozone.apache.org/ozone-logo.png
+sources:
+  - https://github.com/apache/ozone
+keywords:
+  - apache
+  - ozone
+  - object-storage
+  - S3
+  - storage

--- a/charts/ozone/README.md
+++ b/charts/ozone/README.md
@@ -1,0 +1,39 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Helm Chart for Apache Ozone
+
+[Apache Ozone](https://ozone.apache.org) is a highly scalable, distributed storage for Analytics, Big data and Cloud Native applications.
+
+
+## Introduction
+
+This chart bootstraps an [Ozone](https://ozone.apache.org) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Requirements
+
+- Kubernetes cluster 1.27+
+- Helm 3.0+
+
+## Documentation
+
+Documentation lives on the Apache Ozone [website](https://ozone.apache.org/docs/).
+
+## Contributing
+
+Want to help build Apache Ozone? Check out our [Contribution guideline](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).

--- a/charts/ozone/templates/NOTES.txt
+++ b/charts/ozone/templates/NOTES.txt
@@ -1,0 +1,47 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+The chart has been installed!
+
+In order to check the release status, use:
+  helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+    or for more detailed info
+  helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+****************
+*   Services   *
+****************
+
+Ozone Manager
+ To access Ozone Manager from a browser, use the following command and visit localhost:{{ .Values.om.service.port }}
+ $ kubectl port-forward svc/{{ .Release.Name }}-om {{ .Values.om.service.port }}:{{ .Values.om.service.port }}
+
+Storage Container Manager
+ To access Storage Container Manager from a browser, use the following command and visit localhost:{{ .Values.scm.service.port }}
+ $ kubectl port-forward svc/{{ .Release.Name }}-scm {{ .Values.scm.service.port }}:{{ .Values.scm.service.port }}
+
+Datanode
+ To access Datanode instances from a browser, use one of the following commands and visit localhost:{{ .Values.datanode.service.port }}
+ {{- $replicas := .Values.datanode.replicas | int }}
+ {{- range $i := until $replicas }}
+ $ kubectl port-forward pod/{{ $.Release.Name }}-datanode-{{ $i }} {{ $.Values.datanode.service.port }}:{{ $.Values.datanode.service.port }}
+ {{- end }}
+
+S3 Gateway
+ To access S3 Gateway from a local environment, use the following command and specify localhost:{{ .Values.s3g.service.port }} as S3 endpoint
+ $ kubectl port-forward svc/{{ .Release.Name }}-s3g {{ .Values.s3g.service.port }}:{{ .Values.s3g.service.port }}

--- a/charts/ozone/templates/_helpers.tpl
+++ b/charts/ozone/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{/* Common labels */}}
+{{- define "ozone.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels */}}
+{{- define "ozone.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* List of comma separated SCM pod names */}}
+{{- define "ozone.scm.pods" -}}
+  {{- $pods := list }}
+  {{- $replicas := .Values.scm.replicas | int }}
+  {{- range $i := until $replicas }}
+    {{- $pods = append $pods (printf "%s-scm-%d.%s-scm-headless" $.Release.Name $i $.Release.Name) }}
+  {{- end }}
+  {{- $pods | join "," }}
+{{- end }}
+
+{{/* List of comma separated OM pod names */}}
+{{- define "ozone.om.pods" -}}
+  {{- $pods := list }}
+  {{- $replicas := .Values.om.replicas | int }}
+  {{- range $i := until $replicas }}
+    {{- $pods = append $pods (printf "%s-om-%d.%s-om-headless" $.Release.Name $i $.Release.Name) }}
+  {{- end }}
+  {{- $pods | join "," }}
+{{- end }}
+
+{{/* Common configuration environment variables */}}
+{{- define "ozone.configuration.env" -}}
+- name: OZONE-SITE.XML_hdds.datanode.dir
+  value: /data/storage
+- name: OZONE-SITE.XML_ozone.scm.datanode.id.dir
+  value: /data
+- name: OZONE-SITE.XML_ozone.metadata.dirs
+  value: /data/metadata
+- name: OZONE-SITE.XML_ozone.scm.block.client.address
+  value: {{ include "ozone.scm.pods" . }}
+- name: OZONE-SITE.XML_ozone.scm.client.address
+  value: {{ include "ozone.scm.pods" . }}
+- name: OZONE-SITE.XML_ozone.scm.names
+  value: {{ include "ozone.scm.pods" . }}
+- name: OZONE-SITE.XML_ozone.om.address
+  value: {{ include "ozone.om.pods" . }}
+- name: OZONE-SITE.XML_hdds.scm.safemode.min.datanode
+  value: "3"
+- name: OZONE-SITE.XML_ozone.datanode.pipeline.limit
+  value: "1"
+- name: OZONE-SITE.XML_dfs.datanode.use.datanode.hostname
+  value: "true"
+{{- end }}

--- a/charts/ozone/templates/datanode/datanode-pvc.yaml
+++ b/charts/ozone/templates/datanode/datanode-pvc.yaml
@@ -1,0 +1,34 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if and .Values.datanode.persistence.enabled (not .Values.datanode.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-datanode
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: datanode
+spec:
+  resources:
+    requests:
+      storage: {{ .Values.datanode.persistence.size }}
+  {{- with .Values.datanode.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/ozone/templates/datanode/datanode-service-headless.yaml
+++ b/charts/ozone/templates/datanode/datanode-service-headless.yaml
@@ -1,0 +1,33 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-datanode-headless
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: datanode
+spec:
+  clusterIP: None
+  ports:
+    - name: ui
+      port: {{ .Values.datanode.service.port }}
+  selector:
+    {{- include "ozone.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: datanode

--- a/charts/ozone/templates/datanode/datanode-service.yaml
+++ b/charts/ozone/templates/datanode/datanode-service.yaml
@@ -1,0 +1,36 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-datanode
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: datanode
+spec:
+  type: {{ .Values.datanode.service.type }}
+  ports:
+    - name: ui
+      port: {{ .Values.datanode.service.port }}
+      {{- if and (eq .Values.datanode.service.type "NodePort") (.Values.datanode.service.nodePort) }}
+      nodePort: {{ .Values.datanode.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "ozone.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: datanode

--- a/charts/ozone/templates/datanode/datanode-statefulset.yaml
+++ b/charts/ozone/templates/datanode/datanode-statefulset.yaml
@@ -1,0 +1,106 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- $env := concat .Values.env .Values.datanode.env }}
+{{- $envFrom := concat .Values.envFrom .Values.datanode.envFrom }}
+{{- $nodeSelector := or .Values.datanode.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.datanode.affinity .Values.affinity }}
+{{- $tolerations := or .Values.datanode.tolerations .Values.tolerations }}
+{{- $securityContext := or .Values.datanode.securityContext .Values.securityContext }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-datanode
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: datanode
+spec:
+  replicas: {{ .Values.datanode.replicas }}
+  serviceName: {{ .Release.Name }}-datanode-headless
+  selector:
+    matchLabels:
+      {{- include "ozone.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: datanode
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ozone-configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "ozone.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: datanode
+    spec:
+      containers:
+        - name: datanode
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.datanode.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.datanode.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "ozone.configuration.env" . | nindent 12 }}
+            {{- with $env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: ui
+              containerPort: {{ .Values.datanode.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: ui
+            initialDelaySeconds: 30
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.configuration.dir }}
+            - name: data
+              mountPath: {{ .Values.datanode.persistence.path }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ .Release.Name }}
+              {{- with .Values.configuration.filesFrom }}
+                {{- tpl (toYaml .) $ | nindent 8 }}
+              {{- end }}
+        {{- if .Values.datanode.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.datanode.persistence.existingClaim | default (printf "%s-%s" .Release.Name "datanode") }}
+        {{- else }}
+        - name: data
+          emptyDir: {}
+        {{- end }}

--- a/charts/ozone/templates/om/om-pvc.yaml
+++ b/charts/ozone/templates/om/om-pvc.yaml
@@ -1,0 +1,34 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if and .Values.om.persistence.enabled (not .Values.om.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-om
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: om
+spec:
+  resources:
+    requests:
+      storage: {{ .Values.om.persistence.size }}
+  {{- with .Values.om.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/ozone/templates/om/om-service-headless.yaml
+++ b/charts/ozone/templates/om/om-service-headless.yaml
@@ -1,0 +1,33 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-om-headless
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: om
+spec:
+  clusterIP: None
+  ports:
+    - name: ui
+      port: {{ .Values.om.service.port }}
+  selector:
+    {{- include "ozone.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: om

--- a/charts/ozone/templates/om/om-service.yaml
+++ b/charts/ozone/templates/om/om-service.yaml
@@ -1,0 +1,36 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-om
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: om
+spec:
+  type: {{ .Values.om.service.type }}
+  ports:
+    - name: ui
+      port: {{ .Values.om.service.port }}
+      {{- if and (eq .Values.om.service.type "NodePort") (.Values.om.service.nodePort) }}
+      nodePort: {{ .Values.om.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "ozone.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: om

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -1,0 +1,112 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- $env := concat .Values.env .Values.om.env }}
+{{- $envFrom := concat .Values.envFrom .Values.om.envFrom }}
+{{- $nodeSelector := or .Values.om.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.om.affinity .Values.affinity }}
+{{- $tolerations := or .Values.om.tolerations .Values.tolerations }}
+{{- $securityContext := or .Values.om.securityContext .Values.securityContext }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-om
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: om
+spec:
+  replicas: {{ .Values.om.replicas }}
+  serviceName: {{ .Release.Name }}-om-headless
+  selector:
+    matchLabels:
+      {{- include "ozone.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: om
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ozone-configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "ozone.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: om
+    spec:
+      containers:
+        - name: om
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.om.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.om.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "ozone.configuration.env" . | nindent 12 }}
+            - name: WAITFOR
+              value: {{ $.Release.Name }}-scm-0.{{ $.Release.Name }}-scm-headless:9876
+            - name: ENSURE_OM_INITIALIZED
+              value: /data/metadata/om/current/VERSION
+            {{- with $env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: rpc
+              containerPort: 9862
+            - name: ui
+              containerPort: {{ .Values.om.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: ui
+            initialDelaySeconds: 60
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.configuration.dir }}
+            - name: data
+              mountPath: {{ .Values.om.persistence.path }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ .Release.Name }}
+              {{- with .Values.configuration.filesFrom }}
+                {{- tpl (toYaml .) $ | nindent 8 }}
+              {{- end }}
+        {{- if .Values.om.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.om.persistence.existingClaim | default (printf "%s-%s" .Release.Name "om") }}
+        {{- else }}
+        - name: data
+          emptyDir: {}
+        {{- end }}

--- a/charts/ozone/templates/ozone-configmap.yaml
+++ b/charts/ozone/templates/ozone-configmap.yaml
@@ -1,0 +1,25 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  labels: {{- include "ozone.labels" . | nindent 4 }}
+data:
+  {{- tpl (toYaml .Values.configuration.files) $ | nindent 4 }}

--- a/charts/ozone/templates/s3g/s3g-pvc.yaml
+++ b/charts/ozone/templates/s3g/s3g-pvc.yaml
@@ -1,0 +1,34 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if and .Values.s3g.persistence.enabled (not .Values.s3g.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-s3g
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3g
+spec:
+  resources:
+    requests:
+      storage: {{ .Values.s3g.persistence.size }}
+  {{- with .Values.s3g.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/ozone/templates/s3g/s3g-service-headless.yaml
+++ b/charts/ozone/templates/s3g/s3g-service-headless.yaml
@@ -1,0 +1,33 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-s3g-headless
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3g
+spec:
+  clusterIP: None
+  ports:
+    - name: rest
+      port: {{ .Values.s3g.service.port }}
+  selector:
+    {{- include "ozone.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: s3g

--- a/charts/ozone/templates/s3g/s3g-service.yaml
+++ b/charts/ozone/templates/s3g/s3g-service.yaml
@@ -1,0 +1,36 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-s3g
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3g
+spec:
+  type: {{ .Values.s3g.service.type }}
+  ports:
+    - name: rest
+      port: {{ .Values.s3g.service.port }}
+      {{- if and (eq .Values.s3g.service.type "NodePort") (.Values.s3g.service.nodePort) }}
+      nodePort: {{ .Values.s3g.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "ozone.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: s3g

--- a/charts/ozone/templates/s3g/s3g-statefulset.yaml
+++ b/charts/ozone/templates/s3g/s3g-statefulset.yaml
@@ -1,0 +1,106 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- $env := concat .Values.env .Values.s3g.env }}
+{{- $envFrom := concat .Values.envFrom .Values.s3g.envFrom }}
+{{- $nodeSelector := or .Values.s3g.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.s3g.affinity .Values.affinity }}
+{{- $tolerations := or .Values.s3g.tolerations .Values.tolerations }}
+{{- $securityContext := or .Values.s3g.securityContext .Values.securityContext }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-s3g
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: s3g
+spec:
+  replicas: {{ .Values.s3g.replicas }}
+  serviceName: {{ .Release.Name }}-s3g-headless
+  selector:
+    matchLabels:
+      {{- include "ozone.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: s3g
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ozone-configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "ozone.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: s3g
+    spec:
+      containers:
+        - name: s3g
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.s3g.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.s3g.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "ozone.configuration.env" . | nindent 12 }}
+            {{- with $env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: rest
+              containerPort: {{ .Values.s3g.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: rest
+            initialDelaySeconds: 30
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.configuration.dir }}
+            - name: data
+              mountPath: {{ .Values.s3g.persistence.path }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ .Release.Name }}
+              {{- with .Values.configuration.filesFrom }}
+                {{- tpl (toYaml .) $ | nindent 8 }}
+              {{- end }}
+        {{- if .Values.s3g.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.s3g.persistence.existingClaim | default (printf "%s-%s" .Release.Name "s3g") }}
+        {{- else }}
+        - name: data
+          emptyDir: {}
+        {{- end }}

--- a/charts/ozone/templates/scm/scm-pvc.yaml
+++ b/charts/ozone/templates/scm/scm-pvc.yaml
@@ -1,0 +1,34 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if and .Values.scm.persistence.enabled (not .Values.scm.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-scm
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scm
+spec:
+  resources:
+    requests:
+      storage: {{ .Values.scm.persistence.size }}
+  {{- with .Values.scm.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/ozone/templates/scm/scm-service-headless.yaml
+++ b/charts/ozone/templates/scm/scm-service-headless.yaml
@@ -1,0 +1,33 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-scm-headless
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scm
+spec:
+  clusterIP: None
+  ports:
+    - name: ui
+      port: {{ .Values.scm.service.port }}
+  selector:
+    {{- include "ozone.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: scm

--- a/charts/ozone/templates/scm/scm-service.yaml
+++ b/charts/ozone/templates/scm/scm-service.yaml
@@ -1,0 +1,36 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-scm
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scm
+spec:
+  type: {{ .Values.scm.service.type }}
+  ports:
+    - name: ui
+      port: {{ .Values.scm.service.port }}
+      {{- if and (eq .Values.scm.service.type "NodePort") (.Values.scm.service.nodePort) }}
+      nodePort: {{ .Values.scm.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "ozone.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: scm

--- a/charts/ozone/templates/scm/scm-statefulset.yaml
+++ b/charts/ozone/templates/scm/scm-statefulset.yaml
@@ -1,0 +1,127 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- $env := concat .Values.env .Values.scm.env }}
+{{- $envFrom := concat .Values.envFrom .Values.scm.envFrom }}
+{{- $nodeSelector := or .Values.scm.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.scm.affinity .Values.affinity }}
+{{- $tolerations := or .Values.scm.tolerations .Values.tolerations }}
+{{- $securityContext := or .Values.scm.securityContext .Values.securityContext }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-scm
+  labels:
+    {{- include "ozone.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scm
+spec:
+  replicas: {{ .Values.scm.replicas }}
+  serviceName: {{ .Release.Name }}-scm-headless
+  selector:
+    matchLabels:
+      {{- include "ozone.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: scm
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ozone-configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "ozone.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: scm
+    spec:
+      initContainers:
+        - name: init
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args: ["ozone", "scm", "--init"]
+          env:
+            {{- include "ozone.configuration.env" . | nindent 12 }}
+            {{- with $env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.configuration.dir }}
+            - name: data
+              mountPath: {{ .Values.scm.persistence.path }}
+      containers:
+        - name: scm
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.scm.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.scm.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "ozone.configuration.env" . | nindent 12 }}
+            {{- with $env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: rpc-client
+              containerPort: 9860
+            - name: rpc-datanode
+              containerPort: 9861
+            - name: ui
+              containerPort: {{ .Values.scm.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: ui
+            initialDelaySeconds: 30
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.configuration.dir }}
+            - name: data
+              mountPath: {{ .Values.scm.persistence.path }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ .Release.Name }}
+              {{- with .Values.configuration.filesFrom }}
+                {{- tpl (toYaml .) $ | nindent 8 }}
+              {{- end }}
+        {{- if .Values.scm.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.scm.persistence.existingClaim | default (printf "%s-%s" .Release.Name "scm") }}
+        {{- else }}
+        - name: data
+          emptyDir: {}
+        {{- end }}

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -1,0 +1,212 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+image:
+  repository: apache/ozone
+  pullPolicy: IfNotPresent
+  tag: ~
+
+imagePullSecrets: []
+
+# Common environment variables (templated)
+env: []
+# Common envFrom items to set up environment variables (templated)
+envFrom: []
+
+# Configuration management
+configuration:
+  # Configuration directory, i.e. $OZONE_CONF_DIR
+  dir: /opt/hadoop/etc/hadoop
+  # Configuration files from the specified keys (file name) and values (file content)
+  files:
+    'log4j.properties': |-
+      log4j.rootLogger=INFO,stdout
+      log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+      log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+      log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
+  # Configuration files from the existing ConfigMaps and Secrets
+  filesFrom: []
+  #  - configMap:
+  #      name: ozone-config-files
+  #  - secret:
+  #      name: ozone-secret-files
+  #  - secret:
+  #      name: common-secret-files
+  #      items:
+  #        - key: ozone
+  #          path: /etc/hadoop/ozone-site.xml
+
+# Constrain all Ozone pods to nodes with specific node labels
+nodeSelector: {}
+# Constrain all Ozone pods to nodes by affinity/anti-affinity rules
+affinity: {}
+# Allow to schedule all Ozone pods on nodes with matching taints
+tolerations: []
+
+# Common security context
+securityContext: {}
+
+# Datanode configuration
+datanode:
+  # Number of Datanode replicas
+  replicas: 3
+  # Command to launch Datanode (templated)
+  command: ~
+  # Arguments to launch Datanode (templated)
+  args: ["ozone", "datanode"]
+  # Additional Datanode environment variables (templated)
+  env: []
+  # Additional Datanode envFrom items to set up environment variables (templated)
+  envFrom: []
+  # Constrain Datanode pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain Datanode pods to nodes by affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule Datanode pods on nodes with matching taints
+  tolerations: []
+  # Datanode security context (overwrites common security context)
+  securityContext: {}
+  # Datanode service configuration
+  service:
+    type: ClusterIP
+    port: 9882
+    nodePort: ~
+  # Datanode persistence
+  persistence:
+    # Enable persistence
+    enabled: false
+    # Path for datanode volume mount
+    path: /data
+    # Existing PVC name to use
+    existingClaim: ~
+    # Volume size
+    size: 10Gi
+    # The name of a specific storage class name to use
+    storageClassName: ~
+
+# Ozone Manager configuration
+om:
+  # Number of Ozone Manager replicas
+  replicas: 1
+  # Command to launch Ozone Manager (templated)
+  command: ~
+  # Arguments to launch Ozone Manager (templated)
+  args: ["ozone", "om"]
+  # Additional Ozone Manager environment variables (templated)
+  env: []
+  # Additional Ozone Manager envFrom items to set up environment variables (templated)
+  envFrom: []
+  # Constrain Ozone Manager pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain Ozone Manager pods to nodes by affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule Ozone Manager pods on nodes with matching taints
+  tolerations: []
+  # Ozone Manager security context (overwrites common security context)
+  securityContext: {}
+  # Ozone Manager service configuration
+  service:
+    type: ClusterIP
+    port: 9874
+    nodePort: ~
+  # Ozone Manager persistence
+  persistence:
+    # Enable persistence
+    enabled: false
+    # Path for Ozone Manager volume mount
+    path: /data
+    # Existing PVC name to use
+    existingClaim: ~
+    # Volume size
+    size: 10Gi
+    # The name of a specific storage class name to use
+    storageClassName: ~
+
+# S3 Gateway configuration
+s3g:
+  # Number of S3 Gateway replicas
+  replicas: 1
+  # Command to launch S3 Gateway (templated)
+  command: ~
+  # Arguments to launch S3 Gateway (templated)
+  args: ["ozone", "s3g"]
+  # Additional S3 Gateway environment variables (templated)
+  env: []
+  # Additional S3 Gateway envFrom items to set up environment variables (templated)
+  envFrom: []
+  # Constrain S3 Gateway pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain S3 Gateway pods to nodes by affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule S3 Gateway pods on nodes with matching taints
+  tolerations: []
+  # S3 Gateway security context (overwrites common security context)
+  securityContext: {}
+  # S3 Gateway service configuration
+  service:
+    type: ClusterIP
+    port: 9878
+    nodePort: ~
+  # S3 Gateway persistence
+  persistence:
+    # Enable persistence
+    enabled: false
+    # Path for S3 Gateway volume mount
+    path: /data
+    # Existing PVC name to use
+    existingClaim: ~
+    # Volume size
+    size: 10Gi
+    # The name of a specific storage class name to use
+    storageClassName: ~
+
+# Storage Container Manager configuration
+scm:
+  # Number of Storage Container Manager replicas
+  replicas: 1
+  # Command to launch Storage Container Manager (templated)
+  command: ~
+  # Arguments to launch Storage Container Manager (templated)
+  args: ["ozone", "scm"]
+  # Additional Storage Container Manager environment variables (templated)
+  env: []
+  # Additional Storage Container Manager envFrom items to set up environment variables (templated)
+  envFrom: []
+  # Constrain Storage Container Manager pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain Storage Container Manager pods to nodes by affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule Storage Container Manager pods on nodes with matching taints
+  tolerations: []
+  # Storage Container Manager security context (overwrites common security context)
+  securityContext: {}
+  # Storage Container Manager service configuration
+  service:
+    type: ClusterIP
+    port: 9876
+    nodePort: ~
+  # Storage Container Manager persistence
+  persistence:
+    # Enable persistence
+    enabled: false
+    # Path for Storage Container Manager volume mount
+    path: /data
+    # Existing PVC name to use
+    existingClaim: ~
+    # Volume size
+    size: 10Gi
+    # The name of a specific storage class name to use
+    storageClassName: ~


### PR DESCRIPTION
## What changes were proposed in this pull request?
There is a common practice to provide an official Helm chart for a product to increase its usage and adoption. I propose to create an initial version of Helm chart to be used by the community for effortless deployment of Apache Ozone on Kubernetes.

The following steps should to be done in order to release initial Helm chart version:
- [x] Implement initial version of the Helm chart;
- [ ] Add CI pipeline for the chart (lint, release etc);
- [ ] Update documentation with the chart details;
- [ ] Release initial version.

**Comments, suggestions and feedback are very welcome!**

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11027

## How was this patch tested?

Tested manually on Minikube
```sh
helm install ozone charts/ozone
```
Status check
```sh
$ kubectl get pod 
NAME               READY   STATUS    RESTARTS   AGE
ozone-datanode-0   1/1     Running   0          2m11s
ozone-datanode-1   1/1     Running   0          2m10s
ozone-datanode-2   1/1     Running   0          2m9s
ozone-om-0         1/1     Running   0          2m11s
ozone-s3g-0        1/1     Running   0          2m11s
ozone-scm-0        1/1     Running   0          2m11s

$ kubectl get service
NAME                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
kubernetes                ClusterIP   10.96.0.1        <none>        443/TCP    5h59m
ozone-datanode            ClusterIP   10.98.184.181    <none>        9882/TCP   2m21s
ozone-datanode-headless   ClusterIP   None             <none>        9882/TCP   2m21s
ozone-om                  ClusterIP   10.100.191.112   <none>        9874/TCP   2m21s
ozone-om-headless         ClusterIP   None             <none>        9874/TCP   2m21s
ozone-s3g                 ClusterIP   10.100.105.252   <none>        9878/TCP   2m21s
ozone-s3g-headless        ClusterIP   None             <none>        9878/TCP   2m21s
ozone-scm                 ClusterIP   10.107.10.164    <none>        9876/TCP   2m21s
ozone-scm-headless        ClusterIP   None             <none>        9876/TCP   2m21s
```
