### PR TITLE
HDDS-11106. Save logs for stopped containers

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -212,7 +212,7 @@ execute_robot_test(){
       "$SMOKETEST_DIR_INSIDE/$TEST"
   local -i rc=$?
 
-  FULL_CONTAINER_NAME=$(docker-compose ps | grep "[-_]${CONTAINER}[-_]" | head -n 1 | awk '{print $1}')
+  FULL_CONTAINER_NAME=$(docker-compose ps -a | grep "[-_]${CONTAINER}[-_]" | head -n 1 | awk '{print $1}')
   docker cp "$FULL_CONTAINER_NAME:$OUTPUT_PATH" "$RESULT_DIR/"
 
   if [[ ${rc} -gt 0 ]] && [[ ${rc} -le 250 ]]; then
@@ -251,7 +251,7 @@ create_stack_dumps() {
 ## @description Copy any 'out' files for daemon processes to the result dir
 copy_daemon_logs() {
   local c f
-  for c in $(docker-compose ps | grep "^${COMPOSE_ENV_NAME}[_-]" | awk '{print $1}'); do
+  for c in $(docker-compose ps -a | grep "^${COMPOSE_ENV_NAME}[_-]" | awk '{print $1}'); do
     for f in $(docker exec "${c}" ls -1 /var/log/hadoop 2> /dev/null | grep -F -e '.out' -e audit); do
       docker cp "${c}:/var/log/hadoop/${f}" "$RESULT_DIR/"
     done
@@ -305,7 +305,7 @@ get_output_name() {
 save_container_logs() {
   local output_name=$(get_output_name)
   local c
-  for c in $(docker-compose ps "$@" | cut -f1 -d' ' | tail -n +3); do
+  for c in $(docker-compose ps -a "$@" | cut -f1 -d' ' | tail -n +3); do
     docker logs "${c}" >> "$RESULT_DIR/docker-${output_name}${c}.log" 2>&1
   done
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance test saves Docker container logs, but only for those still running at the end of the test.  It should collect logs from stopped containers, too.

https://issues.apache.org/jira/browse/HDDS-11106

## How was this patch tested?

Changed `ozone/test.sh` to simulate stopped container:

```
COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
export COMPOSE_DIR

export SECURITY_ENABLED=false
export OZONE_REPLICATION_FACTOR=3

# shellcheck source=/dev/null
source "$COMPOSE_DIR/../testlib.sh"

start_docker_env

sleep 30
docker-compose ps
docker-compose stop httpfs recon

sleep 30
docker-compose ps

sleep 30
```

Log files after "test" finished:

```
$ ls -1sh result
total 656K
   0 dn-audit-2581c25f46e7.log
   0 dn-audit-71ca6309050a.log
   0 dn-audit-90d141c9629a.log
116K docker-ozone-datanode-2.log
124K docker-ozone-datanode-3.log
 16K docker-ozone-httpfs-1.log
108K docker-ozone-om-1.log
 76K docker-ozone-recon-1.log
 40K docker-ozone-s3g-1.log
148K docker-ozone-scm-1.log
4.0K om-audit-63d6dd0df5be.log
   0 s3g-audit-0bbd3a47ba4e.log
 24K scm-audit-0b998d695c2b.log
```

Without the patch, logs for `httpfs` and `recon` are missing:

```
$ ls -1sh result
total 624K
   0 dn-audit-09c25669fa47.log
   0 dn-audit-aad129e3fa83.log
   0 dn-audit-d8981fc63cc9.log
148K docker-ozone-datanode-2.log
140K docker-ozone-datanode-3.log
104K docker-ozone-om-1.log
 40K docker-ozone-s3g-1.log
160K docker-ozone-scm-1.log
   0 om-audit-ec2b7675c0fa.log
   0 s3g-audit-fa2b1d870aa0.log
 32K scm-audit-7750e6277429.log
```