### PR TITLE
HDDS-11187. Fix Event Handling in Recon OMDBUpdatesHandler to Prevent ClassCastException

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -111,6 +111,10 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
       final Object key = cf.getKeyCodec().fromPersistedFormat(keyBytes);
       builder.setKey(key);
 
+      // Initialize table-specific event map if it does not exist
+      omdbLatestUpdateEvents.putIfAbsent(tableName, new HashMap<>());
+      Map<Object, OMDBUpdateEvent> tableEventsMap = omdbLatestUpdateEvents.get(tableName);
+
       // Handle the event based on its type:
       // - PUT with a new key: Insert the new value.
       // - PUT with an existing key: Update the existing value.
@@ -118,8 +122,6 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
       // - DELETE with a non-existing key: No action, log a warning if
       // necessary.
       Table table = omMetadataManager.getTable(tableName);
-      Map<Object, OMDBUpdateEvent> tableEventsMap =
-          omdbLatestUpdateEvents.computeIfAbsent(tableName, k -> new HashMap<>());
 
       OMDBUpdateEvent latestEvent = tableEventsMap.get(key);
       Object oldValue;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -48,8 +48,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
   private Map<Integer, String> tablesNames;
   private OMMetadataManager omMetadataManager;
   private List<OMDBUpdateEvent> omdbUpdateEvents = new ArrayList<>();
-  private Map<Object, OMDBUpdateEvent> omdbLatestUpdateEvents
-      = new HashMap<>();
+  private Map<String, Map<Object, OMDBUpdateEvent>> omdbLatestUpdateEvents = new HashMap<>();
   private OMDBDefinition omdbDefinition;
   private OmUpdateEventValidator omUpdateEventValidator;
 
@@ -119,8 +118,10 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
       // - DELETE with a non-existing key: No action, log a warning if
       // necessary.
       Table table = omMetadataManager.getTable(tableName);
+      Map<Object, OMDBUpdateEvent> tableEventsMap =
+          omdbLatestUpdateEvents.computeIfAbsent(tableName, k -> new HashMap<>());
 
-      OMDBUpdateEvent latestEvent = omdbLatestUpdateEvents.get(key);
+      OMDBUpdateEvent latestEvent = tableEventsMap.get(key);
       Object oldValue;
       if (latestEvent != null) {
         oldValue = latestEvent.getValue();
@@ -184,7 +185,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
                 "action = %s", tableName, action));
       }
       omdbUpdateEvents.add(event);
-      omdbLatestUpdateEvents.put(key, event);
+      tableEventsMap.put(key, event);
     } else {
       // Log and ignore events if key or value types are undetermined.
       if (LOG.isWarnEnabled()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Explanation of the Changes :- 
Map Structure Change: The `omdbLatestUpdateEvents` map has been changed from `Map<Object, OMDBUpdateEvent>` to `Map<String, Map<Object, OMDBUpdateEvent>>`. This nested map structure ensures that each table's events are stored separately, avoiding key collisions between different tables.

Event Processing Logic: The `processEvent` method now uses the table name as the first-level key in the map. If a key already exists for a table, it retrieves the nested map and updates or adds the event. This change ensures that events from different tables with the same key structure are isolated and correctly processed.

### How it Fixes the Problem
This change ensures that events from different tables with the same key structure do not overwrite each other, preventing the `ClassCastException` caused by fetching incorrect event types. By segregating events by table name, we avoid the corruption caused by key collisions, leading to more reliable event processing in Recon.

### Logs and Future Fixes
We have previously added logs to capture events that could lead to `ClassCastException`. These logs help identify corrupted events generated from the OM side, which need to be fixed. Our changes in this patch address possible corruption in event creation on the Recon side. The root problem on the OM side persists and requires fixing. The logs added in the previous patch (**HDDS-8310**) will help report these issues, and we should wait for these logs to guide further fixes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11187

## How was this patch tested?
Existing UT's for `TestOMDBUpdatesHandler` passed successfully.
