### PR TITLE
HDDS-10508. OmUtils.getAllOMHAAddresses may throw NPE

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -855,6 +855,12 @@ public final class OmUtils {
       try {
         OMNodeDetails omNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
             conf, omServiceId, nodeId);
+        if (omNodeDetails == null) {
+          LOG.error(
+              "There is no OM configuration for node ID {} in ozone-site.xml.",
+              nodeId);
+          continue;
+        }
         if (decommissionedNodeIds.contains(omNodeDetails.getNodeId())) {
           omNodeDetails.setDecommissioningState();
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the conf is not set, there is a NPE:

In `OmUtils#getAllOMHAAddresses`, if `omNodeDetails` was null, then `omNodeDetails.getNodeId()` throws NPE.
```
        OMNodeDetails omNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
            conf, omServiceId, nodeId);
        if (decommissionedNodeIds.contains(omNodeDetails.getNodeId())) {
          omNodeDetails.setDecommissioningState();
        }
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10508

## How was this patch tested?

CI:
https://github.com/chungen0126/ozone/actions/runs/9716680901