### PR TITLE
HDDS-11198. Fix Typescript configs for Recon

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/.vscode/extensions.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+  ]
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/.vscode/settings.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.locale": "en",
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "typescript.suggest.autoImports": true,
+  "prettier.printWidth": 120,
+  "prettier.semi": true,
+  "prettier.tabWidth": 2
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/tsconfig.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/tsconfig.json
@@ -21,7 +21,7 @@
     "rootDir": "src",
     "baseUrl": "src",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["*"]
     },
     "types": ["vite/client", "vite-plugin-svgr/client"]
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-11198.  Fix Typescript configs for Ozone Recon

Please describe your PR in detail:
- Currently the tsconfig is not up to standard recommended by TypeScript. We are explicitly specifying the complete path.
- While the builds happen properly, but the editor/IDE cannot properly resolve the modules
- This PR fixes the issue by properly specify the path relative to the baseUrl
- It also adds a .vscode configuration folder to help new contributors setup their editor/environment out of the box.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11198

## How was this patch tested?
The patch was tested manually by running build, as well as checking if the resolution errors go away after changing the settings