### PR TITLE
HDDS-11257. Ozone write does not work when http proxy is set for the JVM.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -191,7 +191,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(dn.getIpAddress(), port).usePlaintext()
             .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
-            .proxyDetector(uri-> null)
+            .proxyDetector(uri -> null)
             .intercept(new GrpcClientInterceptor());
     if (secConfig.isSecurityEnabled() && secConfig.isGrpcTlsEnabled()) {
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -191,6 +191,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(dn.getIpAddress(), port).usePlaintext()
             .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
+            .proxyDetector(uri-> null)
             .intercept(new GrpcClientInterceptor());
     if (secConfig.isSecurityEnabled() && secConfig.isGrpcTlsEnabled()) {
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -75,7 +75,8 @@ public class GrpcReplicationClient implements AutoCloseable {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(host, port)
             .usePlaintext()
-            .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE);
+            .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
+            .proxyDetector(uri -> null);
 
     if (secConfig.isSecurityEnabled() && secConfig.isGrpcTlsEnabled()) {
       channelBuilder.useTransportSecurity();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
@@ -68,7 +68,8 @@ public class InterSCMGrpcClient implements SCMSnapshotDownloader {
             TimeUnit.MILLISECONDS);
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(host, port).usePlaintext()
-            .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE);
+            .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
+            .proxyDetector(uri->null);
     SecurityConfig securityConfig = new SecurityConfig(conf);
     if (securityConfig.isSecurityEnabled()
         && securityConfig.isGrpcTlsEnabled()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
@@ -69,7 +69,7 @@ public class InterSCMGrpcClient implements SCMSnapshotDownloader {
     NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(host, port).usePlaintext()
             .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
-            .proxyDetector(uri->null);
+            .proxyDetector(uri -> null);
     SecurityConfig securityConfig = new SecurityConfig(conf);
     if (securityConfig.isSecurityEnabled()
         && securityConfig.isGrpcTlsEnabled()) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
@@ -145,6 +145,7 @@ public class GrpcOmTransport implements OmTransport {
       NettyChannelBuilder channelBuilder =
           NettyChannelBuilder.forAddress(hp.getHost(), hp.getPort())
               .usePlaintext()
+              .proxyDetector(uri -> null)
               .maxInboundMessageSize(maxSize);
 
       if (secConfig.isSecurityEnabled() && secConfig.isGrpcTlsEnabled()) {

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -257,13 +257,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
         </configuration>
       </plugin>
-      <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-surefire-plugin</artifactId>
-      <configuration>
-        <argLine>-Dhttps.proxyHost=127.0.0.1</argLine>
-      </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -257,6 +257,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
         </configuration>
       </plugin>
+      <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-surefire-plugin</artifactId>
+      <configuration>
+        <argLine>-Dhttps.proxyHost=127.0.0.1</argLine>
+      </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
@@ -168,7 +168,8 @@ public class FollowerAppendLogEntryGenerator extends BaseAppendLogGenerator
         .build();
 
     NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forTarget(serverAddress);
+        NettyChannelBuilder.forTarget(serverAddress)
+            .proxyDetector(uri -> null);
     channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
     ManagedChannel build = channelBuilder.build();
     stub = RaftServerProtocolServiceGrpc.newStub(build);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
@@ -144,8 +144,7 @@ public class LeaderAppendLogEntryGenerator extends BaseAppendLogGenerator
         .build();
 
     NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forTarget(serverAddress)
-            .proxyDetector(uri->null);
+        NettyChannelBuilder.forTarget(serverAddress).proxyDetector(uri -> null);
     channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
     ManagedChannel build = channelBuilder.build();
     stub = RaftServerProtocolServiceGrpc.newStub(build);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
@@ -144,7 +144,8 @@ public class LeaderAppendLogEntryGenerator extends BaseAppendLogGenerator
         .build();
 
     NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forTarget(serverAddress);
+        NettyChannelBuilder.forTarget(serverAddress)
+            .proxyDetector(uri->null);
     channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
     ManagedChannel build = channelBuilder.build();
     stub = RaftServerProtocolServiceGrpc.newStub(build);


### PR DESCRIPTION
## What changes were proposed in this pull request?
GRPC uses HTTP internally for its connections and due to this, if http proxy is configured for any Ozone process using grpc , it directs each call through the proxy even for grpc which is not [desirable](https://github.com/apache/ratis-thirdparty/pull/53#issuecomment-2262233350) for performance. Hence disabling proxy for grpc connections that ozone uses.
This has been fixed in RATIS via RATIS-2133. For the complete fix we need to update Ozone's ratis version to one which has the fix but that would happen whenever the next ratis update happens.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11257

## How was this patch tested?
Since current Ratis version in Ozone does not have the fix, used the flaky test check with custom ratis commit to point to latest commits in apache/ratis
Tested a unit test with this [commit ](https://github.com/apache/ozone/pull/7036/commits/822879e374eb7daf7f116ce422257c017c6a85af)having proxy config set in the maven sure fire plugin
```xml
      <plugin>
      <groupId>org.apache.maven.plugins</groupId>
      <artifactId>maven-surefire-plugin</artifactId>
      <configuration>
        <argLine>-Dhttps.proxyHost=127.0.0.1</argLine>
      </configuration>
      </plugin>
```
https://github.com/sadanand48/hadoop-ozone/actions/runs/10261429774/job/28389549624
