### PR TITLE
HDDS-11195. state machine fail configuration for critical/non-critical operation

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4429,4 +4429,13 @@
       maximum number of buckets across all volumes.
     </description>
   </property>
+  <property>
+    <name>ozone.om.requests.ignore.terminate.on.failure</name>
+    <value>DeleteOpenKeys,EchoRPC</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      list of request commands separated by comma which will not terminate ozone manager on unhandled exception
+      while handling request. OM logic handles all exceptions of IOException type.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -612,4 +612,7 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_MAX_BUCKET =
       "ozone.om.max.buckets";
   public static final int OZONE_OM_MAX_BUCKET_DEFAULT = 100000;
+
+  public static final String OZONE_OM_IGNORED_REQUEST_FAILURE =
+      "ozone.om.requests.ignore.terminate.on.failure";
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -258,6 +259,19 @@ public class TestOzoneManagerStateMachine {
     } catch (Exception ex) {
       // do nothing
     }
+  }
+
+  @Test
+  public void testEpochFailureDoNotCauseTermination() throws Exception {
+    OMRequest omRequest = OMRequest.newBuilder()
+        .setEchoRPCRequest(OzoneManagerProtocolProtos.EchoRPCRequest.newBuilder().build())
+        .setCmdType(Type.EchoRPC).setClientId("123")
+        .setUserInfo(UserInfo.newBuilder().setUserName("user").setHostName("localhost").setRemoteAddress("127.0.0.1"))
+        .build();
+    TransactionContext submittedTrx = mockTransactionContext(omRequest);
+    CompletableFuture<Message> messageCompletableFuture = ozoneManagerStateMachine.applyTransaction(submittedTrx);
+    Message message = messageCompletableFuture.get();
+    assertTrue(message.getContent().toString().contains("java.lang.NullPointerException"));
   }
 
   private TransactionContext mockTransactionContext(OMRequest request) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

configuring request type that will be treated as non-critical and those failure should not cause termination of ozone state machine. 
Configuration added: `ozone.om.requests.ignore.terminate.on.failure`
Default value: DeleteOpenKeys,EchoRPC

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11195

## How was this patch tested?

- unit test cases added
