### PR TITLE
HDDS-11272. Statistics some node status information

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
@@ -227,6 +227,15 @@ public class DatanodeInfo extends DatanodeDetails {
     }
   }
 
+  public int getFailedVolumeCount() {
+    try {
+      lock.readLock().lock();
+      return failedVolumeCount;
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
   /**
    * Returns count of healthy metadata volumes reported from datanode.
    * @return count of healthy metdata log volumes

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
@@ -227,6 +227,10 @@ public class DatanodeInfo extends DatanodeDetails {
     }
   }
 
+  /**
+   * Returns count of failed volumes reported by the data node.
+   * @return count of failed volumes
+   */
   public int getFailedVolumeCount() {
     try {
       lock.readLock().lock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -19,7 +19,13 @@
 package org.apache.hadoop.hdds.scm.node;
 
 import java.io.Closeable;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -19,12 +19,7 @@
 package org.apache.hadoop.hdds.scm.node;
 
 import java.io.Closeable;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -477,6 +472,22 @@ public class NodeStateManager implements Runnable, Closeable {
     return getNodes(null, NodeState.DEAD);
   }
 
+  public List<DatanodeInfo> getDecommissioningNodes() {
+    return getNodes(NodeOperationalState.DECOMMISSIONING, null);
+  }
+
+  public int getDecommissioningNodeCount() {
+    return getDecommissioningNodes().size();
+  }
+
+  public List<DatanodeInfo> getEnteringMaintenanceNodes() {
+    return getNodes(NodeOperationalState.ENTERING_MAINTENANCE, null);
+  }
+
+  public int getEnteringMaintenanceNodeCount() {
+    return getEnteringMaintenanceNodes().size();
+  }
+
   /**
    * Returns all the nodes with the specified status.
    *
@@ -499,6 +510,26 @@ public class NodeStateManager implements Runnable, Closeable {
   public List<DatanodeInfo> getNodes(
       NodeOperationalState opState, NodeState health) {
     return nodeStateMap.getDatanodeInfos(opState, health);
+  }
+
+  public List<DatanodeInfo> getVolumeFailuresNodes() {
+    List<DatanodeInfo> allNodes = nodeStateMap.getAllDatanodeInfos();
+    if (allNodes.size() < 1) {
+      return allNodes;
+    }
+
+    List<DatanodeInfo> failedVolumeNodes = new ArrayList<>();
+    for (DatanodeInfo dn : allNodes) {
+      if (dn.getFailedVolumeCount() > 0) {
+        failedVolumeNodes.add(dn);
+      }
+    }
+
+    return failedVolumeNodes;
+  }
+
+  public int getVolumeFailuresNodeCount() {
+    return getVolumeFailuresNodes().size();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -22,7 +22,6 @@ import java.io.Closeable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -30,6 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -478,18 +478,34 @@ public class NodeStateManager implements Runnable, Closeable {
     return getNodes(null, NodeState.DEAD);
   }
 
+  /**
+   * Returns all nodes that are in the decommissioning state.
+   * @return list of decommissioning nodes
+   */
   public List<DatanodeInfo> getDecommissioningNodes() {
     return getNodes(NodeOperationalState.DECOMMISSIONING, null);
   }
 
+  /**
+   * Returns the count of decommissioning nodes.
+   * @return decommissioning node count
+   */
   public int getDecommissioningNodeCount() {
     return getDecommissioningNodes().size();
   }
 
+  /**
+   * Returns all nodes that are in the entering maintenance state.
+   * @return list of entering maintenance nodes
+   */
   public List<DatanodeInfo> getEnteringMaintenanceNodes() {
     return getNodes(NodeOperationalState.ENTERING_MAINTENANCE, null);
   }
 
+  /**
+   * Returns the count of entering maintenance nodes.
+   * @return entering maintenance node count
+   */
   public int getEnteringMaintenanceNodeCount() {
     return getEnteringMaintenanceNodes().size();
   }
@@ -518,22 +534,25 @@ public class NodeStateManager implements Runnable, Closeable {
     return nodeStateMap.getDatanodeInfos(opState, health);
   }
 
+  /**
+   * Returns all nodes that contain failed volumes.
+   * @return list of nodes containing failed volumes
+   */
   public List<DatanodeInfo> getVolumeFailuresNodes() {
     List<DatanodeInfo> allNodes = nodeStateMap.getAllDatanodeInfos();
     if (allNodes.size() < 1) {
       return allNodes;
     }
 
-    List<DatanodeInfo> failedVolumeNodes = new ArrayList<>();
-    for (DatanodeInfo dn : allNodes) {
-      if (dn.getFailedVolumeCount() > 0) {
-        failedVolumeNodes.add(dn);
-      }
-    }
-
+    List<DatanodeInfo> failedVolumeNodes = allNodes.stream().
+        filter(dn -> dn.getFailedVolumeCount() > 0).collect(Collectors.toList());
     return failedVolumeNodes;
   }
 
+  /**
+   * Returns the count of nodes containing the failed volume.
+   * @return failed volume node count
+   */
   public int getVolumeFailuresNodeCount() {
     return getVolumeFailuresNodes().size();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -540,10 +540,6 @@ public class NodeStateManager implements Runnable, Closeable {
    */
   public List<DatanodeInfo> getVolumeFailuresNodes() {
     List<DatanodeInfo> allNodes = nodeStateMap.getAllDatanodeInfos();
-    if (allNodes.size() < 1) {
-      return allNodes;
-    }
-
     List<DatanodeInfo> failedVolumeNodes = allNodes.stream().
         filter(dn -> dn.getFailedVolumeCount() > 0).collect(Collectors.toList());
     return failedVolumeNodes;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1273,11 +1273,11 @@ public class SCMNodeManager implements NodeManager {
     int decommissioningNodeCount = nodeStateManager.getDecommissioningNodeCount();
     int enteringMaintenanceNodeCount = nodeStateManager.getEnteringMaintenanceNodeCount();
     int volumeFailuresNodeCount = nodeStateManager.getVolumeFailuresNodeCount();
-    nodeStatics.put(StateStatics.HEALTHY.getLabel(), String.valueOf(healthyNodeCount));
-    nodeStatics.put(StateStatics.DEAD.getLabel(), String.valueOf(deadNodeCount));
-    nodeStatics.put(StateStatics.DECOMMISSIONING.getLabel(), String.valueOf(decommissioningNodeCount));
-    nodeStatics.put(StateStatics.ENTERING_MAINTENANCE.getLabel(), String.valueOf(enteringMaintenanceNodeCount));
-    nodeStatics.put(StateStatics.VOLUME_FAILURES.getLabel(), String.valueOf(volumeFailuresNodeCount));
+    nodeStatics.put(StateStatistics.HEALTHY.getLabel(), String.valueOf(healthyNodeCount));
+    nodeStatics.put(StateStatistics.DEAD.getLabel(), String.valueOf(deadNodeCount));
+    nodeStatics.put(StateStatistics.DECOMMISSIONING.getLabel(), String.valueOf(decommissioningNodeCount));
+    nodeStatics.put(StateStatistics.ENTERING_MAINTENANCE.getLabel(), String.valueOf(enteringMaintenanceNodeCount));
+    nodeStatics.put(StateStatistics.VOLUME_FAILURES.getLabel(), String.valueOf(volumeFailuresNodeCount));
   }
 
   /**
@@ -1361,7 +1361,7 @@ public class SCMNodeManager implements NodeManager {
     }
   }
 
-  private enum StateStatics {
+  private enum StateStatistics {
     HEALTHY("Healthy"),
     DEAD("Dead"),
     DECOMMISSIONING("Decommissioning"),
@@ -1371,7 +1371,7 @@ public class SCMNodeManager implements NodeManager {
     public String getLabel() {
       return label;
     }
-    StateStatics(String label) {
+    StateStatistics(String label) {
       this.label = label;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -1223,6 +1223,8 @@ public class SCMNodeManager implements NodeManager {
     Map<String, String> nodeStatistics = new HashMap<>();
     // Statistics node usaged
     nodeUsageStatistics(nodeStatistics);
+    // Statistics node states
+    nodeStateStatistics(nodeStatistics);
     // todo: Statistics of other instances
     return nodeStatistics;
   }
@@ -1263,6 +1265,19 @@ public class SCMNodeManager implements NodeManager {
     DecimalFormat decimalFormat = new DecimalFormat("#0.00");
     decimalFormat.setRoundingMode(RoundingMode.HALF_UP);
     nodeStatics.put(UsageStatics.STDEV.getLabel(), decimalFormat.format(dev));
+  }
+
+  private void nodeStateStatistics(Map<String, String> nodeStatics) {
+    int healthyNodeCount = nodeStateManager.getHealthyNodeCount();
+    int deadNodeCount = nodeStateManager.getDeadNodeCount();
+    int decommissioningNodeCount = nodeStateManager.getDecommissioningNodeCount();
+    int enteringMaintenanceNodeCount = nodeStateManager.getEnteringMaintenanceNodeCount();
+    int volumeFailuresNodeCount = nodeStateManager.getVolumeFailuresNodeCount();
+    nodeStatics.put(StateStatics.HEALTHY.getLabel(), String.valueOf(healthyNodeCount));
+    nodeStatics.put(StateStatics.DEAD.getLabel(), String.valueOf(deadNodeCount));
+    nodeStatics.put(StateStatics.DECOMMISSIONING.getLabel(), String.valueOf(decommissioningNodeCount));
+    nodeStatics.put(StateStatics.ENTERING_MAINTENANCE.getLabel(), String.valueOf(enteringMaintenanceNodeCount));
+    nodeStatics.put(StateStatics.VOLUME_FAILURES.getLabel(), String.valueOf(volumeFailuresNodeCount));
   }
 
   /**
@@ -1342,6 +1357,21 @@ public class SCMNodeManager implements NodeManager {
       return label;
     }
     UsageStatics(String label) {
+      this.label = label;
+    }
+  }
+
+  private enum StateStatics {
+    HEALTHY("Healthy"),
+    DEAD("Dead"),
+    DECOMMISSIONING("Decommissioning"),
+    ENTERING_MAINTENANCE("EnteringMaintenance"),
+    VOLUME_FAILURES("VolumeFailures");
+    private String label;
+    public String getLabel() {
+      return label;
+    }
+    StateStatics(String label) {
       this.label = label;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -28,7 +28,7 @@
     </tbody>
 </table>
 
-<h2>Statistics</h2>
+<h2>Usage Statistics</h2>
 <table class="table table-bordered table-striped">
     <tbody>
     <tr>
@@ -51,6 +51,12 @@
         <td>Standard Deviation</td>
         <td>{{statistics.nodes.usages.stdev}}</td>
     </tr>
+    </tbody>
+</table>
+
+<h2>State Statistics</h2>
+<table class="table table-bordered table-striped">
+    <tbody>
     <tr>
         <th>Datanode State</th>
         <th>Count</th>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -51,6 +51,30 @@
         <td>Standard Deviation</td>
         <td>{{statistics.nodes.usages.stdev}}</td>
     </tr>
+    <tr>
+        <th>Datanode State</th>
+        <th>Count</th>
+    </tr>
+    <tr>
+        <td>Healthy Nodes</td>
+        <td>{{statistics.nodes.state.healthy}}</td>
+    </tr>
+    <tr>
+        <td>Dead Nodes</td>
+        <td>{{statistics.nodes.state.dead}}</td>
+    </tr>
+    <tr>
+        <td>Decommissioning Nodes</td>
+        <td>{{statistics.nodes.state.decommissioning}}</td>
+    </tr>
+    <tr>
+        <td>Entering Maintenance Nodes</td>
+        <td>{{statistics.nodes.state.enteringmaintenance}}</td>
+    </tr>
+    <tr>
+        <td>Volume Failures Nodes</td>
+        <td>{{statistics.nodes.state.volumefailures}}</td>
+    </tr>
     </tbody>
 </table>
 

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -39,6 +39,13 @@
                         max : "N/A",
                         median : "N/A",
                         stdev : "N/A"
+                    },
+                    state : {
+                        healthy : "N/A",
+                        dead : "N/A",
+                        decommissioning : "N/A",
+                        enteringmaintenance : "N/A",
+                        volumefailures : "N/A"
                     }
                 }
             }
@@ -92,15 +99,25 @@
                     $scope.lastIndex = Math.ceil(nodeStatusCopy.length / $scope.RecordsToDisplay);
                     $scope.nodeStatus = nodeStatusCopy.slice(0, $scope.RecordsToDisplay);
 
-                    ctrl.nodemanagermetrics.NodeStatistics.forEach(function(obj) {
-                        if(obj.key == "Min") {
-                            $scope.statistics.nodes.usages.min = obj.value;
-                        } else if(obj.key == "Max") {
-                            $scope.statistics.nodes.usages.max = obj.value;
-                        } else if(obj.key == "Median") {
-                            $scope.statistics.nodes.usages.median = obj.value;
-                        } else if(obj.key == "Stdev") {
-                            $scope.statistics.nodes.usages.stdev = obj.value;
+                    ctrl.nodemanagermetrics.NodeStatistics.forEach(({key, value}) => {
+                        if(key == "Min") {
+                            $scope.statistics.nodes.usages.min = value;
+                        } else if(key == "Max") {
+                            $scope.statistics.nodes.usages.max = value;
+                        } else if(key == "Median") {
+                            $scope.statistics.nodes.usages.median = value;
+                        } else if(key == "Stdev") {
+                            $scope.statistics.nodes.usages.stdev = value;
+                        } else if(key == "Healthy") {
+                            $scope.statistics.nodes.state.healthy = value;
+                        } else if(key == "Dead") {
+                            $scope.statistics.nodes.state.dead = value;
+                        } else if(key == "Decommissioning") {
+                            $scope.statistics.nodes.state.decommissioning = value;
+                        } else if(key == "EnteringMaintenance") {
+                            $scope.statistics.nodes.state.enteringmaintenance = value;
+                        } else if(key == "VolumeFailures") {
+                            $scope.statistics.nodes.state.volumefailures = value;
                         }
                     });
                 });


### PR DESCRIPTION
## What changes were proposed in this pull request?
In Ozone, there is no statistical node status information, such as healthy nodes, dead nodes, decommissioning nodes, etc. The purpose of this PR is to improve these.
After adding this PR, jmx and UI will be updated.
New jmx:
![image](https://github.com/user-attachments/assets/3a5ba16c-3441-4694-a9d3-f2d195e874b8)


New ui:
![image](https://github.com/user-attachments/assets/8e9e5a80-809c-42f8-91fa-df3499cb2933)



## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11272

## How was this patch tested?
You need to ensure that JMX displays normally.
You need to ensure that the UI displays normally.
