### PR TITLE
HDDS-11215. Quota count can go wrong when double buffer flush takes time

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2031,6 +2031,9 @@ public class KeyManagerImpl implements KeyManager {
           parentInfo.getObjectID())) {
         break;
       }
+      if (!metadataManager.getDirectoryTable().isExist(entry.getKey())) {
+        continue;
+      }
       String dirName = OMFileRequest.getAbsolutePath(parentInfo.getKeyName(),
           dirInfo.getName());
       OmKeyInfo omKeyInfo = OMFileRequest.getOmKeyInfo(
@@ -2064,6 +2067,9 @@ public class KeyManagerImpl implements KeyManager {
         if (!OMFileRequest.isImmediateChild(fileInfo.getParentObjectID(),
             parentInfo.getObjectID())) {
           break;
+        }
+        if (!metadataManager.getFileTable().isExist(entry.getKey())) {
+          continue;
         }
         fileInfo.setFileName(fileInfo.getKeyName());
         String fullKeyPath = OMFileRequest.getAbsolutePath(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -290,7 +290,7 @@ public final class OzoneManagerDoubleBuffer {
    * and commit to DB.
    */
   @VisibleForTesting
-  void flushTransactions() {
+  public void flushTransactions() {
     while (isRunning.get() && canFlush()) {
       flushCurrentBuffer();
     }
@@ -617,7 +617,7 @@ public final class OzoneManagerDoubleBuffer {
   }
 
   @VisibleForTesting
-  void resume() {
+  public void resume() {
     isRunning.set(true);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -95,6 +97,10 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
           if (null != omBucketInfo
               && omBucketInfo.getObjectID() == path.getBucketId()) {
             omBucketInfo.incrUsedNamespace(-1L);
+            String ozoneDbKey = omMetadataManager.getOzonePathKey(path.getVolumeId(),
+                path.getBucketId(), keyInfo.getParentObjectID(), keyInfo.getFileName());
+            omMetadataManager.getDirectoryTable().addCacheEntry(new CacheKey<>(ozoneDbKey),
+                CacheValue.get(termIndex.getIndex()));
             volBucketInfoMap.putIfAbsent(volBucketPair, omBucketInfo);
           }
         }
@@ -119,6 +125,10 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
               && omBucketInfo.getObjectID() == path.getBucketId()) {
             omBucketInfo.incrUsedBytes(-sumBlockLengths(keyInfo));
             omBucketInfo.incrUsedNamespace(-1L);
+            String ozoneDbKey = omMetadataManager.getOzonePathKey(path.getVolumeId(),
+                path.getBucketId(), keyInfo.getParentObjectID(), keyInfo.getFileName());
+            omMetadataManager.getFileTable().addCacheEntry(new CacheKey<>(ozoneDbKey),
+                CacheValue.get(termIndex.getIndex()));
             volBucketInfoMap.putIfAbsent(volBucketPair, omBucketInfo);
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

bucketInfo can have incorrect count, and even can go -ve value. This is as DirectoryDeletingService keeps sending purgeDirectory request till rocksdb delectedDirectoryTable is not flushed with deletion. For the fix,
- Cache is added for directoryTable and fileTable marking the key is deleted
- in directoryDeletetingService, applicable list to delete directory / files are obtained with check from cache if deleted

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11215

## How was this patch tested?

- Integration test covering scenario (reproduced without fix)
