### PR TITLE
HDDS-10490. Intermittent NPE in TestSnapshotDiffManager#testLoadJobsOnStartUp

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -64,6 +64,7 @@ import org.apache.ozone.rocksdb.util.RdbUtil;
 import org.apache.ozone.rocksdiff.DifferSnapshotInfo;
 import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 import org.apache.ozone.rocksdiff.RocksDiffUtils;
+import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.TimeDuration;
@@ -1300,7 +1301,7 @@ public class TestSnapshotDiffManager {
 
     spy.loadJobsOnStartUp();
 
-    // Wait for sometime to make sure that job finishes.
+    // Wait for sometime to make sure that job run.
     attempt(() ->
         verify(spy, atLeast(1))
             .generateSnapshotDiffReport(anyString(), anyString(),
@@ -1308,6 +1309,12 @@ public class TestSnapshotDiffManager {
                 eq(snapshotInfoList.get(1).getName()), eq(false),
                 eq(false)),
         10, TimeDuration.ONE_SECOND, null, null);
+
+    // Wait for the job to finish
+    LambdaTestUtils.await(5000, 1000, () -> {
+      SnapshotDiffJob job = getSnapshotDiffJobFromDb(snapshotInfo, snapshotInfoList.get(1));
+      return DONE.equals(job.getStatus());
+    });
 
     SnapshotDiffJob snapDiffJob = getSnapshotDiffJobFromDb(snapshotInfo,
         snapshotInfoList.get(1));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Around 1% of time following assert error occured :
Error:  org.apache.hadoop.ozone.om.snapshot.TestSnapshotDiffManager.testLoadJobsOnStartUp  Time elapsed: 0.035 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <DONE> but was: <IN_PROGRESS>

It takes time to put data into rocksDB after running `SnapshotDiffManager#generateSnapshotDiffReport`. Make changes to check the status of the job for several times over five seconds.

## What is the link to the Apache JIRA

[HDDS-10490](https://issues.apache.org/jira/browse/HDDS-10490)

## How was this patch tested?

Test 20*10 iterations befor the changes:
https://github.com/chungen0126/ozone/actions/runs/10268539273

Test 20*10 iterations after the changes:
https://github.com/chungen0126/ozone/actions/runs/10261085937
