### PR TITLE
HDDS-11138. Remove version from compose files

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-secure.yaml
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-secure.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   rm:
     image: ${HADOOP_IMAGE}:${HADOOP_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop.yaml
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   rm:
     image: ${HADOOP_IMAGE}:${HADOOP_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/common/s3-haproxy.yaml
+++ b/hadoop-ozone/dist/src/main/compose/common/s3-haproxy.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-s3-worker:
   &s3-worker
   image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/compatibility/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 services:
   datanode:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
    datanode:
       build:

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
    datanode_1:
       image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/ozone/freon-ockg.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/freon-ockg.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   freon:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/ozone/freon-rk.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/freon-rk.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   freon:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/ozone/legacy-bucket.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/legacy-bucket.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-legacy-bucket-config:
   &legacy-bucket-config
   environment:

--- a/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/monitoring.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-monitoring-config:
   &monitoring-config
   env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone/profiling.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/profiling.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-profiling-config:
   &profiling-config
   privileged: true

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
    datanode:
       image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
    datanode:
       build:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   kdc:
     image: ${OZONE_TESTKRB5_IMAGE}

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/om-bootstrap.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/om-bootstrap.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-OM-Ratis-config:
   &common-env-file
   env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/root-ca-rotation.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/root-ca-rotation.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-root-cert-rotation-config:
   &root-cert-rotation-config
   environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/s3g-virtual-host.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/s3g-virtual-host.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-s3g-virtual-host-config:
   &s3g-virtual-host-config
   environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/scm-decommission.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/scm-decommission.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   scm4.org:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   kdc:
     image: ${OZONE_TESTKRB5_IMAGE}

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/certificate-rotation.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/certificate-rotation.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-cert-rotation-config:
   &cert-rotation-config
   environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   kdc:
     image: ${OZONE_TESTKRB5_IMAGE}

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/fcq.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/fcq.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-FCQ-config:
   &FCQ-config
   environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/root-ca-rotation.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 x-root-cert-rotation-config:
   &root-cert-rotation-config
   environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/vault.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/vault.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   om:
     env_file:

--- a/hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/om-ha/docker-compose.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 services:
   old_client_1_0_0:
     image: apache/ozone:1.0.0

--- a/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-new-config:
   &new-config

--- a/hadoop-ozone/dist/src/main/compose/xcompat/old-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/old-cluster.yaml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
-
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-old-config:
   &old-config


### PR DESCRIPTION
## What changes were proposed in this pull request?

Compose file element `version` is [obsolete](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete), results in warnings, e.g.:

```
level=warning msg="/home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose/ozone/docker-compose.yaml: `version` is obsolete"
```

Remove `version` to avoid the warnings.

https://issues.apache.org/jira/browse/HDDS-11138

## How was this patch tested?

Tried with Docker Compose v1 locally:

```
$ cd hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose/ozone

$ docker-compose --version               
docker-compose version 1.29.2

$ docker-compose up -d --scale datanode=3
Creating network "ozone_default" with the default driver
Creating ozone_scm_1      ... done
Creating ozone_recon_1    ... done
Creating ozone_datanode_1 ... done
Creating ozone_datanode_2 ... done
Creating ozone_datanode_3 ... done
Creating ozone_httpfs_1   ... done
Creating ozone_om_1       ... done
Creating ozone_s3g_1      ... done

$ docker-compose exec scm ozone admin safemode wait    
...
SCM is out of safe mode.
```

v2 is tested in CI:
https://github.com/adoroszlai/ozone/actions/runs/9884575792

No warnings seen, e.g.:
https://github.com/adoroszlai/ozone/actions/runs/9884575792/job/27301600919#step:5:49