### PR TITLE
HDDS-11116. OM state machine move to readonly mode on failure

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4430,11 +4430,12 @@
     </description>
   </property>
   <property>
-    <name>ozone.om.onfailure.readonly.enable</name>
-    <value>false</value>
+    <name>ozone.om.readonly.on.failure</name>
+    <value>true</value>
     <tag>OZONE, OM</tag>
     <description>
-      enable readonly mode when om state machine failure is observed.
+      put the Ozone Manager in readonly mode instead of shutting down when there is a fatal error
+      while handling a write request.
     </description>
   </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4429,4 +4429,12 @@
       maximum number of buckets across all volumes.
     </description>
   </property>
+  <property>
+    <name>ozone.om.onfailure.readonly.enable</name>
+    <value>false</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      enable readonly mode when om state machine failure is observed.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -614,6 +614,6 @@ public final class OMConfigKeys {
   public static final int OZONE_OM_MAX_BUCKET_DEFAULT = 100000;
 
   public static final String OZONE_OM_ONFAILURE_READONLY =
-      "ozone.om.onfailure.readonly.enable";
-  public static final boolean OZONE_OM_ONFAILURE_READONLY_DEFAULT = false;
+      "ozone.om.readonly.on.failure";
+  public static final boolean OZONE_OM_ONFAILURE_READONLY_DEFAULT = true;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -612,4 +612,8 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_MAX_BUCKET =
       "ozone.om.max.buckets";
   public static final int OZONE_OM_MAX_BUCKET_DEFAULT = 100000;
+
+  public static final String OZONE_OM_ONFAILURE_READONLY =
+      "ozone.om.onfailure.readonly.enable";
+  public static final boolean OZONE_OM_ONFAILURE_READONLY_DEFAULT = false;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -269,6 +269,8 @@ public class OMException extends IOException {
     
     INVALID_PATH,
 
-    TOO_MANY_BUCKETS
+    TOO_MANY_BUCKETS,
+
+    READONLY_MODE
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerReadonlyMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerReadonlyMode.java
@@ -41,7 +41,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doThrow;
 
 /**
  * Test some client operations after cluster starts. And perform restart and
@@ -104,7 +103,7 @@ public class TestOzoneManagerReadonlyMode {
     // mock PerfMetrics to throw exception when executing request
     for (OzoneManager om : ((MiniOzoneHAClusterImpl) cluster).getOzoneManagersList()) {
       OMPerformanceMetrics pf1 = Mockito.spy(om.getPerfMetrics());
-      doThrow(new IllegalArgumentException("test throw")).when(pf1).getValidateAndUpdateCacheLatencyNs();
+      Mockito.when(pf1.getValidateAndUpdateCacheLatencyNs()).thenThrow(new IllegalArgumentException("test throw"));
       om.setPerfMetrics(pf1);
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerReadonlyMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerReadonlyMode.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import java.io.IOException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+
+/**
+ * Test some client operations after cluster starts. And perform restart and
+ * then performs client operations and check the behavior is expected or not.
+ */
+@Timeout(240)
+public class TestOzoneManagerReadonlyMode {
+  private static MiniOzoneCluster cluster = null;
+  private static OzoneConfiguration conf;
+  private static OzoneClient client;
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   * <p>
+   * Ozone is made active by setting OZONE_ENABLED = true
+   *
+   * @throws IOException
+   */
+  @BeforeAll
+  public static void init() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_ACL_ENABLED, true);
+    conf.set(OZONE_ADMINISTRATORS, OZONE_ADMINISTRATORS_WILDCARD);
+    conf.setInt(OZONE_SCM_RATIS_PIPELINE_LIMIT, 10);
+    // Use OBS layout for key rename testing.
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.OBJECT_STORE.name());
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ONFAILURE_READONLY, true);
+    cluster =  MiniOzoneCluster.newHABuilder(conf).setOMServiceId("om-service-test1")
+        .setSCMServiceId("scm-service-test1").setNumOfOzoneManagers(3)
+        .setNumOfStorageContainerManagers(1).setNumOfActiveSCMs(1).setNumDatanodes(1)
+        .build();
+    cluster.waitForClusterToBeReady();
+    client = cluster.newClient();
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @AfterAll
+  public static void shutdown() {
+    IOUtils.closeQuietly(client);
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testReadonlyModeWhileExceptionAndRestart() throws Exception {
+    cluster.stopRecon();
+    cluster.getHddsDatanodes().stream().forEach(e -> e.stop());
+    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+
+    ObjectStore objectStore = client.getObjectStore();
+    objectStore.createVolume(volumeName);
+
+    OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
+    assertEquals(volumeName, ozoneVolume.getName());
+
+    // mock PerfMetrics to throw exception when executing request
+    for (OzoneManager om : ((MiniOzoneHAClusterImpl) cluster).getOzoneManagersList()) {
+      OMPerformanceMetrics pf1 = Mockito.spy(om.getPerfMetrics());
+      doThrow(new IllegalArgumentException("test throw")).when(pf1).getValidateAndUpdateCacheLatencyNs();
+      om.setPerfMetrics(pf1);
+    }
+
+    // volume creation should fail
+    try {
+      objectStore.createVolume(volumeName + "12");
+    } catch (Exception ex) {
+      assertTrue(ex.getMessage().contains("Exception occurred and moving to readonly mode"));
+    }
+
+    GenericTestUtils.waitFor(() -> {
+      for (OzoneManager om : ((MiniOzoneHAClusterImpl) cluster).getOzoneManagersList()) {
+        if (om.getOmRatisServer().getOmStateMachine().isReadOnly()) {
+          return true;
+        }
+      }
+      return false;
+    }, 100, 1000);
+
+    try {
+      objectStore.createVolume(volumeName + "1112");
+    } catch (Exception ex) {
+      assertTrue(ex.getMessage().contains("OM is running in readonly mode"));
+    }
+
+    // verify list operation working fine
+    for (int i = 0; i < 10; ++i) {
+      cluster.newClient().getObjectStore().listVolumes("");
+    }
+
+    cluster.restartOzoneManager();
+
+    // restart, verify state machine remains in readonly mode
+    GenericTestUtils.waitFor(() -> {
+      for (OzoneManager om : ((MiniOzoneHAClusterImpl) cluster).getOzoneManagersList()) {
+        if (om.getOmRatisServer().getOmStateMachine().isReadOnly()) {
+          return true;
+        }
+      }
+      return false;
+    }, 100, 10000);
+
+    try {
+      objectStore.createVolume(volumeName + "1112");
+    } catch (Exception ex) {
+      assertTrue(ex.getMessage().contains("OM is running in readonly mode"));
+    }
+
+    for (int i = 0; i < 10; ++i) {
+      cluster.newClient().getObjectStore().listVolumes("");
+    }
+  }
+}

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -529,6 +529,8 @@ enum Status {
     INVALID_PATH = 93;
 
     TOO_MANY_BUCKETS = 94;
+
+    READONLY_MODE = 95;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -455,7 +455,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private static UserGroupInformation testUgi;
 
   private final OzoneLockProvider ozoneLockProvider;
-  private final OMPerformanceMetrics perfMetrics;
+  private OMPerformanceMetrics perfMetrics;
   private final BucketUtilizationMetrics bucketUtilizationMetrics;
 
   private boolean fsSnapshotEnabled;
@@ -4917,5 +4917,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     } else {
       getOmServerProtocol().awaitDoubleBufferFlush();
     }
+  }
+
+  @VisibleForTesting
+  public void setPerfMetrics(OMPerformanceMetrics perfMetrics) {
+    this.perfMetrics = perfMetrics;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.protocolPB;
 
+import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_NOT_READY;
 import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_READY;
 import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.NOT_LEADER;
 import static org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils.createClientRequest;
@@ -258,7 +259,9 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
       throws ServiceException {
     // Check if this OM is the leader.
     RaftServerStatus raftServerStatus = omRatisServer.checkLeaderStatus();
-    if (raftServerStatus == LEADER_AND_READY ||
+    boolean readOnlyMachineMode = raftServerStatus == LEADER_AND_NOT_READY
+        && omRatisServer.getOmStateMachine().isReadOnly();
+    if (raftServerStatus == LEADER_AND_READY || readOnlyMachineMode ||
         request.getCmdType().equals(PrepareStatus)) {
       return handler.handleReadRequest(request);
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

readonly mode is provided for applyTransaction request handling failure. By default, this is "enabled".

On enable the conf `ozone.om.onfailure.readonly.enable` , the feature gets enabled. And on any request failure (earlier causing crash), it moves to readonly mode, providing support for only read request.
OMStateMachine is paused(), and do not process any further request. This can be recovered only during startup when related raft log execution gets success (or skipped).

OM will enter this state for errors (other than IOException) that happen during validateAndUpdateCache, not for errors related to the DB (RocksDB exception). DB errors should probably still be fatal since that is not caused by an Ozone bug. So this mostly cover logical problem which can happen while handling the request at OM, and do not cause any inconsistency as DB state is not getting changed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11116

## How was this patch tested?

- Unit test
- integration test covering scenario of moving to readonly mode on failure, and over restart remain in readonly mode as failed again for the raft log

Observation: in this mode in integration test, frequent election is happening. This might be due to state machine is not getting updated with latest transaction. This is avoided because on re-start, all these transaction needs replayed after fixing the problem.