### PR TITLE
HDDS-10955. [hsync] Adopt Ratis 3.1.0 when it's released

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- HDDS Rocks Native dependency version-->
     <hdds.rocks.native.version>${hdds.version}</hdds.rocks.native.version>
     <!-- Apache Ratis version -->
-    <ratis.version>3.0.1</ratis.version>
+    <ratis.version>3.1.0</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
-    <ratis.thirdparty.version>1.0.5</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.6</ratis.thirdparty.version>
 
     <!-- Apache Ranger plugin version -->
     <ranger.version>2.3.0</ranger.version>
@@ -242,7 +242,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <enforced.maven.version>[3.3.0,)</enforced.maven.version>
 
     <!-- Plugin versions and config -->
-    <maven-surefire-plugin.argLine>-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
+    <maven-surefire-plugin.argLine>-Xmx8192m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
     <maven-surefire-plugin.argLineAccessArgs></maven-surefire-plugin.argLineAccessArgs>
     <unstable-test-groups>flaky | native | slow | unhealthy</unstable-test-groups>
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move up to Ratis 3.1.0

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10955

## How was this patch tested?

CI:
https://github.com/chungen0126/ozone/actions/runs/9703602797

