### PR TITLE
HDDS-11048. Remove dev-only toggle functionality of rewrite CLI

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FreonReplicationOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FreonReplicationOptions.java
@@ -52,10 +52,17 @@ public class FreonReplicationOptions extends ReplicationOptions {
 
   // -t is already taken for number of threads
   @Option(names = {"--type", "--replication-type"},
-      description = "Replication type. Supported types are: RATIS, EC")
+      description = TYPE_DESCRIPTION)
   @Override
   public void setType(String type) {
     super.setType(type);
+  }
+
+  @Option(names = {"--replication", "-r"},
+      description = REPLICATION_DESCRIPTION)
+  @Override
+  public void setReplication(String replication) {
+    super.setReplication(replication);
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/MandatoryReplicationOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/MandatoryReplicationOptions.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,25 +17,27 @@
  */
 package org.apache.hadoop.ozone.shell;
 
-import picocli.CommandLine.Option;
+import picocli.CommandLine;
 
 /**
- * Options for specifying replication config in 'ozone shell' commands.
+ * Options for requiring replication config in 'ozone shell' commands.
  */
-public class ShellReplicationOptions extends ReplicationOptions {
+public class MandatoryReplicationOptions extends ReplicationOptions {
 
-  @Option(names = {"-t", "--type", "--replication-type"},
-      description = TYPE_DESCRIPTION)
-  @Override
-  public void setType(String type) {
-    super.setType(type);
-  }
-
-  @Option(names = {"--replication", "-r"},
-      description = REPLICATION_DESCRIPTION)
+  @CommandLine.Option(names = {"--replication", "-r"},
+      description = REPLICATION_DESCRIPTION,
+      required = true)
   @Override
   public void setReplication(String replication) {
     super.setReplication(replication);
+  }
+
+  @CommandLine.Option(names = {"-t", "--type", "--replication-type"},
+      description = TYPE_DESCRIPTION,
+      required = true)
+  @Override
+  public void setType(String type) {
+    super.setType(type);
   }
 
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ReplicationOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ReplicationOptions.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.fs.ozone.OzoneClientUtils;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import picocli.CommandLine;
 
 import java.util.Optional;
 
@@ -34,6 +33,14 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
  * Ozone Shell and Freon commands.
  */
 public abstract class ReplicationOptions {
+
+  protected static final String REPLICATION_DESCRIPTION =
+      "Replication definition. Valid values are replication"
+          + " type-specific.  For RATIS: ONE or THREE."
+          + " In case of EC, pass CODEC-DATA-PARITY-CHUNKSIZE, "
+          + " e.g. rs-3-2-1024k, rs-6-3-1024k, rs-10-4-1024k";
+  protected static final String TYPE_DESCRIPTION =
+      "Replication type. Supported types are: RATIS, EC";
 
   private ReplicationType type;
   private String replication;
@@ -71,17 +78,13 @@ public abstract class ReplicationOptions {
             .orElse(null));
   }
 
-  @CommandLine.Option(names = {"--replication", "-r"},
-      description = "Replication definition. Valid values are replication"
-          + " type-specific.  For RATIS: ONE or THREE."
-          + " In case of EC, pass CODEC-DATA-PARITY-CHUNKSIZE, "
-          + " e.g. rs-3-2-1024k, rs-6-3-1024k, rs-10-4-1024k")
-  public void setReplication(String replication) {
+  // Option is defined in subclasses
+  protected void setReplication(String replication) {
     this.replication = replication;
   }
 
   // Option is defined in subclasses
-  public void setType(String type) {
+  protected void setType(String type) {
     try {
       ReplicationType replicationType = ReplicationType.valueOf(type);
       if (replicationType == ReplicationType.CHAINED

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/RewriteKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/RewriteKeyHandler.java
@@ -17,18 +17,15 @@
  */
 package org.apache.hadoop.ozone.shell.keys;
 
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.shell.MandatoryReplicationOptions;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
-import org.apache.hadoop.ozone.shell.ShellReplicationOptions;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -45,7 +42,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.MB;
 public class RewriteKeyHandler extends KeyHandler {
 
   @CommandLine.Mixin
-  private ShellReplicationOptions replication;
+  private MandatoryReplicationOptions replication;
 
   @Override
   protected void execute(OzoneClient client, OzoneAddress address) throws IOException, OzoneClientException {
@@ -58,11 +55,8 @@ public class RewriteKeyHandler extends KeyHandler {
     OzoneKeyDetails key = bucket.getKey(keyName);
 
     ReplicationConfig newReplication = replication.fromParamsOrConfig(getConf());
-    if (newReplication == null) {
-      newReplication = key.getReplicationConfig().getReplicationType() == HddsProtos.ReplicationType.RATIS
-          ? new ECReplicationConfig(3, 2)
-          : RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
-    } else if (newReplication.equals(key.getReplicationConfig())) {
+    if (newReplication == null ||
+        newReplication.equals(key.getReplicationConfig())) {
       System.err.println("Replication unchanged: " + key.getReplicationConfig());
       return;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone sh key rewrite` has a convenience feature to simply change between Ratis and EC(3,2) replication, when invoked without replication options.  The goal of this task is to remove it, and make replication options mandatory.

https://issues.apache.org/jira/browse/HDDS-11048

## How was this patch tested?

```
$ ozone freon ockg -n1 -t1 -p test
...
$ ozone sh key rewrite /vol1/bucket1/test/0
Missing required options: '--replication-type=<type>', '--replication=<replication>'
...

$ ozone sh key rewrite --type RATIS -r ONE /vol1/bucket1/test/0
$ ozone sh key info /vol1/bucket1/test/0
...
    "replicationFactor" : "ONE",
    "replicationType" : "RATIS"
```

Options are still not required for other commands:

```
$ ozone sh key put /vol1/bucket1/passwd /etc/passwd
$
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/9616596034