### PR TITLE
HDDS-11288. Add tests for quota level boundary conditions

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -121,7 +121,7 @@ Test ozone shell errors
     ${result} =     Execute and checkrc    ozone sh key put ${volume}/bucket1/key1 /opt/hadoop/NOTICE.txt                   255
                     Should contain      ${result}       QUOTA_EXCEEDED
     ${result} =     Execute and checkrc    ozone sh volume setquota ${volume} --space-quota 1KB                             255
-                    Should contain      ${result}       QUOTA_ERROR
+                    Should contain      ${result}       QUOTA_EXCEEDED
                     Execute and checkrc    ozone sh bucket clrquota ${volume}/bucket1 --space-quota                         0
     ${result} =     Execute and checkrc    ozone sh volume setquota ${volume} --space-quota 1GB                             255
                     Should contain      ${result}       QUOTA_ERROR

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -101,7 +101,7 @@ Test ozone shell errors
                     Should contain      ${result}       INVALID_BUCKET_NAME
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1 --space-quota 1.5GB    255
                     Should contain      ${result}       1.5GB is invalid
-    ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1 --namespace-quota 1.5GB    255
+    ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1 --namespace-quota 1.5    255
                     Should contain      ${result}       1.5 is invalid
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1 --layout Invalid   2
                     Should contain      ${result}       Usage

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -92,18 +92,43 @@ Test ozone shell
 
 Test ozone shell errors
     [arguments]     ${protocol}         ${server}       ${volume}
-    ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --space-quota invalid      255
-                    Should contain      ${result}       invalid
+    ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --space-quota 1.5GB      255
+                    Should contain      ${result}       1.5GB is invalid
+    ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --namespace-quota 1.5      255
+                    Should contain      ${result}       1.5 is invalid
                     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume}                            0
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket_1                   255
                     Should contain      ${result}       INVALID_BUCKET_NAME
+    ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1 --space-quota 1.5GB    255
+                    Should contain      ${result}       1.5GB is invalid
+    ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1 --namespace-quota 1.5GB    255
+                    Should contain      ${result}       1.5 is invalid
     ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1 --layout Invalid   2
                     Should contain      ${result}       Usage
                     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    0
     ${result} =     Execute and checkrc    ozone sh key info ${protocol}${server}/${volume}/bucket1/non-existing           255
                     Should contain      ${result}       KEY_NOT_FOUND
     ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 unexisting --type invalid    2
+    ${result} =     Execute and checkrc    ozone sh bucket setquota ${volume}/bucket1 --space-quota 1.5                     255
+                    Should contain      ${result}       1.5 is invalid
+    ${result} =     Execute and checkrc    ozone sh bucket setquota ${volume}/bucket1 --namespace-quota 1.5                 255
+                    Should contain      ${result}       1.5 is invalid
+    ${result} =     Execute and checkrc    ozone sh volume setquota ${volume} --space-quota 1.5                             255
+                    Should contain      ${result}       1.5 is invalid
+    ${result} =     Execute and checkrc    ozone sh volume setquota ${volume} --namespace-quota 1.5                         255
+                    Should contain      ${result}       1.5 is invalid
+                    Execute and checkrc    ozone sh bucket setquota ${volume}/bucket1 --space-quota 2KB                     0
+    ${result} =     Execute and checkrc    ozone sh key put ${volume}/bucket1/key1 /opt/hadoop/NOTICE.txt                   255
+                    Should contain      ${result}       QUOTA_EXCEEDED
+    ${result} =     Execute and checkrc    ozone sh volume setquota ${volume} --space-quota 1KB                             255
+                    Should contain      ${result}       QUOTA_ERROR
+                    Execute and checkrc    ozone sh bucket clrquota ${volume}/bucket1 --space-quota                         0
+    ${result} =     Execute and checkrc    ozone sh volume setquota ${volume} --space-quota 1GB                             255
+                    Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh bucket delete ${protocol}${server}/${volume}/bucket1                    0
+                    Execute and checkrc    ozone sh volume setquota ${volume} --space-quota 1GB                             0
+    ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    255
+                    Should contain      ${result}       QUOTA_ERROR
                     Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -1568,6 +1568,39 @@ public class TestOzoneShellHA {
         .contains("Missing required parameter");
     out.reset();
 
+    // Test incompatible volume-bucket quota
+    args = new String[]{"volume", "create", "vol6"};
+    execute(ozoneShell, args);
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol6/buck6"};
+    execute(ozoneShell, args);
+    out.reset();
+
+    args = new String[]{"volume", "setquota", "vol6", "--space-quota", "1000B"};
+    executeWithError(ozoneShell, args, "Can not set volume space quota " +
+        "on volume as some of buckets in this volume have no quota set");
+    out.reset();
+
+    args = new String[]{"bucket", "setquota", "vol6/buck6", "--space-quota", "1000B"};
+    execute(ozoneShell, args);
+    out.reset();
+
+    args = new String[]{"volume", "setquota", "vol6", "--space-quota", "2000B"};
+    execute(ozoneShell, args);
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol6/buck62"};
+    executeWithError(ozoneShell, args, "Bucket space quota in this " +
+        "volume should be set as volume space quota is already set.");
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol6/buck62", "--space-quota", "2000B"};
+    executeWithError(ozoneShell, args, "Total buckets quota in this volume " +
+        "should not be greater than volume quota : the total space quota is set to:3000. " +
+        "But the volume space quota is:2000");
+    out.reset();
+
     // Test set bucket spaceQuota or nameSpaceQuota to normal value.
     String[] bucketArgs8 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "1000B"};


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added tests for quota level boundary conditions
Tests added -
1. `hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java` - `testShQuota`
2. `hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot` - `Test ozone shell errors`
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11288

## How was this patch tested?

```
mvn -l testlog.out -Dtest=TestOzoneShellHA#testShQuota test
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.shell.TestOzoneShellHA
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 66.925 s - in org.apache.hadoop.ozone.shell.TestOzoneShellHA
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```
