### PR TITLE
HDDS-11238. Converge redundant getBucket calls for FileSystem client delete

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -768,12 +768,12 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   private boolean deleteBucket(Path f, boolean recursive, OFSPath ofsPath)
       throws IOException {
-      OzoneBucket bucket;
-      try {
-        bucket = adapterImpl.getBucket(ofsPath, false);
-      } catch (Exception ex) {
-        return false;
-      }
+    OzoneBucket bucket;
+    try {
+      bucket = adapterImpl.getBucket(ofsPath, false);
+    } catch (Exception ex) {
+      return false;
+    }
     // check status of normal bucket
     try {
       getFileStatus(f);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -772,6 +772,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     try {
       bucket = adapterImpl.getBucket(ofsPath, false);
     } catch (Exception ex) {
+      LOG.error("Exception while getting bucket link information, " +
+          "considered it as false", ex);
       return false;
     }
     // check status of normal bucket

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -704,7 +704,6 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     String key = pathToKey(f);
     OFSPath ofsPath = new OFSPath(key,
         ozoneConfiguration);
-    OzoneBucket bucket = adapterImpl.getBucket(ofsPath, false);
     // Handle rm root
     if (ofsPath.isRoot()) {
       // Intentionally drop support for rm root

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -727,7 +727,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
     // delete bucket
     if (ofsPath.isBucket()) {
-      return deleteBucket(f, recursive, bucket);
+      return deleteBucket(f, recursive, ofsPath);
     }
     
     // delete files and directory

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -91,6 +91,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_EMPTY;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_EMPTY;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 
 /**
  * The minimal Rooted Ozone Filesystem implementation.
@@ -771,9 +773,13 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     OzoneBucket bucket;
     try {
       bucket = adapterImpl.getBucket(ofsPath, false);
+    } catch (OMException ex) {
+      if (ex.getResult() != BUCKET_NOT_FOUND && ex.getResult() != VOLUME_NOT_FOUND) {
+        LOG.error("OMException while getting bucket information, considered it as false", ex);
+      }
+      return false;
     } catch (Exception ex) {
-      LOG.error("Exception while getting bucket link information, " +
-          "considered it as false", ex);
+      LOG.error("Exception while getting bucket information, considered it as false", ex);
       return false;
     }
     // check status of normal bucket

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -764,8 +764,14 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     return result;
   }
 
-  private boolean deleteBucket(Path f, boolean recursive, OzoneBucket bucket)
+  private boolean deleteBucket(Path f, boolean recursive, OFSPath ofsPath)
       throws IOException {
+      OzoneBucket bucket;
+      try {
+        bucket = adapterImpl.getBucket(ofsPath, false);
+      } catch (Exception ex) {
+        return false;
+      }
     // check status of normal bucket
     try {
       getFileStatus(f);


### PR DESCRIPTION
## What changes were proposed in this pull request?

A few internal calls as part of FileSystem client delete involve repeated computation of getBucket(). Instead, we may precompute the OzoneBucket object and then pass it onto other dependent calls as they again compute the same object internally.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11238

## How was this patch tested?

Existing unit and integration tests should cover the changes
