### PR TITLE
HDDS-11103. Do not assume working dir is writable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,7 +428,6 @@ jobs:
           mkdir -p hadoop-ozone/dist/target
           tar xzvf ozone*.tar.gz -C hadoop-ozone/dist/target
           rm ozone*.tar.gz
-          sudo chmod -R a+rwX hadoop-ozone/dist/target
       - name: Execute tests
         run: |
           pushd hadoop-ozone/dist/target/ozone-*

--- a/hadoop-ozone/dist/src/main/compose/compatibility/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/docker-config
@@ -30,6 +30,7 @@ OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
 OZONE-SITE.XML_ozone.recon.address=recon:9891
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 HADOOP_OPTS="-Dhadoop.opts=test"
 HDFS_STORAGECONTAINERMANAGER_OPTS="-Dhdfs.scm.opts=test"

--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-config
@@ -52,6 +52,7 @@ OZONE-SITE.XML_hdds.container.report.interval=30s
 OZONE-SITE.XML_ozone.om.s3.grpc.server_enabled=true
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-config
@@ -35,6 +35,7 @@ OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
@@ -50,6 +50,7 @@ OZONE-SITE.XML_ozone.recon.address=recon:9891
 OZONE-SITE.XML_ozone.recon.http-address=0.0.0.0:9888
 OZONE-SITE.XML_ozone.recon.https-address=0.0.0.0:9889
 OZONE-SITE.XML_hdds.container.ratis.datastream.enabled=true
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-config
@@ -38,6 +38,7 @@ OZONE-SITE.XML_hdds.profiler.endpoint.enabled=true
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_hdds.container.report.interval=60s
 OZONE-SITE.XML_ozone.om.s3.grpc.server_enabled=true
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 ASYNC_PROFILER_HOME=/opt/profiler

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-config
@@ -32,5 +32,6 @@ OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_ozone.client.failover.max.attempts=6
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 no_proxy=om1,om2,om3,scm,s3g,recon,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-config
@@ -43,6 +43,7 @@ OZONE-SITE.XML_net.topology.node.switch.mapping.impl=org.apache.hadoop.net.Table
 OZONE-SITE.XML_net.topology.table.file.name=/opt/hadoop/compose/ozone-topology/network-config
 OZONE-SITE.XML_ozone.network.topology.aware.read=true
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -51,6 +51,7 @@ OZONE-SITE.XML_hdds.scm.replication.thread.interval=15s
 OZONE-SITE.XML_hdds.scm.replication.under.replicated.interval=5s
 OZONE-SITE.XML_hdds.scm.replication.over.replicated.interval=5s
 OZONE-SITE.XML_hdds.scm.wait.time.after.safemode.exit=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE-SITE.XML_hdds.container.ratis.datastream.enabled=true
 

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-config
@@ -39,6 +39,7 @@ OZONE-SITE.XML_hdds.scm.replication.event.timeout=10s
 OZONE-SITE.XML_dfs.ratis.server.failure.duration=35s
 OZONE-SITE.XML_hdds.scm.safemode.min.datanode=3
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-config
@@ -27,6 +27,7 @@ OZONE-SITE.XML_ozone.server.default.replication=1
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -124,6 +124,7 @@ OZONE-SITE.XML_ozone.httpfs.http.auth.kerberos.principal=HTTP/httpfs@EXAMPLE.COM
 OZONE-SITE.XML_ozone.recon.http.auth.kerberos.principal=HTTP/recon@EXAMPLE.COM
 OZONE-SITE.XML_ozone.recon.http.auth.kerberos.keytab=/etc/security/keytabs/recon.keytab
 OZONE-SITE.XML_ozone.recon.http.auth.kerberos.keytab=/etc/security/keytabs/recon.keytab
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 CORE-SITE.XML_hadoop.http.authentication.simple.anonymous.allowed=false
 CORE-SITE.XML_hadoop.http.authentication.signature.secret.file=/etc/security/http_secret

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -37,6 +37,7 @@ OZONE-SITE.XML_ozone.om.kerberos.principal=om/om@EXAMPLE.COM
 OZONE-SITE.XML_ozone.om.kerberos.keytab.file=/etc/security/keytabs/om.keytab
 OZONE-SITE.XML_ozone.administrators=*
 OZONE-SITE.XML_ozone.s3.administrators="s3g"
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE-SITE.XML_ozone.security.enabled=true
 OZONE-SITE.XML_ozone.security.http.kerberos.enabled=true

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -38,6 +38,7 @@ OZONE-SITE.XML_hdds.grpc.tls.enabled=true
 OZONE-SITE.XML_ozone.server.default.replication=3
 OZONE-SITE.XML_ozone.datanode.pipeline.limit=1
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon

--- a/hadoop-ozone/dist/src/main/compose/restart/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/restart/docker-config
@@ -31,6 +31,7 @@ OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
 OZONE-SITE.XML_ozone.recon.address=recon:9891
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
@@ -39,6 +39,7 @@ OZONE-SITE.XML_ozone.scm.datanode.id.dir=/data
 OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 # If SCM sends container close commands as part of upgrade finalization while
 # datanodes are doing a leader election, all 3 replicas may end up in the

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-config
@@ -36,6 +36,7 @@ OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/om-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/om-ha/docker-config
@@ -31,6 +31,7 @@ OZONE-SITE.XML_ozone.scm.datanode.id.dir=/data
 OZONE-SITE.XML_ozone.scm.block.client.address=scm
 OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_ozone.scm.client.address=scm
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB

--- a/hadoop-ozone/dist/src/main/compose/xcompat/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/docker-config
@@ -35,4 +35,5 @@ OZONE-SITE.XML_ozone.scm.pipeline.owner.container.count=1
 OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_ozone.default.bucket.layout=LEGACY
+OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
 no_proxy=om,recon,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/cert.robot
@@ -30,10 +30,9 @@ List certificates
 
 List certificates as JSON
     Pass Execution If      '${SECURITY_ENABLED}' == 'false'    N/A
-    Execute                 ozone admin cert list --json 1>> outStream 2>> errStream
-    ${output}               Execute             cat outStream | jq -r '.[0] | keys'
+    Execute                 ozone admin cert list --json 1>> ${TEMP_DIR}/outStream 2>> ${TEMP_DIR}/errStream
+    ${output}               Execute             cat ${TEMP_DIR}/outStream | jq -r '.[0] | keys'
                             Should Contain          ${output}           serialNumber
-    ${errOutput} =          Execute                 cat errStream
+    ${errOutput} =          Execute                 cat ${TEMP_DIR}/errStream
                             Should Contain          ${errOutput}        Certificate list:(BatchSize=
-    Execute                 rm outStream
-    Execute                 rm errStream
+    [teardown]              Remove Files            ${TEMP_DIR}/outStream    ${TEMP_DIR}/errStream

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
@@ -20,6 +20,9 @@ Resource            ../commonlib.robot
 Suite Setup         Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 Test Timeout        5 minutes
 
+*** Variables ***
+${LIST_FILE}    ${TEMP_DIR}/datanode.list
+
 *** Keywords ***
 Assert Output
     [arguments]    ${output}    ${expected}    ${uuid}
@@ -31,57 +34,57 @@ Assert Output
 
 *** Test Cases ***
 List datanodes
-                        Execute      ozone admin datanode list > datanode.list
-    ${output} =         Get File     datanode.list
+                        Execute      ozone admin datanode list > ${LIST_FILE}
+    ${output} =         Get File     ${LIST_FILE}
                         Should contain   ${output}   Datanode:
                         Should contain   ${output}   Related pipelines:
 
 Filter list by UUID
-    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
+    ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
     ${output} =         Execute      ozone admin datanode list --id "${uuid}"
     Assert Output       ${output}    1    ${uuid}
 
 Filter list by Ip address
-    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
-    ${ip} =             Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$3 }'
+    ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
+    ${ip} =             Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$3 }'
     ${output} =         Execute      ozone admin datanode list --ip "${ip}"
     Assert Output       ${output}    1    ${uuid}
 
 Filter list by Hostname
-    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
-    ${hostname} =       Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$4 }'
+    ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
+    ${hostname} =       Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$4 }'
     ${output} =         Execute      ozone admin datanode list --hostname "${hostname}"
     Assert Output       ${output}    1    ${uuid}
 
 Filter list by NodeOperationalState
-    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
-    ${expected} =       Execute      grep -c 'Operational State: IN_SERVICE' datanode.list
+    ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
+    ${expected} =       Execute      grep -c 'Operational State: IN_SERVICE' ${LIST_FILE}
     ${output} =         Execute      ozone admin datanode list --operational-state IN_SERVICE
     Assert Output       ${output}    ${expected}    ${uuid}
 
 Filter list by NodeState
-    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
-    ${expected} =       Execute      grep -c 'Health State: HEALTHY' datanode.list
+    ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
+    ${expected} =       Execute      grep -c 'Health State: HEALTHY' ${LIST_FILE}
     ${output} =         Execute      ozone admin datanode list --node-state HEALTHY
     Assert Output       ${output}    ${expected}    ${uuid}
 
 Get usage info by UUID
-    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
+    ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
     ${output} =         Execute      ozone admin datanode usageinfo --uuid "${uuid}"
     Should contain      ${output}    Usage Information (1 Datanodes)
 
 Get usage info by Ip address
-    ${ip} =             Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$3 }'
+    ${ip} =             Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$3 }'
     ${output} =         Execute      ozone admin datanode usageinfo --address "${ip}"
     Should contain      ${output}    Usage Information (1 Datanodes)
 
 Get usage info by Hostname
-    ${hostname} =       Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$4 }'
+    ${hostname} =       Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$3 }' | awk -F '[/]' '{ print \$4 }'
     ${output} =         Execute      ozone admin datanode usageinfo --address "${hostname}"
     Should contain      ${output}    Usage Information (1 Datanodes)
 
 Get usage info with invalid address
-    ${uuid} =           Execute      grep '^Datanode:' datanode.list | head -1 | awk '{ print \$2 }'
+    ${uuid} =           Execute      grep '^Datanode:' ${LIST_FILE} | head -1 | awk '{ print \$2 }'
     ${output} =         Execute      ozone admin datanode usageinfo --address "${uuid}"
     Should contain      ${output}    Usage Information (0 Datanodes)
 

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -21,6 +21,7 @@ Resource            ../commonlib.robot
 *** Variables ***
 ${prefix}    generated
 ${SCM}       scm
+${TMP_JSON}  ${TEMP_DIR}/bb1.json
 
 *** Keywords ***
 
@@ -44,18 +45,18 @@ Test ozone shell
                     Should Be Equal     ${result}       10995116277760
     ${result} =     Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1 --space-quota 10TB --namespace-quota 100
                     Should Be Empty     ${result}
-                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > bb1.json
-    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .storageType' bb1.json
+                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > ${TMP_JSON}
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .storageType' ${TMP_JSON}
                     Should Be Equal     ${result}       DISK
-    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' bb1.json
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' ${TMP_JSON}
                     Should Be Equal     ${result}       10995116277760
-    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' bb1.json
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' ${TMP_JSON}
                     Should Be Equal     ${result}       100
                     Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 1TB --namespace-quota 1000
-                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > bb1.json
-    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' bb1.json
+                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > ${TMP_JSON}
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' ${TMP_JSON}
                     Should Be Equal     ${result}       1099511627776
-    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' bb1.json
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' ${TMP_JSON}
                     Should Be Equal     ${result}       1000
     ${result} =     Execute             ozone sh bucket list ${protocol}${server}/${volume}/ | jq -r '.[] | select(.name=="bb1") | .volumeName'
                     Should Be Equal     ${result}       ${volume}
@@ -75,16 +76,16 @@ Test ozone shell
                     Execute             ozone sh bucket delete -r --yes ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
                     Execute             ozone sh volume create ${protocol}${server}/${volume}
-                    Execute             ozone sh volume info ${protocol}${server}/${volume} > volume.json
-    ${result} =     Execute             jq -r '. | select(.name=="${volume}") | .quotaInBytes' volume.json
+                    Execute             ozone sh volume info ${protocol}${server}/${volume} > ${TMP_JSON}
+    ${result} =     Execute             jq -r '. | select(.name=="${volume}") | .quotaInBytes' ${TMP_JSON}
                     Should Be Equal     ${result}       -1
-    ${result} =     Execute             jq -r '. | select(.name=="${volume}") | .quotaInNamespace' volume.json
+    ${result} =     Execute             jq -r '. | select(.name=="${volume}") | .quotaInNamespace' ${TMP_JSON}
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1
-                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > bb1.json
-    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' bb1.json
+                    Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 > ${TMP_JSON}
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInBytes' ${TMP_JSON}
                     Should Be Equal     ${result}       -1
-    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' bb1.json
+    ${result} =     Execute             jq -r '. | select(.name=="bb1") | .quotaInNamespace' ${TMP_JSON}
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/cli/classpath.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/cli/classpath.robot
@@ -23,24 +23,25 @@ Suite Setup         Find Jars Dir
 
 *** Test Cases ***
 Ignores HADOOP_CLASSPATH if OZONE_CLASSPATH is set
-    [setup]    Create File         %{HDDS_LIB_JARS_DIR}/hadoop-classpath.jar
-    Set Environment Variable   HADOOP_CLASSPATH  %{HDDS_LIB_JARS_DIR}/hadoop-classpath.jar
+    [setup]    Create File         ${TEMP_DIR}/hadoop-classpath.jar
+    Set Environment Variable   HADOOP_CLASSPATH  ${TEMP_DIR}/hadoop-classpath.jar
     Set Environment Variable   OZONE_CLASSPATH   ${EMPTY}
     ${output} =         Execute          ozone classpath ozone-insight
                         Should Contain   ${output}   hdds-interface
-                        Should Not Contain   ${output}   %{HDDS_LIB_JARS_DIR}/hadoop-classpath.jar
-    [teardown]    Remove File         %{HDDS_LIB_JARS_DIR}/hadoop-classpath.jar
+                        Should Not Contain   ${output}   ${TEMP_DIR}/hadoop-classpath.jar
+    [teardown]    Remove File         ${TEMP_DIR}/hadoop-classpath.jar
 
 Picks up items from OZONE_CLASSPATH
-    [setup]    Create File         %{HDDS_LIB_JARS_DIR}/ozone-classpath.jar
-    Set Environment Variable   OZONE_CLASSPATH  %{HDDS_LIB_JARS_DIR}/ozone-classpath.jar
+    [setup]    Create File         ${TEMP_DIR}/ozone-classpath.jar
+    Set Environment Variable   OZONE_CLASSPATH  ${TEMP_DIR}/ozone-classpath.jar
     ${output} =         Execute          ozone classpath ozone-insight
-                        Should Contain   ${output}   %{HDDS_LIB_JARS_DIR}/ozone-classpath.jar
-    [teardown]    Remove File         %{HDDS_LIB_JARS_DIR}/ozone-classpath.jar
+                        Should Contain   ${output}   ${TEMP_DIR}/ozone-classpath.jar
+    [teardown]    Remove File         ${TEMP_DIR}/ozone-classpath.jar
 
-Adds optional dir entries
-    [setup]    Create File         %{HDDS_LIB_JARS_DIR}/ozone-insight/optional.jar
-    Set Environment Variable   OZONE_CLASSPATH  ${EMPTY}
-    ${output} =         Execute          ozone classpath ozone-insight
-                        Should Contain   ${output}   %{HDDS_LIB_JARS_DIR}/ozone-insight/optional.jar
-    [teardown]    Remove File    %{HDDS_LIB_JARS_DIR}/ozone-insight/optional.jar
+# disabled: cannot implement with read-only working dir
+# Adds optional dir entries
+#     [setup]    Create File         %{HDDS_LIB_JARS_DIR}/ozone-insight/optional.jar
+#     Set Environment Variable   OZONE_CLASSPATH  ${EMPTY}
+#     ${output} =         Execute          ozone classpath ozone-insight
+#                         Should Contain   ${output}   %{HDDS_LIB_JARS_DIR}/ozone-insight/optional.jar
+#     [teardown]    Remove File    %{HDDS_LIB_JARS_DIR}/ozone-insight/optional.jar

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
@@ -35,7 +35,7 @@ Test ozone debug read-replicas with corrupt block replica
     Should Be Equal As Integers         ${count_files}     7
 
     ${json} =                           Read Replicas Manifest
-    ${md5sum} =                         Execute     md5sum testfile | awk '{print $1}'
+    ${md5sum} =                         Execute     md5sum ${TEMP_DIR}/${TESTFILE} | awk '{print $1}'
 
     FOR    ${replica}    IN RANGE    3
         ${datanode} =    Set Variable    ${json}[blocks][0][replicas][${replica}][hostname]

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-dead-datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-dead-datanode.robot
@@ -34,7 +34,7 @@ Test ozone debug read-replicas with one datanode DEAD
     Should Be Equal As Integers    ${count_files}     5
 
     ${json} =                      Read Replicas Manifest
-    ${md5sum} =                    Execute     md5sum testfile | awk '{print $1}'
+    ${md5sum} =                    Execute     md5sum ${TEMP_DIR}/${TESTFILE} | awk '{print $1}'
 
     FOR    ${replica}    IN RANGE    2
         Verify Healthy Replica   ${json}    ${replica}    ${md5sum}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-lease-recovery.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-lease-recovery.robot
@@ -30,8 +30,8 @@ ${TESTFILE}         testfile22
 Create volume bucket and put key
     Execute                 ozone sh volume create /${VOLUME}
     Execute                 ozone sh bucket create /${VOLUME}/${BUCKET}
-    Create File             ${TESTFILE}
-    Execute                 ozone sh key put /${VOLUME}/${BUCKET}/${TESTFILE} ${TESTFILE}
+    Create File             ${TEMP_DIR}/${TESTFILE}
+    Execute                 ozone sh key put /${VOLUME}/${BUCKET}/${TESTFILE} ${TEMP_DIR}/${TESTFILE}
 
 *** Test Cases ***
 Test ozone debug recover for o3fs

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
@@ -35,7 +35,7 @@ Test ozone debug read-replicas with one datanode STALE
     Should Be Equal As Integers    ${count_files}     7
 
     ${json} =                      Read Replicas Manifest
-    ${md5sum} =                    Execute     md5sum testfile | awk '{print $1}'
+    ${md5sum} =                    Execute     md5sum ${TEMP_DIR}/${TESTFILE} | awk '{print $1}'
 
     FOR    ${replica}    IN RANGE    3
         ${datanode} =    Set Variable    ${json}[blocks][0][replicas][${replica}][hostname]

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -32,8 +32,8 @@ ${TESTFILE}         testfile
 Write keys
     Execute             ozone sh volume create o3://om/${VOLUME} --space-quota 100TB --namespace-quota 100
     Execute             ozone sh bucket create o3://om/${VOLUME}/${BUCKET} --space-quota 1TB
-    Execute             dd if=/dev/urandom of=${TESTFILE} bs=100000 count=15
-    Execute             ozone sh key put o3://om/${VOLUME}/${BUCKET}/${TESTFILE} ${TESTFILE}
+    Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE} bs=100000 count=15
+    Execute             ozone sh key put o3://om/${VOLUME}/${BUCKET}/${TESTFILE} ${TEMP_DIR}/${TESTFILE}
 
 *** Test Cases ***
 Test ozone debug read-replicas
@@ -44,7 +44,7 @@ Test ozone debug read-replicas
     Should Be Equal As Integers         ${count_files}     7
 
     ${json} =                           Read Replicas Manifest
-    ${md5sum} =                         Execute     md5sum ${TESTFILE} | awk '{print $1}'
+    ${md5sum} =                         Execute     md5sum ${TEMP_DIR}/${TESTFILE} | awk '{print $1}'
 
     FOR    ${replica}    IN RANGE    3
         Verify Healthy Replica   ${json}    ${replica}    ${md5sum}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
@@ -20,8 +20,8 @@ Resource            ../lib/os.robot
 
 *** Keywords ***
 Execute read-replicas CLI tool
-    Execute                         ozone debug -Dozone.network.topology.aware.read=true read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
-    ${directory} =                  Execute     ls -d /opt/hadoop/${VOLUME}_${BUCKET}_${TESTFILE}_*/ | tail -n 1
+    Execute                         ozone debug -Dozone.network.topology.aware.read=true read-replicas --output-dir ${TEMP_DIR} o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
+    ${directory} =                  Execute     ls -d ${TEMP_DIR}/${VOLUME}_${BUCKET}_${TESTFILE}_*/ | tail -n 1
     Directory Should Exist          ${directory}
     File Should Exist               ${directory}/${TESTFILE}_manifest
     [Return]                        ${directory}
@@ -40,7 +40,7 @@ Read Replicas Manifest
 Validate JSON
     [arguments]                     ${json}
     Should Be Equal                 ${json}[filename]                   ${VOLUME}/${BUCKET}/${TESTFILE}
-    ${file_size} =                  Get File Size                       ${TESTFILE}
+    ${file_size} =                  Get File Size                       ${TEMP_DIR}/${TESTFILE}
     Should Be Equal                 ${json}[datasize]                   ${file_size}
     Should Be Equal As Integers     ${json}[blocks][0][blockIndex]      1
     Should Not Be Empty             Convert To String       ${json}[blocks][0][containerId]

--- a/hadoop-ozone/dist/src/main/smoketest/httpfs/operations.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/httpfs/operations.robot
@@ -42,8 +42,3 @@ Execute create file command
     ${output2}        Run process       curl -X PUT -T ${file_name} ${curl_extra_commands} "${final_url2}" -H"Content-Type: application/octet-stream"   shell=True
     Should Be Equal As Integers         ${output2.rc}    0
     [return]          ${output2}
-
-Create file
-    [Arguments]     ${file_name}
-    Run process     touch ${file_name}  shell=True
-    Run process     echo "Hello world!">${file_name}     shell=True

--- a/hadoop-ozone/dist/src/main/smoketest/httpfs/operations_tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/httpfs/operations_tests.robot
@@ -18,6 +18,7 @@ Documentation       HttpFS gateway test with curl commands
 Library             Process
 Library             String
 Library             BuiltIn
+Library             OperatingSystem
 Resource            operations.robot
 Resource            ../lib/os.robot
 Resource            ../commonlib.robot
@@ -61,10 +62,10 @@ Create second bucket
     Should contain  ${bucket.stdout}   true
 
 Create local testfile
-    Create file       testfile
+    Create File       ${TEMP_DIR}/testfile    "Hello world!"
 
 Create testfile
-    ${file} =       Execute create file command     ${volume}/buck1/testfile     testfile
+    ${file} =       Execute create file command     ${volume}/buck1/testfile     ${TEMP_DIR}/testfile
     Should contain     ${file.stdout}     http://httpfs:14000/webhdfs/v1/${volume}/buck1/testfile
 
 Read file

--- a/hadoop-ozone/dist/src/main/smoketest/omha/data-creation-before-om-bootstrap.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/data-creation-before-om-bootstrap.robot
@@ -20,7 +20,7 @@ Test Timeout        5 minutes
 Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 
 *** Variables ***
-${TMP_FILE}         tmp.txt
+${TMP_FILE}    ${TEMP_DIR}/tmp.txt
 ${VOLUME}
 ${BUCKET}
 ${SNAP_1}
@@ -36,19 +36,6 @@ Create volume and bucket
                         Should Be Empty     ${vol_res}
     ${bucket_res} =     Execute             ozone sh bucket create /${volume}/${bucket}
                         Should Be Empty     ${bucket_res}
-
-Create tmp file
-    [arguments]         ${file_name}
-    ${create_res} =     Execute             touch ${file_name}
-                        Should Be Empty     ${create_res}
-    ${ls_grep_res} =    Execute             ls -lah | grep '${file_name}'
-                        Should contain      ${ls_grep_res}      ${file_name}
-
-Delete tmp file
-    [arguments]         ${file_name}
-    Execute             rm ${file_name}
-    ${file_exists} =    Execute             [[ -f ${file_name} ]] && echo "File exists" || echo "File doesn't exist"
-                        Should contain      ${file_exists}      File doesn't exist
 
 Create a key and set contents same as the keyName
     [arguments]         ${volume}           ${bucket}      ${key_prefix}       ${key_name}         ${tmp_file}
@@ -83,14 +70,9 @@ Create 100 metadata keys under /${VOLUME}/${BUCKET}
 Create snapshot '${SNAP_1}'
     Create snapshot         ${VOLUME}               ${BUCKET}       ${SNAP_1}
 
-Create tmp file to be used for key creation
-    Create tmp file         ${TMP_FILE}
-
 Create 2 actual keys with prefix '${KEY_PREFIX}', key contents the same as the key name
     Create actual keys      ${VOLUME}               ${BUCKET}       ${KEY_PREFIX}       ${KEY_1}        ${KEY_2}        ${TMP_FILE}
+    [teardown]    Remove File    ${TMP_FILE}
 
 Create snapshot '${SNAP_2}'
     Create snapshot         ${VOLUME}               ${BUCKET}       ${SNAP_2}
-
-Cleanup tmp file
-    Delete tmp file         ${TMP_FILE}

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -21,13 +21,16 @@ Library             BuiltIn
 Resource            ../commonlib.robot
 Test Timeout        5 minutes
 
+*** Variables ***
+${TOKEN_FILE}    ${TEMP_DIR}/ozone.token
+
 *** Keywords ***
 Get and use Token in Secure Cluster
     Run Keyword   Kinit test user     testuser     testuser.keytab
-    Execute                      ozone sh token get -t ./ozone.token
-    File Should Not Be Empty     ./ozone.token
+    Execute                      ozone sh token get -t ${TOKEN_FILE}
+    File Should Not Be Empty     ${TOKEN_FILE}
     Execute                      kdestroy
-    Set Environment Variable     HADOOP_TOKEN_FILE_LOCATION    ./ozone.token
+    Set Environment Variable     HADOOP_TOKEN_FILE_LOCATION    ${TOKEN_FILE}
     ${output} =                  Execute             ozone sh volume list /
     Should not contain           ${output}           Client cannot authenticate
     Remove Environment Variable  HADOOP_TOKEN_FILE_LOCATION
@@ -36,13 +39,13 @@ Get and use Token in Secure Cluster
     Run Keyword                  Kinit test user     testuser  testuser.keytab
 
 Get Token in Unsecure Cluster
-    ${output} =                  Execute             ozone sh token get -t ./ozone.token
+    ${output} =                  Execute             ozone sh token get -t ${TOKEN_FILE}
     Should Contain               ${output}           ozone sh token get
     Should Contain               ${output}           only when security is enabled
 
 # should be executed after Get Token
 Print Valid Token File
-    ${output} =                  Execute             ozone sh token print -t ./ozone.token
+    ${output} =                  Execute             ozone sh token print -t ${TOKEN_FILE}
     Should Not Be Empty          ${output}
 
 Print Nonexistent Token File
@@ -50,20 +53,20 @@ Print Nonexistent Token File
     Should Contain               ${output}           operation failed as token file: /asdf
 
 Renew Token in Secure Cluster
-    ${output} =                  Execute             ozone sh token renew -t ./ozone.token
+    ${output} =                  Execute             ozone sh token renew -t ${TOKEN_FILE}
     Should contain               ${output}           Token renewed successfully
 
 Renew Token in Unsecure Cluster
-    ${output} =                  Execute             ozone sh token renew -t ./ozone.token
+    ${output} =                  Execute             ozone sh token renew -t ${TOKEN_FILE}
     Should Contain               ${output}           ozone sh token renew
     Should Contain               ${output}           only when security is enabled
 
 Cancel Token in Secure Cluster
-    ${output} =                  Execute             ozone sh token cancel -t ./ozone.token
+    ${output} =                  Execute             ozone sh token cancel -t ${TOKEN_FILE}
     Should contain               ${output}           Token canceled successfully
 
 Cancel Token in Unsecure Cluster
-    ${output} =                  Execute             ozone sh token cancel -t ./ozone.token
+    ${output} =                  Execute             ozone sh token cancel -t ${TOKEN_FILE}
     Should Contain               ${output}           ozone sh token cancel
     Should Contain               ${output}           only when security is enabled
 

--- a/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-acls.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/snapshot/snapshot-acls.robot
@@ -64,10 +64,10 @@ Test reading first snapshot as user2
     Execute             kdestroy
     Kinit test user     ${USER2}                ${USER2}.keytab
     ${keyDest} =        Generate Random String  5   [LOWER]
-    ${result} =         Get key                 ${FIRST_SNAPSHOT}     ${keyDest}
+    ${result} =         Get key                 ${FIRST_SNAPSHOT}     ${TEMP_DIR}/${keyDest}
     Should contain      ${result}               PERMISSION_DENIED
 
 Test reading second snapshot as user2
     ${keyDest} =            Generate Random String  5   [LOWER]
-    ${result} =             Get key                 ${SECOND_SNAPSHOT}     ${keyDest}
+    ${result} =             Get key                 ${SECOND_SNAPSHOT}     ${TEMP_DIR}/${keyDest}
     Should not contain      ${result}               PERMISSION_DENIED


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance check relies on a hack (`sudo chmod -R a+rwX hadoop-ozone/dist/target`) to let all tests pass, because some of those assume "current directory" is writable.  Developers may encounter the same problem locally, where such hack is not desired.

Most acceptance tests already use `/tmp` for temporary files.  The goal of this change is to fix all remaining tests, which rely on writable working dir.

- Create local files in `${TEMP_DIR}` instead of the working dir.
- Configure `ozone.http.basedir`, because S3 Gateway also defaults to the working dir.
- Simplify some tests to use built-in keywords.
- Disable the test case `Adds optional dir entries`, which needs to create subdir in `share/ozone/lib/`.

https://issues.apache.org/jira/browse/HDDS-11103

## How was this patch tested?

Removed the `chmod` hack, so existing tests now run in "read-only" environment, thus validate the change.

https://github.com/adoroszlai/ozone/actions/runs/9843024729