### PR TITLE
HDDS-11280. Add Synchronize in AbstractCommitWatcher.addAckDataLength

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
@@ -83,7 +83,7 @@ abstract class AbstractCommitWatcher<BUFFER> {
     return totalAckDataLength;
   }
 
-  long addAckDataLength(long acked) {
+  synchronized long addAckDataLength(long acked) {
     totalAckDataLength += acked;
     return totalAckDataLength;
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * This class executes watchForCommit on ratis pipeline and releases
@@ -62,7 +63,7 @@ abstract class AbstractCommitWatcher<BUFFER> {
 
   private final XceiverClientSpi client;
 
-  private long totalAckDataLength;
+  private final AtomicLong totalAckDataLength = new AtomicLong();
 
   AbstractCommitWatcher(XceiverClientSpi client) {
     this.client = client;
@@ -79,13 +80,12 @@ abstract class AbstractCommitWatcher<BUFFER> {
   }
 
   /** @return the total data which has been acknowledged. */
-  synchronized long getTotalAckDataLength() {
-    return totalAckDataLength;
+  long getTotalAckDataLength() {
+    return totalAckDataLength.get();
   }
 
-  synchronized long addAckDataLength(long acked) {
-    totalAckDataLength += acked;
-    return totalAckDataLength;
+  long addAckDataLength(long acked) {
+    return totalAckDataLength.addAndGet(acked);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.PutBlock;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.WriteChunk;
@@ -476,9 +477,9 @@ class TestBlockOutputStream {
   }
 
   @ParameterizedTest
-  @MethodSource("clientParameters")
-  void testWriteMoreThanFlushSize(boolean flushDelay, boolean enablePiggybacking) throws Exception {
-    OzoneClientConfig config = newClientConfig(cluster.getConf(), flushDelay, enablePiggybacking);
+  @ValueSource(booleans = {true, false})
+  void testWriteMoreThanFlushSize(boolean flushDelay) throws Exception {
+    OzoneClientConfig config = newClientConfig(cluster.getConf(), flushDelay, false);
     try (OzoneClient client = newClient(cluster.getConf(), config)) {
       XceiverClientMetrics metrics =
           XceiverClientManager.getXceiverClientMetrics();
@@ -550,9 +551,9 @@ class TestBlockOutputStream {
       assertEquals(writeChunkCount + 3,
           metrics.getContainerOpCountMetrics(WriteChunk));
       // If the flushDelay was disabled, it sends PutBlock with the data in the buffer.
-      assertEquals(putBlockCount + (flushDelay ? 2 : 3) - (enablePiggybacking ? 1 : 0),
+      assertEquals(putBlockCount + (flushDelay ? 2 : 3),
           metrics.getContainerOpCountMetrics(PutBlock));
-      assertEquals(totalOpCount + (flushDelay ? 5 : 6) - (enablePiggybacking ? 1 : 0),
+      assertEquals(totalOpCount + (flushDelay ? 5 : 6),
           metrics.getTotalOpCount());
       assertEquals(dataLength, blockOutputStream.getTotalAckDataLength());
       // make sure the bufferPool is empty


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestBlockOutputStream.testWriteMoreThanFlushSize is flaky after HDDS-9844 fix.
It is due to addAckDataLength is not kept as thread safe which is causing wrong totalAckDataLength.
In this PR we are adding synchronized in AbstractCommitWatcher.addAckDataLength to make thread safe.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11280

## How was this patch tested?

Verified in 10X10 run and it is green after the fix
https://github.com/ashishkumar50/ozone/actions/runs/10244918136/workflow
