### PR TITLE
HDDS-11054. native check fails with Java11+

### DIFF
--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -46,11 +46,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <properties>
-
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
 
   <build>
     <plugins>

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -66,7 +66,7 @@ for i in $(seq 1 ${ITERATIONS}); do
     mkdir -p "${REPORT_DIR}"
   fi
 
-  mvn ${MAVEN_OPTIONS} -Dmaven-surefire-plugin.argLineAccessArgs="${OZONE_MODULE_ACCESS_ARGS}" "$@" test \
+  mvn ${MAVEN_OPTIONS} -Dmaven-surefire-plugin.argLineAccessArgs="${OZONE_MODULE_ACCESS_ARGS}" "$@" verify \
     | tee "${REPORT_DIR}/output.log"
   irc=$?
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`native` check fails when run with Java 11 or later.

```
$ export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
$ mvn -Drocks_tools_native -Pnative clean test
...
Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy-dependencies (copy-jars) on project hdds-rocks-native: Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187
```

This was reported earlier in HDDS-10118, but mistakenly thought to be fixed, because we were trying to reproduce with `mvn clean install`.  The problem only happens if Maven goal preceding `package` is executed.

The workaround is to run tests by using `verify` goal, which is after `package` in the lifecycle.

Also, remove hard-coded compile source/target of Java 8 in the native module.

https://issues.apache.org/jira/browse/HDDS-11054

## How was this patch tested?

Native check with Java 11:
https://github.com/adoroszlai/ozone/actions/runs/9625813024/job/26551221261#step:6:14
https://github.com/adoroszlai/ozone/actions/runs/9625813024/job/26551221261#step:6:1383

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/9625801311