### PR TITLE
HDDS-11281. Optimize the lock of ReadChunk

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -96,7 +96,7 @@ public final class ChunkUtils {
       ));
   public static final FileAttribute<?>[] NO_ATTRIBUTES = {};
   public static final int DEFAULT_FILE_LOCK_STRIPED_SIZE = 512;
-  public static Striped<ReadWriteLock> fileStripedLock =
+  private static Striped<ReadWriteLock> fileStripedLock =
       Striped.readWriteLock(DEFAULT_FILE_LOCK_STRIPED_SIZE);
 
   /** Never constructed. **/

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -27,9 +27,11 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -83,7 +85,6 @@ class TestChunkUtils {
   @Test
   void concurrentReadOfSameFile() throws Exception {
     int threads = 10;
-    ChunkUtils.setStripedLock(Striped.readWriteLock(threads));
     String s = "Hello World";
     byte[] array = s.getBytes(UTF_8);
     ChunkBuffer data = ChunkBuffer.wrap(ByteBuffer.wrap(array));
@@ -126,43 +127,71 @@ class TestChunkUtils {
       executor.shutdownNow();
     }
     assertFalse(failed.get());
-
-    ChunkUtils.clearStripedLock();
   }
 
   @Test
-  void concurrentProcessing() throws Exception {
-    final int perThreadWait = 1000;
-    final int maxTotalWait = 5000;
-    int threads = 20;
+  void concurrentReadWriteOfSameFile() {
+    final int threads = 10;
+    ChunkUtils.setStripedLock(Striped.readWriteLock(threads));
+    final byte[] array = "Hello World".getBytes(UTF_8);
 
-    ExecutorService executor = new ThreadPoolExecutor(threads, threads,
+    Path tempFile = tempDir.toPath().resolve("concurrent_read_write");
+    File file = tempFile.toFile();
+    AtomicInteger success = new AtomicInteger(0);
+    AtomicInteger fail = new AtomicInteger(0);
+
+    ExecutorService executor = new ThreadPoolExecutor(10, 10,
         0, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
-    AtomicInteger processed = new AtomicInteger();
+
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+
     for (int i = 0; i < threads; i++) {
-      Path path = tempDir.toPath().resolve(String.valueOf(i));
-      executor.execute(() -> {
+      final int threadNumber = i;
+      final ChunkBuffer data = ChunkBuffer.wrap(ByteBuffer.wrap(array));
+      final int len = data.limit();
+      final int offset = i * len;
+
+      CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
         try {
-          ChunkUtils.processFileExclusively(path, () -> {
-            try {
-              Thread.sleep(perThreadWait);
-            } catch (InterruptedException e) {
-              e.printStackTrace();
-            }
-            processed.incrementAndGet();
-            return null;
-          });
-        } catch (InterruptedException e) {
-          e.printStackTrace();
+          ChunkUtils.writeData(file, data, offset, len, null, true);
+          success.getAndIncrement();
+        } catch (StorageContainerException e) {
+          throw new RuntimeException(e);
         }
-      });
+      }, executor).whenCompleteAsync((v, e) -> {
+        if (e == null) {
+          try {
+            final ChunkBuffer chunk = readData(file, offset, len);
+            // There should be only one element in readBuffers
+            final List<ByteBuffer> buffers = chunk.asByteBufferList();
+            assertEquals(1, buffers.size());
+            final ByteBuffer readBuffer = buffers.get(0);
+
+            LOG.info("Read data ({}): {}", threadNumber,
+                new String(readBuffer.array(), UTF_8));
+            if (!Arrays.equals(array, readBuffer.array())) {
+              fail.getAndIncrement();
+            }
+            assertEquals(len, readBuffer.remaining());
+          } catch (Exception ee) {
+            LOG.error("Failed to read data ({})", threadNumber, ee);
+            fail.getAndIncrement();
+          }
+        } else {
+          fail.getAndIncrement();
+        }
+      }, executor);
+      futures.add(future);
     }
     try {
-      GenericTestUtils.waitFor(() -> processed.get() == threads,
-          100, maxTotalWait);
+      for (CompletableFuture<Void> future : futures) {
+        future.join();
+      }
     } finally {
       executor.shutdownNow();
     }
+    assertEquals(success.get(), threads);
+    assertEquals(fail.get(), 0);
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.util.concurrent.Striped;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
@@ -81,6 +82,8 @@ class TestChunkUtils {
 
   @Test
   void concurrentReadOfSameFile() throws Exception {
+    int threads = 10;
+    ChunkUtils.setStripedLock(Striped.readWriteLock(threads));
     String s = "Hello World";
     byte[] array = s.getBytes(UTF_8);
     ChunkBuffer data = ChunkBuffer.wrap(ByteBuffer.wrap(array));
@@ -89,7 +92,6 @@ class TestChunkUtils {
     int offset = 0;
     File file = tempFile.toFile();
     ChunkUtils.writeData(file, data, offset, len, null, true);
-    int threads = 10;
     ExecutorService executor = new ThreadPoolExecutor(threads, threads,
         0, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
     AtomicInteger processed = new AtomicInteger();
@@ -124,6 +126,8 @@ class TestChunkUtils {
       executor.shutdownNow();
     }
     assertFalse(failed.get());
+
+    ChunkUtils.clearStripedLock();
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

The user repeatedly reads the same block, and I observed that the access time for the read chunk is too slow, which is caused by spin lock in processFileExclusive in ChunkUtils. I added the corresponding slow request log to see this issue.

see detail:  https://issues.apache.org/jira/browse/HDDS-11281

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11281

## How was this patch tested?

org.apache.hadoop.ozone.container.keyvalue.helpers.TestChunkUtils#concurrentReadWriteOfSameFile
