### PR TITLE
HDDS-11267. Datanode Reporting Negative values for Container UsedBytes and BlockCount

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
@@ -438,6 +438,9 @@ public class BlockDeletingTask implements BackgroundTask {
 
     for (DeletedBlocksTransaction entry : delBlocks) {
       for (Long blkLong : entry.getLocalIDList()) {
+        // Increment blocksProcessed for every block processed
+        blocksProcessed++;
+
         // Check if the block has already been deleted
         if (deletedBlockSet.contains(blkLong)) {
           LOG.debug("Skipping duplicate deletion for block {}", blkLong);
@@ -454,8 +457,6 @@ public class BlockDeletingTask implements BackgroundTask {
             LOG.error("Failed to delete files for unreferenced block {} of" +
                     " container {}", blkLong,
                 container.getContainerData().getContainerID(), e);
-          } finally {
-            blocksProcessed++;
           }
           continue;
         }
@@ -473,8 +474,6 @@ public class BlockDeletingTask implements BackgroundTask {
           //  otherwise invalid numPendingDeletionBlocks could accumulate
           //  beyond the limit and the following deletion will stop.
           LOG.error("Failed to delete files for block {}", blkLong, e);
-        } finally {
-          blocksProcessed++;
         }
 
         if (deleted) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this pull request, a fix was implemented to address an issue where datanodes reported negative container sizes due to duplicate block deletion requests. The root cause was identified as multiple deletion requests being sent for the same blocks, leading to incorrect updates in container metrics. The solution involved improving the block deletion logic by tracking already-deleted blocks and ignoring duplicate deletion attempts. This ensures that the container's used bytes and block count metrics remain accurate, preventing negative values. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11267
## How was this patch tested?
Manually Tested