### PR TITLE
HDDS-11190. Add --fields option to ldb scan command

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ValueSchema.java
@@ -88,7 +88,7 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
 
     String dbPath = parent.getDbPath();
     Map<String, Object> fields = new HashMap<>();
-    success = getValueFields(dbPath, fields);
+    success = getValueFields(dbPath, fields, depth, tableName);
 
     out().println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(fields));
 
@@ -101,7 +101,7 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
     return null;
   }
 
-  private boolean getValueFields(String dbPath, Map<String, Object> valueSchema) {
+  public boolean getValueFields(String dbPath, Map<String, Object> valueSchema, int d, String table) {
 
     dbPath = removeTrailingSlashIfNeeded(dbPath);
     DBDefinitionFactory.setDnDBSchemaVersion(dnDBSchemaVersion);
@@ -111,14 +111,14 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
       return false;
     }
     final DBColumnFamilyDefinition<?, ?> columnFamilyDefinition =
-        dbDefinition.getColumnFamily(tableName);
+        dbDefinition.getColumnFamily(table);
     if (columnFamilyDefinition == null) {
-      err().print("Error: Table with name '" + tableName + "' not found");
+      err().print("Error: Table with name '" + table + "' not found");
       return false;
     }
 
     Class<?> c = columnFamilyDefinition.getValueType();
-    valueSchema.put(c.getSimpleName(), getFieldsStructure(c, depth));
+    valueSchema.put(c.getSimpleName(), getFieldsStructure(c, d));
 
     return true;
   }
@@ -148,7 +148,7 @@ public class ValueSchema implements Callable<Void>, SubcommandWithParent {
     }
   }
 
-  private List<Field> getAllFields(Class clazz) {
+  public List<Field> getAllFields(Class clazz) {
     // NOTE: Schema of interface type, like ReplicationConfig, cannot be fetched.
     //       An empty list "[]" will be shown for such types of fields.
     if (clazz == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
RocksDB stores data in key-value pairs. The value itself may have some kind of key-value structure. Currently, `ozone debug ldb scan` command shows the full value for each record being displayed. This could be very verbose and include information that is not needed for the use case.
Having a --fields option which filters the fields being displayed for each record will help to get concise output.

For example, if a value has many fields like [name, location->[address, DN, IP], version, lastUpdateTime] , using the option "--fields=name,location.address,version" will display only (name, address in location and version) in the output.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11190

## How was this patch tested?

Tested manually in docker cluster:
```
sh-4.2$ ozone debug ldb --db=/data/metadata/om.db scan --cf=fileTable --fields=volumeName,bucketName,keyName,keyLocationVersions.locationVersionMap         
{ "/-9223372036854775040/-9223372036854774528/-9223372036854771967/k1": {
  "bucketName" : "bb1",
  "volumeName" : "vol1",
  "keyName" : "k1",
  "keyLocationVersions.locationVersionMap" : [ {
    "locationVersionMap" : {
      "0" : [ {
        "blockID" : {
          "containerBlockID" : {
            "containerID" : 1,
            "localID" : 113750153625600003
          },
          "blockCommitSequenceId" : 10
        },
        "length" : 3,
        "offset" : 0,
        "createVersion" : 0,
        "partNumber" : 0
      } ]
    }
  } ]
}
, "/-9223372036854775040/-9223372036854774528/-9223372036854774528/k1": {
  "bucketName" : "bb1",
  "volumeName" : "vol1",
  "keyName" : "k1",
  "keyLocationVersions.locationVersionMap" : [ {
    "locationVersionMap" : {
      "0" : [ {
        "blockID" : {
          "containerBlockID" : {
            "containerID" : 1,
            "localID" : 113750153625600001
          },
          "blockCommitSequenceId" : 2
        },
        "length" : 3,
        "offset" : 0,
        "createVersion" : 0,
        "partNumber" : 0
      } ]
    }
  } ]
}
```
