### PR TITLE
HDDS-11279. Add direct dependencies in hadoop-ozone

### DIFF
--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -33,16 +33,70 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-erasurecode</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-interface-client</artifactId>
+    </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-thirdparty-misc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -63,19 +63,103 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-interface-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-proto</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-thirdparty-misc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
 
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
     <!-- Test dependencies -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-inprocess</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -34,6 +34,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
       <version>${grpc.protobuf-compile.version}</version>
@@ -71,6 +75,15 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hdds-server-framework</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
@@ -89,6 +102,14 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -113,7 +134,21 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -132,6 +167,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -42,6 +42,14 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-server-framework</artifactId>
     </dependency>
     <dependency>
@@ -85,6 +93,10 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>ch.qos.reload4j</groupId>
@@ -139,12 +151,28 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>hk2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -33,6 +33,26 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-container-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-admin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-manager</artifactId>
     </dependency>
     <dependency>
@@ -53,11 +73,27 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-server-framework</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-tools</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -239,6 +239,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-server</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
     </dependency>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -34,12 +34,32 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-interface-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop.thirdparty</groupId>
+      <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -33,9 +33,30 @@
 
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>rocksdb-checkpoint-differ</artifactId>
+    </dependency>
 
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -32,6 +32,35 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-annotation-processing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-managed-rocksdb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-interface-client</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.aspectj</groupId>
@@ -86,13 +115,88 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerby-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-grpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-netty</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-proto</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-server-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-thirdparty-misc</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
     </dependency>
 
     <dependency>
@@ -101,8 +205,40 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
 
     <!-- Overrider ranger-intg jackson version -->
@@ -134,7 +270,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <dependency>
       <groupId>org.apache.ranger</groupId>
-      <artifactId>ranger-intg</artifactId>
+      <artifactId>ranger-plugins-common</artifactId>
       <version>${ranger.version}</version>
       <scope>compile</scope>
       <!-- Workaround to prevent slf4j binding conflicts until ranger-intg is
@@ -199,8 +335,38 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.ranger</groupId>
+      <artifactId>ranger-intg</artifactId>
+      <version>${ranger.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-rocks-native</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -45,7 +45,19 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-hadoop-dependency-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
@@ -58,6 +70,45 @@
     <dependency>
       <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -75,11 +75,45 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-filesystem-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -140,6 +140,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-annotation-processing</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
         <artifactId>hdds-config</artifactId>
         <version>${hdds.version}</version>
       </dependency>
@@ -150,7 +155,22 @@
       </dependency>
       <dependency>
         <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-interface-admin</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
         <artifactId>hdds-interface-client</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-interface-server</artifactId>
+        <version>${hdds.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ozone</groupId>
+        <artifactId>hdds-managed-rocksdb</artifactId>
         <version>${hdds.version}</version>
       </dependency>
       <dependency>

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -30,15 +30,33 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jooq</groupId>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -240,7 +240,43 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-container-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-managed-rocksdb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-server-framework</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-interface-storage</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
@@ -272,6 +308,48 @@
       <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-server-scm</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-proto</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>aopalliance</groupId>
+      <artifactId>aopalliance</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
@@ -285,8 +363,16 @@
       <artifactId>guice-servlet</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
@@ -295,6 +381,14 @@
     <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>guice-bridge</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2.external</groupId>
+      <artifactId>jakarta.inject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
@@ -333,16 +427,72 @@
       <artifactId>derby</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>

--- a/hadoop-ozone/s3-secret-store/pom.xml
+++ b/hadoop-ozone/s3-secret-store/pom.xml
@@ -47,6 +47,14 @@
       <groupId>com.bettercloud</groupId>
       <artifactId>vault-java-driver</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -33,8 +33,28 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-common</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-interface-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>
@@ -45,12 +65,53 @@
       <artifactId>hdds-server-framework</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kerby</groupId>
+      <artifactId>kerby-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.weld.servlet</groupId>
       <artifactId>weld-servlet-shaded</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.ext.cdi</groupId>
@@ -69,6 +130,14 @@
       <artifactId>hk2-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>
@@ -77,8 +146,28 @@
       <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
@@ -91,6 +180,10 @@
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -117,6 +210,18 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -31,6 +31,42 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-container-service</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-admin</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-interface-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-managed-rocksdb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-server-scm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-manager</artifactId>
     </dependency>
     <dependency>
@@ -47,7 +83,19 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-filesystem-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-filesystem</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-interface-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-interface-storage</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
@@ -69,12 +117,65 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-proto</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-server-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-thirdparty-misc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-tools</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.activation</groupId>
@@ -85,6 +186,14 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
     </dependency>
@@ -93,8 +202,40 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>aws-java-sdk-s3</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jooq</groupId>
+      <artifactId>jooq</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -201,9 +201,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <stax2.version>4.2.2</stax2.version>
     <jakarta.inject.version>2.6.1</jakarta.inject.version>
     <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
+    <jakarta.validation.version>2.0.2</jakarta.validation.version>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
+    <javax.inject.version>1</javax.inject.version>
     <joda.time.version>2.12.7</joda.time.version>
 
+    <aopalliance.version>1.0</aopalliance.version>
     <compile-testing.version>0.21.0</compile-testing.version>
     <errorprone-annotations.version>2.29.2</errorprone-annotations.version>
     <guava.version>32.1.3-jre</guava.version>
@@ -413,6 +416,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <type>test-jar</type>
       </dependency>
       <dependency>
+        <groupId>aopalliance</groupId>
+        <artifactId>aopalliance</artifactId>
+        <version>${aopalliance.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
@@ -469,6 +477,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>${kerby.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerby-util</artifactId>
+        <version>${kerby.version}</version>
+      </dependency>
+      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
@@ -512,6 +525,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
         <version>${cdi-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>${javax.inject.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
@@ -599,6 +617,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>jersey-container-servlet-core</artifactId>
+        <version>${jersey2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-common</artifactId>
         <version>${jersey2.version}</version>
       </dependency>
       <dependency>
@@ -937,7 +960,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>spring-jdbc</artifactId>
+        <artifactId>spring-core</artifactId>
         <version>${spring.version}</version>
         <exclusions>
           <exclusion>
@@ -945,6 +968,16 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <artifactId>spring-jcl</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-jdbc</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-tx</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
@@ -1047,6 +1080,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>io.opentracing</groupId>
         <artifactId>opentracing-api</artifactId>
+        <version>${opentracing.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-noop</artifactId>
         <version>${opentracing.version}</version>
       </dependency>
       <dependency>
@@ -1207,6 +1245,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>jakarta.annotation</groupId>
         <artifactId>jakarta.annotation-api</artifactId>
         <version>${jakarta.annotation.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>${jakarta.validation.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.ws.rs</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to #7029, for `hadoop-ozone` instead of `hadoop-hdds`.

Add direct dependency for modules used in `hadoop-ozone`, instead of relying on transitive dependencies for the same.  (Except "test-only" modules `integration-test` and `mini-chaos-test`, to avoid too big patch.)

This should get rid of most items under `Used undeclared dependencies` part of dependency analysis.

Exceptions:

- Test dependencies declared in `hdds-test-utils` and `hdds-hadoop-dependency-test` for convenience.
- Hadoop dependencies declared in `hdds-hadoop-dependency-client` and `hdds-hadoop-dependency-server` for convenience.
- `commons-lang` (v2) not added, because it will be replaced with v3 (HDDS-11305).

https://issues.apache.org/jira/browse/HDDS-11279

## How was this patch tested?

Compared output of `mvn dependency:analyze` before/after the change.

(Some dependencies (e.g. `assertj-core`, `junit-jupiter-params`) appear as new under `Used undeclared`, but it's only due to change in order of dependencies in plugin's output.

```diff
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-interface-client ---
-[WARNING] Used undeclared dependencies found:
-[WARNING]    io.grpc:grpc-api:jar:1.58.0:compile
-[WARNING]    org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:jar:1.1.1:compile
-[WARNING]    com.google.guava:guava:jar:32.1.3-jre:compile
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-common ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    io.netty:netty-handler:jar:4.1.109.Final:compile
-[WARNING]    org.apache.ratis:ratis-thirdparty-misc:jar:1.0.6:compile
-[WARNING]    io.grpc:grpc-api:jar:1.58.0:compile
-[WARNING]    io.grpc:grpc-inprocess:jar:1.58.0:test
-[WARNING]    com.google.protobuf:protobuf-java:jar:2.5.0:compile
-[WARNING]    org.assertj:assertj-core:jar:3.26.3:test
-[WARNING]    org.apache.httpcomponents:httpcore:jar:4.4.16:compile
-[WARNING]    org.apache.ratis:ratis-common:jar:3.1.0:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
-[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
-[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
-[WARNING]    org.apache.ozone:hdds-interface-client:jar:1.5.0-SNAPSHOT:compile
 [WARNING]    org.mockito:mockito-core:jar:4.11.0:test
-[WARNING]    org.apache.commons:commons-lang3:jar:3.14.0:compile
-[WARNING]    com.google.guava:guava:jar:32.1.3-jre:compile
-[WARNING]    io.grpc:grpc-stub:jar:1.58.0:compile
-[WARNING]    org.apache.httpcomponents:httpclient:jar:4.5.14:compile
-[WARNING]    io.netty:netty-common:jar:4.1.109.Final:compile
+[WARNING]    org.assertj:assertj-core:jar:3.26.3:test
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
 [WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
-[WARNING]    org.apache.ozone:hdds-config:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ratis:ratis-proto:jar:3.1.0:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.16.2:compile
-[WARNING]    org.slf4j:slf4j-api:jar:2.0.13:compile
+[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-interface-storage ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    com.google.guava:guava:jar:32.1.3-jre:compile
 [WARNING]    org.assertj:assertj-core:jar:3.26.3:test
-[WARNING]    org.apache.ozone:rocksdb-checkpoint-differ:jar:1.5.0-SNAPSHOT:compile
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
 [WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
-[WARNING]    org.apache.ratis:ratis-common:jar:3.1.0:compile
-[WARNING]    org.apache.ozone:hdds-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-interface-client:jar:1.5.0-SNAPSHOT:compile
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-client ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    org.apache.ratis:ratis-thirdparty-misc:jar:1.0.6:compile
-[WARNING]    org.apache.ozone:hdds-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ratis:ratis-common:jar:3.1.0:compile
-[WARNING]    commons-collections:commons-collections:jar:3.2.2:compile
-[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
-[WARNING]    org.apache.ozone:hdds-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
 [WARNING]    org.mockito:mockito-core:jar:4.11.0:test
-[WARNING]    org.apache.ozone:ozone-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.commons:commons-lang3:jar:3.14.0:compile
-[WARNING]    com.google.guava:guava:jar:32.1.3-jre:compile
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
 [WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
-[WARNING]    org.apache.ozone:hdds-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-config:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.16.2:compile
-[WARNING]    org.slf4j:slf4j-api:jar:2.0.13:compile
+[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-reconcodegen ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    org.springframework:spring-tx:jar:5.3.37:compile
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
-[WARNING]    org.apache.ozone:hdds-config:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    commons-io:commons-io:jar:2.16.1:compile
-[WARNING]    org.slf4j:slf4j-api:jar:2.0.13:compile
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-recon ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    org.eclipse.jetty:jetty-servlet:jar:9.4.55.v20240627:compile
-[WARNING]    org.rocksdb:rocksdbjni:jar:7.7.3:compile
-[WARNING]    info.picocli:picocli:jar:4.7.6:compile
-[WARNING]    org.reflections:reflections:jar:0.10.2:compile
-[WARNING]    com.google.protobuf:protobuf-java:jar:2.5.0:compile
-[WARNING]    org.apache.ozone:hdds-interface-server:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    aopalliance:aopalliance:jar:1.0:compile
-[WARNING]    org.apache.ratis:ratis-common:jar:3.1.0:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
-[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
-[WARNING]    org.apache.hadoop:hadoop-hdfs-client:jar:3.3.6:compile
-[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
 [WARNING]    org.mockito:mockito-core:jar:4.11.0:test
-[WARNING]    org.apache.ozone:hdds-container-service:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:ozone-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    com.google.guava:guava:jar:32.1.3-jre:compile
-[WARNING]    org.apache.commons:commons-lang3:jar:3.14.0:compile
-[WARNING]    org.glassfish.hk2:hk2-api:jar:2.6.1:compile
-[WARNING]    org.apache.ozone:hdds-server-framework:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ratis:ratis-proto:jar:3.1.0:compile
-[WARNING]    jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
-[WARNING]    javax.inject:javax.inject:jar:1:compile
-[WARNING]    org.apache.commons:commons-compress:jar:1.27.0:compile
-[WARNING]    org.apache.ozone:hdds-managed-rocksdb:jar:1.5.0-SNAPSHOT:compile
 [WARNING]    org.assertj:assertj-core:jar:3.26.3:test
-[WARNING]    javax.servlet:javax.servlet-api:jar:3.1.0:compile
-[WARNING]    commons-collections:commons-collections:jar:3.2.2:compile
-[WARNING]    org.apache.ozone:ozone-interface-storage:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
-[WARNING]    org.glassfish.jersey.core:jersey-common:jar:2.43:compile
-[WARNING]    org.apache.ozone:hdds-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.springframework:spring-core:jar:5.3.37:compile
-[WARNING]    org.eclipse.jetty:jetty-util:jar:9.4.55.v20240627:compile
-[WARNING]    org.springframework:spring-tx:jar:5.3.37:compile
-[WARNING]    jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
 [WARNING]    org.apache.hadoop:hadoop-auth:jar:3.3.6:compile
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
 [WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
-[WARNING]    commons-io:commons-io:jar:2.16.1:compile
-[WARNING]    org.apache.ozone:hdds-config:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.slf4j:slf4j-api:jar:2.0.13:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.16.2:compile
+[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
+[WARNING]    org.apache.hadoop:hadoop-hdfs-client:jar:3.3.6:compile
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-tools ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    com.amazonaws:aws-java-sdk-kms:jar:1.12.661:compile
-[WARNING]    org.rocksdb:rocksdbjni:jar:7.7.3:compile
-[WARNING]    info.picocli:picocli:jar:4.7.6:compile
-[WARNING]    org.apache.ozone:hdds-interface-server:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ratis:ratis-server-api:jar:3.1.0:compile
-[WARNING]    org.apache.ratis:ratis-common:jar:3.1.0:compile
-[WARNING]    org.apache.ozone:hdds-server-scm:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
-[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
-[WARNING]    org.apache.hadoop:hadoop-hdfs-client:jar:3.3.6:compile
-[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
 [WARNING]    org.mockito:mockito-core:jar:4.11.0:test
-[WARNING]    org.apache.ozone:hdds-container-service:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:ozone-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    com.google.guava:guava:jar:32.1.3-jre:compile
-[WARNING]    org.apache.commons:commons-lang3:jar:3.14.0:compile
-[WARNING]    io.opentracing:opentracing-util:jar:0.33.0:compile
-[WARNING]    org.jooq:jooq:jar:3.11.10:compile
-[WARNING]    commons-codec:commons-codec:jar:1.17.0:compile
-[WARNING]    org.apache.ratis:ratis-tools:jar:3.1.0:compile
-[WARNING]    org.apache.ratis:ratis-client:jar:3.1.0:compile
-[WARNING]    org.mockito:mockito-junit-jupiter:jar:4.11.0:test
-[WARNING]    org.apache.ozone:hdds-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ratis:ratis-proto:jar:3.1.0:compile
-[WARNING]    org.apache.ozone:hdds-interface-admin:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ratis:ratis-thirdparty-misc:jar:1.0.6:compile
+[WARNING]    com.amazonaws:aws-java-sdk-kms:jar:1.12.661:compile
 [WARNING]    ch.qos.reload4j:reload4j:jar:1.2.25:compile
-[WARNING]    org.apache.ozone:hdds-managed-rocksdb:jar:1.5.0-SNAPSHOT:compile
 [WARNING]    org.assertj:assertj-core:jar:3.26.3:test
-[WARNING]    org.apache.ozone:hdds-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.httpcomponents:httpcore:jar:4.4.16:compile
-[WARNING]    org.apache.ozone:ozone-filesystem-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:ozone-interface-storage:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-core:jar:2.16.2:compile
-[WARNING]    org.apache.httpcomponents:httpclient:jar:4.5.14:compile
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
 [WARNING]    org.apache.hadoop:hadoop-hdfs:jar:3.3.6:compile
 [WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
-[WARNING]    commons-io:commons-io:jar:2.16.1:compile
-[WARNING]    org.apache.ozone:hdds-config:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.16.2:compile
-[WARNING]    io.opentracing:opentracing-api:jar:0.33.0:compile
-[WARNING]    org.slf4j:slf4j-api:jar:2.0.13:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.16.2:compile
+[WARNING]    org.mockito:mockito-junit-jupiter:jar:4.11.0:test
+[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
+[WARNING]    org.apache.hadoop:hadoop-hdfs-client:jar:3.3.6:compile
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-s3gateway ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    org.eclipse.jetty:jetty-servlet:jar:9.4.55.v20240627:compile
-[WARNING]    io.opentracing:opentracing-noop:jar:0.33.0:compile
-[WARNING]    info.picocli:picocli:jar:4.7.6:compile
-[WARNING]    org.apache.ratis:ratis-common:jar:3.1.0:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
-[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
-[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
 [WARNING]    org.mockito:mockito-core:jar:4.11.0:test
-[WARNING]    org.apache.ozone:ozone-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    com.google.guava:guava:jar:32.1.3-jre:compile
-[WARNING]    io.opentracing:opentracing-util:jar:0.33.0:compile
-[WARNING]    commons-codec:commons-codec:jar:1.17.0:compile
-[WARNING]    org.apache.ozone:hdds-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.mockito:mockito-junit-jupiter:jar:4.11.0:test
-[WARNING]    jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
-[WARNING]    org.glassfish.jersey.core:jersey-server:jar:2.43:compile
-[WARNING]    org.apache.kerby:kerby-util:jar:1.0.1:compile
-[WARNING]    javax.annotation:javax.annotation-api:jar:1.3.2:compile
-[WARNING]    org.eclipse.jetty:jetty-webapp:jar:9.4.55.v20240627:compile
-[WARNING]    javax.servlet:javax.servlet-api:jar:3.1.0:compile
 [WARNING]    org.assertj:assertj-core:jar:3.26.3:test
-[WARNING]    org.apache.ozone:hdds-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.httpcomponents:httpcore:jar:4.4.16:compile
-[WARNING]    org.apache.ozone:hdds-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.glassfish.jersey.core:jersey-common:jar:2.43:compile
-[WARNING]    org.apache.httpcomponents:httpclient:jar:4.5.14:compile
 [WARNING]    org.apache.hadoop:hadoop-auth:jar:3.3.6:compile
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
 [WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
-[WARNING]    commons-io:commons-io:jar:2.16.1:compile
-[WARNING]    org.apache.ozone:hdds-config:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    io.opentracing:opentracing-api:jar:0.33.0:compile
-[WARNING]    org.slf4j:slf4j-api:jar:2.0.13:compile
+[WARNING]    org.mockito:mockito-junit-jupiter:jar:4.11.0:test
+[WARNING]    org.junit.jupiter:junit-jupiter-params:jar:5.10.3:test
+[WARNING]    org.apache.ozone:hdds-interface-client:jar:1.5.0-SNAPSHOT:compile
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-csi ---
-[WARNING] Used undeclared dependencies found:
-[WARNING]    io.grpc:grpc-api:jar:1.58.0:compile
-[WARNING]    info.picocli:picocli:jar:4.7.6:compile
-[WARNING]    io.netty:netty-transport:jar:4.1.109.Final:compile
-[WARNING]    io.netty:netty-transport-classes-epoll:jar:4.1.109.Final:compile
-[WARNING]    org.apache.ozone:ozone-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    commons-io:commons-io:jar:2.16.1:compile
-[WARNING]    org.slf4j:slf4j-api:jar:2.0.13:compile
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-insight ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    org.apache.ozone:hdds-container-service:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:ozone-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.httpcomponents:httpclient:jar:4.5.14:compile
-[WARNING]    info.picocli:picocli:jar:4.7.6:compile
 [WARNING]    org.apache.ozone:hdds-interface-server:jar:1.5.0-SNAPSHOT:compile
 [WARNING]    org.assertj:assertj-core:jar:3.26.3:test
-[WARNING]    org.apache.httpcomponents:httpcore:jar:4.4.16:compile
 [WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
-[WARNING]    org.apache.ozone:hdds-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-config:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-interface-client:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-interface-admin:jar:1.5.0-SNAPSHOT:compile
...
 [INFO] --- maven-dependency-plugin:3.7.1:analyze-only (default-cli) @ ozone-httpfsgateway ---
 [WARNING] Used undeclared dependencies found:
-[WARNING]    org.apache.commons:commons-lang3:jar:3.14.0:compile
-[WARNING]    com.google.guava:guava:jar:32.1.3-jre:compile
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
 [WARNING]    org.apache.hadoop:hadoop-auth:jar:3.3.6:compile
-[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
-[WARNING]    org.apache.ozone:hdds-common:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    org.apache.ozone:hdds-config:jar:1.5.0-SNAPSHOT:compile
-[WARNING]    jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
-[WARNING]    org.glassfish.jersey.core:jersey-server:jar:2.43:compile
... (s3-secret-store)
 [WARNING]    org.mockito:mockito-core:jar:4.11.0:test
 [WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.10.3:test
 [WARNING]    org.apache.hadoop:hadoop-common:jar:3.3.6:compile
-[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
-[WARNING]    org.slf4j:slf4j-api:jar:2.0.13:compile
```