### PR TITLE
HDDS-11059. Reduce OM DEBUG messages

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -681,7 +681,7 @@ public final class RocksDatabase implements Closeable {
     try (UncheckedAutoCloseable ignored = acquire()) {
       final int size = db.get().get(family.getHandle(),
           DEFAULT_READ_OPTION, key, outValue);
-      LOG.debug("get: size={}, remaining={}",
+      LOG.trace("get: size={}, remaining={}",
           size, outValue.asReadOnlyBuffer().remaining());
       return size == ManagedRocksDB.NOT_FOUND ? null : size;
     } catch (RocksDBException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When DEBUG logging is enabled for OM, there are many un-useful messages as mentioned in the JIRA description. These messages are now in TRACE log level. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11059

## How was this patch tested?
Tested the patch on docker.
Before changing the log level:
```
2024-06-27 07:56:36 2024-06-27 02:26:36 INFO  OzoneManager:1228 - Creating RPC Server
2024-06-27 07:56:36 2024-06-27 02:26:36 DEBUG RocksDatabase:684 - get: size=-1, remaining=4096
2024-06-27 07:56:36 2024-06-27 02:26:36 INFO  RaftServer$Division:256 - om1: new RaftServerImpl for group-C5BA1605619E:[om1|om:9872] with OzoneManagerStateMachine:uninitialized
2024-06-27 07:56:36 2024-06-27 02:26:36 DEBUG LifeCycle:154 - om1: NEW
```

After changing the log level:
```
2024-06-27 08:00:29 2024-06-27 02:30:29 INFO  OzoneManager:1228 - Creating RPC Server
2024-06-27 08:00:29 2024-06-27 02:30:29 INFO  RaftServer$Division:256 - om1: new RaftServerImpl for group-C5BA1605619E:[om1|om:9872] with OzoneManagerStateMachine:uninitialized
2024-06-27 08:00:29 2024-06-27 02:30:29 DEBUG LifeCycle:154 - om1: NEW
```

When TRACE log level is enabled, we can see this line in the output:
```
2024-06-27 07:52:42 2024-06-27 02:22:42 INFO  OzoneManager:1228 - Creating RPC Server
2024-06-27 07:52:42 2024-06-27 02:22:42 TRACE SecurityUtil:577 - Name lookup for om took 0 ms.
2024-06-27 07:52:42 2024-06-27 02:22:42 TRACE RocksDatabase:684 - get: size=-1, remaining=4096
2024-06-27 07:52:42 2024-06-27 02:22:42 INFO  RaftServer$Division:256 - om1: new RaftServerImpl for group-C5BA1605619E:[om1|om:9872] with OzoneManagerStateMachine:uninitialized
2024-06-27 07:52:42 2024-06-27 02:22:42 DEBUG LifeCycle:154 - om1: NEW
```

