### PR TITLE
HDDS-10942. OM decommission config support for default serviceID.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -374,8 +374,8 @@ public final class OmUtils {
   public static Collection<String> getDecommissionedNodeIds(
       ConfigurationSource conf,
       String decommissionedNodesKeyWithServiceIdSuffix) {
-    Collection<String> serviceIds =
-        conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
+    HashSet<String> serviceIds = new HashSet<>(
+        conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
     Collection<String> decommissionedNodeIds = conf.getTrimmedStringCollection(
         decommissionedNodesKeyWithServiceIdSuffix);
     // If only one serviceID is configured, also check property without prefix

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -355,13 +355,35 @@ public final class OmUtils {
       String omServiceId) {
     String nodeIdsKey = ConfUtils.addSuffix(OZONE_OM_NODES_KEY, omServiceId);
     Collection<String> nodeIds = conf.getTrimmedStringCollection(nodeIdsKey);
-    String decommNodesKey = ConfUtils.addKeySuffixes(
-        OZONE_OM_DECOMMISSIONED_NODES_KEY, omServiceId);
-    Collection<String> decommNodeIds = conf.getTrimmedStringCollection(
-        decommNodesKey);
-    nodeIds.removeAll(decommNodeIds);
+    String decommissionNodesKeyWithServiceIdSuffix =
+        ConfUtils.addKeySuffixes(OZONE_OM_DECOMMISSIONED_NODES_KEY,
+            omServiceId);
+    Collection<String> decommissionedNodeIds =
+        getDecommissionedNodeIds(conf, decommissionNodesKeyWithServiceIdSuffix);
+    nodeIds.removeAll(decommissionedNodeIds);
 
     return nodeIds;
+  }
+
+  /**
+   * Returns a collection of configured nodeId's that are to be decommissioned.
+   * Aggregate results from both config keys - with and without serviceId
+   * suffix. If ozone.om.service.ids contains a single service ID, then a config
+   * key without suffix defaults to nodeID associated with that serviceID.
+   */
+  public static Collection<String> getDecommissionedNodeIds(
+      ConfigurationSource conf,
+      String decommissionedNodesKeyWithServiceIdSuffix) {
+    Collection<String> serviceIds =
+        conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
+    Collection<String> decommissionedNodeIds = conf.getTrimmedStringCollection(
+        decommissionedNodesKeyWithServiceIdSuffix);
+    // If only one serviceID is configured, also check property without prefix
+    if (decommissionedNodeIds.isEmpty() && serviceIds.size() == 1) {
+      decommissionedNodeIds.addAll(
+          conf.getTrimmedStringCollection(OZONE_OM_DECOMMISSIONED_NODES_KEY));
+    }
+    return decommissionedNodeIds;
   }
 
   /**
@@ -377,6 +399,7 @@ public final class OmUtils {
 
     nodeIds.addAll(conf.getTrimmedStringCollection(nodeIdsKey));
     nodeIds.addAll(conf.getTrimmedStringCollection(decommNodesKey));
+    nodeIds.addAll(conf.getTrimmedStringCollection(OZONE_OM_DECOMMISSIONED_NODES_KEY));
 
     return nodeIds;
   }
@@ -819,10 +842,9 @@ public final class OmUtils {
     } else {
       omNodeIds = OmUtils.getActiveOMNodeIds(conf, omServiceId);
     }
-    Collection<String> decommissionedNodeIds = conf.getTrimmedStringCollection(
+    Collection<String> decommissionedNodeIds = getDecommissionedNodeIds(conf,
             ConfUtils.addKeySuffixes(OZONE_OM_DECOMMISSIONED_NODES_KEY,
                     omServiceId));
-
     if (omNodeIds.isEmpty()) {
       // If there are no nodeIds present, return empty list
       return Collections.emptyList();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -376,8 +376,9 @@ public final class OmUtils {
       String decommissionedNodesKeyWithServiceIdSuffix) {
     HashSet<String> serviceIds = new HashSet<>(
         conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
-    Collection<String> decommissionedNodeIds = conf.getTrimmedStringCollection(
-        decommissionedNodesKeyWithServiceIdSuffix);
+    HashSet<String> decommissionedNodeIds = new HashSet<>(
+        conf.getTrimmedStringCollection(
+            decommissionedNodesKeyWithServiceIdSuffix));
     // If only one serviceID is configured, also check property without prefix
     if (decommissionedNodeIds.isEmpty() && serviceIds.size() == 1) {
       decommissionedNodeIds.addAll(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_DUMMY_SERVICE_ID;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DECOMMISSIONED_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.TestOzoneManagerHA.createKey;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,8 +82,6 @@ public class TestAddRemoveOzoneManager {
   private static final String OM_SERVICE_ID = "om-add-remove";
   private static final String VOLUME_NAME;
   private static final String BUCKET_NAME;
-  private static final String DECOMM_NODES_CONFIG_KEY =
-      "ozone.om.decommissioned.nodes." + OM_SERVICE_ID;
 
   static {
     VOLUME_NAME = "volume" + RandomStringUtils.randomNumeric(5);
@@ -387,9 +386,9 @@ public class TestAddRemoveOzoneManager {
    */
   private void decommissionOM(String decommNodeId) throws Exception {
     Collection<String> decommNodes = conf.getTrimmedStringCollection(
-        DECOMM_NODES_CONFIG_KEY);
+        OZONE_OM_DECOMMISSIONED_NODES_KEY);
     decommNodes.add(decommNodeId);
-    conf.set(DECOMM_NODES_CONFIG_KEY, StringUtils.join(",", decommNodes));
+    conf.set(OZONE_OM_DECOMMISSIONED_NODES_KEY, StringUtils.join(",", decommNodes));
     List<OzoneManager> activeOMs = new ArrayList<>();
     for (OzoneManager om : cluster.getOzoneManagersList()) {
       String omNodeId = om.getOMNodeId();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -156,8 +156,8 @@ public class DecommissionOMSubcommand implements Callable<Void> {
   private void verifyConfigUpdatedOnAllOMs() throws IOException {
     String decommNodesKey = ConfUtils.addKeySuffixes(
         OZONE_OM_DECOMMISSIONED_NODES_KEY, omServiceId);
-    Collection<String> decommNodes = ozoneConf.getTrimmedStringCollection(
-        decommNodesKey);
+    Collection<String> decommNodes =
+        OmUtils.getDecommissionedNodeIds(ozoneConf, decommNodesKey);
     if (!decommNodes.contains(decommNodeId)) {
       throw new IOException("Please add the to be decommissioned OM "
           + decommNodeId + " to the " + decommNodesKey + " config in " +


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, before we decommission an OM, Ozone needs to configure with "ozone.om.decommissioned.nodes.serviceID" to vary of OM's to be decommissioned.

It would be nice to add a constant suffix-less config key support i.e. if only one serviceId is configured, "ozone.om.decommissioned.nodes" should be an acceptable config key that defaults to the only configured ID.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10942

## How was this patch tested?

Tested Manually + Unit tests
