### PR TITLE
HDDS-11224. Increase hdds.datanode.handler.count

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -366,7 +366,7 @@ public final class HddsConfigKeys {
   public static final int HDDS_DATANODE_CLIENT_PORT_DEFAULT = 19864;
   public static final String HDDS_DATANODE_HANDLER_COUNT_KEY =
       "hdds.datanode.handler.count";
-  public static final int HDDS_DATANODE_HANDLER_COUNT_DEFAULT = 1;
+  public static final int HDDS_DATANODE_HANDLER_COUNT_DEFAULT = 10;
   public static final String HDDS_DATANODE_HTTP_BIND_HOST_DEFAULT = "0.0.0.0";
   public static final int HDDS_DATANODE_HTTP_BIND_PORT_DEFAULT = 9882;
   public static final int HDDS_DATANODE_HTTPS_BIND_PORT_DEFAULT = 9883;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2930,7 +2930,7 @@
   </property>
   <property>
     <name>hdds.datanode.handler.count</name>
-    <value>1</value>
+    <value>10</value>
     <tag>OZONE, HDDS, MANAGEMENT</tag>
     <description>
       The number of RPC handler threads for Datanode client


### PR DESCRIPTION
## What changes were proposed in this pull request?
[HDDS-11224](https://issues.apache.org/jira/browse/HDDS-11224). Increase hdds.datanode.handler.count

hdds.datanode.handler.count is default to 1. This property defines the number of DataNode RPC handlers. Increasing to 10 improves DN Echo throughput


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11224

## How was this patch tested?

Just change a configuration property value. No new tests.
The change was applied to a cluster and then benchmarked the throughput change using
`ozone freon dne --clients=32 -t 32 -n 1000000 --sleep-time-ms=0 --ratis --payload-req=0 --container-id=1 `