### PR TITLE
HDDS-11069. Block location is missing in output of Ozone debug chunkinfo command for EC.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -332,18 +332,10 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     boolean isEcRequest = pipeline.getReplicationConfig()
         .getReplicationType() == HddsProtos.ReplicationType.EC;
     if (request.hasGetBlock() && isEcRequest) {
-      int replicaIdx = pipeline.getReplicaIndex(dn);
-      ContainerProtos.GetBlockRequestProto getBlockRequestProto =
-          request.getGetBlock();
-      DatanodeBlockID datanodeBlockID = getBlockRequestProto.getBlockID();
-      DatanodeBlockID newDatanodeBlockID =
-          DatanodeBlockID.newBuilder(datanodeBlockID)
-              .setReplicaIndex(replicaIdx).build();
-      ContainerProtos.GetBlockRequestProto newGetBlockRequestProto =
-          ContainerProtos.GetBlockRequestProto.newBuilder(getBlockRequestProto)
-              .setBlockID(newDatanodeBlockID).build();
-      request = ContainerCommandRequestProto.newBuilder(request)
-          .setGetBlock(newGetBlockRequestProto).build();
+      ContainerProtos.GetBlockRequestProto gbr = request.getGetBlock();
+      request = request.toBuilder().setGetBlock(gbr.toBuilder().setBlockID(
+          gbr.getBlockID().toBuilder().setReplicaIndex(
+              pipeline.getReplicaIndex(dn)).build()).build()).build();
     }
     return request;
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -285,7 +285,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     }
     for (DatanodeDetails dn : datanodeList) {
       try {
-        request = reconstructRequestIfNeeded(request, dn, pipeline);
+        request = reconstructRequestIfNeeded(request, dn);
         futureHashMap.put(dn, sendCommandAsync(request, dn).getResponse());
       } catch (InterruptedException e) {
         LOG.error("Command execution was interrupted.");
@@ -328,7 +328,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
    * @return new updated Request
    */
   private ContainerCommandRequestProto reconstructRequestIfNeeded(
-      ContainerCommandRequestProto request, DatanodeDetails dn, Pipeline pipeline) {
+      ContainerCommandRequestProto request, DatanodeDetails dn) {
     boolean isEcRequest = pipeline.getReplicationConfig()
         .getReplicationType() == HddsProtos.ReplicationType.EC;
     if (request.hasGetBlock() && isEcRequest) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -111,7 +111,7 @@ public class ChunkKeyHandler extends KeyHandler implements
             keyPipeline.getReplicationConfig().getReplicationType() ==
                 HddsProtos.ReplicationType.EC;
         Pipeline pipeline;
-        if (keyPipeline.getType() != HddsProtos.ReplicationType.STAND_ALONE) {
+        if (!isECKey && keyPipeline.getType() != HddsProtos.ReplicationType.STAND_ALONE) {
           pipeline = Pipeline.newBuilder(keyPipeline)
               .setReplicationConfig(StandaloneReplicationConfig
                   .getInstance(ONE)).build();


### PR DESCRIPTION
## What changes were proposed in this pull request?
After HDDS-10983 , it requires every getBlock request be assigned a replicaIndex in case of an EC block. The request constructed for getBlock in this tool didn't have that. This change sets the replicaIndex if key is EC in the getBlock request.
I have reconstructed the request after unpacking the existing request which could have been avoided but since the usecase is just a debug tool and it was simple change, I went with it.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11069

## How was this patch tested?
Unit test
