### PR TITLE
HDDS-11180. Simplify HttpServer2#inferMimeType return statement

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -1673,8 +1673,7 @@ public final class HttpServer2 implements FilterContainer {
       String path = ((HttpServletRequest) request).getRequestURI();
       ServletContextHandler.Context sContext =
           (ServletContextHandler.Context) config.getServletContext();
-      String mime = sContext.getMimeType(path);
-      return (mime == null) ? null : mime;
+      return sContext.getMimeType(path);
     }
 
     private void initHttpHeaderMap() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11180. Simplify HttpServer2#inferMimeType return statement

Please describe your PR in detail:
The additional null check is removed. The intermediate variable mime was removed, making the return statement directly return the result of sContext.getMimeType(path).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11180

## How was this patch tested?
workflow run on the fork git repo
