### PR TITLE
HDDS-11249. Bump ozone-runner to 20240729-jdk17-1

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20240712-jdk17-2</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20240729-jdk17-1</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>apache/ozone-testkrb5:20230318-1</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
   </properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `ozone-runner` to latest `20240729-jdk17-1`, which reduces image size.

https://issues.apache.org/jira/browse/HDDS-11249

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/10146353761