### PR TITLE
HDDS-11284. refactor quota repair non-blocking while upgrade

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -168,6 +168,14 @@ public interface DBStore extends Closeable, BatchOperationHandler {
   DBCheckpoint getCheckpoint(boolean flush) throws IOException;
 
   /**
+   * Get current snapshot of DB store as an artifact stored on
+   * the local filesystem with relative path.
+   * @return An object that encapsulates the checkpoint information along with
+   * location.
+   */
+  DBCheckpoint getCheckpoint(String relatedPath, boolean flush) throws IOException;
+
+  /**
    * Get DB Store location.
    * @return DB file location.
    */

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -169,11 +169,11 @@ public interface DBStore extends Closeable, BatchOperationHandler {
 
   /**
    * Get current snapshot of DB store as an artifact stored on
-   * the local filesystem with relative path.
+   * the local filesystem with different parent path.
    * @return An object that encapsulates the checkpoint information along with
    * location.
    */
-  DBCheckpoint getCheckpoint(String relatedPath, boolean flush) throws IOException;
+  DBCheckpoint getCheckpoint(String parentDir, boolean flush) throws IOException;
 
   /**
    * Get DB Store location.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -339,11 +339,11 @@ public class RDBStore implements DBStore {
   }
 
   @Override
-  public DBCheckpoint getCheckpoint(String relativePath, boolean flush) throws IOException {
+  public DBCheckpoint getCheckpoint(String parentPath, boolean flush) throws IOException {
     if (flush) {
       this.flushDB();
     }
-    return checkPointManager.createCheckpoint(checkpointsParentDir, relativePath);
+    return checkPointManager.createCheckpoint(parentPath, null);
   }
 
   public DBCheckpoint getSnapshot(String name) throws IOException {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -338,6 +338,14 @@ public class RDBStore implements DBStore {
     return checkPointManager.createCheckpoint(checkpointsParentDir);
   }
 
+  @Override
+  public DBCheckpoint getCheckpoint(String relativePath, boolean flush) throws IOException {
+    if (flush) {
+      this.flushDB();
+    }
+    return checkPointManager.createCheckpoint(checkpointsParentDir, relativePath);
+  }
+
   public DBCheckpoint getSnapshot(String name) throws IOException {
     this.flushLog(true);
     return checkPointManager.createCheckpoint(snapshotsParentDir, name);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -327,6 +327,7 @@ public final class OmUtils {
     case SetTimes:
     case AbortExpiredMultiPartUploads:
     case SetSnapshotProperty:
+    case QuotaRepair:
     case UnknownCommand:
       return false;
     case EchoRPC:

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -147,8 +147,8 @@ enum Type {
   ListStatusLight = 129;
   GetSnapshotInfo = 130;
   RenameSnapshot = 131;
-
   ListOpenFiles = 132;
+  QuotaRepair = 133;
 }
 
 enum SafeMode {
@@ -285,8 +285,8 @@ message OMRequest {
   optional SetSnapshotPropertyRequest       SetSnapshotPropertyRequest     = 127;
   optional SnapshotInfoRequest              SnapshotInfoRequest            = 128;
   optional RenameSnapshotRequest            RenameSnapshotRequest          = 129;
-
   optional ListOpenFilesRequest             ListOpenFilesRequest           = 130;
+  optional QuotaRepairRequest               QuotaRepairRequest             = 131;
 }
 
 message OMResponse {
@@ -410,8 +410,8 @@ message OMResponse {
   optional SnapshotInfoResponse              SnapshotInfoResponse          = 130;
   optional OMLockDetailsProto                omLockDetails                 = 131;
   optional RenameSnapshotResponse            RenameSnapshotResponse        = 132;
-
   optional ListOpenFilesResponse             ListOpenFilesResponse         = 133;
+  optional QuotaRepairResponse            QuotaRepairResponse        = 134;
 }
 
 enum Status {
@@ -2185,6 +2185,21 @@ message SetSafeModeRequest {
 
 message SetSafeModeResponse {
   optional bool response = 1;
+}
+
+message QuotaRepairRequest {
+    repeated BucketQuotaCount bucketCount = 1;
+    required bool supportVolumeOldQuota = 2 [default=false];
+}
+message BucketQuotaCount {
+    required string volName = 1;
+    required string bucketName = 2;
+    required int64 diffUsedBytes = 3;
+    required int64 diffUsedNamespace = 4;
+    required bool supportOldQuota = 5 [default=false];
+}
+
+message QuotaRepairResponse {
 }
 
 message OMLockDetailsProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -84,6 +84,7 @@ import org.apache.hadoop.ozone.om.request.upgrade.OMCancelPrepareRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMFinalizeUpgradeRequest;
 import org.apache.hadoop.ozone.om.request.upgrade.OMPrepareRequest;
 import org.apache.hadoop.ozone.om.request.util.OMEchoRPCWriteRequest;
+import org.apache.hadoop.ozone.om.request.volume.OMQuotaRepairRequest;
 import org.apache.hadoop.ozone.om.request.volume.OMVolumeCreateRequest;
 import org.apache.hadoop.ozone.om.request.volume.OMVolumeDeleteRequest;
 import org.apache.hadoop.ozone.om.request.volume.OMVolumeSetOwnerRequest;
@@ -331,6 +332,8 @@ public final class OzoneManagerRatisUtils {
       return new OMEchoRPCWriteRequest(omRequest);
     case AbortExpiredMultiPartUploads:
       return new S3ExpiredMultipartUploadsAbortRequest(omRequest);
+    case QuotaRepair:
+      return new OMQuotaRepairRequest(omRequest);
     default:
       throw new OMException("Unrecognized write command type request "
           + cmdType, OMException.ResultCodes.INVALID_REQUEST);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMQuotaRepairRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMQuotaRepairRequest.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.volume;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.volume.OMQuotaRepairResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OLD_QUOTA_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConsts.QUOTA_RESET;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
+
+/**
+ * Handle OMQuotaRepairRequest Request.
+ */
+public class OMQuotaRepairRequest extends OMClientRequest {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMQuotaRepairRequest.class);
+
+  public OMQuotaRepairRequest(OMRequest omRequest) {
+    super(omRequest);
+  }
+
+  @Override
+  @SuppressWarnings("methodlength")
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, TermIndex termIndex) {
+    final long transactionLogIndex = termIndex.getIndex();
+    OzoneManagerProtocolProtos.QuotaRepairRequest quotaRepairRequest =
+        getOmRequest().getQuotaRepairRequest();
+    Preconditions.checkNotNull(quotaRepairRequest);
+
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    OzoneManagerProtocolProtos.OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(getOmRequest());
+    Map<Pair<String, String>, OmBucketInfo> bucketMap = new HashMap<>();
+    OMClientResponse omClientResponse = null;
+    try {
+      for (int i = 0; i < quotaRepairRequest.getBucketCountCount(); ++i) {
+        OzoneManagerProtocolProtos.BucketQuotaCount bucketCountInfo = quotaRepairRequest.getBucketCount(i);
+        updateBucketInfo(omMetadataManager, bucketCountInfo, transactionLogIndex, bucketMap);
+      }
+      Map<String, OmVolumeArgs> volUpdateMap = updateOldVolumeQuotaSupport(omMetadataManager, transactionLogIndex);
+      omResponse.setQuotaRepairResponse(
+          OzoneManagerProtocolProtos.QuotaRepairResponse.newBuilder().build());
+      omClientResponse = new OMQuotaRepairResponse(omResponse.build(), volUpdateMap, bucketMap);
+    } catch (IOException ex) {
+      LOG.error("failed to update repair count", ex);
+      omClientResponse = new OMQuotaRepairResponse(createErrorOMResponse(omResponse, ex));
+    } finally {
+      if (omClientResponse != null) {
+        omClientResponse.setOmLockDetails(getOmLockDetails());
+      }
+    }
+
+    return omClientResponse;
+  }
+  
+  private void updateBucketInfo(
+      OMMetadataManager omMetadataManager, OzoneManagerProtocolProtos.BucketQuotaCount bucketCountInfo,
+      long transactionLogIndex, Map<Pair<String, String>, OmBucketInfo> bucketMap) throws IOException {
+    // acquire lock.
+    mergeOmLockDetails(omMetadataManager.getLock().acquireWriteLock(
+        BUCKET_LOCK, bucketCountInfo.getVolName(), bucketCountInfo.getBucketName()));
+    boolean acquiredBucketLock = getOmLockDetails().isLockAcquired();
+    try {
+      String bucketKey = omMetadataManager.getBucketKey(bucketCountInfo.getVolName(),
+          bucketCountInfo.getBucketName());
+      OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+      if (null == bucketInfo) {
+        // bucket might be deleted when running repair count parallel
+        return;
+      }
+      bucketInfo.incrUsedBytes(bucketCountInfo.getDiffUsedBytes());
+      bucketInfo.incrUsedNamespace(bucketCountInfo.getDiffUsedNamespace());
+      if (bucketCountInfo.getSupportOldQuota()) {
+        OmBucketInfo.Builder builder = bucketInfo.toBuilder();
+        if (bucketInfo.getQuotaInBytes() == OLD_QUOTA_DEFAULT) {
+          builder.setQuotaInBytes(QUOTA_RESET);
+        }
+        if (bucketInfo.getQuotaInNamespace() == OLD_QUOTA_DEFAULT) {
+          builder.setQuotaInNamespace(QUOTA_RESET);
+        }
+        bucketInfo = builder.build();
+      }
+
+      omMetadataManager.getBucketTable().addCacheEntry(
+          new CacheKey<>(bucketKey), CacheValue.get(transactionLogIndex, bucketInfo));
+      bucketMap.put(Pair.of(bucketCountInfo.getVolName(), bucketCountInfo.getBucketName()), bucketInfo);
+    } finally {
+      if (acquiredBucketLock) {
+        mergeOmLockDetails(omMetadataManager.getLock()
+            .releaseWriteLock(BUCKET_LOCK, bucketCountInfo.getVolName(), bucketCountInfo.getBucketName()));
+      }
+    }
+  }
+
+  private Map<String, OmVolumeArgs> updateOldVolumeQuotaSupport(
+      OMMetadataManager metadataManager, long transactionLogIndex) throws IOException {
+    LOG.info("Starting volume quota support update");
+    Map<String, OmVolumeArgs> volUpdateMap = new HashMap<>();
+    try (TableIterator<String, ? extends Table.KeyValue<String, OmVolumeArgs>>
+             iterator = metadataManager.getVolumeTable().iterator()) {
+      while (iterator.hasNext()) {
+        Table.KeyValue<String, OmVolumeArgs> entry = iterator.next();
+        OmVolumeArgs omVolumeArgs = entry.getValue();
+        if (!(omVolumeArgs.getQuotaInBytes() == OLD_QUOTA_DEFAULT
+            || omVolumeArgs.getQuotaInNamespace() == OLD_QUOTA_DEFAULT)) {
+          continue;
+        }
+        mergeOmLockDetails(metadataManager.getLock().acquireWriteLock(
+            VOLUME_LOCK, omVolumeArgs.getVolume()));
+        boolean acquiredVolumeLock = getOmLockDetails().isLockAcquired();
+        try {
+          boolean isQuotaReset = false;
+          if (omVolumeArgs.getQuotaInBytes() == OLD_QUOTA_DEFAULT) {
+            omVolumeArgs.setQuotaInBytes(QUOTA_RESET);
+            isQuotaReset = true;
+          }
+          if (omVolumeArgs.getQuotaInNamespace() == OLD_QUOTA_DEFAULT) {
+            omVolumeArgs.setQuotaInNamespace(QUOTA_RESET);
+            isQuotaReset = true;
+          }
+          if (isQuotaReset) {
+            metadataManager.getVolumeTable().addCacheEntry(
+                new CacheKey<>(entry.getKey()), CacheValue.get(transactionLogIndex, omVolumeArgs));
+            volUpdateMap.put(entry.getKey(), omVolumeArgs);
+          }
+        } finally {
+          if (acquiredVolumeLock) {
+            mergeOmLockDetails(metadataManager.getLock().releaseWriteLock(VOLUME_LOCK, omVolumeArgs.getVolume()));
+          }
+        }
+      }
+    }
+    LOG.info("Completed volume quota support update for volume count {}", volUpdateMap.size());
+    return volUpdateMap;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMQuotaRepairRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMQuotaRepairRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.volume;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
@@ -74,7 +75,12 @@ public class OMQuotaRepairRequest extends OMClientRequest {
         OzoneManagerProtocolProtos.BucketQuotaCount bucketCountInfo = quotaRepairRequest.getBucketCount(i);
         updateBucketInfo(omMetadataManager, bucketCountInfo, transactionLogIndex, bucketMap);
       }
-      Map<String, OmVolumeArgs> volUpdateMap = updateOldVolumeQuotaSupport(omMetadataManager, transactionLogIndex);
+      Map<String, OmVolumeArgs> volUpdateMap;
+      if (quotaRepairRequest.getSupportVolumeOldQuota()) {
+        volUpdateMap = updateOldVolumeQuotaSupport(omMetadataManager, transactionLogIndex);
+      } else {
+        volUpdateMap = Collections.emptyMap();
+      }
       omResponse.setQuotaRepairResponse(
           OzoneManagerProtocolProtos.QuotaRepairResponse.newBuilder().build());
       omClientResponse = new OMQuotaRepairResponse(omResponse.build(), volUpdateMap, bucketMap);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMQuotaRepairResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMQuotaRepairResponse.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.volume;
+
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.request.volume.OMQuotaRepairRequest;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
+
+/**
+ * Response for {@link OMQuotaRepairRequest} request.
+ */
+@CleanupTableInfo(cleanupTables = {VOLUME_TABLE, BUCKET_TABLE})
+public class OMQuotaRepairResponse extends OMClientResponse {
+  private Map<String, OmVolumeArgs> volumeArgsMap;
+  private Map<Pair<String, String>, OmBucketInfo> volBucketInfoMap;
+
+  /**
+   * for quota failure response update.
+   */
+  public OMQuotaRepairResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+  }
+
+  public OMQuotaRepairResponse(
+      @Nonnull OMResponse omResponse, Map<String, OmVolumeArgs> volumeArgsMap,
+      Map<Pair<String, String>, OmBucketInfo> volBucketInfoMap) {
+    super(omResponse);
+    this.volBucketInfoMap = volBucketInfoMap;
+    this.volumeArgsMap = volumeArgsMap;
+  }
+
+  @Override
+  public void addToDBBatch(OMMetadataManager metadataManager,
+      BatchOperation batchOp) throws IOException {
+    for (OmBucketInfo omBucketInfo : volBucketInfoMap.values()) {
+      metadataManager.getBucketTable().putWithBatch(batchOp,
+          metadataManager.getBucketKey(omBucketInfo.getVolumeName(),
+              omBucketInfo.getBucketName()), omBucketInfo);
+    }
+    for (OmVolumeArgs volArgs : volumeArgsMap.values()) {
+      metadataManager.getVolumeTable().putWithBatch(batchOp, volArgs.getVolume(), volArgs);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
@@ -98,8 +98,8 @@ public class QuotaRepairTask {
     LOG.info("Starting quota repair task {}", REPAIR_STATUS);
     OMMetadataManager activeMetaManager = null;
     try {
-      // thread pool with 3 Table type * (1 task each + 3 thread each)
-      executor = Executors.newFixedThreadPool(12);
+      // thread pool with 3 Table type * (1 task each + 3 thread for each task)
+      executor = Executors.newFixedThreadPool(3 * (1 + TASK_THREAD_CNT));
       OzoneManagerProtocolProtos.QuotaRepairRequest.Builder builder
           = OzoneManagerProtocolProtos.QuotaRepairRequest.newBuilder();
       // repair active db
@@ -116,9 +116,10 @@ public class QuotaRepairTask {
           .setClientId(clientId.toString())
           .build();
       OzoneManagerProtocolProtos.OMResponse response = submitRequest(omRequest, clientId);
-      if (response != null && response.getSuccess()) {
+      if (response != null && !response.getSuccess()) {
         LOG.error("update quota repair count response failed");
         REPAIR_STATUS.updateStatus("Response for update DB is failed");
+        return false;
       } else {
         REPAIR_STATUS.updateStatus(builder, om.getMetadataManager());
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
@@ -48,8 +48,9 @@ public class QuotaRepairUpgradeAction implements OmUpgradeAction {
         QuotaRepairTask quotaRepairTask = new QuotaRepairTask(arg);
         quotaRepairTask.repair();
       } catch (OMNotLeaderException | OMLeaderNotReadyException ex) {
-        // on leader node, repair will be triggered where finalize is called
-        LOG.warn("Unable to start quota repair as this is not a leader node");
+        // on leader node, repair will be triggered where finalize is called. For other nodes, it will be ignored.
+        // This can be triggered on need basis via CLI tool.
+        LOG.warn("Skip quota repair operation during upgrade on the node as this is not a leader node.");
       }
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
@@ -38,8 +38,7 @@ public class QuotaRepairUpgradeAction implements OmUpgradeAction {
         OMConfigKeys.OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE,
         OMConfigKeys.OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE_DEFAULT);
     if (enabled) {
-      QuotaRepairTask quotaRepairTask = new QuotaRepairTask(
-          arg.getMetadataManager());
+      QuotaRepairTask quotaRepairTask = new QuotaRepairTask(arg);
       quotaRepairTask.repair();
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
@@ -24,13 +24,12 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.service.QuotaRepairTask;
 
 import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.QUOTA;
-import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.ON_FIRST_UPGRADE_START;
+import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.ON_FINALIZE;
 
 /**
- * Quota repair for usages action to be triggered during first upgrade.
+ * Quota repair for usages action to be triggered after upgrade.
  */
-@UpgradeActionOm(type = ON_FIRST_UPGRADE_START, feature =
-    QUOTA)
+@UpgradeActionOm(type = ON_FINALIZE, feature = QUOTA)
 public class QuotaRepairUpgradeAction implements OmUpgradeAction {
   @Override
   public void execute(OzoneManager arg) throws Exception {
@@ -38,6 +37,7 @@ public class QuotaRepairUpgradeAction implements OmUpgradeAction {
         OMConfigKeys.OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE,
         OMConfigKeys.OZONE_OM_UPGRADE_QUOTA_RECALCULATE_ENABLE_DEFAULT);
     if (enabled) {
+      // just trigger quota repair and status can be checked via CLI
       QuotaRepairTask quotaRepairTask = new QuotaRepairTask(arg);
       quotaRepairTask.repair();
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/QuotaRepairUpgradeAction.java
@@ -44,7 +44,9 @@ public class QuotaRepairUpgradeAction implements OmUpgradeAction {
     if (enabled) {
       // just trigger quota repair and status can be checked via CLI
       try {
-        arg.checkLeaderStatus();
+        if (arg.isRatisEnabled()) {
+          arg.checkLeaderStatus();
+        }
         QuotaRepairTask quotaRepairTask = new QuotaRepairTask(arg);
         quotaRepairTask.repair();
       } catch (OMNotLeaderException | OMLeaderNotReadyException ex) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
@@ -22,8 +22,16 @@ package org.apache.hadoop.ozone.om.service;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -32,6 +40,11 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.request.volume.OMQuotaRepairRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.volume.OMQuotaRepairResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +57,16 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
 
   @Test
   public void testQuotaRepair() throws Exception {
+    when(ozoneManager.isRatisEnabled()).thenReturn(false);
+    OzoneManagerProtocolProtos.OMResponse respMock = mock(OzoneManagerProtocolProtos.OMResponse.class);
+    when(respMock.getSuccess()).thenReturn(true);
+    OzoneManagerProtocolServerSideTranslatorPB serverMock = mock(OzoneManagerProtocolServerSideTranslatorPB.class);
+    AtomicReference<OzoneManagerProtocolProtos.OMRequest> ref = new AtomicReference<>();
+    doAnswer(invocation -> {
+      ref.set(invocation.getArgument(1, OzoneManagerProtocolProtos.OMRequest.class));
+      return respMock;
+    }).when(serverMock).submitRequest(any(), any());
+    when(ozoneManager.getOmServerProtocol()).thenReturn(serverMock);
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, BucketLayout.OBJECT_STORE);
 
@@ -89,8 +112,15 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     assertEquals(0, fsoBucketInfo.getUsedBytes());
     
     QuotaRepairTask quotaRepairTask = new QuotaRepairTask(ozoneManager);
-    quotaRepairTask.repair();
+    CompletableFuture<Boolean> repair = quotaRepairTask.repair();
+    Boolean repairStatus = repair.get();
+    assertTrue(repairStatus);
 
+    OMQuotaRepairRequest omQuotaRepairRequest = new OMQuotaRepairRequest(ref.get());
+    OMClientResponse omClientResponse = omQuotaRepairRequest.validateAndUpdateCache(ozoneManager, 1);
+    BatchOperation batchOperation = omMetadataManager.getStore().initBatchOperation();
+    ((OMQuotaRepairResponse)omClientResponse).addToDBBatch(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
     // 10 files of each type, obs have replication of three and
     // fso have replication of one
     OmBucketInfo obsUpdateBucketInfo = omMetadataManager.getBucketTable().get(
@@ -105,6 +135,16 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
 
   @Test
   public void testQuotaRepairForOldVersionVolumeBucket() throws Exception {
+    when(ozoneManager.isRatisEnabled()).thenReturn(false);
+    OzoneManagerProtocolProtos.OMResponse respMock = mock(OzoneManagerProtocolProtos.OMResponse.class);
+    when(respMock.getSuccess()).thenReturn(true);
+    OzoneManagerProtocolServerSideTranslatorPB serverMock = mock(OzoneManagerProtocolServerSideTranslatorPB.class);
+    AtomicReference<OzoneManagerProtocolProtos.OMRequest> ref = new AtomicReference<>();
+    doAnswer(invocation -> {
+      ref.set(invocation.getArgument(1, OzoneManagerProtocolProtos.OMRequest.class));
+      return respMock;
+    }).when(serverMock).submitRequest(any(), any());
+    when(ozoneManager.getOmServerProtocol()).thenReturn(serverMock);
     // add volume with -2 value
     OmVolumeArgs omVolumeArgs =
         OmVolumeArgs.newBuilder().setCreationTime(Time.now())
@@ -117,13 +157,14 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
         new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
         CacheValue.get(1L, omVolumeArgs));
     
-    // add bucket with -2 value
+    // add bucket with -2 value and add to db
     OMRequestTestUtils.addBucketToDB(volumeName, bucketName,
         omMetadataManager, -2);
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    omMetadataManager.getBucketTable().put(bucketKey, omMetadataManager.getBucketTable().get(bucketKey));
 
     // pre check for quota flag
-    OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(
-        omMetadataManager.getBucketKey(volumeName, bucketName));
+    OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
     assertEquals(-2, bucketInfo.getQuotaInBytes());
     
     omVolumeArgs = omMetadataManager.getVolumeTable().get(
@@ -132,10 +173,17 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     assertEquals(-2, omVolumeArgs.getQuotaInNamespace());
 
     QuotaRepairTask quotaRepairTask = new QuotaRepairTask(ozoneManager);
-    quotaRepairTask.repair();
+    CompletableFuture<Boolean> repair = quotaRepairTask.repair();
+    Boolean repairStatus = repair.get();
+    assertTrue(repairStatus);
 
+    OMQuotaRepairRequest omQuotaRepairRequest = new OMQuotaRepairRequest(ref.get());
+    OMClientResponse omClientResponse = omQuotaRepairRequest.validateAndUpdateCache(ozoneManager, 1);
+    BatchOperation batchOperation = omMetadataManager.getStore().initBatchOperation();
+    ((OMQuotaRepairResponse)omClientResponse).addToDBBatch(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
     bucketInfo = omMetadataManager.getBucketTable().get(
-        omMetadataManager.getBucketKey(volumeName, bucketName));
+        bucketKey);
     assertEquals(-1, bucketInfo.getQuotaInBytes());
     OmVolumeArgs volArgsVerify = omMetadataManager.getVolumeTable()
         .get(omMetadataManager.getVolumeKey(volumeName));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestQuotaRepairTask.java
@@ -88,7 +88,7 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     assertEquals(0, fsoBucketInfo.getUsedNamespace());
     assertEquals(0, fsoBucketInfo.getUsedBytes());
     
-    QuotaRepairTask quotaRepairTask = new QuotaRepairTask(omMetadataManager);
+    QuotaRepairTask quotaRepairTask = new QuotaRepairTask(ozoneManager);
     quotaRepairTask.repair();
 
     // 10 files of each type, obs have replication of three and
@@ -131,7 +131,7 @@ public class TestQuotaRepairTask extends TestOMKeyRequest {
     assertEquals(-2, omVolumeArgs.getQuotaInBytes());
     assertEquals(-2, omVolumeArgs.getQuotaInNamespace());
 
-    QuotaRepairTask quotaRepairTask = new QuotaRepairTask(omMetadataManager);
+    QuotaRepairTask quotaRepairTask = new QuotaRepairTask(ozoneManager);
     quotaRepairTask.repair();
 
     bucketInfo = omMetadataManager.getBucketTable().get(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes:
1. refactor quota repair for running non-blocking
  - DB checkpoint is created before starting quota usages calculation
  - Diff quota usages is identified from checkpoint with original and new quota
  - For diff, quota update is send via ratis to correct quota usages
  - Status is added to be integrated for last run with CLI
2. while upgrade case, change handling as non-blocking
  - quota repair trigger on FiNALIZE trigger for upgrade (as ratis dependency, its initialized during this phase only)
  - Just trigger, but actual run will happen async

The target for this refactor is to `integrate with tool CLI` option to trigger again and verify for correctness. This is tracked with `Parent ID:` [HDDS-8824](https://issues.apache.org/jira/browse/HDDS-8824)



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11284

## How was this patch tested?

- Unit test is updated to cover scenario
