### PR TITLE
HDDS-11252. Statistics of some storage space indicators

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1155,29 +1155,37 @@ public class SCMNodeManager implements NodeManager {
       }
     }
 
-    double ua = capacityByte;
+    return convertUnit(capacityByte);
+  }
+
+  /**
+   * Convert byte value to other units, such as KB, MB, GB, TB.
+   * @param value Original value, in byte.
+   * @return
+   */
+  private static String convertUnit(double value) {
     StringBuilder unit = new StringBuilder("B");
-    if (ua > 1024) {
-      ua = ua / 1024;
+    if (value > 1024) {
+      value = value / 1024;
       unit.replace(0, 1, "KB");
     }
-    if (ua > 1024) {
-      ua = ua / 1024;
+    if (value > 1024) {
+      value = value / 1024;
       unit.replace(0, 2, "MB");
     }
-    if (ua > 1024) {
-      ua = ua / 1024;
+    if (value > 1024) {
+      value = value / 1024;
       unit.replace(0, 2, "GB");
     }
-    if (ua > 1024) {
-      ua = ua / 1024;
+    if (value > 1024) {
+      value = value / 1024;
       unit.replace(0, 2, "TB");
     }
 
     DecimalFormat decimalFormat = new DecimalFormat("#0.0");
     decimalFormat.setRoundingMode(RoundingMode.HALF_UP);
-    String capacity = decimalFormat.format(ua);
-    return capacity + unit.toString();
+    String newValue = decimalFormat.format(value);
+    return newValue + unit.toString();
   }
 
   /**
@@ -1225,6 +1233,8 @@ public class SCMNodeManager implements NodeManager {
     nodeUsageStatistics(nodeStatistics);
     // Statistics node states
     nodeStateStatistics(nodeStatistics);
+    // Statistics node space
+    nodeSpaceStatistics(nodeStatistics);
     // todo: Statistics of other instances
     return nodeStatistics;
   }
@@ -1278,6 +1288,38 @@ public class SCMNodeManager implements NodeManager {
     nodeStatics.put(StateStatistics.DECOMMISSIONING.getLabel(), String.valueOf(decommissioningNodeCount));
     nodeStatics.put(StateStatistics.ENTERING_MAINTENANCE.getLabel(), String.valueOf(enteringMaintenanceNodeCount));
     nodeStatics.put(StateStatistics.VOLUME_FAILURES.getLabel(), String.valueOf(volumeFailuresNodeCount));
+  }
+
+  private void nodeSpaceStatistics(Map<String, String> nodeStatics) {
+    if (nodeStateManager.getAllNodes().size() < 1) {
+      return;
+    }
+    long capacityByte = 0;
+    long scmUsedByte = 0;
+    long remainingByte = 0;
+    for (DatanodeInfo dni : nodeStateManager.getAllNodes()) {
+      List<StorageReportProto> storageReports = dni.getStorageReports();
+      if (storageReports != null && !storageReports.isEmpty()) {
+        for (StorageReportProto storageReport : storageReports) {
+          capacityByte += storageReport.getCapacity();
+          scmUsedByte += storageReport.getScmUsed();
+          remainingByte += storageReport.getRemaining();
+        }
+      }
+    }
+
+    long nonScmUsedByte = capacityByte - scmUsedByte - remainingByte;
+    if (nonScmUsedByte < 0) {
+      nonScmUsedByte = 0;
+    }
+    String capacity = convertUnit(capacityByte);
+    String scmUsed = convertUnit(scmUsedByte);
+    String remaining = convertUnit(remainingByte);
+    String nonScmUsed = convertUnit(nonScmUsedByte);
+    nodeStatics.put(SpaceStatistics.CAPACITY.getLabel(), capacity);
+    nodeStatics.put(SpaceStatistics.SCM_USED.getLabel(), scmUsed);
+    nodeStatics.put(SpaceStatistics.REMAINING.getLabel(), remaining);
+    nodeStatics.put(SpaceStatistics.NON_SCM_USED.getLabel(), nonScmUsed);
   }
 
   /**
@@ -1372,6 +1414,20 @@ public class SCMNodeManager implements NodeManager {
       return label;
     }
     StateStatistics(String label) {
+      this.label = label;
+    }
+  }
+
+  private enum SpaceStatistics {
+    CAPACITY("Capacity"),
+    SCM_USED("Scmused"),
+    NON_SCM_USED("NonScmused"),
+    REMAINING("Remaining");
+    private String label;
+    public String getLabel() {
+      return label;
+    }
+    SpaceStatistics(String label) {
       this.label = label;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -84,6 +84,32 @@
     </tbody>
 </table>
 
+<h2>Space Statistics</h2>
+<table class="table table-bordered table-striped">
+    <tbody>
+    <tr>
+        <th>Datanode Space</th>
+        <th>Size</th>
+    </tr>
+    <tr>
+        <td>Capacity</td>
+        <td>{{statistics.nodes.space.capacity}}</td>
+    </tr>
+    <tr>
+        <td>ScmUsed</td>
+        <td>{{statistics.nodes.space.scmused}}</td>
+    </tr>
+    <tr>
+        <td>Remaining</td>
+        <td>{{statistics.nodes.space.remaining}}</td>
+    </tr>
+    <tr>
+        <td>Non ScmUsed</td>
+        <td>{{statistics.nodes.space.nonscmused}}</td>
+    </tr>
+    </tbody>
+</table>
+
 <h2>Node Status</h2>
 <div class="row">
     <div class="col-md-6 text-left">

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -46,6 +46,12 @@
                         decommissioning : "N/A",
                         enteringmaintenance : "N/A",
                         volumefailures : "N/A"
+                    },
+                    space : {
+                        capacity : "N/A",
+                        scmused : "N/A",
+                        remaining : "N/A",
+                        nonscmused : "N/A"
                     }
                 }
             }
@@ -118,6 +124,14 @@
                             $scope.statistics.nodes.state.enteringmaintenance = value;
                         } else if(key == "VolumeFailures") {
                             $scope.statistics.nodes.state.volumefailures = value;
+                        } else if(key == "Capacity") {
+                            $scope.statistics.nodes.space.capacity = value;
+                        } else if(key == "Scmused") {
+                            $scope.statistics.nodes.space.scmused = value;
+                        } else if(key == "Remaining") {
+                            $scope.statistics.nodes.space.remaining = value;
+                        } else if(key == "NonScmused") {
+                            $scope.statistics.nodes.space.nonscmused = value;
                         }
                     });
                 });


### PR DESCRIPTION
## What changes were proposed in this pull request?
In SCM, there are no statistics related to storage space, such as Capacity, Scmused, remaining, NonScmused. These indicators are very useful, and the purpose of this PR is to improve them.
Below is the effect after adding this patch.
jmx:
![image](https://github.com/user-attachments/assets/25b6f2b5-abc8-40c2-971d-ba4a87a228ed)

ui:
![image](https://github.com/user-attachments/assets/00a55b1c-64bd-4a7a-bafd-5ce366662557)



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11252

## How was this patch tested?
You need to ensure that JMX is displayed correctly.
You need to ensure that the UI is displayed correctly.