### PR TITLE
HDDS-11169. Upgrade packageManager version for Recon package.json

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/package.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@7.33.6",
+  "packageManager": "pnpm@8.15.7",
   "name": "ozone-recon",
   "version": "0.2.0",
   "keywords": [


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11169. Updates the package manager field for Recon package.json

Please describe your PR in detail:
* Currently dependabot uses the package.json packageManager field to identify the version and the package manager that is being used by the project.
* This field was not updated, but pnpm version was changed to v8.
* This causes dependabot to use v7 to generate the lockfile, but we are using pnpm v8 to build the project.
* Hence dependabot PRs related to JS upgrades are failing in CI builds.
* This PR will fix that issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11169

## How was this patch tested?
This patch was tested manually in forked repo via dependabot upgrade PR request.