### PR TITLE
HDDS-11221. Resolve potential time discrepancy for expired multipart upload cleanup

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -22,7 +22,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -1815,7 +1814,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
              mpuInfoTableIterator = getMultipartInfoTable().iterator()) {
 
       final long expiredCreationTimestamp =
-          Instant.now().minus(expireThreshold).toEpochMilli();
+          expireThreshold.negated().plusMillis(Time.now()).toMillis();
 
       ExpiredMultipartUploadInfo.Builder builder =
           ExpiredMultipartUploadInfo.newBuilder();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -777,7 +776,7 @@ public class TestOmMetadataManager {
     final Duration expireThreshold = Duration.ofMillis(expireThresholdMillis);
 
     final long expiredMPUCreationTime =
-        Instant.now().minus(expireThreshold).toEpochMilli();
+        expireThreshold.negated().plusMillis(Time.now()).toMillis();
 
     // Add expired MPUs to multipartInfoTable.
     // The method under test does not check for expired open keys in the
@@ -785,7 +784,7 @@ public class TestOmMetadataManager {
     Set<String> expiredMPUs = new HashSet<>();
     for (int i = 0; i < numExpiredMPUs + numUnexpiredMPUs; i++) {
       final long creationTime = i < numExpiredMPUs ?
-          expiredMPUCreationTime : Instant.now().toEpochMilli();
+          expiredMPUCreationTime : Time.now();
 
       String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
       final OmMultipartKeyInfo mpuKeyInfo = OMRequestTestUtils


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to [HDDS-7764](https://issues.apache.org/jira/browse/HDDS-7764), we need to update this to prevent expired multipart upload being cleaned up prematurely.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11221

## How was this patch tested?

Update existing unit tests.