### PR TITLE
HDDS-11110. Allow running test-all.sh from any directory

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -36,8 +36,8 @@ if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
    export OZONE_OPTS="-javaagent:share/coverage/jacoco-agent.jar=output=tcpclient,address=$DOCKER_BRIDGE_IP,includes=org.apache.hadoop.ozone.*:org.apache.hadoop.hdds.*:org.apache.hadoop.fs.ozone.*"
 fi
 
-tests=$(find_tests)
 cd "$SCRIPT_DIR"
+tests=$(find_tests)
 
 RESULT=0
 run_test_scripts ${tests} || RESULT=$?


### PR DESCRIPTION
## What changes were proposed in this pull request?

`compose/test-all.sh` assumes it is executed with `compose` being the current directory.  This assumption is needed only for finding tests, since right after that step the script changes to its own directory.

With this trivial change, `test-all.sh` can be executed from any directory, it changes dir before finding tests.

https://issues.apache.org/jira/browse/HDDS-11110

## How was this patch tested?

Tweaked `test-all.sh`, so that after finding tests it prints current dir, lists tests found (would normally be executed), and then exit:

```
pwd
echo $tests
exit
```

Tested in various dirs.  Verified both current dir and list of tests are the same in each case:

```
$ cd hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose/ozone
$ ../test-all.sh 
hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose
compatibility/test.sh ozone-balancer/test.sh ozone-csi/test.sh ozone-ha/test-hadoop.sh ozone-ha/test.sh ozone-om-prepare/test.sh ozonesecure-ha/test-leadership.sh ozonesecure-ha/test-om-bootstrap.sh ozonesecure-ha/test-s3a.sh ozonesecure-ha/test-s3g-virtual-host.sh ozonesecure-ha/test-scm-decommission.sh ozonesecure-ha/test.sh ozonesecure-mr/test.sh ozonesecure/test-certificate-rotation.sh ozonesecure/test-ec.sh ozonesecure/test-fcq.sh ozonesecure/test-root-ca-rotation.sh ozonesecure/test.sh ozonesecure/test-vault.sh ozone/test-ec.sh ozone/test-hadoop.sh ozone/test-legacy-bucket.sh ozone/test-s3a.sh ozone/test.sh ozone-topology/test.sh restart/test.sh upgrade/testlib.sh upgrade/test.sh xcompat/test.sh

$ cd ..
$ ./test-all.sh 
hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose
compatibility/test.sh ozone-balancer/test.sh ozone-csi/test.sh ozone-ha/test-hadoop.sh ozone-ha/test.sh ozone-om-prepare/test.sh ozonesecure-ha/test-leadership.sh ozonesecure-ha/test-om-bootstrap.sh ozonesecure-ha/test-s3a.sh ozonesecure-ha/test-s3g-virtual-host.sh ozonesecure-ha/test-scm-decommission.sh ozonesecure-ha/test.sh ozonesecure-mr/test.sh ozonesecure/test-certificate-rotation.sh ozonesecure/test-ec.sh ozonesecure/test-fcq.sh ozonesecure/test-root-ca-rotation.sh ozonesecure/test.sh ozonesecure/test-vault.sh ozone/test-ec.sh ozone/test-hadoop.sh ozone/test-legacy-bucket.sh ozone/test-s3a.sh ozone/test.sh ozone-topology/test.sh restart/test.sh upgrade/testlib.sh upgrade/test.sh xcompat/test.sh

$ cd ..
$ compose/test-all.sh 
hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose
compatibility/test.sh ozone-balancer/test.sh ozone-csi/test.sh ozone-ha/test-hadoop.sh ozone-ha/test.sh ozone-om-prepare/test.sh ozonesecure-ha/test-leadership.sh ozonesecure-ha/test-om-bootstrap.sh ozonesecure-ha/test-s3a.sh ozonesecure-ha/test-s3g-virtual-host.sh ozonesecure-ha/test-scm-decommission.sh ozonesecure-ha/test.sh ozonesecure-mr/test.sh ozonesecure/test-certificate-rotation.sh ozonesecure/test-ec.sh ozonesecure/test-fcq.sh ozonesecure/test-root-ca-rotation.sh ozonesecure/test.sh ozonesecure/test-vault.sh ozone/test-ec.sh ozone/test-hadoop.sh ozone/test-legacy-bucket.sh ozone/test-s3a.sh ozone/test.sh ozone-topology/test.sh restart/test.sh upgrade/testlib.sh upgrade/test.sh xcompat/test.sh

$ cd ../../../.. # source root
$ hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose/test-all.sh 
hadoop-ozone/dist/target/ozone-1.5.0-SNAPSHOT/compose
compatibility/test.sh ozone-balancer/test.sh ozone-csi/test.sh ozone-ha/test-hadoop.sh ozone-ha/test.sh ozone-om-prepare/test.sh ozonesecure-ha/test-leadership.sh ozonesecure-ha/test-om-bootstrap.sh ozonesecure-ha/test-s3a.sh ozonesecure-ha/test-s3g-virtual-host.sh ozonesecure-ha/test-scm-decommission.sh ozonesecure-ha/test.sh ozonesecure-mr/test.sh ozonesecure/test-certificate-rotation.sh ozonesecure/test-ec.sh ozonesecure/test-fcq.sh ozonesecure/test-root-ca-rotation.sh ozonesecure/test.sh ozonesecure/test-vault.sh ozone/test-ec.sh ozone/test-hadoop.sh ozone/test-legacy-bucket.sh ozone/test-s3a.sh ozone/test.sh ozone-topology/test.sh restart/test.sh upgrade/testlib.sh upgrade/test.sh xcompat/test.sh
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/9896809487