### PR TITLE
HDDS-11045. Recon Decommissioning Info API throws NPE.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DecommissionUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DecommissionUtils.java
@@ -126,8 +126,9 @@ public final class DecommissionUtils {
                                                  Map<String, Object> countsMap, String errMsg)
       throws IOException {
     for (int i = 1; i <= numDecomNodes; i++) {
-      String dNHostName = (counts.get("tag.datanode." + i) != null) ? (counts.get("tag.datanode." + i).asText()) : "";
-      if (datanode.getHostName().equals(dNHostName)) {
+      String datanodeHostName =
+          (counts.get("tag.datanode." + i) != null) ? (counts.get("tag.datanode." + i).asText()) : "";
+      if (datanode.getHostName().equals(datanodeHostName)) {
         JsonNode pipelinesDN = counts.get("PipelinesWaitingToCloseDN." + i);
         JsonNode underReplicatedDN = counts.get("UnderReplicatedDN." + i);
         JsonNode unclosedDN = counts.get("UnclosedContainersDN." + i);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DecommissionUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/DecommissionUtils.java
@@ -126,7 +126,8 @@ public final class DecommissionUtils {
                                                  Map<String, Object> countsMap, String errMsg)
       throws IOException {
     for (int i = 1; i <= numDecomNodes; i++) {
-      if (datanode.getHostName().equals(counts.get("tag.datanode." + i).asText())) {
+      String dNHostName = (counts.get("tag.datanode." + i) != null) ? (counts.get("tag.datanode." + i).asText()) : "";
+      if (datanode.getHostName().equals(dNHostName)) {
         JsonNode pipelinesDN = counts.get("PipelinesWaitingToCloseDN." + i);
         JsonNode underReplicatedDN = counts.get("UnderReplicatedDN." + i);
         JsonNode unclosedDN = counts.get("UnclosedContainersDN." + i);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to fix the NullPointerException for datanode tag in Decommissioning Info API JSON.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11045

## How was this patch tested?
Patch was tested manually with existing Junit test cases.
