### PR TITLE
HDDS-9844. [hsync] De-synchronize write APIs demo

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
@@ -166,7 +166,7 @@ abstract class AbstractCommitWatcher<BUFFER> {
   /** Release the buffers for the given index. */
   abstract void releaseBuffers(long index);
 
-  void adjustBuffers(long commitIndex) {
+  synchronized void adjustBuffers(long commitIndex) {
     commitIndexMap.keySet().stream()
         .filter(p -> p <= commitIndex)
         .forEach(this::releaseBuffers);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
@@ -62,7 +62,7 @@ abstract class AbstractCommitWatcher<BUFFER> {
 
   private final XceiverClientSpi client;
 
-  private long totalAckDataLength;
+  private volatile long totalAckDataLength;
 
   AbstractCommitWatcher(XceiverClientSpi client) {
     this.client = client;
@@ -83,7 +83,7 @@ abstract class AbstractCommitWatcher<BUFFER> {
     return totalAckDataLength;
   }
 
-  long addAckDataLength(long acked) {
+  synchronized long addAckDataLength(long acked) {
     totalAckDataLength += acked;
     return totalAckDataLength;
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -605,6 +605,10 @@ public class BlockOutputStream extends OutputStream {
     }
   }
 
+  CompletableFuture<Void> getCombinedFlushFuture() {
+    return null;
+  }
+
   void waitOnFlushFutures() throws InterruptedException, ExecutionException {
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
@@ -68,10 +68,12 @@ class CommitWatcher extends AbstractCommitWatcher<ChunkBuffer> {
     // When putBlock is called, a future is added.
     // When putBlock is replied, the future is removed below.
     // Therefore, the removed future should not be null.
-    final CompletableFuture<ContainerCommandResponseProto> removed =
-        futureMap.remove(totalLength);
-    Objects.requireNonNull(removed, () -> "Future not found for "
-        + totalLength + ": existing = " + futureMap.keySet());
+
+    // TODO: futureMap to be moved to RatisBlockOutputStream
+//    final CompletableFuture<ContainerCommandResponseProto> removed =
+//        futureMap.remove(totalLength);
+//    Objects.requireNonNull(removed, () -> "Future not found for "
+//        + totalLength + ": existing = " + futureMap.keySet());
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
@@ -28,6 +28,8 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -40,6 +42,8 @@ import java.util.concurrent.ExecutionException;
  * buffers once data successfully gets replicated.
  */
 class CommitWatcher extends AbstractCommitWatcher<ChunkBuffer> {
+  private static final Logger LOG = LoggerFactory.getLogger(CommitWatcher.class);
+
   // A reference to the pool of buffers holding the data
   private final BufferPool bufferPool;
 
@@ -60,6 +64,7 @@ class CommitWatcher extends AbstractCommitWatcher<ChunkBuffer> {
       bufferPool.releaseBuffer(buffer);
     }
     final long totalLength = addAckDataLength(acked);
+    LOG.warn("!!! Release buffers for index {} with total length {}", index, totalLength);
     // When putBlock is called, a future is added.
     // When putBlock is replied, the future is removed below.
     // Therefore, the removed future should not be null.

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -198,7 +198,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
       ContainerCommandResponseProto> executePutBlock(boolean close,
       boolean force, long blockGroupLength) throws IOException {
     updateBlockGroupLengthInPutBlockMeta(blockGroupLength);
-    return executePutBlock(close, force).responseFuture;
+    return executePutBlock(close, force).thenApply(r -> r.response);
   }
 
   private void updateBlockGroupLengthInPutBlockMeta(final long blockGroupLen) {
@@ -229,10 +229,10 @@ public class ECBlockOutputStream extends BlockOutputStream {
   /**
    * @param close whether putBlock is happening as part of closing the stream
    * @param force true if no data was written since most recent putBlock and
-   *            stream is being closed
+   *              stream is being closed
    */
   @Override
-  public PutBlockResult executePutBlock(boolean close,
+  public CompletableFuture<PutBlockResult> executePutBlock(boolean close,
       boolean force) throws IOException {
     checkOpen();
 
@@ -274,7 +274,8 @@ public class ECBlockOutputStream extends BlockOutputStream {
       handleInterruptedException(ex, false);
     }
     this.putBlkRspFuture = flushFuture;
-    return new PutBlockResult(0, CompletableFuture.completedFuture(0L), flushFuture);
+    assert flushFuture != null;
+    return flushFuture.thenApply(f -> new PutBlockResult(0, 0, f));
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -198,7 +198,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
       ContainerCommandResponseProto> executePutBlock(boolean close,
       boolean force, long blockGroupLength) throws IOException {
     updateBlockGroupLengthInPutBlockMeta(blockGroupLength);
-    return executePutBlock(close, force);
+    return executePutBlock(close, force).responseFuture;
   }
 
   private void updateBlockGroupLengthInPutBlockMeta(final long blockGroupLen) {
@@ -231,8 +231,8 @@ public class ECBlockOutputStream extends BlockOutputStream {
    * @param force true if no data was written since most recent putBlock and
    *            stream is being closed
    */
-  public CompletableFuture<ContainerProtos.
-      ContainerCommandResponseProto> executePutBlock(boolean close,
+  @Override
+  public PutBlockResult executePutBlock(boolean close,
       boolean force) throws IOException {
     checkOpen();
 
@@ -274,7 +274,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
       handleInterruptedException(ex, false);
     }
     this.putBlkRspFuture = flushFuture;
-    return flushFuture;
+    return new PutBlockResult(0, CompletableFuture.completedFuture(0L), flushFuture);
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/NonBlockingSyncable.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/NonBlockingSyncable.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hdds.scm.storage;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -31,18 +30,20 @@ import org.apache.hadoop.classification.InterfaceStability;
 @InterfaceStability.Evolving
 public interface NonBlockingSyncable {
 
-  /** Flush out the data in client's user buffer.
+  /**
+   * Flush out the data in client's user buffer.
    * Returns a future. After the future is completed, new readers will see the data.
-   * @return CompletableFuture<Void>
+   *
    * @throws IOException if any error occurs
    */
-  CompletableFuture<Void> hflush() throws IOException;
+  void hflush() throws IOException;
 
-  /** Similar to posix fsync, flush out the data in client's user buffer
+  /**
+   * Similar to posix fsync, flush out the data in client's user buffer
    * all the way to the disk device (but the disk may have it in its cache)
    * when the future returned is completed.
-   * @return CompletableFuture<Void>
+   *
    * @throws IOException if error occurs
    */
-  CompletableFuture<Void> hsync() throws IOException;
+  void hsync() throws IOException;
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/NonBlockingSyncable.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/NonBlockingSyncable.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.storage;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+/**
+ * This is the interface for non-blocking flush/sync operations.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface NonBlockingSyncable {
+
+  /** Flush out the data in client's user buffer.
+   * Returns a future. After the future is completed, new readers will see the data.
+   * @return CompletableFuture<Void>
+   * @throws IOException if any error occurs
+   */
+  CompletableFuture<Void> hflush() throws IOException;
+
+  /** Similar to posix fsync, flush out the data in client's user buffer
+   * all the way to the disk device (but the disk may have it in its cache)
+   * when the future returned is completed.
+   * @return CompletableFuture<Void>
+   * @throws IOException if error occurs
+   */
+  CompletableFuture<Void> hsync() throws IOException;
+}

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
@@ -118,6 +118,11 @@ public class RatisBlockOutputStream extends BlockOutputStream
   }
 
   @Override
+  public CompletableFuture<Void> getCombinedFlushFuture() {
+    return commitWatcher.getCombinedFlushFuture();
+  }
+
+  @Override
   void waitOnFlushFutures() throws InterruptedException, ExecutionException {
     commitWatcher.waitOnFlushFutures();
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
@@ -27,6 +27,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.UncheckedAutoCloseable;
 
@@ -34,6 +35,7 @@ import org.apache.ratis.util.UncheckedAutoCloseable;
 final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
   private final ByteBuffer buffer;
   private final UncheckedAutoCloseable underlying;
+  private int identity = RandomUtils.nextInt();
 
   ChunkBufferImplWithByteBuffer(ByteBuffer buffer) {
     this(buffer, null);
@@ -161,6 +163,6 @@ final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
   @Override
   public String toString() {
     return getClass().getSimpleName() + ":limit=" + buffer.limit()
-        + "@" + Integer.toHexString(hashCode());
+        + "@" + Integer.toHexString(identity);
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -161,7 +161,7 @@ public class BlockOutputStreamEntry extends OutputStream {
     return CompletableFuture.completedFuture(null);
   }
 
-  CompletableFuture<Void> hsync() throws IOException {
+  void hsync() throws IOException {
     if (isInitialized()) {
       final OutputStream out = getOutputStream();
       if (!(out instanceof Syncable || out instanceof NonBlockingSyncable)) {
@@ -169,9 +169,7 @@ public class BlockOutputStreamEntry extends OutputStream {
             out.getClass() + " is not " + Syncable.class.getSimpleName());
       }
 
-      return ((NonBlockingSyncable) out).hsync();
-    } else {
-      return CompletableFuture.completedFuture(null);
+      ((NonBlockingSyncable) out).hsync();
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
@@ -39,6 +40,7 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.ratis.thirdparty.io.netty.util.concurrent.CompleteFuture;
 import org.apache.ratis.util.JavaUtils;
 
 /**
@@ -150,6 +152,13 @@ public class BlockOutputStreamEntry extends OutputStream {
     if (isInitialized()) {
       getOutputStream().flush();
     }
+  }
+
+  CompletableFuture<Void> getCombinedFlushFuture() {
+    if (isInitialized()) {
+      return ((RatisBlockOutputStream) getOutputStream()).getCombinedFlushFuture();
+    }
+    return null;
   }
 
   void hsync() throws IOException {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.ratis.thirdparty.io.netty.util.concurrent.CompleteFuture;
 import org.apache.ratis.util.JavaUtils;
 
 /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -334,11 +334,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
 
   void hsyncKey(long offset) throws IOException {
     if (keyArgs != null) {
-      // in test, this could be null
-      long length = getKeyLength();
-      Preconditions.checkArgument(offset == length,
-              "Expected offset: " + offset + " expected len: " + length);
-      keyArgs.setDataSize(length);
+      keyArgs.setDataSize(offset);
       keyArgs.setLocationInfoList(getLocationInfoList());
       // When the key is multipart upload part file upload, we should not
       // commit the key, as this is not an actual key, this is a just a

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -168,12 +168,12 @@ public class KeyOutputStream extends OutputStream
    * @param version the set of blocks that are pre-allocated.
    * @param openVersion the version corresponding to the pre-allocation.
    */
-  public synchronized void addPreallocateBlocks(OmKeyLocationInfoGroup version, long openVersion) {
+  public void addPreallocateBlocks(OmKeyLocationInfoGroup version, long openVersion) {
     blockOutputStreamEntryPool.addPreallocateBlocks(version, openVersion);
   }
 
   @Override
-  public synchronized void write(int b) throws IOException {
+  public void write(int b) throws IOException {
     byte[] buf = new byte[1];
     buf[0] = (byte) b;
     write(buf, 0, 1);
@@ -192,7 +192,7 @@ public class KeyOutputStream extends OutputStream
    * @throws IOException
    */
   @Override
-  public synchronized void write(byte[] b, int off, int len)
+  public void write(byte[] b, int off, int len)
       throws IOException {
     checkNotClosed();
     if (b == null) {
@@ -432,7 +432,7 @@ public class KeyOutputStream extends OutputStream
   }
 
   @Override
-  public synchronized void flush() throws IOException {
+  public void flush() throws IOException {
     checkNotClosed();
     handleFlushOrClose(StreamAction.FLUSH);
   }
@@ -443,7 +443,7 @@ public class KeyOutputStream extends OutputStream
   }
 
   @Override
-  public synchronized void hsync() throws IOException {
+  public void hsync() throws IOException {
     if (replication.getReplicationType() != ReplicationType.RATIS) {
       throw new UnsupportedOperationException(
           "Replication type is not " + ReplicationType.RATIS);
@@ -534,7 +534,7 @@ public class KeyOutputStream extends OutputStream
    * @throws IOException
    */
   @Override
-  public synchronized void close() throws IOException {
+  public void close() throws IOException {
     if (closed) {
       return;
     }
@@ -556,7 +556,7 @@ public class KeyOutputStream extends OutputStream
     }
   }
 
-  synchronized OmMultipartCommitUploadPartInfo
+  OmMultipartCommitUploadPartInfo
       getCommitUploadPartInfo() {
     return blockOutputStreamEntryPool.getCommitUploadPartInfo();
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -462,16 +462,8 @@ public class KeyOutputStream extends OutputStream
     }
     checkNotClosed();
 
-    final long hsyncPos;
-    final CompletableFuture<Void> combinedFlushFutureToWait;
-    synchronized (this) {
-      hsyncPos = writeOffset;
-      handleFlushOrClose(StreamAction.HSYNC);  // This no longer waits for future completion
-      combinedFlushFutureToWait = combinedFlushFuture;
-      combinedFlushFuture = CompletableFuture.completedFuture(null);
-    }
-
-    waitForFutureToComplete(combinedFlushFutureToWait);
+    final long hsyncPos = writeOffset;
+    handleFlushOrClose(StreamAction.HSYNC);
 
     synchronized (this) {
       // Sanity check: written data offset must be equal or have gone past hsync position once acked
@@ -558,7 +550,7 @@ public class KeyOutputStream extends OutputStream
       entry.flush();
       break;
     case HSYNC:
-      this.combinedFlushFuture = entry.hsync();
+      entry.hsync();
       break;
     default:
       throw new IOException("Invalid Operation");

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java
@@ -79,7 +79,7 @@ public class OzoneOutputStream extends ByteArrayStreamOutput
     this.outputStream = Objects.requireNonNull(outputStream,
         "outputStream == null");
     this.syncable = syncable != null ? syncable
-        : outputStream instanceof Syncable ? (Syncable) outputStream
+        : outputStream instanceof Syncable ? (Syncable) outputStream  // Should this switch to NonBlocking as well?
         : null;
     this.enableHsync = enableHsync;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -407,22 +407,22 @@ public class TestHSync {
     final long start = Time.monotonicNow();
     // two threads: write and hsync
     Runnable writer = () -> {
-      while ((Time.monotonicNow() - start < 10000)) {
+      while ((Time.monotonicNow() - start < 1000)) {
         try {
           out.write(data);
-        } catch (IOException e) {
-          writerException.set(e);
+        } catch (Throwable e) {
+          writerException.set(new IOException(e));
           throw new RuntimeException(e);
         }
       }
     };
 
     Runnable syncer = () -> {
-      while ((Time.monotonicNow() - start < 10000)) {
+      while ((Time.monotonicNow() - start < 1000)) {
         try {
           out.hsync();
-        } catch (IOException e) {
-          syncerException.set(e);
+        } catch (Throwable e) {
+          syncerException.set(new IOException(e));
           throw new RuntimeException(e);
         }
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -97,7 +97,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test HSync.
  */
-@Timeout(value = 300)
+//@Timeout(value = 300)
 public class TestHSync {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestHSync.class);
@@ -454,7 +454,7 @@ public class TestHSync {
         + OZONE_URI_DELIMITER + bucket.getName();
 
     try (FileSystem fs = FileSystem.get(CONF)) {
-      for (int i = 0; i < 10; i++) {
+      for (int i = 0; i < 1; i++) {
         final Path file = new Path(dir, "file" + i);
         try (FSDataOutputStream out =
             fs.create(file, true)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.XceiverClientRatis;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -71,15 +72,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.event.Level;
 
 /**
  * Tests Exception handling by Ozone Client.
  */
-@Timeout(300)
+//@Timeout(300)
 public class TestFailureHandlingByClient {
+
+  private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(TestFailureHandlingByClient.class);
 
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
@@ -150,6 +155,8 @@ public class TestFailureHandlingByClient {
     bucketName = volumeName;
     objectStore.createVolume(volumeName);
     objectStore.getVolume(volumeName).createBucket(bucketName);
+
+    GenericTestUtils.setLogLevel(XceiverClientRatis.LOG, Level.DEBUG);
   }
 
   private void startCluster() throws Exception {
@@ -443,6 +450,7 @@ public class TestFailureHandlingByClient {
     // shutdown 1 datanode. This will make sure the 2 way commit happens for
     // next write ops.
     cluster.shutdownHddsDatanode(datanodes.get(0));
+    LOG.warn("!!! datanode is shut: {}", datanodes.get(0).getUuid());
 
     key.write(data.getBytes(UTF_8));
     key.write(data.getBytes(UTF_8));


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PoC seems to work concurrently in happy-case and the number of syncer threads is smaller than BufferPool capacity.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9844


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
