### PR TITLE
HDDS-10932. Reduce number of watch requests by using CommitInfoProto from NotReplicatedException

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -56,8 +56,10 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.api.DataStreamApi;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.protocol.exceptions.GroupMismatchException;
+import org.apache.ratis.protocol.exceptions.NotReplicatedException;
 import org.apache.ratis.protocol.exceptions.RaftException;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.retry.RetryPolicy;
@@ -315,29 +317,44 @@ public final class XceiverClientRatis extends XceiverClientSpi {
         throw e;
       }
       if (watchType == ReplicationLevel.ALL_COMMITTED) {
-        final RaftClientReply reply = getClient().async()
-            .watch(index, RaftProtos.ReplicationLevel.MAJORITY_COMMITTED)
-            .get();
-        final XceiverClientReply clientReply = newWatchReply(
-            index, ReplicationLevel.MAJORITY_COMMITTED, index);
-        reply.getCommitInfos().stream()
-            .filter(i -> i.getCommitIndex() < index)
-            .forEach(proto -> {
-              UUID address = RatisHelper.toDatanodeId(proto.getServer());
-              addDatanodetoReply(address, clientReply);
-              // since 3 way commit has failed, the updated map from now on will
-              // only store entries for those datanodes which have had successful
-              // replication.
-              commitInfoMap.remove(address);
-              LOG.info(
-                  "Could not commit index {} on pipeline {} to all the nodes. " +
-                      "Server {} has failed. Committed by majority.",
-                  index, pipeline, address);
-            });
-        return clientReply;
+        Throwable nre =
+            HddsClientUtils.containsException(e, NotReplicatedException.class);
+        Collection<CommitInfoProto> commitInfoProtoList;
+        if (nre instanceof NotReplicatedException) {
+          // If NotReplicatedException is thrown from the Datanode leader
+          // we can save one watch request round trip by using the CommitInfoProto
+          // in the NotReplicatedException
+          commitInfoProtoList = ((NotReplicatedException) nre).getCommitInfos();
+        } else {
+          final RaftClientReply reply = getClient().async()
+              .watch(index, RaftProtos.ReplicationLevel.MAJORITY_COMMITTED)
+              .get();
+          commitInfoProtoList = reply.getCommitInfos();
+        }
+        return handleFailedAllCommit(index, commitInfoProtoList);
       }
       throw e;
     }
+  }
+
+  private XceiverClientReply handleFailedAllCommit(long index, Collection<CommitInfoProto> commitInfoProtoList) {
+    final XceiverClientReply clientReply = newWatchReply(
+        index, ReplicationLevel.MAJORITY_COMMITTED, index);
+    commitInfoProtoList.stream()
+        .filter(i -> i.getCommitIndex() < index)
+        .forEach(proto -> {
+          UUID address = RatisHelper.toDatanodeId(proto.getServer());
+          addDatanodetoReply(address, clientReply);
+          // since 3 way commit has failed, the updated map from now on  will
+          // only store entries for those datanodes which have had successful
+          // replication.
+          commitInfoMap.remove(address);
+          LOG.info(
+              "Could not commit index {} on pipeline {} to all the nodes. " +
+                  "Server {} has failed. Committed by majority.",
+              index, pipeline, address);
+        });
+    return clientReply;
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -97,7 +97,7 @@ class TestBlockOutputStream {
     RatisClientConfig.RaftConfig raftClientConfig =
         conf.getObject(RatisClientConfig.RaftConfig.class);
     raftClientConfig.setRpcRequestTimeout(Duration.ofSeconds(3));
-    raftClientConfig.setRpcWatchRequestTimeout(Duration.ofSeconds(3));
+    raftClientConfig.setRpcWatchRequestTimeout(Duration.ofSeconds(5));
     conf.setFromObject(raftClientConfig);
 
     RatisClientConfig ratisClientConfig =


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can use CommitInfoProto in NotReplicatedException introduced in [RATIS-2089](https://issues.apache.org/jira/browse/RATIS-2089) to remove the need for watch MAJORITY_COMMITTED calls if NotReplicatedException is thrown from the DN Ratis leader.

This also requires DN Ratis server watch timeout configuration change hdds.ratis.raft.server.watch.timeout to be lower than the client watch timeout hdds.ratis.raft.client.rpc.watch.request.timeout so that NotReplicatedException will be thrown instead of TimeoutException.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10932

## How was this patch tested?

Existing tests. Increased the client watch RPC timeout in `TestBlockOutputStream` to be strictly larger than the server watch timeout to reflect the current default configurations.

Clean CI: https://github.com/ivandika3/ozone/actions/runs/9707025051
