### PR TITLE
HDDS-11214. Added config to set rocksDB's max log file size and num of log files

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -413,6 +413,10 @@ public final class DBStoreBuilder {
       dbOptions.setLogger(logger);
     }
 
+    // RocksDB log settings.
+    dbOptions.setMaxLogFileSize(rocksDBConfiguration.getMaxLogFileSize());
+    dbOptions.setKeepLogFileNum(rocksDBConfiguration.getKeepLogFileNum());
+
     // Apply WAL settings.
     dbOptions.setWalTtlSeconds(rocksDBConfiguration.getWalTTL());
     dbOptions.setWalSizeLimitMB(rocksDBConfiguration.getWalSizeLimit());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
@@ -46,6 +46,20 @@ public class RocksDBConfiguration {
       description = "OM RocksDB logging level (INFO/DEBUG/WARN/ERROR/FATAL)")
   private String rocksdbLogLevel;
 
+  @Config(key = "rocksdb.max.log.file.size",
+      type = ConfigType.SIZE,
+      defaultValue = "0MB",
+      tags = {OM, SCM, DATANODE},
+      description = "Maximum size of RocksDB application log file.")
+  private long rocksdbMaxLogFileSize = 0;
+
+  @Config(key = "rocksdb.keep.log.file.num",
+      type = ConfigType.INT,
+      defaultValue = "1000",
+      tags = {OM, SCM, DATANODE},
+      description = "Maximum number of RocksDB application log files.")
+  private int rocksdbKeepLogFileNum = 1000;
+
   @Config(key = "rocksdb.writeoption.sync",
       type = ConfigType.BOOLEAN,
       defaultValue = "false",
@@ -109,5 +123,21 @@ public class RocksDBConfiguration {
 
   public long getWalSizeLimit() {
     return walSizeLimit;
+  }
+
+  public void setMaxLogFileSize(long fileSize) {
+    rocksdbMaxLogFileSize = fileSize;
+  }
+
+  public long getMaxLogFileSize() {
+    return rocksdbMaxLogFileSize;
+  }
+
+  public void setKeepLogFileNum(int fileNum) {
+    rocksdbKeepLogFileNum = fileNum;
+  }
+
+  public int getKeepLogFileNum() {
+    return rocksdbKeepLogFileNum;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
By default, RocksDB keeps a single log file for application logs ([Logger](https://github.com/facebook/rocksdb/wiki/Logger) and [default values](https://github.com/facebook/rocksdb/blob/main/include/rocksdb/options.h#L864)). It can eat up a lot of disk space under heavy load as mentioned in the  HDDS-11214 if logs files are not rolled over and kept to a certain number.
This change provides an option to set the maximum log file size and number of log files for RocksDB.  It will enable the auto roll logging and keep the log size to the limited value.

## What is the link to the Apache JIRA
HDDS-11214

## How was this patch tested?
Existing tests.
