### PR TITLE
HDDS-11232. Spare InfoBucket RPC call for the FileSystem#getFileStatus calls for the general case.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2156,6 +2156,8 @@ public class RpcClient implements ClientProtocol {
   @Override
   public OzoneFileStatus getOzoneFileStatus(String volumeName,
       String bucketName, String keyName) throws IOException {
+    verifyVolumeName(volumeName);
+    verifyBucketName(bucketName);
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -659,20 +659,19 @@ public class BasicRootedOzoneClientAdapterImpl
    * valid bucket path or valid snapshot path.
    * Throws exception in case of failure.
    */
-  private FileStatusAdapter getFileStatusForKeyOrSnapshot(
-      OFSPath ofsPath, URI uri, Path qualifiedPath, String userName)
+  private FileStatusAdapter getFileStatusForKeyOrSnapshot(OFSPath ofsPath, URI uri, Path qualifiedPath, String userName)
       throws IOException {
+    String volumeName = ofsPath.getVolumeName();
+    String bucketName = ofsPath.getBucketName();
     String key = ofsPath.getKeyName();
     try {
-      OzoneBucket bucket = getBucket(ofsPath, false);
       if (ofsPath.isSnapshotPath()) {
-        OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
-        return getFileStatusAdapterWithSnapshotIndicator(
-            volume, bucket, uri);
+        OzoneVolume volume = objectStore.getVolume(volumeName);
+        OzoneBucket bucket = getBucket(volumeName, bucketName, false);
+        return getFileStatusAdapterWithSnapshotIndicator(volume, bucket, uri);
       } else {
-        OzoneFileStatus status = bucket.getFileStatus(key);
-        return toFileStatusAdapter(status, userName, uri, qualifiedPath,
-            ofsPath.getNonKeyPath());
+        OzoneFileStatus status = objectStore.getClientProxy().getOzoneFileStatus(volumeName, bucketName, key);
+        return toFileStatusAdapter(status, userName, uri, qualifiedPath, ofsPath.getNonKeyPath());
       }
     } catch (OMException e) {
       if (e.getResult() == OMException.ResultCodes.FILE_NOT_FOUND) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -670,7 +670,7 @@ public class BasicRootedOzoneClientAdapterImpl
         OzoneBucket bucket = getBucket(volumeName, bucketName, false);
         return getFileStatusAdapterWithSnapshotIndicator(volume, bucket, uri);
       } else {
-        OzoneFileStatus status = objectStore.getClientProxy().getOzoneFileStatus(volumeName, bucketName, key);
+        OzoneFileStatus status = proxy.getOzoneFileStatus(volumeName, bucketName, key);
         return toFileStatusAdapter(status, userName, uri, qualifiedPath, ofsPath.getNonKeyPath());
       }
     } catch (OMException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the BasicRootedOzoneClientAdapterImpl#getFileStatus call within the getFileStatusForKeyOrSnapshot method, in most of the cases we do not need just the name of the bucket to get to OM and ask for the file status.

In those cases we should not get the bucketInfo first in a separate RPC, and then get the bucket object to call the client protocol for the file status in an other RPC as we do now.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11232

## How was this patch tested?
I have created a special client that logs RPC calls that it makes, and ran some FS API call tests with a client that emits some additional logs, before and after this change. Logging in this client was added to the OzoneManagerProtocolClientSideTranslatorPB@submitRequest call, and nothing else was changed to get the logging. (It is just basically simpler than to collect information from the client side TRACE logs from hadoop ipc.)

Output before the change:
Before:
Submitting RPC request: ServiceList
Creating base directory /pifta/test/dir in Ozone (api call: fs.mkdirs)
Submitting RPC request: InfoBucket
Submitting RPC request: CreateDirectory
Copy from local to /pifta/test/dir/copyFromLocal (api call: fs.copyFromLocalFile)
Submitting RPC request: InfoBucket
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: CreateFile
Submitting RPC request: CommitKey
Cross bucket copy from /pifta/test/dir/copyFromLocal to /test/test/foo (api call: FileUtil.copy)
Submitting RPC request: InfoBucket
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: GetKeyInfo
Submitting RPC request: InfoBucket
Submitting RPC request: CreateFile
Submitting RPC request: CommitKey
Cleanup /test/test/foo (api call: fs.delete - on file)
Submitting RPC request: InfoBucket
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: DeleteKey
Submitting RPC request: InfoBucket
 Submitting RPC request: GetFileStatus
Cleanup /pifta/test/dir (api call: fs.delete - on directory recursively)
Submitting RPC request: InfoBucket
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: InfoBucket
Submitting RPC request: DeleteKey



After the change the same code generates the following output:
Submitting RPC request: ServiceList
Creating base directory /pifta/test/dir in Ozone (api call: fs.mkdirs)
Submitting RPC request: InfoBucket
Submitting RPC request: CreateDirectory
Copy from local to /pifta/test/dir/copyFromLocal (api call: fs.copyFromLocalFile)
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: CreateFile
Submitting RPC request: CommitKey
Cross bucket copy from /pifta/test/dir/copyFromLocal to /test/test/foo (api call: FileUtil.copy)
Submitting RPC request: GetFileStatus
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: GetKeyInfo
Submitting RPC request: InfoBucket
Submitting RPC request: CreateFile
Submitting RPC request: CommitKey
Cleanup /test/test/foo (api call: fs.delete - on file)
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: DeleteKey
Submitting RPC request: GetFileStatus
Cleanup /pifta/test/dir (api call: fs.delete - on directory recursively)
Submitting RPC request: GetFileStatus
Submitting RPC request: InfoBucket
Submitting RPC request: InfoBucket
Submitting RPC request: DeleteKey

AS you can see copyFromLocalFile use 1 less InfoBucket RPC calls, copy uses 2 less InfoBucket calls, and non recursive delete of a file uses 2 less while recursive delete of a dir with one file uses 1 less InfoBucket RPC calls.
Besides this there are probably a couple of other functionalities that spare these excess calls, I do not have coverage for the full API available to be able to list all cases.

Other than this the current tests should cover for the change.