### PR TITLE
HDDS-11009. Increase Surefire fork heap to 8GB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <enforced.maven.version>[3.3.0,)</enforced.maven.version>
 
     <!-- Plugin versions and config -->
-    <maven-surefire-plugin.argLine>-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
+    <maven-surefire-plugin.argLine>-Xmx8192m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
     <maven-surefire-plugin.argLineAccessArgs></maven-surefire-plugin.argLineAccessArgs>
     <excluded-test-groups>native | unhealthy</excluded-test-groups> <!-- test groups excluded by default (without any manual profile activation) -->
     <unstable-test-groups>flaky | native | slow | unhealthy</unstable-test-groups> <!-- test groups excluded in CI (except in dedicated profiles for flaky and native) -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `OutOfMemoryError` in `TestRandomKeyGenerator` with Ratis 3.1.0 release candidates.

https://issues.apache.org/jira/browse/HDDS-11009

## How was this patch tested?

Tested using `ci-with-ratis` workflow (this run is from a different branch, to workaround HDDS-11042, a bug in the workflow):
https://github.com/adoroszlai/ozone/actions/runs/9615310805

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/9616439402