### PR TITLE
HDDS-11068. Move SstFiltered flag to another SnapshotProperties table

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4315,6 +4315,16 @@
   </property>
 
   <property>
+    <name>ozone.om.snapshot.prop.cleanup.service.interval</name>
+    <value>5m</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      Interval for snapshot property clean up service for removing purged snapshot properties from the table.
+      Uses millisecond by default when no time unit is specified.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.snapshot.cache.cleanup.service.run.interval</name>
     <value>1m</value>
     <tag>OZONE, OM</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -591,6 +591,12 @@ public final class OMConfigKeys {
       OZONE_OM_SNAPSHOT_DIFF_CLEANUP_SERVICE_TIMEOUT_DEFAULT
       = TimeUnit.MINUTES.toMillis(5);
 
+  public static final String OZONE_OM_SNAPSHOT_PROP_CLEANUP_SERVICE_INTERVAL
+      = "ozone.om.snapshot.prop.cleanup.service.interval";
+
+  public static final long OZONE_OM_SNAPSHOT_PROP_CLEANUP_SERVICE_DEFAULT
+      = TimeUnit.MINUTES.toMillis(5);
+
   public static final String
       OZONE_OM_SNAPSHOT_DIFF_MAX_ALLOWED_KEYS_CHANGED_PER_DIFF_JOB
       = "ozone.om.snapshot.diff.max.allowed.keys.changed.per.job";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -118,7 +118,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
    */
   private long dbTxSequenceNumber;
   private boolean deepClean;
-  private boolean sstFiltered;
   private long referencedSize;
   private long referencedReplicatedSize;
   private long exclusiveSize;
@@ -139,7 +138,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     this.checkpointDir = b.checkpointDir;
     this.dbTxSequenceNumber = b.dbTxSequenceNumber;
     this.deepClean = b.deepClean;
-    this.sstFiltered = b.sstFiltered;
     this.referencedSize = b.referencedSize;
     this.referencedReplicatedSize = b.referencedReplicatedSize;
     this.exclusiveSize = b.exclusiveSize;
@@ -235,14 +233,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     return checkpointDir;
   }
 
-  public boolean isSstFiltered() {
-    return sstFiltered;
-  }
-
-  public void setSstFiltered(boolean sstFiltered) {
-    this.sstFiltered = sstFiltered;
-  }
-
   public static org.apache.hadoop.ozone.om.helpers.SnapshotInfo.Builder
       newBuilder() {
     return new org.apache.hadoop.ozone.om.helpers.SnapshotInfo.Builder();
@@ -262,7 +252,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
         .setSnapshotPath(snapshotPath)
         .setCheckpointDir(checkpointDir)
         .setDeepClean(deepClean)
-        .setSstFiltered(sstFiltered)
         .setReferencedSize(referencedSize)
         .setReferencedReplicatedSize(referencedReplicatedSize)
         .setExclusiveSize(exclusiveSize)
@@ -287,7 +276,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     private String checkpointDir;
     private long dbTxSequenceNumber;
     private boolean deepClean;
-    private boolean sstFiltered;
     private long referencedSize;
     private long referencedReplicatedSize;
     private long exclusiveSize;
@@ -377,11 +365,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
       return this;
     }
 
-    public Builder setSstFiltered(boolean sstFiltered) {
-      this.sstFiltered = sstFiltered;
-      return this;
-    }
-
     /** @param referencedSize - Snapshot referenced size. */
     public Builder setReferencedSize(long referencedSize) {
       this.referencedSize = referencedSize;
@@ -430,7 +413,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
             .setSnapshotStatus(snapshotStatus.toProto())
             .setCreationTime(creationTime)
             .setDeletionTime(deletionTime)
-            .setSstFiltered(sstFiltered)
             .setReferencedSize(referencedSize)
             .setReferencedReplicatedSize(referencedReplicatedSize)
             .setExclusiveSize(exclusiveSize)
@@ -482,10 +464,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
 
     if (snapshotInfoProto.hasDeepClean()) {
       osib.setDeepClean(snapshotInfoProto.getDeepClean());
-    }
-
-    if (snapshotInfoProto.hasSstFiltered()) {
-      osib.setSstFiltered(snapshotInfoProto.getSstFiltered());
     }
 
     if (snapshotInfoProto.hasReferencedSize()) {
@@ -668,7 +646,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
         snapshotPath.equals(that.snapshotPath) &&
         checkpointDir.equals(that.checkpointDir) &&
         deepClean == that.deepClean &&
-        sstFiltered == that.sstFiltered &&
         referencedSize == that.referencedSize &&
         referencedReplicatedSize == that.referencedReplicatedSize &&
         exclusiveSize == that.exclusiveSize &&
@@ -682,8 +659,7 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
         snapshotStatus,
         creationTime, deletionTime, pathPreviousSnapshotId,
         globalPreviousSnapshotId, snapshotPath, checkpointDir,
-        deepClean, sstFiltered,
-        referencedSize, referencedReplicatedSize,
+        deepClean, referencedSize, referencedReplicatedSize,
         exclusiveSize, exclusiveReplicatedSize, deepCleanedDeletedDir);
   }
 
@@ -706,7 +682,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
         .setCheckpointDir(checkpointDir)
         .setDbTxSequenceNumber(dbTxSequenceNumber)
         .setDeepClean(deepClean)
-        .setSstFiltered(sstFiltered)
         .setReferencedSize(referencedSize)
         .setReferencedReplicatedSize(referencedReplicatedSize)
         .setExclusiveSize(exclusiveSize)
@@ -731,7 +706,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
         ", checkpointDir: '" + checkpointDir + '\'' +
         ", dbTxSequenceNumber: '" + dbTxSequenceNumber + '\'' +
         ", deepClean: '" + deepClean + '\'' +
-        ", sstFiltered: '" + sstFiltered + '\'' +
         ", referencedSize: '" + referencedSize + '\'' +
         ", referencedReplicatedSize: '" + referencedReplicatedSize + '\'' +
         ", exclusiveSize: '" + exclusiveSize + '\'' +

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotProperties.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotProperties.java
@@ -1,0 +1,175 @@
+package org.apache.hadoop.ozone.om.helpers;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
+import org.apache.hadoop.hdds.utils.db.Proto2Codec;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+
+import java.util.Objects;
+
+/**
+ * This class is used for storing info related to Snapshots.
+ *
+ * Each snapshot created has an associated SnapshotInfo entry
+ * containing the snapshotId, snapshot path,
+ * snapshot checkpoint directory, previous snapshotId
+ * for the snapshot path & global amongst other necessary fields.
+ */
+public final class SnapshotProperties {
+  private static final Codec<SnapshotProperties> CODEC = new DelegatedCodec<>(
+      Proto2Codec.get(
+          OzoneManagerProtocolProtos.SnapshotProperties.getDefaultInstance()),
+      SnapshotProperties::getFromProtobuf,
+      SnapshotProperties::getProtobuf);
+
+  public static Codec<SnapshotProperties> getCodec() {
+    return CODEC;
+  }
+
+  private boolean sstFiltered;
+  private String snapshotTableKey;
+  private boolean snapshotPurged;
+
+  public void setSnapshotPurged(boolean snapshotPurged) {
+    this.snapshotPurged = snapshotPurged;
+  }
+
+  private SnapshotProperties(Builder b) {
+    this.sstFiltered = b.sstFiltered;
+    this.snapshotTableKey = b.snapshotTableKey;
+    this.snapshotPurged = b.snapshotPurged;
+  }
+
+  public boolean isSstFiltered() {
+    return sstFiltered;
+  }
+
+  public String getSnapshotTableKey() {
+    return snapshotTableKey;
+  }
+
+  public boolean isSnapshotPurged() {
+    return snapshotPurged;
+  }
+
+  public void setSstFiltered(boolean sstFiltered) {
+    this.sstFiltered = sstFiltered;
+  }
+
+  public static SnapshotProperties.Builder
+      newBuilder() {
+    return new SnapshotProperties.Builder();
+  }
+
+  public SnapshotProperties.Builder toBuilder() {
+    return new Builder().setSstFiltered(sstFiltered);
+  }
+
+  /**
+   * Builder of SnapshotInfo.
+   */
+  public static class Builder {
+    private boolean sstFiltered;
+    private String snapshotTableKey;
+    private boolean snapshotPurged;
+
+    public Builder() {
+      sstFiltered = false;
+      snapshotPurged = false;
+    }
+
+    public Builder setSstFiltered(boolean sstFiltered) {
+      this.sstFiltered = sstFiltered;
+      return this;
+    }
+
+    public Builder setSnapshotTableKey(String snapshotTableKey) {
+      this.snapshotTableKey = snapshotTableKey;
+      return this;
+    }
+
+    public Builder setSnapshotPurged(boolean snapshotPurged) {
+      this.snapshotPurged = snapshotPurged;
+      return this;
+    }
+
+    public SnapshotProperties build() {
+      return new SnapshotProperties(this);
+    }
+  }
+
+  /**
+   * Creates SnapshotProperties protobuf from SnapshotProperties.
+   */
+  public OzoneManagerProtocolProtos.SnapshotProperties getProtobuf() {
+    return OzoneManagerProtocolProtos.SnapshotProperties.newBuilder()
+        .setSstFiltered(sstFiltered).setSnapshotTableKey(snapshotTableKey)
+        .setSnapshotPurged(snapshotPurged).build();
+  }
+
+  /**
+   * Parses SnapshotProperties protobuf and creates SnapshotProperties.
+   * @param snapshotProperties protobuf
+   * @return instance of SnapshotInfo
+   */
+  public static SnapshotProperties getFromProtobuf(
+      OzoneManagerProtocolProtos.SnapshotProperties snapshotProperties) {
+
+    SnapshotProperties.Builder snapshotProps = SnapshotProperties.newBuilder();
+    if (snapshotProperties.hasSstFiltered()) {
+      snapshotProps.setSstFiltered(snapshotProperties.getSstFiltered());
+    }
+    if (snapshotProperties.hasSnapshotPurged()) {
+      snapshotProps.setSnapshotPurged(snapshotProperties.getSnapshotPurged());
+    }
+    return snapshotProps.setSnapshotTableKey(snapshotProperties.getSnapshotTableKey()).build();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SnapshotProperties that = (SnapshotProperties) o;
+
+    if (sstFiltered != that.sstFiltered) {
+      return false;
+    }
+    return snapshotTableKey.equals(that.snapshotTableKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sstFiltered, snapshotTableKey);
+  }
+
+  @Override
+  public String toString() {
+    return "SnapshotProperties{" +
+        "sstFiltered=" + sstFiltered +
+        ", snapshotTableKey='" + snapshotTableKey + '\'' +
+        '}';
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsUtils.toProtobuf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Tests SnapshotInfo metadata data structure holding state info for
@@ -90,7 +91,6 @@ public class TestOmSnapshotInfo {
         .setCheckpointDir(CHECKPOINT_DIR)
         .setDbTxSequenceNumber(DB_TX_SEQUENCE_NUMBER)
         .setDeepClean(false)
-        .setSstFiltered(false)
         .setReferencedSize(2000L)
         .setReferencedReplicatedSize(6000L)
         .setExclusiveSize(1000L)
@@ -129,8 +129,7 @@ public class TestOmSnapshotInfo {
         snapshotInfoEntryActual.getDbTxSequenceNumber());
     assertEquals(snapshotInfoEntryExpected.getDeepClean(),
         snapshotInfoEntryActual.getDeepClean());
-    assertEquals(snapshotInfoEntryExpected.getSstFiltered(),
-        snapshotInfoEntryActual.getSstFiltered());
+    assertFalse(snapshotInfoEntryActual.hasSstFiltered());
     assertEquals(snapshotInfoEntryExpected.getReferencedSize(),
         snapshotInfoEntryActual.getReferencedSize());
     assertEquals(

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmSnapshotInfo.java
@@ -67,7 +67,6 @@ public class TestOmSnapshotInfo {
         .setCheckpointDir(CHECKPOINT_DIR)
         .setDbTxSequenceNumber(DB_TX_SEQUENCE_NUMBER)
         .setDeepClean(false)
-        .setSstFiltered(false)
         .setReferencedSize(2000L)
         .setReferencedReplicatedSize(6000L)
         .setExclusiveSize(1000L)
@@ -171,8 +170,6 @@ public class TestOmSnapshotInfo {
         snapshotInfoActual.getDbTxSequenceNumber());
     assertEquals(snapshotInfoExpected.getDeepClean(),
         snapshotInfoActual.getDeepClean());
-    assertEquals(snapshotInfoExpected.isSstFiltered(),
-        snapshotInfoActual.isSstFiltered());
     assertEquals(snapshotInfoExpected.getReferencedSize(),
         snapshotInfoActual.getReferencedSize());
     assertEquals(snapshotInfoExpected.getReferencedReplicatedSize(),

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -858,6 +858,16 @@ message SnapshotInfo {
   optional bool deepCleanedDeletedDir = 19;
 }
 
+
+/**
+ Snapshot internal properties saved for Bucket/Volume snapshot
+*/
+message SnapshotProperties {
+    optional bool sstFiltered = 1;
+    optional string snapshotTableKey = 2;
+    optional bool snapshotPurged = 3;
+}
+
 message SnapshotDiffJobProto {
   optional uint64 creationTime = 1;
   optional string jobId = 2;
@@ -2154,3 +2164,4 @@ service OzoneManagerService {
     rpc submitRequest(OMRequest)
           returns(OMResponse);
 }
+

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotPropertiesManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotPropertiesManager.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import com.google.common.collect.Sets;
+import org.apache.hadoop.hdds.utils.Scheduler;
+import org.apache.hadoop.hdds.utils.db.UuidCodec;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
+import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksIterator;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.helpers.SnapshotProperties;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class managing Snapshot Properties corresponding to a snapshot.
+ */
+public class SnapshotPropertiesManager {
+  private final ManagedRocksDB db;
+  private final ColumnFamilyHandle snapshotPropertiesCf;
+  private final Map<UUID, SnapshotProperties> snapshotPropertiesMap;
+  private final Set<UUID> purgedSnapshots;
+  private final Scheduler scheduler;
+
+  private final OMMetadataManager omMetadataManager;
+  private static final String PURGED_SNAPSHOT_CLEANUP_SERVICE =
+      "PurgedSnapshotCleanupService";
+
+
+  public SnapshotPropertiesManager(OMMetadataManager omMetadataManager,
+                                   ManagedRocksDB snapshotDB,
+                                   ColumnFamilyHandle snapshotPropertiesCf,
+                                   long cleanupInterval) throws IOException {
+    this.db = snapshotDB;
+    this.snapshotPropertiesCf = snapshotPropertiesCf;
+    this.snapshotPropertiesMap = new ConcurrentHashMap<>();
+    this.purgedSnapshots = Sets.newConcurrentHashSet();
+    this.omMetadataManager = omMetadataManager;
+    initValues();
+    this.scheduler = new Scheduler(PURGED_SNAPSHOT_CLEANUP_SERVICE,
+        true, 1);
+    this.scheduler.scheduleWithFixedDelay(this::cleanup, cleanupInterval,
+        cleanupInterval, TimeUnit.MILLISECONDS);
+  }
+
+  private void cleanup() {
+    try {
+      for (UUID purgedSnapshot : purgedSnapshots) {
+        Optional<SnapshotProperties> snapshotProperties = getSnapshotProperties(purgedSnapshot);
+        if (!snapshotProperties.isPresent()) {
+          continue;
+        }
+        SnapshotInfo snapshotInfo =
+            this.omMetadataManager.getSnapshotInfoTable().getSkipCache(snapshotProperties.get().getSnapshotTableKey());
+        if (snapshotInfo == null) {
+          deleteSnapshotProperties(purgedSnapshot);
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void initValues() throws IOException {
+    try (ManagedRocksIterator iterator = ManagedRocksIterator.managed(
+        this.db.get().newIterator(this.snapshotPropertiesCf))) {
+      iterator.get().seekToFirst();
+      while (iterator.get().isValid()) {
+        UUID key = UuidCodec.get().fromPersistedFormat(iterator.get().key());
+        SnapshotProperties snapshotProperties =
+            SnapshotProperties.getCodec().fromPersistedFormat(iterator.get().value());
+        snapshotPropertiesMap.put(key, snapshotProperties);
+        if (snapshotProperties.isSnapshotPurged()) {
+          purgedSnapshots.add(key);
+        }
+      }
+    }
+  }
+
+  /**
+   * @param snapshotId UUID of snapshot
+   * @return the snapshot property corresponding to snapshot if exists otherwise null value is returned.
+   */
+  public Optional<SnapshotProperties> getSnapshotProperties(UUID snapshotId) {
+    return Optional.ofNullable(this.snapshotPropertiesMap.get(snapshotId));
+  }
+
+  /**
+   * @param snapshotId UUID of snapshot
+   * @param snapshotProperties SnapshotProperties object corresponding to snapshot
+   * @return the snapshot property corresponding to snapshot if exists otherwise null value is returned.
+   */
+  public void setSnapshotProperties(UUID snapshotId,
+                                    SnapshotProperties snapshotProperties) throws IOException {
+    try {
+      this.db.get().put(this.snapshotPropertiesCf, UuidCodec.get().toPersistedFormat(snapshotId),
+          SnapshotProperties.getCodec()
+              .toPersistedFormat(snapshotProperties));
+      this.snapshotPropertiesMap.put(snapshotId, snapshotProperties);
+      if (snapshotProperties.isSnapshotPurged()) {
+        purgedSnapshots.add(snapshotId);
+      }
+    } catch (RocksDBException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public void deleteSnapshotProperties(UUID snapshotId) throws IOException {
+    try {
+      this.db.get().delete(this.snapshotPropertiesCf, UuidCodec.get().toPersistedFormat(snapshotId));
+      this.snapshotPropertiesMap.remove(snapshotId);
+      this.purgedSnapshots.remove(snapshotId);
+    } catch (RocksDBException e) {
+      throw new IOException(e);
+    }
+  }
+
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SstFilteringService.java
@@ -133,6 +133,10 @@ public class SstFilteringService extends BackgroundService
           String snapshotTableKey = SnapshotInfo.getTableKey(volume, bucket,
               snapshotName);
           SnapshotInfo snapshotInfo = snapshotInfoTable.get(snapshotTableKey);
+          if (snapshotInfo == null) {
+            LOG.info("Snapshot {} has been purged. Ignoring updating the snapshot properties", snapshotTableKey);
+            return;
+          }
           SnapshotProperties snapshotProperties =
               ozoneManager.getOmSnapshotManager().getSnapshotPropertiesManager().
               getSnapshotProperties(snapshotInfo.getSnapshotId()).orElse(SnapshotProperties.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
@@ -88,7 +88,7 @@ public class TestOmSnapshotUtils {
 
   private static Stream<Arguments> testCasesForIgnoreSnapshotGc() {
     SnapshotProperties filteredSnapshotProperties = SnapshotProperties.newBuilder().setSstFiltered(true).build();
-    SnapshotProperties unfilteredSnapshotProperties = SnapshotProperties.newBuilder().setSstFiltered(true).build();
+    SnapshotProperties unfilteredSnapshotProperties = SnapshotProperties.newBuilder().setSstFiltered(false).build();
     SnapshotInfo filteredSnapshot =
         SnapshotInfo.newBuilder().setName("snap1").build();
     SnapshotInfo unFilteredSnapshot =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotInfo.java
@@ -101,17 +101,4 @@ public class TestSnapshotInfo {
     snapshotInfo.delete(EXPECTED_SNAPSHOT_KEY);
     assertFalse(snapshotInfo.isExist(EXPECTED_SNAPSHOT_KEY));
   }
-
-  @Test
-  public void testSnapshotSSTFilteredFlag() throws Exception {
-    Table<String, SnapshotInfo> snapshotInfo =
-            omMetadataManager.getSnapshotInfoTable();
-    SnapshotInfo info = createSnapshotInfo();
-    info.setSstFiltered(false);
-    snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, info);
-    assertFalse(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).isSstFiltered());
-    info.setSstFiltered(true);
-    snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, info);
-    assertTrue(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).isSstFiltered());
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
SstFiltering service directly updates the snapshotInfo and doesn't go through DoubleBufferFlush to update the DB. This interferes with SnapshotInfo updated during SnapshotPurgeRequest.

Consider the case:

S1 <- S2(SstFiltered) <- S3 (Sst unfiltered)

At T1 if S2 is purged and submitted to OM ratis but it hasn't been flushed to the rocksDb but just present in the cache which makes the chain.

S1 <- S3 (Sst Unfiltered in cache)

S2(SstFiltered, deleted in Cache but present in table)

 

Suppose at T2  SstFiltering service runs on the chain and marks S3 to be SstFiltered which would be directly flushed to DB

S1 <- S3 (Sst filtered in DB)

S1 <- S2 (Present in DB but not present in cache)

Now if the OM is restarted, snapshot chain would have gotten corrupted since both S2 & S3 are pointing S1 in the DB.

Changes made in the patch:

1. Create a snapshot property table in Snapshot DB which would store all properties allied to a snapshot specific to one OM. This would hold a sstFiltered flag correspoding to the snapshotId which would be set when the SstFiltering service marks the snapshot as filtered.
2. SnapshotPropertyManager which would be responsible to maintain a full cache for the table in memory and handling updates to the db.
3. In OmSnapshotPurgeRequest mark the boolean property snapshotPurged, a background service will be running in OM which would wait for the double buffer flush for the SnapshotPurgeRequest which would remove the entry from the table. Post which the service will clean up the property entry corresponding to the snapshot.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11068

## How was this patch tested?
Exisiting unit tests and additional unit tests.

