### PR TITLE
HDDS-11028. Replace PKCS10CertificationRequest usage in CertificateClient

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -157,10 +157,11 @@ public interface CertificateClient extends Closeable {
       X509Certificate cert) throws CertificateException;
 
   /**
-   * Returns a CertificateSignRequest object, that can be used to retrieve
-   * a signed certificate from our CA server implementation.
+   * Returns a CertificateSignRequest Builder object, that can be used to configure the sign request
+   * which we use to get  a signed certificate from our CA server implementation.
    *
-   * @return CertificateSignRequest a CSR based on which the certificate can be issued.
+   * @return CertificateSignRequest.Builder a {@link CertificateSignRequest}
+   *           based on which the certificate may be issued to this client.
    */
   CertificateSignRequest.Builder configureCSRBuilder() throws SCMSecurityException;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.client;
 import org.apache.hadoop.hdds.security.exception.OzoneSecurityException;
 import org.apache.hadoop.hdds.security.ssl.ReloadingX509KeyManager;
 import org.apache.hadoop.hdds.security.ssl.ReloadingX509TrustManager;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 
@@ -156,13 +157,12 @@ public interface CertificateClient extends Closeable {
       X509Certificate cert) throws CertificateException;
 
   /**
-   * Returns a CSR builder that can be used to create a Certificate sigining
-   * request.
+   * Returns a CertificateSignRequest object, that can be used to retrieve
+   * a signed certificate from our CA server implementation.
    *
-   * @return CertificateSignRequest.Builder
+   * @return CertificateSignRequest a CSR based on which the certificate can be issued.
    */
-  CertificateSignRequest.Builder getCSRBuilder()
-      throws CertificateException;
+  CertificateSignRequest.Builder configureCSRBuilder() throws SCMSecurityException;
 
   default void assertValidKeysAndCertificate() throws OzoneSecurityException {
     try {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateSignRequest.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateSignRequest.java
@@ -157,34 +157,37 @@ public final class CertificateSignRequest {
     throw new CertificateException("No PKCS#9 extension found in CSR");
   }
 
-  private PKCS10CertificationRequest generateCSR() throws
-      OperatorCreationException {
-    X500Name dnName = getDistinguishedName(subject, scmID, clusterID);
-    PKCS10CertificationRequestBuilder p10Builder =
-        new JcaPKCS10CertificationRequestBuilder(dnName, keyPair.getPublic());
-
-    ContentSigner contentSigner =
-        new JcaContentSignerBuilder(config.getSignatureAlgo())
-            .setProvider(config.getProvider())
-            .build(keyPair.getPrivate());
-
-    if (extensions != null) {
-      p10Builder.addAttribute(
-          PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extensions);
-    }
-    return p10Builder.build(contentSigner);
-  }
-  public static String getEncodedString(PKCS10CertificationRequest request)
-      throws IOException {
-    PemObject pemObject =
-        new PemObject("CERTIFICATE REQUEST", request.getEncoded());
+  //TODO: ApiDoc!
+  public String toEncodedFormat() throws IOException {
     StringWriter str = new StringWriter();
     try (JcaPEMWriter pemWriter = new JcaPEMWriter(str)) {
+      PemObject pemObject = new PemObject("CERTIFICATE REQUEST", generateCSR().getEncoded());
       pemWriter.writeObject(pemObject);
     }
     return str.toString();
   }
 
+  //TODO: this should be private once the server side of removing PKCS10CertReq class is done.
+  public PKCS10CertificationRequest generateCSR() throws IOException {
+    X500Name dnName = getDistinguishedName(subject, scmID, clusterID);
+    PKCS10CertificationRequestBuilder p10Builder =
+        new JcaPKCS10CertificationRequestBuilder(dnName, keyPair.getPublic());
+
+    try {
+      ContentSigner contentSigner =
+          new JcaContentSignerBuilder(config.getSignatureAlgo())
+              .setProvider(config.getProvider())
+              .build(keyPair.getPrivate());
+
+      if (extensions != null) {
+        p10Builder.addAttribute(
+            PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extensions);
+      }
+      return p10Builder.build(contentSigner);
+    } catch (OperatorCreationException e) {
+      throw new IOException(e);
+    }
+  }
 
   /**
    * Gets a CertificateRequest Object from PEM encoded CSR.
@@ -413,7 +416,7 @@ public final class CertificateSignRequest {
           extensions.toArray(new Extension[extensions.size()]));
     }
 
-    public PKCS10CertificationRequest build() throws SCMSecurityException {
+    public CertificateSignRequest build() throws SCMSecurityException {
       Preconditions.checkNotNull(key, "KeyPair cannot be null");
       Preconditions.checkArgument(StringUtils.isNotBlank(subject), "Subject " +
           "cannot be blank");
@@ -421,15 +424,11 @@ public final class CertificateSignRequest {
       try {
         CertificateSignRequest csr = new CertificateSignRequest(subject, scmID,
             clusterID, key, config, createExtensions());
-        return csr.generateCSR();
+        return csr;
       } catch (IOException ioe) {
         throw new CertificateException(String.format("Unable to create " +
             "extension for certificate sign request for %s.",
             getDistinguishedName(subject, scmID, clusterID)), ioe.getCause());
-      } catch (OperatorCreationException ex) {
-        throw new CertificateException(String.format("Unable to create " +
-            "certificate sign request for %s.",
-            getDistinguishedName(subject, scmID, clusterID)), ex.getCause());
       }
     }
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateSignRequest.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateSignRequest.java
@@ -157,7 +157,13 @@ public final class CertificateSignRequest {
     throw new CertificateException("No PKCS#9 extension found in CSR");
   }
 
-  //TODO: ApiDoc!
+  /**
+   * Encodes this CertificateSignRequest to a String representation, that can be transferred over the wire to
+   * the CA server for signing.
+   *
+   * @return the Certificate Sign Request encoded to a String
+   * @throws IOException if an error occurs during encoding.
+   */
   public String toEncodedFormat() throws IOException {
     StringWriter str = new StringWriter();
     try (JcaPEMWriter pemWriter = new JcaPEMWriter(str)) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -23,10 +23,10 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.SecurityConfig;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,6 @@ import java.net.InetAddress;
 import java.security.KeyPair;
 import java.util.function.Consumer;
 
-import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getEncodedString;
 import static org.apache.hadoop.hdds.security.x509.exception.CertificateException.ErrorCode.CSR_ERROR;
 
 /**
@@ -70,9 +69,9 @@ public class DNCertificateClient extends DefaultCertificateClient {
    * @return CertificateSignRequest.Builder
    */
   @Override
-  public CertificateSignRequest.Builder getCSRBuilder()
-      throws CertificateException {
-    CertificateSignRequest.Builder builder = super.getCSRBuilder();
+  public CertificateSignRequest.Builder configureCSRBuilder()
+      throws SCMSecurityException {
+    CertificateSignRequest.Builder builder = super.configureCSRBuilder();
 
     try {
       String hostname = InetAddress.getLocalHost().getCanonicalHostName();
@@ -93,10 +92,8 @@ public class DNCertificateClient extends DefaultCertificateClient {
   }
 
   @Override
-  public SCMGetCertResponseProto getCertificateSignResponse(
-      PKCS10CertificationRequest csr) throws IOException {
-    return getScmSecureClient().getDataNodeCertificateChain(
-        dn.getProtoBufMessage(), getEncodedString(csr));
+  public SCMGetCertResponseProto sign(CertificateSignRequest csr) throws IOException {
+    return getScmSecureClient().getDataNodeCertificateChain(dn.getProtoBufMessage(), csr.toEncodedFormat());
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -153,6 +153,7 @@ public class TestDefaultCAServer {
     String clusterId = RandomStringUtils.randomAlphabetic(4);
     KeyPair keyPair =
         new HDDSKeyGenerator(securityConfig).generateKey();
+    //TODO: generateCSR!
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("8.8.8.8")
@@ -163,7 +164,8 @@ public class TestDefaultCAServer {
         .setSubject("Ozone Cluster")
         .setConfiguration(securityConfig)
         .setKey(keyPair)
-        .build();
+        .build()
+        .generateCSR();
 
     CertificateServer testCA = new DefaultCAServer("testCA",
         clusterId, scmId, caStore,
@@ -204,6 +206,7 @@ public class TestDefaultCAServer {
   public void testRequestCertificateWithInvalidSubject() throws Exception {
     KeyPair keyPair =
         new HDDSKeyGenerator(securityConfig).generateKey();
+    //TODO: generateCSR!
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("8.8.8.8")
@@ -211,7 +214,8 @@ public class TestDefaultCAServer {
         .setSubject("Ozone Cluster")
         .setConfiguration(securityConfig)
         .setKey(keyPair)
-        .build();
+        .build()
+        .generateCSR();
 
     CertificateServer testCA = new DefaultCAServer("testCA",
         RandomStringUtils.randomAlphabetic(4),
@@ -232,6 +236,7 @@ public class TestDefaultCAServer {
   public void testRequestCertificateWithInvalidSubjectFailure() throws Exception {
     KeyPair keyPair =
         new HDDSKeyGenerator(securityConfig).generateKey();
+    //TODO: generateCSR!
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("8.8.8.8")
@@ -241,7 +246,8 @@ public class TestDefaultCAServer {
         .setSubject("Ozone Cluster")
         .setConfiguration(securityConfig)
         .setKey(keyPair)
-        .build();
+        .build()
+        .generateCSR();
 
     CertificateServer testCA = new DefaultCAServer("testCA",
         RandomStringUtils.randomAlphabetic(4),
@@ -344,6 +350,7 @@ public class TestDefaultCAServer {
       LocalDate beginDate = LocalDate.now().atStartOfDay().toLocalDate();
       LocalDate endDate =
           LocalDate.from(LocalDate.now().atStartOfDay().plusDays(10));
+      //TODO: generateCSR!
       PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
           .addDnsName("hadoop.apache.org")
           .addIpAddress("8.8.8.8")
@@ -354,7 +361,8 @@ public class TestDefaultCAServer {
           .setSubject("Ozone Cluster")
           .setConfiguration(securityConfig)
           .setKey(keyPair)
-          .build();
+          .build()
+          .generateCSR();
       X509Certificate externalCert = generateExternalCert(keyPair);
       X509Certificate signedCert = approver.sign(securityConfig,
           keyPair.getPrivate(), externalCert,
@@ -405,6 +413,7 @@ public class TestDefaultCAServer {
       // Generate cert
       KeyPair keyPair =
           new HDDSKeyGenerator(securityConfig).generateKey();
+      //TODO: generateCSR!
       PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
           .addDnsName("hadoop.apache.org")
           .addIpAddress("8.8.8.8")
@@ -412,7 +421,8 @@ public class TestDefaultCAServer {
           .setSubject("testCA")
           .setConfiguration(securityConfig)
           .setKey(keyPair)
-          .build();
+          .build()
+          .generateCSR();
 
       Future<CertPath> holder = rootCA.requestCertificate(csr,
           CertificateApprover.ApprovalType.TESTING_AUTOMATIC, SCM,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultProfile.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultProfile.java
@@ -41,7 +41,6 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
-import org.bouncycastle.pkcs.PKCSException;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,8 +49,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -94,14 +91,10 @@ public class TestDefaultProfile {
 
   /**
    * Test valid keys are validated correctly.
-   *
-   * @throws SCMSecurityException      - on Error.
-   * @throws PKCSException             - on Error.
-   * @throws OperatorCreationException - on Error.
    */
   @Test
-  public void testVerifyCertificate() throws SCMSecurityException,
-      PKCSException, OperatorCreationException {
+  public void testVerifyCertificate() throws Exception {
+    //TODO: generateCSR!
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("8.8.8.8")
@@ -112,7 +105,8 @@ public class TestDefaultProfile {
         .setSubject("Ozone Cluster")
         .setConfiguration(securityConfig)
         .setKey(keyPair)
-        .build();
+        .build()
+        .generateCSR();
     assertTrue(approver.verifyPkcs10Request(csr));
   }
 
@@ -121,20 +115,13 @@ public class TestDefaultProfile {
 
   /**
    * Test invalid keys fail in the validation.
-   *
-   * @throws SCMSecurityException      - on Error.
-   * @throws PKCSException             - on Error.
-   * @throws OperatorCreationException - on Error.
-   * @throws NoSuchProviderException   - on Error.
-   * @throws NoSuchAlgorithmException  - on Error.
    */
   @Test
-  public void testVerifyCertificateInvalidKeys() throws SCMSecurityException,
-      PKCSException, OperatorCreationException,
-      NoSuchProviderException, NoSuchAlgorithmException {
+  public void testVerifyCertificateInvalidKeys() throws Exception {
     KeyPair newKeyPair = new HDDSKeyGenerator(securityConfig).generateKey();
     KeyPair wrongKey = new KeyPair(keyPair.getPublic(),
         newKeyPair.getPrivate());
+    //TODO: generateCSR!
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("8.8.8.8")
@@ -144,7 +131,8 @@ public class TestDefaultProfile {
         .setSubject("Ozone Cluster")
         .setConfiguration(securityConfig)
         .setKey(wrongKey)
-        .build();
+        .build()
+        .generateCSR();
     // Signature verification should fail here, since the public/private key
     // does not match.
     assertFalse(approver.verifyPkcs10Request(csr));
@@ -152,13 +140,10 @@ public class TestDefaultProfile {
 
   /**
    * Tests that normal valid extensions work with the default profile.
-   *
-   * @throws SCMSecurityException      - on Error.
-   * @throws PKCSException             - on Error.
-   * @throws OperatorCreationException - on Error.
    */
   @Test
-  public void testExtensions() throws SCMSecurityException {
+  public void testExtensions() throws Exception {
+    //TODO: generateCSR!
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("192.10.234.6")
@@ -168,7 +153,8 @@ public class TestDefaultProfile {
         .setSubject("Ozone Cluster")
         .setConfiguration(securityConfig)
         .setKey(keyPair)
-        .build();
+        .build()
+        .generateCSR();
     assertTrue(approver.verfiyExtensions(csr));
   }
 
@@ -180,7 +166,8 @@ public class TestDefaultProfile {
    */
 
   @Test
-  public void testInvalidExtensionsWithCA() throws SCMSecurityException {
+  public void testInvalidExtensionsWithCA() throws Exception {
+    //TODO: generateCSR!
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("192.10.234.6")
@@ -190,7 +177,8 @@ public class TestDefaultProfile {
         .setSubject("Ozone Cluster")
         .setConfiguration(securityConfig)
         .setKey(keyPair)
-        .build();
+        .build()
+        .generateCSR();
     assertFalse(approver.verfiyExtensions(csr));
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClientTestImpl.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClientTestImpl.java
@@ -48,6 +48,7 @@ import java.util.function.Function;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.ssl.ReloadingX509KeyManager;
 import org.apache.hadoop.hdds.security.ssl.ReloadingX509TrustManager;
@@ -135,13 +136,14 @@ public class CertificateClientTestImpl implements CertificateClient {
     start = LocalDateTime.now();
     String certDuration = conf.get(HDDS_X509_DEFAULT_DURATION,
         HDDS_X509_DEFAULT_DURATION_DEFAULT);
+    //TODO: generateCSR should not be called...
     x509Certificate = approver.sign(securityConfig, rootKeyPair.getPrivate(),
-        rootCert,
-        Date.from(start.atZone(ZoneId.systemDefault()).toInstant()),
-        Date.from(start.plus(Duration.parse(certDuration))
-            .atZone(ZoneId.systemDefault()).toInstant()),
-        csrBuilder.build(), "scm1", "cluster1",
-        String.valueOf(System.nanoTime()));
+            rootCert,
+            Date.from(start.atZone(ZoneId.systemDefault()).toInstant()),
+            Date.from(start.plus(Duration.parse(certDuration))
+                .atZone(ZoneId.systemDefault()).toInstant()),
+            csrBuilder.build().generateCSR(), "scm1", "cluster1",
+            String.valueOf(System.nanoTime()));
     certificateMap.put(x509Certificate.getSerialNumber().toString(),
         x509Certificate);
 
@@ -227,7 +229,7 @@ public class CertificateClientTestImpl implements CertificateClient {
   }
 
   @Override
-  public CertificateSignRequest.Builder getCSRBuilder() {
+  public CertificateSignRequest.Builder configureCSRBuilder() throws SCMSecurityException {
     return new CertificateSignRequest.Builder();
   }
 
@@ -298,9 +300,10 @@ public class CertificateClientTestImpl implements CertificateClient {
 
     Duration certDuration = securityConfig.getDefaultCertDuration();
     Date start = new Date();
+    //TODO: get rid of generateCSR call here, once the server side changes happened.
     X509Certificate newX509Certificate =
         approver.sign(securityConfig, rootKeyPair.getPrivate(), rootCert, start,
-            new Date(start.getTime() + certDuration.toMillis()), csrBuilder.build(), "scm1", "cluster1",
+            new Date(start.getTime() + certDuration.toMillis()), csrBuilder.build().generateCSR(), "scm1", "cluster1",
             String.valueOf(System.nanoTime())
         );
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCer
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
@@ -560,21 +561,12 @@ public class TestDefaultCertificateClient {
     ) {
 
       @Override
-      protected String signAndStoreCertificate(
-          PKCS10CertificationRequest request, Path certificatePath) {
-        return "";
-      }
-
-      @Override
-      protected SCMGetCertResponseProto getCertificateSignResponse(
-          PKCS10CertificationRequest request) {
+      protected SCMGetCertResponseProto sign(CertificateSignRequest request) {
         return null;
       }
 
       @Override
-      protected String signAndStoreCertificate(
-          PKCS10CertificationRequest request, Path certificatePath,
-          boolean renew) {
+      protected String signAndStoreCertificate(CertificateSignRequest request, Path certificatePath, boolean renew) {
         return null;
       }
     };

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateSignRequest.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/utils/TestCertificateSignRequest.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hdds.security.x509.certificate.utils;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 import org.bouncycastle.asn1.ASN1Encodable;
@@ -33,10 +32,8 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.operator.ContentVerifierProvider;
-import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.bouncycastle.pkcs.PKCSException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,8 +41,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.util.Iterator;
 import java.util.UUID;
 
@@ -73,9 +68,7 @@ public class TestCertificateSignRequest {
   }
 
   @Test
-  public void testGenerateCSR() throws NoSuchProviderException,
-      NoSuchAlgorithmException, SCMSecurityException,
-      OperatorCreationException, PKCSException {
+  public void testGenerateCSR() throws Exception {
     String clusterID = UUID.randomUUID().toString();
     String scmID = UUID.randomUUID().toString();
     String subject = "DN001";
@@ -90,7 +83,8 @@ public class TestCertificateSignRequest {
             .setClusterID(clusterID)
             .setKey(keyPair)
             .setConfiguration(securityConfig);
-    PKCS10CertificationRequest csr = builder.build();
+    //TODO: generateCSR!
+    PKCS10CertificationRequest csr = builder.build().generateCSR();
 
     // Check the Subject Name is in the expected format.
     String dnName = String.format(getDistinguishedNameFormat(),
@@ -124,9 +118,7 @@ public class TestCertificateSignRequest {
   }
 
   @Test
-  public void testGenerateCSRwithSan() throws NoSuchProviderException,
-      NoSuchAlgorithmException, SCMSecurityException,
-      OperatorCreationException, PKCSException {
+  public void testGenerateCSRwithSan() throws Exception {
     String clusterID = UUID.randomUUID().toString();
     String scmID = UUID.randomUUID().toString();
     String subject = "DN001";
@@ -149,7 +141,8 @@ public class TestCertificateSignRequest {
 
     builder.addDnsName("dn1.abc.com");
 
-    PKCS10CertificationRequest csr = builder.build();
+    //TODO: generateCSR!
+    PKCS10CertificationRequest csr = builder.build().generateCSR();
 
     // Check the Subject Name is in the expected format.
     String dnName = String.format(getDistinguishedNameFormat(),
@@ -181,8 +174,7 @@ public class TestCertificateSignRequest {
   }
 
   @Test
-  public void testGenerateCSRWithInvalidParams() throws NoSuchProviderException,
-      NoSuchAlgorithmException, SCMSecurityException {
+  public void testGenerateCSRWithInvalidParams() throws Exception {
     String clusterID = UUID.randomUUID().toString();
     String scmID = UUID.randomUUID().toString();
     String subject = "DN001";
@@ -225,7 +217,8 @@ public class TestCertificateSignRequest {
       builder.build();
     });
 
-    PKCS10CertificationRequest csr = builder.build();
+    //TODO: generateCSR!
+    PKCS10CertificationRequest csr = builder.build().generateCSR();
 
     // Check the Subject Name is in the expected format.
     String dnName = String.format(getDistinguishedNameFormat(),
@@ -244,8 +237,7 @@ public class TestCertificateSignRequest {
   }
 
   @Test
-  public void testCsrSerialization() throws NoSuchProviderException,
-      NoSuchAlgorithmException, SCMSecurityException, IOException {
+  public void testCsrSerialization() throws Exception {
     String clusterID = UUID.randomUUID().toString();
     String scmID = UUID.randomUUID().toString();
     String subject = "DN001";
@@ -261,7 +253,8 @@ public class TestCertificateSignRequest {
             .setKey(keyPair)
             .setConfiguration(securityConfig);
 
-    PKCS10CertificationRequest csr = builder.build();
+    //TODO: generateCSR!
+    PKCS10CertificationRequest csr = builder.build().generateCSR();
     byte[] csrBytes = csr.getEncoded();
 
     // Verify de-serialized CSR matches with the original CSR

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
@@ -584,7 +584,7 @@ public class RootCARotationManager extends StatefulService {
           String newCertSerialId = "";
           try {
             CertificateSignRequest.Builder csrBuilder =
-                scmCertClient.getCSRBuilder();
+                scmCertClient.configureCSRBuilder();
             csrBuilder.setKey(newKeyPair);
             newCertSerialId = scmCertClient.signAndStoreCertificate(
                 csrBuilder.build(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -1449,11 +1449,12 @@ final class TestSecureOzoneCluster {
     addIpAndDnsDataToBuilder(csrBuilder);
     LocalDateTime start = LocalDateTime.now();
     Duration certDuration = conf.getDefaultCertDuration();
+    //TODO: generateCSR!
     return approver.sign(conf, rootKeyPair.getPrivate(), rootCert,
             Date.from(start.atZone(ZoneId.systemDefault()).toInstant()),
             Date.from(start.plus(certDuration)
                 .atZone(ZoneId.systemDefault()).toInstant()),
-            csrBuilder.build(), "test", clusterId,
+            csrBuilder.build().generateCSR(), "test", clusterId,
             String.valueOf(System.nanoTime()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OMCertificateClient.java
@@ -25,12 +25,12 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.SecurityConfig;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificate.client.DefaultCertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.security.KeyPair;
 import java.util.function.Consumer;
 
-import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getEncodedString;
 
 /**
  * Certificate client for OzoneManager.
@@ -81,9 +80,9 @@ public class OMCertificateClient extends DefaultCertificateClient {
    * @return CertificateSignRequest.Builder
    */
   @Override
-  public CertificateSignRequest.Builder getCSRBuilder()
-      throws CertificateException {
-    CertificateSignRequest.Builder builder = super.getCSRBuilder();
+  public CertificateSignRequest.Builder configureCSRBuilder()
+      throws SCMSecurityException {
+    CertificateSignRequest.Builder builder = super.configureCSRBuilder();
 
     String hostname = omInfo.getHostName();
     String subject;
@@ -118,10 +117,8 @@ public class OMCertificateClient extends DefaultCertificateClient {
   }
 
   @Override
-  protected SCMGetCertResponseProto getCertificateSignResponse(
-      PKCS10CertificationRequest request) throws IOException {
-    return getScmSecureClient().getOMCertChain(
-        omInfo, getEncodedString(request));
+  protected SCMGetCertResponseProto sign(CertificateSignRequest request) throws IOException {
+    return getScmSecureClient().getOMCertChain(omInfo, request.toEncodedFormat());
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/security/ReconCertificateClient.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/security/ReconCertificateClient.java
@@ -21,12 +21,12 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.SecurityConfig;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificate.client.DefaultCertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageConfig;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,6 @@ import java.net.InetAddress;
 import java.security.KeyPair;
 import java.util.function.Consumer;
 
-import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getEncodedString;
 import static org.apache.hadoop.hdds.security.x509.exception.CertificateException.ErrorCode.CSR_ERROR;
 
 /**
@@ -62,11 +61,11 @@ public class ReconCertificateClient  extends DefaultCertificateClient {
   }
 
   @Override
-  public CertificateSignRequest.Builder getCSRBuilder()
-      throws CertificateException {
+  public CertificateSignRequest.Builder configureCSRBuilder()
+      throws SCMSecurityException {
     LOG.info("Creating CSR for Recon.");
     try {
-      CertificateSignRequest.Builder builder = super.getCSRBuilder();
+      CertificateSignRequest.Builder builder = super.configureCSRBuilder();
       String hostname = InetAddress.getLocalHost().getCanonicalHostName();
       String subject = UserGroupInformation.getCurrentUser()
           .getShortUserName() + "@" + hostname;
@@ -85,8 +84,7 @@ public class ReconCertificateClient  extends DefaultCertificateClient {
   }
 
   @Override
-  protected SCMGetCertResponseProto getCertificateSignResponse(
-      PKCS10CertificationRequest request) throws IOException {
+  protected SCMGetCertResponseProto sign(CertificateSignRequest request) throws IOException {
     SCMGetCertResponseProto response;
     HddsProtos.NodeDetailsProto.Builder reconDetailsProtoBuilder =
         HddsProtos.NodeDetailsProto.newBuilder()
@@ -95,8 +93,7 @@ public class ReconCertificateClient  extends DefaultCertificateClient {
             .setUuid(reconID)
             .setNodeType(HddsProtos.NodeType.RECON);
     // TODO: For SCM CA we should fetch certificate from multiple SCMs.
-    response = getScmSecureClient().getCertificateChain(
-        reconDetailsProtoBuilder.build(), getEncodedString(request));
+    response = getScmSecureClient().getCertificateChain(reconDetailsProtoBuilder.build(), request.toEncodedFormat());
     return response;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Within CertificateClient implementations, we use the CertificateSignRequest class to configure a BouncyCastle PKCS10CertificationRequest object. To remove this dependency, we should use our own CertificateSignRequest class throughout the whole client side, then transform it to a PEM encoded String and transfer it as is to the server side.
This way, the conversion itself can be moved later on to the crypto module, and then we can let implementors implement the conversion to a string based representation separatly, and use that from our CertificateSignRequest object later on dynamically.
This PR fully removes the usage of the BouncyCastle classes from the CertificateClient, and changes the related tests and business logic to use CertificateSignRequest instead.

Note:
On the server side, the certificate sign request should be passed on as this String representation all the way down to the actual act of signing and issueing the certificate. This part will come with HDDS-11029.
This PR contains TODO notices for the usages of CertificateSignRequest#generateCSR() method, as those have to be revisited, and related tests should either be rewritten to use CertificateSignRequest or moved to the crypto modules if they still need to utilize the PKCS10CertificationRequest class from BouncyCastle.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11028

## How was this patch tested?

As this is a code refactoring only, the exsisting tests should be sufficient to prove that everything still works.