### PR TITLE
HDDS-11032. Decommissioned datanodes shows up again after removing in Recon Datanodes page.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
@@ -280,8 +280,7 @@ public class NodeEndpoint {
     AtomicBoolean isContainerOrPipeLineOpen = new AtomicBoolean(false);
     try {
       nodeStatus = nodeManager.getNodeStatus(nodeByUuid);
-      boolean isNodeDecommissioned = nodeByUuid.getPersistedOpState() == NodeOperationalState.DECOMMISSIONED;
-      if (isNodeDecommissioned || nodeStatus.isDead()) {
+      if (nodeStatus.isDead()) {
         checkContainers(nodeByUuid, isContainerOrPipeLineOpen);
         if (isContainerOrPipeLineOpen.get()) {
           failedNodeErrorResponseMap.put(nodeByUuid.getUuidString(), "Open Containers/Pipelines");
@@ -298,8 +297,7 @@ public class NodeEndpoint {
       LOG.error("Node : {} not found", nodeByUuid);
       return false;
     }
-    failedNodeErrorResponseMap.put(nodeByUuid.getUuidString(), "DataNode should be in either DECOMMISSIONED " +
-        "operational state or DEAD node state.");
+    failedNodeErrorResponseMap.put(nodeByUuid.getUuidString(), "DataNode should be in DEAD node status.");
     return false;
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -1281,9 +1281,10 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
         (RemoveDataNodesResponseWrapper) removedDNResponse.getEntity();
     DatanodesResponse errorDataNodes = removeDataNodesResponseWrapper.getDatanodesResponseMap().get("failedDatanodes");
     DatanodesResponse removedNodes = removeDataNodesResponseWrapper.getDatanodesResponseMap().get("removedDatanodes");
-    assertEquals(1, removedNodes.getTotalCount());
-    assertNull(errorDataNodes);
-    removedNodes.getDatanodes().forEach(datanodeMetadata -> {
+
+    assertEquals(1, errorDataNodes.getTotalCount());
+    assertNull(removedNodes);
+    errorDataNodes.getDatanodes().forEach(datanodeMetadata -> {
       assertEquals("host3.datanode", datanodeMetadata.getHostname());
     });
   }
@@ -1301,7 +1302,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     assertFalse(failedNodeErrorResponseMap.isEmpty());
     String nodeError = failedNodeErrorResponseMap.get(dnUUID);
     assertNotNull(nodeError);
-    assertEquals("DataNode should be in either DECOMMISSIONED operational state or DEAD node state.", nodeError);
+    assertEquals("DataNode should be in DEAD node status.", nodeError);
     assertEquals(Response.Status.OK.getStatusCode(), removedDNResponse.getStatus());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to stop showing Decommissioned datanodes again on Recon Datanodes page after removing them explicitly.

Ozone Recon - Decommissioned datanodes shows up again after removing in Recon Datanodes page.
As part of [HDDS-10409](https://issues.apache.org/jira/browse/HDDS-10409)

Recon was allowing to remove the Decommissioned datanodes and was removing from Recon rocksDB nodes table, however Decommissioned datanodes continue to send heartbeats till they are being shutdown, so they get registered and added again in Recon memory map which makes them show up again in datanodes UI.

Solution is to allow only DEAD datanodes to be removed and skip other node status or node operational status datanodes.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11032

## How was this patch tested?
This patch was tested by updating the existing integration test to make sure that only DEAD datanodes are being allowed to remove.
