### PR TITLE
HDDS-11044. Recon Disk Usage need to remove tool tip

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -524,10 +524,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
     return (
       <div className='du-container'>
         <div className='page-header'>
-          Disk Usage&nbsp;&nbsp;
-          <Tooltip placement="rightTop" title="Shows Disk Usage information only for FSO buckets">
-            <Icon type='info-circle' />
-          </Tooltip>
+          Disk Usage
         </div>
         <div className='content-div'>
           {isLoading ? <span><Icon type='loading'/> Loading...</span> : (

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -18,7 +18,7 @@
 
 import React from 'react';
 import Plot from 'react-plotly.js';
-import {Row, Col, Icon, Button, Input, Menu, Dropdown, Tooltip} from 'antd';
+import {Row, Col, Icon, Button, Input, Menu, Dropdown} from 'antd';
 import {DetailPanel} from 'components/rightDrawer/rightDrawer';
 import * as Plotly from 'plotly.js';
 import {byteToSize, showDataFetchError} from 'utils/common';


### PR DESCRIPTION
## What changes were proposed in this pull request?
Need to Remove tooltip from Recon Disk Usage which shows only for FSO Buckets.

Please describe your PR in detail:
Need to Remove tooltip from Recon Disk Usage which shows only for FSO Buckets.

## What is the link to the Apache JIRA
(https://issues.apache.org/jira/browse/HDDS-11044)

## How was this patch tested?
Manually

Before this patch
![image](https://github.com/apache/ozone/assets/112169209/e94e5137-528a-4d10-85f3-e780a881cfcd)

After this patch
![image](https://github.com/apache/ozone/assets/112169209/55513be2-c2f3-49e1-b7f1-58c9ef6b78a3)