### PR TITLE
HDDS-11090. Add explicit dependency for jcip-annotations

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -41,6 +41,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>picocli</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.stephenc.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <scope>compile</scope>

--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -40,6 +40,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>ozone-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.stephenc.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -70,6 +70,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hadoop-hdfs-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.stephenc.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <jetty.version>9.4.54.v20240208</jetty.version>
     <java.dev.jna.version>5.2.0</java.dev.jna.version>
+    <jcip-annotations.version>1.0-1</jcip-annotations.version>
     <curator.version>4.2.0</curator.version>
 
     <!-- number of threads/forks to use when running tests in parallel, see parallel-tests profile -->
@@ -482,6 +483,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
         <version>${zstd-jni.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.stephenc.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>${jcip-annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.annotation</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We started using `@Immutable` from `jcip-annotations` in HDDS-10322 (and some follow-up tasks).  However, `jcip-annotations` is only a transitive dependency via `nimbus-jose-jwt`.  We should add an explicit dependency.

https://issues.apache.org/jira/browse/HDDS-11090

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/9723714947