### PR TITLE
HDDS-10841. Snapshot diff CLI help should print default value for parameters

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -63,7 +63,10 @@ public class SnapshotDiffHandler extends Handler {
 
   @CommandLine.Option(names = {"-p", "--page-size"},
       description = "number of diff entries to be returned in the response" +
-          " (optional)")
+          " (optional)",
+      defaultValue = "1000",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS
+  )
   private int pageSize;
 
   @CommandLine.Option(names = {"--ffd", "--force-full-diff"},

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotDiffHandler.java
@@ -62,8 +62,7 @@ public class SnapshotDiffHandler extends Handler {
   private String token;
 
   @CommandLine.Option(names = {"-p", "--page-size"},
-      description = "number of diff entries to be returned in the response" +
-          " (optional)",
+      description = "number of diff entries to be returned in the response",
       defaultValue = "1000",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS
   )


### PR DESCRIPTION
## What changes were proposed in this pull request?

The pagination logic is already there, so this jira only prints default value for snapshot diff cli.
The default value is 1000 according to:
https://github.com/apache/ozone/blob/4d29b6ce30019fb9b47d5f1a4a88645214cf23b9/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java#L551-L552
And
https://github.com/apache/ozone/blob/4d29b6ce30019fb9b47d5f1a4a88645214cf23b9/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java#L201-L204
And
https://github.com/apache/ozone/blob/4d29b6ce30019fb9b47d5f1a4a88645214cf23b9/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java#L758-L760

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10841

## How was this patch tested?
1. Build in local docker containers
`mvn clean install -DskipTests` and `docker-compose up -d --scale datanode=3`
2. Run CLI commands in docker prints default 1000 as pageSize:
```
docker exec -it ozone-om-1 sh -c "ozone sh snapshot diff -h"
Usage: ozone sh snapshot diff [-chV] [--json] [-p=<pageSize>] [-t=<token>]
                              <value> <fromSnapshot> <toSnapshot>
Get the differences between two snapshots
      <value>           URI of the volume/bucket.
                        Ozone URI could either be a full URI or short URI.
                        Full URI should start with o3://, in case of non-HA
                        clusters it should be followed by the host name and
                        optionally the port number. In case of HA clusters
                        the service id should be used. Service id provides a
                        logical name for multiple hosts and it is defined
                        in the property ozone.om.service.ids.
                        Example of a full URI with host name and port number
                        for a key:
                        o3://omhostname:9862/vol1/bucket1/key1
                        With a service id for a volume:
                        o3://omserviceid/vol1/
                        Short URI should start from the volume.
                        Example of a short URI for a bucket:
                        vol1/bucket1
                        Any unspecified information will be identified from
                        the config files.

      <fromSnapshot>    from snapshot name
      <toSnapshot>      to snapshot name
  -c, --cancel          Request to cancel a running SnapshotDiff job. If the
                          job is not IN_PROGRESS, the request will fail.
  -h, --help            Show this help message and exit.
      --json            Format output as JSON
  -p, --page-size=<pageSize>
                        number of diff entries to be returned in the response
                          (optional)
                          Default: 1000
  -t, --token=<token>   continuation token for next page (optional)
  -V, --version         Print version information and exit.
```