### PR TITLE
HDDS-11140. Recon Disk Usage Metadata Details are not working for du api

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1857,6 +1857,15 @@
     ],
     "sizeDirectKey": 0
   },
+  "replica": {
+    "status": "OK",
+    "path": "/s3v/fso-bucket/dir1/key1-fso",
+    "size": 17289,
+    "sizeWithReplica": 17289,
+    "subPathCount": 0,
+    "subPaths": [],
+    "sizeDirectKey": -1
+  },
   "taskStatus": [
     {
       "taskName": "ContainerKeyMapperTask",

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
@@ -21,6 +21,7 @@
   "/namespace/du?path=/dummyVolume/dummyBucket/key:id*": "/key",
   "/namespace/du?path=/vol1/bucket1/empty&files=true&sortSubPaths=true": "/empty",
   "/namespace/du?path=/clunky&files=true&sortSubpaths=true": "/clunky",
+  "/namespace/du?path=/*&replica=true": "/replica",
   "/namespace/summary?path=*": "/metadata",
   "/namespace/quota?path=*": "/quota",
   "/task/status": "/taskStatus",

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/diskUsage/diskUsage.tsx
@@ -314,7 +314,7 @@ export class DiskUsage extends React.Component<Record<string, object>, IDUState>
       keys.push('Entity Type');
       values.push(summaryResponse.type);
 
-      if (summaryResponse.countStats.type === 'KEY') {
+      if (summaryResponse.type === 'KEY') {
         const keyEndpoint = `/api/v1/namespace/du?path=${path}&replica=true`;
         const { request: metadataRequest, controller: metadataNewController } = AxiosGetHelper(keyEndpoint, cancelKeyMetadataSignal);
         cancelKeyMetadataSignal = metadataNewController;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Metadata summary was not working properly for Entity Type Key.

Please describe your PR in detail:
Metadata summary was not working properly for Entity Type Key.
File Size and File Size Replication was not working earlier so corrected in this PR.


## What is the link to the Apache JIRA



## How was this patch tested?

Manually


After this Patch

For Entity Type KEY

![image](https://github.com/user-attachments/assets/7002c63c-671a-46d3-9a7d-7a5f02199602)