### PR TITLE
HDDS-11076. NoSuchMethodError: ByteBuffer.position compiling with Java 9+, running with Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <weld-servlet.version>3.1.9.Final</weld-servlet.version>
 
     <!-- define the Java language version used by the compiler -->
-    <javac.version>1.8</javac.version>
+    <javac.version>8</javac.version>
 
     <!-- The java version enforced by the maven enforcer -->
     <!-- more complex patterns can be used here, such as
@@ -1322,8 +1322,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
-            <source>${javac.version}</source>
-            <target>${javac.version}</target>
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
         </plugin>
@@ -1968,6 +1966,28 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         </plugins>
       </build>
     </profile>
+
+    <!-- Profiles for specific JDK versions -->
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>[,8]</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.source>${javac.version}</maven.compiler.source>
+        <maven.compiler.target>${javac.version}</maven.compiler.target>
+      </properties>
+    </profile>
+    <profile>
+      <id>java9-or-later</id>
+      <activation>
+        <jdk>[9,]</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>${javac.version}</maven.compiler.release> <!-- supported since Java 9 -->
+      </properties>
+    </profile>
+
     <profile>
       <id>go-offline</id>
       <properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Building Ozone with Java 9+ (but still targeting Java 8 with `javac.version=8`) and running with Java 8 results in:

```
NoSuchMethodError: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer;
	at org.apache.hadoop.ozone.common.ChunkBufferImplWithByteBuffer.duplicate(ChunkBufferImplWithByteBuffer.java:111)
```

It can be reproduced in Hadoop compatibility tests, because Hadoop images still ship with Java 8, while Ozone images have newer Java.

CI tweak for repro:
https://github.com/adoroszlai/ozone/commit/33f7f4b2cc26e380ee7e570b990ef9962021b89c

Failure:
https://github.com/adoroszlai/ozone/actions/runs/9792172547/job/27038142506#step:6:9

Exception can be seen in `log.html` in the [test artifact](https://github.com/adoroszlai/ozone/actions/runs/9792172547/artifacts/1667509237).

Blog with great explanation of the problem and solution:
https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/

It can be fixed by setting `--release` for `javac`, via `maven.compiler.release`.  This is a new option for JDK 9+, so it must be done conditionally, in a profile.

https://issues.apache.org/jira/browse/HDDS-11076

## How was this patch tested?

Using the same CI repro with the fix:
https://github.com/adoroszlai/ozone/actions/runs/9792162687

Regular CI (for testing build with Java 8):
https://github.com/adoroszlai/ozone/actions/runs/9792724664