### PR TITLE
HDDS-11259. [hsync] DataNode should verify HBASE_SUPPORT layout version for every PutBlock.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -145,10 +145,6 @@ public final class ScmConfigKeys {
   public static final String OZONE_CHUNK_READ_MAPPED_BUFFER_THRESHOLD_DEFAULT =
       "32KB";
 
-  public static final String OZONE_CHUNK_LIST_INCREMENTAL =
-      "ozone.incremental.chunk.list";
-  public static final boolean OZONE_CHUNK_LIST_INCREMENTAL_DEFAULT = true;
-
   public static final String OZONE_SCM_CONTAINER_LAYOUT_KEY =
       "ozone.scm.container.layout";
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -852,17 +852,6 @@
     </description>
   </property>
   <property>
-    <name>ozone.incremental.chunk.list</name>
-    <value>true</value>
-    <tag>OZONE, CLIENT, DATANODE, PERFORMANCE</tag>
-    <description>
-      By default, a writer client sends full chunk list of a block when it
-      sends PutBlock requests. Changing this configuration to true will send
-      only incremental chunk list which reduces metadata overhead and improves
-      hsync performance.
-    </description>
-  </property>
-  <property>
     <name>ozone.scm.container.layout</name>
     <value>FILE_PER_BLOCK</value>
     <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -173,6 +173,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     case CONTAINER_UNHEALTHY:
     case CLOSED_CONTAINER_IO:
     case DELETE_ON_OPEN_CONTAINER:
+    case UNSUPPORTED_REQUEST: // Blame client for sending unsupported request.
       return true;
     default:
       return false;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -223,10 +223,6 @@ public class BlockManagerImpl implements BlockManager {
         "be null for finalizeBlock operation.");
     Preconditions.checkState(blockId.getContainerID() >= 0,
         "Container Id cannot be negative");
-    if (!VersionedDatanodeFeatures.isFinalized(HDDSLayoutFeature.HBASE_SUPPORT)) {
-      throw new StorageContainerException("DataNode has not finalized " +
-          "upgrading to a version that supports block finalization.", UNSUPPORTED_REQUEST);
-    }
 
     KeyValueContainer kvContainer = (KeyValueContainer)container;
     long localID = blockId.getLocalID();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import com.google.common.base.Preconditions;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.BCSID_MISMATCH;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,8 +154,8 @@ public class BlockManagerImpl implements BlockManager {
         boolean incrementalEnabled = true;
         if (!VersionedDatanodeFeatures.isFinalized(HDDSLayoutFeature.HBASE_SUPPORT)) {
           if (isPartialChunkList(data)) {
-            throw new UnsupportedOperationException("DataNode has not finalized " +
-                "upgrading to a version that supports incremental chunk list.");
+            throw new StorageContainerException("DataNode has not finalized " +
+                "upgrading to a version that supports incremental chunk list.", UNSUPPORTED_REQUEST);
           }
           incrementalEnabled = false;
         }
@@ -223,8 +224,8 @@ public class BlockManagerImpl implements BlockManager {
     Preconditions.checkState(blockId.getContainerID() >= 0,
         "Container Id cannot be negative");
     if (!VersionedDatanodeFeatures.isFinalized(HDDSLayoutFeature.HBASE_SUPPORT)) {
-      throw new UnsupportedOperationException("DataNode has not finalized " +
-          "upgrading to a version that supports block finalization.");
+      throw new StorageContainerException("DataNode has not finalized " +
+          "upgrading to a version that supports block finalization.", UNSUPPORTED_REQUEST);
     }
 
     KeyValueContainer kvContainer = (KeyValueContainer)container;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil.isSameSchemaVersion;
@@ -84,7 +83,6 @@ public class TestBlockManagerImpl {
     this.schemaVersion = versionInfo.getSchemaVersion();
     this.config = new OzoneConfiguration();
     ContainerTestVersionInfo.setTestSchemaVersion(schemaVersion, config);
-    config.setBoolean(OZONE_CHUNK_LIST_INCREMENTAL, true);
     initilaze();
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 
@@ -74,8 +73,6 @@ public class TestBlockOutputStreamIncrementalPutBlock {
 
     ((InMemoryConfiguration) config).setBoolean(
         OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
-    ((InMemoryConfiguration) config).setBoolean(
-        OZONE_CHUNK_LIST_INCREMENTAL, incrementalChunkList);
 
     RpcClient rpcClient = new RpcClient(config, null) {
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -110,7 +110,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_CHUNK_LIST_INCREMENTAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
@@ -176,7 +175,6 @@ public class TestHSync {
     CONF.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
     CONF.setBoolean("ozone.client.incremental.chunk.list", true);
     CONF.setBoolean("ozone.client.stream.putblock.piggybacking", true);
-    CONF.setBoolean(OZONE_CHUNK_LIST_INCREMENTAL, true);
     CONF.setTimeDuration(OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_INTERVAL,
         SERVICE_INTERVAL, TimeUnit.MILLISECONDS);
     CONF.setTimeDuration(OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD,


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11259. [hsync] DataNode should verify HBASE_SUPPORT layout version for every PutBlock.

The layout version check for incremental chunk list support is performed at DataNode startup only, which means that DataNode would reject any such clients until the next restart after finalization.

The check should be moved later inside PutBlocks handling.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11259

## How was this patch tested?

