### PR TITLE
HDDS-11206. Statistics storage usage indicators include min, max, median, stdev

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
@@ -49,7 +49,7 @@ public interface NodeManagerMXBean {
    */
   Map<String, Map<String, String>> getNodeStatusInfo();
 
-  default Map<String, String> getNodeStatics() {
+  default Map<String, String> getNodeStatistics() {
     return new HashMap<>();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.node;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -47,5 +48,9 @@ public interface NodeManagerMXBean {
    * Commissioned State & Operational State column for dataNode
    */
   Map<String, Map<String, String>> getNodeStatusInfo();
+
+  default Map<String, String> getNodeStatics() {
+    return new HashMap<>();
+  }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -83,6 +83,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -1217,6 +1218,47 @@ public class SCMNodeManager implements NodeManager {
     return storagePercentage;
   }
 
+  @Override
+  public Map<String, String> getNodeStatics() {
+    if (nodeStateManager.getAllNodes().size() < 1) {
+      return new HashMap<>();
+    }
+    Map<String, String> nodeStatics = new HashMap<>();
+    float[] usages = new float[nodeStateManager.getAllNodes().size()];
+    float totalOzoneUsed = 0;
+    int i = 0;
+    for (DatanodeInfo dni : nodeStateManager.getAllNodes()) {
+      String[] storagePercentage = calculateStoragePercentage(
+          dni.getStorageReports());
+      if (storagePercentage[0].equals("N/A")) {
+        usages[i++] = 0;
+      } else {
+        float storagePerc = Float.parseFloat(storagePercentage[0]);
+        usages[i++] = storagePerc;
+        totalOzoneUsed = totalOzoneUsed + storagePerc;
+      }
+    }
+
+    totalOzoneUsed /= nodeStateManager.getAllNodes().size();
+    Arrays.sort(usages);
+    float median = usages[usages.length / 2];
+    nodeStatics.put(UsageStatics.MEDINNA.getLabel(), String.valueOf(median));
+    float max = usages[usages.length - 1];
+    nodeStatics.put(UsageStatics.MAX.getLabel(), String.valueOf(max));
+    float min = usages[0];
+    nodeStatics.put(UsageStatics.MIN.getLabel(), String.valueOf(min));
+
+    float dev = 0;
+    for (i = 0; i < usages.length; i++) {
+      dev += (usages[i] - totalOzoneUsed) * (usages[i] - totalOzoneUsed);
+    }
+    dev = (float) Math.sqrt(dev / usages.length);
+    DecimalFormat decimalFormat = new DecimalFormat("#0.00");
+    decimalFormat.setRoundingMode(RoundingMode.HALF_UP);
+    nodeStatics.put(UsageStatics.STDEV.getLabel(), decimalFormat.format(dev));
+    return nodeStatics;
+  }
+
   /**
    * Based on the current time and the last heartbeat, calculate the time difference
    * and get a string of the relative value. E.g. "2s ago", "1m 2s ago", etc.
@@ -1280,6 +1322,20 @@ public class SCMNodeManager implements NodeManager {
     }
 
     UsageStates(String label) {
+      this.label = label;
+    }
+  }
+
+  private enum UsageStatics {
+    MIN("Min"),
+    MAX("Max"),
+    MEDINNA("Medina"),
+    STDEV("Stdev");
+    private String label;
+    public String getLabel() {
+      return label;
+    }
+    UsageStatics(String label) {
       this.label = label;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1220,14 +1220,14 @@ public class SCMNodeManager implements NodeManager {
 
   @Override
   public Map<String, String> getNodeStatistics() {
-    Map<String, String> nodeStatics = new HashMap<>();
+    Map<String, String> nodeStatistics = new HashMap<>();
     // Statistics node usaged
-    nodeUsageStatics(nodeStatics);
+    nodeUsageStatistics(nodeStatistics);
     // todo: Statistics of other instances
-    return nodeStatics;
+    return nodeStatistics;
   }
 
-  private void nodeUsageStatics(Map<String, String> nodeStatics) {
+  private void nodeUsageStatistics(Map<String, String> nodeStatics) {
     if (nodeStateManager.getAllNodes().size() < 1) {
       return;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1219,17 +1219,24 @@ public class SCMNodeManager implements NodeManager {
   }
 
   @Override
-  public Map<String, String> getNodeStatics() {
-    if (nodeStateManager.getAllNodes().size() < 1) {
-      return new HashMap<>();
-    }
+  public Map<String, String> getNodeStatistics() {
     Map<String, String> nodeStatics = new HashMap<>();
+    // Statistics node usaged
+    nodeUsageStatics(nodeStatics);
+    // todo: Statistics of other instances
+    return nodeStatics;
+  }
+
+  private void nodeUsageStatics(Map<String, String> nodeStatics) {
+    if (nodeStateManager.getAllNodes().size() < 1) {
+      return;
+    }
     float[] usages = new float[nodeStateManager.getAllNodes().size()];
     float totalOzoneUsed = 0;
     int i = 0;
     for (DatanodeInfo dni : nodeStateManager.getAllNodes()) {
       String[] storagePercentage = calculateStoragePercentage(
-          dni.getStorageReports());
+              dni.getStorageReports());
       if (storagePercentage[0].equals("N/A")) {
         usages[i++] = 0;
       } else {
@@ -1242,7 +1249,7 @@ public class SCMNodeManager implements NodeManager {
     totalOzoneUsed /= nodeStateManager.getAllNodes().size();
     Arrays.sort(usages);
     float median = usages[usages.length / 2];
-    nodeStatics.put(UsageStatics.MEDINNA.getLabel(), String.valueOf(median));
+    nodeStatics.put(UsageStatics.MEDIAN.getLabel(), String.valueOf(median));
     float max = usages[usages.length - 1];
     nodeStatics.put(UsageStatics.MAX.getLabel(), String.valueOf(max));
     float min = usages[0];
@@ -1256,7 +1263,6 @@ public class SCMNodeManager implements NodeManager {
     DecimalFormat decimalFormat = new DecimalFormat("#0.00");
     decimalFormat.setRoundingMode(RoundingMode.HALF_UP);
     nodeStatics.put(UsageStatics.STDEV.getLabel(), decimalFormat.format(dev));
-    return nodeStatics;
   }
 
   /**
@@ -1329,7 +1335,7 @@ public class SCMNodeManager implements NodeManager {
   private enum UsageStatics {
     MIN("Min"),
     MAX("Max"),
-    MEDINNA("Medina"),
+    MEDIAN("Median"),
     STDEV("Stdev");
     private String label;
     public String getLabel() {

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -33,7 +33,7 @@
     <tbody>
     <tr>
         <td>DataNodes usages% (Min/Median/Max/stdDev)</td>
-        <td>{{statistical.usages.min}}%/{{statistical.usages.medina}}%/{{statistical.usages.max}}%/{{statistical.usages.stdev}}%</td>
+        <td>{{statistics.nodes.usages.min}}%/{{statistics.nodes.usages.median}}%/{{statistics.nodes.usages.max}}%/{{statistics.nodes.usages.stdev}}%</td>
     </tr>
     </tbody>
 </table>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -28,12 +28,28 @@
     </tbody>
 </table>
 
-<h2>Statistical</h2>
+<h2>Statistics</h2>
 <table class="table table-bordered table-striped">
     <tbody>
     <tr>
-        <td>DataNodes usages% (Min/Median/Max/stdDev)</td>
-        <td>{{statistics.nodes.usages.min}}%/{{statistics.nodes.usages.median}}%/{{statistics.nodes.usages.max}}%/{{statistics.nodes.usages.stdev}}%</td>
+        <th>Datanode Usage</th>
+        <th>in percentage (%)</th>
+    </tr>
+    <tr>
+        <td>Min</td>
+        <td>{{statistics.nodes.usages.min}}</td>
+    </tr>
+    <tr>
+        <td>Median</td>
+        <td>{{statistics.nodes.usages.median}}</td>
+    </tr>
+    <tr>
+        <td>Max</td>
+        <td>{{statistics.nodes.usages.max}}</td>
+    </tr>
+    <tr>
+        <td>Standard Deviation</td>
+        <td>{{statistics.nodes.usages.stdev}}</td>
     </tr>
     </tbody>
 </table>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -28,6 +28,16 @@
     </tbody>
 </table>
 
+<h2>Statistical</h2>
+<table class="table table-bordered table-striped">
+    <tbody>
+    <tr>
+        <td>DataNodes usages% (Min/Median/Max/stdDev)</td>
+        <td>{{statistical.usages.min}}%/{{statistical.usages.medina}}%/{{statistical.usages.max}}%/{{statistical.usages.stdev}}%</td>
+    </tr>
+    </tbody>
+</table>
+
 <h2>Node Status</h2>
 <div class="row">
     <div class="col-md-6 text-left">

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -32,13 +32,15 @@
             $scope.RecordsToDisplay = "10";
             $scope.currentPage = 1;
             $scope.lastIndex = 0;
-            $scope.statistical = {
-                usages : {}
+            $scope.statistics = {
+                nodes : {
+                    usages : {}
+                }
             }
-            $scope.statistical.usages.min = "";
-            $scope.statistical.usages.max = "";
-            $scope.statistical.usages.medina = "";
-            $scope.statistical.usages.stdev = "";
+            $scope.statistics.nodes.usages.min = "";
+            $scope.statistics.nodes.usages.max = "";
+            $scope.statistics.nodes.usages.median = "";
+            $scope.statistics.nodes.usages.stdev = "";
 
             function get_protocol(URLScheme, value, baseProto, fallbackProto) {
                 let protocol = "unknown"
@@ -89,15 +91,15 @@
                     $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
                     $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
 
-                    ctrl.nodemanagermetrics.NodeStatics.map(({ key, value }) => {
+                    ctrl.nodemanagermetrics.NodeStatistics.map(({ key, value }) => {
                         if(key == "Min") {
-                            $scope.statistical.usages.min = value;
+                            $scope.statistics.nodes.usages.min = value;
                         } else if(key == "Max") {
-                            $scope.statistical.usages.max = value;
-                        } else if(key == "Medina") {
-                            $scope.statistical.usages.medina = value;
+                            $scope.statistics.nodes.usages.max = value;
+                        } else if(key == "Median") {
+                            $scope.statistics.nodes.usages.median = value;
                         } else if(key == "Stdev") {
-                            $scope.statistical.usages.stdev = value;
+                            $scope.statistics.nodes.usages.stdev = value;
                         }
                     });
                 });

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -32,6 +32,13 @@
             $scope.RecordsToDisplay = "10";
             $scope.currentPage = 1;
             $scope.lastIndex = 0;
+            $scope.statistical = {
+                usages : {}
+            }
+            $scope.statistical.usages.min = "";
+            $scope.statistical.usages.max = "";
+            $scope.statistical.usages.medina = "";
+            $scope.statistical.usages.stdev = "";
 
             function get_protocol(URLScheme, value, baseProto, fallbackProto) {
                 let protocol = "unknown"
@@ -81,6 +88,18 @@
                     $scope.totalItems = nodeStatusCopy.length;
                     $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
                     $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
+
+                    ctrl.nodemanagermetrics.NodeStatics.map(({ key, value }) => {
+                        if(key == "Min") {
+                            $scope.statistical.usages.min = value;
+                        } else if(key == "Max") {
+                            $scope.statistical.usages.max = value;
+                        } else if(key == "Medina") {
+                            $scope.statistical.usages.medina = value;
+                        } else if(key == "Stdev") {
+                            $scope.statistical.usages.stdev = value;
+                        }
+                    });
                 });
             /*if option is 'All' display all records else display specified record on page*/
             $scope.UpdateRecordsToShow = () => {

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -34,13 +34,14 @@
             $scope.lastIndex = 0;
             $scope.statistics = {
                 nodes : {
-                    usages : {}
+                    usages : {
+                        min : "N/A",
+                        max : "N/A",
+                        median : "N/A",
+                        stdev : "N/A"
+                    }
                 }
             }
-            $scope.statistics.nodes.usages.min = "";
-            $scope.statistics.nodes.usages.max = "";
-            $scope.statistics.nodes.usages.median = "";
-            $scope.statistics.nodes.usages.stdev = "";
 
             function get_protocol(URLScheme, value, baseProto, fallbackProto) {
                 let protocol = "unknown"
@@ -91,15 +92,15 @@
                     $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
                     $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
 
-                    ctrl.nodemanagermetrics.NodeStatistics.map(({ key, value }) => {
-                        if(key == "Min") {
-                            $scope.statistics.nodes.usages.min = value;
-                        } else if(key == "Max") {
-                            $scope.statistics.nodes.usages.max = value;
-                        } else if(key == "Median") {
-                            $scope.statistics.nodes.usages.median = value;
-                        } else if(key == "Stdev") {
-                            $scope.statistics.nodes.usages.stdev = value;
+                    ctrl.nodemanagermetrics.NodeStatistics.forEach(function(obj) {
+                        if(obj.key == "Min") {
+                            $scope.statistics.nodes.usages.min = obj.value;
+                        } else if(obj.key == "Max") {
+                            $scope.statistics.nodes.usages.max = obj.value;
+                        } else if(obj.key == "Median") {
+                            $scope.statistics.nodes.usages.median = obj.value;
+                        } else if(obj.key == "Stdev") {
+                            $scope.statistics.nodes.usages.stdev = obj.value;
                         }
                     });
                 });


### PR DESCRIPTION
## What changes were proposed in this pull request?
For SCM, it is very useful to count the min, max, median, and stdev of node storage.
After adding the patch:
jmx:
![image](https://github.com/user-attachments/assets/b675c4c3-6368-4d1b-9893-2c0ac6978965)

ui:
![image](https://github.com/user-attachments/assets/42809667-bd4b-4587-8667-88fb88995663)


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11206

## How was this patch tested?
It is necessary to ensure that jmx can display NodeStatics correctly.
It is necessary to ensure that the UI can display Statistical correctly.
