### PR TITLE
HDDS-11101. Use `OZONE_RUNNER_IMAGE` for httpfs

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -184,7 +184,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.113
   httpfs:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: httpfs
     volumes:
       - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
       - docker-config
     command: ["/opt/hadoop/bin/ozone","om"]
   httpfs:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: httpfs
     volumes:
       - ../..:/opt/hadoop


### PR DESCRIPTION
## What changes were proposed in this pull request?

`httpfs` container uses hard-coded `apache/ozone-runner` image.  It should use `$OZONE_RUNNER_IMAGE`, like all other Ozone containers, to allow testing new/custom runner image.

https://issues.apache.org/jira/browse/HDDS-11101

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/9818282363