### PR TITLE
HDDS-11070. Separate KeyCodec from reading and storing keys to disk

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.DNCertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertificate;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.ServicePlugin;
@@ -84,7 +84,7 @@ public class TestHddsSecureDatanodeInit {
   private static PublicKey publicKey;
   private static GenericTestUtils.LogCapturer dnLogs;
   private static SecurityConfig securityConfig;
-  private static KeyCodec keyCodec;
+  private static KeyStorage keyStorage;
   private static CertificateCodec certCodec;
   private static X509Certificate cert;
   private static final String DN_COMPONENT = DNCertificateClient.COMPONENT_NAME;
@@ -130,7 +130,7 @@ public class TestHddsSecureDatanodeInit {
     dnLogs = GenericTestUtils.LogCapturer.captureLogs(
         ((DNCertificateClient)service.getCertificateClient()).getLogger());
     certCodec = new CertificateCodec(securityConfig, DN_COMPONENT);
-    keyCodec = new KeyCodec(securityConfig, DN_COMPONENT);
+    keyStorage = new KeyStorage(securityConfig, DN_COMPONENT);
     dnLogs.clearOutput();
     privateKey = service.getCertificateClient().getPrivateKey();
     publicKey = service.getCertificateClient().getPublicKey();
@@ -197,7 +197,7 @@ public class TestHddsSecureDatanodeInit {
   @Test
   public void testSecureDnStartupCase2() throws Exception {
     // Case 2: When private key and certificate is missing.
-    keyCodec.writePublicKey(publicKey);
+    keyStorage.writePublicKey(publicKey);
     RuntimeException rteException = assertThrows(
         RuntimeException.class,
         () -> service.initializeCertificateClient(client));
@@ -213,7 +213,7 @@ public class TestHddsSecureDatanodeInit {
   @Test
   public void testSecureDnStartupCase3() throws Exception {
     // Case 3: When only public key and certificate is present.
-    keyCodec.writePublicKey(publicKey);
+    keyStorage.writePublicKey(publicKey);
     certCodec.writeCertificate(cert);
     RuntimeException rteException = assertThrows(
         RuntimeException.class,
@@ -230,7 +230,7 @@ public class TestHddsSecureDatanodeInit {
   @Test
   public void testSecureDnStartupCase4() throws Exception {
     // Case 4: When public key as well as certificate is missing.
-    keyCodec.writePrivateKey(privateKey);
+    keyStorage.writePrivateKey(privateKey);
     // provide a new valid SCMGetCertResponseProto
     X509Certificate newCert = generateX509Cert(null, null, Duration.ofSeconds(CERT_LIFETIME));
     String pemCert = CertificateCodec.getPEMEncodedString(newCert);
@@ -261,7 +261,7 @@ public class TestHddsSecureDatanodeInit {
   public void testSecureDnStartupCase5() throws Exception {
     // Case 5: If private key and certificate is present.
     certCodec.writeCertificate(cert);
-    keyCodec.writePrivateKey(privateKey);
+    keyStorage.writePrivateKey(privateKey);
     service.initializeCertificateClient(client);
     assertNotNull(client.getPrivateKey());
     assertNotNull(client.getPublicKey());
@@ -273,8 +273,8 @@ public class TestHddsSecureDatanodeInit {
   @Test
   public void testSecureDnStartupCase6() throws Exception {
     // Case 6: If key pair already exist than response should be GETCERT.
-    keyCodec.writePublicKey(publicKey);
-    keyCodec.writePrivateKey(privateKey);
+    keyStorage.writePublicKey(publicKey);
+    keyStorage.writePrivateKey(privateKey);
     assertThrows(Exception.class,
         () -> service.initializeCertificateClient(client));
     assertNotNull(client.getPrivateKey());
@@ -287,8 +287,8 @@ public class TestHddsSecureDatanodeInit {
   @Test
   public void testSecureDnStartupCase7() throws Exception {
     // Case 7 When keypair and certificate is present.
-    keyCodec.writePublicKey(publicKey);
-    keyCodec.writePrivateKey(privateKey);
+    keyStorage.writePublicKey(publicKey);
+    keyStorage.writePrivateKey(privateKey);
     certCodec.writeCertificate(cert);
 
     service.initializeCertificateClient(client);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.authority.profile.PKIPro
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertificate;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
@@ -205,9 +205,9 @@ public class DefaultCAServer implements CertificateServer {
   }
 
   private KeyPair getCAKeys() throws IOException {
-    KeyCodec keyCodec = new KeyCodec(config, componentName);
+    KeyStorage keyStorage = new KeyStorage(config, componentName);
     try {
-      return new KeyPair(keyCodec.readPublicKey(), keyCodec.readPrivateKey());
+      return new KeyPair(keyStorage.readPublicKey(), keyStorage.readPrivateKey());
     } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
       throw new IOException(e);
     }
@@ -475,9 +475,8 @@ public class DefaultCAServer implements CertificateServer {
       throws NoSuchProviderException, NoSuchAlgorithmException, IOException {
     HDDSKeyGenerator keyGenerator = new HDDSKeyGenerator(securityConfig);
     KeyPair keys = keyGenerator.generateKey();
-    KeyCodec keyPEMWriter = new KeyCodec(securityConfig,
-        componentName);
-    keyPEMWriter.writeKey(keys);
+    KeyStorage keyStorage = new KeyStorage(securityConfig, componentName);
+    keyStorage.writeKey(keys);
     return keys;
   }
 
@@ -520,7 +519,7 @@ public class DefaultCAServer implements CertificateServer {
     Path extPrivateKeyPath = Paths.get(conf.getExternalRootCaPrivateKeyPath());
     String externalPublicKeyLocation = conf.getExternalRootCaPublicKeyPath();
 
-    KeyCodec keyCodec = new KeyCodec(config, componentName);
+    KeyStorage keyStorage = new KeyStorage(config, componentName);
     CertificateCodec certificateCodec =
         new CertificateCodec(config, componentName);
     try {
@@ -537,12 +536,12 @@ public class DefaultCAServer implements CertificateServer {
         throw new IOException("External private key path is not correct: " +
             extPrivateKeyPath);
       }
-      PrivateKey privateKey = keyCodec.readPrivateKey(extPrivateKeyParent,
+      PrivateKey privateKey = keyStorage.readPrivateKey(extPrivateKeyParent,
           extPrivateKeyFileName.toString());
       PublicKey publicKey;
       publicKey = readPublicKeyWithExternalData(
-          externalPublicKeyLocation, keyCodec, certificate);
-      keyCodec.writeKey(new KeyPair(publicKey, privateKey));
+          externalPublicKeyLocation, keyStorage, certificate);
+      keyStorage.writeKey(new KeyPair(publicKey, privateKey));
       certificateCodec.writeCertificate(certificate);
     } catch (IOException | CertificateException | NoSuchAlgorithmException |
              InvalidKeySpecException e) {
@@ -551,7 +550,7 @@ public class DefaultCAServer implements CertificateServer {
   }
 
   private PublicKey readPublicKeyWithExternalData(
-      String externalPublicKeyLocation, KeyCodec keyCodec, X509Certificate certificate
+      String externalPublicKeyLocation, KeyStorage keyStorage, X509Certificate certificate
   ) throws CertificateException, NoSuchAlgorithmException, InvalidKeySpecException, IOException {
     PublicKey publicKey;
     if (externalPublicKeyLocation.isEmpty()) {
@@ -563,7 +562,7 @@ public class DefaultCAServer implements CertificateServer {
       if (publicKeyPathFileName == null || publicKeyParent == null) {
         throw new IOException("Public key path incorrect: " + publicKeyParent);
       }
-      publicKey = keyCodec.readPublicKey(
+      publicKey = keyStorage.readPublicKey(
           publicKeyParent, publicKeyPathFileName.toString());
     }
     return publicKey;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -78,7 +78,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.hdds.security.x509.keys.SecurityUtil;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 
@@ -112,7 +112,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
 
   private final Logger logger;
   private final SecurityConfig securityConfig;
-  private final KeyCodec keyCodec;
+  private final KeyStorage keyStorage;
   private PrivateKey privateKey;
   private PublicKey publicKey;
   private CertPath certPath;
@@ -149,7 +149,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     Objects.requireNonNull(securityConfig);
     this.securityConfig = securityConfig;
     this.scmSecurityClient = scmSecurityClient;
-    keyCodec = new KeyCodec(securityConfig, component);
+    keyStorage = new KeyStorage(securityConfig, component);
     this.logger = log;
     this.certificateMap = new ConcurrentHashMap<>();
     this.component = component;
@@ -319,7 +319,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     if (OzoneSecurityUtil.checkIfFileExist(keyPath,
         securityConfig.getPrivateKeyFileName())) {
       try {
-        privateKey = keyCodec.readPrivateKey();
+        privateKey = keyStorage.readPrivateKey();
       } catch (InvalidKeySpecException | NoSuchAlgorithmException
           | IOException e) {
         getLogger().error("Error while getting private key.", e);
@@ -343,7 +343,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     if (OzoneSecurityUtil.checkIfFileExist(keyPath,
         securityConfig.getPublicKeyFileName())) {
       try {
-        publicKey = keyCodec.readPublicKey();
+        publicKey = keyStorage.readPublicKey();
       } catch (InvalidKeySpecException | NoSuchAlgorithmException
           | IOException e) {
         getLogger().error("Error while getting public key.", e);
@@ -855,7 +855,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     try {
 
       if (validateKeyPair(pubKey)) {
-        keyCodec.writePublicKey(pubKey);
+        keyStorage.writePublicKey(pubKey);
         publicKey = pubKey;
       } else {
         getLogger().error("Can't recover public key " +
@@ -885,7 +885,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         PublicKey pubKey = KeyFactory.getInstance(securityConfig.getKeyAlgo())
             .generatePublic(rsaPublicKeySpec);
         if (validateKeyPair(pubKey)) {
-          keyCodec.writePublicKey(pubKey);
+          keyStorage.writePublicKey(pubKey);
           publicKey = pubKey;
           getLogger().info("Public key is recovered from the private key.");
           return true;
@@ -929,20 +929,20 @@ public abstract class DefaultCertificateClient implements CertificateClient {
             "for certificate storage.", BOOTSTRAP_ERROR);
       }
     }
-    KeyPair keyPair = createKeyPair(keyCodec);
+    KeyPair keyPair = createKeyPair(keyStorage);
     privateKey = keyPair.getPrivate();
     publicKey = keyPair.getPublic();
   }
 
-  protected KeyPair createKeyPair(KeyCodec codec) throws CertificateException {
+  protected KeyPair createKeyPair(KeyStorage storage) throws CertificateException {
     HDDSKeyGenerator keyGenerator = new HDDSKeyGenerator(securityConfig);
-    KeyPair keyPair = null;
+    KeyPair keyPair;
     try {
       keyPair = keyGenerator.generateKey();
-      codec.writePublicKey(keyPair.getPublic());
-      codec.writePrivateKey(keyPair.getPrivate());
+      storage.writePublicKey(keyPair.getPublic());
+      storage.writePrivateKey(keyPair.getPrivate());
     } catch (NoSuchProviderException | NoSuchAlgorithmException
-        | IOException e) {
+             | IOException e) {
       getLogger().error("Error while bootstrapping certificate client.", e);
       throw new CertificateException("Error while bootstrapping certificate.",
           BOOTSTRAP_ERROR);
@@ -1135,10 +1135,10 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     }
 
     // Generate key
-    KeyCodec newKeyCodec = new KeyCodec(securityConfig, newKeyDir.toPath());
+    KeyStorage newKeyStorage = new KeyStorage(securityConfig, newKeyDir.toPath());
     KeyPair newKeyPair;
     try {
-      newKeyPair = createKeyPair(newKeyCodec);
+      newKeyPair = createKeyPair(newKeyStorage);
     } catch (CertificateException e) {
       throw new CertificateException("Error while creating new key pair.",
           e, RENEW_ERROR);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyCodec.java
@@ -18,408 +18,70 @@
  */
 package org.apache.hadoop.hdds.security.x509.keys;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.output.FileWriterWithEncoding;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
 import org.bouncycastle.util.io.pem.PemWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.PosixFilePermission;
+import java.io.StringWriter;
+import java.security.Key;
 import java.security.KeyFactory;
-import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Set;
-import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
-import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
-import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
 /**
- * We store all Key material in good old PEM files. This helps in avoiding
- * dealing will persistent Java KeyStore issues. Also when debugging, general
- * tools like OpenSSL can be used to read and decode these files.
+ * KeyCodec for encoding and decoding private and public keys.
  */
 public class KeyCodec {
   public static final String PRIVATE_KEY = "PRIVATE KEY";
   public static final String PUBLIC_KEY = "PUBLIC KEY";
-  public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
-  private static final  Logger LOG =
-      LoggerFactory.getLogger(KeyCodec.class);
-  private final Path location;
   private final SecurityConfig securityConfig;
-  private final Set<PosixFilePermission> dirPermissionSet =
-      Stream.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE)
-          .collect(Collectors.toSet());
-  private final Set<PosixFilePermission> filePermissionSet =
-      Stream.of(OWNER_READ, OWNER_WRITE)
-          .collect(Collectors.toSet());
-  private BooleanSupplier isPosixFileSystem;
 
-  /**
-   * Creates a KeyCodec with component name.
-   *
-   * @param config - Security Config.
-   * @param component - Component String.
-   */
-  public KeyCodec(SecurityConfig config, String component) {
+  public KeyCodec(SecurityConfig config) {
     this.securityConfig = config;
-    isPosixFileSystem = KeyCodec::isPosix;
-    this.location = securityConfig.getKeyLocation(component);
   }
 
-  /**
-   * Creates a KeyCodec with component name.
-   *
-   * @param config - Security Config.
-   * @param keyDir - path to save the key materials.
-   */
-  public KeyCodec(SecurityConfig config, Path keyDir) {
-    this.securityConfig = config;
-    isPosixFileSystem = KeyCodec::isPosix;
-    this.location = keyDir;
-    if (!location.toFile().exists()) {
-      if (!location.toFile().mkdirs()) {
-        throw new RuntimeException("Failed to create directory " + location);
-      }
+  public String encodePublicKey(PublicKey key) throws IOException {
+    return encodeKey(PUBLIC_KEY, key);
+  }
+
+  public String encodePrivateKey(PrivateKey key) throws IOException {
+    return encodeKey(PRIVATE_KEY, key);
+  }
+
+  private String encodeKey(String keyType, Key key) throws IOException {
+    try (StringWriter sw = new StringWriter(); PemWriter publicKeyWriter = new PemWriter(sw)) {
+      publicKeyWriter.writeObject(new PemObject(keyType, key.getEncoded()));
+      publicKeyWriter.flush();
+      return sw.toString();
     }
   }
 
-  /**
-   * Checks if File System supports posix style security permissions.
-   *
-   * @return True if it supports posix.
-   */
-  private static boolean isPosix() {
-    return FileSystems.getDefault().supportedFileAttributeViews()
-        .contains("posix");
-  }
-
-  /**
-   * Returns the keys directory permission set.
-   *
-   * @return Set
-   */
-  @VisibleForTesting
-  public Set<PosixFilePermission> getDirPermissionSet() {
-    return dirPermissionSet;
-  }
-
-  /**
-   * Returns the file permission set.
-   */
-  public Set<PosixFilePermission> getFilePermissionSet() {
-    return filePermissionSet;
-  }
-
-  /**
-   * Returns the Security config used for this object.
-   *
-   * @return SecurityConfig
-   */
-  public SecurityConfig getSecurityConfig() {
-    return securityConfig;
-  }
-
-  /**
-   * This function is used only for testing.
-   *
-   * @param isPosixFileSystem - Sets a boolean function for mimicking files
-   * systems that are not posix.
-   */
-  @VisibleForTesting
-  public void setIsPosixFileSystem(BooleanSupplier isPosixFileSystem) {
-    this.isPosixFileSystem = isPosixFileSystem;
-  }
-
-  /**
-   * Writes a given key using the default config options.
-   *
-   * @param keyPair - Key Pair to write to file.
-   * @throws IOException - On I/O failure.
-   */
-  public void writeKey(KeyPair keyPair) throws IOException {
-    writeKey(location, keyPair, securityConfig.getPrivateKeyFileName(),
-        securityConfig.getPublicKeyFileName(), false);
-  }
-
-  /**
-   * Writes a given private key using the default config options.
-   *
-   * @param key - Key to write to file.
-   * @throws IOException - On I/O failure.
-   */
-  public void writePrivateKey(PrivateKey key) throws IOException {
-    File privateKeyFile =
-        Paths.get(location.toString(),
-            securityConfig.getPrivateKeyFileName()).toFile();
-
-    if (Files.exists(privateKeyFile.toPath())) {
-      throw new IOException("Private key already exist.");
-    }
-
-    try (PemWriter privateKeyWriter = new PemWriter(new
-        FileWriterWithEncoding(privateKeyFile, DEFAULT_CHARSET))) {
-      privateKeyWriter.writeObject(
-          new PemObject(PRIVATE_KEY, key.getEncoded()));
-    }
-    Files.setPosixFilePermissions(privateKeyFile.toPath(), filePermissionSet);
-  }
-
-  /**
-   * Writes a given public key using the default config options.
-   *
-   * @param key - Key to write to file.
-   * @throws IOException - On I/O failure.
-   */
-  public void writePublicKey(PublicKey key) throws IOException {
-    File publicKeyFile = Paths.get(location.toString(),
-        securityConfig.getPublicKeyFileName()).toFile();
-
-    if (Files.exists(publicKeyFile.toPath())) {
-      throw new IOException("Public key already exist.");
-    }
-
-    try (PemWriter keyWriter = new PemWriter(new
-        FileWriterWithEncoding(publicKeyFile, DEFAULT_CHARSET))) {
-      keyWriter.writeObject(
-          new PemObject(PUBLIC_KEY, key.getEncoded()));
-    }
-    Files.setPosixFilePermissions(publicKeyFile.toPath(), filePermissionSet);
-  }
-
-  /**
-   * Writes a given key using default config options.
-   *
-   * @param keyPair - Key pair to write
-   * @param overwrite - Overwrites the keys if they already exist.
-   * @throws IOException - On I/O failure.
-   */
-  public void writeKey(KeyPair keyPair, boolean overwrite) throws IOException {
-    writeKey(location, keyPair, securityConfig.getPrivateKeyFileName(),
-        securityConfig.getPublicKeyFileName(), overwrite);
-  }
-
-  /**
-   * Writes a given key using default config options.
-   *
-   * @param basePath - The location to write to, override the config values.
-   * @param keyPair - Key pair to write
-   * @param overwrite - Overwrites the keys if they already exist.
-   * @throws IOException - On I/O failure.
-   */
-  public void writeKey(Path basePath, KeyPair keyPair, boolean overwrite)
-      throws IOException {
-    writeKey(basePath, keyPair, securityConfig.getPrivateKeyFileName(),
-        securityConfig.getPublicKeyFileName(), overwrite);
-  }
-
-  /**
-   * Reads a Private Key from the PEM Encoded Store.
-   *
-   * @param basePath - Base Path, Directory where the Key is stored.
-   * @param keyFileName - File Name of the private key
-   * @return PrivateKey Object.
-   * @throws IOException - on Error.
-   */
-  private PKCS8EncodedKeySpec readKey(Path basePath, String keyFileName)
-      throws IOException {
-    File fileName = Paths.get(basePath.toString(), keyFileName).toFile();
-    String keyData = FileUtils.readFileToString(fileName, DEFAULT_CHARSET);
-    final byte[] pemContent;
-    try (PemReader pemReader = new PemReader(new StringReader(keyData))) {
+  public PrivateKey decodePrivateKey(String encodedKey) throws IOException, NoSuchAlgorithmException,
+      InvalidKeySpecException {
+    try (PemReader pemReader = new PemReader(new StringReader(encodedKey))) {
       PemObject keyObject = pemReader.readPemObject();
-      pemContent = keyObject.getContent();
-    }
-    return new PKCS8EncodedKeySpec(pemContent);
-  }
-
-  /**
-   * Returns a Private Key from a PEM encoded file.
-   *
-   * @param basePath - base path
-   * @param privateKeyFileName - private key file name.
-   * @return PrivateKey
-   * @throws InvalidKeySpecException  - on Error.
-   * @throws NoSuchAlgorithmException - on Error.
-   * @throws IOException              - on Error.
-   */
-  public PrivateKey readPrivateKey(Path basePath, String privateKeyFileName)
-      throws InvalidKeySpecException, NoSuchAlgorithmException, IOException {
-    PKCS8EncodedKeySpec encodedKeySpec = readKey(basePath, privateKeyFileName);
-    final KeyFactory keyFactory =
-        KeyFactory.getInstance(securityConfig.getKeyAlgo());
-    return
-        keyFactory.generatePrivate(encodedKeySpec);
-  }
-
-  /**
-   * Read the Public Key using defaults.
-   * @return PublicKey.
-   * @throws InvalidKeySpecException - On Error.
-   * @throws NoSuchAlgorithmException - On Error.
-   * @throws IOException - On Error.
-   */
-  public PublicKey readPublicKey() throws InvalidKeySpecException,
-      NoSuchAlgorithmException, IOException {
-    return readPublicKey(this.location.toAbsolutePath(),
-        securityConfig.getPublicKeyFileName());
-  }
-
-  /**
-   * Returns a public key from a PEM encoded file.
-   *
-   * @param basePath - base path.
-   * @param publicKeyFileName - public key file name.
-   * @return PublicKey
-   * @throws NoSuchAlgorithmException - on Error.
-   * @throws InvalidKeySpecException  - on Error.
-   * @throws IOException              - on Error.
-   */
-  public PublicKey readPublicKey(Path basePath, String publicKeyFileName)
-      throws NoSuchAlgorithmException, InvalidKeySpecException, IOException {
-    PKCS8EncodedKeySpec encodedKeySpec = readKey(basePath, publicKeyFileName);
-    final KeyFactory keyFactory =
-        KeyFactory.getInstance(securityConfig.getKeyAlgo());
-    return
-        keyFactory.generatePublic(
-            new X509EncodedKeySpec(encodedKeySpec.getEncoded()));
-
-  }
-
-
-  /**
-   * Returns the private key  using defaults.
-   * @return PrivateKey.
-   * @throws InvalidKeySpecException - On Error.
-   * @throws NoSuchAlgorithmException - On Error.
-   * @throws IOException - On Error.
-   */
-  public PrivateKey readPrivateKey() throws InvalidKeySpecException,
-      NoSuchAlgorithmException, IOException {
-    return readPrivateKey(this.location.toAbsolutePath(),
-        securityConfig.getPrivateKeyFileName());
-  }
-
-
-  /**
-   * Helper function that actually writes data to the files.
-   *
-   * @param basePath - base path to write key
-   * @param keyPair - Key pair to write to file.
-   * @param privateKeyFileName - private key file name.
-   * @param publicKeyFileName - public key file name.
-   * @param force - forces overwriting the keys.
-   * @throws IOException - On I/O failure.
-   */
-  private synchronized void writeKey(Path basePath, KeyPair keyPair,
-      String privateKeyFileName, String publicKeyFileName, boolean force)
-      throws IOException {
-    checkPreconditions(basePath);
-
-    File privateKeyFile =
-        Paths.get(basePath.toString(), privateKeyFileName).toFile();
-    File publicKeyFile =
-        Paths.get(basePath.toString(), publicKeyFileName).toFile();
-    checkKeyFile(privateKeyFile, force, publicKeyFile);
-
-    try (PemWriter privateKeyWriter = new PemWriter(new
-        FileWriterWithEncoding(privateKeyFile, DEFAULT_CHARSET))) {
-      privateKeyWriter.writeObject(
-          new PemObject(PRIVATE_KEY, keyPair.getPrivate().getEncoded()));
-    }
-
-    try (PemWriter publicKeyWriter = new PemWriter(new
-        FileWriterWithEncoding(publicKeyFile, DEFAULT_CHARSET))) {
-      publicKeyWriter.writeObject(
-          new PemObject(PUBLIC_KEY, keyPair.getPublic().getEncoded()));
-    }
-    Files.setPosixFilePermissions(privateKeyFile.toPath(), filePermissionSet);
-    Files.setPosixFilePermissions(publicKeyFile.toPath(), filePermissionSet);
-  }
-
-  /**
-   * Checks if private and public key file already exists. Throws IOException if
-   * file exists and force flag is set to false, else will delete the existing
-   * file.
-   *
-   * @param privateKeyFile - Private key file.
-   * @param force - forces overwriting the keys.
-   * @param publicKeyFile - public key file.
-   * @throws IOException - On I/O failure.
-   */
-  private void checkKeyFile(File privateKeyFile, boolean force,
-                            File publicKeyFile) throws IOException {
-    if (privateKeyFile.exists() && force) {
-      if (!privateKeyFile.delete()) {
-        throw new IOException("Unable to delete private key file.");
-      }
-    }
-
-    if (publicKeyFile.exists() && force) {
-      if (!publicKeyFile.delete()) {
-        throw new IOException("Unable to delete public key file.");
-      }
-    }
-
-    if (privateKeyFile.exists()) {
-      throw new IOException("Private Key file already exists.");
-    }
-
-    if (publicKeyFile.exists()) {
-      throw new IOException("Public Key file already exists.");
+      PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(keyObject.getContent());
+      return getKeyFactory().generatePrivate(pkcs8EncodedKeySpec);
     }
   }
 
-  /**
-   * Checks if base path exists and sets file permissions.
-   *
-   * @param basePath - base path to write key
-   * @throws IOException - On I/O failure.
-   */
-  private void checkPreconditions(Path basePath) throws IOException {
-    Preconditions.checkNotNull(basePath, "Base path cannot be null");
-    if (!isPosixFileSystem.getAsBoolean()) {
-      LOG.error("Keys cannot be stored securely without POSIX file system "
-          + "support for now.");
-      throw new IOException("Unsupported File System for pem file.");
-    }
-
-    if (Files.exists(basePath)) {
-      // Not the end of the world if we reset the permissions on an existing
-      // directory.
-      Files.setPosixFilePermissions(basePath, dirPermissionSet);
-    } else {
-      boolean success = basePath.toFile().mkdirs();
-      if (!success) {
-        LOG.error("Unable to create the directory for the "
-            + "location. Location: {}", basePath);
-        throw new IOException("Unable to create the directory for the "
-            + "location. Location:" + basePath);
-      }
-      Files.setPosixFilePermissions(basePath, dirPermissionSet);
+  public PublicKey decodePublicKey(String encodedKey) throws IOException, NoSuchAlgorithmException,
+      InvalidKeySpecException {
+    try (PemReader pemReader = new PemReader(new StringReader(encodedKey))) {
+      PemObject keyObject = pemReader.readPemObject();
+      PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(keyObject.getContent());
+      return getKeyFactory().generatePublic(new X509EncodedKeySpec(pkcs8EncodedKeySpec.getEncoded()));
     }
   }
 
+  private KeyFactory getKeyFactory() throws NoSuchAlgorithmException {
+    return KeyFactory.getInstance(securityConfig.getKeyAlgo());
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyStorage.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyStorage.java
@@ -81,6 +81,7 @@ public class KeyStorage {
     this.securityConfig = config;
     this.location = keyDir;
     isPosixFileSystem = KeyStorage::isPosix;
+    keyCodec = new KeyCodec(config);
     if (!location.toFile().exists()) {
       if (!location.toFile().mkdirs()) {
         throw new RuntimeException("Failed to create directory " + location);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyStorage.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyStorage.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.hdds.security.x509.keys;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.output.FileWriterWithEncoding;
+import org.apache.hadoop.hdds.security.SecurityConfig;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemReader;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+
+/**
+ * Class for storing key material.
+ */
+public class KeyStorage {
+  public static final String PRIVATE_KEY = "PRIVATE KEY";
+  public static final String PUBLIC_KEY = "PUBLIC KEY";
+  public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+  private static final Logger LOG = LoggerFactory.getLogger(KeyStorage.class);
+  public static final Set<PosixFilePermission> DIR_PERMISSION_SET =
+      ImmutableSet.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE);
+  public static final Set<PosixFilePermission> FILE_PERMISSION_SET = ImmutableSet.of(OWNER_READ, OWNER_WRITE);
+  private Path location;
+  private SecurityConfig securityConfig;
+  private BooleanSupplier isPosixFileSystem;
+  private KeyCodec keyCodec;
+
+  public KeyStorage(SecurityConfig config, String component) {
+    securityConfig = config;
+    isPosixFileSystem = KeyStorage::isPosix;
+    this.location = securityConfig.getKeyLocation(component);
+    keyCodec = new KeyCodec(config);
+  }
+
+  public KeyStorage(SecurityConfig config, Path keyDir) {
+    this.securityConfig = config;
+    this.location = keyDir;
+    isPosixFileSystem = KeyStorage::isPosix;
+    if (!location.toFile().exists()) {
+      if (!location.toFile().mkdirs()) {
+        throw new RuntimeException("Failed to create directory " + location);
+      }
+    }
+  }
+
+  private static boolean isPosix() {
+    return FileSystems.getDefault().supportedFileAttributeViews()
+        .contains("posix");
+  }
+
+  /**
+   * Writes a given key using the default config options.
+   *
+   * @param keyPair - Key Pair to write to file.
+   * @throws IOException - On I/O failure.
+   */
+  public void writeKey(KeyPair keyPair) throws IOException {
+    writeKey(location, keyPair, securityConfig.getPrivateKeyFileName(),
+        securityConfig.getPublicKeyFileName(), false);
+  }
+
+
+  /**
+   * Writes a given private key using the default config options.
+   *
+   * @param key - Key to write to file.
+   * @throws IOException - On I/O failure.
+   */
+  public void writePrivateKey(PrivateKey key) throws IOException {
+    File privateKeyFile =
+        Paths.get(location.toString(),
+            securityConfig.getPrivateKeyFileName()).toFile();
+
+    if (Files.exists(privateKeyFile.toPath())) {
+      throw new IOException("Private key already exist.");
+    }
+
+    try (PemWriter privateKeyWriter = new PemWriter(new
+        FileWriterWithEncoding(privateKeyFile, DEFAULT_CHARSET))) {
+      privateKeyWriter.writeObject(
+          new PemObject(PRIVATE_KEY, key.getEncoded()));
+    }
+    Files.setPosixFilePermissions(privateKeyFile.toPath(), FILE_PERMISSION_SET);
+  }
+
+  /**
+   * Writes a given public key using the default config options.
+   *
+   * @param key - Key to write to file.
+   * @throws IOException - On I/O failure.
+   */
+  public void writePublicKey(PublicKey key) throws IOException {
+    File publicKeyFile = Paths.get(location.toString(),
+        securityConfig.getPublicKeyFileName()).toFile();
+
+    if (Files.exists(publicKeyFile.toPath())) {
+      throw new IOException("Public key already exist.");
+    }
+
+    try (PemWriter keyWriter = new PemWriter(new
+        FileWriterWithEncoding(publicKeyFile, DEFAULT_CHARSET))) {
+      keyWriter.writeObject(
+          new PemObject(PUBLIC_KEY, key.getEncoded()));
+    }
+    Files.setPosixFilePermissions(publicKeyFile.toPath(), FILE_PERMISSION_SET);
+  }
+
+  /**
+   * Writes a given key using default config options.
+   *
+   * @param keyPair   - Key pair to write
+   * @param overwrite - Overwrites the keys if they already exist.
+   * @throws IOException - On I/O failure.
+   */
+  public void writeKey(KeyPair keyPair, boolean overwrite) throws IOException {
+    writeKey(location, keyPair, securityConfig.getPrivateKeyFileName(),
+        securityConfig.getPublicKeyFileName(), overwrite);
+  }
+
+  /**
+   * Writes a given key using default config options.
+   *
+   * @param basePath  - The location to write to, override the config values.
+   * @param keyPair   - Key pair to write
+   * @param overwrite - Overwrites the keys if they already exist.
+   * @throws IOException - On I/O failure.
+   */
+  public void writeKey(Path basePath, KeyPair keyPair, boolean overwrite)
+      throws IOException {
+    writeKey(basePath, keyPair, securityConfig.getPrivateKeyFileName(),
+        securityConfig.getPublicKeyFileName(), overwrite);
+  }
+
+  /**
+   * Reads a Private Key from the PEM Encoded Store.
+   *
+   * @param basePath    - Base Path, Directory where the Key is stored.
+   * @param keyFileName - File Name of the private key
+   * @return PrivateKey Object.
+   * @throws IOException - on Error.
+   */
+  private PKCS8EncodedKeySpec readKey(Path basePath, String keyFileName)
+      throws IOException {
+    String keyData = readKeyFromFile(basePath, keyFileName);
+
+    final byte[] pemContent;
+    try (PemReader pemReader = new PemReader(new StringReader(keyData))) {
+      PemObject keyObject = pemReader.readPemObject();
+      pemContent = keyObject.getContent();
+    }
+    return new PKCS8EncodedKeySpec(pemContent);
+  }
+
+  private String readKeyFromFile(Path basePath, String keyFileName) throws IOException {
+    File fileName = Paths.get(basePath.toString(), keyFileName).toFile();
+    String keyData = FileUtils.readFileToString(fileName, DEFAULT_CHARSET);
+    return keyData;
+  }
+
+  /**
+   * Returns a Private Key from a PEM encoded file.
+   *
+   * @param basePath           - base path
+   * @param privateKeyFileName - private key file name.
+   * @return PrivateKey
+   * @throws InvalidKeySpecException  - on Error.
+   * @throws NoSuchAlgorithmException - on Error.
+   * @throws IOException              - on Error.
+   */
+  public PrivateKey readPrivateKey(Path basePath, String privateKeyFileName)
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    String privateKeyEncoded = readKeyFromFile(basePath, privateKeyFileName);
+    return keyCodec.decodePrivateKey(privateKeyEncoded);
+  }
+
+  /**
+   * Read the Public Key using defaults.
+   *
+   * @return PublicKey.
+   * @throws InvalidKeySpecException  - On Error.
+   * @throws NoSuchAlgorithmException - On Error.
+   * @throws IOException              - On Error.
+   */
+  public PublicKey readPublicKey() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    return readPublicKey(this.location.toAbsolutePath(),
+        securityConfig.getPublicKeyFileName());
+  }
+
+  /**
+   * Returns a public key from a PEM encoded file.
+   *
+   * @param basePath          - base path.
+   * @param publicKeyFileName - public key file name.
+   * @return PublicKey
+   * @throws NoSuchAlgorithmException - on Error.
+   * @throws InvalidKeySpecException  - on Error.
+   * @throws IOException              - on Error.
+   */
+  public PublicKey readPublicKey(Path basePath, String publicKeyFileName)
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+    String publicKeyEncoded = readKeyFromFile(basePath, publicKeyFileName);
+    return keyCodec.decodePublicKey(publicKeyEncoded);
+  }
+
+
+  /**
+   * Returns the private key  using defaults.
+   *
+   * @return PrivateKey.
+   * @throws InvalidKeySpecException  - On Error.
+   * @throws NoSuchAlgorithmException - On Error.
+   * @throws IOException              - On Error.
+   */
+  public PrivateKey readPrivateKey() throws InvalidKeySpecException,
+      NoSuchAlgorithmException, IOException {
+    return readPrivateKey(this.location.toAbsolutePath(),
+        securityConfig.getPrivateKeyFileName());
+  }
+
+
+  /**
+   * Helper function that actually writes data to the files.
+   *
+   * @param basePath           - base path to write key
+   * @param keyPair            - Key pair to write to file.
+   * @param privateKeyFileName - private key file name.
+   * @param publicKeyFileName  - public key file name.
+   * @param force              - forces overwriting the keys.
+   * @throws IOException - On I/O failure.
+   */
+  private synchronized void writeKey(Path basePath, KeyPair keyPair,
+                                     String privateKeyFileName, String publicKeyFileName, boolean force)
+      throws IOException {
+    checkPreconditions(basePath);
+
+    File privateKeyFile =
+        Paths.get(basePath.toString(), privateKeyFileName).toFile();
+    File publicKeyFile =
+        Paths.get(basePath.toString(), publicKeyFileName).toFile();
+    checkKeyFile(privateKeyFile, force, publicKeyFile);
+
+    writeToFile(privateKeyFile, keyCodec.encodePrivateKey(keyPair.getPrivate()));
+    writeToFile(publicKeyFile, keyCodec.encodePublicKey(keyPair.getPublic()));
+    Files.setPosixFilePermissions(privateKeyFile.toPath(), FILE_PERMISSION_SET);
+    Files.setPosixFilePermissions(publicKeyFile.toPath(), FILE_PERMISSION_SET);
+  }
+
+  private void writeToFile(File file, String material) throws IOException {
+    try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+      fileOutputStream.write(material.getBytes(DEFAULT_CHARSET));
+    }
+  }
+
+
+  /**
+   * Checks if private and public key file already exists. Throws IOException if
+   * file exists and force flag is set to false, else will delete the existing
+   * file.
+   *
+   * @param privateKeyFile - Private key file.
+   * @param force          - forces overwriting the keys.
+   * @param publicKeyFile  - public key file.
+   * @throws IOException - On I/O failure.
+   */
+  private void checkKeyFile(File privateKeyFile, boolean force,
+                            File publicKeyFile) throws IOException {
+    if (privateKeyFile.exists() && force) {
+      if (!privateKeyFile.delete()) {
+        throw new IOException("Unable to delete private key file.");
+      }
+    }
+
+    if (publicKeyFile.exists() && force) {
+      if (!publicKeyFile.delete()) {
+        throw new IOException("Unable to delete public key file.");
+      }
+    }
+
+    if (privateKeyFile.exists()) {
+      throw new IOException("Private Key file already exists.");
+    }
+
+    if (publicKeyFile.exists()) {
+      throw new IOException("Public Key file already exists.");
+    }
+  }
+
+  /**
+   * Checks if base path exists and sets file permissions.
+   *
+   * @param basePath - base path to write key
+   * @throws IOException - On I/O failure.
+   */
+  private void checkPreconditions(Path basePath) throws IOException {
+    Preconditions.checkNotNull(basePath, "Base path cannot be null");
+    if (!isPosixFileSystem.getAsBoolean()) {
+      LOG.error("Keys cannot be stored securely without POSIX file system "
+          + "support for now.");
+      throw new IOException("Unsupported File System for pem file.");
+    }
+
+    if (Files.exists(basePath)) {
+      // Not the end of the world if we reset the permissions on an existing
+      // directory.
+      Files.setPosixFilePermissions(basePath, DIR_PERMISSION_SET);
+    } else {
+      boolean success = basePath.toFile().mkdirs();
+      if (!success) {
+        LOG.error("Unable to create the directory for the "
+            + "location. Location: {}", basePath);
+        throw new IOException("Unable to create the directory for the "
+            + "location. Location:" + basePath);
+      }
+      Files.setPosixFilePermissions(basePath, DIR_PERMISSION_SET);
+    }
+  }
+
+  /**
+   * This function is used only for testing.
+   *
+   * @param isPosixFileSystem - Sets a boolean function for mimicking files
+   *                          systems that are not posix.
+   */
+  @VisibleForTesting
+  public void setIsPosixFileSystem(BooleanSupplier isPosixFileSystem) {
+    this.isPosixFileSystem = isPosixFileSystem;
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertificate;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
@@ -284,10 +284,9 @@ public class TestDefaultCAServer {
         new SCMCertificateClient(securityConfig, null, null)) {
 
       KeyPair keyPair = KeyStoreTestUtil.generateKeyPair("RSA");
-      KeyCodec keyPEMWriter = new KeyCodec(securityConfig,
-          scmCertificateClient.getComponentName());
+      KeyStorage keyStorage = new KeyStorage(securityConfig, scmCertificateClient.getComponentName());
 
-      keyPEMWriter.writeKey(tempDir, keyPair, true);
+      keyStorage.writeKey(tempDir, keyPair, true);
       X509Certificate externalCert = generateExternalCert(keyPair);
 
       CertificateCodec certificateCodec = new CertificateCodec(securityConfig,
@@ -337,10 +336,8 @@ public class TestDefaultCAServer {
       String scmId = RandomStringUtils.randomAlphabetic(4);
       String clusterId = RandomStringUtils.randomAlphabetic(4);
       KeyPair keyPair = new HDDSKeyGenerator(securityConfig).generateKey();
-      KeyCodec keyPEMWriter = new KeyCodec(securityConfig,
-          scmCertificateClient.getComponentName());
-
-      keyPEMWriter.writeKey(tempDir, keyPair, true);
+      KeyStorage keyStorage = new KeyStorage(securityConfig, scmCertificateClient.getComponentName());
+      keyStorage.writeKey(tempDir, keyPair, true);
       LocalDate beginDate = LocalDate.now().atStartOfDay().toLocalDate();
       LocalDate endDate =
           LocalDate.from(LocalDate.now().atStartOfDay().plusDays(10));

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslator
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,7 +91,7 @@ public class TestDefaultCertificateClient {
   private SecurityConfig dnSecurityConfig;
   private SCMSecurityProtocolClientSideTranslatorPB scmSecurityClient;
   private static final String DN_COMPONENT = DNCertificateClient.COMPONENT_NAME;
-  private KeyCodec dnKeyCodec;
+  private KeyStorage dnKeyStorage;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -103,7 +103,7 @@ public class TestDefaultCertificateClient {
     dnSecurityConfig = new SecurityConfig(config);
 
     keyGenerator = new HDDSKeyGenerator(dnSecurityConfig);
-    dnKeyCodec = new KeyCodec(dnSecurityConfig, DN_COMPONENT);
+    dnKeyStorage = new KeyStorage(dnSecurityConfig, DN_COMPONENT);
 
     Files.createDirectories(dnSecurityConfig.getKeyLocation(DN_COMPONENT));
     x509Certificate = generateX509Cert(null);
@@ -153,8 +153,8 @@ public class TestDefaultCertificateClient {
   private KeyPair generateKeyPairFiles() throws Exception {
     cleanupOldKeyPair();
     KeyPair keyPair = keyGenerator.generateKey();
-    dnKeyCodec.writePrivateKey(keyPair.getPrivate());
-    dnKeyCodec.writePublicKey(keyPair.getPublic());
+    dnKeyStorage.writePrivateKey(keyPair.getPrivate());
+    dnKeyStorage.writePublicKey(keyPair.getPublic());
     return keyPair;
   }
 
@@ -388,8 +388,8 @@ public class TestDefaultCertificateClient {
     FileUtils.deleteQuietly(Paths.get(
         dnSecurityConfig.getKeyLocation(DN_COMPONENT).toString(),
         dnSecurityConfig.getPublicKeyFileName()).toFile());
-    dnKeyCodec.writePrivateKey(keyPair.getPrivate());
-    dnKeyCodec.writePublicKey(keyPair1.getPublic());
+    dnKeyStorage.writePrivateKey(keyPair.getPrivate());
+    dnKeyStorage.writePublicKey(keyPair1.getPublic());
 
     // Check for DN.
     assertEquals(FAILURE, dnCertClient.init());
@@ -418,7 +418,7 @@ public class TestDefaultCertificateClient {
         dnSecurityConfig.getKeyLocation(DN_COMPONENT).toString(),
         dnSecurityConfig.getPublicKeyFileName()).toFile());
     getCertClient();
-    dnKeyCodec.writePublicKey(keyPair.getPublic());
+    dnKeyStorage.writePublicKey(keyPair.getPublic());
 
     // Check for DN.
     assertEquals(FAILURE, dnCertClient.init());
@@ -513,8 +513,8 @@ public class TestDefaultCertificateClient {
     Files.createDirectories(newKeyDir.toPath());
     Files.createDirectories(newCertDir.toPath());
     KeyPair keyPair = KeyStoreTestUtil.generateKeyPair("RSA");
-    KeyCodec newKeyCodec = new KeyCodec(dnSecurityConfig, newKeyDir.toPath());
-    newKeyCodec.writeKey(keyPair);
+    KeyStorage newKeyStorage = new KeyStorage(dnSecurityConfig, newKeyDir.toPath());
+    newKeyStorage.writeKey(keyPair);
 
     X509Certificate cert = KeyStoreTestUtil.generateCertificate(
         "CN=OzoneMaster", keyPair, 30, "SHA256withRSA");

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDnCertificateClientInit.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDnCertificateClientInit.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -64,7 +64,7 @@ public class TestDnCertificateClientInit {
   @TempDir
   private Path metaDirPath;
   private SecurityConfig securityConfig;
-  private KeyCodec dnKeyCodec;
+  private KeyStorage dnKeyStorage;
   private X509Certificate x509Certificate;
   private static final String DN_COMPONENT = DNCertificateClient.COMPONENT_NAME;
 
@@ -94,7 +94,7 @@ public class TestDnCertificateClientInit {
     dnCertificateClient =
         new DNCertificateClient(
             securityConfig, null, dn, certSerialId, null, null);
-    dnKeyCodec = new KeyCodec(securityConfig, DN_COMPONENT);
+    dnKeyStorage = new KeyStorage(securityConfig, DN_COMPONENT);
 
     Files.createDirectories(securityConfig.getKeyLocation(DN_COMPONENT));
   }
@@ -111,7 +111,7 @@ public class TestDnCertificateClientInit {
   public void testInitDatanode(boolean pvtKeyPresent, boolean pubKeyPresent,
       boolean certPresent, InitResponse expectedResult) throws Exception {
     if (pvtKeyPresent) {
-      dnKeyCodec.writePrivateKey(keyPair.getPrivate());
+      dnKeyStorage.writePrivateKey(keyPair.getPrivate());
     } else {
       FileUtils.deleteQuietly(Paths.get(
           securityConfig.getKeyLocation(DN_COMPONENT).toString(),
@@ -120,7 +120,7 @@ public class TestDnCertificateClientInit {
 
     if (pubKeyPresent) {
       if (dnCertificateClient.getPublicKey() == null) {
-        dnKeyCodec.writePublicKey(keyPair.getPublic());
+        dnKeyStorage.writePublicKey(keyPair.getPublic());
       }
     } else {
       FileUtils.deleteQuietly(

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestKeyCodec.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestKeyCodec.java
@@ -85,21 +85,21 @@ public class TestKeyCodec {
       throws NoSuchProviderException, NoSuchAlgorithmException,
       IOException, InvalidKeySpecException {
     KeyPair keys = keyGenerator.generateKey();
-    KeyCodec pemWriter = new KeyCodec(securityConfig, component);
-    pemWriter.writeKey(keys);
+    KeyStorage keyStorage = new KeyStorage(securityConfig, component);
+    keyStorage.writeKey(keys);
 
     // Assert that locations have been created.
-    Path keyLocation = pemWriter.getSecurityConfig().getKeyLocation(component);
+    Path keyLocation = securityConfig.getKeyLocation(component);
     assertTrue(keyLocation.toFile().exists());
 
     // Assert that locations are created in the locations that we specified
     // using the Config.
     assertTrue(keyLocation.toString().startsWith(prefix));
     Path privateKeyPath = Paths.get(keyLocation.toString(),
-        pemWriter.getSecurityConfig().getPrivateKeyFileName());
+        securityConfig.getPrivateKeyFileName());
     assertTrue(privateKeyPath.toFile().exists());
     Path publicKeyPath = Paths.get(keyLocation.toString(),
-        pemWriter.getSecurityConfig().getPublicKeyFileName());
+        securityConfig.getPublicKeyFileName());
     assertTrue(publicKeyPath.toFile().exists());
 
     // Read the private key and test if the expected String in the PEM file
@@ -115,8 +115,7 @@ public class TestKeyCodec {
     assertThat(publicKeydata).contains("PUBLIC KEY");
 
     // Let us decode the PEM file and parse it back into binary.
-    KeyFactory kf = KeyFactory.getInstance(
-        pemWriter.getSecurityConfig().getKeyAlgo());
+    KeyFactory kf = KeyFactory.getInstance(securityConfig.getKeyAlgo());
 
     // Replace the PEM Human readable guards.
     privateKeydata =
@@ -147,7 +146,7 @@ public class TestKeyCodec {
 
     // Now let us assert the permissions on the Directories and files are as
     // expected.
-    Set<PosixFilePermission> expectedSet = pemWriter.getFilePermissionSet();
+    Set<PosixFilePermission> expectedSet = KeyStorage.FILE_PERMISSION_SET;
     Set<PosixFilePermission> currentSet =
         Files.getPosixFilePermissions(privateKeyPath);
     assertEquals(expectedSet.size(), currentSet.size());
@@ -159,7 +158,7 @@ public class TestKeyCodec {
     currentSet.removeAll(expectedSet);
     assertEquals(0, currentSet.size());
 
-    expectedSet = pemWriter.getDirPermissionSet();
+    expectedSet = KeyStorage.DIR_PERMISSION_SET;
     currentSet =
         Files.getPosixFilePermissions(keyLocation);
     assertEquals(expectedSet.size(), currentSet.size());
@@ -176,20 +175,20 @@ public class TestKeyCodec {
   public void testReWriteKey()
       throws Exception {
     KeyPair kp = keyGenerator.generateKey();
-    KeyCodec pemWriter = new KeyCodec(securityConfig, component);
-    SecurityConfig secConfig = pemWriter.getSecurityConfig();
-    pemWriter.writeKey(kp);
+    SecurityConfig secConfig = securityConfig;
+    KeyStorage keyStorage = new KeyStorage(securityConfig, component);
+    keyStorage.writeKey(kp);
 
     // Assert that rewriting of keys throws exception with valid messages.
     IOException ioException = assertThrows(IOException.class,
-            () -> pemWriter.writeKey(kp));
+        () -> keyStorage.writeKey(kp));
     assertThat(ioException.getMessage())
         .contains("Private Key file already exists.");
     FileUtils.deleteQuietly(Paths.get(
         secConfig.getKeyLocation(component).toString() + "/" + secConfig
             .getPrivateKeyFileName()).toFile());
     ioException = assertThrows(IOException.class,
-            () -> pemWriter.writeKey(kp));
+        () -> keyStorage.writeKey(kp));
     assertThat(ioException.getMessage())
         .contains("Public Key file already exists.");
     FileUtils.deleteQuietly(Paths.get(
@@ -197,9 +196,9 @@ public class TestKeyCodec {
             .getPublicKeyFileName()).toFile());
 
     // Should succeed now as both public and private key are deleted.
-    pemWriter.writeKey(kp);
+    keyStorage.writeKey(kp);
     // Should succeed with overwrite flag as true.
-    pemWriter.writeKey(kp, true);
+    keyStorage.writeKey(kp, true);
 
   }
 
@@ -210,12 +209,12 @@ public class TestKeyCodec {
   public void testWriteKeyInNonPosixFS()
       throws Exception {
     KeyPair kp = keyGenerator.generateKey();
-    KeyCodec pemWriter = new KeyCodec(securityConfig, component);
-    pemWriter.setIsPosixFileSystem(() -> false);
+    KeyStorage keyStorage = new KeyStorage(securityConfig, component);
+    keyStorage.setIsPosixFileSystem(() -> false);
 
     // Assert key rewrite fails in non Posix file system.
     IOException ioException = assertThrows(IOException.class,
-            () -> pemWriter.writeKey(kp));
+        () -> keyStorage.writeKey(kp));
     assertThat(ioException.getMessage())
         .contains("Unsupported File System for pem file.");
   }
@@ -226,10 +225,10 @@ public class TestKeyCodec {
       InvalidKeySpecException {
 
     KeyPair kp = keyGenerator.generateKey();
-    KeyCodec keycodec = new KeyCodec(securityConfig, component);
-    keycodec.writeKey(kp);
+    KeyStorage keyStorage = new KeyStorage(securityConfig, component);
+    keyStorage.writeKey(kp);
 
-    PublicKey pubKey = keycodec.readPublicKey();
+    PublicKey pubKey = keyStorage.readPublicKey();
     assertNotNull(pubKey);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateCli
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -561,14 +561,14 @@ public class RootCARotationManager extends StatefulService {
 
           // Generate key
           Path keyDir = securityConfig.getKeyLocation(progressComponent);
-          KeyCodec keyCodec = new KeyCodec(securityConfig, keyDir);
+          KeyStorage keyStorage = new KeyStorage(securityConfig, keyDir);
           KeyPair newKeyPair = null;
           try {
             HDDSKeyGenerator keyGenerator =
                 new HDDSKeyGenerator(securityConfig);
             newKeyPair = keyGenerator.generateKey();
-            keyCodec.writePublicKey(newKeyPair.getPublic());
-            keyCodec.writePrivateKey(newKeyPair.getPrivate());
+            keyStorage.writePublicKey(newKeyPair.getPublic());
+            keyStorage.writePrivateKey(newKeyPair.getPrivate());
             LOG.info("SubCARotationPrepareTask[rootCertId = {}] - " +
                 "scm key generated.", rootCACertId);
           } catch (Exception e) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDelegationToken.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClientTestImpl;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
@@ -415,8 +415,8 @@ public final class TestDelegationToken {
     SecurityConfig securityConfig = new SecurityConfig(conf);
     HDDSKeyGenerator keyGenerator = new HDDSKeyGenerator(securityConfig);
     KeyPair keyPair = keyGenerator.generateKey();
-    KeyCodec pemWriter = new KeyCodec(securityConfig, COMPONENT);
-    pemWriter.writeKey(keyPair, true);
+    KeyStorage keyStorage = new KeyStorage(securityConfig, COMPONENT);
+    keyStorage.writeKey(keyPair, true);
   }
 
   private void setupOm(OzoneConfiguration config) throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -76,7 +76,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignReq
 import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertificate;
 import org.apache.hadoop.hdds.security.x509.exception.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc.Client;
@@ -643,8 +643,8 @@ final class TestSecureOzoneCluster {
     SecurityConfig securityConfig = new SecurityConfig(conf);
     HDDSKeyGenerator keyGenerator = new HDDSKeyGenerator(securityConfig);
     keyPair = keyGenerator.generateKey();
-    KeyCodec pemWriter = new KeyCodec(securityConfig, COMPONENT);
-    pemWriter.writeKey(keyPair, true);
+    KeyStorage keyStorage = new KeyStorage(securityConfig, COMPONENT);
+    keyStorage.writeKey(keyPair, true);
   }
 
   /**
@@ -960,10 +960,10 @@ final class TestSecureOzoneCluster {
 
     // save first cert
     final int certificateLifetime = 20; // seconds
-    KeyCodec keyCodec =
-        new KeyCodec(securityConfig, securityConfig.getKeyLocation("om"));
+    KeyStorage keyStorage =
+        new KeyStorage(securityConfig, securityConfig.getKeyLocation("om"));
     X509Certificate cert = generateSelfSignedX509Cert(securityConfig,
-        new KeyPair(keyCodec.readPublicKey(), keyCodec.readPrivateKey()),
+        new KeyPair(keyStorage.readPublicKey(), keyStorage.readPrivateKey()),
         null, Duration.ofSeconds(certificateLifetime));
     String certId = cert.getSerialNumber().toString();
     omStorage.setOmCertSerialId(certId);
@@ -1043,8 +1043,8 @@ final class TestSecureOzoneCluster {
 
     // save first cert
     final int certificateLifetime = 20; // seconds
-    KeyCodec keyCodec =
-        new KeyCodec(securityConfig, securityConfig.getKeyLocation("om"));
+    KeyStorage keyCodec =
+        new KeyStorage(securityConfig, securityConfig.getKeyLocation("om"));
     X509Certificate certHolder = generateSelfSignedX509Cert(securityConfig,
         new KeyPair(keyCodec.readPublicKey(), keyCodec.readPrivateKey()),
         null, Duration.ofSeconds(certificateLifetime));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSecureOzoneManager.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.ozone.security.OMCertificateClient;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -135,7 +135,7 @@ class TestSecureOzoneManager {
     client =
         new OMCertificateClient(
             securityConfig, null, omStorage, omInfo, "", null, null, null);
-    KeyCodec keyCodec = new KeyCodec(securityConfig, COMPONENT);
+    KeyStorage keyStorage = new KeyStorage(securityConfig, COMPONENT);
     FileUtils.deleteQuietly(Paths.get(securityConfig.getKeyLocation(COMPONENT)
         .toString(), securityConfig.getPrivateKeyFileName()).toFile());
     assertEquals(CertificateClient.InitResponse.FAILURE, client.init());
@@ -169,7 +169,7 @@ class TestSecureOzoneManager {
             securityConfig, null, omStorage, omInfo, "", scmId, null, null);
     FileUtils.deleteQuietly(Paths.get(securityConfig.getKeyLocation(COMPONENT)
         .toString(), securityConfig.getPublicKeyFileName()).toFile());
-    keyCodec.writePrivateKey(privateKey);
+    keyStorage.writePrivateKey(privateKey);
     assertEquals(CertificateClient.InitResponse.SUCCESS, client.init());
     assertNotNull(client.getPrivateKey());
     assertNotNull(client.getPublicKey());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOmCertificateClientInit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOmCertificateClientInit.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
-import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.security.x509.keys.KeyStorage;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -66,7 +66,7 @@ public class TestOmCertificateClientInit {
   private OMCertificateClient omCertificateClient;
   private HDDSKeyGenerator keyGenerator;
   private SecurityConfig securityConfig;
-  private KeyCodec omKeyCodec;
+  private KeyStorage omKeyCodec;
   private X509Certificate x509Certificate;
   private static final String OM_COMPONENT = OMCertificateClient.COMPONENT_NAME;
 
@@ -101,7 +101,7 @@ public class TestOmCertificateClientInit {
     omCertificateClient =
         new OMCertificateClient(
             securityConfig, null, storage, omInfo, "", null, null, null);
-    omKeyCodec = new KeyCodec(securityConfig, OM_COMPONENT);
+    omKeyCodec = new KeyStorage(securityConfig, OM_COMPONENT);
 
     Files.createDirectories(securityConfig.getKeyLocation(OM_COMPONENT));
   }


### PR DESCRIPTION
KeyCodec is now only responsible for encoding and decoding keys, the rest of the functionality is in KeyStorage

For crypto-compliance we would like the non-compliant parts of the code to be as separated and as small as possible so that they will be easy to move to a new method. Here I'm separating these responsibilities so the KeyCodec is only encoding/decoding keys. Later it can be moved to a new module.

[HDDS-11070](https://issues.apache.org/jira/browse/HDDS-11070)

Tests should already cover this functionality, here is a green CI run: (It contained other changes regarding CertificateCodec)
https://github.com/Galsza/ozone/actions/runs/9678884891