### PR TITLE
HDDS-11080. Remove "Features requiring finalization" section in docs.

### DIFF
--- a/hadoop-hdds/docs/content/feature/Nonrolling-Upgrade.md
+++ b/hadoop-hdds/docs/content/feature/Nonrolling-Upgrade.md
@@ -92,17 +92,3 @@ At this point, the cluster is upgraded to a pre-finalized state and fully operat
     ```
 
 At this point, the cluster is finalized and the upgrade is complete.
-
-## Features Requiring Finalization
-
-Below is a list of backwards incompatible features and the version in which they were introduced. These features can only be used on a finalized ozone cluster with at least the specified version. Run `ozone version` to get the current version of your Ozone cluster.
-
-### Version 1.2.0
-
-- [Prefix based File System Optimization]({{< relref "PrefixFSO.md" >}}) 
-    - Although new 1.2.0 clusters can use this feature, it is currently not supported for clusters upgraded to 1.2.0, even after finalizing.
-
-- [SCM High Availability]({{< relref "SCM-HA.md" >}})
-    - Although new 1.2.0 clusters can use this feature, it is currently not supported for clusters upgraded to 1.2.0, even after finalizing.
-
-


### PR DESCRIPTION
## What changes were proposed in this pull request?

[The upgrade docs](https://ozone.apache.org/docs/current/feature/nonrolling-upgrade.html) have a section that lists which new features require finalization before they can be used in a new version. However, this section hasn't been updated since Ozone 1.2.0. IMO we can remove this section since new features should be documented in the release notes and the system will tell you if finalization is required when you try to use them.

## What is the link to the Apache JIRA

HDDS-11080

## How was this patch tested?

Local preview of the page renders correctly.
