### PR TITLE
HDDS-11239. Fix KeyOutputStream's exception handling when calling hsync concurrently

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ErrorInjector.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/ErrorInjector.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftClientReply;
+
+/**
+ * Client side error injector allowing simulating receiving errors from server side.
+ */
+@FunctionalInterface
+public interface ErrorInjector {
+  RaftClientReply getResponse(ContainerProtos.ContainerCommandRequestProto request, ClientId id, Pipeline pipeline);
+}

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientCreator.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientCreator.java
@@ -31,6 +31,12 @@ import java.io.IOException;
  * Factory for XceiverClientSpi implementations.  Client instances are not cached.
  */
 public class XceiverClientCreator implements XceiverClientFactory {
+  private static ErrorInjector errorInjector;
+
+  public static void enableErrorInjection(ErrorInjector injector) {
+    errorInjector = injector;
+  }
+
   private final ConfigurationSource conf;
   private final boolean topologyAwareRead;
   private final ClientTrustManager trustManager;
@@ -60,7 +66,7 @@ public class XceiverClientCreator implements XceiverClientFactory {
     XceiverClientSpi client;
     switch (pipeline.getType()) {
     case RATIS:
-      client = XceiverClientRatis.newXceiverClientRatis(pipeline, conf, trustManager);
+      client = XceiverClientRatis.newXceiverClientRatis(pipeline, conf, trustManager, errorInjector);
       break;
     case STAND_ALONE:
       client = new XceiverClientGrpc(pipeline, conf, trustManager);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -61,6 +61,13 @@ import org.slf4j.LoggerFactory;
 public class XceiverClientManager extends XceiverClientCreator {
   private static final Logger LOG =
       LoggerFactory.getLogger(XceiverClientManager.class);
+
+  private static ErrorInjector errorInjector;
+
+  public static void enableErrorInjection(ErrorInjector injector) {
+    errorInjector = injector;
+  }
+
   private final Cache<String, XceiverClientSpi> clientCache;
   private final CacheMetrics cacheMetrics;
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -62,12 +62,6 @@ public class XceiverClientManager extends XceiverClientCreator {
   private static final Logger LOG =
       LoggerFactory.getLogger(XceiverClientManager.class);
 
-  private static ErrorInjector errorInjector;
-
-  public static void enableErrorInjection(ErrorInjector injector) {
-    errorInjector = injector;
-  }
-
   private final Cache<String, XceiverClientSpi> clientCache;
   private final CacheMetrics cacheMetrics;
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -29,8 +29,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -102,7 +102,7 @@ public class BlockOutputStream extends OutputStream {
       = new AtomicReference<>();
 
   private final BlockData.Builder containerBlockData;
-  private XceiverClientFactory xceiverClientFactory;
+  private volatile XceiverClientFactory xceiverClientFactory;
   private XceiverClientSpi xceiverClient;
   private OzoneClientConfig config;
   private StreamBufferArgs streamBufferArgs;
@@ -815,7 +815,6 @@ public class BlockOutputStream extends OutputStream {
     if (isClosed()) {
       throw new IOException("BlockOutputStream has been closed.");
     } else if (getIoException() != null) {
-//      adjustBuffersOnException();
       throw getIoException();
     }
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -779,7 +779,7 @@ public class BlockOutputStream extends OutputStream {
   void cleanup() {
   }
 
-  public void cleanup(boolean invalidateClient) {
+  public synchronized void cleanup(boolean invalidateClient) {
     if (xceiverClientFactory != null) {
       xceiverClientFactory.releaseClient(xceiverClient, invalidateClient);
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -255,12 +255,6 @@ public class BlockOutputStream extends OutputStream {
     return true;
   }
 
-  synchronized void refreshCurrentBuffer() {
-    currentBuffer = bufferPool.getCurrentBuffer();
-    currentBufferRemaining =
-        currentBuffer != null ? currentBuffer.remaining() : 0;
-  }
-
   public BlockID getBlockID() {
     return blockID.get();
   }
@@ -420,7 +414,7 @@ public class BlockOutputStream extends OutputStream {
    * @throws IOException if error occurred
    */
 
-  // In this case, the data is already cached in the currentBuffer.
+  // In this case, the data is already cached in the allocated buffers in the BufferPool.
   public synchronized void writeOnRetry(long len) throws IOException {
     if (len == 0) {
       return;
@@ -438,18 +432,18 @@ public class BlockOutputStream extends OutputStream {
       count++;
       writtenDataLength += writeLen;
       updateWriteChunkLength();
-      LOG.info("Write chunk on retry buffer = {}", buffer);
-      writeChunk(buffer);
-      if (writtenDataLength == streamBufferArgs.getStreamBufferMaxSize()) {
-        handleFullBuffer();
+      updatePutBlockLength();
+      LOG.debug("Write chunk on retry buffer = {}", buffer);
+      CompletableFuture<PutBlockResult> f = writeChunkAndPutBlock(buffer, false);
+      CompletableFuture<Void> watchForCommitAsync = watchForCommitAsync(f);
+      try {
+        watchForCommitAsync.get();
+      } catch (InterruptedException e) {
+        handleInterruptedException(e, true);
+      } catch (ExecutionException e) {
+        handleExecutionException(e);
       }
     }
-
-    // flush all pending data due in exception handling.
-    updatePutBlockLength();
-    CompletableFuture<PutBlockResult> putBlockResultFuture = executePutBlock(false, false);
-    recordWatchForCommitAsync(putBlockResultFuture);
-    waitForAllPendingFlushes();
   }
 
   /**
@@ -471,14 +465,6 @@ public class BlockOutputStream extends OutputStream {
   }
 
   void releaseBuffersOnException() {
-  }
-
-  // It may happen that once the exception is encountered , we still might
-  // have successfully flushed up to a certain index. Make sure the buffers
-  // only contain data which have not been sufficiently replicated
-  private void adjustBuffersOnException() {
-    releaseBuffersOnException();
-    refreshCurrentBuffer();
   }
 
   /**
@@ -820,7 +806,7 @@ public class BlockOutputStream extends OutputStream {
     if (isClosed()) {
       throw new IOException("BlockOutputStream has been closed.");
     } else if (getIoException() != null) {
-      adjustBuffersOnException();
+//      adjustBuffersOnException();
       throw getIoException();
     }
   }
@@ -1157,7 +1143,6 @@ public class BlockOutputStream extends OutputStream {
    */
   private void handleExecutionException(Exception ex) throws IOException {
     setIoException(ex);
-    adjustBuffersOnException();
     throw getIoException();
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -421,7 +421,8 @@ public class BlockOutputStream extends OutputStream {
     }
     List<ChunkBuffer> allocatedBuffers = bufferPool.getAllocatedBuffers();
     if (LOG.isDebugEnabled()) {
-      LOG.debug("{}: Retrying write length {} for blockID {}, {} buffers", this, len, blockID, allocatedBuffers.size());
+      LOG.debug("{}: Retrying write length {} on target blockID {}, {} buffers", this, len, blockID,
+          allocatedBuffers.size());
     }
     Preconditions.checkArgument(len <= streamBufferArgs.getStreamBufferMaxSize());
     int count = 0;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -581,7 +581,10 @@ public class ContainerStateMachine extends BaseStateMachine {
     writeChunkFuture.thenApply(r -> {
       if (r.getResult() != ContainerProtos.Result.SUCCESS
           && r.getResult() != ContainerProtos.Result.CONTAINER_NOT_OPEN
-          && r.getResult() != ContainerProtos.Result.CLOSED_CONTAINER_IO) {
+          && r.getResult() != ContainerProtos.Result.CLOSED_CONTAINER_IO
+          // After concurrent flushes are allowed on the same key, chunk file inconsistencies can happen and
+          // that should now
+          && r.getResult() != ContainerProtos.Result.CHUNK_FILE_INCONSISTENCY) {
         StorageContainerException sce =
             new StorageContainerException(r.getMessage(), r.getResult());
         LOG.error(gid + ": writeChunk writeStateMachineData failed: blockId" +
@@ -1061,7 +1064,8 @@ public class ContainerStateMachine extends BaseStateMachine {
         // unhealthy
         if (r.getResult() != ContainerProtos.Result.SUCCESS
             && r.getResult() != ContainerProtos.Result.CONTAINER_NOT_OPEN
-            && r.getResult() != ContainerProtos.Result.CLOSED_CONTAINER_IO) {
+            && r.getResult() != ContainerProtos.Result.CLOSED_CONTAINER_IO
+            && r.getResult() != ContainerProtos.Result.CHUNK_FILE_INCONSISTENCY) {
           StorageContainerException sce =
               new StorageContainerException(r.getMessage(), r.getResult());
           LOG.error(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -583,7 +583,7 @@ public class ContainerStateMachine extends BaseStateMachine {
           && r.getResult() != ContainerProtos.Result.CONTAINER_NOT_OPEN
           && r.getResult() != ContainerProtos.Result.CLOSED_CONTAINER_IO
           // After concurrent flushes are allowed on the same key, chunk file inconsistencies can happen and
-          // that should now
+          // that should not crash the pipeline.
           && r.getResult() != ContainerProtos.Result.CHUNK_FILE_INCONSISTENCY) {
         StorageContainerException sce =
             new StorageContainerException(r.getMessage(), r.getResult());

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -75,7 +75,7 @@ public class BlockOutputStreamEntry extends OutputStream {
 
   /**
    * An indicator that this BlockOutputStream is created to handoff writes from another faulty BlockOutputStream.
-   * Once this flag is on, this BlockOutputStream can only handle writeOneRetry.
+   * Once this flag is on, this BlockOutputStream can only handle writeOnRetry.
    */
   private volatile boolean isHandlingRetry;
 
@@ -125,7 +125,7 @@ public class BlockOutputStreamEntry extends OutputStream {
   }
 
   /**
-   * Register when a call (write or flush) is finised on this block.
+   * Register when a call (write or flush) is finished on this block.
    * @return true if all the calls are done.
    */
   boolean registerCallFinished() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 public class BlockOutputStreamEntry extends OutputStream {
   public static final Logger LOG = LoggerFactory.getLogger(BlockOutputStreamEntry.class);
   private final OzoneClientConfig config;
-  private OutputStream outputStream;
+  private BlockOutputStream outputStream;
   private BlockID blockID;
   private final String key;
   private final XceiverClientFactory xceiverClientManager;
@@ -146,6 +146,10 @@ public class BlockOutputStreamEntry extends OutputStream {
     retryHandlingCond.signalAll();
   }
 
+  void waitForAllPendingFlushes() throws IOException {
+    outputStream.waitForAllPendingFlushes();
+  }
+
   /**
    * Creates the outputStreams that are necessary to start the write.
    * Implementors can override this to instantiate multiple streams instead.
@@ -188,6 +192,7 @@ public class BlockOutputStreamEntry extends OutputStream {
     BlockOutputStream out = (BlockOutputStream) getOutputStream();
     out.writeOnRetry(len);
     incCurrentPosition(len);
+    LOG.info("{}: Finish retrying with len {}, currentPosition {}", this, len, currentPosition);
   }
 
   @Override

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntryPool.java
@@ -37,7 +37,7 @@ public class ECBlockOutputStreamEntryPool extends BlockOutputStreamEntryPool {
   }
 
   @Override
-  ECBlockOutputStreamEntry createStreamEntry(OmKeyLocationInfo subKeyInfo) {
+  ECBlockOutputStreamEntry createStreamEntry(OmKeyLocationInfo subKeyInfo, boolean forRetry) {
     final ECBlockOutputStreamEntry.Builder b = new ECBlockOutputStreamEntry.Builder();
     b.setBlockID(subKeyInfo.getBlockID())
             .setKey(getKeyName())

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -315,7 +315,7 @@ public final class ECKeyOutputStream extends KeyOutputStream
 
   private void writeDataCells(ECChunkBuffers stripe) throws IOException {
     final ECBlockOutputStreamEntryPool blockOutputStreamEntryPool = getBlockOutputStreamEntryPool();
-    blockOutputStreamEntryPool.allocateBlockIfNeeded();
+    blockOutputStreamEntryPool.allocateBlockIfNeeded(false);
     ByteBuffer[] dataCells = stripe.getDataBuffers();
     for (int i = 0; i < numDataBlks; i++) {
       if (dataCells[i].limit() > 0) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -347,7 +347,7 @@ public class KeyOutputStream extends OutputStream
   private void handleExceptionInternal(BlockOutputStreamEntry streamEntry, IOException exception) throws IOException {
     try {
       // Wait for all pending flushes in the faulty stream. It's possible that a prior write is pending completion
-      // successfully. Errors are ignored here and will be handled by the individual flush call. We just wall to ensure
+      // successfully. Errors are ignored here and will be handled by the individual flush call. We just want to ensure
       // all the pending are complete before handling exception.
       streamEntry.waitForAllPendingFlushes();
     } catch (IOException ignored) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -119,8 +119,20 @@ public class KeyOutputStream extends OutputStream
   private final int maxConcurrentWritePerKey;
   private final KeyOutputStreamSemaphore keyOutputStreamSemaphore;
 
+  @VisibleForTesting
   KeyOutputStreamSemaphore getRequestSemaphore() {
     return keyOutputStreamSemaphore;
+  }
+
+  /** Required to spy the object in testing. */
+  @VisibleForTesting
+  @SuppressWarnings("unused")
+  KeyOutputStream() {
+    maxConcurrentWritePerKey = 0;
+    keyOutputStreamSemaphore = null;
+    blockOutputStreamEntryPool = null;
+    retryPolicyMap = null;
+    replication = null;
   }
 
   public KeyOutputStream(ReplicationConfig replicationConfig, BlockOutputStreamEntryPool blockOutputStreamEntryPool) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -95,7 +95,7 @@ public class KeyOutputStream extends OutputStream
   // how much of data is actually written yet to underlying stream
   private long offset;
   // how much data has been ingested into the stream
-  private long writeOffset;
+  private volatile long writeOffset;
   // whether an exception is encountered while write and whole write could
   // not succeed
   private boolean isException;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -345,6 +345,14 @@ public class KeyOutputStream extends OutputStream
    * @throws IOException Throws IOException if Write fails
    */
   private void handleExceptionInternal(BlockOutputStreamEntry streamEntry, IOException exception) throws IOException {
+    try {
+      // Wait for all pending flushes in the faulty stream. It's possible that a prior write is pending completion
+      // successfully. Errors are ignored here and will be handled by the individual flush call. We just wall to ensure
+      // all the pending are complete before handling exception.
+      streamEntry.waitForAllPendingFlushes();
+    } catch (IOException ignored) {
+    }
+
     Throwable t = HddsClientUtils.checkForException(exception);
     Preconditions.checkNotNull(t);
     boolean retryFailure = checkForRetryFailure(t);

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyOutputStream.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/io/TestKeyOutputStream.java
@@ -34,7 +34,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,7 +54,7 @@ public class TestKeyOutputStream {
   void testConcurrentWriteLimitOne() throws Exception {
     // Verify the semaphore is working to limit the number of concurrent writes allowed.
     KeyOutputStreamSemaphore sema1 = new KeyOutputStreamSemaphore(1);
-    KeyOutputStream keyOutputStream = mock(KeyOutputStream.class);
+    KeyOutputStream keyOutputStream = spy(KeyOutputStream.class);
     when(keyOutputStream.getRequestSemaphore()).thenReturn(sema1);
 
     final AtomicInteger countWrite = new AtomicInteger(0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -45,6 +45,9 @@ import org.apache.hadoop.crypto.Encryptor;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.scm.ErrorInjector;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.hdds.scm.storage.BufferPool;
 import org.apache.hadoop.hdds.utils.IOUtils;
@@ -95,6 +98,11 @@ import org.apache.hadoop.ozone.om.service.OpenKeyCleanupService;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.Message;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeerId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -696,6 +704,99 @@ public class TestHSync {
         return false;
       }
     }, 500, 3000);
+  }
+
+
+  public static Stream<Arguments> concurrentExceptionHandling() {
+    return Stream.of(
+        Arguments.of(2, 1),
+        Arguments.of(4, 4),
+        Arguments.of(8, 4)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("concurrentExceptionHandling")
+  public void testConcurrentExceptionHandling(int syncerThreads, int errors) throws Exception {
+    final String rootPath = String.format("%s://%s/", OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));
+    CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    ErrorInjectorImpl errorInjector = new ErrorInjectorImpl();
+    XceiverClientManager.enableErrorInjection(errorInjector);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName() + OZONE_URI_DELIMITER + bucket.getName();
+
+    try (FileSystem fs = FileSystem.get(CONF)) {
+      final Path file = new Path(dir, "exceptionhandling");
+      byte[] data = new byte[8];
+      ThreadLocalRandom.current().nextBytes(data);
+      int writes;
+      try (FSDataOutputStream out = fs.create(file, true)) {
+        writes = runConcurrentWriteHSyncWithException(file, out, data, syncerThreads, errors, errorInjector);
+      }
+      validateWrittenFile(file, fs, data, writes);
+      fs.delete(file, false);
+    }
+  }
+
+  private int runConcurrentWriteHSyncWithException(Path file,
+      final FSDataOutputStream out, byte[] data, int syncThreadsCount, int errors,
+      ErrorInjectorImpl errorInjector) throws Exception {
+
+    AtomicReference<Exception> writerException = new AtomicReference<>();
+    AtomicReference<Exception> syncerException = new AtomicReference<>();
+
+    LOG.info("runConcurrentWriteHSyncWithException {} with size {}", file, data.length);
+    AtomicInteger writes = new AtomicInteger();
+    final long start = Time.monotonicNow();
+
+    Runnable syncer = () -> {
+      while ((Time.monotonicNow() - start < 10000)) {
+        try {
+          out.write(data);
+          writes.incrementAndGet();
+          out.hsync();
+        } catch (Exception e) {
+          LOG.error("Error calling hsync", e);
+          syncerException.compareAndSet(null, e);
+          throw new RuntimeException(e);
+        }
+      }
+    };
+
+    Thread[] syncThreads = new Thread[syncThreadsCount];
+    for (int i = 0; i < syncThreadsCount; i++) {
+      syncThreads[i] = new Thread(syncer);
+      syncThreads[i].setName("Syncer-" + i);
+      syncThreads[i].start();
+    }
+
+    // Inject error at 3rd second.
+    Runnable startErrorInjector = () -> {
+      while ((Time.monotonicNow() - start <= 3000)) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      errorInjector.start(errors);
+      LOG.info("Enabled error injection in XceiverClientRatis");
+    };
+
+    new Thread(startErrorInjector).start();
+
+    for (Thread sync : syncThreads) {
+      sync.join();
+    }
+
+    if (syncerException.get() != null) {
+      throw syncerException.get();
+    }
+    if (writerException.get() != null) {
+      throw writerException.get();
+    }
+    return writes.get();
   }
 
   private int runConcurrentWriteHSync(Path file,
@@ -1319,5 +1420,34 @@ public class TestHSync {
       }
     }
     return keys;
+  }
+
+  private static class ErrorInjectorImpl implements ErrorInjector {
+    private final AtomicInteger remaining = new AtomicInteger();
+    void start(int count) {
+      remaining.set(count);
+    }
+    @Override
+    public RaftClientReply getResponse(ContainerProtos.ContainerCommandRequestProto request, ClientId clientId,
+        Pipeline pipeline) {
+      int errorNum = remaining.decrementAndGet();
+      if (errorNum >= 0) {
+        ContainerProtos.ContainerCommandResponseProto proto = ContainerProtos.ContainerCommandResponseProto.newBuilder()
+            .setResult(ContainerProtos.Result.CLOSED_CONTAINER_IO)
+            .setMessage("Simulated error #" + errorNum)
+            .setCmdType(request.getCmdType())
+            .build();
+        RaftClientReply reply = RaftClientReply.newBuilder()
+            .setSuccess(true)
+            .setMessage(Message.valueOf(proto.toByteString()))
+            .setClientId(clientId)
+            .setServerId(RaftPeerId.getRaftPeerId(pipeline.getLeaderId().toString()))
+            .setGroupId(RaftGroupId.randomId())
+            .build();
+        return reply;
+      }
+
+      return null;
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -526,6 +526,7 @@ public class TestHSync {
 
   @Test
   public void testUncommittedBlocks() throws Exception {
+    waitForEmptyDeletedTable();
     // Set the fs.defaultFS
     final String rootPath = String.format("%s://%s/",
         OZONE_OFS_URI_SCHEME, CONF.get(OZONE_OM_ADDRESS_KEY));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -709,7 +709,7 @@ public class TestHSync {
 
   public static Stream<Arguments> concurrentExceptionHandling() {
     return Stream.of(
-        Arguments.of(2, 1),
+        Arguments.of(4, 1),
         Arguments.of(4, 4),
         Arguments.of(8, 4)
     );


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a block (or `BlockOutputStream`, I'll use them interchangeably in this description) becomes faulty (any exception happens when sending requests to the pipeline), `KeyOutputStream` will allocate a new Block (as the current block), and hand off all pending changes in the `BufferPool` to the current block. This is done by `KeyOutputStream`'s `handleException`.

Two essential changes are needed when allowing KeyOutputStream to be used by multiple threads concurrently.

1. When hsync is called concurrently, `handleException` can be called multiple times for a given block. This is different from when `KeyOutputStream` is fully synchronized.  The second `handleException` on a block call will see the block has been closed already and some assertion that is true in full synchronization is no longer stand. 
<img width="871" alt="Screenshot 2024-08-08 at 9 53 23 AM" src="https://github.com/user-attachments/assets/f1e225e6-c52f-4d6f-8307-1b64863d4e7d">
2. When the first thread finishes calling handleException, it can continue sending normal writes/hsync to the KeyOutputStream while exception handling may be still going on for other threads. These calls will mess up with the ongoing exception handling. 
<img width="942" alt="Screenshot 2024-08-08 at 10 48 54 AM" src="https://github.com/user-attachments/assets/7942b022-2fbc-47f0-9274-5fcf9bf5d24f">
We need to isolate the current block if it's handling retry handoff. When a block is created to handle retry, it must block all the normal calls (write and hsync) until the last (faulty) block finishes the handoff.



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11239

## How was this patch tested?

New tests were added to verify the failure and the fix: TestHSync#testConcurrentExceptionHandling

Before fix: https://github.com/duongkame/ozone/actions/runs/10308913291
After fix: 
 run 1: 20 x 1 https://github.com/duongkame/ozone/actions/runs/10427687646
 run 2: 10x 10 https://github.com/duongkame/ozone/actions/runs/10428271747

Regression test on normal concurrent hsync: https://github.com/duongkame/ozone/actions/runs/10428273927