### PR TITLE
HDDS-11194. OM missing audit log for upgrade prepare, cancel and finalize

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMUpgradeFinalization.java
@@ -36,12 +36,17 @@ import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.audit.AuditEventStatus;
+import org.apache.hadoop.ozone.audit.AuditLogTestUtils;
+import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 
 import org.apache.ratis.util.LifeCycle;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -49,7 +54,18 @@ import org.junit.jupiter.api.Test;
  * TODO: can be merged into class with other OM tests with per-method cluster
  */
 class TestOMUpgradeFinalization {
+  static {
+    AuditLogTestUtils.enableAuditLog();
+  }
 
+  @BeforeEach
+  public void setup() throws Exception {
+    AuditLogTestUtils.truncateAuditLogFile();
+  }
+  @AfterAll
+  public static void shutdown() {
+    AuditLogTestUtils.deleteAuditLogFile();
+  }
   @Test
   void testOMUpgradeFinalizationWithOneOMDown() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
@@ -70,11 +86,14 @@ class TestOMUpgradeFinalization {
         // OMs.
         long prepareIndex = omClient.prepareOzoneManager(120L, 5L);
         assertClusterPrepared(prepareIndex, runningOms);
+        AuditLogTestUtils.verifyAuditLog(OMAction.UPGRADE_PREPARE, AuditEventStatus.SUCCESS);
 
         omClient.cancelOzoneManagerPrepare();
+        AuditLogTestUtils.verifyAuditLog(OMAction.UPGRADE_CANCEL, AuditEventStatus.SUCCESS);
         StatusAndMessages response =
             omClient.finalizeUpgrade("finalize-test");
         System.out.println("Finalization Messages : " + response.msgs());
+        AuditLogTestUtils.verifyAuditLog(OMAction.UPGRADE_FINALIZE, AuditEventStatus.SUCCESS);
 
         waitForFinalization(omClient);
         cluster.restartOzoneManager(downedOM, true);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -103,7 +103,10 @@ public enum OMAction implements AuditAction {
   SNAPSHOT_INFO,
   SET_TIMES,
 
-  ABORT_EXPIRED_MULTIPART_UPLOAD;
+  ABORT_EXPIRED_MULTIPART_UPLOAD,
+  UPGRADE_PREPARE,
+  UPGRADE_CANCEL,
+  UPGRADE_FINALIZE;
 
   @Override
   public String getAction() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
@@ -17,6 +17,10 @@
 
 package org.apache.hadoop.ozone.om.request.upgrade;
 
+import java.util.HashMap;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -54,10 +58,13 @@ public class OMCancelPrepareRequest extends OMClientRequest {
     LOG.info("OM {} Received cancel prepare request with log {}", ozoneManager.getOMNodeId(), termIndex);
 
     OMRequest omRequest = getOmRequest();
+    AuditLogger auditLogger = ozoneManager.getAuditLogger();
+    OzoneManagerProtocolProtos.UserInfo userInfo = omRequest.getUserInfo();
     OMResponse.Builder responseBuilder =
         OmResponseUtil.getOMResponseBuilder(omRequest);
     responseBuilder.setCmdType(Type.CancelPrepare);
     OMClientResponse response = null;
+    Exception exception = null;
 
     try {
       UserGroupInformation ugi = createUGIForApi();
@@ -82,12 +89,15 @@ public class OMCancelPrepareRequest extends OMClientRequest {
       LOG.info("OM {} prepare state cancelled at log {}. Returning response {}",
           ozoneManager.getOMNodeId(), termIndex, omResponse);
     } catch (IOException e) {
+      exception = e;
       LOG.error("Cancel Prepare Request apply failed in {}. ",
           ozoneManager.getOMNodeId(), e);
       response = new OMPrepareResponse(
           createErrorOMResponse(responseBuilder, e));
     }
 
+    auditLog(auditLogger, buildAuditMessage(OMAction.UPGRADE_CANCEL,
+        new HashMap<>(), exception, userInfo));
     return response;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
@@ -20,8 +20,12 @@ package org.apache.hadoop.ozone.om.request.upgrade;
 import static org.apache.hadoop.ozone.OzoneConsts.LAYOUT_VERSION_KEY;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.FinalizeUpgrade;
 
+import java.util.HashMap;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos
     .UpgradeFinalizationStatus;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -58,10 +62,13 @@ public class OMFinalizeUpgradeRequest extends OMClientRequest {
   @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, TermIndex termIndex) {
     LOG.trace("Request: {}", getOmRequest());
+    AuditLogger auditLogger = ozoneManager.getAuditLogger();
+    OzoneManagerProtocolProtos.UserInfo userInfo = getOmRequest().getUserInfo();
     OMResponse.Builder responseBuilder =
         OmResponseUtil.getOMResponseBuilder(getOmRequest());
     responseBuilder.setCmdType(FinalizeUpgrade);
     OMClientResponse response = null;
+    Exception exception = null;
 
     try {
       if (ozoneManager.getAclsEnabled()) {
@@ -103,10 +110,13 @@ public class OMFinalizeUpgradeRequest extends OMClientRequest {
           ozoneManager.getVersionManager().getMetadataLayoutVersion());
       LOG.trace("Returning response: {}", response);
     } catch (IOException e) {
+      exception = e;
       response = new OMFinalizeUpgradeResponse(
           createErrorOMResponse(responseBuilder, e), -1);
     }
 
+    auditLog(auditLogger, buildAuditMessage(OMAction.UPGRADE_FINALIZE,
+        new HashMap<>(), exception, userInfo));
     return response;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Audit log is added for upgrade prepare, cancel and finalize as this was missing. Since this is user request, this also needs logged.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11194

## How was this patch tested?

- added testcase for audit log generation
