### PR TITLE
HDDS-11255. Add replication offpeak parameter for scm

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -1743,15 +1743,15 @@ public class TestReplicationManager {
             * config.getDatanodeReplicationLimit() * 0.75),
         rm.getReplicationInFlightLimit());
 
-    String hour =LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH"));
+    String hour = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH"));
     config.setInflightOffPeakHour(hour);
     config.setInflightOffPeakRatio(2);
     configuration.setFromObject(config);
     rm = createReplicationManager();
     assertEquals(
-            (int) Math.ceil(healthyNodes
-                    * config.getDatanodeReplicationLimit() * 0.75 * 2),
-            rm.getReplicationInFlightLimit());
+        (int) Math.ceil(healthyNodes *
+            config.getDatanodeReplicationLimit() * 0.75 * 2),
+        rm.getReplicationInFlightLimit());
   }
 
   @SafeVarargs

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -65,7 +65,9 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1740,6 +1742,16 @@ public class TestReplicationManager {
         (int) Math.ceil(healthyNodes
             * config.getDatanodeReplicationLimit() * 0.75),
         rm.getReplicationInFlightLimit());
+
+    String hour =LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH"));
+    config.setInflightOffPeakHour(hour);
+    config.setInflightOffPeakRatio(2);
+    configuration.setFromObject(config);
+    rm = createReplicationManager();
+    assertEquals(
+            (int) Math.ceil(healthyNodes
+                    * config.getDatanodeReplicationLimit() * 0.75 * 2),
+            rm.getReplicationInFlightLimit());
   }
 
   @SafeVarargs


### PR DESCRIPTION
## What changes were proposed in this pull request?

Although the current SCM-issued replication commands can be controlled via parameters, many clusters experience distinct business peak and off-peak periods. Therefore, adding a parameter to indicate non-peak business periods and using a ratio to represent the InFlightLimit proportion between off-peak and peak periods would help. 
This approach can prevent replication from causing increased DN iowait during peak periods, while fully utilizing DN resources during off-peak periods to accelerate replication.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11255


## How was this patch tested?
unit tests
