### PR TITLE
HDDS-11067. Capture Throwable execption in BackgroundService#PeriodicalTask

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -142,7 +142,10 @@ public abstract class BackgroundService {
               LOG.debug("task execution result size {}", result.getSize());
             }
           } catch (Throwable e) {
-            LOG.warn("Background task execution failed", e);
+            LOG.error("Background task execution failed", e);
+            if (e instanceof Error) {
+              return;
+            }
           } finally {
             long endTime = System.nanoTime();
             if (endTime - startTime > serviceTimeoutInNanos) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -144,7 +144,7 @@ public abstract class BackgroundService {
           } catch (Throwable e) {
             LOG.error("Background task execution failed", e);
             if (e instanceof Error) {
-              return;
+              throw e;
             }
           } finally {
             long endTime = System.nanoTime();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -141,7 +141,7 @@ public abstract class BackgroundService {
             if (LOG.isDebugEnabled()) {
               LOG.debug("task execution result size {}", result.getSize());
             }
-          } catch (Exception e) {
+          } catch (Throwable e) {
             LOG.warn("Background task execution failed", e);
           } finally {
             long endTime = System.nanoTime();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -144,7 +144,7 @@ public abstract class BackgroundService {
           } catch (Throwable e) {
             LOG.error("Background task execution failed", e);
             if (e instanceof Error) {
-              throw e;
+              throw (Error) e;
             }
           } finally {
             long endTime = System.nanoTime();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently BackgroundService#PeriodicalTask#run will capture Exception type exception and log warning message, change it to capture Throwable to log messages for all failure cases. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11067

## How was this patch tested?

The test will be covered by existing UTs. 
