### PR TITLE
HDDS-10658. Include Transaction ID and Command Name in OM Audit Messages.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.AuditMessage;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+
+/**
+ * This class is used for OM Audit logs.
+ */
+public final class OMAuditLogger {
+  private OMAuditLogger() {
+  }
+
+  private static final Map<Type, OMAction> CMD_AUDIT_ACTION_MAP = new HashMap<>();
+  private static final Logger LOG = LoggerFactory.getLogger(OMAuditLogger.class);
+
+  static {
+    init();
+  }
+
+  private static void init() {
+    CMD_AUDIT_ACTION_MAP.put(Type.CreateVolume, OMAction.CREATE_VOLUME);
+    CMD_AUDIT_ACTION_MAP.put(Type.DeleteVolume, OMAction.DELETE_VOLUME);
+    CMD_AUDIT_ACTION_MAP.put(Type.CreateBucket, OMAction.CREATE_BUCKET);
+    CMD_AUDIT_ACTION_MAP.put(Type.DeleteBucket, OMAction.DELETE_BUCKET);
+    CMD_AUDIT_ACTION_MAP.put(Type.AddAcl, OMAction.ADD_ACL);
+    CMD_AUDIT_ACTION_MAP.put(Type.RemoveAcl, OMAction.REMOVE_ACL);
+    CMD_AUDIT_ACTION_MAP.put(Type.SetAcl, OMAction.SET_ACL);
+    CMD_AUDIT_ACTION_MAP.put(Type.GetDelegationToken, OMAction.GET_DELEGATION_TOKEN);
+    CMD_AUDIT_ACTION_MAP.put(Type.CancelDelegationToken, OMAction.CANCEL_DELEGATION_TOKEN);
+    CMD_AUDIT_ACTION_MAP.put(Type.RenewDelegationToken, OMAction.RENEW_DELEGATION_TOKEN);
+    CMD_AUDIT_ACTION_MAP.put(Type.GetS3Secret, OMAction.GET_S3_SECRET);
+    CMD_AUDIT_ACTION_MAP.put(Type.SetS3Secret, OMAction.SET_S3_SECRET);
+    CMD_AUDIT_ACTION_MAP.put(Type.RevokeS3Secret, OMAction.REVOKE_S3_SECRET);
+    CMD_AUDIT_ACTION_MAP.put(Type.CreateTenant, OMAction.CREATE_TENANT);
+    CMD_AUDIT_ACTION_MAP.put(Type.DeleteTenant, OMAction.DELETE_TENANT);
+    CMD_AUDIT_ACTION_MAP.put(Type.TenantAssignUserAccessId, OMAction.TENANT_ASSIGN_USER_ACCESSID);
+    CMD_AUDIT_ACTION_MAP.put(Type.TenantRevokeUserAccessId, OMAction.TENANT_REVOKE_USER_ACCESSID);
+    CMD_AUDIT_ACTION_MAP.put(Type.TenantRevokeAdmin, OMAction.TENANT_REVOKE_ADMIN);
+    CMD_AUDIT_ACTION_MAP.put(Type.CreateSnapshot, OMAction.CREATE_SNAPSHOT);
+    CMD_AUDIT_ACTION_MAP.put(Type.DeleteSnapshot, OMAction.DELETE_SNAPSHOT);
+    CMD_AUDIT_ACTION_MAP.put(Type.RenameSnapshot, OMAction.RENAME_SNAPSHOT);
+    CMD_AUDIT_ACTION_MAP.put(Type.RecoverLease, OMAction.RECOVER_LEASE);
+    CMD_AUDIT_ACTION_MAP.put(Type.CreateDirectory, OMAction.CREATE_DIRECTORY);
+    CMD_AUDIT_ACTION_MAP.put(Type.CreateFile, OMAction.CREATE_FILE);
+    CMD_AUDIT_ACTION_MAP.put(Type.CreateKey, OMAction.ALLOCATE_KEY);
+    CMD_AUDIT_ACTION_MAP.put(Type.AllocateBlock, OMAction.ALLOCATE_BLOCK);
+    CMD_AUDIT_ACTION_MAP.put(Type.CommitKey, OMAction.COMMIT_KEY);
+    CMD_AUDIT_ACTION_MAP.put(Type.DeleteKey, OMAction.DELETE_KEY);
+    CMD_AUDIT_ACTION_MAP.put(Type.DeleteKeys, OMAction.DELETE_KEYS);
+    CMD_AUDIT_ACTION_MAP.put(Type.RenameKey, OMAction.RENAME_KEY);
+    CMD_AUDIT_ACTION_MAP.put(Type.RenameKeys, OMAction.RENAME_KEYS);
+    CMD_AUDIT_ACTION_MAP.put(Type.InitiateMultiPartUpload, OMAction.INITIATE_MULTIPART_UPLOAD);
+    CMD_AUDIT_ACTION_MAP.put(Type.CommitMultiPartUpload, OMAction.COMMIT_MULTIPART_UPLOAD_PARTKEY);
+    CMD_AUDIT_ACTION_MAP.put(Type.AbortMultiPartUpload, OMAction.ABORT_MULTIPART_UPLOAD);
+    CMD_AUDIT_ACTION_MAP.put(Type.CompleteMultiPartUpload, OMAction.COMPLETE_MULTIPART_UPLOAD);
+    CMD_AUDIT_ACTION_MAP.put(Type.SetTimes, OMAction.SET_TIMES);
+    CMD_AUDIT_ACTION_MAP.put(Type.AbortExpiredMultiPartUploads, OMAction.ABORT_EXPIRED_MULTIPART_UPLOAD);
+    CMD_AUDIT_ACTION_MAP.put(Type.SetVolumeProperty, OMAction.SET_OWNER);
+    CMD_AUDIT_ACTION_MAP.put(Type.SetBucketProperty, OMAction.UPDATE_BUCKET);
+  }
+
+  private static OMAction getAction(OzoneManagerProtocolProtos.OMRequest request) {
+    Type cmdType = request.getCmdType();
+    OMAction omAction = CMD_AUDIT_ACTION_MAP.get(cmdType);
+    if (null != omAction) {
+      if (cmdType.equals(Type.SetVolumeProperty)) {
+        boolean hasQuota = request.getSetVolumePropertyRequest().hasQuotaInBytes();
+        if (hasQuota) {
+          return OMAction.SET_QUOTA;
+        }
+      }
+      if (cmdType.equals(Type.SetVolumeProperty)) {
+        boolean hasBucketOwner = request.getSetBucketPropertyRequest().getBucketArgs().hasOwnerName();
+        if (hasBucketOwner) {
+          return OMAction.SET_OWNER;
+        }
+      }
+    }
+    return omAction;
+  }
+
+  public static void log(OMAuditLogger.Builder builder) {
+    if (builder.isLog.get()) {
+      builder.getAuditLogger().logWrite(builder.getMessageBuilder().build());
+    }
+  }
+
+  public static void log(OMAuditLogger.Builder builder, OMClientRequest request, OzoneManager om,
+                         TermIndex termIndex, Throwable th) {
+    if (builder.isLog.get()) {
+      builder.getAuditLogger().logWrite(builder.getMessageBuilder().build());
+      return;
+    }
+
+    OMAction action = getAction(request.getOmRequest());
+    if (null == action) {
+      // no audit log defined
+      return;
+    }
+    if (builder.getAuditMap() == null) {
+      builder.setAuditMap(new HashMap<>());
+    }
+    try {
+      builder.getAuditMap().put("Command", request.getOmRequest().getCmdType().name());
+      builder.getAuditMap().put("Transaction", "" + termIndex.getIndex());
+      request.buildAuditMessage(action, builder.getAuditMap(),
+          th, request.getUserInfo());
+      builder.setLog(true);
+      builder.setAuditLogger(om.getAuditLogger());
+      log(builder);
+    } catch (Exception ex) {
+      LOG.error("Exception occurred while write audit log, ", ex);
+    }
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder class for build AuditMessage.
+   */
+  public static class Builder {
+    private AuditMessage.Builder messageBuilder = new AuditMessage.Builder();
+    private final AtomicBoolean isLog = new AtomicBoolean(false);
+    private Map<String, String> auditMap = null;
+    private AuditLogger auditLogger;
+
+    public OMAuditLogger build() throws IOException {
+      return new OMAuditLogger();
+    }
+
+    public AuditMessage.Builder getMessageBuilder() {
+      return this.messageBuilder;
+    }
+
+    public void setLog(boolean flag) {
+      this.isLog.set(flag);
+    }
+
+    public void setAuditLogger(AuditLogger auditLogger) {
+      this.auditLogger = auditLogger;
+    }
+
+    public AuditLogger getAuditLogger() {
+      return auditLogger;
+    }
+
+    public void setAuditMap(Map<String, String> auditMap) {
+      this.auditMap = auditMap;
+    }
+    
+    public Map<String, String> getAuditMap() {
+      return this.auditMap;
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
@@ -88,6 +88,9 @@ public final class OMAuditLogger {
     CMD_AUDIT_ACTION_MAP.put(Type.AbortExpiredMultiPartUploads, OMAction.ABORT_EXPIRED_MULTIPART_UPLOAD);
     CMD_AUDIT_ACTION_MAP.put(Type.SetVolumeProperty, OMAction.SET_OWNER);
     CMD_AUDIT_ACTION_MAP.put(Type.SetBucketProperty, OMAction.UPDATE_BUCKET);
+    CMD_AUDIT_ACTION_MAP.put(Type.Prepare, OMAction.UPGRADE_PREPARE);
+    CMD_AUDIT_ACTION_MAP.put(Type.CancelPrepare, OMAction.UPGRADE_CANCEL);
+    CMD_AUDIT_ACTION_MAP.put(Type.FinalizeUpgrade, OMAction.UPGRADE_FINALIZE);
   }
 
   private static OMAction getAction(OzoneManagerProtocolProtos.OMRequest request) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
@@ -110,6 +110,17 @@ public final class OMAuditLogger {
     return omAction;
   }
 
+  public static void log(OMAuditLogger.Builder builder, TermIndex termIndex) {
+    if (builder.isLog.get()) {
+      if (null == builder.getAuditMap()) {
+        builder.setAuditMap(new HashMap<>());
+      }
+      builder.getAuditMap().put("Transaction", "" + termIndex.getIndex());
+      builder.getMessageBuilder().withParams(builder.getAuditMap());
+      builder.getAuditLogger().logWrite(builder.getMessageBuilder().build());
+    }
+  }
+
   public static void log(OMAuditLogger.Builder builder) {
     if (builder.isLog.get()) {
       builder.getMessageBuilder().withParams(builder.getAuditMap());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
@@ -100,7 +100,7 @@ public final class OMAuditLogger {
           return OMAction.SET_QUOTA;
         }
       }
-      if (cmdType.equals(Type.SetVolumeProperty)) {
+      if (cmdType.equals(Type.SetBucketProperty)) {
         boolean hasBucketOwner = request.getSetBucketPropertyRequest().getBucketArgs().hasOwnerName();
         if (hasBucketOwner) {
           return OMAction.SET_OWNER;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/helpers/OMAuditLogger.java
@@ -112,6 +112,7 @@ public final class OMAuditLogger {
 
   public static void log(OMAuditLogger.Builder builder) {
     if (builder.isLog.get()) {
+      builder.getMessageBuilder().withParams(builder.getAuditMap());
       builder.getAuditLogger().logWrite(builder.getMessageBuilder().build());
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -480,7 +480,7 @@ public abstract class OMClientRequest implements RequestAuditor {
    * @param auditLogger
    * @param builder
    */
-  protected void auditLog(AuditLogger auditLogger, OMAuditLogger.Builder builder) {
+  protected void markForAudit(AuditLogger auditLogger, OMAuditLogger.Builder builder) {
     builder.setLog(true);
     builder.setAuditLogger(auditLogger);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.ozone.om.helpers.OMAuditLogger;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ozone.OmUtils;
@@ -29,7 +30,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import org.apache.hadoop.ozone.audit.AuditLogger;
-import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.IOmMetadataReader;
 import org.apache.hadoop.ozone.om.OmMetadataReader;
 import org.apache.hadoop.ozone.om.OzoneAclUtils;
@@ -79,6 +79,11 @@ public abstract class OMClientRequest implements RequestAuditor {
   private UserGroupInformation userGroupInformation;
   private InetAddress inetAddress;
   private final OMLockDetails omLockDetails = new OMLockDetails();
+  private final OMAuditLogger.Builder auditBuilder = OMAuditLogger.newBuilder();
+
+  public OMAuditLogger.Builder getAuditBuilder() {
+    return auditBuilder;
+  }
 
   /**
    * Stores the result of request execution in
@@ -471,27 +476,29 @@ public abstract class OMClientRequest implements RequestAuditor {
   }
 
   /**
-   * Log the auditMessage.
+   * Mark ready for log audit.
    * @param auditLogger
-   * @param auditMessage
+   * @param builder
    */
-  protected void auditLog(AuditLogger auditLogger, AuditMessage auditMessage) {
-    auditLogger.logWrite(auditMessage);
+  protected void auditLog(AuditLogger auditLogger, OMAuditLogger.Builder builder) {
+    builder.setLog(true);
+    builder.setAuditLogger(auditLogger);
   }
 
   @Override
-  public AuditMessage buildAuditMessage(AuditAction op,
+  public OMAuditLogger.Builder buildAuditMessage(AuditAction op,
       Map< String, String > auditMap, Throwable throwable,
       OzoneManagerProtocolProtos.UserInfo userInfo) {
-    return new AuditMessage.Builder()
+    auditBuilder.getMessageBuilder()
         .setUser(userInfo != null ? userInfo.getUserName() : null)
         .atIp(userInfo != null ? userInfo.getRemoteAddress() : null)
         .forOperation(op)
         .withParams(auditMap)
         .withResult(throwable != null ? AuditEventStatus.FAILURE :
             AuditEventStatus.SUCCESS)
-        .withException(throwable)
-        .build();
+        .withException(throwable);
+    auditBuilder.setAuditMap(auditMap);
+    return auditBuilder;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditMessage;
+import org.apache.hadoop.ozone.om.helpers.OMAuditLogger;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -47,8 +48,8 @@ public interface RequestAuditor {
    * @param userInfo
    * @return
    */
-  AuditMessage buildAuditMessage(AuditAction op,
-      Map<String, String> auditMap, Throwable throwable, UserInfo userInfo);
+  OMAuditLogger.Builder buildAuditMessage(
+      AuditAction op, Map<String, String> auditMap, Throwable throwable, UserInfo userInfo);
 
   /**
    * Build auditMap with specified volume.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditAction;
-import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.helpers.OMAuditLogger;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .KeyArgs;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -285,7 +285,7 @@ public class OMBucketCreateRequest extends OMClientRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(auditLogger, buildAuditMessage(OMAction.CREATE_BUCKET,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.CREATE_BUCKET,
         omBucketInfo.toAuditMap(), exception, userInfo));
 
     // return response.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -215,7 +215,7 @@ public class OMBucketDeleteRequest extends OMClientRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(auditLogger, buildAuditMessage(OMAction.DELETE_BUCKET,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.DELETE_BUCKET,
         auditMap, exception, userInfo));
 
     // return response.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
@@ -183,7 +183,7 @@ public class OMBucketSetOwnerRequest extends OMClientRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(auditLogger, buildAuditMessage(OMAction.SET_OWNER,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.SET_OWNER,
         omBucketArgs.toAuditMap(), exception, userInfo));
 
     // return response.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -237,7 +237,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(auditLogger, buildAuditMessage(OMAction.UPDATE_BUCKET,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.UPDATE_BUCKET,
         omBucketArgs.toAuditMap(), exception, userInfo));
 
     // return response.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
@@ -115,7 +115,7 @@ public class OMBucketAddAclRequest extends OMBucketAclRequest {
   void onComplete(boolean operationResult, Exception exception,
       OMMetrics omMetrics, AuditLogger auditLogger,
       Map<String, String> auditMap) {
-    auditLog(auditLogger, buildAuditMessage(OMAction.ADD_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.ADD_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
 
     if (operationResult) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
@@ -113,7 +113,7 @@ public class OMBucketRemoveAclRequest extends OMBucketAclRequest {
   void onComplete(boolean operationResult, Exception exception,
       OMMetrics omMetrics, AuditLogger auditLogger,
       Map<String, String> auditMap) {
-    auditLog(auditLogger, buildAuditMessage(OMAction.REMOVE_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.REMOVE_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
 
     if (operationResult) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
@@ -112,7 +112,7 @@ public class OMBucketSetAclRequest extends OMBucketAclRequest {
   void onComplete(boolean operationResult, Exception exception,
       OMMetrics omMetrics, AuditLogger auditLogger,
       Map<String, String> auditMap) {
-    auditLog(auditLogger, buildAuditMessage(OMAction.SET_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.SET_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
 
     if (operationResult) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -240,7 +240,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       }
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.CREATE_DIRECTORY,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.CREATE_DIRECTORY,
         auditMap, exception, userInfo));
 
     logResult(createDirectoryRequest, keyArgs, omMetrics, result,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -193,7 +193,7 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
       }
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.CREATE_DIRECTORY,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.CREATE_DIRECTORY,
         auditMap, exception, userInfo));
 
     logResult(createDirectoryRequest, keyArgs, omMetrics, numKeysCreated,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -323,7 +323,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
     }
 
     // Audit Log outside the lock
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.CREATE_FILE, auditMap, exception,
         getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -241,7 +241,7 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
     }
 
     // Audit Log outside the lock
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.CREATE_FILE, auditMap, exception,
         getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -175,7 +175,7 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
     }
 
     // Audit Log outside the lock
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.RECOVER_LEASE, auditMap, exception,
         getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -261,7 +261,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
       }
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.ALLOCATE_BLOCK, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.ALLOCATE_BLOCK, auditMap,
         exception, getOmRequest().getUserInfo()));
 
     return omClientResponse;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -184,7 +184,7 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
       }
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.ALLOCATE_BLOCK, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.ALLOCATE_BLOCK, auditMap,
             exception, getOmRequest().getUserInfo()));
 
     return omClientResponse;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -354,7 +354,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         result == Result.SUCCESS ? "succeeded" : "failed", isHSync, omKeyInfo);
 
     if (!isHSync) {
-      auditLog(auditLogger, buildAuditMessage(OMAction.COMMIT_KEY, auditMap,
+      markForAudit(auditLogger, buildAuditMessage(OMAction.COMMIT_KEY, auditMap,
               exception, getOmRequest().getUserInfo()));
       processResult(commitKeyRequest, volumeName, bucketName, keyName,
           omMetrics, exception, omKeyInfo, result);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -289,7 +289,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         result == Result.SUCCESS ? "succeeded" : "failed", isHSync, omKeyInfo);
 
     if (!isHSync) {
-      auditLog(auditLogger, buildAuditMessage(OMAction.COMMIT_KEY, auditMap,
+      markForAudit(auditLogger, buildAuditMessage(OMAction.COMMIT_KEY, auditMap,
               exception, getOmRequest().getUserInfo()));
       processResult(commitKeyRequest, volumeName, bucketName, keyName,
           omMetrics, exception, omKeyInfo, result);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -355,7 +355,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
     }
 
     // Audit Log outside the lock
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.ALLOCATE_KEY, auditMap, exception,
         getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -228,7 +228,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
     }
 
     // Audit Log outside the lock
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
             OMAction.ALLOCATE_KEY, auditMap, exception,
             getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -207,7 +207,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(auditLogger,
+    markForAudit(auditLogger,
         buildAuditMessage(OMAction.DELETE_KEY, auditMap, exception, userInfo));
 
     switch (result) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -194,7 +194,7 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(auditLogger, buildAuditMessage(OMAction.DELETE_KEY, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.DELETE_KEY, auditMap,
         exception, userInfo));
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -227,7 +227,7 @@ public class OMKeyRenameRequest extends OMKeyRequest {
       }
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.RENAME_KEY, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.RENAME_KEY, auditMap,
         exception, getOmRequest().getUserInfo()));
 
     switch (result) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -218,7 +218,7 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
       }
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.RENAME_KEY, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.RENAME_KEY, auditMap,
             exception, getOmRequest().getUserInfo()));
 
     switch (result) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeySetTimesRequest.java
@@ -160,7 +160,7 @@ public class OMKeySetTimesRequest extends OMKeyRequest {
     auditMap.put(OzoneConsts.KEY, getKeyName());
     auditMap.put(OzoneConsts.MODIFICATION_TIME,
         String.valueOf(getModificationTime()));
-    auditLog(auditLogger, buildAuditMessage(OMAction.SET_TIMES, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.SET_TIMES, auditMap,
         exception, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -236,7 +236,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
 
     addDeletedKeys(auditMap, deleteKeys, unDeletedKeys.getKeysList());
 
-    auditLog(auditLogger,
+    markForAudit(auditLogger,
         buildAuditMessage(DELETE_KEYS, auditMap, exception, userInfo));
 
     switch (result) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -245,7 +245,7 @@ public class OMKeysRenameRequest extends OMKeyRequest {
     }
 
     auditMap = buildAuditMap(auditMap, renamedKeys, unRenamedKeys);
-    auditLog(auditLogger, buildAuditMessage(OMAction.RENAME_KEYS, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.RENAME_KEYS, auditMap,
         exception, getOmRequest().getUserInfo()));
 
     switch (result) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -138,7 +138,7 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
     if (ozoneAcls != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcls.toString());
     }
-    auditLog(auditLogger, buildAuditMessage(OMAction.ADD_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.ADD_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
@@ -122,7 +122,7 @@ public class OMKeyAddAclRequestWithFSO extends OMKeyAclRequestWithFSO {
     if (ozoneAcls != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcls.toString());
     }
-    auditLog(auditLogger,
+    markForAudit(auditLogger,
         buildAuditMessage(OMAction.ADD_ACL, auditMap, exception,
             getOmRequest().getUserInfo()));
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -139,7 +139,7 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
     if (ozoneAcls != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcls.toString());
     }
-    auditLog(auditLogger, buildAuditMessage(OMAction.REMOVE_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.REMOVE_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
@@ -131,7 +131,7 @@ public class OMKeyRemoveAclRequestWithFSO extends OMKeyAclRequestWithFSO {
     if (ozoneAcls != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcls.toString());
     }
-    auditLog(auditLogger,
+    markForAudit(auditLogger,
         buildAuditMessage(OMAction.REMOVE_ACL, auditMap, exception,
             getOmRequest().getUserInfo()));
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -135,7 +135,7 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
     if (ozoneAcls != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcls.toString());
     }
-    auditLog(auditLogger, buildAuditMessage(OMAction.SET_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.SET_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
@@ -124,7 +124,7 @@ public class OMKeySetAclRequestWithFSO extends OMKeyAclRequestWithFSO {
     if (ozoneAcls != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcls.toString());
     }
-    auditLog(auditLogger,
+    markForAudit(auditLogger,
         buildAuditMessage(OMAction.SET_ACL, auditMap, exception,
             getOmRequest().getUserInfo()));
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAddAclRequest.java
@@ -120,7 +120,7 @@ public class OMPrefixAddAclRequest extends OMPrefixAclRequest {
     if (ozoneAcl != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcl.toString());
     }
-    auditLog(auditLogger, buildAuditMessage(OMAction.ADD_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.ADD_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixRemoveAclRequest.java
@@ -120,7 +120,7 @@ public class OMPrefixRemoveAclRequest extends OMPrefixAclRequest {
     if (ozoneAcls != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcls.toString());
     }
-    auditLog(auditLogger, buildAuditMessage(OMAction.REMOVE_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.REMOVE_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
@@ -116,7 +116,7 @@ public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
     if (ozoneAcls != null) {
       auditMap.put(OzoneConsts.ACL, ozoneAcls.toString());
     }
-    auditLog(auditLogger, buildAuditMessage(OMAction.SET_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.SET_ACL, auditMap,
         exception, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3ExpiredMultipartUploadsAbortRequest.java
@@ -161,7 +161,7 @@ public class S3ExpiredMultipartUploadsAbortRequest extends OMKeyRequest {
         Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgsForAudit);
         auditMap.put(OzoneConsts.UPLOAD_ID, abortInfo.getOmMultipartKeyInfo()
             .getUploadID());
-        auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+        markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
             OMAction.ABORT_EXPIRED_MULTIPART_UPLOAD, auditMap,
             null, getOmRequest().getUserInfo()));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -264,7 +264,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
       Map<String, String> auditMap, String volumeName, String bucketName,
       String keyName, Exception exception, Result result) {
     // audit log
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.INITIATE_MULTIPART_UPLOAD, auditMap,
         exception, getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -205,7 +205,7 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
     }
 
     // audit log
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.ABORT_MULTIPART_UPLOAD, auditMap,
         exception, getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -320,7 +320,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
     auditMap.put(OzoneConsts.MULTIPART_UPLOAD_PART_NUMBER,
         String.valueOf(keyArgs.getMultipartNumber()));
     auditMap.put(OzoneConsts.MULTIPART_UPLOAD_PART_NAME, partName);
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.COMMIT_MULTIPART_UPLOAD_PARTKEY,
         auditMap, exception,
         getOmRequest().getUserInfo()));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -436,7 +436,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         .replaceAll("\\n", " "));
 
     // audit log
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.COMPLETE_MULTIPART_UPLOAD, auditMap, exception,
         getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
@@ -147,7 +147,7 @@ public class OMSetSecretRequest extends OMClientRequest {
     auditMap.put(OzoneConsts.S3_SETSECRET_USER, accessId);
 
     // audit log
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.SET_S3_SECRET, auditMap,
         exception, getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
@@ -214,7 +214,7 @@ public class S3GetSecretRequest extends OMClientRequest {
     auditMap.put(OzoneConsts.S3_GETSECRET_USER, accessId);
 
     // audit log
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.GET_S3_SECRET, auditMap,
         exception, getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3RevokeSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3RevokeSecretRequest.java
@@ -118,7 +118,7 @@ public class S3RevokeSecretRequest extends OMClientRequest {
 
     Map<String, String> auditMap = new HashMap<>();
     auditMap.put(OzoneConsts.S3_REVOKESECRET_USER, kerberosID);
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.REVOKE_S3_SECRET, auditMap,
         exception, getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -237,7 +237,7 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
 
     // Audit
     auditMap.put(OzoneConsts.TENANT, tenantId);
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.TENANT_ASSIGN_ADMIN, auditMap, exception,
         getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -350,7 +350,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
     auditMap.put(OzoneConsts.TENANT, tenantId);
     auditMap.put("user", userPrincipal);
     auditMap.put("accessId", accessId);
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.TENANT_ASSIGN_USER_ACCESSID, auditMap, exception,
             getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -375,12 +375,8 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
     // Perform audit logging
     auditMap.put(OzoneConsts.TENANT, tenantId);
     // Note auditMap contains volume creation info
-    auditLog(ozoneManager.getAuditLogger(),
+    markForAudit(ozoneManager.getAuditLogger(),
         buildAuditMessage(OMAction.CREATE_TENANT, auditMap, exception,
-            getOmRequest().getUserInfo()));
-    // Log CREATE_VOLUME as well since a volume is created
-    auditLog(ozoneManager.getAuditLogger(),
-        buildAuditMessage(OMAction.CREATE_VOLUME, auditMap, exception,
             getOmRequest().getUserInfo()));
 
     if (exception == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
@@ -228,13 +228,13 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
     auditMap.put(OzoneConsts.TENANT, tenantId);
     // Audit volume ref count update
     if (decVolumeRefCount) {
-      auditLog(ozoneManager.getAuditLogger(),
+      markForAudit(ozoneManager.getAuditLogger(),
           buildAuditMessage(OMAction.UPDATE_VOLUME,
               buildVolumeAuditMap(volumeName),
               exception, getOmRequest().getUserInfo()));
     }
     // Audit tenant deletion
-    auditLog(ozoneManager.getAuditLogger(),
+    markForAudit(ozoneManager.getAuditLogger(),
         buildAuditMessage(OMAction.DELETE_TENANT,
             auditMap, exception, getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -227,7 +227,7 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
 
     // Audit
     auditMap.put(OzoneConsts.TENANT, tenantId);
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.TENANT_REVOKE_ADMIN, auditMap, exception,
         getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
@@ -247,7 +247,7 @@ public class OMTenantRevokeUserAccessIdRequest extends OMClientRequest {
     auditMap.put(OzoneConsts.TENANT, tenantId);
     auditMap.put("accessId", accessId);
     auditMap.put("userPrincipal", userPrincipal);
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+    markForAudit(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.TENANT_REVOKE_USER_ACCESSID, auditMap, exception,
         getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMCancelDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMCancelDelegationTokenRequest.java
@@ -77,7 +77,7 @@ public class OMCancelDelegationTokenRequest extends OMClientRequest {
       return request;
 
     } catch (IOException ioe) {
-      auditLog(auditLogger,
+      markForAudit(auditLogger,
           buildAuditMessage(OMAction.CANCEL_DELEGATION_TOKEN, auditMap, ioe,
               request.getUserInfo()));
       throw ioe;
@@ -125,7 +125,7 @@ public class OMCancelDelegationTokenRequest extends OMClientRequest {
           createErrorOMResponse(omResponse, exception));
     }
 
-    auditLog(auditLogger,
+    markForAudit(auditLogger,
         buildAuditMessage(OMAction.CANCEL_DELEGATION_TOKEN, auditMap, exception,
             getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMGetDelegationTokenRequest.java
@@ -78,7 +78,7 @@ public class OMGetDelegationTokenRequest extends OMClientRequest {
       token = ozoneManager
           .getDelegationToken(new Text(getDelegationTokenRequest.getRenewer()));
     } catch (IOException ioe) {
-      auditLog(auditLogger,
+      markForAudit(auditLogger,
           buildAuditMessage(OMAction.GET_DELEGATION_TOKEN,
               new LinkedHashMap<>(), ioe, request.getUserInfo()));
       throw ioe;
@@ -195,7 +195,7 @@ public class OMGetDelegationTokenRequest extends OMClientRequest {
           createErrorOMResponse(omResponse, exception));
     }
 
-    auditLog(auditLogger,
+    markForAudit(auditLogger,
         buildAuditMessage(OMAction.GET_DELEGATION_TOKEN, auditMap, exception,
             getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMRenewDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMRenewDelegationTokenRequest.java
@@ -85,7 +85,7 @@ public class OMRenewDelegationTokenRequest extends OMClientRequest {
       // Call OM to renew token
       renewTime = ozoneManager.renewDelegationToken(token);
     } catch (IOException ioe) {
-      auditLog(auditLogger,
+      markForAudit(auditLogger,
           buildAuditMessage(OMAction.RENEW_DELEGATION_TOKEN, auditMap, ioe,
               request.getUserInfo()));
       throw ioe;
@@ -181,7 +181,7 @@ public class OMRenewDelegationTokenRequest extends OMClientRequest {
           createErrorOMResponse(omResponse, exception));
     }
 
-    auditLog(auditLogger,
+    markForAudit(auditLogger,
         buildAuditMessage(OMAction.RENEW_DELEGATION_TOKEN, auditMap, exception,
             getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -211,7 +211,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
     }
 
     // Performing audit logging outside the lock.
-    auditLog(auditLogger, buildAuditMessage(OMAction.CREATE_SNAPSHOT,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.CREATE_SNAPSHOT,
         snapshotInfo.toAuditMap(), exception, userInfo));
 
     if (exception == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotDeleteRequest.java
@@ -214,7 +214,7 @@ public class OMSnapshotDeleteRequest extends OMClientRequest {
     }
 
     // Perform audit logging outside the lock
-    auditLog(auditLogger, buildAuditMessage(OMAction.DELETE_SNAPSHOT,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.DELETE_SNAPSHOT,
         snapshotInfo.toAuditMap(), exception, userInfo));
 
     final String snapshotPath = snapshotInfo.getSnapshotPath();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotRenameRequest.java
@@ -223,7 +223,7 @@ public class OMSnapshotRenameRequest extends OMClientRequest {
     }
 
     // Perform audit logging outside the lock
-    auditLog(auditLogger, buildAuditMessage(OMAction.RENAME_SNAPSHOT,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.RENAME_SNAPSHOT,
                                             snapshotOldInfo.toAuditMap(), exception, userInfo));
     return omClientResponse;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
@@ -96,7 +96,7 @@ public class OMCancelPrepareRequest extends OMClientRequest {
           createErrorOMResponse(responseBuilder, e));
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.UPGRADE_CANCEL,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.UPGRADE_CANCEL,
         new HashMap<>(), exception, userInfo));
     return response;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
@@ -115,7 +115,7 @@ public class OMFinalizeUpgradeRequest extends OMClientRequest {
           createErrorOMResponse(responseBuilder, e), -1);
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.UPGRADE_FINALIZE,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.UPGRADE_FINALIZE,
         new HashMap<>(), exception, userInfo));
     return response;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -157,7 +157,7 @@ public class OMPrepareRequest extends OMClientRequest {
       }
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.UPGRADE_PREPARE,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.UPGRADE_PREPARE,
         new HashMap<>(), exception, userInfo));
     return response;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -189,7 +189,7 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(ozoneManager.getAuditLogger(),
+    markForAudit(ozoneManager.getAuditLogger(),
         buildAuditMessage(OMAction.CREATE_VOLUME, auditMap, exception,
             getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
@@ -161,7 +161,7 @@ public class OMVolumeDeleteRequest extends OMVolumeRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(ozoneManager.getAuditLogger(),
+    markForAudit(ozoneManager.getAuditLogger(),
         buildAuditMessage(OMAction.DELETE_VOLUME, buildVolumeAuditMap(volume),
             exception, getOmRequest().getUserInfo()));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
@@ -194,7 +194,7 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(auditLogger, buildAuditMessage(OMAction.SET_OWNER, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.SET_OWNER, auditMap,
         exception, userInfo));
 
     // return response after releasing lock.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -172,7 +172,7 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
     }
 
     // Performing audit logging outside of the lock.
-    auditLog(auditLogger, buildAuditMessage(OMAction.SET_QUOTA, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.SET_QUOTA, auditMap,
         exception, userInfo));
 
     // return response after releasing lock.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
@@ -136,7 +136,7 @@ public class OMVolumeAddAclRequest extends OMVolumeAclRequest {
           getOmRequest());
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.ADD_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.ADD_ACL, auditMap,
         ex, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
@@ -135,7 +135,7 @@ public class OMVolumeRemoveAclRequest extends OMVolumeAclRequest {
       LOG.error("Unrecognized Result for OMVolumeRemoveAclRequest: {}",
           getOmRequest());
     }
-    auditLog(auditLogger, buildAuditMessage(OMAction.REMOVE_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.REMOVE_ACL, auditMap,
         ex, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
@@ -133,7 +133,7 @@ public class OMVolumeSetAclRequest extends OMVolumeAclRequest {
           getOmRequest());
     }
 
-    auditLog(auditLogger, buildAuditMessage(OMAction.SET_ACL, auditMap,
+    markForAudit(auditLogger, buildAuditMessage(OMAction.SET_ACL, auditMap,
         ex, getOmRequest().getUserInfo()));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.helpers.OMAuditLogger;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
@@ -217,6 +218,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
         requestToSubmit = preExecute(finalOmClientRequest);
         this.lastRequestToSubmit = requestToSubmit;
       } catch (IOException ex) {
+        OMAuditLogger.log(omClientRequest.getAuditBuilder());
         if (omClientRequest != null) {
           omClientRequest.handleRequestFailure(ozoneManager);
         }
@@ -296,7 +298,13 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
       } else {
         OMClientRequest omClientRequest =
             createClientRequest(request, ozoneManager);
-        request = omClientRequest.preExecute(ozoneManager);
+        try {
+          request = omClientRequest.preExecute(ozoneManager);
+        } catch (IOException ex) {
+          // log only when audit build is complete as required
+          OMAuditLogger.log(omClientRequest.getAuditBuilder());
+          throw ex;
+        }
         final TermIndex termIndex = TransactionInfo.getTermIndex(transactionIndex.incrementAndGet());
         omClientResponse = handler.handleWriteRequest(request, termIndex, ozoneManagerDoubleBuffer);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -218,8 +218,8 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
         requestToSubmit = preExecute(finalOmClientRequest);
         this.lastRequestToSubmit = requestToSubmit;
       } catch (IOException ex) {
-        OMAuditLogger.log(omClientRequest.getAuditBuilder());
         if (omClientRequest != null) {
+          OMAuditLogger.log(omClientRequest.getAuditBuilder());
           omClientRequest.handleRequestFailure(ozoneManager);
         }
         return createErrorResponse(request, ex);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.protocolPB.OzonePBHelper;
 import org.apache.hadoop.hdds.utils.FaultInjector;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.helpers.OMAuditLogger;
 import org.apache.hadoop.ozone.util.PayloadUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
@@ -393,10 +394,17 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     injectPause();
     OMClientRequest omClientRequest =
         OzoneManagerRatisUtils.createClientRequest(omRequest, impl);
-    return captureLatencyNs(
-        impl.getPerfMetrics().getValidateAndUpdateCacheLatencyNs(),
-        () -> Objects.requireNonNull(omClientRequest.validateAndUpdateCache(getOzoneManager(), termIndex),
-            "omClientResponse returned by validateAndUpdateCache cannot be null"));
+    try {
+      OMClientResponse omClientResponse = captureLatencyNs(
+          impl.getPerfMetrics().getValidateAndUpdateCacheLatencyNs(),
+          () -> Objects.requireNonNull(omClientRequest.validateAndUpdateCache(getOzoneManager(), termIndex),
+              "omClientResponse returned by validateAndUpdateCache cannot be null"));
+      OMAuditLogger.log(omClientRequest.getAuditBuilder());
+      return omClientResponse;
+    } catch (Throwable th) {
+      OMAuditLogger.log(omClientRequest.getAuditBuilder(), omClientRequest, getOzoneManager(), termIndex, th);
+      throw th;
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -399,6 +399,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
           impl.getPerfMetrics().getValidateAndUpdateCacheLatencyNs(),
           () -> Objects.requireNonNull(omClientRequest.validateAndUpdateCache(getOzoneManager(), termIndex),
               "omClientResponse returned by validateAndUpdateCache cannot be null"));
+      omClientRequest.getAuditBuilder().getAuditMap().put("Transaction", "" + termIndex.getIndex());
       OMAuditLogger.log(omClientRequest.getAuditBuilder());
       return omClientResponse;
     } catch (Throwable th) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -399,8 +399,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
           impl.getPerfMetrics().getValidateAndUpdateCacheLatencyNs(),
           () -> Objects.requireNonNull(omClientRequest.validateAndUpdateCache(getOzoneManager(), termIndex),
               "omClientResponse returned by validateAndUpdateCache cannot be null"));
-      omClientRequest.getAuditBuilder().getAuditMap().put("Transaction", "" + termIndex.getIndex());
-      OMAuditLogger.log(omClientRequest.getAuditBuilder());
+      OMAuditLogger.log(omClientRequest.getAuditBuilder(), termIndex);
       return omClientResponse;
     } catch (Throwable th) {
       OMAuditLogger.log(omClientRequest.getAuditBuilder(), omClientRequest, getOzoneManager(), termIndex, th);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -45,6 +45,7 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.LogProtoUtils;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.util.ExitUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,7 +53,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -247,7 +247,7 @@ public class TestOzoneManagerStateMachine {
     Mockito.doAnswer((i) -> {
       if (!((AuditMessage) i.getArgument(0)).getFormattedMessage().contains("Transaction=10") ||
           !((AuditMessage) i.getArgument(0)).getFormattedMessage().contains("Command=CreateVolume")) {
-        fail("transaction and command not found");
+        Assertions.fail("transaction and command not found");
       }
       // throw another exception to change to new exception to avoid terminate call
       throw new OMException("test", OMException.ResultCodes.VOLUME_IS_REFERENCED);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -16,8 +16,11 @@
  */
 package org.apache.hadoop.ozone.om.ratis;
 
+import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -25,6 +28,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareRequestArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
@@ -35,15 +39,20 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Prepare
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.server.raftlog.LogProtoUtils;
 import org.apache.ratis.statemachine.TransactionContext;
+import org.apache.ratis.util.ExitUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import org.mockito.Mockito;
 
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -63,6 +72,7 @@ public class TestOzoneManagerStateMachine {
 
   private OzoneManagerStateMachine ozoneManagerStateMachine;
   private OzoneManagerPrepareState prepareState;
+  private AuditLogger auditLogger;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -81,7 +91,9 @@ public class TestOzoneManagerStateMachine {
         ozoneManager);
 
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    auditLogger = mock(AuditLogger.class);
 
+    when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     prepareState = new OzoneManagerPrepareState(conf);
     when(ozoneManager.getPrepareState()).thenReturn(prepareState);
 
@@ -220,6 +232,34 @@ public class TestOzoneManagerStateMachine {
     // the pre-append state machine step, so it is tested in other classes.
   }
 
+  @Test
+  public void testApplyTransactionExceptionAuditLog() throws Exception {
+    ExitUtils.disableSystemExit();
+    // submit a create volume request having null pointer exception
+    OzoneManagerProtocolProtos.VolumeInfo volInfo = OzoneManagerProtocolProtos.VolumeInfo.newBuilder()
+        .setAdminName("a").setOwnerName("a").setVolume("a").build();
+    OMRequest createVolRequest = OMRequest.newBuilder()
+        .setCreateVolumeRequest(OzoneManagerProtocolProtos.CreateVolumeRequest.newBuilder().setVolumeInfo(volInfo))
+        .setCmdType(Type.CreateVolume).setClientId("123")
+        .setUserInfo(UserInfo.newBuilder().setUserName("user").setHostName("localhost").setRemoteAddress("127.0.0.1"))
+        .build();
+    TransactionContext submittedTrx = mockTransactionContext(createVolRequest);
+    Mockito.doAnswer((i) -> {
+      if (!((AuditMessage) i.getArgument(0)).getFormattedMessage().contains("Transaction=10") ||
+          !((AuditMessage) i.getArgument(0)).getFormattedMessage().contains("Command=CreateVolume")) {
+        fail("transaction and command not found");
+      }
+      // throw another exception to change to new exception to avoid terminate call
+      throw new OMException("test", OMException.ResultCodes.VOLUME_IS_REFERENCED);
+    }).when(auditLogger).logWrite(any());
+    CompletableFuture<Message> messageCompletableFuture = ozoneManagerStateMachine.applyTransaction(submittedTrx);
+    try {
+      messageCompletableFuture.get();
+    } catch (Exception ex) {
+      // do nothing
+    }
+  }
+
   private TransactionContext mockTransactionContext(OMRequest request) {
     RaftProtos.StateMachineLogEntryProto logEntry =
         RaftProtos.StateMachineLogEntryProto.newBuilder()
@@ -229,6 +269,8 @@ public class TestOzoneManagerStateMachine {
     TransactionContext mockTrx = mock(TransactionContext.class);
     when(mockTrx.getStateMachineLogEntry()).thenReturn(logEntry);
     when(mockTrx.getStateMachineContext()).thenReturn(request);
+    RaftProtos.LogEntryProto logEntryProto = LogProtoUtils.toLogEntryProto(10, 10, 10);
+    when(mockTrx.getLogEntry()).thenReturn(logEntryProto);
 
     return mockTrx;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

For debuggability of om transaction and audit log mapping, audit log is included with transaction Id. And additionally unknown failure case, also having audit log with exception message and transaction id.

Refactor is done to have audit log at exit of method of request at common place -
- preExecute() -- only if marked for audit as all failure do not need audit
- validateAndUpdateCache() -- for both success and failure case

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10658

## How was this patch tested?

- Unit test is added
-
