### PR TITLE
HDDS-11119. Unnecessary UPDATE_VOLUME audit entry for DELETE_TENANT

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -39,6 +39,7 @@ public enum OMAction implements AuditAction {
   RENAME_KEYS,
   SET_OWNER,
   SET_QUOTA,
+  UPDATE_VOLUME,
   UPDATE_BUCKET,
   UPDATE_KEY,
   PURGE_KEYS,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -39,7 +39,6 @@ public enum OMAction implements AuditAction {
   RENAME_KEYS,
   SET_OWNER,
   SET_QUOTA,
-  UPDATE_VOLUME,
   UPDATE_BUCKET,
   UPDATE_KEY,
   PURGE_KEYS,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
@@ -226,13 +226,6 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
 
     // Perform audit logging
     auditMap.put(OzoneConsts.TENANT, tenantId);
-    // Audit volume ref count update
-    if (decVolumeRefCount) {
-      markForAudit(ozoneManager.getAuditLogger(),
-          buildAuditMessage(OMAction.UPDATE_VOLUME,
-              buildVolumeAuditMap(volumeName),
-              exception, getOmRequest().getUserInfo()));
-    }
     // Audit tenant deletion
     markForAudit(ozoneManager.getAuditLogger(),
         buildAuditMessage(OMAction.DELETE_TENANT,


### PR DESCRIPTION
## What changes were proposed in this pull request?

removal of duplicate audit logging of UPDATE_VOLUME for delete tenant case. Already DELETE_TENANT audit log is present.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11119

## How was this patch tested?

- existing test cases for impact
