### PR TITLE
HDDS-10136. Recon displaying DELETED container as missing.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -342,11 +342,7 @@ public class ContainerHealthTask extends ReconScmTask {
       }
 
       if (h.getContainer().getState() == HddsProtos.LifeCycleState.DELETING) {
-        LOG.info("Container {} is in DELETING state. It has {} keys and {} " +
-                "bytes used according to SCM metadata. Please visit Recon's " +
-                "unhealthy container endpoint for more details.",
-            h.getContainer().getContainerID(), h.getNumKeys(),
-            h.getContainer().getUsedBytes());
+        LOG.info("Container {} is in DELETING state.", h.getContainerID());
         return;
       }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -336,13 +336,11 @@ public class ContainerHealthTask extends ReconScmTask {
       if (h.isHealthilyReplicated() || h.isDeleted()) {
         return;
       }
-      // For containers deleted in SCM, we sync the container state here.
-      if (h.isMissing() && containerDeletedInSCM(container)) {
-        return;
-      }
 
-      if (h.getContainer().getState() == HddsProtos.LifeCycleState.DELETING) {
-        LOG.info("Container {} is in DELETING state.", h.getContainerID());
+      // For containers in DELETING or DELETED state, we sync the container state here.
+      if (h.getContainer().getState() == HddsProtos.LifeCycleState.DELETING ||
+          (h.isMissing() && containerDeletedInSCM(container))) {
+        LOG.info("Container {} is in DELETING or DELETED state.", h.getContainerID());
         return;
       }
 
@@ -350,8 +348,7 @@ public class ContainerHealthTask extends ReconScmTask {
           ContainerHealthRecords.generateUnhealthyRecords(h, currentTime,
               unhealthyContainerStateStatsMap));
     } catch (ContainerNotFoundException e) {
-      LOG.error("Container not found while processing container in Container " +
-          "Health task", e);
+      LOG.error("Container not found while processing container in Container Health task", e);
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -340,6 +340,16 @@ public class ContainerHealthTask extends ReconScmTask {
       if (h.isMissing() && containerDeletedInSCM(container)) {
         return;
       }
+
+      if (h.getContainer().getState() == HddsProtos.LifeCycleState.DELETING) {
+        LOG.info("Container {} is in DELETING state. It has {} keys and {} " +
+                "bytes used according to SCM metadata. Please visit Recon's " +
+                "unhealthy container endpoint for more details.",
+            h.getContainer().getContainerID(), h.getNumKeys(),
+            h.getContainer().getUsedBytes());
+        return;
+      }
+
       containerHealthSchemaManager.insertUnhealthyContainerRecords(
           ContainerHealthRecords.generateUnhealthyRecords(h, currentTime,
               unhealthyContainerStateStatsMap));


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Root Cause

The main problem is with how container state transitions are handled. During the deletion process, if a container is in the DELETING state, Recon might mark it as MISSING due to no healthy replicas being reported. This happens because Recon checks the container state periodically, and during the sync delay, the state change to DELETED might not be reflected immediately.

### Known Behavior

This is a known behavior and is generally not a cause for concern. The discrepancy is temporary and resolves itself once the `ContainerHealthTask` in Recon synchronizes the container state with SCM. The brief period where a container is shown as MISSING despite being DELETED in SCM is due to the inherent delay in state synchronization between Recon and SCM.

### Solution

The solution involves modifying the `ContainerHealthTask` in Recon to handle these states correctly:

1. **Skip DELETING Containers**: When Recon finds a container marked as MISSING, it now checks if the container is actually in the DELETED state in SCM. If so, it skips any further processing for that container.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10136

## How was this patch tested?

UT's 
