### PR TITLE
HDDS-11060. ReflectionsException caused by bad magic number

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/ValidatorRegistry.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/ValidatorRegistry.java
@@ -21,6 +21,7 @@ import org.reflections.Reflections;
 import org.reflections.scanners.MethodAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -72,6 +73,7 @@ public class ValidatorRegistry {
         .setUrls(searchUrls)
         .setScanners(new MethodAnnotationsScanner())
         .setParallel(true)
+        .filterInputsBy(new FilterBuilder().excludePattern(".*META-INF/MANIFEST.MF.*"))
     );
 
     Set<Method> describedValidators =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutVersionManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutVersionManager.java
@@ -134,7 +134,8 @@ public final class OMLayoutVersionManager
         .setUrls(ClasspathHelper.forPackage(packageName))
         .setScanners(new SubTypesScanner())
         .setExpandSuperTypes(false)
-        .setParallel(true));
+        .setParallel(true)
+        .filterInputsBy(new FilterBuilder().excludePattern(".*META-INF/MANIFEST.MF.*")));
     Set<Class<? extends OMClientRequest>> validRequests = new HashSet<>();
 
     Set<Class<? extends OMClientRequest>> subTypes =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutVersionManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutVersionManager.java
@@ -35,6 +35,7 @@ import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,7 +97,8 @@ public final class OMLayoutVersionManager
         .forPackages(packageName)
         .setScanners(new TypeAnnotationsScanner(), new SubTypesScanner())
         .setExpandSuperTypes(false)
-        .setParallel(true));
+        .setParallel(true)
+        .filterInputsBy(new FilterBuilder().excludePattern(".*META-INF/MANIFEST.MF.*")));
     Set<Class<?>> typesAnnotatedWith =
         reflections.getTypesAnnotatedWith(UpgradeActionOm.class);
     typesAnnotatedWith.forEach(actionClass -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When DEBUG logging is enabled, numerous `ReflectionsException` errors occur due to "bad magic number" caused by attempts to scan non-class files like "META-INF/MANIFEST.MF". 
```
2024-06-23 23:27:57,490 DEBUG [org.reflections-scanner-0]-org.reflections.Reflections: could not scan 
file META-INF/MANIFEST.MF in url jar:file:/opt/.../ozone-manager-VERSION.jar!/ with scanner SubTypesScanner
org.reflections.ReflectionsException: could not create class object from file META-INF/MANIFEST.MF
```
To resolve this, we can utilize `FilterBuilder` to exclude these files from the scanning process, preventing the exceptions and improving log clarity.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11060

## How was this patch tested?
NA
