### PR TITLE
HDDS-11117. Introduce debug CLI command to show the value schema of any rocksDB

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -299,7 +299,7 @@ public class TestLDBCli {
     // Prepare scan args
     List<String> completeScanArgs = new ArrayList<>(Arrays.asList(
         "--db", dbStore.getDbLocation().getAbsolutePath(),
-        "schema",
+        "value-schema",
         "--column-family", KEY_TABLE));
 
     int exitCode = cmd.execute(completeScanArgs.toArray(new String[0]));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -59,12 +59,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.STAND_ALONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class tests `ozone debug ldb` CLI that reads from a RocksDB directory.
@@ -96,6 +99,7 @@ public class TestLDBCli {
 
     cmd = new CommandLine(new RDBParser())
         .addSubcommand(new DBScanner())
+        .addSubcommand(new ValueSchema())
         .setOut(pstdout)
         .setErr(pstderr);
 
@@ -283,6 +287,29 @@ public class TestLDBCli {
     // Check stdout
     assertEquals("{  }\n", stdout.toString());
 
+    // Check stderr
+    assertEquals("", stderr.toString());
+  }
+
+  @Test
+  void testSchemaCommand() throws IOException {
+    // Prepare dummy table
+    prepareTable(KEY_TABLE, false);
+
+    // Prepare scan args
+    List<String> completeScanArgs = new ArrayList<>(Arrays.asList(
+        "--db", dbStore.getDbLocation().getAbsolutePath(),
+        "schema",
+        "--column-family", KEY_TABLE));
+
+    int exitCode = cmd.execute(completeScanArgs.toArray(new String[0]));
+    // Check exit code. Print stderr if not expected
+    assertEquals(0, exitCode, stderr.toString());
+
+    // Check stdout
+    Pattern p = Pattern.compile(".*keyName.*", Pattern.MULTILINE);
+    Matcher m = p.matcher(stdout.toString());
+    assertTrue(m.find());
     // Check stderr
     assertEquals("", stderr.toString());
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
@@ -81,10 +81,6 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
 
     boolean success = true;
 
-    List<ColumnFamilyDescriptor> cfDescList =
-        RocksDBUtils.getColumnFamilyDescriptors(parent.getDbPath());
-    final List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
-
     String dbPath = parent.getDbPath();
     Map<String, List<String>> fields = new HashMap<>();
     success = getValueFields(dbPath, fields);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
@@ -25,8 +25,6 @@ import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.kohsuke.MetaInfServices;
-import org.rocksdb.ColumnFamilyDescriptor;
-import org.rocksdb.ColumnFamilyHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -73,12 +74,15 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
   private String dnDBSchemaVersion;
 
   @CommandLine.Option(names = {"--depth"},
-      description = "The level till which the value-schema should be shown, negative value shows full depth schema",
-      defaultValue = "-1")
+      description = "The level till which the value-schema should be shown (1-10 are the values allowed)",
+      defaultValue = "10")
   private int depth;
 
   @Override
   public Void call() throws Exception {
+    if (depth < 1 || depth > 10) {
+      throw new IOException("depth should be specified in the range [1, 10]");
+    }
 
     boolean success = true;
 
@@ -145,6 +149,8 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
   }
 
   private List<Field> getAllFields(Class clazz) {
+    // NOTE: Schema of interface type, like ReplicationConfig, cannot be fetched.
+    //       An empty list "[]" will be shown for such types of fields.
     if (clazz == null) {
       return Collections.emptyList();
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.server.JsonUtils;
+import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
+import org.apache.hadoop.hdds.utils.db.DBDefinition;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.kohsuke.MetaInfServices;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+/**
+ * Get schema of value for scm.db, om.db or container db file.
+ */
+@CommandLine.Command(
+    name = "schema",
+    description = "Schema of value in metadataTable"
+)
+@MetaInfServices(SubcommandWithParent.class)
+public class ValueSchema implements Callable<Void>, SubcommandWithParent {
+
+  @CommandLine.ParentCommand
+  private RDBParser parent;
+
+  public static final Logger LOG = LoggerFactory.getLogger(ValueSchema.class);
+
+  @CommandLine.Spec
+  private static CommandLine.Model.CommandSpec spec;
+
+  @CommandLine.Option(names = {"--column_family", "--column-family", "--cf"},
+      required = true,
+      description = "Table name")
+  private String tableName;
+
+  @CommandLine.Option(names = {"--dnSchema", "--dn-schema", "-d"},
+      description = "Datanode DB Schema Version: V1/V2/V3",
+      defaultValue = "V3")
+  private String dnDBSchemaVersion;
+
+  private static volatile boolean exception;
+
+  @Override
+  public Void call() throws Exception {
+
+    boolean success = true;
+
+    List<ColumnFamilyDescriptor> cfDescList =
+        RocksDBUtils.getColumnFamilyDescriptors(parent.getDbPath());
+    final List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
+
+    String dbPath = parent.getDbPath();
+    Map<String, List<String>> fields = new HashMap<>();
+    success = getValueFields(dbPath, fields);
+
+    out().println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(fields));
+
+    if (!success) {
+      // Trick to set exit code to 1 on error.
+      // TODO: Properly set exit code hopefully by refactoring GenericCli
+      throw new Exception(
+          "Exit code is non-zero. Check the error message above");
+    }
+    return null;
+  }
+
+  private boolean getValueFields(String dbPath, Map<String, List<String>> valueSchema) {
+
+    dbPath = removeTrailingSlashIfNeeded(dbPath);
+    DBDefinitionFactory.setDnDBSchemaVersion(dnDBSchemaVersion);
+    DBDefinition dbDefinition = DBDefinitionFactory.getDefinition(Paths.get(dbPath), new OzoneConfiguration());
+    if (dbDefinition == null) {
+      err().println("Error: Incorrect DB Path");
+      return false;
+    }
+    final DBColumnFamilyDefinition<?, ?> columnFamilyDefinition =
+        dbDefinition.getColumnFamily(tableName);
+    if (columnFamilyDefinition == null) {
+      err().print("Error: Table with name '" + tableName + "' not found");
+      return false;
+    }
+
+    Class<?> c = columnFamilyDefinition.getValueType();
+    List<Field> fieldDescriptors = getAllFields(c);
+    if (null == fieldDescriptors || fieldDescriptors.size() == 0) {
+      return false;
+    }
+
+    for (Field field : fieldDescriptors) {
+      if (!java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
+        Class<?> fieldClass;
+        if (Collection.class.isAssignableFrom(field.getType())) {
+          fieldClass = (Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
+        } else {
+          fieldClass = field.getType();
+        }
+
+        List<String> subfieldNames = new ArrayList<>();
+        if (!fieldClass.isPrimitive() && !fieldClass.equals(String.class)) {
+          List<Field> subfields = getAllFields(fieldClass);
+          for (Field subfield : subfields) {
+            if (!java.lang.reflect.Modifier.isStatic(subfield.getModifiers())) {
+              subfieldNames.add(subfield.getName());
+            }
+          }
+        }
+        valueSchema.put(field.getName(), subfieldNames);
+      }
+    }
+    return true;
+  }
+
+  private List<Field> getAllFields(Class clazz) {
+    if (clazz == null) {
+      return Collections.emptyList();
+    }
+    List<Field> result = new ArrayList<>(getAllFields(clazz.getSuperclass()));
+    List<Field> filteredFields = Arrays.stream(clazz.getDeclaredFields())
+        .filter(f -> !Modifier.isStatic(f.getModifiers()))
+        .collect(Collectors.toList());
+    result.addAll(filteredFields);
+    return result;
+  }
+
+
+  private static PrintWriter err() {
+    return spec.commandLine().getErr();
+  }
+
+  private static PrintWriter out() {
+    return spec.commandLine().getOut();
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return RDBParser.class;
+  }
+
+  private String removeTrailingSlashIfNeeded(String dbPath) {
+    if (dbPath.endsWith(OzoneConsts.OZONE_URI_DELIMITER)) {
+      dbPath = dbPath.substring(0, dbPath.length() - 1);
+    }
+    return dbPath;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
@@ -77,8 +77,6 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
       defaultValue = "-1")
   private int depth;
 
-  private static volatile boolean exception;
-
   @Override
   public Void call() throws Exception {
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
@@ -74,14 +74,14 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
   private String dnDBSchemaVersion;
 
   @CommandLine.Option(names = {"--depth"},
-      description = "The level till which the value-schema should be shown (1-10 are the values allowed)",
+      description = "The level till which the value-schema should be shown. Values in the range [0-10] are allowed)",
       defaultValue = "10")
   private int depth;
 
   @Override
   public Void call() throws Exception {
-    if (depth < 1 || depth > 10) {
-      throw new IOException("depth should be specified in the range [1, 10]");
+    if (depth < 0 || depth > 10) {
+      throw new IOException("depth should be specified in the range [0, 10]");
     }
 
     boolean success = true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

RocksDB stores data in key-value pairs. The value itself may have some kind of key-value structure. A command is needed which shows what structure this value has and prints the same. This would help in parsing and filtering the output of `ozone debug ldb scan` command to obtain only the required details from the value.
In this PR, A command `ozone debug ldb --db=<db-path> value-schema --cf=<table-name>` has been introduced, which uses java reflections to fetch the fields of the value type of a rocksDB for all levels. `--depth` option can be used to limit the hierarchy till which it fetches the fields.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11117

## How was this patch tested?

Tested manually in docker setup, also added test in TestLDBCli. Sample output:
```
sh-4.2$ ozone debug ldb --db=/data/metadata/om.db value-schema --cf=keyTable --depth=1
{
  "OmKeyInfo" : {
    "bucketName" : "String",
    "metadata" : "struct",
    "fileName" : "String",
    "creationTime" : "long",
    "isFile" : "boolean",
    "acls" : "struct",
    "keyName" : "String",
    "replicationConfig" : "struct",
    "encInfo" : "struct",
    "dataSize" : "long",
    "tags" : "struct",
    "keyLocationVersions" : "struct",
    "updateID" : "long",
    "ownerName" : "String",
    "modificationTime" : "long",
    "parentObjectID" : "long",
    "volumeName" : "String",
    "fileChecksum" : "struct",
    "objectID" : "long"
  }
}

sh-4.2$ ozone debug ldb --db=/data/metadata/om.db value-schema --cf=keyTable 
{
  "OmKeyInfo" : {
    "bucketName" : "String",
    "metadata" : { },
    "fileName" : "String",
    "creationTime" : "long",
    "isFile" : "boolean",
    "acls" : {
      "toStringMethod" : { },
      "hashCodeMethod" : { },
      "name" : "String",
      "type" : {
        "name" : "String",
        "value" : "String",
        "ordinal" : "int"
      },
      "aclScope" : {
        "name" : "String",
        "ordinal" : "int"
      },
      "aclBits" : "int"
    },
    "keyName" : "String",
    "replicationConfig" : { },
    "encInfo" : {
      "ezKeyVersionName" : "String",
      "keyName" : "String",
      "edek" : { },
      "cipherSuite" : {
        "unknownValue" : {
          "value" : "int"
        },
        "name" : "String",
        "algoBlockSize" : "int",
        "ordinal" : "int"
      },
      "version" : {
        "unknownValue" : {
          "value" : "int"
        },
        "name" : "String",
        "description" : "String",
        "version" : "int",
        "ordinal" : "int"
      },
      "iv" : { }
    },
    "dataSize" : "long",
    "tags" : { },
    "keyLocationVersions" : {
      "isMultipartKey" : "boolean",
      "locationVersionMap" : { },
      "version" : "long"
    },
    "updateID" : "long",
    "ownerName" : "String",
    "modificationTime" : "long",
    "parentObjectID" : "long",
    "volumeName" : "String",
    "fileChecksum" : { },
    "objectID" : "long"
  }
}
```