### PR TITLE
HDDS-11100. OM/SCM Metrics support displaying Netty off-heap memory.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1713,10 +1713,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       metrics.unRegister();
     }
 
-    if (this.nettyMetrics != null) {
-      this.nettyMetrics.unregister();
-    }
-
+    nettyMetrics.unregister();
     if (perfMetrics != null) {
       perfMetrics.unRegister();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -146,6 +146,7 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.hdds.utils.HddsVersionInfo;
+import org.apache.hadoop.hdds.utils.NettyMetrics;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ipc.RPC;
@@ -236,6 +237,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private static SCMMetrics metrics;
   private static SCMPerformanceMetrics perfMetrics;
   private SCMHAMetrics scmHAMetrics;
+  private final NettyMetrics nettyMetrics;
 
   /*
    * RPC Endpoints exposed by SCM.
@@ -456,6 +458,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     registerMXBean();
     registerMetricsSource(this);
+    this.nettyMetrics = NettyMetrics.create();
   }
 
   private void initializeEventHandlers() {
@@ -1708,6 +1711,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     if (metrics != null) {
       metrics.unRegister();
+    }
+
+    if (this.nettyMetrics != null) {
+      this.nettyMetrics.unregister();
     }
 
     if (perfMetrics != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

JIRA: HDDS-11100. OM/SCM Metrics support displaying Netty off-heap memory.

During a recent period, our cluster's DataNode (DN) exhibited high off-heap memory utilization, triggering frequent system.gc() calls. Upon reading relevant GC logs, we observed normal heap memory usage and monitored heap metrics. It became apparent that off-heap memory usage might be causing the system.gc() calls. We identified that DataNode can display off-heap memory usage, which indirectly helped us infer potential off-heap memory overflow. In [HDDS-9070](https://issues.apache.org/jira/browse/HDDS-9070), we now support displaying Netty off-heap memory usage on DataNode, facilitating off-heap memory monitoring. Similarly, we can display Netty off-heap memory usage on OM and SCM.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11100

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)
