### PR TITLE
HDDS-11235. Spare InfoBucket RPC call in FileSystem#mkdir() call.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2169,6 +2169,8 @@ public class RpcClient implements ClientProtocol {
   @Override
   public void createDirectory(String volumeName, String bucketName,
       String keyName) throws IOException {
+    verifyVolumeName(volumeName);
+    verifyBucketName(bucketName);
     String ownerName = getRealUserInfo().getShortUserName();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -522,8 +522,9 @@ public class BasicRootedOzoneClientAdapterImpl
       // Create volume and bucket if they do not exist, and retry key creation.
       // This call will throw an exception if it fails, or the exception is different than it handles.
       handleVolumeOrBucketCreationOnException(volumeName, bucketName, e);
-      proxy.createDirectory(volumeName, bucketName, keyStr);
-      throw e;
+      if (keyStr != null && !keyStr.isEmpty()) {
+        proxy.createDirectory(volumeName, bucketName, keyStr);
+      }
     }
     return true;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In BasicRootedOzoneFileSystem#mkdir() method we use getBucket in all circumstances, as that call is also used to create the bucket if it does not exists.
However, this results in a GetBucketInfo RPC call every time, even when the bucket exists, and we create a key with this call. In this latter case we should not call getBucket() but use the RPCClient (ClientProtocol) directly using the bucket name to create the directory.
In order to achieve functional parity with the old approach, I have extracted the logic that handles non existent volumes and buckets in the getBucket() call, and in createDirectory I am changing the getBucket call also to directly call getBucketInfo if keyStr is not present.

The RpcClient#createDirectory change is to ensure verification of the volume and bucket name that was done by the getBucket call earlier in the client adapter impl.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11235

## How was this patch tested?
I have created a special client that logs RPC calls that it makes, and ran mkdir FS API calls with a client that emits some additional logs.
Logging in this client was added to the OzoneManagerProtocolClientSideTranslatorPB@submitRequest call, nothing else was changed to get the logging.

Output before the change:
Submitting RPC request: ServiceList
Creating base directory /pifta/test/dir in Ozone
Submitting RPC request: InfoBucket
Submitting RPC request: CreateDirectory

After the change the same code using fs.mkdirs() generates the following output:
Submitting RPC request: ServiceList
Creating base directory /pifta/test/dir in Ozone
Submitting RPC request: CreateDirectory


This test above was done against a directory that was created in an exiting volume and bucket.
I tested the following scenarios after addressing missing volume and bucket creation for the new code, the test uses fs.mkdirs() to create a path:

Volume does not exists, and creating a directory multiple levels down the tree:
Submitting RPC request: CreateDirectory
Submitting RPC request: CreateVolume
Submitting RPC request: CreateBucket
Submitting RPC request: CreateDirectory

Volume exists, but bucket does not exist, and creating a directory multiple levels down the tree:
Submitting RPC request: CreateDirectory
Submitting RPC request: CreateBucket
Submitting RPC request: CreateDirectory

Volume and bucket exists, and creating directory multiple levels down the tree:
Submitting RPC request: CreateDirectory

Volume and bucket does not exists, and creating bucket:
Submitting RPC request: InfoBucket
Submitting RPC request: CreateVolume
Submitting RPC request: CreateBucket

Volume exists, and creating bucket:
Submitting RPC request: InfoBucket
Submitting RPC request: CreateBucket

Creating volume:
Submitting RPC request: CreateVolume

When I tried to supply empty path, or "/" as a path, then the code did not send any RPCs besides the getServiceInfo, which is being sent at FileSystem initialization.

Interestingly, if I try to create a volume twice that leads to a VOLUME_ALREADY_EXISTS, while if I try to create a bucket or a key twice, then the secondary call does not throw an already exists exception (it did not do it originally either), however the code suggest that it was an intention to throw a FileAlreadyExistsException at least... I leave this part of the functionality unchanged.