### PR TITLE
HDDS-11185. Fix ContainerOpsLatencies metrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -110,8 +110,7 @@ public class ContainerMetrics {
     numOpsArray.get(type).incr();
   }
 
-  public void incContainerOpsLatencies(ContainerProtos.Type type,
-                                       long latencyNs) {
+  public void incContainerOpsLatencies(ContainerProtos.Type type, long latencyNs) {
     opsLatency.get(type).add(latencyNs);
     for (MutableQuantiles q: opsLatQuantiles.get(type)) {
       q.add(latencyNs);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -78,13 +78,13 @@ public class ContainerMetrics {
           "num" + type, "number of " + type + " ops", (long) 0));
       opsBytesArray.put(type, registry.newCounter(
           "bytes" + type, "bytes used by " + type + "op", (long) 0));
-      opsLatency.put(type, registry.newRate("latency" + type, type + " op"));
+      opsLatency.put(type, registry.newRate("latencyNs" + type, type + " op"));
 
       for (int j = 0; j < len; j++) {
         int interval = intervals[j];
         String quantileName = type + "Nanos" + interval + "s";
         latQuantiles[j] = registry.newQuantiles(quantileName,
-            "latency of Container ops", "ops", "latency", interval);
+            "latency of Container ops", "ops", "latencyNs", interval);
       }
       opsLatQuantiles.put(type, latQuantiles);
     }
@@ -111,10 +111,10 @@ public class ContainerMetrics {
   }
 
   public void incContainerOpsLatencies(ContainerProtos.Type type,
-                                       long latencyMillis) {
-    opsLatency.get(type).add(latencyMillis);
+                                       long latencyNs) {
+    opsLatency.get(type).add(latencyNs);
     for (MutableQuantiles q: opsLatQuantiles.get(type)) {
-      q.add(latencyMillis);
+      q.add(latencyNs);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -214,7 +214,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
 
     ContainerType containerType;
     ContainerCommandResponseProto responseProto = null;
-    long startTime = Time.monotonicNow();
+    long startTime = Time.monotonicNowNanos();
     Type cmdType = msg.getCmdType();
     long containerID = msg.getContainerID();
     metrics.incContainerOpsMetrics(cmdType);
@@ -290,7 +290,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         responseProto = createContainer(msg);
         metrics.incContainerOpsMetrics(Type.CreateContainer);
         metrics.incContainerOpsLatencies(Type.CreateContainer,
-                Time.monotonicNow() - startTime);
+                Time.monotonicNowNanos() - startTime);
 
         if (responseProto.getResult() != Result.SUCCESS) {
           StorageContainerException sce = new StorageContainerException(
@@ -343,9 +343,9 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     }
     perf.appendPreOpLatencyMs(Time.monotonicNow() - startTime);
     responseProto = handler.handle(msg, container, dispatcherContext);
-    long oPLatencyMS = Time.monotonicNow() - startTime;
+    long opLatencyNs = Time.monotonicNowNanos() - startTime;
     if (responseProto != null) {
-      metrics.incContainerOpsLatencies(cmdType, oPLatencyMS);
+      metrics.incContainerOpsLatencies(cmdType, opLatencyNs);
 
       // If the request is of Write Type and the container operation
       // is unsuccessful, it implies the applyTransaction on the container
@@ -418,8 +418,8 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         audit(action, eventType, msg, AuditEventStatus.FAILURE,
             new Exception(responseProto.getMessage()));
       }
-      perf.appendOpLatencyMs(oPLatencyMS);
-      performanceAudit(action, msg, perf, oPLatencyMS);
+      perf.appendOpLatencyMs(opLatencyNs);
+      performanceAudit(action, msg, perf, opLatencyNs);
 
       return responseProto;
     } else {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -122,6 +122,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
 import static org.apache.hadoop.ozone.ClientVersion.EC_REPLICA_INDEX_REQUIRED_IN_BLOCK_REQUEST;
 import static org.apache.hadoop.ozone.container.common.interfaces.Container.ScanResult;
 
+import org.apache.hadoop.util.Time;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.slf4j.Logger;
@@ -882,6 +883,7 @@ public class KeyValueHandler extends Handler {
 
       final boolean isCommit = dispatcherContext.getStage().isCommit();
       if (isCommit && writeChunk.hasBlock()) {
+        long startTime = Time.monotonicNowNanos();
         metrics.incContainerOpsMetrics(Type.PutBlock);
         BlockData blockData = BlockData.getFromProtoBuf(
             writeChunk.getBlock().getBlockData());
@@ -898,6 +900,7 @@ public class KeyValueHandler extends Handler {
         blockDataProto = blockData.getProtoBufMessage();
         final long numBytes = blockDataProto.getSerializedSize();
         metrics.incContainerBytesStats(Type.PutBlock, numBytes);
+        metrics.incContainerOpsLatencies(Type.PutBlock, Time.monotonicNowNanos() - startTime);
       }
 
       // We should increment stats after writeChunk

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/StreamDataChannelBase.java
@@ -130,11 +130,11 @@ abstract class StreamDataChannelBase
 
   final int writeFileChannel(ByteBuffer src) throws IOException {
     try {
-      final long startTime = Time.monotonicNow();
+      final long startTime = Time.monotonicNowNanos();
       final int writeBytes = getChannel().write(src);
       metrics.incContainerBytesStats(getType(), writeBytes);
       containerData.updateWriteStats(writeBytes, false);
-      metrics.incContainerOpsLatencies(getType(), Time.monotonicNow() - startTime);
+      metrics.incContainerOpsLatencies(getType(), Time.monotonicNowNanos() - startTime);
       return writeBytes;
     } catch (IOException e) {
       checkVolume();

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/MetricsAsserts.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/MetricsAsserts.java
@@ -396,7 +396,7 @@ public final class MetricsAsserts {
    */
   public static void assertQuantileGauges(String prefix,
       MetricsRecordBuilder rb) {
-    assertQuantileGauges(prefix, rb, "Latency");
+    assertQuantileGauges(prefix, rb, "LatencyNs");
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
ContainerOpsLatencies are now measured by milliseconds while most container op latencies are submilliseconds. This results in  ContainerOpsLatencies recorded as zeros. 
ContainerOpsLatencies should be captured as nanoseconds.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11185

## How was this patch tested?

CI.
