### PR TITLE
HDDS-11182. OM pause operation can have terminate of service

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -291,7 +291,7 @@ public final class OzoneManagerDoubleBuffer {
    */
   @VisibleForTesting
   void flushTransactions() {
-    while (isRunning.get() && canFlush()) {
+    while (canFlush()) {
       flushCurrentBuffer();
     }
   }
@@ -562,14 +562,14 @@ public final class OzoneManagerDoubleBuffer {
    */
   private synchronized boolean canFlush() {
     try {
-      while (currentBuffer.isEmpty()) {
+      while (currentBuffer.isEmpty() && isRunning.get()) {
         // canFlush() only gets called when the readyBuffer is empty.
         // Since both buffers are empty, notify once for each.
         flushNotifier.notifyFlush();
         flushNotifier.notifyFlush();
         wait(1000L);
       }
-      return true;
+      return isRunning.get();
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       LOG.info("OMDoubleBuffer flush thread {} is interrupted and will "

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -572,12 +572,6 @@ public final class OzoneManagerDoubleBuffer {
       return true;
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
-      if (isRunning.get()) {
-        final String message = "OMDoubleBuffer flush thread " +
-            Thread.currentThread().getName() + " encountered Interrupted " +
-            "exception while running";
-        ExitUtils.terminate(1, message, ex, LOG);
-      }
       LOG.info("OMDoubleBuffer flush thread {} is interrupted and will "
           + "exit.", Thread.currentThread().getName());
       return false;


### PR DESCRIPTION
## What changes were proposed in this pull request?

OMStateMachine->pause() trigger doubleBuffer->close() which trigger interrupt to doubleBuffer's daemon thread. On interrupt, it can trigger terminate() of service.

As fix, removed terminate of service, as this is not required in case daemon is getting stopped.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11182

## How was this patch tested?

- existing cases for impact
