### PR TITLE
HDDS-11150. Recon Overview page crashes due to failed API Calls

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
@@ -139,9 +139,7 @@ class OverviewCard extends React.Component<IOverviewCardProps> {
 
   render() {
     let { icon, data, title, loading, hoverable, storageReport, linkToUrl, error } = this.props;
-    console.log(title);
-    console.log(data);
-    console.log(typeof data)
+
     let meta = <Meta title={data} description={title} />;
     let errorClass = error ? 'card-error' : '';
     if (typeof data === 'string' && data === 'N/A'){

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
@@ -142,9 +142,11 @@ class OverviewCard extends React.Component<IOverviewCardProps> {
 
     let meta = <Meta title={data} description={title} />;
     let errorClass = error ? 'card-error' : '';
+
     if (typeof data === 'string' && data === 'N/A'){
       errorClass = 'card-error';
     }
+
     if (storageReport) {
       meta = (
         <div className='ant-card-percentage'>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/overviewCard/overviewCard.tsx
@@ -139,8 +139,14 @@ class OverviewCard extends React.Component<IOverviewCardProps> {
 
   render() {
     let { icon, data, title, loading, hoverable, storageReport, linkToUrl, error } = this.props;
+    console.log(title);
+    console.log(data);
+    console.log(typeof data)
     let meta = <Meta title={data} description={title} />;
-    const errorClass = error ? 'card-error' : '';
+    let errorClass = error ? 'card-error' : '';
+    if (typeof data === 'string' && data === 'N/A'){
+      errorClass = 'card-error';
+    }
     if (storageReport) {
       meta = (
         <div className='ant-card-percentage'>
@@ -156,7 +162,7 @@ class OverviewCard extends React.Component<IOverviewCardProps> {
 
     return (
       <OverviewCardWrapper linkToUrl={linkToUrl}>
-        <Card className={`overview-card ${ errorClass }`} loading={loading} hoverable={hoverable}>
+        <Card className={`overview-card ${errorClass}`} loading={loading} hoverable={hoverable}>
           <Row type='flex' justify='space-between'>
             <Col span={18}>
               <Row>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
@@ -69,6 +69,26 @@ export const PromiseAllSettledGetHelper = (
   }
 }
 
+export class PromiseAllSettledError extends Error {
+
+  _urls: string[];
+  _errors: string[];
+
+  constructor(urls: string[], errors: string[], ...opts){
+    super(...opts);
+    this._urls = urls;
+    this._errors = errors;
+  }
+
+  getFaultyUrls() {
+    return this._urls;
+  }
+
+  getResponseErrors() {
+    return this._errors;
+  }
+}
+
 export const cancelRequests = (cancelSignal: AbortController[]) => {
   cancelSignal.forEach((signal) => {
     signal && signal.abort();

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
@@ -48,11 +48,11 @@ export const AxiosPutHelper = (
   }
 }
 
-export const AxiosAllGetHelper = (
+export const PromiseAllSettledGetHelper = (
   urls: string[],
   controller: AbortController,
   message: string = ''
-): { requests: Promise<AxiosResponse<any, any>[]>; controller: AbortController } => {
+): { requests: Promise<PromiseSettledResult<AxiosResponse<any, any>>[]>; controller: AbortController } => {
 
   controller && controller.abort(message);
   controller = new AbortController(); // generate new AbortController for the upcoming request
@@ -63,8 +63,9 @@ export const AxiosAllGetHelper = (
     axiosGetRequests.push(axios.get(url, { signal: controller.signal }))
   });
 
+  console.log(axiosGetRequests);
   return {
-    requests: axios.all(axiosGetRequests),
+    requests: Promise.allSettled(axiosGetRequests),
     controller: controller
   }
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
@@ -63,7 +63,6 @@ export const PromiseAllSettledGetHelper = (
     axiosGetRequests.push(axios.get(url, { signal: controller.signal }))
   });
 
-  console.log(axiosGetRequests);
   return {
     requests: Promise.allSettled(axiosGetRequests),
     controller: controller

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/utils/axiosRequestHelper.tsx
@@ -69,26 +69,6 @@ export const PromiseAllSettledGetHelper = (
   }
 }
 
-export class PromiseAllSettledError extends Error {
-
-  _urls: string[];
-  _errors: string[];
-
-  constructor(urls: string[], errors: string[], ...opts){
-    super(...opts);
-    this._urls = urls;
-    this._errors = errors;
-  }
-
-  getFaultyUrls() {
-    return this._urls;
-  }
-
-  getResponseErrors() {
-    return this._errors;
-  }
-}
-
 export const cancelRequests = (cancelSignal: AbortController[]) => {
   cancelSignal.forEach((signal) => {
     signal && signal.abort();

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -556,12 +556,6 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
       </Menu>
     )
 
-    console.log(plotData);
-    console.log(plotData.map((value) => {
-      return {
-        name: value.name
-      }
-    }))
     const eChartsOptions = {
       title: {
         text: `Disk Usage for ${returnPath} (Total Size: ${byteToSize(duResponse.size, 1)})`,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
@@ -17,9 +17,9 @@
  */
 
 import React from 'react';
-import axios, { CanceledError } from 'axios';
+import axios, { CanceledError, AxiosError } from 'axios';
 import filesize from 'filesize';
-import { Row, Col, Tabs } from 'antd';
+import { Row, Col, Tabs, message } from 'antd';
 import { LoadingOutlined } from '@ant-design/icons';
 import { ActionMeta, ValueType } from 'react-select';
 import { type EChartsOption } from 'echarts';
@@ -274,7 +274,7 @@ export class Insights extends React.Component<Record<string, object>, IInsightsS
 
       if (responseError.length !== 0) {
         responseError.forEach((err) => {
-          if (err.reason.toString().includes("CanceledError")){
+          if (err.reason.toString().includes("CanceledError")) {
             throw new CanceledError('canceled', "ERR_CANCELED");
           }
           else {
@@ -286,10 +286,10 @@ export class Insights extends React.Component<Record<string, object>, IInsightsS
       }
 
       const fileCountsResponse: IFileCountResponse[] = fileCountresponse.value?.data ?? [{
-          volume: '0',
-          bucket: '0',
-          fileSize: '0',
-          count: 0
+        volume: '0',
+        bucket: '0',
+        fileSize: '0',
+        count: 0
       }];
       const containerCountResponse: IContainerCountResponse[] = containerCountresponse.value?.data ?? [{
         containerSize: 0,

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/insights/insights.tsx
@@ -195,10 +195,6 @@ export class Insights extends React.Component<Record<string, object>, IInsightsS
         return (size(value));
       });
 
-      console.log(xyFileCountMap);
-      console.log(xContainerCountValues);
-      console.log(xyContainerCountMap);
-
       this.setState({
         fileCountData: {
           title: {
@@ -279,16 +275,19 @@ export class Insights extends React.Component<Record<string, object>, IInsightsS
       )) {
         throw new CanceledError('canceled', "ERR_CANCELED",)
       }
-      const fileCountsResponse: IFileCountResponse[] = fileCountresponse.value?.data ?? {
+      const fileCountsResponse: IFileCountResponse[] = fileCountresponse.value?.data ?? [{
           volume: '0',
           bucket: '0',
           fileSize: '0',
           count: 0
-      };
-      const containerCountResponse: IContainerCountResponse[] = containerCountresponse.value?.data ?? {
+      }];
+      const containerCountResponse: IContainerCountResponse[] = containerCountresponse.value?.data ?? [{
         containerSize: 0,
         count: 0
-      };
+      }];
+
+      console.log(fileCountsResponse);
+      console.log(containerCountResponse);
       // Construct volume -> bucket[] map for populating filters
       // Ex: vol1 -> [bucket1, bucket2], vol2 -> [bucket1]
       const volumeBucketMap: Map<string, Set<string>> = fileCountsResponse.reduce(

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -194,12 +194,12 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         lastRefreshed: Number(moment()),
         lastUpdatedOMDBDelta: omDBDeltaObject && omDBDeltaObject.lastUpdatedTimestamp,
         lastUpdatedOMDBFull: omDBFullObject && omDBFullObject.lastUpdatedTimestamp,
-        openSummarytotalUnrepSize: openResponse.value.data && openResponse.value.data.totalUnreplicatedDataSize,
-        openSummarytotalRepSize: openResponse.value.data && openResponse.value.data.totalReplicatedDataSize,
-        openSummarytotalOpenKeys: openResponse.value.data && openResponse.value.data.totalOpenKeys,
-        deletePendingSummarytotalUnrepSize: deletePendingResponse.value.data && deletePendingResponse.value.data.totalUnreplicatedDataSize,
-        deletePendingSummarytotalRepSize: deletePendingResponse.value.data && deletePendingResponse.value.data.totalReplicatedDataSize,
-        deletePendingSummarytotalDeletedKeys: deletePendingResponse.value.data && deletePendingResponse.value.data.totalDeletedKeys,
+        openSummarytotalUnrepSize: openResponse.value?.data?.totalUnreplicatedDataSize,
+        openSummarytotalRepSize: openResponse.value?.data?.totalReplicatedDataSize,
+        openSummarytotalOpenKeys: openResponse.value?.data?.totalOpenKeys,
+        deletePendingSummarytotalUnrepSize: deletePendingResponse.value?.data?.totalUnreplicatedDataSize,
+        deletePendingSummarytotalRepSize: deletePendingResponse.value?.data?.totalReplicatedDataSize,
+        deletePendingSummarytotalDeletedKeys: deletePendingResponse.value?.data?.totalDeletedKeys,
         scmServiceId: clusterState.scmServiceId,
         omServiceId: clusterState.omServiceId
       });

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -35,18 +35,18 @@ import './overview.less';
 const size = filesize.partial({ round: 1 });
 
 interface IClusterStateResponse {
-  missingContainers: number;
-  totalDatanodes: number;
-  healthyDatanodes: number;
-  pipelines: number;
+  missingContainers: number | string;
+  totalDatanodes: number | string;
+  healthyDatanodes: number | string;
+  pipelines: number | string;
   storageReport: IStorageReport;
-  containers: number;
-  volumes: number;
-  buckets: number;
-  keys: number;
-  openContainers: number;
-  deletedContainers: number;
-  keysPendingDeletion: number;
+  containers: number | string;
+  volumes: number | string;
+  buckets: number | string;
+  keys: number | string;
+  openContainers: number | string;
+  deletedContainers: number | string;
+  keysPendingDeletion: number | string;
   scmServiceId: string;
   omServiceId: string;
 }
@@ -54,25 +54,25 @@ interface IClusterStateResponse {
 interface IOverviewState {
   loading: boolean;
   datanodes: string;
-  pipelines: number;
+  pipelines: number | string;
   storageReport: IStorageReport;
-  containers: number;
-  volumes: number;
-  buckets: number;
-  keys: number;
-  missingContainersCount: number;
-  lastRefreshed: number;
-  lastUpdatedOMDBDelta: number;
-  lastUpdatedOMDBFull: number;
+  containers: number | string;
+  volumes: number | string;
+  buckets: number | string;
+  keys: number | string;
+  missingContainersCount: number | string;
+  lastRefreshed: number | string;
+  lastUpdatedOMDBDelta: number | string;
+  lastUpdatedOMDBFull: number | string;
   omStatus: string;
-  openContainers: number;
-  deletedContainers: number;
-  openSummarytotalUnrepSize: number;
-  openSummarytotalRepSize: number;
-  openSummarytotalOpenKeys: number;
-  deletePendingSummarytotalUnrepSize: number;
-  deletePendingSummarytotalRepSize: number;
-  deletePendingSummarytotalDeletedKeys: number;
+  openContainers: number | string;
+  deletedContainers: number | string;
+  openSummarytotalUnrepSize: number | string;
+  openSummarytotalRepSize: number | string;
+  openSummarytotalOpenKeys: number | string;
+  deletePendingSummarytotalUnrepSize: number | string;
+  deletePendingSummarytotalRepSize: number | string;
+  deletePendingSummarytotalDeletedKeys: number | string;
   scmServiceId: string;
   omServiceId: string;
 }
@@ -148,32 +148,32 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         deletePendingResponse].some(
           (resp) =>
             resp.status === 'rejected' && resp.reason.toString().includes('CanceledError')
-      )) {
+        )) {
         throw new CanceledError('canceled', "ERR_CANCELED",)
       }
       const clusterState: IClusterStateResponse = clusterStateResponse.value?.data ?? {
-        missingContainers: '??',
-        totalDatanodes: '??',
-        healthyDatanodes: '??',
-        pipelines: '??',
+        missingContainers: 'N/A',
+        totalDatanodes: 'N/A',
+        healthyDatanodes: 'N/A',
+        pipelines: 'N/A',
         storageReport: {
           capacity: 0,
           used: 0,
           remaining: 0,
           committed: 0
         },
-        containers: '??',
-        volumes: '??',
-        buckets: '??',
-        keys: '??',
-        openContainers: '??',
-        deletedContainers: '??',
-        keysPendingDeletion: '??',
-        scmServiceId: '??',
-        omServiceId: '??'
+        containers: 'N/A',
+        volumes: 'N/A',
+        buckets: 'N/A',
+        keys: 'N/A',
+        openContainers: 'N/A',
+        deletedContainers: 'N/A',
+        keysPendingDeletion: 'N/A',
+        scmServiceId: 'N/A',
+        omServiceId: 'N/A',
       };
       const taskStatus = taskstatusResponse.value?.data ?? [{
-        taskName: '??', lastUpdatedTimestamp: 0, lastUpdatedSeqNumber: 0
+        taskName: 'N/A', lastUpdatedTimestamp: 0, lastUpdatedSeqNumber: 0
       }];
       const missingContainersCount = clusterState.missingContainers;
       const omDBDeltaObject = taskStatus && taskStatus.find((item: any) => item.taskName === 'OmDeltaRequest');
@@ -181,7 +181,9 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
 
       this.setState({
         loading: false,
-        datanodes: `${clusterState.healthyDatanodes}/${clusterState.totalDatanodes}`,
+        datanodes: clusterState.healthyDatanodes !== 'N/A'
+          ? `${clusterState.healthyDatanodes}/${clusterState.totalDatanodes}`
+          : `N/A`,
         storageReport: clusterState.storageReport,
         pipelines: clusterState.pipelines,
         containers: clusterState.containers,
@@ -257,11 +259,24 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       keys, missingContainersCount, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull,
       omStatus, openContainers, deletedContainers, scmServiceId, omServiceId } = this.state;
 
-    const datanodesElement = (
-      <span>
-        <CheckCircleFilled className='icon-success icon-small' /> {datanodes} <span className='ant-card-meta-description meta'>HEALTHY</span>
-      </span>
-    );
+    console.log(datanodes);
+    const datanodesElement = datanodes !== 'N/A'
+      ? (
+        <span>
+          <CheckCircleFilled className='icon-success icon-small' /> {datanodes} <span className='ant-card-meta-description meta'>HEALTHY</span>
+        </span>
+      )
+      : (
+        <span>
+          <Tooltip
+            placement='bottom'
+            title={'Failed to fetch Datanodes count'}>
+            <ExclamationCircleFilled className='icon-failure icon-small' />
+            <span className='padded-text'>{datanodes}</span>
+            <span className='ant-card-meta-description meta padded-text'>UNHEALTHY</span>
+          </Tooltip>
+        </span>
+      )
     const openSummaryData = (
       <div>
         {openSummarytotalRepSize !== undefined ? byteToSize(openSummarytotalRepSize, 1) : '0'}   <span className='ant-card-meta-description meta'>Total Replicated Data Size</span><br />
@@ -277,23 +292,38 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       </div>
     );
     const containersTooltip = missingContainersCount === 1 ? 'container is missing' : 'containers are missing';
-    const containersLink = missingContainersCount > 0 ? '/MissingContainers' : '/Containers';
+    const containersLink = missingContainersCount as number > 0 ? '/MissingContainers' : '/Containers';
     const volumesLink = '/Volumes';
     const bucketsLink = '/Buckets';
-    const containersElement = missingContainersCount > 0 ? (
-      <span>
-        <Tooltip placement='bottom' title={missingContainersCount > 1000 ? `1000+ Containers are missing. For more information, go to the Containers page.` : `${missingContainersCount} ${containersTooltip}`}>
-          <ExclamationCircleFilled className='icon-failure icon-small' />
-        </Tooltip>
-        <span className='padded-text'>{containers - missingContainersCount}/{containers}</span>
-      </span>
-    ) :
-      <div>
-        <span>{containers.toString()}   </span>
-        <Tooltip placement='bottom' title='Number of open containers'>
-          <span>({openContainers})</span>
-        </Tooltip>
-      </div>
+    const containersElement = missingContainersCount !== 'N/A'
+      ? missingContainersCount as number > 0
+        ? (<span>
+          <Tooltip
+            placement='bottom'
+            title={
+              missingContainersCount as number > 1000
+                ? `1000+ Containers are missing. For more information, go to the Containers page.`
+                : `${missingContainersCount} ${containersTooltip}`}>
+            <ExclamationCircleFilled className='icon-failure icon-small' />
+          </Tooltip>
+          <span className='padded-text'>{(containers as number) - (missingContainersCount as number)}/{containers}</span>
+        </span>
+        )
+        :
+        (<div>
+          <span>{containers.toString()}   </span>
+          <Tooltip placement='bottom' title='Number of open containers'>
+            <span>({openContainers})</span>
+          </Tooltip>
+        </div>)
+      : (
+        <span>
+          <Tooltip placement='bottom' title={`Failed to fetch Container Count`}>
+            <ExclamationCircleFilled className='icon-failure icon-small' />
+            <span className='padded-text'>{missingContainersCount}</span>
+          </Tooltip>
+        </span>
+      )
     const clusterCapacity = `${size(storageReport.capacity - storageReport.remaining)}/${size(storageReport.capacity)}`;
     return (
       <div className='overview-content'>
@@ -308,6 +338,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
             <OverviewCard
               hoverable loading={loading} title='Datanodes'
               data={datanodesElement} icon='cluster'
+              error={datanodes === 'N/A'}
               linkToUrl='/Datanodes' />
           </Col>
           <Col xs={24} sm={18} md={12} lg={12} xl={6}>
@@ -326,7 +357,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
             <OverviewCard
               loading={loading} title='Containers' data={containersElement}
               icon='container'
-              error={missingContainersCount > 0} linkToUrl={containersLink} />
+              error={missingContainersCount as number > 0 || missingContainersCount === 'N/A'} linkToUrl={containersLink} />
           </Col>
           <Col xs={24} sm={18} md={12} lg={12} xl={6}>
             <OverviewCard loading={loading} title='Volumes' data={volumes.toString()} icon='inbox' linkToUrl={volumesLink} />

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -151,6 +151,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
         )) {
         throw new CanceledError('canceled', "ERR_CANCELED",)
       }
+
       const clusterState: IClusterStateResponse = clusterStateResponse.value?.data ?? {
         missingContainers: 'N/A',
         totalDatanodes: 'N/A',
@@ -259,7 +260,25 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       keys, missingContainersCount, lastRefreshed, lastUpdatedOMDBDelta, lastUpdatedOMDBFull,
       omStatus, openContainers, deletedContainers, scmServiceId, omServiceId } = this.state;
 
-    console.log(datanodes);
+    let openKeysError: boolean = false;
+    let pendingDeleteKeysError: boolean = false;
+    if ([
+      openSummarytotalRepSize,
+      openSummarytotalUnrepSize,
+      openSummarytotalOpenKeys].some(
+        (data) => data === undefined
+      )) {
+      openKeysError = true;
+    }
+
+    if ([
+      deletePendingSummarytotalRepSize,
+      deletePendingSummarytotalUnrepSize,
+      deletePendingSummarytotalDeletedKeys].some(
+        (data) => data === undefined
+      )) {
+        pendingDeleteKeysError = true;
+      }
     const datanodesElement = datanodes !== 'N/A'
       ? (
         <span>
@@ -279,16 +298,16 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
       )
     const openSummaryData = (
       <div>
-        {openSummarytotalRepSize !== undefined ? byteToSize(openSummarytotalRepSize, 1) : '0'}   <span className='ant-card-meta-description meta'>Total Replicated Data Size</span><br />
-        {openSummarytotalUnrepSize !== undefined ? byteToSize(openSummarytotalUnrepSize, 1) : '0'}  <span className='ant-card-meta-description meta'>Total UnReplicated Data Size</span><br />
-        {openSummarytotalOpenKeys !== undefined ? openSummarytotalOpenKeys : '0'}  <span className='ant-card-meta-description meta'>Total Open Keys</span>
+        {openSummarytotalRepSize !== undefined ? byteToSize(openSummarytotalRepSize, 1) : 'N/A'}   <span className='ant-card-meta-description meta'>Total Replicated Data Size</span><br />
+        {openSummarytotalUnrepSize !== undefined ? byteToSize(openSummarytotalUnrepSize, 1) : 'N/A'}  <span className='ant-card-meta-description meta'>Total UnReplicated Data Size</span><br />
+        {openSummarytotalOpenKeys !== undefined ? openSummarytotalOpenKeys : 'N/A'}  <span className='ant-card-meta-description meta'>Total Open Keys</span>
       </div>
     );
     const deletePendingSummaryData = (
       <div>
-        {deletePendingSummarytotalRepSize !== undefined ? byteToSize(deletePendingSummarytotalRepSize, 1) : '0'}  <span className='ant-card-meta-description meta'>Total Replicated Data Size</span><br />
-        {deletePendingSummarytotalUnrepSize !== undefined ? byteToSize(deletePendingSummarytotalUnrepSize, 1) : '0'}  <span className='ant-card-meta-description meta'>Total UnReplicated Data Size</span><br />
-        {deletePendingSummarytotalDeletedKeys !== undefined ? deletePendingSummarytotalDeletedKeys : '0'}  <span className='ant-card-meta-description meta'>Total Pending Delete Keys</span>
+        {deletePendingSummarytotalRepSize !== undefined ? byteToSize(deletePendingSummarytotalRepSize, 1) : 'N/A'}  <span className='ant-card-meta-description meta'>Total Replicated Data Size</span><br />
+        {deletePendingSummarytotalUnrepSize !== undefined ? byteToSize(deletePendingSummarytotalUnrepSize, 1) : 'N/A'}  <span className='ant-card-meta-description meta'>Total UnReplicated Data Size</span><br />
+        {deletePendingSummarytotalDeletedKeys !== undefined ? deletePendingSummarytotalDeletedKeys : 'N/A'}  <span className='ant-card-meta-description meta'>Total Pending Delete Keys</span>
       </div>
     );
     const containersTooltip = missingContainersCount === 1 ? 'container is missing' : 'containers are missing';
@@ -372,10 +391,22 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
             <OverviewCard loading={loading} title='Deleted Containers' data={deletedContainers.toString()} icon='delete' />
           </Col>
           <Col xs={24} sm={18} md={12} lg={12} xl={6} className='summary-font'>
-            <OverviewCard loading={loading} title='Open Keys Summary' data={openSummaryData} icon='file-text' linkToUrl='/Om' />
+            <OverviewCard
+              loading={loading}
+              title='Open Keys Summary'
+              data={openSummaryData}
+              icon='file-text'
+              linkToUrl='/Om'
+              error={openKeysError} />
           </Col>
           <Col xs={24} sm={18} md={12} lg={12} xl={6} className='summary-font'>
-            <OverviewCard loading={loading} title='Pending Deleted Keys Summary' data={deletePendingSummaryData} icon='delete' linkToUrl='/Om' />
+            <OverviewCard
+              loading={loading}
+              title='Pending Deleted Keys Summary'
+              data={deletePendingSummaryData}
+              icon='delete'
+              linkToUrl='/Om'
+              error={pendingDeleteKeysError} />
           </Col>
           {scmServiceId &&
             <Col xs={24} sm={18} md={12} lg={12} xl={6}>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-11150. Shift Axios.all to Promise.allSettled and add fallback for error in failed requests

Please describe your PR in detail:

- Currently Axios.all() uses Promise.all() in the background, but this causes all further promises to reject if one request is rejected
- So we have migrated to Promise.allSettled() which allows to wait for all requests to complete instead of immediately rejecting
- Along with this new fallbacks have been added to allow data to be shown even if there is an error while fetching the data
- Scope of fallback scenario
   - When the API is unreachable, say because of an API timeout or the backend is not able to respond
   - When the network might go down and the call to the backend fails
   - If the API returns any error (like 500, or 404 etc.) where the data is not present

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11150

## How was this patch tested?
Patch was tested manually
| Screenshot | Description |
|------------|-------------|
|<img width="1724" alt="Screenshot 2024-07-15 at 21 56 03" src="https://github.com/user-attachments/assets/88bae1e3-ee67-4a11-ba45-48b23219f8de"> | Fallback when clusterState request fails |
|<img width="1722" alt="Screenshot 2024-07-18 at 12 35 26" src="https://github.com/user-attachments/assets/079e81ba-9f62-48d5-ac31-ad5aaa7dfa6a">| Fallback when open keys summary fails |
|<img width="1726" alt="Screenshot 2024-07-18 at 12 35 06" src="https://github.com/user-attachments/assets/e0729453-14a3-4c03-bc29-bb27420d43fb"> | Fallback when deletePending keys summary fails |
| <img width="1726" alt="Screenshot 2024-07-18 at 12 36 01" src="https://github.com/user-attachments/assets/d4e70ad9-d7df-4f14-89f3-17db640c55fd"> | Fallback when File Size Distribution API fails |
|<img width="1727" alt="Screenshot 2024-07-18 at 12 35 46" src="https://github.com/user-attachments/assets/c808225f-282c-48c2-a84c-9d173e7f1c1a">| Fallback when Container Size Distribution API fails |

