### PR TITLE
HDDS-10055. [hsync] Optimize FilePerBlockStrategy.writeChunk().

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -217,13 +217,7 @@ public class FilePerBlockStrategy implements ChunkManager {
   public void finishWriteChunks(KeyValueContainer container,
       BlockData blockData) throws IOException {
     final File chunkFile = getChunkFile(container, blockData.getBlockID());
-    try {
-      files.close(chunkFile);
-      verifyChunkFileExists(chunkFile);
-    } catch (IOException e) {
-      onFailure(container.getContainerData().getVolume());
-      throw e;
-    }
+    files.close(chunkFile);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -214,6 +214,12 @@ public class FilePerBlockStrategy implements ChunkManager {
   }
 
   @Override
+  public void shutdown() {
+    // invalidate all open files
+    files.files.invalidateAll();
+  }
+
+  @Override
   public void finishWriteChunks(KeyValueContainer container,
       BlockData blockData) throws IOException {
     final File chunkFile = getChunkFile(container, blockData.getBlockID());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -731,7 +731,7 @@ public class TestContainerStateMachineFailures {
       key.flush();
     }
 
-    validateData("ratis1", 2, "ratisratisratisratis");
+    validateData("ratis1", 1, "ratisratisratisratis");
   }
 
   @Test
@@ -762,7 +762,7 @@ public class TestContainerStateMachineFailures {
     key.write("ratis".getBytes(UTF_8));
     key.flush();
     key.close();
-    validateData("ratis1", 2, "ratisratisratisratis");
+    validateData("ratis1", 1, "ratisratisratisratis");
   }
 
   private void induceFollowerFailure(OmKeyLocationInfo omKeyLocationInfo,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -375,7 +375,7 @@ class TestContainerReplication {
             // Reading the Stripe 2 from the pre initialized inputStream
             inputStream.read(readData, firstReadLen, size - firstReadLen);
             // Asserting there was a failure in the first read chunk.
-            Assertions.assertEquals(ImmutableMap.of(1, 1, 3, 1), failedReadChunkCountMap);
+            Assertions.assertEquals(ImmutableMap.of(1, 3), failedReadChunkCountMap);
             Assertions.assertArrayEquals(readData, originalData);
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10055. [hsync] Optimize FilePerBlockStrategy.writeChunk().

Please describe your PR in detail:
Profiler report shows DN repeatedly instantiates File object for the same block file. This is especially problematic for hsync where the same block file is appended over and over again. This PR removes instantiating File object in subsequent hsync requests.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10055

## How was this patch tested?

No new tests. Benchmark report is attached.
<img width="1720" alt="Screenshot 2024-07-10 at 3 08 13 PM" src="https://github.com/apache/ozone/assets/2691807/c7faae45-f11a-427f-adaa-6d0ba6da07f8">

