### PR TITLE
HDDS-9844. [hsync] De-synchronize write APIs

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
@@ -79,7 +79,7 @@ abstract class AbstractCommitWatcher<BUFFER> {
   }
 
   /** @return the total data which has been acknowledged. */
-  long getTotalAckDataLength() {
+  synchronized long getTotalAckDataLength() {
     return totalAckDataLength;
   }
 
@@ -166,7 +166,7 @@ abstract class AbstractCommitWatcher<BUFFER> {
   /** Release the buffers for the given index. */
   abstract void releaseBuffers(long index);
 
-  void adjustBuffers(long commitIndex) {
+  synchronized void adjustBuffers(long commitIndex) {
     commitIndexMap.keySet().stream()
         .filter(p -> p <= commitIndex)
         .forEach(this::releaseBuffers);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -377,10 +377,12 @@ public class BlockOutputStream extends OutputStream {
   }
 
   private void updateWriteChunkLength() {
+    Preconditions.checkState(Thread.holdsLock(this));
     totalWriteChunkLength = writtenDataLength;
   }
 
   private void updatePutBlockLength() {
+    Preconditions.checkState(Thread.holdsLock(this));
     totalPutBlockLength = totalWriteChunkLength;
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -679,9 +679,10 @@ public class BlockOutputStream extends OutputStream {
       putBlockResultFuture = executePutBlock(true, true);
     } else {
       LOG.debug("Flushing without data");
-      return null;
     }
-    lastFlushFuture = watchForCommitAsync(putBlockResultFuture);
+    if (putBlockResultFuture != null) {
+      this.lastFlushFuture = watchForCommitAsync(putBlockResultFuture);
+    }
     return lastFlushFuture;
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -660,7 +660,7 @@ public class BlockOutputStream extends OutputStream {
           putBlockResultFuture = executePutBlock(close, false);
         }
         if (!close) {
-          // reset current buffer so that thenext write will allocate a new one..
+          // reset current buffer so that the next write will allocate a new one.
           currentBuffer = null;
           currentBufferRemaining = 0;
         }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -149,7 +149,7 @@ public class BlockOutputStream extends OutputStream {
   private final ContainerClientMetrics clientMetrics;
   private boolean allowPutBlockPiggybacking;
 
-  private volatile CompletableFuture<Void> lastFlushFuture;
+  private CompletableFuture<Void> lastFlushFuture;
 
   /**
    * Creates a new BlockOutputStream.

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -325,7 +325,8 @@ public class BlockOutputStream extends OutputStream {
     }
     if ((off < 0) || (off > b.length) || (len < 0) || ((off + len) > b.length)
         || ((off + len) < 0)) {
-      throw new IndexOutOfBoundsException();
+      throw new IndexOutOfBoundsException("Offset=" + off + " and len="
+          + len + " don't match the array length of " + b.length);
     }
     if (len == 0) {
       return;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -20,29 +20,43 @@ package org.apache.hadoop.hdds.scm.storage;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.Preconditions;
-
-import static java.util.Collections.emptyList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * This class creates and manages pool of n buffers.
+ * A bounded pool implementation that provides {@link ChunkBuffer}s. This pool allows allocating and releasing
+ * {@link ChunkBuffer}.
+ * This pool is designed for concurrent access to allocation and release. It imposes a maximum number of buffers to be
+ * allocated at the same time and once the limit has been approached, the thread requesting a new allocation needs to
+ * wait until a allocated buffer is released.
  */
 public class BufferPool {
+  public static final Logger LOG = LoggerFactory.getLogger(BufferPool.class);
 
   private static final BufferPool EMPTY = new BufferPool(0, 0);
-
-  private final List<ChunkBuffer> bufferList;
-  private int currentBufferIndex;
   private final int bufferSize;
   private final int capacity;
   private final Function<ByteBuffer, ByteString> byteStringConversion;
+
+  private final LinkedList<ChunkBuffer> allocated = new LinkedList<>();
+  private final LinkedList<ChunkBuffer> released = new LinkedList<>();
+  private ChunkBuffer currentBuffer = null;
+  private final Lock lock = new ReentrantLock();
+  private final Condition notFull = lock.newCondition();
+
 
   public static BufferPool empty() {
     return EMPTY;
@@ -57,8 +71,6 @@ public class BufferPool {
       Function<ByteBuffer, ByteString> byteStringConversion) {
     this.capacity = capacity;
     this.bufferSize = bufferSize;
-    bufferList = capacity == 0 ? emptyList() : new ArrayList<>(capacity);
-    currentBufferIndex = -1;
     this.byteStringConversion = byteStringConversion;
   }
 
@@ -67,81 +79,134 @@ public class BufferPool {
   }
 
   ChunkBuffer getCurrentBuffer() {
-    return currentBufferIndex == -1 ? null : bufferList.get(currentBufferIndex);
+    return doInLock(() -> currentBuffer);
   }
 
   /**
-   * If the currentBufferIndex is less than the buffer size - 1,
-   * it means, the next buffer in the list has been freed up for
-   * rewriting. Reuse the next available buffer in such cases.
-   * <p>
-   * In case, the currentBufferIndex == buffer.size and buffer size is still
-   * less than the capacity to be allocated, just allocate a buffer of size
-   * chunk size.
+   * Allocate a new {@link ChunkBuffer}, waiting for a buffer to be released when this pool already allocates at
+   * capacity.
    */
-  public ChunkBuffer allocateBuffer(int increment) {
-    final int nextBufferIndex = currentBufferIndex + 1;
+  public ChunkBuffer allocateBuffer(int increment) throws InterruptedException {
+    lock.lockInterruptibly();
+    try {
+      Preconditions.assertTrue(allocated.size() + released.size() <= capacity, () ->
+          "Total created buffer must not exceed capacity.");
 
-    Preconditions.assertTrue(nextBufferIndex < capacity, () ->
-        "next index: " + nextBufferIndex + " >= capacity: " + capacity);
+      while (allocated.size() == capacity) {
+        LOG.debug("Allocation needs to wait the pool is at capacity (allocated = capacity = {}).", capacity);
+        notFull.await();
+      }
+      // Get a buffer to allocate, preferably from the released ones.
+      final ChunkBuffer buffer = released.isEmpty() ?
+          ChunkBuffer.allocate(bufferSize, increment) : released.removeFirst();
+      allocated.add(buffer);
+      currentBuffer = buffer;
 
-    currentBufferIndex = nextBufferIndex;
-
-    if (currentBufferIndex < bufferList.size()) {
-      return getBuffer(currentBufferIndex);
-    } else {
-      final ChunkBuffer newBuffer = ChunkBuffer.allocate(bufferSize, increment);
-      bufferList.add(newBuffer);
-      return newBuffer;
+      LOG.debug("Allocated new buffer {}, number of used buffers {}, capacity {}.",
+          buffer, allocated.size(), capacity);
+      return buffer;
+    } finally {
+      lock.unlock();
     }
   }
 
-  void releaseBuffer(ChunkBuffer chunkBuffer) {
-    Preconditions.assertTrue(!bufferList.isEmpty(), "empty buffer list");
-    Preconditions.assertSame(bufferList.get(0), chunkBuffer,
-        "only the first buffer can be released");
-    Preconditions.assertTrue(currentBufferIndex >= 0,
-        () -> "current buffer: " + currentBufferIndex);
+  void releaseBuffer(ChunkBuffer buffer) {
+    LOG.debug("Releasing buffer {}", buffer);
+    lock.lock();
+    try {
+      Preconditions.assertTrue(removeByIdentity(allocated, buffer), "Releasing unknown buffer");
+      buffer.clear();
+      released.add(buffer);
+      if (buffer == currentBuffer) {
+        currentBuffer = null;
+      }
+      notFull.signal();
+    } finally {
+      lock.unlock();
+    }
+  }
 
-    // always remove from head of the list and append at last
-    final ChunkBuffer buffer = bufferList.remove(0);
-    buffer.clear();
-    bufferList.add(buffer);
-    currentBufferIndex--;
+  /**
+   * Remove an item from a list by identity.
+   * @return true if the item is found and removed from the list, otherwise false.
+   */
+  private static <T> boolean removeByIdentity(List<T> list, T toRemove) {
+    int i = 0;
+    for (T item : list) {
+      if (item == toRemove) {
+        break;
+      } else {
+        i++;
+      }
+    }
+    if (i < list.size()) {
+      list.remove(i);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Wait until one buffer is available.
+   * @throws InterruptedException
+   */
+  public void waitUntilAvailable() throws InterruptedException {
+    lock.lockInterruptibly();
+    try {
+      while (allocated.size() == capacity) {
+        notFull.await();
+      }
+    } finally {
+      lock.unlock();
+    }
   }
 
   public void clearBufferPool() {
-    bufferList.forEach(ChunkBuffer::close);
-    bufferList.clear();
-    currentBufferIndex = -1;
-  }
-
-  public void checkBufferPoolEmpty() {
-    Preconditions.assertSame(0, computeBufferData(), "total buffer size");
+    lock.lock();
+    try {
+      allocated.forEach(ChunkBuffer::close);
+      released.forEach(ChunkBuffer::close);
+      allocated.clear();
+      released.clear();
+      currentBuffer = null;
+    } finally {
+      lock.unlock();
+    }
   }
 
   public long computeBufferData() {
-    long totalBufferSize = 0;
-    for (ChunkBuffer buf : bufferList) {
-      totalBufferSize += buf.position();
-    }
-    return totalBufferSize;
+    return doInLock(() -> {
+      long totalBufferSize = 0;
+      for (ChunkBuffer buf : allocated) {
+        totalBufferSize += buf.position();
+      }
+      return totalBufferSize;
+    });
   }
 
   public int getSize() {
-    return bufferList.size();
+    return doInLock(() -> allocated.size() + released.size());
   }
 
-  public ChunkBuffer getBuffer(int index) {
-    return bufferList.get(index);
-  }
-
-  int getCurrentBufferIndex() {
-    return currentBufferIndex;
+  public List<ChunkBuffer> getAllocatedBuffers() {
+    return doInLock(() -> new ArrayList<>(allocated));
   }
 
   public int getNumberOfUsedBuffers() {
-    return currentBufferIndex + 1;
+    return doInLock(allocated::size);
+  }
+
+  private <T> T doInLock(Supplier<T> supplier) {
+    lock.lock();
+    try {
+      return supplier.get();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public boolean isAtCapacity() {
+    return getNumberOfUsedBuffers() == capacity;
   }
 
   public int getCapacity() {
@@ -151,4 +216,5 @@ public class BufferPool {
   public int getBufferSize() {
     return bufferSize;
   }
+
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 
@@ -150,6 +151,7 @@ public class BufferPool {
    * Wait until one buffer is available.
    * @throws InterruptedException
    */
+  @VisibleForTesting
   public void waitUntilAvailable() throws InterruptedException {
     lock.lockInterruptibly();
     try {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -20,8 +20,11 @@ package org.apache.hadoop.hdds.scm.storage;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -52,7 +55,7 @@ public class BufferPool {
   private final int capacity;
   private final Function<ByteBuffer, ByteString> byteStringConversion;
 
-  private final LinkedList<ChunkBuffer> allocated = new LinkedList<>();
+  private final Set<ChunkBuffer> allocated = Collections.newSetFromMap(new IdentityHashMap<>());
   private final LinkedList<ChunkBuffer> released = new LinkedList<>();
   private ChunkBuffer currentBuffer = null;
   private final Lock lock = new ReentrantLock();
@@ -115,7 +118,7 @@ public class BufferPool {
     LOG.debug("Releasing buffer {}", buffer);
     lock.lock();
     try {
-      Preconditions.assertTrue(removeByIdentity(allocated, buffer), "Releasing unknown buffer");
+      Preconditions.assertTrue(allocated.remove(buffer), "Releasing unknown buffer");
       buffer.clear();
       released.add(buffer);
       if (buffer == currentBuffer) {
@@ -125,26 +128,6 @@ public class BufferPool {
     } finally {
       lock.unlock();
     }
-  }
-
-  /**
-   * Remove an item from a list by identity.
-   * @return true if the item is found and removed from the list, otherwise false.
-   */
-  private static <T> boolean removeByIdentity(List<T> list, T toRemove) {
-    int i = 0;
-    for (T item : list) {
-      if (item == toRemove) {
-        break;
-      } else {
-        i++;
-      }
-    }
-    if (i < list.size()) {
-      list.remove(i);
-      return true;
-    }
-    return false;
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -87,16 +87,16 @@ public class ECBlockOutputStream extends BlockOutputStream {
   }
 
   @Override
-  public void write(byte[] b, int off, int len) throws IOException {
+  public synchronized void write(byte[] b, int off, int len) throws IOException {
     this.currentChunkRspFuture =
         writeChunkToContainer(
-            ChunkBuffer.wrap(ByteBuffer.wrap(b, off, len)), false, false);
+            ChunkBuffer.wrap(ByteBuffer.wrap(b, off, len)));
     updateWrittenDataLength(len);
   }
 
   public CompletableFuture<ContainerProtos.ContainerCommandResponseProto> write(
       ByteBuffer buff) throws IOException {
-    return writeChunkToContainer(ChunkBuffer.wrap(buff), false, false);
+    return writeChunkToContainer(ChunkBuffer.wrap(buff));
   }
 
   public CompletableFuture<ContainerProtos.
@@ -199,7 +199,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
       ContainerCommandResponseProto> executePutBlock(boolean close,
       boolean force, long blockGroupLength) throws IOException {
     updateBlockGroupLengthInPutBlockMeta(blockGroupLength);
-    return executePutBlock(close, force);
+    return executePutBlock(close, force).thenApply(PutBlockResult::getResponse);
   }
 
   private void updateBlockGroupLengthInPutBlockMeta(final long blockGroupLen) {
@@ -232,13 +232,13 @@ public class ECBlockOutputStream extends BlockOutputStream {
    * @param force true if no data was written since most recent putBlock and
    *            stream is being closed
    */
-  public CompletableFuture<ContainerProtos.
-      ContainerCommandResponseProto> executePutBlock(boolean close,
+  @Override
+  public CompletableFuture<PutBlockResult> executePutBlock(boolean close,
       boolean force) throws IOException {
     checkOpen();
 
     CompletableFuture<ContainerProtos.
-        ContainerCommandResponseProto> flushFuture = null;
+        ContainerCommandResponseProto> flushFuture;
     try {
       ContainerProtos.BlockData blockData = getContainerBlockData().build();
       XceiverClientReply asyncReply =
@@ -273,9 +273,11 @@ public class ECBlockOutputStream extends BlockOutputStream {
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       handleInterruptedException(ex, false);
+      // never reach.
+      return null;
     }
     this.putBlkRspFuture = flushFuture;
-    return flushFuture;
+    return flushFuture.thenApply(r -> new PutBlockResult(0, 0, r));
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.storage;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.Syncable;
 import org.apache.hadoop.hdds.client.BlockID;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.scm.ContainerClientMetrics;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.StreamBufferArgs;
@@ -102,9 +101,8 @@ public class RatisBlockOutputStream extends BlockOutputStream
   }
 
   @Override
-  XceiverClientReply sendWatchForCommit(boolean bufferFull) throws IOException {
-    return bufferFull ? commitWatcher.watchOnFirstIndex()
-        : commitWatcher.watchOnLastIndex();
+  XceiverClientReply sendWatchForCommit(long commitIndex) throws IOException {
+    return commitWatcher.watchForCommit(commitIndex);
   }
 
   @Override
@@ -113,13 +111,11 @@ public class RatisBlockOutputStream extends BlockOutputStream
   }
 
   @Override
-  void putFlushFuture(long flushPos, CompletableFuture<ContainerCommandResponseProto> flushFuture) {
-    commitWatcher.putFlushFuture(flushPos, flushFuture);
-  }
-
-  @Override
-  void waitOnFlushFutures() throws InterruptedException, ExecutionException {
-    commitWatcher.waitOnFlushFutures();
+  void waitOnFlushFuture() throws InterruptedException, ExecutionException {
+    CompletableFuture<Void> flushFuture = getLastFlushFuture();
+    if (flushFuture != null) {
+      flushFuture.get();
+    }
   }
 
   @Override
@@ -135,10 +131,7 @@ public class RatisBlockOutputStream extends BlockOutputStream
   @Override
   public void hsync() throws IOException {
     if (!isClosed()) {
-      if (getBufferPool() != null && getBufferPool().getSize() > 0) {
-        handleFlush(false);
-      }
-      waitForFlushAndCommit(false);
+      handleFlush(false);
     }
   }
 }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
@@ -20,38 +20,106 @@ package org.apache.hadoop.hdds.scm.storage;
 
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 
+import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils.LogCapturer;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
 
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for {@link BufferPool}.
  */
 class TestBufferPool {
 
+  @BeforeAll
+  static void init() {
+    GenericTestUtils.setLogLevel(BufferPool.LOG, Level.DEBUG);
+  }
+
   @Test
-  void testBufferPool() {
+  void testBufferPool() throws Exception {
     testBufferPool(BufferPool.empty());
     testBufferPool(1, 1);
     testBufferPool(3, 1 << 20);
     testBufferPool(10, 1 << 10);
   }
 
-  private static void testBufferPool(final int capacity, final int bufferSize) {
+  @Test
+  void testBufferPoolConcurrently() throws Exception {
+    final BufferPool pool = new BufferPool(1 << 20, 10);
+    final Deque<ChunkBuffer> buffers = assertAllocate(pool);
+
+    assertAllocationBlocked(pool);
+    assertAllocationBlockedUntilReleased(pool, buffers);
+  }
+
+  private void assertAllocationBlockedUntilReleased(BufferPool pool, Deque<ChunkBuffer> buffers) throws Exception {
+    // As the pool is full, allocation will need to wait until a buffer is released.
+    assertFull(pool);
+
+    LogCapturer logCapturer = LogCapturer.captureLogs(BufferPool.LOG);
+    AtomicReference<ChunkBuffer> allocated = new AtomicReference<>();
+    Thread allocator = new Thread(() -> {
+      try {
+        allocated.set(pool.allocateBuffer(0));
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    ChunkBuffer toRelease = buffers.removeFirst();
+    Thread releaser = new Thread(() -> {
+      pool.releaseBuffer(toRelease);
+    });
+    allocator.start();
+    Thread.sleep(100);
+    releaser.start();
+    allocator.join();
+    assertEquals(toRelease, allocated.get());
+    assertTrue(logCapturer.getOutput().contains("Allocation needs to wait the pool is at capacity"));
+  }
+
+  private void assertAllocationBlocked(BufferPool pool) throws Exception {
+    // As the pool is full, new allocation will be blocked interruptably if no allocated buffer is released.
+    assertFull(pool);
+
+    LogCapturer logCapturer = LogCapturer.captureLogs(BufferPool.LOG);
+    AtomicBoolean interrupted = new AtomicBoolean(false);
+    Thread allocator = new Thread(() -> {
+      try {
+        pool.allocateBuffer(0);
+      } catch (InterruptedException e) {
+        interrupted.set(true);
+      }
+    });
+    allocator.start();
+    Thread.sleep(100);
+    allocator.interrupt();
+    allocator.join();
+    assertTrue(interrupted.get());
+    assertTrue(logCapturer.getOutput().contains("Allocation needs to wait the pool is at capacity"));
+  }
+
+  private static void testBufferPool(final int capacity, final int bufferSize) throws Exception {
     final BufferPool pool = new BufferPool(bufferSize, capacity);
     assertEquals(capacity, pool.getCapacity());
     assertEquals(bufferSize, pool.getBufferSize());
     testBufferPool(pool);
   }
 
-  private static void testBufferPool(final BufferPool pool) {
+  private static void testBufferPool(final BufferPool pool) throws Exception {
     assertEmpty(pool);
     final Deque<ChunkBuffer> buffers = assertAllocate(pool);
     assertFull(pool);
@@ -62,10 +130,10 @@ class TestBufferPool {
   private static void assertEmpty(BufferPool pool) {
     assertEquals(0, pool.getNumberOfUsedBuffers());
     assertEquals(0, pool.getSize());
-    assertEquals(-1, pool.getCurrentBufferIndex());
+    assertNull(pool.getCurrentBuffer());
   }
 
-  private static Deque<ChunkBuffer> assertAllocate(BufferPool pool) {
+  private static Deque<ChunkBuffer> assertAllocate(BufferPool pool) throws Exception {
     final int capacity = pool.getCapacity();
     final int size = pool.getBufferSize();
     final Deque<ChunkBuffer> buffers = new LinkedList<>();
@@ -96,19 +164,13 @@ class TestBufferPool {
     final int capacity = pool.getCapacity();
     assertEquals(capacity, pool.getSize());
     assertEquals(capacity, pool.getNumberOfUsedBuffers());
-    assertThrows(IllegalStateException.class, () -> pool.allocateBuffer(0));
   }
 
-  // buffers are released and reallocated FIFO
+  // buffers are released and reallocated
   private static void assertReallocate(BufferPool pool,
-      Deque<ChunkBuffer> buffers) {
+      Deque<ChunkBuffer> buffers) throws Exception {
     final int capacity = pool.getCapacity();
     for (int i = 0; i < 3 * capacity; i++) {
-      if (capacity > 1) {
-        assertThrows(IllegalStateException.class,
-            () -> pool.releaseBuffer(buffers.getLast()));
-      }
-
       final ChunkBuffer released = buffers.removeFirst();
       pool.releaseBuffer(released);
       assertEquals(0, released.position());
@@ -122,18 +184,20 @@ class TestBufferPool {
     }
   }
 
-  private static void assertRelease(BufferPool pool,
-      Deque<ChunkBuffer> buffers) {
+  private static void assertRelease(BufferPool pool, Deque<ChunkBuffer> buffers) {
+    // assert that allcated buffers can be released in any order.
     final int capacity = pool.getCapacity();
+    boolean pickFirst = false;
     for (int i = capacity - 1; i >= 0; i--) {
-      final ChunkBuffer released = buffers.removeFirst();
+      final ChunkBuffer released = pickFirst ? buffers.removeFirst() : buffers.removeLast();
+      pickFirst = !pickFirst;
       pool.releaseBuffer(released);
       assertEquals(i, pool.getNumberOfUsedBuffers());
       assertThrows(IllegalStateException.class,
           () -> pool.releaseBuffer(released));
     }
 
-    pool.checkBufferPoolEmpty();
+    assertEquals(0, pool.computeBufferData());
   }
 
   private static void fill(ChunkBuffer buf) {

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBufferPool.java
@@ -207,7 +207,7 @@ class TestBufferPool {
   }
 
   private static void assertRelease(BufferPool pool, Deque<ChunkBuffer> buffers) {
-    // assert that allcated buffers can be released in any order.
+    // assert that allocated buffers can be released in any order.
     final int capacity = pool.getCapacity();
     boolean pickFirst = false;
     for (int i = capacity - 1; i >= 0; i--) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Function;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -34,6 +35,7 @@ import org.apache.ratis.util.UncheckedAutoCloseable;
 final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
   private final ByteBuffer buffer;
   private final UncheckedAutoCloseable underlying;
+  private final UUID identity = UUID.randomUUID();
 
   ChunkBufferImplWithByteBuffer(ByteBuffer buffer) {
     this(buffer, null);
@@ -161,6 +163,6 @@ final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
   @Override
   public String toString() {
     return getClass().getSimpleName() + ":limit=" + buffer.limit()
-        + "@" + Integer.toHexString(hashCode());
+        + "@" + identity;
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -171,7 +171,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
             .build();
   }
 
-  private void addKeyLocationInfo(OmKeyLocationInfo subKeyInfo) {
+  private synchronized void addKeyLocationInfo(OmKeyLocationInfo subKeyInfo) {
     Preconditions.checkNotNull(subKeyInfo.getPipeline());
     streamEntries.add(createStreamEntry(subKeyInfo));
   }
@@ -248,7 +248,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
    * @param containerID id of the closed container
    * @param pipelineId id of the associated pipeline
    */
-  void discardPreallocatedBlocks(long containerID, PipelineID pipelineId) {
+  synchronized void discardPreallocatedBlocks(long containerID, PipelineID pipelineId) {
     // currentStreamIndex < streamEntries.size() signifies that, there are still
     // pre allocated blocks available.
 
@@ -283,7 +283,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
     return keyArgs.getKeyName();
   }
 
-  long getKeyLength() {
+  synchronized long getKeyLength() {
     return streamEntries.stream()
         .mapToLong(BlockOutputStreamEntry::getCurrentPosition).sum();
   }
@@ -339,10 +339,7 @@ public class BlockOutputStreamEntryPool implements KeyMetadataAware {
   void hsyncKey(long offset) throws IOException {
     if (keyArgs != null) {
       // in test, this could be null
-      long length = getKeyLength();
-      Preconditions.checkArgument(offset == length,
-              "Expected offset: " + offset + " expected len: " + length);
-      keyArgs.setDataSize(length);
+      keyArgs.setDataSize(offset);
       keyArgs.setLocationInfoList(getLocationInfoList());
       // When the key is multipart upload part file upload, we should not
       // commit the key, as this is not an actual key, this is a just a

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -90,7 +90,7 @@ public class KeyOutputStream extends OutputStream
   // how much of data is actually written yet to underlying stream
   private long offset;
   // how much data has been ingested into the stream
-  private long writeOffset;
+  private volatile long writeOffset;
   // whether an exception is encountered while write and whole write could
   // not succeed
   private boolean isException;
@@ -195,7 +195,7 @@ public class KeyOutputStream extends OutputStream
    * @throws IOException
    */
   @Override
-  public synchronized void write(byte[] b, int off, int len)
+  public void write(byte[] b, int off, int len)
       throws IOException {
     checkNotClosed();
     if (b == null) {
@@ -208,8 +208,10 @@ public class KeyOutputStream extends OutputStream
     if (len == 0) {
       return;
     }
-    handleWrite(b, off, len, false);
-    writeOffset += len;
+    synchronized (this) {
+      handleWrite(b, off, len, false);
+      writeOffset += len;
+    }
   }
 
   private void handleWrite(byte[] b, int off, long len, boolean retry)
@@ -361,7 +363,7 @@ public class KeyOutputStream extends OutputStream
     }
   }
 
-  private void markStreamClosed() {
+  private synchronized void markStreamClosed() {
     blockOutputStreamEntryPool.cleanup();
     closed = true;
   }
@@ -446,7 +448,7 @@ public class KeyOutputStream extends OutputStream
   }
 
   @Override
-  public synchronized void hsync() throws IOException {
+  public void hsync() throws IOException {
     if (replication.getReplicationType() != ReplicationType.RATIS) {
       throw new UnsupportedOperationException(
           "Replication type is not " + ReplicationType.RATIS);
@@ -460,11 +462,12 @@ public class KeyOutputStream extends OutputStream
 
     handleFlushOrClose(StreamAction.HSYNC);
 
-    Preconditions.checkState(offset >= hsyncPos,
-        "offset = %s < hsyncPos = %s", offset, hsyncPos);
-
-    MetricUtil.captureLatencyNs(clientMetrics::addHsyncLatency,
-        () -> blockOutputStreamEntryPool.hsyncKey(hsyncPos));
+    synchronized (this) {
+      Preconditions.checkState(offset >= hsyncPos,
+          "offset = %s < hsyncPos = %s", offset, hsyncPos);
+      MetricUtil.captureLatencyNs(clientMetrics::addHsyncLatency,
+          () -> blockOutputStreamEntryPool.hsyncKey(hsyncPos));
+    }
   }
 
   /**
@@ -729,7 +732,7 @@ public class KeyOutputStream extends OutputStream
    * the last state of the volatile {@link #closed} field.
    * @throws IOException if the connection is closed.
    */
-  private void checkNotClosed() throws IOException {
+  private synchronized void checkNotClosed() throws IOException {
     if (closed) {
       throw new IOException(
           ": " + FSExceptionMessages.STREAM_IS_CLOSED + " Key: "

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -437,7 +437,7 @@ public class KeyOutputStream extends OutputStream
   }
 
   @Override
-  public synchronized void flush() throws IOException {
+  public void flush() throws IOException {
     checkNotClosed();
     handleFlushOrClose(StreamAction.FLUSH);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -729,13 +729,10 @@ public class TestHSync {
         Arguments.of(1, 1, true),
         Arguments.of(2, 1, true),
         Arguments.of(4, 1, true),
-        Arguments.of(6, 2, true),
         Arguments.of(8, 2, true),
-        Arguments.of(8, 3, true),
         Arguments.of(8, 4, true),
         Arguments.of(8, 8, true),
         Arguments.of(8, 16, true),
-
         Arguments.of(1, 1, false),
         Arguments.of(8, 2, false),
         Arguments.of(8, 16, false)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -44,6 +45,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
+import org.apache.hadoop.hdds.scm.storage.BufferPool;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -153,7 +155,7 @@ public class TestHSync {
   private static final BucketLayout BUCKET_LAYOUT = BucketLayout.FILE_SYSTEM_OPTIMIZED;
 
   private static final int CHUNK_SIZE = 4 << 12;
-  private static final int FLUSH_SIZE = 2 * CHUNK_SIZE;
+  private static final int FLUSH_SIZE = 3 * CHUNK_SIZE;
   private static final int MAX_FLUSH_SIZE = 2 * FLUSH_SIZE;
   private static final int BLOCK_SIZE = 2 * MAX_FLUSH_SIZE;
   private static final int SERVICE_INTERVAL = 100;
@@ -208,6 +210,8 @@ public class TestHSync {
     GenericTestUtils.setLogLevel(BlockOutputStream.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(BlockInputStream.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(KeyValueHandler.LOG, Level.DEBUG);
+
+    GenericTestUtils.setLogLevel(BufferPool.LOG, Level.DEBUG);
 
     openKeyCleanupService =
         (OpenKeyCleanupService) cluster.getOzoneManager().getKeyManager().getOpenKeyCleanupService();
@@ -627,45 +631,58 @@ public class TestHSync {
     out.writeAndHsync(data);
 
     final byte[] buffer = new byte[4 << 10];
-    int offset = 0;
-    try (FSDataInputStream in = fs.open(file)) {
-      final long skipped = in.skip(length);
-      assertEquals(length, skipped);
+    AtomicInteger attempted = new AtomicInteger();
 
-      for (; ;) {
-        final int n = in.read(buffer, 0, buffer.length);
-        if (n <= 0) {
-          break;
+    // hsync returns when all datanodes acknowledge they have received the PutBlock request. Yet, the PutBlock
+    // may not been applied to their database. So, an immediate read right after hsync may not see the synced data
+    // yet. This does not violate hsync guarantee: it ensures all current pending data becomes persistent.
+    GenericTestUtils.waitFor(() -> {
+      attempted.addAndGet(1);
+      int offset = 0;
+      try (FSDataInputStream in = fs.open(file)) {
+        final long skipped = in.skip(length);
+        assertEquals(length, skipped);
+
+        for (; ;) {
+          final int n = in.read(buffer, 0, buffer.length);
+          if (n <= 0) {
+            break;
+          }
+          for (int i = 0; i < n; i++) {
+            assertEquals(data[offset + i], buffer[i], "expected at offset " + offset + " i=" + i);
+          }
+          offset += n;
         }
-        for (int i = 0; i < n; i++) {
-          assertEquals(data[offset + i], buffer[i],
-              "expected at offset " + offset + " i=" + i);
+        if (offset != data.length) {
+          LOG.error("Read attempt #{} failed. offset {}, expected data.length {}", attempted, offset, data.length);
+          return false;
+        } else {
+          LOG.debug("Read attempt #{} succeeded. offset {}, expected data.length {}", attempted, offset, data.length);
+          return true;
         }
-        offset += n;
+      } catch (IOException e) {
+        LOG.error("Exception is thrown during read", e);
+        return false;
       }
-    }
-    assertEquals(data.length, offset);
+    }, 500, 3000);
   }
 
-  private void runConcurrentWriteHSync(Path file,
-      final FSDataOutputStream out, int initialDataSize)
-      throws InterruptedException, IOException {
-    final byte[] data = new byte[initialDataSize];
-    ThreadLocalRandom.current().nextBytes(data);
+  private int runConcurrentWriteHSync(Path file,
+      final FSDataOutputStream out, byte[] data, int syncThreadsCount) throws Exception {
 
-    AtomicReference<IOException> writerException = new AtomicReference<>();
-    AtomicReference<IOException> syncerException = new AtomicReference<>();
+    AtomicReference<Exception> writerException = new AtomicReference<>();
+    AtomicReference<Exception> syncerException = new AtomicReference<>();
 
-    LOG.info("runConcurrentWriteHSync {} with size {}",
-        file, initialDataSize);
-
+    LOG.info("runConcurrentWriteHSync {} with size {}", file, data.length);
+    AtomicInteger writes = new AtomicInteger();
     final long start = Time.monotonicNow();
     // two threads: write and hsync
     Runnable writer = () -> {
       while ((Time.monotonicNow() - start < 10000)) {
         try {
           out.write(data);
-        } catch (IOException e) {
+          writes.incrementAndGet();
+        } catch (Exception e) {
           writerException.set(e);
           throw new RuntimeException(e);
         }
@@ -676,7 +693,7 @@ public class TestHSync {
       while ((Time.monotonicNow() - start < 10000)) {
         try {
           out.hsync();
-        } catch (IOException e) {
+        } catch (Exception e) {
           syncerException.set(e);
           throw new RuntimeException(e);
         }
@@ -684,11 +701,19 @@ public class TestHSync {
     };
 
     Thread writerThread = new Thread(writer);
+    writerThread.setName("Writer");
     writerThread.start();
-    Thread syncThread = new Thread(syncer);
-    syncThread.start();
+    Thread[] syncThreads = new Thread[syncThreadsCount];
+    for (int i = 0; i < syncThreadsCount; i++) {
+      syncThreads[i] = new Thread(syncer);
+      syncThreads[i].setName("Syncer-" + i);
+      syncThreads[i].start();
+    }
+
     writerThread.join();
-    syncThread.join();
+    for (Thread sync : syncThreads) {
+      sync.join();
+    }
 
     if (writerException.get() != null) {
       throw writerException.get();
@@ -696,29 +721,54 @@ public class TestHSync {
     if (syncerException.get() != null) {
       throw syncerException.get();
     }
+    return writes.get();
   }
 
-  @Test
-  public void testConcurrentWriteHSync()
-      throws IOException, InterruptedException {
-    final String rootPath = String.format("%s://%s/",
-        OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
+  public static Stream<Arguments> concurrentWriteHSync() {
+    return Stream.of(
+        Arguments.of(1, 1),
+        Arguments.of(2, 1),
+        Arguments.of(4, 1),
+        Arguments.of(6, 2),
+        Arguments.of(8, 2),
+        Arguments.of(8, 3),
+        // this may fail.
+        Arguments.of(8, 4),
+        Arguments.of(8, 8),
+        Arguments.of(8, 16)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("concurrentWriteHSync")
+  public void testConcurrentWriteHSync(int writeSampleSize, int syncThreadsCount) throws Exception {
+    final String rootPath = String.format("%s://%s/", OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
     CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
 
-    final String dir = OZONE_ROOT + bucket.getVolumeName()
-        + OZONE_URI_DELIMITER + bucket.getName();
+    final String dir = OZONE_ROOT + bucket.getVolumeName() + OZONE_URI_DELIMITER + bucket.getName();
 
     try (FileSystem fs = FileSystem.get(CONF)) {
-      for (int i = 0; i < 5; i++) {
-        final Path file = new Path(dir, "file" + i);
-        try (FSDataOutputStream out =
-            fs.create(file, true)) {
-          int initialDataSize = 1 << i;
-          runConcurrentWriteHSync(file, out, initialDataSize);
-        }
-
-        fs.delete(file, false);
+      final Path file = new Path(dir, "file" + writeSampleSize);
+      byte[] data = new byte[writeSampleSize];
+      ThreadLocalRandom.current().nextBytes(data);
+      int writes;
+      try (FSDataOutputStream out = fs.create(file, true)) {
+        writes = runConcurrentWriteHSync(file, out, data, syncThreadsCount);
       }
+      validateWrittenFile(file, fs, data, writes);
+      fs.delete(file, false);
+    }
+  }
+
+  private void validateWrittenFile(Path file, FileSystem fs, byte[] expected, int times) throws IOException {
+    try (FSDataInputStream is = fs.open(file)) {
+      byte[] actual = new byte[expected.length];
+      for (int i = 0; i < times; i++) {
+        assertEquals(expected.length, is.read(actual));
+        assertArrayEquals(expected, actual);
+      }
+      // ensure nothing more can be read.
+      assertEquals(-1, is.read(expected));
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -728,9 +728,7 @@ public class TestHSync {
     return Stream.of(
         Arguments.of(1, 1, true),
         Arguments.of(2, 1, true),
-        Arguments.of(4, 1, true),
         Arguments.of(8, 2, true),
-        Arguments.of(8, 4, true),
         Arguments.of(8, 8, true),
         Arguments.of(8, 16, true),
         Arguments.of(1, 1, false),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -726,23 +726,28 @@ public class TestHSync {
 
   public static Stream<Arguments> concurrentWriteHSync() {
     return Stream.of(
-        Arguments.of(1, 1),
-        Arguments.of(2, 1),
-        Arguments.of(4, 1),
-        Arguments.of(6, 2),
-        Arguments.of(8, 2),
-        Arguments.of(8, 3),
-        // this may fail.
-        Arguments.of(8, 4),
-        Arguments.of(8, 8),
-        Arguments.of(8, 16)
+        Arguments.of(1, 1, true),
+        Arguments.of(2, 1, true),
+        Arguments.of(4, 1, true),
+        Arguments.of(6, 2, true),
+        Arguments.of(8, 2, true),
+        Arguments.of(8, 3, true),
+        Arguments.of(8, 4, true),
+        Arguments.of(8, 8, true),
+        Arguments.of(8, 16, true),
+
+        Arguments.of(1, 1, false),
+        Arguments.of(8, 2, false),
+        Arguments.of(8, 16, false)
     );
   }
 
   @ParameterizedTest
   @MethodSource("concurrentWriteHSync")
-  public void testConcurrentWriteHSync(int writeSampleSize, int syncThreadsCount) throws Exception {
+  public void testConcurrentWriteHSync(int writeSampleSize, int syncThreadsCount,
+      boolean piggybackingEnabled) throws Exception {
     final String rootPath = String.format("%s://%s/", OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
+    CONF.setBoolean("ozone.client.stream.putblock.piggybacking", piggybackingEnabled);
     CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
 
     final String dir = OZONE_ROOT + bucket.getVolumeName() + OZONE_URI_DELIMITER + bucket.getName();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestCommitWatcher.java
@@ -209,7 +209,6 @@ public class TestCommitWatcher {
                 return v;
               });
           futures.add(future);
-          watcher.putFlushFuture(length, future);
           replies.add(reply);
         }
 
@@ -220,21 +219,15 @@ public class TestCommitWatcher {
         CompletableFuture<ContainerCommandResponseProto> future2 =
             futures.get(1);
         future1.get();
-        assertEquals(future1, watcher.getFutureMap().get((long) chunkSize));
-        // wait on 2nd putBlock to complete
         future2.get();
-        assertEquals(future2, watcher.getFutureMap().get((long) 2 * chunkSize));
         assertEquals(2, watcher.
             getCommitIndexMap().size());
         watcher.watchOnFirstIndex();
         assertThat(watcher.getCommitIndexMap()).doesNotContainKey(replies.get(0).getLogIndex());
-        assertThat(watcher.getFutureMap()).doesNotContainKey((long) chunkSize);
         assertThat(watcher.getTotalAckDataLength()).isGreaterThanOrEqualTo(chunkSize);
         watcher.watchOnLastIndex();
         assertThat(watcher.getCommitIndexMap()).doesNotContainKey(replies.get(1).getLogIndex());
-        assertThat(watcher.getFutureMap()).doesNotContainKey((long) 2 * chunkSize);
         assertEquals(2 * chunkSize, watcher.getTotalAckDataLength());
-        assertThat(watcher.getFutureMap()).isEmpty();
         assertThat(watcher.getCommitIndexMap()).isEmpty();
       }
     } finally {
@@ -282,7 +275,6 @@ public class TestCommitWatcher {
                 return v;
               });
           futures.add(future);
-          watcher.putFlushFuture(length, future);
           replies.add(reply);
         }
 
@@ -293,14 +285,11 @@ public class TestCommitWatcher {
         CompletableFuture<ContainerCommandResponseProto> future2 =
             futures.get(1);
         future1.get();
-        assertEquals(future1, watcher.getFutureMap().get((long) chunkSize));
         // wait on 2nd putBlock to complete
         future2.get();
-        assertEquals(future2, watcher.getFutureMap().get((long) 2 * chunkSize));
         assertEquals(2, watcher.getCommitIndexMap().size());
         watcher.watchOnFirstIndex();
         assertThat(watcher.getCommitIndexMap()).doesNotContainKey(replies.get(0).getLogIndex());
-        assertThat(watcher.getFutureMap()).doesNotContainKey((long) chunkSize);
         assertThat(watcher.getTotalAckDataLength()).isGreaterThanOrEqualTo(chunkSize);
         cluster.shutdownHddsDatanode(pipeline.getNodes().get(0));
         cluster.shutdownHddsDatanode(pipeline.getNodes().get(1));
@@ -325,10 +314,8 @@ public class TestCommitWatcher {
             .getLogIndex()) {
           assertEquals(chunkSize, watcher.getTotalAckDataLength());
           assertEquals(1, watcher.getCommitIndexMap().size());
-          assertEquals(1, watcher.getFutureMap().size());
         } else {
           assertEquals(2 * chunkSize, watcher.getTotalAckDataLength());
-          assertThat(watcher.getFutureMap()).isEmpty();
           assertThat(watcher.getCommitIndexMap()).isEmpty();
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make KeyOutputStream/BlockOutputStream ready for multiple threads calling hsync.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-9844

## How was this patch tested?

Test
