### PR TITLE
HDDS-11303. Bump up hdds.container.ratis configurations

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -54,7 +54,7 @@ public final class ScmConfigKeys {
       = "hdds.container.ratis.num.write.chunk.threads.per.volume";
   public static final int
       HDDS_CONTAINER_RATIS_NUM_WRITE_CHUNK_THREADS_PER_VOLUME_DEFAULT
-      = 10;
+      = 20;
   public static final String HDDS_CONTAINER_RATIS_REPLICATION_LEVEL_KEY
       = "hdds.container.ratis.replication.level";
   public static final ReplicationLevel
@@ -62,7 +62,7 @@ public final class ScmConfigKeys {
   public static final String HDDS_CONTAINER_RATIS_NUM_CONTAINER_OP_EXECUTORS_KEY
       = "hdds.container.ratis.num.container.op.executors";
   public static final int HDDS_CONTAINER_RATIS_NUM_CONTAINER_OP_EXECUTORS_DEFAULT
-      = 10;
+      = 20;
   public static final String HDDS_CONTAINER_RATIS_SEGMENT_SIZE_KEY =
       "hdds.container.ratis.segment.size";
   public static final String HDDS_CONTAINER_RATIS_SEGMENT_SIZE_DEFAULT =
@@ -113,7 +113,7 @@ public final class ScmConfigKeys {
   public static final String HDDS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT =
       "hdds.container.ratis.leader.pending.bytes.limit";
   public static final String
-      HDDS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT = "1GB";
+      HDDS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT = "4GB";
 
   public static final String HDDS_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DURATION_KEY =
       "hdds.ratis.server.retry-cache.timeout.duration";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -289,7 +289,7 @@
   </property>
   <property>
     <name>hdds.container.ratis.num.write.chunk.threads.per.volume</name>
-    <value>10</value>
+    <value>20</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>
     <description>Maximum number of threads in the thread pool that Datanode
       will use for writing replicated chunks.
@@ -300,7 +300,7 @@
   <property>
     <name>hdds.container.ratis.leader.pending.bytes.limit
 </name>
-    <value>1GB</value>
+    <value>4GB</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>
     <description>Limit on the total bytes of pending requests after which
       leader starts rejecting requests from client.
@@ -317,7 +317,7 @@
   </property>
   <property>
     <name>hdds.container.ratis.num.container.op.executors</name>
-    <value>10</value>
+    <value>20</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>
     <description>Number of executors that will be used by Ratis to execute
       container ops.(10 by default).


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump up the following configuration defaults:

- `hdds.container.ratis.num.write.chunk.threads.per.volume` to 20 (default: 10)
- `hdds.container.ratis.leader.pending.bytes.limit` to 4 GB (default: 1 GB)
- `hdds.container.ratis.num.container.op.executors` to 20 (default: 10)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11303

## How was this patch tested?

Existing unit and integration tests should cover the changes (no functional change).
