### PR TITLE
HDDS-11014. [hsync] Block finalization should also merge last chunk to blockDataTable.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -573,13 +573,13 @@ public class BlockOutputStream extends OutputStream {
   private void writeChunk(ChunkBuffer buffer)
       throws IOException {
     writeChunkCommon(buffer);
-    writeChunkToContainer(buffer.duplicate(0, buffer.position()), false);
+    writeChunkToContainer(buffer.duplicate(0, buffer.position()), false, false);
   }
 
-  private void writeChunkAndPutBlock(ChunkBuffer buffer)
+  private void writeChunkAndPutBlock(ChunkBuffer buffer, boolean close)
       throws IOException {
     writeChunkCommon(buffer);
-    writeChunkToContainer(buffer.duplicate(0, buffer.position()), true);
+    writeChunkToContainer(buffer.duplicate(0, buffer.position()), true, close);
   }
 
   /**
@@ -618,7 +618,7 @@ public class BlockOutputStream extends OutputStream {
       if (currentBuffer.hasRemaining()) {
         if (allowPutBlockPiggybacking) {
           updateFlushLength();
-          writeChunkAndPutBlock(currentBuffer);
+          writeChunkAndPutBlock(currentBuffer, close);
         } else {
           writeChunk(currentBuffer);
           updateFlushLength();
@@ -743,7 +743,7 @@ public class BlockOutputStream extends OutputStream {
    * @return
    */
   CompletableFuture<ContainerCommandResponseProto> writeChunkToContainer(
-      ChunkBuffer chunk, boolean putBlockPiggybacking) throws IOException {
+      ChunkBuffer chunk, boolean putBlockPiggybacking, boolean close) throws IOException {
     int effectiveChunkSize = chunk.remaining();
     final long offset = chunkOffset.getAndAdd(effectiveChunkSize);
     final ByteString data = chunk.toByteString(
@@ -805,7 +805,7 @@ public class BlockOutputStream extends OutputStream {
       }
 
       XceiverClientReply asyncReply = writeChunkAsync(xceiverClient, chunkInfo,
-          blockID.get(), data, tokenString, replicationIndex, blockData);
+          blockID.get(), data, tokenString, replicationIndex, blockData, close);
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
           respFuture = asyncReply.getResponse();
       validateFuture = respFuture.thenApplyAsync(e -> {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -90,13 +90,13 @@ public class ECBlockOutputStream extends BlockOutputStream {
   public void write(byte[] b, int off, int len) throws IOException {
     this.currentChunkRspFuture =
         writeChunkToContainer(
-            ChunkBuffer.wrap(ByteBuffer.wrap(b, off, len)), false);
+            ChunkBuffer.wrap(ByteBuffer.wrap(b, off, len)), false, false);
     updateWrittenDataLength(len);
   }
 
   public CompletableFuture<ContainerProtos.ContainerCommandResponseProto> write(
       ByteBuffer buff) throws IOException {
-    return writeChunkToContainer(ChunkBuffer.wrap(buff), false);
+    return writeChunkToContainer(ChunkBuffer.wrap(buff), false, false);
   }
 
   public CompletableFuture<ContainerProtos.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -436,6 +436,7 @@ public final class ContainerProtocolCalls  {
    * @param tokenString serialized block token
    * @throws IOException if there is an I/O error while performing the call
    */
+  @SuppressWarnings("parameternumber")
   public static XceiverClientReply writeChunkAsync(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
       ByteString data, String tokenString,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -439,7 +439,7 @@ public final class ContainerProtocolCalls  {
   public static XceiverClientReply writeChunkAsync(
       XceiverClientSpi xceiverClient, ChunkInfo chunk, BlockID blockID,
       ByteString data, String tokenString,
-      int replicationIndex, BlockData blockData)
+      int replicationIndex, BlockData blockData, boolean close)
       throws IOException, ExecutionException, InterruptedException {
 
     WriteChunkRequestProto.Builder writeChunkRequest =
@@ -455,7 +455,8 @@ public final class ContainerProtocolCalls  {
     if (blockData != null) {
       PutBlockRequestProto.Builder createBlockRequest =
           PutBlockRequestProto.newBuilder()
-              .setBlockData(blockData);
+              .setBlockData(blockData)
+              .setEof(close);
       writeChunkRequest.setBlock(createBlockRequest);
     }
     String id = xceiverClient.getPipeline().getFirstNode().getUuidString();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -877,13 +877,11 @@ public class KeyValueHandler extends Handler {
         // block metadata is piggybacked in the same message.
         // there will not be an additional PutBlock request.
         //
-        // End of block will always be sent as a standalone PutBlock.
-        // the PutBlock piggybacked in WriteChunk is never end of block.
-        //
         // do not do this in WRITE_DATA phase otherwise PutBlock will be out
         // of order.
         blockData.setBlockCommitSequenceId(dispatcherContext.getLogIndex());
-        blockManager.putBlock(kvContainer, blockData, false);
+        boolean eob = writeChunk.getBlock().getEof();
+        blockManager.putBlock(kvContainer, blockData, eob);
         blockDataProto = blockData.getProtoBufMessage();
         final long numBytes = blockDataProto.getSerializedSize();
         metrics.incContainerBytesStats(Type.PutBlock, numBytes);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -244,6 +244,9 @@ public class BlockManagerImpl implements BlockManager {
         db.getStore().getFinalizeBlocksTable().putWithBatch(batch,
             kvContainer.getContainerData().getBlockKey(localID), localID);
         db.getStore().getBatchHandler().commitBatchOperation(batch);
+
+        BlockData emptyBlockData = new BlockData(blockId);
+        db.getStore().putBlockByID(batch, incrementalEnabled, localID, emptyBlockData, kvContainer.getContainerData(), true);
       }
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -246,7 +246,8 @@ public class BlockManagerImpl implements BlockManager {
         db.getStore().getBatchHandler().commitBatchOperation(batch);
 
         BlockData emptyBlockData = new BlockData(blockId);
-        db.getStore().putBlockByID(batch, incrementalEnabled, localID, emptyBlockData, kvContainer.getContainerData(), true);
+        db.getStore().putBlockByID(batch, incrementalEnabled, localID,
+            emptyBlockData, kvContainer.getContainerData(), true);
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11014. [hsync] Block finalization should also merge last chunk to blockDataTable.

Please describe your PR in detail:
There are two scenarios where the last chunk should be merged into blockDataTable:
(1) when block is being closed by client. In this case, an endOfBlock flag is added to WriteChunk/PutBlock combo request to tell the DataNode to merge the last chunk.
(2) if an open file is closed by recoverLease, in which case, the DataNode finalizeBlock handler must merge the last chunk too.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11014

## How was this patch tested?

TBD