### PR TITLE
HDDS-11095. Generate fixed length string with Robot builtin

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -158,7 +158,7 @@ Test Multipart Upload Complete
     Compare files               /tmp/part2        /tmp/${PREFIX}-multipartKey1-part2.result
 
 Test Multipart Upload with user defined metadata size larger than 2 KB
-    ${custom_metadata_value} =  Execute                               printf 'v%.0s' {1..3000}
+    ${custom_metadata_value} =  Generate Random String   3000
     ${result} =                 Execute AWSS3APICli and checkrc       create-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/mpuWithLargeMetadata --metadata="custom-key1=${custom_metadata_value}"    255
                                 Should contain                        ${result}   MetadataTooLarge
                                 Should not contain                    ${result}   custom-key1: ${custom_metadata_value}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
@@ -112,6 +112,6 @@ Copy Object using an invalid copy directive
 
 Copy Object with user defined metadata size larger than 2 KB
                                 Execute                    echo "Randomtext" > /tmp/testfile2
-    ${custom_metadata_value} =  Execute                    printf 'v%.0s' {1..3000}
+    ${custom_metadata_value} =  Generate Random String    3000
     ${result} =                 Execute AWSS3ApiCli and checkrc       copy-object --bucket ${DESTBUCKET} --key ${PREFIX}/copyobject/key=value/f1 --copy-source ${BUCKET}/${PREFIX}/copyobject/key=value/f1 --metadata="custom-key1=${custom_metadata_value}" --metadata-directive REPLACE       255
                                 Should contain                        ${result}   MetadataTooLarge

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
@@ -191,7 +191,7 @@ Create file with user defined metadata with gdpr enabled value in request
 
 Create file with user defined metadata size larger than 2 KB
                                 Execute                    echo "Randomtext" > /tmp/testfile2
-    ${custom_metadata_value} =  Execute                    printf 'v%.0s' {1..3000}
+    ${custom_metadata_value} =  Generate Random String    3000
     ${result} =                 Execute AWSS3APICli and checkrc       put-object --bucket ${BUCKET} --key ${PREFIX}/putobject/custom-metadata/key2 --body /tmp/testfile2 --metadata="custom-key1=${custom_metadata_value}"    255
                                 Should contain                        ${result}   MetadataTooLarge
                                 Should not contain                    ${result}   custom-key1: ${custom_metadata_value}
@@ -199,10 +199,10 @@ Create file with user defined metadata size larger than 2 KB
 Create files invalid tags
     ${result} =                 Execute AWSS3APICli and checkrc       put-object --bucket ${BUCKET} --key ${PREFIX}/putobject/custom-metadata/key2 --body /tmp/testfile2 --tagging="tag-key1=tag-value1&tag-key1=tag-value2"    255
                                 Should contain                        ${result}   InvalidTag
-    ${long_tag_key} =           Execute                               printf 'v%.0s' {1..129}
+    ${long_tag_key} =           Generate Random String    129
     ${result} =                 Execute AWSS3APICli and checkrc       put-object --bucket ${BUCKET} --key ${PREFIX}/putobject/custom-metadata/key2 --body /tmp/testfile2 --tagging="${long_tag_key}=tag-value1"    255
                                 Should contain                        ${result}   InvalidTag
-    ${long_tag_value} =         Execute                               printf 'v%.0s' {1..257}
+    ${long_tag_value} =         Generate Random String    257
     ${result} =                 Execute AWSS3APICli and checkrc       put-object --bucket ${BUCKET} --key ${PREFIX}/putobject/custom-metadata/key2 --body /tmp/testfile2 --tagging="tag-key1=${long_tag_value}"    255
                                 Should contain                        ${result}   InvalidTag
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3 Robot tests have some test cases using shell function `printf` to generate fixed length string.

```
hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
115:    ${custom_metadata_value} =  Execute                    printf 'v%.0s' {1..3000}

hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
194:    ${custom_metadata_value} =  Execute                    printf 'v%.0s' {1..3000}
202:    ${long_tag_key} =           Execute                               printf 'v%.0s' {1..129}
205:    ${long_tag_value} =         Execute                               printf 'v%.0s' {1..257}

hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
161:    ${custom_metadata_value} =  Execute                               printf 'v%.0s' {1..3000}
```

This does not work on more recent bash and/or python versions, only a single `v` is printed.

The problem can be reproduced using the following simplified test script:

```
*** Settings ***
Library     OperatingSystem
Library     String

*** Test Cases ***
Test Printf 123
    ${rc}               ${output} =    Run And Return Rc And Output           printf 'v%.0s' 1 2 3
    Length Should Be    ${output}      3

Test Printf {}
    ${rc}               ${output} =    Run And Return Rc And Output           printf 'v%.0s' {1..5}
    Length Should Be    ${output}      5
```

and running:

```
$ docker run -it --rm \
  -v $(pwd)/test.robot:/test.robot
  python:3.6.8 \
  bash -c 'pip install robotframework==6.1.1 && bash --version && robot --version; robot test.robot'
...
GNU bash, version 4.4.12(1)-release (x86_64-pc-linux-gnu)
...
Robot Framework 6.1.1 (Python 3.6.8 on linux)
...
==============================================================================
Test Printf 123                                                       | PASS |
------------------------------------------------------------------------------
Test Printf {}                                                        | FAIL |
Length of 'v' should be 5 but is 1.
```

I propose to replace with `Generate Random String   N` from Robot's `String` library.

https://issues.apache.org/jira/browse/HDDS-11095

## How was this patch tested?

Existing tests:
https://github.com/adoroszlai/ozone/actions/runs/9749872256