### PR TITLE
HDDS-11258. [hsync] Add new OM layout version.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -90,7 +90,10 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.service.OpenKeyCleanupService;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
+import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
@@ -119,6 +122,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
 import static org.apache.hadoop.ozone.TestDataUtil.cleanupDeletedTable;
 import static org.apache.hadoop.ozone.TestDataUtil.cleanupOpenKeyTable;
+import static org.apache.hadoop.ozone.admin.scm.FinalizeUpgradeCommandUtil.isDone;
+import static org.apache.hadoop.ozone.admin.scm.FinalizeUpgradeCommandUtil.isStarting;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
@@ -126,6 +131,9 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DIR_DELETING_SERVICE
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_LEASE_HARD_LIMIT;
+import static org.apache.hadoop.ozone.om.OmUpgradeConfig.ConfigStrings.OZONE_OM_INIT_DEFAULT_LAYOUT_VERSION;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION;
+import static org.apache.ozone.test.LambdaTestUtils.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -163,6 +171,9 @@ public class TestHSync {
 
   private static OpenKeyCleanupService openKeyCleanupService;
 
+  private static final int POLL_INTERVAL_MILLIS = 500;
+  private static final int POLL_MAX_WAIT_MILLIS = 120_000;
+
   @BeforeAll
   public static void init() throws Exception {
     final BucketLayout layout = BUCKET_LAYOUT;
@@ -184,6 +195,7 @@ public class TestHSync {
     CONF.setTimeDuration(OZONE_OM_LEASE_HARD_LIMIT,
         EXPIRE_THRESHOLD_MS, TimeUnit.MILLISECONDS);
     CONF.set(OzoneConfigKeys.OZONE_OM_LEASE_SOFT_LIMIT, "0s");
+    CONF.setInt(OZONE_OM_INIT_DEFAULT_LAYOUT_VERSION, OMLayoutFeature.QUOTA.layoutVersion());
 
     ClientConfigForTesting.newBuilder(StorageUnit.BYTES)
         .setBlockSize(BLOCK_SIZE)
@@ -216,6 +228,9 @@ public class TestHSync {
     openKeyCleanupService =
         (OpenKeyCleanupService) cluster.getOzoneManager().getKeyManager().getOpenKeyCleanupService();
     openKeyCleanupService.suspend();
+
+    preFinalizationChecks();
+    finalizeOMUpgrade();
   }
 
   @AfterAll
@@ -224,6 +239,72 @@ public class TestHSync {
     if (cluster != null) {
       cluster.shutdown();
     }
+  }
+
+  private static void preFinalizationChecks() throws IOException {
+    final String rootPath = String.format("%s://%s/",
+        OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
+    CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName()
+        + OZONE_URI_DELIMITER + bucket.getName();
+
+    final Path file = new Path(dir, "pre-finalization");
+    try (RootedOzoneFileSystem fs = (RootedOzoneFileSystem)FileSystem.get(CONF)) {
+      try (FSDataOutputStream outputStream = fs.create(file, true)) {
+        OMException omException  = assertThrows(OMException.class, outputStream::hsync);
+        assertFinalizationExceptionForHsyncLeaseRecovery(omException);
+      }
+      final OzoneManagerProtocol omClient = client.getObjectStore()
+          .getClientProxy().getOzoneManagerClient();
+      OMException omException  = assertThrows(OMException.class,
+          () -> omClient.listOpenFiles("", 100, ""));
+      assertFinalizationException(omException);
+
+      omException = assertThrows(OMException.class,
+          () -> fs.recoverLease(file));
+      assertFinalizationException(omException);
+
+      fs.delete(file, false);
+    }
+  }
+
+  private static void assertFinalizationExceptionForHsyncLeaseRecovery(OMException omException) {
+    assertEquals(NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION,
+        omException.getResult());
+    assertThat(omException.getMessage())
+        .contains("Cluster does not have the HBase support feature finalized yet");
+  }
+
+  private static void assertFinalizationException(OMException omException) {
+    assertEquals(NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION,
+        omException.getResult());
+    assertThat(omException.getMessage())
+        .contains("cannot be invoked before finalization.");
+  }
+
+  /**
+   * Trigger OM upgrade finalization from the client and block until completion
+   * (status FINALIZATION_DONE).
+   */
+  private static void finalizeOMUpgrade() throws Exception {
+    // Trigger OM upgrade finalization. Ref: FinalizeUpgradeSubCommand#call
+    final OzoneManagerProtocol omClient = client.getObjectStore()
+        .getClientProxy().getOzoneManagerClient();
+    final String upgradeClientID = "Test-Upgrade-Client-" + UUID.randomUUID();
+    UpgradeFinalizer.StatusAndMessages finalizationResponse =
+        omClient.finalizeUpgrade(upgradeClientID);
+
+    // The status should transition as soon as the client call above returns
+    assertTrue(isStarting(finalizationResponse.status()));
+    // Wait for the finalization to be marked as done.
+    // 10s timeout should be plenty.
+    await(POLL_MAX_WAIT_MILLIS, POLL_INTERVAL_MILLIS, () -> {
+      final UpgradeFinalizer.StatusAndMessages progress =
+          omClient.queryUpgradeFinalizationProgress(
+              upgradeClientID, false, false);
+      return isDone(progress.status());
+    });
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMRecoverLeaseRequest.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.file.OMRecoverLeaseResponse;
+import org.apache.hadoop.ozone.om.upgrade.DisallowedUntilLayoutVersion;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverLeaseRequest;
@@ -46,6 +47,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretP
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.WRITE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_LEASE_SOFT_LIMIT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_LEASE_SOFT_LIMIT_DEFAULT;
+import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.HBASE_SUPPORT;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.RecoverLease;
 
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -101,6 +103,7 @@ public class OMRecoverLeaseRequest extends OMKeyRequest {
   }
 
   @Override
+  @DisallowedUntilLayoutVersion(HBASE_SUPPORT)
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     OMRequest request = super.preExecute(ozoneManager);
     RecoverLeaseRequest recoverLeaseRequest = request.getRecoverLeaseRequest();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -545,9 +545,32 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     return req;
   }
 
+  @RequestFeatureValidator(
+      conditions = ValidationCondition.CLUSTER_NEEDS_FINALIZATION,
+      processingPhase = RequestProcessingPhase.PRE_PROCESS,
+      requestType = Type.CommitKey
+  )
+  public static OMRequest disallowHsync(
+      OMRequest req, ValidationContext ctx) throws OMException {
+    if (!ctx.versionManager()
+        .isAllowed(OMLayoutFeature.HSYNC)) {
+      CommitKeyRequest commitKeyRequest = req.getCommitKeyRequest();
+      boolean isHSync = commitKeyRequest.hasHsync() &&
+          commitKeyRequest.getHsync();
+      if (isHSync) {
+        throw new OMException("Cluster does not have the hsync support "
+            + "feature finalized yet, but the request contains"
+            + " an hsync field. Rejecting the request,"
+            + " please finalize the cluster upgrade and then try again.",
+            OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
+      }
+    }
+    return req;
+  }
+
   /**
    * Validates key commit requests.
-   * We do not want to allow clients to perform hsync or lease recovery requests
+   * We do not want to allow clients to perform lease recovery requests
    * until the cluster has finalized the HBase support feature.
    *
    * @param req - the request to validate
@@ -560,19 +583,18 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       processingPhase = RequestProcessingPhase.PRE_PROCESS,
       requestType = Type.CommitKey
   )
-  public static OMRequest disallowHBase(
+
+  public static OMRequest disallowRecovery(
       OMRequest req, ValidationContext ctx) throws OMException {
     if (!ctx.versionManager()
         .isAllowed(OMLayoutFeature.HBASE_SUPPORT)) {
       CommitKeyRequest commitKeyRequest = req.getCommitKeyRequest();
-      boolean isHSync = commitKeyRequest.hasHsync() &&
-          commitKeyRequest.getHsync();
       boolean isRecovery = commitKeyRequest.hasRecovery() &&
           commitKeyRequest.getRecovery();
-      if (isHSync || isRecovery) {
+      if (isRecovery) {
         throw new OMException("Cluster does not have the HBase support "
             + "feature finalized yet, but the request contains"
-            + " an hsync or a recovery field. Rejecting the request,"
+            + " an recovery field. Rejecting the request,"
             + " please finalize the cluster upgrade and then try again.",
             OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
@@ -45,7 +45,7 @@ public enum OMLayoutFeature implements LayoutFeature {
   FILESYSTEM_SNAPSHOT(5, "Ozone version supporting snapshot"),
 
   QUOTA(6, "Ozone quota re-calculate"),
-  HBASE_SUPPORT(7, "Full support of hsync for HBase");
+  HBASE_SUPPORT(7, "Full support of hsync, lease recovery and listOpenFiles APIs for HBase");
 
   ///////////////////////////////  /////////////////////////////
   //    Example OM Layout Feature with Actions

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
@@ -44,7 +44,8 @@ public enum OMLayoutFeature implements LayoutFeature {
 
   FILESYSTEM_SNAPSHOT(5, "Ozone version supporting snapshot"),
 
-  QUOTA(6, "Ozone quota re-calculate");
+  QUOTA(6, "Ozone quota re-calculate"),
+  HBASE_SUPPORT(7, "Full support of hsync for HBase");
 
   ///////////////////////////////  /////////////////////////////
   //    Example OM Layout Feature with Actions

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -144,6 +144,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 
 import com.google.common.collect.Lists;
 
+import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.HBASE_SUPPORT;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.MULTITENANCY_SCHEMA;
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.FILESYSTEM_SNAPSHOT;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
@@ -914,6 +915,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     return resp;
   }
 
+  @DisallowedUntilLayoutVersion(HBASE_SUPPORT)
   private ListOpenFilesResponse listOpenFiles(ListOpenFilesRequest req,
                                               int clientVersion)
       throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11258. [hsync] Add new OM layout version.

Please describe your PR in detail:

Add a new OM layout version HBASE_SUPPORT in Ozone 1.5.0 to prevent any misuse of the APIs (hsync, recoverLease, listOpenFiles) until upgrade finalizes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11258

## How was this patch tested?

Unit tests covering OM upgrade code path.