### PR TITLE
HDDS-11096. Error creating s3 auth info for request with Authorization: Negotiate

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/RootPageDisplayFilter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/RootPageDisplayFilter.java
@@ -46,12 +46,15 @@ public class RootPageDisplayFilter implements Filter {
     String httpMethod = httpRequest.getMethod();
     String uri = httpRequest.getRequestURI();
     String authorizationHeader = httpRequest.getHeader("Authorization");
-    if (httpMethod.equalsIgnoreCase("GET") && authorizationHeader == null && uri
-        .equals("/")) {
+    if (httpMethod.equalsIgnoreCase("GET") && !containsAWSAuth(authorizationHeader) && uri.equals("/")) {
       ((HttpServletResponse) servletResponse).sendRedirect("/static/");
     } else {
       filterChain.doFilter(httpRequest, servletResponse);
     }
+  }
+
+  private boolean containsAWSAuth(String authorizationHeader) {
+    return authorizationHeader != null && authorizationHeader.startsWith("AWS");
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Newer `curl` sends `Authorization: Negotiate` in initial request, so redirect from `/` to `/static/` fails with 403:

```
$ curl --negotiate -u : -vvv http://s3g:9878/
...
* Connected to s3g (172.20.0.9) port 9878 (#0)
* Server auth using Negotiate with user ''
> GET / HTTP/1.1
> Host: s3g:9878
> Authorization: Negotiate <redacted>
> User-Agent: curl/7.81.0
...
< HTTP/1.1 403 Forbidden
...
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>InvalidRequest</Code>
  <Message>Error creating s3 auth info. The request may not be signed using AWS V4 signing algorithm, or might be invalid</Message>
  <Resource/>
  <RequestId/>
</Error>
```

Using old `curl`:

```
$ curl --negotiate -u : -vvv http://s3g:9878/
...
* Connected to s3g (172.20.0.9) port 9878 (#0)
> GET / HTTP/1.1
> User-Agent: curl/7.29.0
> Host: s3g:9878
...
< HTTP/1.1 302 Found
...
< Location: http://s3g:9878/static/
< Content-Length: 0
```

https://issues.apache.org/jira/browse/HDDS-11096

## How was this patch tested?

```
$ curl --negotiate -u : -vvv http://s3g:9878/
...
* Connected to s3g (192.168.80.6) port 9878 (#0)
* Server auth using Negotiate with user ''
> GET / HTTP/1.1
> Host: s3g:9878
> Authorization: Negotiate <redacted>
> User-Agent: curl/7.81.0
...
< HTTP/1.1 302 Found
< Location: http://s3g:9878/static/
< Content-Length: 0
```

Old `curl` and AWS CLI are verified in existing tests:
https://github.com/adoroszlai/ozone/actions/runs/9758906348