### PR TITLE
HDDS-11305. Avoid accidental usage of commons-lang v2

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Arrays.asList;
-import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.hadoop.hdds.client.ReplicationConfig.fromTypeAndFactor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;

--- a/pom.xml
+++ b/pom.xml
@@ -1576,6 +1576,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                       <bannedImport>org.jetbrains.annotations.Nullable</bannedImport>
                     </bannedImports>
                   </restrictImports>
+                  <restrictImports>
+                    <includeTestCode>true</includeTestCode>
+                    <reason>Use commons-lang v3</reason>
+                    <bannedImports>
+                      <bannedImport>org.apache.commons.lang.**</bannedImport>
+                    </bannedImports>
+                  </restrictImports>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`commons-lang` v2 is a transitive dependency via Hadoop and Ranger.  Ozone and most of its other dependencies use `commons-lang` v3.

The goal of this PR:

- Replace existing usage of `commons-lang` v2 with v3.
- Ban import of v2 classes to avoid new usage.

https://issues.apache.org/jira/browse/HDDS-11305

## How was this patch tested?

Tested `pom.xml` change without import changes on `master`:

```
[ERROR] Rule 6: org.apache.maven.plugins.enforcer.RestrictImports failed with message:
[ERROR] 
[ERROR] Banned imports detected in TEST code:
[ERROR] 
[ERROR] Reason: Use commons-lang v3
[ERROR] 	in hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestScmClient.java
[ERROR] 		static org.apache.commons.lang.RandomStringUtils.randomAlphabetic 	(Line: 46, Matched by: org.apache.commons.lang.**)
[ERROR] 	in hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestKeyDeletingService.java
[ERROR] 		org.apache.commons.lang.RandomStringUtils                         	(Line: 37, Matched by: org.apache.commons.lang.**)
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/10367830837