### PR TITLE
HDDS-11226. Make ExponentialBackoffPolicy maxRetries configurable

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
@@ -207,7 +207,7 @@ public class RatisClientConfig {
       defaultValue =  "2147483647",
       type = ConfigType.INT,
       tags = { OZONE, CLIENT, PERFORMANCE },
-      description = "Max retry count for the  exponential backoff policy.")
+      description = "Client's max retry value for the exponential backoff policy.")
   private int exponentialPolicyMaxRetries = Integer.MAX_VALUE;
 
   public int getExponentialPolicyMaxRetries() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/conf/RatisClientConfig.java
@@ -203,6 +203,21 @@ public class RatisClientConfig {
     exponentialPolicyMaxSleep = duration;
   }
 
+  @Config(key = "client.exponential.backoff.max.retries",
+      defaultValue =  "2147483647",
+      type = ConfigType.INT,
+      tags = { OZONE, CLIENT, PERFORMANCE },
+      description = "Max retry count for the  exponential backoff policy.")
+  private int exponentialPolicyMaxRetries = Integer.MAX_VALUE;
+
+  public int getExponentialPolicyMaxRetries() {
+    return exponentialPolicyMaxRetries;
+  }
+
+  public void setExponentialPolicyMaxRetries(int retry) {
+    exponentialPolicyMaxRetries = retry;
+  }
+
   @Config(key = "client.retrylimited.retry.interval",
       defaultValue = "1s",
       type = ConfigType.TIME,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/retrypolicy/RequestTypeDependentRetryPolicyCreator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/retrypolicy/RequestTypeDependentRetryPolicyCreator.java
@@ -96,6 +96,8 @@ public class RequestTypeDependentRetryPolicyCreator
             toTimeDuration(ratisClientConfig.getExponentialPolicyBaseSleep()))
         .setMaxSleepTime(
             toTimeDuration(ratisClientConfig.getExponentialPolicyMaxSleep()))
+        .setMaxAttempts(
+            ratisClientConfig.getExponentialPolicyMaxRetries())
         .build();
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/conf/TestRatisClientConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/conf/TestRatisClientConfig.java
@@ -44,6 +44,8 @@ class TestRatisClientConfig {
         subject.getWatchRequestTimeout());
     assertEquals(fromConfig.getWriteRequestTimeout(),
         subject.getWriteRequestTimeout());
+    assertEquals(fromConfig.getExponentialPolicyMaxRetries(),
+        subject.getExponentialPolicyMaxRetries());
   }
 
   @Test
@@ -53,16 +55,19 @@ class TestRatisClientConfig {
     final Duration maxSleep = Duration.ofMinutes(2);
     final Duration watchRequestTimeout = Duration.ofMillis(555);
     final Duration writeRequestTimeout = Duration.ofMillis(444);
+    final int maxRetry = 10;
 
     subject.setExponentialPolicyBaseSleep(baseSleep);
     subject.setExponentialPolicyMaxSleep(maxSleep);
     subject.setWatchRequestTimeout(watchRequestTimeout);
     subject.setWriteRequestTimeout(writeRequestTimeout);
+    subject.setExponentialPolicyMaxRetries(maxRetry);
 
     assertEquals(baseSleep, subject.getExponentialPolicyBaseSleep());
     assertEquals(maxSleep, subject.getExponentialPolicyMaxSleep());
     assertEquals(watchRequestTimeout, subject.getWatchRequestTimeout());
     assertEquals(writeRequestTimeout, subject.getWriteRequestTimeout());
+    assertEquals(maxRetry, subject.getExponentialPolicyMaxRetries());
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Default max retries count is very high for ExponentialBackoffPolicy which in some cases leads to longer wait for client. Client like HBase by default timesout after 5 minutes which leads to unexpected crash. 
In this PR making retry count as configurable so that after max retry client can try on different DN and doesn't need to wait for long.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11226

## How was this patch tested?

Updated existing test