### PR TITLE
HDDS-11135. [hsync] Replace expensive VolumeUsage.getMinVolumeFreeSpace()

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -113,6 +113,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   private ContainerMetrics metrics;
   private final TokenVerifier tokenVerifier;
   private long slowOpThresholdMs;
+  private VolumeUsage.MinFreeSpaceCalculator freeSpaceCalculator;
 
   /**
    * Constructs an OzoneContainer that receives calls from
@@ -147,6 +148,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
             LOG,
             HddsUtils::processForDebug,
             HddsUtils::processForDebug);
+    this.freeSpaceCalculator = new VolumeUsage.MinFreeSpaceCalculator(conf);
   }
 
   @Override
@@ -612,7 +614,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
           volume.getCurrentUsage();
       long volumeCapacity = precomputedVolumeSpace.getCapacity();
       long volumeFreeSpaceToSpare =
-          VolumeUsage.getMinVolumeFreeSpace(conf, volumeCapacity);
+          freeSpaceCalculator.get(volumeCapacity);
       long volumeFree = precomputedVolumeSpace.getAvailable();
       long volumeCommitted = volume.getCommittedBytes();
       long volumeAvailable = volumeFree - volumeCommitted;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
@@ -189,7 +189,7 @@ public final class StorageLocationReport implements
         .setStorageLocation(getStorageLocation())
         .setFailed(isFailed())
         .setFreeSpaceToSpare(conf != null ?
-            VolumeUsage.getMinVolumeFreeSpace(conf, getCapacity()) : 0)
+            new VolumeUsage.MinFreeSpaceCalculator(conf).get(getCapacity()) : 0)
         .build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
@@ -43,7 +43,7 @@ public class AvailableSpaceFilter implements Predicate<HddsVolume> {
     long committed = vol.getCommittedBytes();
     long available = free - committed;
     long volumeFreeSpaceToSpare =
-        VolumeUsage.getMinVolumeFreeSpace(vol.getConf(), volumeCapacity);
+        new VolumeUsage.MinFreeSpaceCalculator(vol.getConf()).get(volumeCapacity);
     boolean hasEnoughSpace = VolumeUsage.hasVolumeEnoughSpace(free, committed,
         requiredSpace, volumeFreeSpaceToSpare);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -140,37 +140,55 @@ public class VolumeUsage {
   }
 
   /**
-   * If 'hdds.datanode.volume.min.free.space' is defined,
-   * it will be honored first. If it is not defined and
-   * 'hdds.datanode.volume.min.free.space.' is defined,it will honor this
-   * else it will fall back to 'hdds.datanode.volume.min.free.space.default'
+   * Convenience class to calculate minimum free space.
    */
-  public static long getMinVolumeFreeSpace(ConfigurationSource conf,
-      long capacity) {
-    if (conf.isConfigured(
-        HDDS_DATANODE_VOLUME_MIN_FREE_SPACE) && conf.isConfigured(
-        HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT)) {
-      LOG.error(
-          "Both {} and {} are set. Set either one, not both. If both are set,"
-              + "it will use default value which is {} as min free space",
-          HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
-          HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT,
-          HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT);
-    }
-
-    if (conf.isConfigured(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE)) {
-      return (long) conf.getStorageSize(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
+  public static class MinFreeSpaceCalculator {
+    private final boolean minFreeSpaceConfigured;
+    private final boolean minFreeSpacePercentConfigured;
+    private final long freeSpace;
+    private float freeSpacePercent;
+    private final long defaultFreeSpace;
+    public MinFreeSpaceCalculator(ConfigurationSource conf) {
+      // cache these values to avoid repeated lookups
+      minFreeSpaceConfigured = conf.isConfigured(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE);
+      minFreeSpacePercentConfigured = conf.isConfigured(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT);
+      freeSpace = (long)conf.getStorageSize(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
           HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT, StorageUnit.BYTES);
-    } else if (conf.isConfigured(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT)) {
-      float volumeMinFreeSpacePercent = Float.parseFloat(
-          conf.get(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT));
-      return (long) (capacity * volumeMinFreeSpacePercent);
+      if (minFreeSpacePercentConfigured) {
+        freeSpacePercent = Float.parseFloat(
+            conf.get(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT));
+      }
+      StorageSize measure = StorageSize.parse(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT);
+      double byteValue = measure.getUnit().toBytes(measure.getValue());
+      defaultFreeSpace = (long)StorageUnit.BYTES.fromBytes(byteValue);
     }
-    // either properties are not configured,then return
-    // HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT,
-    return (long) conf.getStorageSize(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
-        HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT, StorageUnit.BYTES);
 
+    /**
+     * If 'hdds.datanode.volume.min.free.space' is defined,
+     * it will be honored first. If it is not defined and
+     * 'hdds.datanode.volume.min.free.space.' is defined,it will honor this
+     * else it will fall back to 'hdds.datanode.volume.min.free.space.default'
+     */
+    public long get(long capacity) {
+      if (minFreeSpaceConfigured && minFreeSpacePercentConfigured) {
+        LOG.error(
+            "Both {} and {} are set. Set either one, not both. If both are set,"
+                + "it will use default value which is {} as min free space",
+            HDDS_DATANODE_VOLUME_MIN_FREE_SPACE,
+            HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT,
+            HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT);
+        return defaultFreeSpace;
+      }
+
+      if (minFreeSpaceConfigured) {
+        return freeSpace;
+      } else if (minFreeSpacePercentConfigured) {
+        return (long) (capacity * freeSpacePercent);
+      }
+      // either properties are not configured,then return
+      // HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_DEFAULT
+      return defaultFreeSpace;
+    }
   }
 
   public static boolean hasVolumeEnoughSpace(long volumeAvailableSpace,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -166,7 +166,7 @@ public class VolumeUsage {
     /**
      * If 'hdds.datanode.volume.min.free.space' is defined,
      * it will be honored first. If it is not defined and
-     * 'hdds.datanode.volume.min.free.space.' is defined,it will honor this
+     * 'hdds.datanode.volume.min.free.space' is defined, it will honor this
      * else it will fall back to 'hdds.datanode.volume.min.free.space.default'
      */
     public long get(long capacity) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11135. [hsync] Replace expensive VolumeUsage.getMinVolumeFreeSpace()

Please describe your PR in detail:
VolumeUsage.getMinVolumeFreeSpace() has a lot of expensive ConfigurationSource lookups, which is wastes CPU cycles in one of the most critical performance bottleneck area for hsync (DataNode ContainerStateMachine.writeStateMachiine()).

The values never changes and should be cached and reused.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11135

## How was this patch tested?

New UT in TestReservedVolumeSpace to cover the new code.
Async profiler confirms the CPU time is removed from flame graph.