### PR TITLE
HDDS-11244. Keys should not be purged from file table while processing deleted directories in snapshot & should be purged from AOS instead

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -46,7 +46,7 @@ public interface DBStore extends Closeable, BatchOperationHandler {
    * @return - TableStore.
    * @throws IOException on Failure
    */
-  Table<byte[], byte[]> getTable(String name) throws IOException;
+  Table<byte[], byte[]> getTable(String name, boolean readOnlyTable) throws IOException;
 
 
   /**
@@ -60,7 +60,7 @@ public interface DBStore extends Closeable, BatchOperationHandler {
    * @throws IOException on Failure
    */
   <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
-      Class<KEY> keyType, Class<VALUE> valueType) throws IOException;
+      Class<KEY> keyType, Class<VALUE> valueType, boolean readOnlyTable) throws IOException;
 
   /**
    * Gets an existing TableStore with implicit key/value conversion and
@@ -74,7 +74,7 @@ public interface DBStore extends Closeable, BatchOperationHandler {
    */
   <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
       Class<KEY> keyType, Class<VALUE> valueType,
-      TableCache.CacheType cacheType) throws IOException;
+      TableCache.CacheType cacheType, boolean readOnlyTable) throws IOException;
 
   /**
    * Lists the Known list of Tables in a DB.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -286,26 +286,29 @@ public class RDBStore implements DBStore {
   }
 
   @Override
-  public RDBTable getTable(String name) throws IOException {
+  public RDBTable getTable(String name, boolean readOnlyTable) throws IOException {
     final ColumnFamily handle = db.getColumnFamily(name);
     if (handle == null) {
       throw new IOException("No such table in this DB. TableName : " + name);
+    }
+    if (readOnlyTable) {
+      return new ReadOnlyRDBTable(this.db, handle, rdbMetrics);
     }
     return new RDBTable(this.db, handle, rdbMetrics);
   }
 
   @Override
   public <K, V> TypedTable<K, V> getTable(String name,
-      Class<K> keyType, Class<V> valueType) throws IOException {
-    return new TypedTable<>(getTable(name), codecRegistry, keyType,
+      Class<K> keyType, Class<V> valueType, boolean readOnlyTable) throws IOException {
+    return new TypedTable<>(getTable(name, readOnlyTable), codecRegistry, keyType,
         valueType);
   }
 
   @Override
   public <K, V> Table<K, V> getTable(String name,
       Class<K> keyType, Class<V> valueType,
-      TableCache.CacheType cacheType) throws IOException {
-    return new TypedTable<>(getTable(name), codecRegistry, keyType,
+      TableCache.CacheType cacheType, boolean readOnlyTable) throws IOException {
+    return new TypedTable<>(getTable(name, readOnlyTable), codecRegistry, keyType,
         valueType, cacheType, threadNamePrefix);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ReadOnlyRDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ReadOnlyRDBTable.java
@@ -1,0 +1,101 @@
+package org.apache.hadoop.hdds.utils.db;
+
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class ReadOnlyRDBTable extends RDBTable {
+  private String unsupportedErrorMessage;
+
+  private static String UNSUPPORTED_OPERATION_EXCEPTION_MESSAGE_FORMAT = "Updating value %s to the table is not " +
+      "supported for readOnlyTable";
+  /**
+   * Constructs a TableStore.
+   *
+   * @param db         - DBstore that we are using.
+   * @param family     - ColumnFamily Handle.
+   * @param rdbMetrics
+   */
+  ReadOnlyRDBTable(RocksDatabase db, RocksDatabase.ColumnFamily family, RDBMetrics rdbMetrics) {
+    super(db, family, rdbMetrics);
+    unsupportedErrorMessage = String.format(UNSUPPORTED_OPERATION_EXCEPTION_MESSAGE_FORMAT, family.getName());
+  }
+
+  @Override
+  void put(ByteBuffer key, ByteBuffer value) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void put(byte[] key, byte[] value) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  void putWithBatch(BatchOperation batch, CodecBuffer key, CodecBuffer value) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void putWithBatch(BatchOperation batch, byte[] key, byte[] value) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void delete(byte[] key) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void delete(ByteBuffer key) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void deleteRange(byte[] beginKey, byte[] endKey) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void deleteWithBatch(BatchOperation batch, byte[] key) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void deleteBatchWithPrefix(BatchOperation batch, byte[] prefix) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public byte[] getReadCopy(byte[] bytes) throws IOException {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void addCacheEntry(CacheKey<byte[]> cacheKey, CacheValue<byte[]> cacheValue) {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void addCacheEntry(byte[] cacheKey, long epoch) {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void addCacheEntry(byte[] cacheKey, byte[] bytes, long epoch) {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public CacheValue<byte[]> getCacheValue(CacheKey<byte[]> cacheKey) {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+
+  @Override
+  public void cleanupCache(List<Long> epochs) {
+    throw new UnsupportedOperationException(unsupportedErrorMessage);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -389,14 +390,14 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     omEpoch = 0;
     setStore(loadDB(conf, dir, name, true,
         java.util.Optional.of(Boolean.TRUE), Optional.empty()));
-    initializeOmTables(CacheType.PARTIAL_CACHE, false);
+    initializeOmTables(CacheType.PARTIAL_CACHE, false, Collections.emptySet());
     perfMetrics = null;
   }
 
 
   // metadata constructor for snapshots
   OmMetadataManagerImpl(OzoneConfiguration conf, String snapshotDirName,
-      boolean isSnapshotInCache, int maxOpenFiles) throws IOException {
+      boolean isSnapshotInCache, int maxOpenFiles, Set<String> readOnlyTables) throws IOException {
     try {
       lock = new OmReadOnlyLock();
       omEpoch = 0;
@@ -423,7 +424,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       setStore(loadDB(conf, metaDir, dbName, false,
           java.util.Optional.of(Boolean.TRUE),
           Optional.of(maxOpenFiles), false, false));
-      initializeOmTables(CacheType.PARTIAL_CACHE, false);
+      initializeOmTables(CacheType.PARTIAL_CACHE, false, readOnlyTables);
     } catch (IOException e) {
       stop();
       throw e;
@@ -566,7 +567,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
 
       this.store = loadDB(configuration, metaDir, Optional.of(maxOpenFiles));
 
-      initializeOmTables(CacheType.FULL_CACHE, true);
+      initializeOmTables(CacheType.FULL_CACHE, true, Collections.emptySet());
     }
 
     snapshotChainManager = new SnapshotChainManager(this);
@@ -661,116 +662,103 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .addCodec(CompactionLogEntry.class, CompactionLogEntry.getCodec());
   }
 
+  private <K, V> Table<K, V> getTable(String tableName, Class<K> keyClass, Class<V> valueClass,
+                                      Set<String> readOnlyTables) throws IOException {
+    return this.store.getTable(tableName, keyClass, valueClass, readOnlyTables.contains(tableName));
+  }
+
+  private <K, V> Table<K, V> getTable(String tableName, Class<K> keyClass, Class<V> valueClass,
+                                      CacheType cacheType, Set<String> readOnlyTables) throws IOException {
+    return this.store.getTable(tableName, keyClass, valueClass, cacheType, readOnlyTables.contains(tableName));
+  }
+
   /**
    * Initialize OM Tables.
    *
    * @throws IOException
    */
   protected void initializeOmTables(CacheType cacheType,
-                                    boolean addCacheMetrics)
+                                    boolean addCacheMetrics,
+                                    Set<String> readOnlyTables)
       throws IOException {
-    userTable =
-        this.store.getTable(USER_TABLE, String.class,
-            PersistedUserVolumeInfo.class);
+    userTable = getTable(USER_TABLE, String.class, PersistedUserVolumeInfo.class, readOnlyTables);
     checkTableStatus(userTable, USER_TABLE, addCacheMetrics);
 
-    volumeTable =
-        this.store.getTable(VOLUME_TABLE, String.class, OmVolumeArgs.class,
-            cacheType);
+    volumeTable = getTable(VOLUME_TABLE, String.class, OmVolumeArgs.class, cacheType, readOnlyTables);
     checkTableStatus(volumeTable, VOLUME_TABLE, addCacheMetrics);
 
-    bucketTable =
-        this.store.getTable(BUCKET_TABLE, String.class, OmBucketInfo.class,
-            cacheType);
+    bucketTable = getTable(BUCKET_TABLE, String.class, OmBucketInfo.class, cacheType, readOnlyTables);
 
     checkTableStatus(bucketTable, BUCKET_TABLE, addCacheMetrics);
 
-    keyTable = this.store.getTable(KEY_TABLE, String.class, OmKeyInfo.class);
+    keyTable = getTable(KEY_TABLE, String.class, OmKeyInfo.class, readOnlyTables);
     checkTableStatus(keyTable, KEY_TABLE, addCacheMetrics);
 
-    deletedTable = this.store.getTable(DELETED_TABLE, String.class,
-        RepeatedOmKeyInfo.class);
+    deletedTable = getTable(DELETED_TABLE, String.class, RepeatedOmKeyInfo.class, readOnlyTables);
     checkTableStatus(deletedTable, DELETED_TABLE, addCacheMetrics);
 
-    openKeyTable =
-        this.store.getTable(OPEN_KEY_TABLE, String.class,
-            OmKeyInfo.class);
+    openKeyTable = getTable(OPEN_KEY_TABLE, String.class, OmKeyInfo.class, readOnlyTables);
     checkTableStatus(openKeyTable, OPEN_KEY_TABLE, addCacheMetrics);
 
-    multipartInfoTable = this.store.getTable(MULTIPARTINFO_TABLE,
-        String.class, OmMultipartKeyInfo.class);
+    multipartInfoTable = getTable(MULTIPARTINFO_TABLE, String.class, OmMultipartKeyInfo.class, readOnlyTables);
     checkTableStatus(multipartInfoTable, MULTIPARTINFO_TABLE, addCacheMetrics);
 
-    dTokenTable = this.store.getTable(DELEGATION_TOKEN_TABLE,
-        OzoneTokenIdentifier.class, Long.class);
+    dTokenTable = getTable(DELEGATION_TOKEN_TABLE, OzoneTokenIdentifier.class, Long.class, readOnlyTables);
     checkTableStatus(dTokenTable, DELEGATION_TOKEN_TABLE, addCacheMetrics);
 
-    s3SecretTable = this.store.getTable(S3_SECRET_TABLE, String.class,
-        S3SecretValue.class);
+    s3SecretTable = getTable(S3_SECRET_TABLE, String.class, S3SecretValue.class, readOnlyTables);
     checkTableStatus(s3SecretTable, S3_SECRET_TABLE, addCacheMetrics);
 
-    prefixTable = this.store.getTable(PREFIX_TABLE, String.class,
-        OmPrefixInfo.class);
+    prefixTable = getTable(PREFIX_TABLE, String.class, OmPrefixInfo.class, readOnlyTables);
     checkTableStatus(prefixTable, PREFIX_TABLE, addCacheMetrics);
 
-    dirTable = this.store.getTable(DIRECTORY_TABLE, String.class,
-            OmDirectoryInfo.class);
+    dirTable = getTable(DIRECTORY_TABLE, String.class, OmDirectoryInfo.class, readOnlyTables);
     checkTableStatus(dirTable, DIRECTORY_TABLE, addCacheMetrics);
 
-    fileTable = this.store.getTable(FILE_TABLE, String.class,
-            OmKeyInfo.class);
+    fileTable = getTable(FILE_TABLE, String.class, OmKeyInfo.class, readOnlyTables);
     checkTableStatus(fileTable, FILE_TABLE, addCacheMetrics);
 
-    openFileTable = this.store.getTable(OPEN_FILE_TABLE, String.class,
-            OmKeyInfo.class);
+    openFileTable = getTable(OPEN_FILE_TABLE, String.class, OmKeyInfo.class, readOnlyTables);
     checkTableStatus(openFileTable, OPEN_FILE_TABLE, addCacheMetrics);
 
-    deletedDirTable = this.store.getTable(DELETED_DIR_TABLE, String.class,
-        OmKeyInfo.class);
+    deletedDirTable = getTable(DELETED_DIR_TABLE, String.class, OmKeyInfo.class, readOnlyTables);
     checkTableStatus(deletedDirTable, DELETED_DIR_TABLE, addCacheMetrics);
 
-    transactionInfoTable = this.store.getTable(TRANSACTION_INFO_TABLE,
-        String.class, TransactionInfo.class);
+    transactionInfoTable = getTable(TRANSACTION_INFO_TABLE, String.class, TransactionInfo.class, readOnlyTables);
     checkTableStatus(transactionInfoTable, TRANSACTION_INFO_TABLE,
         addCacheMetrics);
 
-    metaTable = this.store.getTable(META_TABLE, String.class, String.class);
+    metaTable = getTable(META_TABLE, String.class, String.class, readOnlyTables);
     checkTableStatus(metaTable, META_TABLE, addCacheMetrics);
 
     // accessId -> OmDBAccessIdInfo (tenantId, secret, Kerberos principal)
-    tenantAccessIdTable = this.store.getTable(TENANT_ACCESS_ID_TABLE,
-        String.class, OmDBAccessIdInfo.class);
+    tenantAccessIdTable = getTable(TENANT_ACCESS_ID_TABLE, String.class, OmDBAccessIdInfo.class, readOnlyTables);
     checkTableStatus(tenantAccessIdTable, TENANT_ACCESS_ID_TABLE,
         addCacheMetrics);
 
     // User principal -> OmDBUserPrincipalInfo (a list of accessIds)
-    principalToAccessIdsTable = this.store.getTable(
-        PRINCIPAL_TO_ACCESS_IDS_TABLE,
-        String.class, OmDBUserPrincipalInfo.class);
+    principalToAccessIdsTable = getTable(PRINCIPAL_TO_ACCESS_IDS_TABLE,
+        String.class, OmDBUserPrincipalInfo.class, readOnlyTables);
     checkTableStatus(principalToAccessIdsTable, PRINCIPAL_TO_ACCESS_IDS_TABLE,
         addCacheMetrics);
 
     // tenant name -> tenant (tenant states)
-    tenantStateTable = this.store.getTable(TENANT_STATE_TABLE,
-        String.class, OmDBTenantState.class);
+    tenantStateTable = getTable(TENANT_STATE_TABLE, String.class, OmDBTenantState.class, readOnlyTables);
     checkTableStatus(tenantStateTable, TENANT_STATE_TABLE, addCacheMetrics);
 
     // TODO: [SNAPSHOT] Consider FULL_CACHE for snapshotInfoTable since
     //  exclusiveSize in SnapshotInfo can be frequently updated.
     // path -> snapshotInfo (snapshot info for snapshot)
-    snapshotInfoTable = this.store.getTable(SNAPSHOT_INFO_TABLE,
-        String.class, SnapshotInfo.class);
+    snapshotInfoTable = getTable(SNAPSHOT_INFO_TABLE, String.class, SnapshotInfo.class, readOnlyTables);
     checkTableStatus(snapshotInfoTable, SNAPSHOT_INFO_TABLE, addCacheMetrics);
 
     // volumeName/bucketName/objectID -> renamedKey or renamedDir
-    snapshotRenamedTable = this.store.getTable(SNAPSHOT_RENAMED_TABLE,
-        String.class, String.class);
+    snapshotRenamedTable = getTable(SNAPSHOT_RENAMED_TABLE, String.class, String.class, readOnlyTables);
     checkTableStatus(snapshotRenamedTable, SNAPSHOT_RENAMED_TABLE,
         addCacheMetrics);
     // TODO: [SNAPSHOT] Initialize table lock for snapshotRenamedTable.
 
-    compactionLogTable = this.store.getTable(COMPACTION_LOG_TABLE,
-        String.class, CompactionLogEntry.class);
+    compactionLogTable = getTable(COMPACTION_LOG_TABLE, String.class, CompactionLogEntry.class, readOnlyTables);
     checkTableStatus(compactionLogTable, COMPACTION_LOG_TABLE,
         addCacheMetrics);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import java.util.UUID;
 
 import com.google.common.cache.RemovalListener;
+import com.google.common.collect.Sets;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.server.ServerUtils;
@@ -371,7 +372,8 @@ public final class OmSnapshotManager implements AutoCloseable {
         try {
           snapshotMetadataManager = new OmMetadataManagerImpl(conf,
               snapshotInfo.getCheckpointDirName(), isSnapshotInCache,
-              maxOpenSstFilesInSnapshotDb);
+              maxOpenSstFilesInSnapshotDb, Sets.newHashSet(OmMetadataManagerImpl.KEY_TABLE,
+              OmMetadataManagerImpl.FILE_TABLE));
         } catch (IOException e) {
           LOG.error("Failed to retrieve snapshot: {}", snapshotTableKey, e);
           throw e;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMDirectoriesPurgeResponseWithFSO;
@@ -58,24 +57,16 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, TermIndex termIndex) {
     OzoneManagerProtocolProtos.PurgeDirectoriesRequest purgeDirsRequest =
         getOmRequest().getPurgeDirectoriesRequest();
-    String fromSnapshot = purgeDirsRequest.hasSnapshotTableKey() ?
-        purgeDirsRequest.getSnapshotTableKey() : null;
 
     List<OzoneManagerProtocolProtos.PurgePathRequest> purgeRequests =
             purgeDirsRequest.getDeletedPathList();
 
-    SnapshotInfo fromSnapshotInfo = null;
     Set<Pair<String, String>> lockSet = new HashSet<>();
     Map<Pair<String, String>, OmBucketInfo> volBucketInfoMap = new HashMap<>();
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
 
     OMMetrics omMetrics = ozoneManager.getMetrics();
     try {
-      if (fromSnapshot != null) {
-        fromSnapshotInfo = ozoneManager.getMetadataManager()
-            .getSnapshotInfoTable()
-            .get(fromSnapshot);
-      }
 
       for (OzoneManagerProtocolProtos.PurgePathRequest path : purgeRequests) {
         for (OzoneManagerProtocolProtos.KeyInfo key :
@@ -152,7 +143,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
         getOmRequest());
     OMClientResponse omClientResponse = new OMDirectoriesPurgeResponseWithFSO(
         omResponse.build(), purgeRequests, ozoneManager.isRatisEnabled(),
-            getBucketLayout(), volBucketInfoMap, fromSnapshotInfo);
+            getBucketLayout(), volBucketInfoMap);
 
     return omClientResponse;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/RequestFeatureValidator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/validation/RequestFeatureValidator.java
@@ -94,6 +94,6 @@ public @interface RequestFeatureValidator {
    * The type of the request handled by this validator method.
    * @return the requestType to whihc the validator shoudl be applied
    */
-  Type requestType();
+  Type[] requestType();
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -292,14 +292,9 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     map.get(volumeBucketPair).add(objectKey);
   }
 
-  protected void submitPurgePaths(List<PurgePathRequest> requests,
-                                  String snapTableKey) {
+  protected void submitPurgePaths(List<PurgePathRequest> requests) {
     OzoneManagerProtocolProtos.PurgeDirectoriesRequest.Builder purgeDirRequest =
         OzoneManagerProtocolProtos.PurgeDirectoriesRequest.newBuilder();
-
-    if (snapTableKey != null) {
-      purgeDirRequest.setSnapshotTableKey(snapTableKey);
-    }
     purgeDirRequest.addAllDeletedPath(requests);
 
     OzoneManagerProtocolProtos.OMRequest omRequest =
@@ -412,8 +407,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
       long dirNum, long subDirNum, long subFileNum,
       List<Pair<String, OmKeyInfo>> allSubDirList,
       List<PurgePathRequest> purgePathRequestList,
-      String snapTableKey, long startTime,
-      int remainingBufLimit, KeyManager keyManager) {
+      long startTime, int remainingBufLimit, KeyManager keyManager) {
 
     // Optimization to handle delete sub-dir and keys to remove quickly
     // This case will be useful to handle when depth of directory is high
@@ -453,7 +447,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     }
 
     if (!purgePathRequestList.isEmpty()) {
-      submitPurgePaths(purgePathRequestList, snapTableKey);
+      submitPurgePaths(purgePathRequestList);
     }
 
     if (dirNum != 0 || subDirNum != 0 || subFileNum != 0) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/DirectoryDeletingService.java
@@ -202,7 +202,7 @@ public class DirectoryDeletingService extends AbstractKeyDeletingService {
 
           optimizeDirDeletesAndSubmitRequest(
               remainNum, dirNum, subDirNum, subFileNum,
-              allSubDirList, purgePathRequestList, null, startTime,
+              allSubDirList, purgePathRequestList, startTime,
               ratisByteLimit - consumedSize,
               getOzoneManager().getKeyManager());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -443,7 +443,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
 
         remainNum = optimizeDirDeletesAndSubmitRequest(remainNum, dirNum,
             subDirNum, subFileNum, allSubDirList, purgePathRequestList,
-            snapInfo.getTableKey(), startTime, ratisByteLimit - consumedSize,
+            startTime, ratisByteLimit - consumedSize,
             omSnapshot.getKeyManager());
       } catch (IOException e) {
         LOG.error("Error while running delete directories and files for " +

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -25,6 +25,7 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -104,7 +105,7 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
       LOG.error("Unable to initialize Recon OM DB snapshot store.", ioEx);
     }
     if (getStore() != null) {
-      initializeOmTables(TableCache.CacheType.FULL_CACHE, true);
+      initializeOmTables(TableCache.CacheType.FULL_CACHE, true, Collections.emptySet());
       omTablesInitialized = true;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Keys should not be purged from file table while processing deleted directories in snapshot & should be purged from AOS instead. 

We should also look into implementing read only table interfaces in RDB table to prevent future regression to block writes to key table and directory table.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11244

## How was this patch tested?
Unit tests & Integration tests