### PR TITLE
HDDS-11132. Update the OLDER_CLIENT_REQUEST validations so that validations don't fail

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -290,11 +290,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     transport.close();
   }
 
+
   /**
    * Returns a OMRequest builder with specified type.
    * @param cmdType type of the request
    */
-  private OMRequest.Builder createOMRequest(Type cmdType) {
+  @VisibleForTesting
+  public OMRequest.Builder createOMRequest(Type cmdType) {
     return OMRequest.newBuilder()
         .setCmdType(cmdType)
         .setVersion(ClientVersion.CURRENT_VERSION)
@@ -307,7 +309,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * @return response from OM
    * @throws IOException thrown if any Protobuf service exception occurs
    */
-  private OMResponse submitRequest(OMRequest omRequest)
+  @VisibleForTesting
+  public OMResponse submitRequest(OMRequest omRequest)
       throws IOException {
     OMRequest.Builder  builder = OMRequest.newBuilder(omRequest);
     // Insert S3 Authentication information for each request.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -23,6 +23,7 @@ import java.nio.file.InvalidPathException;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -287,13 +288,17 @@ public class OMBucketDeleteRequest extends OMClientRequest {
   )
   public static OMRequest blockBucketDeleteWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    DeleteBucketRequest request = req.getDeleteBucketRequest();
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0) {
+      DeleteBucketRequest request = req.getDeleteBucketRequest();
 
-    if (request.hasBucketName() && request.hasVolumeName()) {
-      BucketLayout bucketLayout = ctx.getBucketLayout(
-          request.getVolumeName(), request.getBucketName());
-      bucketLayout.validateSupportedOperation();
+      if (request.hasBucketName() && request.hasVolumeName()) {
+        BucketLayout bucketLayout = ctx.getBucketLayout(
+            request.getVolumeName(), request.getBucketName());
+        bucketLayout.validateSupportedOperation();
+      }
     }
     return req;
+
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -289,16 +289,16 @@ public class OMBucketDeleteRequest extends OMClientRequest {
   public static OMRequest blockBucketDeleteWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0) {
-      DeleteBucketRequest request = req.getDeleteBucketRequest();
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    DeleteBucketRequest request = req.getDeleteBucketRequest();
 
-      if (request.hasBucketName() && request.hasVolumeName()) {
-        BucketLayout bucketLayout = ctx.getBucketLayout(
-            request.getVolumeName(), request.getBucketName());
-        bucketLayout.validateSupportedOperation();
-      }
+    if (request.hasBucketName() && request.hasVolumeName()) {
+      BucketLayout bucketLayout = ctx.getBucketLayout(
+          request.getVolumeName(), request.getBucketName());
+      bucketLayout.validateSupportedOperation();
     }
     return req;
-
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -31,6 +31,7 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -438,7 +439,8 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
   )
   public static OMRequest blockCreateDirectoryWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getCreateDirectoryRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCreateDirectoryRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCreateDirectoryRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -440,7 +440,10 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
   public static OMRequest blockCreateDirectoryWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCreateDirectoryRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getCreateDirectoryRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCreateDirectoryRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -431,7 +432,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
   )
   public static OMRequest blockCreateFileWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getCreateFileRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCreateFileRequest().hasKeyArgs()) {
 
       KeyArgs keyArgs = req.getCreateFileRequest().getKeyArgs();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -433,7 +433,10 @@ public class OMFileCreateRequest extends OMKeyRequest {
   public static OMRequest blockCreateFileWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCreateFileRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getCreateFileRequest().hasKeyArgs()) {
 
       KeyArgs keyArgs = req.getCreateFileRequest().getKeyArgs();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -304,7 +305,8 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
   )
   public static OMRequest blockAllocateBlockWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getAllocateBlockRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getAllocateBlockRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getAllocateBlockRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -306,7 +306,11 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
   public static OMRequest blockAllocateBlockWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getAllocateBlockRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+
+    if (req.getAllocateBlockRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getAllocateBlockRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -471,7 +471,10 @@ public class OMKeyCommitRequest extends OMKeyRequest {
   public static OMRequest blockCommitKeyWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCommitKeyRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getCommitKeyRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCommitKeyRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -469,7 +470,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
   )
   public static OMRequest blockCommitKeyWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getCommitKeyRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCommitKeyRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCommitKeyRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -432,7 +432,10 @@ public class OMKeyCreateRequest extends OMKeyRequest {
   public static OMRequest blockCreateKeyWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCreateKeyRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getCreateKeyRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCreateKeyRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -430,7 +431,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
   )
   public static OMRequest blockCreateKeyWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getCreateKeyRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCreateKeyRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCreateKeyRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -241,7 +241,10 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
   public static OMRequest blockDeleteKeyWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getDeleteKeyRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getDeleteKeyRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getDeleteKeyRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -23,6 +23,7 @@ import java.nio.file.InvalidPathException;
 import java.util.Map;
 
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OmUtils;
@@ -239,7 +240,8 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
   )
   public static OMRequest blockDeleteKeyWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getDeleteKeyRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getDeleteKeyRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getDeleteKeyRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -23,6 +23,7 @@ import java.nio.file.InvalidPathException;
 import java.util.Map;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -276,7 +277,8 @@ public class OMKeyRenameRequest extends OMKeyRequest {
   )
   public static OMRequest blockRenameKeyWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getRenameKeyRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getRenameKeyRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getRenameKeyRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -278,7 +278,10 @@ public class OMKeyRenameRequest extends OMKeyRequest {
   public static OMRequest blockRenameKeyWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getRenameKeyRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getRenameKeyRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getRenameKeyRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -359,7 +359,10 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
   public static OMRequest blockDeleteKeysWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getDeleteKeysRequest().hasDeleteKeys()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getDeleteKeysRequest().hasDeleteKeys()) {
       DeleteKeyArgs keyArgs = req.getDeleteKeysRequest().getDeleteKeys();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.key;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -357,7 +358,8 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
   )
   public static OMRequest blockDeleteKeysWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getDeleteKeysRequest().hasDeleteKeys()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getDeleteKeysRequest().hasDeleteKeys()) {
       DeleteKeyArgs keyArgs = req.getDeleteKeysRequest().getDeleteKeys();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -305,7 +305,10 @@ public class OMKeysRenameRequest extends OMKeyRequest {
   public static OMRequest blockRenameKeysWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getRenameKeysRequest().hasRenameKeysArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getRenameKeysRequest().hasRenameKeysArgs()) {
       RenameKeysArgs keyArgs = req.getRenameKeysRequest().getRenameKeysArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.request.key;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -303,7 +304,8 @@ public class OMKeysRenameRequest extends OMKeyRequest {
   )
   public static OMRequest blockRenameKeysWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getRenameKeysRequest().hasRenameKeysArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getRenameKeysRequest().hasRenameKeysArgs()) {
       RenameKeysArgs keyArgs = req.getRenameKeysRequest().getRenameKeysArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -171,7 +172,8 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
   )
   public static OMRequest blockAddAclWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getAddAclRequest().hasObj()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getAddAclRequest().hasObj()) {
       OzoneObj obj = OzoneObjInfo.fromProtobuf(req.getAddAclRequest().getObj());
       String path = obj.getPath();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -173,7 +173,10 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
   public static OMRequest blockAddAclWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getAddAclRequest().hasObj()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getAddAclRequest().hasObj()) {
       OzoneObj obj = OzoneObjInfo.fromProtobuf(req.getAddAclRequest().getObj());
       String path = obj.getPath();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -174,7 +174,10 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
   public static OMRequest blockRemoveAclWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getRemoveAclRequest().hasObj()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getRemoveAclRequest().hasObj()) {
       OzoneObj obj =
           OzoneObjInfo.fromProtobuf(req.getRemoveAclRequest().getObj());
       String path = obj.getPath();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -172,7 +173,8 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
   )
   public static OMRequest blockRemoveAclWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getRemoveAclRequest().hasObj()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getRemoveAclRequest().hasObj()) {
       OzoneObj obj =
           OzoneObjInfo.fromProtobuf(req.getRemoveAclRequest().getObj());
       String path = obj.getPath();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -168,7 +169,8 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
   )
   public static OMRequest blockSetAclWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getSetAclRequest().hasObj()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getSetAclRequest().hasObj()) {
       OzoneObj obj =
           OzoneObjInfo.fromProtobuf(req.getSetAclRequest().getObj());
       String path = obj.getPath();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -170,7 +170,10 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
   public static OMRequest blockSetAclWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getSetAclRequest().hasObj()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getSetAclRequest().hasObj()) {
       OzoneObj obj =
           OzoneObjInfo.fromProtobuf(req.getSetAclRequest().getObj());
       String path = obj.getPath();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -326,7 +327,8 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
   )
   public static OMRequest blockInitiateMPUWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getInitiateMultiPartUploadRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getInitiateMultiPartUploadRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getInitiateMultiPartUploadRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -328,7 +328,10 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
   public static OMRequest blockInitiateMPUWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getInitiateMultiPartUploadRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getInitiateMultiPartUploadRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getInitiateMultiPartUploadRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.util.Map;
 
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -295,7 +296,8 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
   )
   public static OMRequest blockMPUAbortWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getAbortMultiPartUploadRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getAbortMultiPartUploadRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getAbortMultiPartUploadRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -297,7 +297,10 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
   public static OMRequest blockMPUAbortWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getAbortMultiPartUploadRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getAbortMultiPartUploadRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getAbortMultiPartUploadRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -388,7 +388,10 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
   public static OMRequest blockMPUCommitWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCommitMultiPartUploadRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getCommitMultiPartUploadRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCommitMultiPartUploadRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
@@ -386,7 +387,8 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
   )
   public static OMRequest blockMPUCommitWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getCommitMultiPartUploadRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCommitMultiPartUploadRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCommitMultiPartUploadRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.om.OzoneConfigUtil;
 import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
@@ -748,7 +749,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
   )
   public static OMRequest blockMPUCompleteWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
-    if (req.getCompleteMultiPartUploadRequest().hasKeyArgs()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCompleteMultiPartUploadRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCompleteMultiPartUploadRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -750,7 +750,10 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
   public static OMRequest blockMPUCompleteWithBucketLayoutFromOldClient(
       OMRequest req, ValidationContext ctx) throws IOException {
     if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) < 0 && req.getCompleteMultiPartUploadRequest().hasKeyArgs()) {
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return req;
+    }
+    if (req.getCompleteMultiPartUploadRequest().hasKeyArgs()) {
       KeyArgs keyArgs = req.getCompleteMultiPartUploadRequest().getKeyArgs();
 
       if (keyArgs.hasVolumeName() && keyArgs.hasBucketName()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -637,8 +637,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowLookupKeyResponseWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasLookupKeyResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasLookupKeyResponse()) {
       return resp;
     }
     if (resp.getLookupKeyResponse().getKeyInfo().hasEcReplicationConfig()) {
@@ -665,6 +667,9 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowLookupKeyWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return resp;
+    }
     if (ClientVersion.fromProtoValue(req.getVersion())
         .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0 || !resp.hasLookupKeyResponse()) {
       return resp;
@@ -753,8 +758,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListKeysResponseWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasListKeysResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasListKeysResponse()) {
       return resp;
     }
     List<KeyInfo> keys = resp.getListKeysResponse().getKeyInfoList();
@@ -781,8 +788,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListKeysWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0 || !resp.hasListKeysResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasListKeysResponse()) {
       return resp;
     }
 
@@ -843,8 +852,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListTrashWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasListTrashResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasListTrashResponse()) {
       return resp;
     }
     List<RepeatedKeyInfo> repeatedKeys =
@@ -874,8 +885,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListTrashWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0 || !resp.hasListTrashResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasListTrashResponse()) {
       return resp;
     }
 
@@ -1062,7 +1075,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowGetFileStatusWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasGetFileStatusResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasGetFileStatusResponse()) {
       return resp;
     }
     if (resp.getGetFileStatusResponse().getStatus().getKeyInfo()
@@ -1092,8 +1108,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowGetFileStatusWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0
-        || !resp.hasGetFileStatusResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasGetFileStatusResponse()) {
       return resp;
     }
 
@@ -1142,8 +1160,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowLookupFileWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasLookupFileResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasLookupFileResponse()) {
       return resp;
     }
     if (resp.getLookupFileResponse().getKeyInfo().hasEcReplicationConfig()) {
@@ -1171,8 +1191,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowLookupFileWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0  || !resp.hasLookupFileResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasLookupFileResponse()) {
       return resp;
     }
     KeyInfo keyInfo = resp.getLookupFileResponse().getKeyInfo();
@@ -1254,8 +1276,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListStatusResponseWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasListStatusResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasListStatusResponse()) {
       return resp;
     }
     List<OzoneFileStatusProto> statuses =
@@ -1283,8 +1307,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListStatusResponseWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (ClientVersion.fromProtoValue(req.getVersion())
-        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0 || !resp.hasListStatusResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0) {
+      return resp;
+    }
+    if (!resp.hasListStatusResponse()) {
       return resp;
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.UpgradeFinalizationStatu
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.protocolPB.OzonePBHelper;
 import org.apache.hadoop.hdds.utils.FaultInjector;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.util.PayloadUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -636,7 +637,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowLookupKeyResponseWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (!resp.hasLookupKeyResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasLookupKeyResponse()) {
       return resp;
     }
     if (resp.getLookupKeyResponse().getKeyInfo().hasEcReplicationConfig()) {
@@ -663,7 +665,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowLookupKeyWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (!resp.hasLookupKeyResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0 || !resp.hasLookupKeyResponse()) {
       return resp;
     }
     KeyInfo keyInfo = resp.getLookupKeyResponse().getKeyInfo();
@@ -750,7 +753,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListKeysResponseWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (!resp.hasListKeysResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasListKeysResponse()) {
       return resp;
     }
     List<KeyInfo> keys = resp.getListKeysResponse().getKeyInfoList();
@@ -777,7 +781,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListKeysWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (!resp.hasListKeysResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0 || !resp.hasListKeysResponse()) {
       return resp;
     }
 
@@ -838,7 +843,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListTrashWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (!resp.hasListTrashResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasListTrashResponse()) {
       return resp;
     }
     List<RepeatedKeyInfo> repeatedKeys =
@@ -868,7 +874,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListTrashWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (!resp.hasListTrashResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0 || !resp.hasListTrashResponse()) {
       return resp;
     }
 
@@ -1055,7 +1062,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowGetFileStatusWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (!resp.hasGetFileStatusResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasGetFileStatusResponse()) {
       return resp;
     }
     if (resp.getGetFileStatusResponse().getStatus().getKeyInfo()
@@ -1085,7 +1092,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowGetFileStatusWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (!resp.hasGetFileStatusResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion()).compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0
+        || !resp.hasGetFileStatusResponse()) {
       return resp;
     }
 
@@ -1134,7 +1142,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowLookupFileWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (!resp.hasLookupFileResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasLookupFileResponse()) {
       return resp;
     }
     if (resp.getLookupFileResponse().getKeyInfo().hasEcReplicationConfig()) {
@@ -1162,7 +1171,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowLookupFileWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (!resp.hasLookupFileResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0  || !resp.hasLookupFileResponse()) {
       return resp;
     }
     KeyInfo keyInfo = resp.getLookupFileResponse().getKeyInfo();
@@ -1244,7 +1254,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListStatusResponseWithECReplicationConfig(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException {
-    if (!resp.hasListStatusResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.ERASURE_CODING_SUPPORT) >= 0 || !resp.hasListStatusResponse()) {
       return resp;
     }
     List<OzoneFileStatusProto> statuses =
@@ -1272,7 +1283,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   public static OMResponse disallowListStatusResponseWithBucketLayout(
       OMRequest req, OMResponse resp, ValidationContext ctx)
       throws ServiceException, IOException {
-    if (!resp.hasListStatusResponse()) {
+    if (ClientVersion.fromProtoValue(req.getVersion())
+        .compareTo(ClientVersion.BUCKET_LAYOUT_SUPPORT) >= 0 || !resp.hasListStatusResponse()) {
       return resp;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
With the introduction of a new client version in https://issues.apache.org/jira/browse/HDDS-10983, the latest version is 4.
The OLDER_CLIENT_REQUEST validation checked against the latest versions for access to newer non-legacy buckets but since the addition of a newer version all client versions prior to 4 becomes an older client. This blocks access to OBS/FSO buckets and EC key lookups for older clients version 2 & 3.
This is related to the original patch submitted by @sadanand48 https://github.com/apache/ozone/pull/6919

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11132

## How was this patch tested?
Unit tests need to be added.