### PR TITLE
HDDS-11020. Implement RoundRobinPipelineChoosePolicy

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -65,49 +65,45 @@ public class ScmConfig extends ReconfigurableConfig {
 
   @Config(key = "pipeline.choose.policy.impl",
       type = ConfigType.STRING,
-      defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms" +
-          ".RandomPipelineChoosePolicy",
+      defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy",
       tags = { ConfigTag.SCM, ConfigTag.PIPELINE },
       description =
-          "The full name of class which implements "
-          + "org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
-          + "The class decides which pipeline will be used to find or "
-          + "allocate Ratis containers. If not set, "
-          + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms."
-          + "RandomPipelineChoosePolicy will be used as default value. "
+          "The full name of class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
+          + "The class decides which pipeline will be used to find or allocate Ratis containers. If not set, "
+          + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
+          + " will be used as default value. "
           + "The following values can be used, "
-          + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms."
-          + "RandomPipelineChoosePolicy : random choose one pipeline. "
-          + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms."
-          + "HealthyPipelineChoosePolicy : random choose one healthy pipeline. "
-          + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms."
-          + "CapacityPipelineChoosePolicy : choose the pipeline with lower "
-          + "utilization from the two pipelines. Note that random choose "
-          + "method will be executed twice in this policy."
+          + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
+          + " : choose a pipeline randomly. "
+          + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy"
+          + " : choose a healthy pipeline randomly. "
+          + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy"
+          + " : choose the pipeline with lower utilization from the two pipelines. Note that"
+          + " random choose method will be executed twice in this policy."
+          + "(4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy"
+          + " : choose a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only."
   )
   private String pipelineChoosePolicyName;
 
   @Config(key = "ec.pipeline.choose.policy.impl",
       type = ConfigType.STRING,
-      defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms" +
-          ".RandomPipelineChoosePolicy",
+      defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy",
       tags = { ConfigTag.SCM, ConfigTag.PIPELINE },
       description =
-          "The full name of class which implements "
-          + "org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
-          + "The class decides which pipeline will be used when "
-          + "selecting an EC Pipeline. If not set, "
-          + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms."
-          + "RandomPipelineChoosePolicy will be used as default value. "
+          "The full name of class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
+          + "The class decides which pipeline will be used when selecting an EC Pipeline. If not set, "
+          + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
+          + " will be used as default value. "
           + "The following values can be used, "
-          + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms."
-          + "RandomPipelineChoosePolicy : random choose one pipeline. "
-          + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms."
-          + "HealthyPipelineChoosePolicy : random choose one healthy pipeline. "
-          + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms."
-          + "CapacityPipelineChoosePolicy : choose the pipeline with lower "
-          + "utilization from the two pipelines. Note that random choose "
-          + "method will be executed twice in this policy."
+          + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
+          + " : choose a pipeline randomly. "
+          + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy"
+          + " : choose a healthy pipeline randomly. "
+          + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy"
+          + " : choose a pipeline with lower utilization from two random pipelines. Note that"
+          + " random choose method will be executed twice in this policy."
+          + "(4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy"
+          + " : choose a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only."
   )
   private String ecPipelineChoosePolicyName;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -63,7 +63,7 @@ public class ScmConfig extends ReconfigurableConfig {
   )
   private String action;
 
-  private final String descriptionPipelinePolicyImplChoices =
+  private static final String DESCRIPTION_COMMON_CHOICES_OF_PIPELINE_CHOOSE_POLICY_IMPL =
       "One of the following values can be used: "
       + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
       + " : chooses a pipeline randomly. "
@@ -85,7 +85,7 @@ public class ScmConfig extends ReconfigurableConfig {
           + "the full name of a class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
           + "The class decides which pipeline will be used to find or allocate Ratis containers. If not set, "
           + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
-          + " will be used as default value. " + descriptionPipelinePolicyImplChoices
+          + " will be used as default value. " + DESCRIPTION_COMMON_CHOICES_OF_PIPELINE_CHOOSE_POLICY_IMPL
   )
   private String pipelineChoosePolicyName;
 
@@ -99,7 +99,7 @@ public class ScmConfig extends ReconfigurableConfig {
           + "the full name of a class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
           + "The class decides which pipeline will be used when selecting an EC Pipeline. If not set, "
           + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
-          + " will be used as default value. " + descriptionPipelinePolicyImplChoices
+          + " will be used as default value. " + DESCRIPTION_COMMON_CHOICES_OF_PIPELINE_CHOOSE_POLICY_IMPL
   )
   private String ecPipelineChoosePolicyName;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -68,20 +68,21 @@ public class ScmConfig extends ReconfigurableConfig {
       defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy",
       tags = { ConfigTag.SCM, ConfigTag.PIPELINE },
       description =
-          "The full name of class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
+          "Sets the policy for choosing a pipeline for a Ratis container. The value should be "
+          + "the full name of a class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
           + "The class decides which pipeline will be used to find or allocate Ratis containers. If not set, "
           + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
           + " will be used as default value. "
-          + "The following values can be used, "
+          + "One of the following values can be used: "
           + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
-          + " : choose a pipeline randomly. "
+          + " : chooses a pipeline randomly. "
           + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy"
-          + " : choose a healthy pipeline randomly. "
+          + " : chooses a healthy pipeline randomly. "
           + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy"
-          + " : choose the pipeline with lower utilization from the two pipelines. Note that"
+          + " : chooses the pipeline with lower utilization from two random pipelines. Note that"
           + " random choose method will be executed twice in this policy."
           + "(4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy"
-          + " : choose a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only."
+          + " : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only."
   )
   private String pipelineChoosePolicyName;
 
@@ -90,20 +91,21 @@ public class ScmConfig extends ReconfigurableConfig {
       defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy",
       tags = { ConfigTag.SCM, ConfigTag.PIPELINE },
       description =
-          "The full name of class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
+          "Sets the policy for choosing an EC pipeline. The value should be "
+          + "the full name of a class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
           + "The class decides which pipeline will be used when selecting an EC Pipeline. If not set, "
           + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
           + " will be used as default value. "
-          + "The following values can be used, "
+          + "One of the following values can be used: "
           + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
-          + " : choose a pipeline randomly. "
+          + " : chooses a pipeline randomly. "
           + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy"
-          + " : choose a healthy pipeline randomly. "
+          + " : chooses a healthy pipeline randomly. "
           + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy"
-          + " : choose a pipeline with lower utilization from two random pipelines. Note that"
+          + " : chooses a pipeline with lower utilization from two random pipelines. Note that"
           + " random choose method will be executed twice in this policy."
           + "(4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy"
-          + " : choose a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only."
+          + " : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only."
   )
   private String ecPipelineChoosePolicyName;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -63,6 +63,18 @@ public class ScmConfig extends ReconfigurableConfig {
   )
   private String action;
 
+  private final String descriptionPipelinePolicyImplChoices =
+      "One of the following values can be used: "
+      + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
+      + " : chooses a pipeline randomly. "
+      + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy"
+      + " : chooses a healthy pipeline randomly. "
+      + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy"
+      + " : chooses the pipeline with lower utilization from two random pipelines. Note that"
+      + " random choose method will be executed twice in this policy."
+      + "(4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy"
+      + " : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only.";
+
   // hdds.scm.pipeline.choose.policy.impl
   @Config(key = "pipeline.choose.policy.impl",
       type = ConfigType.STRING,
@@ -73,17 +85,7 @@ public class ScmConfig extends ReconfigurableConfig {
           + "the full name of a class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
           + "The class decides which pipeline will be used to find or allocate Ratis containers. If not set, "
           + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
-          + " will be used as default value. "
-          + "One of the following values can be used: "
-          + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
-          + " : chooses a pipeline randomly. "
-          + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy"
-          + " : chooses a healthy pipeline randomly. "
-          + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy"
-          + " : chooses the pipeline with lower utilization from two random pipelines. Note that"
-          + " random choose method will be executed twice in this policy."
-          + "(4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy"
-          + " : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only."
+          + " will be used as default value. " + descriptionPipelinePolicyImplChoices
   )
   private String pipelineChoosePolicyName;
 
@@ -97,17 +99,7 @@ public class ScmConfig extends ReconfigurableConfig {
           + "the full name of a class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy. "
           + "The class decides which pipeline will be used when selecting an EC Pipeline. If not set, "
           + "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
-          + " will be used as default value. "
-          + "One of the following values can be used: "
-          + "(1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy"
-          + " : chooses a pipeline randomly. "
-          + "(2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy"
-          + " : chooses a healthy pipeline randomly. "
-          + "(3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy"
-          + " : chooses a pipeline with lower utilization from two random pipelines. Note that"
-          + " random choose method will be executed twice in this policy."
-          + "(4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy"
-          + " : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only."
+          + " will be used as default value. " + descriptionPipelinePolicyImplChoices
   )
   private String ecPipelineChoosePolicyName;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -63,6 +63,7 @@ public class ScmConfig extends ReconfigurableConfig {
   )
   private String action;
 
+  // hdds.scm.pipeline.choose.policy.impl
   @Config(key = "pipeline.choose.policy.impl",
       type = ConfigType.STRING,
       defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy",
@@ -86,6 +87,7 @@ public class ScmConfig extends ReconfigurableConfig {
   )
   private String pipelineChoosePolicyName;
 
+  // hdds.scm.ec.pipeline.choose.policy.impl
   @Config(key = "ec.pipeline.choose.policy.impl",
       type = ConfigType.STRING,
       defaultValue = "org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy",

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1573,54 +1573,6 @@
   </property>
 
   <property>
-    <name>hdds.scm.pipeline.choose.policy.impl</name>
-    <value>org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy</value>
-    <tag>SCM, PIPELINE</tag>
-    <description>
-      Sets the policy for choosing a pipeline for a Ratis container. The value should be
-      the full name of class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy.
-      The class decides which pipeline will be used to find or allocate Ratis containers. If not set,
-      org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
-      will be used as default value.
-
-      The following values can be used,
-      (1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
-      : choose a pipeline randomly.
-      (2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy
-      : choose a healthy pipeline randomly.
-      (3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy
-      : choose the pipeline with lower utilization from two random pipelines. Note that
-      random choose method will be executed twice in this policy.
-      (4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy
-      : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only.
-    </description>
-  </property>
-
-  <property>
-  <name>hdds.scm.pipeline.choose.policy.impl</name>
-  <value>org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy</value>
-  <tag>SCM, PIPELINE</tag>
-  <description>
-    Sets the policy for choosing an EC pipeline. The value should be
-    the full name of a class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy.
-    The class decides which pipeline will be used when selecting an EC Pipeline. If not set,
-    org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
-    will be used as default value.
-
-    One of the following values can be used:
-    (1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
-     : chooses a pipeline randomly.
-    (2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy
-     : chooses a healthy pipeline randomly.
-    (3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy
-     : chooses a pipeline with lower utilization from two random pipelines. Note that
-     random choose method will be executed twice in this policy.
-    (4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy
-     : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only.
-  </description>
-  </property>
-
-  <property>
     <name>hdds.scm.safemode.threshold.pct</name>
     <value>0.99</value>
     <tag>HDDS,SCM,OPERATION</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1571,7 +1571,6 @@
       If enabled, SCM will auto create RATIS factor ONE pipeline.
     </description>
   </property>
-
   <property>
     <name>hdds.scm.safemode.threshold.pct</name>
     <value>0.99</value>
@@ -3066,7 +3065,7 @@
     <name>ozone.freon.http.auth.type</name>
     <value>simple</value>
     <tag>FREON, SECURITY</tag>
-    <description> simple or kerberos. If kerberos is set, SPNEGO
+    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
   </property>
@@ -3074,7 +3073,7 @@
     <name>ozone.om.http.auth.type</name>
     <value>simple</value>
     <tag>OM, SECURITY, KERBEROS</tag>
-    <description> simple or kerberos. If kerberos is set, SPNEGO
+    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
   </property>
@@ -3082,7 +3081,7 @@
     <name>hdds.scm.http.auth.type</name>
     <value>simple</value>
     <tag>OM, SECURITY, KERBEROS</tag>
-    <description> simple or kerberos. If kerberos is set, SPNEGO
+    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
   </property>
@@ -3090,7 +3089,7 @@
     <name>ozone.recon.http.auth.type</name>
     <value>simple</value>
     <tag>RECON, SECURITY, KERBEROS</tag>
-    <description> simple or kerberos. If kerberos is set, SPNEGO
+    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
   </property>
@@ -3098,7 +3097,7 @@
     <name>ozone.s3g.http.auth.type</name>
     <value>simple</value>
     <tag>S3GATEWAY, SECURITY, KERBEROS</tag>
-    <description> simple or kerberos. If kerberos is set, SPNEGO
+    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
   </property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1571,6 +1571,55 @@
       If enabled, SCM will auto create RATIS factor ONE pipeline.
     </description>
   </property>
+
+  <property>
+    <name>hdds.scm.pipeline.choose.policy.impl</name>
+    <value>org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy</value>
+    <tag>SCM, PIPELINE</tag>
+    <description>
+      Sets the policy for choosing a pipeline for a Ratis container. The value should be
+      the full name of class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy.
+      The class decides which pipeline will be used to find or allocate Ratis containers. If not set,
+      org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
+      will be used as default value.
+
+      The following values can be used,
+      (1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
+      : choose a pipeline randomly.
+      (2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy
+      : choose a healthy pipeline randomly.
+      (3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy
+      : choose the pipeline with lower utilization from two random pipelines. Note that
+      random choose method will be executed twice in this policy.
+      (4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy
+      : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only.
+    </description>
+  </property>
+
+  <property>
+  <name>hdds.scm.pipeline.choose.policy.impl</name>
+  <value>org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy</value>
+  <tag>SCM, PIPELINE</tag>
+  <description>
+    Sets the policy for choosing an EC pipeline. The value should be
+    the full name of a class which implements org.apache.hadoop.hdds.scm.PipelineChoosePolicy.
+    The class decides which pipeline will be used when selecting an EC Pipeline. If not set,
+    org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
+    will be used as default value.
+
+    One of the following values can be used:
+    (1) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
+     : chooses a pipeline randomly.
+    (2) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy
+     : chooses a healthy pipeline randomly.
+    (3) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.CapacityPipelineChoosePolicy
+     : chooses a pipeline with lower utilization from two random pipelines. Note that
+     random choose method will be executed twice in this policy.
+    (4) org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy
+     : chooses a pipeline in a round robin fashion. Intended for troubleshooting and testing purposes only.
+  </description>
+  </property>
+
   <property>
     <name>hdds.scm.safemode.threshold.pct</name>
     <value>0.99</value>
@@ -3065,7 +3114,7 @@
     <name>ozone.freon.http.auth.type</name>
     <value>simple</value>
     <tag>FREON, SECURITY</tag>
-    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
+    <description> simple or kerberos. If kerberos is set, SPNEGO
       will be used for http authentication.
     </description>
   </property>
@@ -3073,7 +3122,7 @@
     <name>ozone.om.http.auth.type</name>
     <value>simple</value>
     <tag>OM, SECURITY, KERBEROS</tag>
-    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
+    <description> simple or kerberos. If kerberos is set, SPNEGO
       will be used for http authentication.
     </description>
   </property>
@@ -3081,7 +3130,7 @@
     <name>hdds.scm.http.auth.type</name>
     <value>simple</value>
     <tag>OM, SECURITY, KERBEROS</tag>
-    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
+    <description> simple or kerberos. If kerberos is set, SPNEGO
       will be used for http authentication.
     </description>
   </property>
@@ -3089,7 +3138,7 @@
     <name>ozone.recon.http.auth.type</name>
     <value>simple</value>
     <tag>RECON, SECURITY, KERBEROS</tag>
-    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
+    <description> simple or kerberos. If kerberos is set, SPNEGO
       will be used for http authentication.
     </description>
   </property>
@@ -3097,7 +3146,7 @@
     <name>ozone.s3g.http.auth.type</name>
     <value>simple</value>
     <tag>S3GATEWAY, SECURITY, KERBEROS</tag>
-    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
+    <description> simple or kerberos. If kerberos is set, SPNEGO
       will be used for http authentication.
     </description>
   </property>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RoundRobinPipelineChoosePolicy.java
@@ -52,12 +52,13 @@ public class RoundRobinPipelineChoosePolicy implements PipelineChoosePolicy {
   @Override
   public int choosePipelineIndex(List<Pipeline> pipelineList,
       PipelineRequestInformation pri) {
-    int nextIndex;
+    final int numPipelines = pipelineList.size();
+    int chosenIndex;
     synchronized (this) {
-      nextPipelineIndex = nextPipelineIndex % pipelineList.size();
-      nextIndex = nextPipelineIndex++;
+      nextPipelineIndex = nextPipelineIndex % numPipelines;
+      chosenIndex = nextPipelineIndex++;
     }
-    LOG.debug("pipeline index chosen = {}, pipelineList size = {}", nextIndex, pipelineList.size());
-    return nextIndex;
+    LOG.debug("chosenIndex = {}, numPipelines = {}", chosenIndex, numPipelines);
+    return chosenIndex;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RoundRobinPipelineChoosePolicy.java
@@ -37,7 +37,6 @@ public class RoundRobinPipelineChoosePolicy implements PipelineChoosePolicy {
   private int nextPipelineIndex = 0;
 
   @Override
-  @SuppressWarnings("java:S2245") // no need for secure random
   public Pipeline choosePipeline(List<Pipeline> pipelineList,
       PipelineRequestInformation pri) {
     return pipelineList.get(choosePipelineIndex(pipelineList, pri));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/RoundRobinPipelineChoosePolicy.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.pipeline.choose.algorithms;
+
+import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
+import org.apache.hadoop.hdds.scm.PipelineRequestInformation;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Round-robin choose policy that chooses pipeline in a round-robin fashion.
+ * Only useful for debugging and testing purposes, at least for now.
+ */
+public class RoundRobinPipelineChoosePolicy implements PipelineChoosePolicy {
+
+  public static final Logger LOG = LoggerFactory.getLogger(RoundRobinPipelineChoosePolicy.class);
+
+  // Stores the index of the next pipeline to be returned.
+  private int nextPipelineIndex = 0;
+
+  @Override
+  @SuppressWarnings("java:S2245") // no need for secure random
+  public Pipeline choosePipeline(List<Pipeline> pipelineList,
+      PipelineRequestInformation pri) {
+    return pipelineList.get(choosePipelineIndex(pipelineList, pri));
+  }
+
+  /**
+   * Given a list of pipelines, return the index of the chosen pipeline.
+   * @param pipelineList List of pipelines
+   * @param pri          PipelineRequestInformation
+   * @return Index in the list of the chosen pipeline.
+   */
+  @Override
+  public int choosePipelineIndex(List<Pipeline> pipelineList,
+      PipelineRequestInformation pri) {
+    int nextIndex;
+    synchronized (this) {
+      nextPipelineIndex = nextPipelineIndex % pipelineList.size();
+      nextIndex = nextPipelineIndex++;
+    }
+    LOG.debug("pipeline index chosen = {}, pipelineList size = {}", nextIndex, pipelineList.size());
+    return nextIndex;
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
@@ -39,8 +39,8 @@ import static org.mockito.Mockito.mock;
  * Test for the round-robin pipeline choose policy.
  */
 public class TestRoundRobinPipelineChoosePolicy {
-  private final int numDatanodes = 4;
-  private final int numPipelines = 4;
+  private static final int NUM_DATANODES = 4;
+  private static final int NUM_PIPELINES = 4;
   private PipelineChoosePolicy policy;
   private List<Pipeline> allPipelines;
 
@@ -48,7 +48,7 @@ public class TestRoundRobinPipelineChoosePolicy {
   public void setup() throws Exception {
 
     List<DatanodeDetails> datanodes = new ArrayList<>();
-    for (int i = 0; i < numDatanodes; i++) {
+    for (int i = 0; i < NUM_DATANODES; i++) {
       datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
     }
 
@@ -63,7 +63,7 @@ public class TestRoundRobinPipelineChoosePolicy {
     //  pipeline3    dn0   dn1   dn2
     //
     allPipelines = new ArrayList<>();
-    for (int i = 0; i < numPipelines; i++) {
+    for (int i = 0; i < NUM_PIPELINES; i++) {
       List<DatanodeDetails> dns = new ArrayList<>();
       for (int j = 0; j < datanodes.size(); j++) {
         if (i != j) {
@@ -78,7 +78,7 @@ public class TestRoundRobinPipelineChoosePolicy {
   }
 
   private void verifySelectedCountMap(Map<Pipeline, Integer> selectedCountMap, int[] arrExpectCount) {
-    for (int i = 0; i < numPipelines; i++) {
+    for (int i = 0; i < NUM_PIPELINES; i++) {
       assertEquals(arrExpectCount[i], selectedCountMap.getOrDefault(allPipelines.get(i), 0));
     }
   }
@@ -91,7 +91,7 @@ public class TestRoundRobinPipelineChoosePolicy {
     for (int i = 0; i < numContainers; i++) {
       Pipeline pipeline = policy.choosePipeline(allPipelines, null);
       assertNotNull(pipeline);
-      assertEquals(allPipelines.get(i % numPipelines), pipeline);
+      assertEquals(allPipelines.get(i % NUM_PIPELINES), pipeline);
       selectedCountMap.compute(pipeline, (k, v) -> v == null ? 1 : v + 1);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -31,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -41,9 +42,9 @@ public class TestRoundRobinPipelineChoosePolicy {
   @Test
   public void testChoosePipeline() throws Exception {
 
-    // given 4 datanode
+    final int numDatanodes = 4;
     List<DatanodeDetails> datanodes = new ArrayList<>();
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < numDatanodes; i++) {
       datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
     }
 
@@ -73,19 +74,20 @@ public class TestRoundRobinPipelineChoosePolicy {
 
     Map<Pipeline, Integer> selectedCountMap = new HashMap<>();
 
-    final int numContainers = 1000;
+    final int numContainers = 100;
     for (int i = 0; i < numContainers; i++) {
       Pipeline pipeline = policy.choosePipeline(pipelines, null);
-      Assertions.assertNotNull(pipeline);
+      assertNotNull(pipeline);
       final int expectedPipelineIndex = i % numPipelines;
       final Pipeline expectedPipelineChosen = pipelines.get(expectedPipelineIndex);
-      Assertions.assertEquals(expectedPipelineChosen, pipeline);
+      assertEquals(expectedPipelineChosen, pipeline);
       selectedCountMap.compute(pipeline, (k, v) -> v == null ? 1 : v + 1);
     }
 
-    // Each pipeline would be chosen 1000/4 = 250 times
+    // Each pipeline would be chosen 100/4 = 25 times
+    final int expectedCount = numContainers / numPipelines;
     for (int i = 0; i < numPipelines; i++) {
-      Assertions.assertEquals(numContainers / numPipelines, selectedCountMap.get(pipelines.get(i)));
+      assertEquals(expectedCount, selectedCountMap.get(pipelines.get(i)));
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm.pipeline.choose.algorithms;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test for the round-robin pipeline choose policy.
+ */
+public class TestRoundRobinPipelineChoosePolicy {
+
+  @Test
+  public void testChoosePipeline() throws Exception {
+
+    // given 4 datanode
+    List<DatanodeDetails> datanodes = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    }
+
+    NodeManager mockNodeManager = mock(NodeManager.class);
+    PipelineChoosePolicy policy = new RoundRobinPipelineChoosePolicy().init(mockNodeManager);
+
+    // generate 4 pipelines, and every pipeline has 3 datanodes
+    //
+    //  pipeline0    dn1   dn2   dn3
+    //  pipeline1    dn0   dn2   dn3
+    //  pipeline2    dn0   dn1   dn3
+    //  pipeline3    dn0   dn1   dn2
+    //
+    final int numPipelines = 4;
+    List<Pipeline> pipelines = new ArrayList<>();
+    for (int i = 0; i < numPipelines; i++) {
+      List<DatanodeDetails> dns = new ArrayList<>();
+      for (int j = 0; j < datanodes.size(); j++) {
+        if (i != j) {
+          dns.add(datanodes.get(j));
+        }
+      }
+      Pipeline pipeline = MockPipeline.createPipeline(dns);
+      MockRatisPipelineProvider.markPipelineHealthy(pipeline);
+      pipelines.add(pipeline);
+    }
+
+    Map<Pipeline, Integer> selectedCountMap = new HashMap<>();
+
+    final int numBlocks = 1000;
+    for (int i = 0; i < numBlocks; i++) {
+      Pipeline pipeline = policy.choosePipeline(pipelines, null);
+      Assertions.assertNotNull(pipeline);
+      final int expectedPipelineIndex = i % numPipelines;
+      final Pipeline expectedPipelineChosen = pipelines.get(expectedPipelineIndex);
+      Assertions.assertEquals(expectedPipelineChosen, pipeline);
+      selectedCountMap.compute(pipeline, (k, v) -> v == null ? 1 : v + 1);
+    }
+
+    // Each pipeline would be chosen 1000/4 = 250 times
+    for (int i = 0; i < numPipelines; i++) {
+      Assertions.assertEquals(numBlocks / numPipelines, selectedCountMap.get(pipelines.get(i)));
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
@@ -131,7 +131,7 @@ public class TestRoundRobinPipelineChoosePolicy {
     // pipeline0 and pipeline1 are selected 5 times each
     verifySelectedCountMap(selectedCountMap, new int[] {5, 5, 0, 0});
 
-    // Case 2. pipeline0, pipeline1 and pipeline2 are available
+    // Case 3. pipeline0, pipeline1 and pipeline2 are available
     availablePipelines.add(allPipelines.get(2));
     numAvailablePipeline = availablePipelines.size();
     selectedCountMap = new HashMap<>();
@@ -143,7 +143,7 @@ public class TestRoundRobinPipelineChoosePolicy {
     // pipeline0-2 are selected 3-4 times each
     verifySelectedCountMap(selectedCountMap, new int[] {3, 4, 3, 0});
 
-    // Case 3. All 4 pipelines are available
+    // Case 4. All 4 pipelines are available
     availablePipelines.add(allPipelines.get(3));
     numAvailablePipeline = availablePipelines.size();
     selectedCountMap = new HashMap<>();
@@ -155,7 +155,7 @@ public class TestRoundRobinPipelineChoosePolicy {
     // pipeline0-3 are selected 2-3 times each
     verifySelectedCountMap(selectedCountMap, new int[] {2, 2, 3, 3});
 
-    // Case 4. Remove pipeline0 from the available pipeline list
+    // Case 5. Remove pipeline0 from the available pipeline list
     availablePipelines.remove(allPipelines.get(0));
     numAvailablePipeline = availablePipelines.size();
     selectedCountMap = new HashMap<>();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
@@ -39,10 +39,10 @@ import static org.mockito.Mockito.mock;
  * Test for the round-robin pipeline choose policy.
  */
 public class TestRoundRobinPipelineChoosePolicy {
-  final int numDatanodes = 4;
-  final int numPipelines = 4;
-  PipelineChoosePolicy policy;
-  List<Pipeline> allPipelines;
+  private final int numDatanodes = 4;
+  private final int numPipelines = 4;
+  private PipelineChoosePolicy policy;
+  private List<Pipeline> allPipelines;
 
   @BeforeEach
   public void setup() throws Exception {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestRoundRobinPipelineChoosePolicy.java
@@ -73,8 +73,8 @@ public class TestRoundRobinPipelineChoosePolicy {
 
     Map<Pipeline, Integer> selectedCountMap = new HashMap<>();
 
-    final int numBlocks = 1000;
-    for (int i = 0; i < numBlocks; i++) {
+    final int numContainers = 1000;
+    for (int i = 0; i < numContainers; i++) {
       Pipeline pipeline = policy.choosePipeline(pipelines, null);
       Assertions.assertNotNull(pipeline);
       final int expectedPipelineIndex = i % numPipelines;
@@ -85,7 +85,7 @@ public class TestRoundRobinPipelineChoosePolicy {
 
     // Each pipeline would be chosen 1000/4 = 250 times
     for (int i = 0; i < numPipelines; i++) {
-      Assertions.assertEquals(numBlocks / numPipelines, selectedCountMap.get(pipelines.get(i)));
+      Assertions.assertEquals(numContainers / numPipelines, selectedCountMap.get(pipelines.get(i)));
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
@@ -218,7 +218,7 @@ public class TestOzoneClientRetriesOnExceptions {
                 .getPipeline(container.getPipelineID());
         XceiverClientSpi xceiverClient =
             xceiverClientManager.acquireClient(pipeline);
-        Assumptions.assumeFalse(containerList.contains(containerID));
+        assertThat(containerList.contains(containerID));
         containerList.add(containerID);
         xceiverClient.sendCommand(ContainerTestHelper
             .getCreateContainerRequest(containerID, pipeline));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptions.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerNotOpenException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RoundRobinPipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.ozone.ClientConfigForTesting;
@@ -107,6 +108,7 @@ public class TestOzoneClientRetriesOnExceptions {
     conf.set(OzoneConfigKeys.OZONE_SCM_CLOSE_CONTAINER_WAIT_DURATION, "2s");
     conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_SCRUB_INTERVAL, "2s");
     conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, "5s");
+    conf.set("hdds.scm.pipeline.choose.policy.impl", RoundRobinPipelineChoosePolicy.class.getName());
     conf.setQuietMode(false);
 
     ClientConfigForTesting.newBuilder(StorageUnit.BYTES)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement `RoundRobinPipelineChoosePolicy` for test case `TestOzoneClientRetriesOnExceptions#testMaxRetriesByOzoneClient`, in order to make sure the test is properly run every time instead of depending on the randomness in `RandomPipelineChoosePolicy`.

`Assume.assumeFalse(containerList.contains(containerID))` was added in HDDS-4577 (#1689) to skip the test if the condition of each block being in a different container is not satisfied. That can now be guaranteed with `RoundRobinPipelineChoosePolicy` and has thus been switched to `assert`.

At this moment, `RoundRobinPipelineChoosePolicy` might only be useful for testing and debugging purposes.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11020


## How was this patch tested?

- Added UT.