### PR TITLE
HDDS-11302. Wrapper configurations to increase ipc.server.read.threadpool.size for SCM and Datanode

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -367,6 +367,9 @@ public final class HddsConfigKeys {
   public static final String HDDS_DATANODE_HANDLER_COUNT_KEY =
       "hdds.datanode.handler.count";
   public static final int HDDS_DATANODE_HANDLER_COUNT_DEFAULT = 10;
+  public static final String HDDS_DATANODE_READ_THREADPOOL_KEY =
+      "hdds.datanode.read.threadpool";
+  public static final int HDDS_DATANODE_READ_THREADPOOL_DEFAULT = 10;
   public static final String HDDS_DATANODE_HTTP_BIND_HOST_DEFAULT = "0.0.0.0";
   public static final int HDDS_DATANODE_HTTP_BIND_PORT_DEFAULT = 9882;
   public static final int HDDS_DATANODE_HTTPS_BIND_PORT_DEFAULT = 9883;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -228,15 +228,27 @@ public final class ScmConfigKeys {
       "ozone.scm.handler.count.key";
   public static final String OZONE_SCM_CLIENT_HANDLER_COUNT_KEY =
       "ozone.scm.client.handler.count.key";
+  public static final String OZONE_SCM_CLIENT_READ_THREADPOOL_KEY =
+      "ozone.scm.client.read.threadpool";
+  public static final int OZONE_SCM_CLIENT_READ_THREADPOOL_DEFAULT = 10;
   public static final String OZONE_SCM_BLOCK_HANDLER_COUNT_KEY =
       "ozone.scm.block.handler.count.key";
+  public static final String OZONE_SCM_BLOCK_READ_THREADPOOL_KEY =
+      "ozone.scm.block.read.threadpool";
+  public static final int OZONE_SCM_BLOCK_READ_THREADPOOL_DEFAULT = 10;
   public static final String OZONE_SCM_DATANODE_HANDLER_COUNT_KEY =
       "ozone.scm.datanode.handler.count.key";
+  public static final String OZONE_SCM_DATANODE_READ_THREADPOOL_KEY =
+      "ozone.scm.datanode.read.threadpool";
+  public static final int OZONE_SCM_DATANODE_READ_THREADPOOL_DEFAULT = 10;
   public static final int OZONE_SCM_HANDLER_COUNT_DEFAULT = 100;
 
   public static final String OZONE_SCM_SECURITY_HANDLER_COUNT_KEY =
       "ozone.scm.security.handler.count.key";
   public static final int OZONE_SCM_SECURITY_HANDLER_COUNT_DEFAULT = 2;
+  public static final String OZONE_SCM_SECURITY_READ_THREADPOOL_KEY =
+      "ozone.scm.security.read.threadpool";
+  public static final int OZONE_SCM_SECURITY_READ_THREADPOOL_DEFAULT = 1;
 
   public static final String OZONE_SCM_DEADNODE_INTERVAL =
       "ozone.scm.dead.node.interval";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1141,6 +1141,36 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.client.read.threadpool</name>
+    <value>10</value>
+    <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
+    <description>
+      The number of threads in RPC server reading from the socket used by Client to access SCM.
+      This config overrides Hadoop configuration "ipc.server.read.threadpool.size" for SCMClientProtocolServer.
+      The default value is 10.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.block.read.threadpool</name>
+    <value>10</value>
+    <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
+    <description>
+      The number of threads in RPC server reading from the socket when accessing blocks.
+      This config overrides Hadoop configuration "ipc.server.read.threadpool.size" for SCMBlockProtocolServer.
+      The default value is 10.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.datanode.read.threadpool</name>
+    <value>10</value>
+    <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
+    <description>
+      The number of threads in RPC server reading from the socket used by DataNode to access SCM.
+      This config overrides Hadoop configuration "ipc.server.read.threadpool.size" for SCMDatanodeProtocolServer.
+      The default value is 10.
+    </description>
+  </property>
+  <property>
     <name>hdds.heartbeat.interval</name>
     <value>30s</value>
     <tag>OZONE, MANAGEMENT</tag>
@@ -2494,6 +2524,16 @@
     <description>Threads configured for SCMSecurityProtocolServer.</description>
   </property>
   <property>
+    <name>ozone.scm.security.read.threadpool</name>
+    <value>1</value>
+    <tag>OZONE, HDDS, SECURITY, PERFORMANCE</tag>
+    <description>
+      The number of threads in RPC server reading from the socket when performing security related operations with SCM.
+      This config overrides Hadoop configuration "ipc.server.read.threadpool.size" for SCMSecurityProtocolServer.
+      The default value is 1.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.security.service.address</name>
     <value/>
     <tag>OZONE, HDDS, SECURITY</tag>
@@ -2933,6 +2973,16 @@
     <description>
       The number of RPC handler threads for Datanode client
       service endpoints.
+    </description>
+  </property>
+  <property>
+    <name>hdds.datanode.read.threadpool</name>
+    <value>10</value>
+    <tag>OZONE, HDDS, PERFORMANCE</tag>
+    <description>
+      The number of threads in RPC server reading from the socket for Datanode client service endpoints.
+      This config overrides Hadoop configuration "ipc.server.read.threadpool.size" for HddsDatanodeClientProtocolServer.
+      The default value is 10.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -73,6 +73,8 @@ import com.google.protobuf.ProtocolMessageEnum;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_READ_THREADPOOL_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_READ_THREADPOOL_DEFAULT;
 import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.IO_EXCEPTION;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.NODE_COST_DEFAULT;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT;
@@ -117,6 +119,8 @@ public class SCMBlockProtocolServer implements
     final int handlerCount = conf.getInt(OZONE_SCM_BLOCK_HANDLER_COUNT_KEY,
         OZONE_SCM_HANDLER_COUNT_KEY, OZONE_SCM_HANDLER_COUNT_DEFAULT,
             LOG::info);
+    final int readThreads = conf.getInt(OZONE_SCM_BLOCK_READ_THREADPOOL_KEY,
+        OZONE_SCM_BLOCK_READ_THREADPOOL_DEFAULT);
 
     RPC.setProtocolEngine(conf, ScmBlockLocationProtocolPB.class,
         ProtobufRpcEngine.class);
@@ -142,7 +146,8 @@ public class SCMBlockProtocolServer implements
             scmBlockAddress,
             ScmBlockLocationProtocolPB.class,
             blockProtoPbService,
-            handlerCount);
+            handlerCount,
+            readThreads);
     blockRpcAddress =
         updateRPCListenAddress(
             conf, scm.getScmNodeDetails().getBlockProtocolServerAddressKey(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -120,6 +120,8 @@ import static org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProt
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_READ_THREADPOOL_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_READ_THREADPOOL_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmUtils.checkIfCertSignRequestAllowed;
 import static org.apache.hadoop.hdds.scm.ha.HASecurityUtils.createSCMRatisTLSConfig;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer;
@@ -150,6 +152,8 @@ public class SCMClientProtocolServer implements
     final int handlerCount = conf.getInt(OZONE_SCM_CLIENT_HANDLER_COUNT_KEY,
         OZONE_SCM_HANDLER_COUNT_KEY, OZONE_SCM_HANDLER_COUNT_DEFAULT,
             LOG::info);
+    final int readThreads = conf.getInt(OZONE_SCM_CLIENT_READ_THREADPOOL_KEY,
+        OZONE_SCM_CLIENT_READ_THREADPOOL_DEFAULT);
     RPC.setProtocolEngine(conf, StorageContainerLocationProtocolPB.class,
         ProtobufRpcEngine.class);
 
@@ -173,7 +177,8 @@ public class SCMClientProtocolServer implements
             scmAddress,
             StorageContainerLocationProtocolPB.class,
             storageProtoPbService,
-            handlerCount);
+            handlerCount,
+            readThreads);
 
     // Add reconfigureProtocolService.
     ReconfigureProtocolServerSideTranslatorPB reconfigureServerProtocol

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -102,6 +102,8 @@ import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProt
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_READ_THREADPOOL_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_READ_THREADPOOL_DEFAULT;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CONTAINER_REPORT;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.PIPELINE_REPORT;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer;
@@ -161,6 +163,8 @@ public class SCMDatanodeProtocolServer implements
     final int handlerCount = conf.getInt(OZONE_SCM_DATANODE_HANDLER_COUNT_KEY,
         OZONE_SCM_HANDLER_COUNT_KEY, OZONE_SCM_HANDLER_COUNT_DEFAULT,
             LOG::info);
+    final int readThreads = conf.getInt(OZONE_SCM_DATANODE_READ_THREADPOOL_KEY,
+        OZONE_SCM_DATANODE_READ_THREADPOOL_DEFAULT);
 
     RPC.setProtocolEngine(conf, getProtocolClass(), ProtobufRpcEngine.class);
 
@@ -176,7 +180,8 @@ public class SCMDatanodeProtocolServer implements
         datanodeRpcAddr,
         getProtocolClass(),
         dnProtoPbService,
-        handlerCount);
+        handlerCount,
+        readThreads);
 
     datanodeRpcAddress = updateRPCListenAddress(
             conf, getDatanodeAddressKey(), datanodeRpcAddr,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -129,6 +129,8 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
     final int handlerCount =
         conf.getInt(ScmConfigKeys.OZONE_SCM_SECURITY_HANDLER_COUNT_KEY,
             ScmConfigKeys.OZONE_SCM_SECURITY_HANDLER_COUNT_DEFAULT);
+    final int readThreads = conf.getInt(ScmConfigKeys.OZONE_SCM_SECURITY_READ_THREADPOOL_KEY,
+        ScmConfigKeys.OZONE_SCM_SECURITY_READ_THREADPOOL_DEFAULT);
     rpcAddress = HddsServerUtil
         .getScmSecurityInetAddress(conf);
     // SCM security service RPC service.
@@ -157,7 +159,8 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
             rpcAddress,
             SCMSecurityProtocolPB.class,
             secureProtoPbService,
-            handlerCount);
+            handlerCount,
+            readThreads);
     HddsServerUtil.addPBProtocol(conf, SecretKeyProtocolDatanodePB.class,
         secretKeyService, rpcServer);
     HddsServerUtil.addPBProtocol(conf, SecretKeyProtocolOmPB.class,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1103,7 +1103,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       InetSocketAddress addr,
       Class<?> protocol,
       BlockingService instance,
-      int handlerCount)
+      int handlerCount,
+      int readThreads)
       throws IOException {
 
     RPC.Server rpcServer = preserveThreadName(() -> new RPC.Builder(conf)
@@ -1112,6 +1113,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         .setBindAddress(addr.getHostString())
         .setPort(addr.getPort())
         .setNumHandlers(handlerCount)
+        .setNumReaders(readThreads)
         .setVerbose(false)
         .setSecretManager(null)
         .build());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce newer Ozone wrapper configurations for increasing the `ipc.server.read.threadpool.size` from the default value of **1** to **10** for both SCM and Datanode RPC Servers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11302

## How was this patch tested?

Existing unit and integration tests should cover the changes (no functional change).