### PR TITLE
HDDS-11076. Revert HDDS-11076 and HDDS-11078

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StringUtils.java
@@ -20,9 +20,19 @@ package org.apache.hadoop.hdds;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.SignalLogger;
+import org.apache.hadoop.hdds.utils.VersionInfo;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.util.ShutdownHookManager;
 import org.apache.ratis.thirdparty.io.netty.buffer.Unpooled;
+import org.slf4j.Logger;
 
 /**
  * Simple utility class to collection string conversion methods.
@@ -33,6 +43,11 @@ public final class StringUtils {
   }
 
   private static final Charset UTF8 = StandardCharsets.UTF_8;
+
+  /**
+   * Priority of the StringUtils shutdown hook.
+   */
+  private static final int SHUTDOWN_HOOK_PRIORITY = 0;
 
   /**
    * Decode a specific range of bytes of the given byte array to a string
@@ -90,6 +105,70 @@ public final class StringUtils {
    */
   public static byte[] string2Bytes(String str) {
     return str.getBytes(UTF8);
+  }
+
+  /**
+   * Return a message for logging.
+   * @param prefix prefix keyword for the message
+   * @param msg content of the message
+   * @return a message for logging
+   */
+  public static String toStartupShutdownString(String prefix, String... msg) {
+    StringBuilder b = new StringBuilder(prefix);
+    b.append("\n/************************************************************");
+    for (String s : msg) {
+      b.append("\n").append(prefix).append(s);
+    }
+    b.append("\n************************************************************/");
+    return b.toString();
+  }
+
+  public static void startupShutdownMessage(VersionInfo versionInfo,
+      Class<?> clazz, String[] args, Logger log, OzoneConfiguration conf) {
+    final String hostname = NetUtils.getHostname();
+    final String className = clazz.getSimpleName();
+
+    if (log.isInfoEnabled()) {
+      log.info(createStartupShutdownMessage(versionInfo, className, hostname,
+          args, HddsUtils.processForLogging(conf)));
+    }
+
+    if (SystemUtils.IS_OS_UNIX) {
+      try {
+        SignalLogger.INSTANCE.register(log);
+      } catch (Throwable t) {
+        log.warn("failed to register any UNIX signal loggers: ", t);
+      }
+    }
+    ShutdownHookManager.get().addShutdownHook(
+        () -> log.info(toStartupShutdownString("SHUTDOWN_MSG: ",
+            "Shutting down " + className + " at " + hostname)),
+        SHUTDOWN_HOOK_PRIORITY);
+
+  }
+
+  /**
+   * Generate the text for the startup/shutdown message of processes.
+   * @param className short name of the class
+   * @param hostname hostname
+   * @param args Command arguments
+   * @return a string to log.
+   */
+  public static String createStartupShutdownMessage(VersionInfo versionInfo,
+      String className, String hostname, String[] args,
+      Map<String, String> conf) {
+    return toStartupShutdownString("STARTUP_MSG: ",
+        "Starting " + className,
+        "  host = " + hostname,
+        "  args = " + (args != null ? Arrays.asList(args) : new ArrayList<>()),
+        "  version = " + versionInfo.getVersion(),
+        "  classpath = " + System.getProperty("java.class.path"),
+        "  build = " + versionInfo.getUrl() + "/"
+            + versionInfo.getRevision()
+            + " ; compiled by '" + versionInfo.getUser()
+            + "' on " + versionInfo.getDate(),
+        "  java = " + System.getProperty("java.version"),
+        "  conf = " + conf);
   }
 
   public static String appendIfNotPresent(String str, char c) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.DatanodeVersion;
 import org.apache.hadoop.hdds.HddsUtils;
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -171,7 +172,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
   public Void call() throws Exception {
     OzoneConfiguration configuration = createOzoneConfiguration();
     if (printBanner) {
-      HddsServerUtil.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
+      StringUtils.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
           HddsDatanodeService.class, args, LOG, configuration);
     }
     start(configuration);

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -145,10 +145,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.jnr</groupId>
-      <artifactId>jnr-posix</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs-client</artifactId>
       <exclusions>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -25,10 +25,8 @@ import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
@@ -41,10 +39,8 @@ import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
-import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
@@ -103,7 +99,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 import static org.apache.hadoop.hdds.server.ServerUtils.sanitizeUserArgs;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_CONTAINER_DB_DIR;
 
-import org.apache.hadoop.util.ShutdownHookManager;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,8 +110,6 @@ public final class HddsServerUtil {
 
   private HddsServerUtil() {
   }
-
-  private static final int SHUTDOWN_HOOK_PRIORITY = 0;
 
   public static final String OZONE_RATIS_SNAPSHOT_COMPLETE_FLAG_NAME =
       "OZONE_RATIS_SNAPSHOT_COMPLETE";
@@ -685,68 +678,4 @@ public final class HddsServerUtil {
   public static void addSuppressedLoggingExceptions(RPC.Server server) {
     server.addSuppressedLoggingExceptions(ServerNotLeaderException.class);
   }
-
-  public static void startupShutdownMessage(VersionInfo versionInfo,
-      Class<?> clazz, String[] args, Logger log, OzoneConfiguration conf) {
-    final String hostname = NetUtils.getHostname();
-    final String className = clazz.getSimpleName();
-
-    if (log.isInfoEnabled()) {
-      log.info(createStartupShutdownMessage(versionInfo, className, hostname,
-          args, HddsUtils.processForLogging(conf)));
-    }
-
-    if (SystemUtils.IS_OS_UNIX) {
-      try {
-        SignalLogger.INSTANCE.register(log);
-      } catch (Throwable t) {
-        log.warn("failed to register any UNIX signal loggers: ", t);
-      }
-    }
-    ShutdownHookManager.get().addShutdownHook(
-        () -> log.info(toStartupShutdownString("SHUTDOWN_MSG: ",
-            "Shutting down " + className + " at " + hostname)),
-        SHUTDOWN_HOOK_PRIORITY);
-  }
-
-  /**
-   * Return a message for logging.
-   * @param prefix prefix keyword for the message
-   * @param msg content of the message
-   * @return a message for logging
-   */
-  public static String toStartupShutdownString(String prefix, String... msg) {
-    StringBuilder b = new StringBuilder(prefix);
-    b.append("\n/************************************************************");
-    for (String s : msg) {
-      b.append("\n").append(prefix).append(s);
-    }
-    b.append("\n************************************************************/");
-    return b.toString();
-  }
-
-  /**
-   * Generate the text for the startup/shutdown message of processes.
-   * @param className short name of the class
-   * @param hostname hostname
-   * @param args Command arguments
-   * @return a string to log.
-   */
-  public static String createStartupShutdownMessage(VersionInfo versionInfo,
-      String className, String hostname, String[] args,
-      Map<String, String> conf) {
-    return toStartupShutdownString("STARTUP_MSG: ",
-        "Starting " + className,
-        "  host = " + hostname,
-        "  args = " + (args != null ? Arrays.asList(args) : new ArrayList<>()),
-        "  version = " + versionInfo.getVersion(),
-        "  classpath = " + System.getProperty("java.class.path"),
-        "  build = " + versionInfo.getUrl() + "/"
-            + versionInfo.getRevision()
-            + " ; compiled by '" + versionInfo.getUser()
-            + "' on " + versionInfo.getDate(),
-        "  java = " + System.getProperty("java.version"),
-        "  conf = " + conf);
-  }
-
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -21,11 +21,11 @@
  */
 package org.apache.hadoop.hdds.scm.server;
 
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
-import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.utils.HddsVersionInfo;
 import org.apache.hadoop.ozone.common.StorageInfo;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
@@ -155,7 +155,7 @@ public class StorageContainerManagerStarter extends GenericCli {
 
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
-    HddsServerUtil.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
+    StringUtils.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
         StorageContainerManager.class, originalArgs, LOG, conf);
   }
 

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -67,10 +67,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.ozone</groupId>
-      <artifactId>hdds-server-framework</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>

--- a/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
+++ b/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
@@ -19,13 +19,13 @@ package org.apache.hadoop.ozone.csi;
 
 import java.util.concurrent.Callable;
 
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.util.OzoneVersionInfo;
@@ -55,7 +55,7 @@ public class CsiServer extends GenericCli implements Callable<Void> {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
             .toArray(new String[0]);
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
-    HddsServerUtil.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
+    StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
             CsiServer.class, originalArgs, LOG, ozoneConfiguration);
     CsiConfig csiConfig = ozoneConfiguration.getObject(CsiConfig.class);
 

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -218,7 +218,6 @@ EDL 1.0
 EPL 2.0
 =====================
 
-   com.github.jnr:jnr-posix
    jakarta.annotation:jakarta.annotation-api
    jakarta.ws.rs:jakarta.ws.rs-api
    org.aspectj:aspectjrt
@@ -278,10 +277,6 @@ Apache License 2.0
    com.fasterxml.jackson.datatype:jackson-datatype-jsr310
    com.fasterxml.jackson.module:jackson-module-jaxb-annotations
    com.fasterxml.woodstox:woodstox-core
-   com.github.jnr:jnr-a64asm
-   com.github.jnr:jnr-constants
-   com.github.jnr:jnr-ffi
-   com.github.jnr:jffi
    com.github.stephenc.jcip:jcip-annotations
    com.google.android:annotations
    com.google.api.grpc:proto-google-common-protos
@@ -448,7 +443,6 @@ MIT
 =====================
 
    com.bettercloud:vault-java-driver
-   com.github.jnr:jnr-x86asm
    com.kstruct:gethostname4j
    org.bouncycastle:bcpkix-jdk18on
    org.bouncycastle:bcprov-jdk18on
@@ -475,11 +469,6 @@ BSD 3-Clause
    com.google.re2j:re2j
    com.jcraft:jsch
    com.thoughtworks.paranamer:paranamer
-   org.ow2.asm:asm
-   org.ow2.asm:asm-analysis
-   org.ow2.asm:asm-commons
-   org.ow2.asm:asm-tree
-   org.ow2.asm:asm-util
 
 
 BSD 2-Clause

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -3,11 +3,6 @@ share/ozone/lib/annotations.jar
 share/ozone/lib/annotations.jar
 share/ozone/lib/aopalliance.jar
 share/ozone/lib/aopalliance-repackaged.jar
-share/ozone/lib/asm-analysis.jar
-share/ozone/lib/asm-commons.jar
-share/ozone/lib/asm.jar
-share/ozone/lib/asm-tree.jar
-share/ozone/lib/asm-util.jar
 share/ozone/lib/aspectjrt.jar
 share/ozone/lib/aspectjweaver.jar
 share/ozone/lib/aws-java-sdk-core.jar
@@ -144,8 +139,6 @@ share/ozone/lib/jetty-util-ajax.jar
 share/ozone/lib/jetty-util.jar
 share/ozone/lib/jetty-webapp.jar
 share/ozone/lib/jetty-xml.jar
-share/ozone/lib/jffi.jar
-share/ozone/lib/jffi-native.jar
 share/ozone/lib/jgrapht-core.jar
 share/ozone/lib/jgrapht-ext.jar
 share/ozone/lib/jgraphx.jar
@@ -153,11 +146,6 @@ share/ozone/lib/jheaps.jar
 share/ozone/lib/jmespath-java.jar
 share/ozone/lib/jna.jar
 share/ozone/lib/jna-platform.jar
-share/ozone/lib/jnr-a64asm.jar
-share/ozone/lib/jnr-constants.jar
-share/ozone/lib/jnr-ffi.jar
-share/ozone/lib/jnr-posix.jar
-share/ozone/lib/jnr-x86asm.jar
 share/ozone/lib/joda-time.jar
 share/ozone/lib/jooq-codegen.jar
 share/ozone/lib/jooq.jar

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -17,11 +17,11 @@
 
 package org.apache.hadoop.ozone.om;
 
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
-import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
 import org.apache.hadoop.ozone.util.OzoneVersionInfo;
 import org.apache.hadoop.ozone.util.ShutdownHookManager;
@@ -172,7 +172,7 @@ public class OzoneManagerStarter extends GenericCli {
 
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
-    HddsServerUtil.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
+    StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
         OzoneManager.class, originalArgs, LOG, conf);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.hadoop.hdds.HddsUtils;
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
@@ -101,7 +102,7 @@ public class ReconServer extends GenericCli {
         .toArray(new String[0]);
 
     configuration = createOzoneConfiguration();
-    HddsServerUtil.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
+    StringUtils.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
             ReconServer.class, originalArgs, LOG, configuration);
     ConfigurationProvider.setConfiguration(configuration);
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 
+import static org.apache.hadoop.hdds.StringUtils.startupShutdownMessage;
 import static org.apache.hadoop.hdds.ratis.RatisHelper.newJvmPauseMonitor;
 import static org.apache.hadoop.hdds.server.http.HttpServer2.setHttpBaseDir;
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
@@ -94,7 +95,7 @@ public class Gateway extends GenericCli {
   public void start() throws IOException {
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);
-    HddsServerUtil.startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
+    startupShutdownMessage(OzoneVersionInfo.OZONE_VERSION_INFO,
         Gateway.class, originalArgs, LOG, ozoneConfiguration);
 
     LOG.info("Starting Ozone S3 gateway");

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <weld-servlet.version>3.1.9.Final</weld-servlet.version>
 
     <!-- define the Java language version used by the compiler -->
-    <javac.version>8</javac.version>
+    <javac.version>1.8</javac.version>
 
     <!-- The java version enforced by the maven enforcer -->
     <!-- more complex patterns can be used here, such as
@@ -1296,6 +1296,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
+            <source>${javac.version}</source>
+            <target>${javac.version}</target>
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
         </plugin>
@@ -1961,28 +1963,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         </plugins>
       </build>
     </profile>
-
-    <!-- Profiles for specific JDK versions -->
-    <profile>
-      <id>java8</id>
-      <activation>
-        <jdk>[,8]</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.source>${javac.version}</maven.compiler.source>
-        <maven.compiler.target>${javac.version}</maven.compiler.target>
-      </properties>
-    </profile>
-    <profile>
-      <id>java9-or-later</id>
-      <activation>
-        <jdk>[9,]</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.release>${javac.version}</maven.compiler.release> <!-- supported since Java 9 -->
-      </properties>
-    </profile>
-
     <profile>
       <id>go-offline</id>
       <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <activation-api.version>1.2.2</activation-api.version>
     <jaxb-api.version>2.3.3</jaxb-api.version>
     <jaxb-runtime.version>2.3.9</jaxb-runtime.version>
-    <jnr-posix.version>3.1.19</jnr-posix.version>
     <jsch.version>0.1.55</jsch.version>
     <cdi-api.version>2.0</cdi-api.version>
     <servlet-api.version>3.1.0</servlet-api.version>
@@ -479,11 +478,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
         <version>${commons-validator.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.jnr</groupId>
-        <artifactId>jnr-posix</artifactId>
-        <version>${jnr-posix.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.luben</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Revert HDDS-11076 and HDDS-11078.

HDDS-11078 causes loss of signal handling functionality.  In addition to Ozone-side fix, it also requires a fix in (and new release of) `jnr-posix`, thus we must revert the change for now.

HDDS-11076 requires HDDS-11078 (does not compile on Java 9+ with usage of `sun.misc.Signal`), so we must revert these two together.

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/10148894587