### PR TITLE
HDDS-11179. DBConfigFromFile#readFromFile result of toIOException not thrown

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
@@ -136,7 +136,7 @@ public final class DBConfigFromFile {
               env, options, cfDescs, true);
 
         } catch (RocksDBException rdEx) {
-          toIOException("Unable to find/open Options file.", rdEx);
+          throw toIOException("Unable to find/open Options file.", rdEx);
         }
       }
     }


### PR DESCRIPTION
HDDS-11179. DBConfigFromFile#readFromFile result of toIOException not thrown

Please describe your PR in detail:
* throw the toIOException

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11179

## How was this patch tested?
github CI test passed
