### PR TITLE
HDDS-11132. Update the OLDER_CLIENT_REQUEST validations to check against bucket types.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -74,6 +74,10 @@ public enum ClientVersion implements ComponentVersion {
     return version;
   }
 
+  public int getVersion() {
+    return version;
+  }
+
   public static ClientVersion fromProtoValue(int value) {
     return BY_PROTO_VALUE.getOrDefault(value, FUTURE_VERSION);
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -301,13 +301,22 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setClientId(clientID);
   }
 
+  @VisibleForTesting
+  public OMRequest.Builder createOMRequest(Type cmdType,int clientVersion) {
+    return OMRequest.newBuilder()
+        .setCmdType(cmdType)
+        .setVersion(clientVersion)
+        .setClientId(clientID);
+  }
+
   /**
    * Submits client request to OM server.
    * @param omRequest client request
    * @return response from OM
    * @throws IOException thrown if any Protobuf service exception occurs
    */
-  private OMResponse submitRequest(OMRequest omRequest)
+  @VisibleForTesting
+  public OMResponse submitRequest(OMRequest omRequest)
       throws IOException {
     OMRequest.Builder  builder = OMRequest.newBuilder(omRequest);
     // Insert S3 Authentication information for each request.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -302,10 +302,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @VisibleForTesting
-  public OMRequest.Builder createOMRequest(Type cmdType,int clientVersion) {
-    return OMRequest.newBuilder()
-        .setCmdType(cmdType)
-        .setVersion(clientVersion)
+  public OMRequest.Builder createOMRequest(Type cmdType, int clientVersion) {
+    return OMRequest.newBuilder().setCmdType(cmdType).setVersion(clientVersion)
         .setClientId(clientID);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -276,9 +276,9 @@ public class TestObjectStoreWithFSO {
     OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
     assertEquals(bucketName, ozoneBucket.getName());
     String data = "random data";
-    try(OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(key,
+    try (OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(key,
         data.length(), ReplicationType.RATIS, ReplicationFactor.ONE,
-        new HashMap<>())){
+        new HashMap<>())) {
       ozoneOutputStream.write(data.getBytes(StandardCharsets.UTF_8));
     }
     // try to read from older client
@@ -292,7 +292,7 @@ public class TestObjectStoreWithFSO {
           () -> getFileStatus(keyArgs, clientVersion),
           "Expecting Unsupported Operation Exception");
     } else {
-      assertNotNull(getFileStatus(keyArgs,clientVersion));
+      assertNotNull(getFileStatus(keyArgs, clientVersion));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -460,7 +460,7 @@ public class OMBucketCreateRequest extends OMClientRequest {
    * they do not understand.
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CreateBucket
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -281,7 +281,7 @@ public class OMBucketDeleteRequest extends OMClientRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.DeleteBucket
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -432,7 +432,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CreateDirectory
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -425,7 +425,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CreateFile
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -298,7 +298,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.AllocateBlock
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -457,7 +457,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CommitKey
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -423,7 +423,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CreateKey
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -233,7 +233,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.DeleteKey
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -270,7 +270,7 @@ public class OMKeyRenameRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.RenameKey
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -351,7 +351,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.DeleteKeys
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -297,7 +297,7 @@ public class OMKeysRenameRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.RenameKeys
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -165,7 +165,7 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.AddAcl
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -166,7 +166,7 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.RemoveAcl
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -162,7 +162,7 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.SetAcl
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -320,7 +320,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.InitiateMultiPartUpload
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -289,7 +289,7 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.AbortMultiPartUpload
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -380,7 +380,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CommitMultiPartUpload
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -742,7 +742,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
    * @throws OMException if the request is invalid
    */
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CompleteMultiPartUpload
   )

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/ValidationCondition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/ValidationCondition.java
@@ -47,7 +47,7 @@ public enum ValidationCondition {
   OLDER_CLIENT_REQUESTS {
     @Override
     public boolean shouldApply(OMRequest req, ValidationContext ctx) {
-      return req.getVersion() < ClientVersion.CURRENT_VERSION;
+      return req.getVersion() < ClientVersion.BUCKET_LAYOUT_SUPPORT.getVersion();
     }
   };
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/ValidationCondition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/ValidationCondition.java
@@ -42,9 +42,10 @@ public enum ValidationCondition {
 
   /**
    * Classifies validations that has to run, when the client uses an older
-   * protocol version than the server.
+   * protocol version than the bucket layout version i.e the version where
+   * bucket types where introduced.
    */
-  OLDER_CLIENT_REQUESTS {
+  OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS {
     @Override
     public boolean shouldApply(OMRequest req, ValidationContext ctx) {
       return req.getVersion() < ClientVersion.BUCKET_LAYOUT_SUPPORT.getVersion();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -629,7 +629,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.LookupKey
   )
@@ -656,7 +656,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.LookupKey
   )
@@ -743,7 +743,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.ListKeys
   )
@@ -770,7 +770,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.ListKeys
   )
@@ -831,7 +831,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.ListTrash
   )
@@ -861,7 +861,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.ListTrash
   )
@@ -1048,7 +1048,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.GetFileStatus
   )
@@ -1078,7 +1078,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.GetFileStatus
   )
@@ -1127,7 +1127,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.LookupFile
   )
@@ -1155,7 +1155,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.LookupFile
   )
@@ -1237,7 +1237,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.ListStatus
   )
@@ -1265,7 +1265,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   @RequestFeatureValidator(
-      conditions = ValidationCondition.OLDER_CLIENT_REQUESTS,
+      conditions = ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS,
       processingPhase = RequestProcessingPhase.POST_PROCESS,
       requestType = Type.ListStatus
   )

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestRequestFeatureValidatorProcessor.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestRequestFeatureValidatorProcessor.java
@@ -365,7 +365,7 @@ public class TestRequestFeatureValidatorProcessor {
 
   private ValidationCondition[] someConditions() {
     return
-        new ValidationCondition[] {ValidationCondition.OLDER_CLIENT_REQUESTS};
+        new ValidationCondition[] {ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS };
   }
 
   private ValidationCondition[] emptyConditions() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestRequestValidations.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestRequestValidations.java
@@ -284,7 +284,8 @@ public class TestRequestValidations {
   }
 
   private int olderClientVersion() {
-    return ClientVersion.CURRENT_VERSION - 1;
+    // older than bucket type version
+    return ClientVersion.BUCKET_LAYOUT_SUPPORT.getVersion() - 1;
   }
 
   private int currentClientVersion() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestValidatorRegistry.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/TestValidatorRegistry.java
@@ -34,7 +34,7 @@ import static java.util.Collections.emptyList;
 import static org.apache.hadoop.ozone.om.request.validation.RequestProcessingPhase.POST_PROCESS;
 import static org.apache.hadoop.ozone.om.request.validation.RequestProcessingPhase.PRE_PROCESS;
 import static org.apache.hadoop.ozone.om.request.validation.ValidationCondition.CLUSTER_NEEDS_FINALIZATION;
-import static org.apache.hadoop.ozone.om.request.validation.ValidationCondition.OLDER_CLIENT_REQUESTS;
+import static org.apache.hadoop.ozone.om.request.validation.ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS;
 import static org.apache.hadoop.ozone.om.request.validation.testvalidatorset1.GeneralValidatorsForTesting.startValidatorTest;
 import static org.apache.hadoop.ozone.om.request.validation.testvalidatorset1.GeneralValidatorsForTesting.finishValidatorTest;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateDirectory;
@@ -107,7 +107,7 @@ public class TestValidatorRegistry {
     ValidatorRegistry registry = new ValidatorRegistry(PACKAGE);
     List<Method> validators =
         registry.validationsFor(
-            asList(OLDER_CLIENT_REQUESTS), CreateKey, PRE_PROCESS);
+            asList(OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS), CreateKey, PRE_PROCESS);
 
     assertEquals(2, validators.size());
     List<String> methodNames =
@@ -121,7 +121,7 @@ public class TestValidatorRegistry {
     ValidatorRegistry registry = new ValidatorRegistry(PACKAGE);
     List<Method> validators =
         registry.validationsFor(
-            asList(OLDER_CLIENT_REQUESTS), CreateKey, POST_PROCESS);
+            asList(OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS), CreateKey, POST_PROCESS);
 
     assertEquals(2, validators.size());
     List<String> methodNames =
@@ -138,7 +138,7 @@ public class TestValidatorRegistry {
             asList(CLUSTER_NEEDS_FINALIZATION), CreateVolume, PRE_PROCESS);
     List<Method> newClientValidators =
         registry.validationsFor(
-            asList(OLDER_CLIENT_REQUESTS), CreateVolume, PRE_PROCESS);
+            asList(OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS), CreateVolume, PRE_PROCESS);
 
     assertEquals(1, preFinalizeValidators.size());
     assertEquals(1, newClientValidators.size());
@@ -155,7 +155,7 @@ public class TestValidatorRegistry {
             asList(CLUSTER_NEEDS_FINALIZATION), CreateVolume, POST_PROCESS);
     List<Method> oldClientValidators =
         registry.validationsFor(
-            asList(OLDER_CLIENT_REQUESTS), CreateVolume, POST_PROCESS);
+            asList(OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS), CreateVolume, POST_PROCESS);
 
     assertEquals(1, preFinalizeValidators.size());
     assertEquals(1, oldClientValidators.size());
@@ -169,7 +169,8 @@ public class TestValidatorRegistry {
     ValidatorRegistry registry = new ValidatorRegistry(PACKAGE);
     List<Method> validators =
         registry.validationsFor(
-            asList(CLUSTER_NEEDS_FINALIZATION, OLDER_CLIENT_REQUESTS),
+            asList(CLUSTER_NEEDS_FINALIZATION,
+                OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS),
             CreateKey, POST_PROCESS);
 
     assertEquals(3, validators.size());
@@ -185,7 +186,7 @@ public class TestValidatorRegistry {
     ValidatorRegistry registry = new ValidatorRegistry(PACKAGE_WO_VALIDATORS);
 
     assertTrue(registry.validationsFor(
-        asList(OLDER_CLIENT_REQUESTS), CreateKey, PRE_PROCESS).isEmpty());
+        asList(OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS), CreateKey, PRE_PROCESS).isEmpty());
   }
 
   @Test
@@ -207,7 +208,7 @@ public class TestValidatorRegistry {
     ValidatorRegistry registry = new ValidatorRegistry(PACKAGE);
 
     assertTrue(registry.validationsFor(
-        asList(OLDER_CLIENT_REQUESTS), CreateDirectory, null).isEmpty());
+        asList(OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS), CreateDirectory, null).isEmpty());
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/testvalidatorset1/GeneralValidatorsForTesting.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/testvalidatorset1/GeneralValidatorsForTesting.java
@@ -29,7 +29,7 @@ import java.util.List;
 import static org.apache.hadoop.ozone.om.request.validation.RequestProcessingPhase.POST_PROCESS;
 import static org.apache.hadoop.ozone.om.request.validation.RequestProcessingPhase.PRE_PROCESS;
 import static org.apache.hadoop.ozone.om.request.validation.ValidationCondition.CLUSTER_NEEDS_FINALIZATION;
-import static org.apache.hadoop.ozone.om.request.validation.ValidationCondition.OLDER_CLIENT_REQUESTS;
+import static org.apache.hadoop.ozone.om.request.validation.ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateKey;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateVolume;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
@@ -109,7 +109,7 @@ public final class GeneralValidatorsForTesting {
   }
 
   @RequestFeatureValidator(
-      conditions = { OLDER_CLIENT_REQUESTS },
+      conditions = { OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS },
       processingPhase = PRE_PROCESS,
       requestType = CreateKey)
   public static OMRequest oldClientPreProcessCreateKeyValidator(
@@ -119,7 +119,7 @@ public final class GeneralValidatorsForTesting {
   }
 
   @RequestFeatureValidator(
-      conditions = { OLDER_CLIENT_REQUESTS },
+      conditions = { OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS },
       processingPhase = POST_PROCESS,
       requestType = CreateKey)
   public static OMResponse oldClientPostProcessCreateKeyValidator(
@@ -129,7 +129,8 @@ public final class GeneralValidatorsForTesting {
   }
 
   @RequestFeatureValidator(
-      conditions = { CLUSTER_NEEDS_FINALIZATION, OLDER_CLIENT_REQUESTS },
+      conditions = { CLUSTER_NEEDS_FINALIZATION,
+          OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS },
       processingPhase = PRE_PROCESS,
       requestType = CreateVolume)
   public static OMRequest multiPurposePreProcessCreateVolumeValidator(
@@ -139,7 +140,7 @@ public final class GeneralValidatorsForTesting {
   }
 
   @RequestFeatureValidator(
-      conditions = { OLDER_CLIENT_REQUESTS, CLUSTER_NEEDS_FINALIZATION },
+      conditions = { OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS, CLUSTER_NEEDS_FINALIZATION },
       processingPhase = POST_PROCESS,
       requestType = CreateVolume)
   public static OMResponse multiPurposePostProcessCreateVolumeValidator(
@@ -149,7 +150,7 @@ public final class GeneralValidatorsForTesting {
   }
 
   @RequestFeatureValidator(
-      conditions = { OLDER_CLIENT_REQUESTS },
+      conditions = { OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS },
       processingPhase = POST_PROCESS,
       requestType = CreateKey)
   public static OMResponse oldClientPostProcessCreateKeyValidator2(
@@ -159,7 +160,7 @@ public final class GeneralValidatorsForTesting {
   }
 
   @RequestFeatureValidator(
-      conditions = {OLDER_CLIENT_REQUESTS},
+      conditions = { OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS },
       processingPhase = PRE_PROCESS,
       requestType = DeleteKeys
   )
@@ -173,7 +174,7 @@ public final class GeneralValidatorsForTesting {
   }
 
   @RequestFeatureValidator(
-      conditions = {OLDER_CLIENT_REQUESTS},
+      conditions = { OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS },
       processingPhase = POST_PROCESS,
       requestType = DeleteKeys
   )

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/testvalidatorset2/ValidatorsForOnlyOldClientValidations.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/validation/testvalidatorset2/ValidatorsForOnlyOldClientValidations.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 
 import static org.apache.hadoop.ozone.om.request.validation.RequestProcessingPhase.PRE_PROCESS;
-import static org.apache.hadoop.ozone.om.request.validation.ValidationCondition.OLDER_CLIENT_REQUESTS;
+import static org.apache.hadoop.ozone.om.request.validation.ValidationCondition.OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateKey;
 
 /**
@@ -33,7 +33,7 @@ public final class ValidatorsForOnlyOldClientValidations {
   private ValidatorsForOnlyOldClientValidations() { }
 
   @RequestFeatureValidator(
-      conditions = { OLDER_CLIENT_REQUESTS },
+      conditions = { OLDER_BUCKET_LAYOUT_CLIENT_REQUESTS },
       processingPhase = PRE_PROCESS,
       requestType = CreateKey)
   public static OMRequest oldClientPreProcessCreateKeyValidator2(


### PR DESCRIPTION
## What changes were proposed in this pull request?
With the introduction of a new client version in https://issues.apache.org/jira/browse/HDDS-10983, the latest version is 4.
The OLDER_CLIENT_REQUEST validation checked against the latest versions for access to newer non-legacy buckets but since the addition of a newer version all client versions prior to 4 becomes an older client and blocks access to OBS/FSO buckets.  This should be fixed to check against version 3.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11132

## How was this patch tested?
Added unit test
