### PR TITLE
HDDS-10844. Clarify snapshot create error message

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -171,7 +171,7 @@ public final class HddsClientUtils {
 
     if (isIPv4) {
       throw new IllegalArgumentException(resType +
-          "Bucket or Volume name cannot be an IPv4 address or all numeric");
+          " name cannot be an IPv4 address or all numeric");
     }
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -67,27 +67,26 @@ public final class HddsClientUtils {
           .add(NotReplicatedException.class)
           .build();
 
-  private static void doNameChecks(String resName) {
+  private static void doNameChecks(String resName, String resType) {
     if (resName == null) {
-      throw new IllegalArgumentException("Bucket or Volume name is null");
+      throw new IllegalArgumentException(resType + " name is null");
     }
 
     if (resName.length() < OzoneConsts.OZONE_MIN_BUCKET_NAME_LENGTH ||
         resName.length() > OzoneConsts.OZONE_MAX_BUCKET_NAME_LENGTH) {
-      throw new IllegalArgumentException(
-          "Bucket or Volume length is illegal, "
-              + "valid length is 3-63 characters");
+      throw new IllegalArgumentException(resType +
+          " length is illegal, " + "valid length is 3-63 characters");
     }
 
     if (resName.charAt(0) == '.' || resName.charAt(0) == '-') {
-      throw new IllegalArgumentException(
-          "Bucket or Volume name cannot start with a period or dash");
+      throw new IllegalArgumentException(resType +
+          " name cannot start with a period or dash");
     }
 
     if (resName.charAt(resName.length() - 1) == '.' ||
         resName.charAt(resName.length() - 1) == '-') {
-      throw new IllegalArgumentException("Bucket or Volume name "
-          + "cannot end with a period or dash");
+      throw new IllegalArgumentException(resType +
+          " name cannot end with a period or dash");
     }
   }
 
@@ -108,27 +107,27 @@ public final class HddsClientUtils {
     return false;
   }
 
-  private static void doCharacterChecks(char currChar, char prev,
+  private static void doCharacterChecks(char currChar, char prev, String resType,
       boolean isStrictS3) {
     if (Character.isUpperCase(currChar)) {
-      throw new IllegalArgumentException(
-          "Bucket or Volume name does not support uppercase characters");
+      throw new IllegalArgumentException(resType +
+          " name does not support uppercase characters");
     }
     if (!isSupportedCharacter(currChar, isStrictS3)) {
-      throw new IllegalArgumentException("Bucket or Volume name has an " +
-          "unsupported character : " + currChar);
+      throw new IllegalArgumentException(resType +
+          " name has an unsupported character : " + currChar);
     }
     if (prev == '.' && currChar == '.') {
-      throw new IllegalArgumentException("Bucket or Volume name should not " +
-          "have two contiguous periods");
+      throw new IllegalArgumentException(resType +
+          " name should not have two contiguous periods");
     }
     if (prev == '-' && currChar == '.') {
-      throw new IllegalArgumentException(
-          "Bucket or Volume name should not have period after dash");
+      throw new IllegalArgumentException(resType +
+          " name should not have period after dash");
     }
     if (prev == '.' && currChar == '-') {
-      throw new IllegalArgumentException(
-          "Bucket or Volume name should not have dash after period");
+      throw new IllegalArgumentException(resType +
+          " name should not have dash after period");
     }
   }
 
@@ -140,7 +139,11 @@ public final class HddsClientUtils {
    * @throws IllegalArgumentException
    */
   public static void verifyResourceName(String resName) {
-    verifyResourceName(resName, true);
+    verifyResourceName(resName, "resource", true);
+  }
+
+  public static void verifyResourceName(String resName, String resType) {
+    verifyResourceName(resName, resType, true);
   }
 
   /**
@@ -150,9 +153,9 @@ public final class HddsClientUtils {
    *
    * @throws IllegalArgumentException
    */
-  public static void verifyResourceName(String resName, boolean isStrictS3) {
+  public static void verifyResourceName(String resName, String resType, boolean isStrictS3) {
 
-    doNameChecks(resName);
+    doNameChecks(resName, resType);
 
     boolean isIPv4 = true;
     char prev = (char) 0;
@@ -162,12 +165,12 @@ public final class HddsClientUtils {
       if (currChar != '.') {
         isIPv4 = ((currChar >= '0') && (currChar <= '9')) && isIPv4;
       }
-      doCharacterChecks(currChar, prev, isStrictS3);
+      doCharacterChecks(currChar, prev, resType, isStrictS3);
       prev = currChar;
     }
 
     if (isIPv4) {
-      throw new IllegalArgumentException(
+      throw new IllegalArgumentException(resType +
           "Bucket or Volume name cannot be an IPv4 address or all numeric");
     }
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -709,7 +709,7 @@ public class RpcClient implements ClientProtocol {
 
   private static void verifyVolumeName(String volumeName) throws OMException {
     try {
-      HddsClientUtils.verifyResourceName(volumeName, false);
+      HddsClientUtils.verifyResourceName(volumeName, "volume", false);
     } catch (IllegalArgumentException e) {
       throw new OMException(e.getMessage(),
           OMException.ResultCodes.INVALID_VOLUME_NAME);
@@ -718,7 +718,7 @@ public class RpcClient implements ClientProtocol {
 
   private static void verifyBucketName(String bucketName) throws OMException {
     try {
-      HddsClientUtils.verifyResourceName(bucketName, false);
+      HddsClientUtils.verifyResourceName(bucketName, "bucket", false);
     } catch (IllegalArgumentException e) {
       throw new OMException(e.getMessage(),
           OMException.ResultCodes.INVALID_BUCKET_NAME);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -522,7 +522,7 @@ public final class OmUtils {
   public static void validateVolumeName(String volumeName, boolean isStrictS3)
       throws OMException {
     try {
-      HddsClientUtils.verifyResourceName(volumeName, isStrictS3);
+      HddsClientUtils.verifyResourceName(volumeName, "volume", isStrictS3);
     } catch (IllegalArgumentException e) {
       throw new OMException("Invalid volume name: " + volumeName,
           OMException.ResultCodes.INVALID_VOLUME_NAME);
@@ -535,7 +535,7 @@ public final class OmUtils {
   public static void validateBucketName(String bucketName, boolean isStrictS3)
       throws OMException {
     try {
-      HddsClientUtils.verifyResourceName(bucketName, isStrictS3);
+      HddsClientUtils.verifyResourceName(bucketName, "bucket", isStrictS3);
     } catch (IllegalArgumentException e) {
       throw new OMException("Invalid bucket name: " + bucketName,
           OMException.ResultCodes.INVALID_BUCKET_NAME);
@@ -571,9 +571,9 @@ public final class OmUtils {
       return;
     }
     try {
-      HddsClientUtils.verifyResourceName(snapshotName);
+      HddsClientUtils.verifyResourceName(snapshotName, "snapshot");
     } catch (IllegalArgumentException e) {
-      throw new OMException("Invalid snapshot name: " + snapshotName,
+      throw new OMException("Invalid snapshot name: " + snapshotName + "\n" + e.getMessage(),
           OMException.ResultCodes.INVALID_SNAPSHOT_ERROR);
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -799,7 +799,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneVolume volume = store.getVolume(volumeName);
     OMException omException = assertThrows(OMException.class,
         () -> volume.createBucket(bucketName));
-    assertEquals("Bucket or Volume name has an unsupported character : #",
+    assertEquals("bucket name has an unsupported character : #",
         omException.getMessage());
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -162,8 +162,8 @@ public class TestOMSnapshotCreateRequest {
         bucketName, snapshotName);
     OMException omException =
         assertThrows(OMException.class, () -> doPreExecute(omRequest));
-    assertEquals("Invalid snapshot name: " + snapshotName,
-        omException.getMessage());
+    assertTrue(omException.getMessage()
+        .contains("Invalid snapshot name: " + snapshotName));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotDeleteRequest.java
@@ -159,8 +159,8 @@ public class TestOMSnapshotDeleteRequest {
         bucketName, deleteSnapshotName);
     OMException omException =
         assertThrows(OMException.class, () -> doPreExecute(omRequest));
-    assertEquals("Invalid snapshot name: " + deleteSnapshotName,
-        omException.getMessage());
+    assertTrue(omException.getMessage()
+        .contains("Invalid snapshot name: " + deleteSnapshotName));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotRenameRequest.java
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -172,8 +173,7 @@ public class TestOMSnapshotRenameRequest {
         bucketName, currentSnapshotName, toSnapshotName);
     OMException omException =
         assertThrows(OMException.class, () -> doPreExecute(omRequest));
-    assertEquals("Invalid snapshot name: " + toSnapshotName,
-        omException.getMessage());
+    assertTrue(omException.getMessage().contains("Invalid snapshot name: " + toSnapshotName));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-10844. Clarify snapshot create error message

Please describe your PR in detail:
* Show the specific reason why the snapshot name is invalid by throwing the specific IllegalArgumentException using `e.getMessage()`

* Enhance HddsClientUtils.verifyResourceName to support validation for volumes, buckets, and snapshots by introducing a resType parameter. This modification allows specifying the resource type in error messages, making them more context-specific.

Usage examples:

    HddsClientUtils.verifyResourceName(snapshotName, "snapshot");
    HddsClientUtils.verifyResourceName(volumeName, "volume", isStrictS3);
    HddsClientUtils.verifyResourceName(bucketName, "bucket", isStrictS3);

Example output:

    docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 s1"
    INVALID_SNAPSHOT_ERROR snapshot length is illegal, valid length is 3-63 characters

If don't pass resType into verifyResourceName, it will show default resType as string "resource"

Previously, the method generated fixed error messages such as "Bucket or Volume name has an unsupported character". This update ensures the error messages are relevant to the type of resource being validated, addressing inaccuracies when used with volumes, buckets, and snapshots.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10844

## How was this patch tested?
Tested below scenarios in local docker according to hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java  

1. 
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket s1"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: s1
snapshot length is illegal, valid length is 3-63 characters


2.
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 .s1"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: .s1
snapshot name cannot start with a period or dash

3.
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 s1."
INVALID_SNAPSHOT_ERROR Invalid snapshot name: s1.
snapshot name cannot end with a period or dash

docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 s1-"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: s1-
snapshot name cannot end with a period or dash

4.
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 ssA"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: ssA
snapshot name does not support uppercase characters

5.
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 s%s"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: s%s
snapshot name has an unsupported character : %

6.
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 s..s"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: s..s
snapshot name should not have two contiguous periods

7.
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 s-.s"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: s-.s
snapshot name should not have period after dash

8.
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 s.-s"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: s.-s
snapshot name should not have dash after period

9.
docker exec -it ozone-om-1 sh -c "ozone sh snapshot create /s3v/bucket1 192.168.1.1"
INVALID_SNAPSHOT_ERROR Invalid snapshot name: 192.168.1.1
snapshotBucket or Volume name cannot be an IPv4 address or all numeric