### PR TITLE
HDDS-11191. Add a config to set max_open_files for OM RocksDB.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4217,6 +4217,20 @@
   </property>
 
   <property>
+    <name>ozone.om.db.max.open.files</name>
+    <value>-1</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      Max number of open files that OM RocksDB will open simultaneously
+      Essentially sets `max_open_files` config for the active OM RocksDB instance.
+      This will limit the total number of files opened by OM db.
+      Default is -1 which is unlimited and gives max performance.
+      If you are certain that your ulimit will always be bigger than number of files in the database,
+      set max_open_files to -1, or else set it to a value lesser than or equal to ulimit.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.snapshot.db.max.open.files</name>
     <value>100</value>
     <tag>OZONE, OM</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -53,6 +53,11 @@ public final class OMConfigKeys {
       "ozone.om.handler.count.key";
   public static final int OZONE_OM_HANDLER_COUNT_DEFAULT = 100;
 
+  public static final String OZONE_OM_DB_MAX_OPEN_FILES
+      = "ozone.om.db.max.open.files";
+  public static final int OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT
+      = -1;
+
   public static final String OZONE_OM_INTERNAL_SERVICE_ID =
       "ozone.om.internal.service.id";
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -573,7 +573,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir)
       throws IOException {
-    return loadDB(configuration, metaDir,Optional.empty());
+    return loadDB(configuration, metaDir, Optional.empty());
   }
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir, Optional<Integer> maxOpenFiles)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -107,6 +107,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
@@ -558,7 +560,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         rocksDBConfiguration.setSyncOption(true);
       }
 
-      this.store = loadDB(configuration, metaDir);
+      int maxOpenFiles = configuration.getInt(OZONE_OM_DB_MAX_OPEN_FILES,
+          OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT);
+
+      this.store = loadDB(configuration, metaDir, Optional.of(maxOpenFiles));
 
       initializeOmTables(CacheType.FULL_CACHE, true);
     }
@@ -568,8 +573,13 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir)
       throws IOException {
+    return loadDB(configuration, metaDir,Optional.empty());
+  }
+
+  public static DBStore loadDB(OzoneConfiguration configuration, File metaDir, Optional<Integer> maxOpenFiles)
+      throws IOException {
     return loadDB(configuration, metaDir, OM_DB_NAME, false,
-            java.util.Optional.empty(), Optional.empty(), true, true);
+        java.util.Optional.empty(), maxOpenFiles, true, true);
   }
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the max_open_files rocksdb config is -1 by default and not set anywhere via Ozone code. However in situations where the number of SST Files in the rocksdb instance becomes greater than the ulimit (open file limit of the OS), Rocksdb will not respect the OS config and try to open all files at once thereby leading to "Too many open files" error. 

Introducing a config in Ozone to set this is helpful to avoid/recover from such crashes. Default is still kept unchanged as -1 as [RocksDB recommends](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB#indexes-and-filter-blocks) -1 for best performance.

>  If you are certain that your ulimit will always be bigger than number of files in the database, we recommend setting max_open_files to -1, which means infinity. 
Setting max_open_files to -1 will get you the best possible performance.

This patch adds an option to reconfigure the value if we hit the issue thereby preserving existing behaviour and adding a recovery mechanism in case of this issue.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11191

## How was this patch tested?
Verified that the config takes effect via docker

In docker-config
```bash 
OZONE-SITE.XML_ozone.om.db.max.open.files=2048 
```
Checking the rocksdb LOG
```bash 
bash-4.2$ cat /data/metadata/om.db/LOG | grep "Options.max_open_file"
2024/07/16-11:56:59.830522 139896182388480                          Options.max_open_files: 2048
```
Without any config change:
```bash 
bash-4.2$ cat /data/metadata/om.db/LOG | grep "Options.max_open_file"
2024/07/16-11:51:54.934483 140099612952320                          Options.max_open_files: -1
bash-4.2$ exit
```