### PR TITLE
HDDS-11310. Remove EndpointStateMachine.EndPointStates.value.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -286,7 +286,7 @@ public class EndpointStateMachine
      */
     public EndPointStates getNextState() {
       final int n = this.ordinal();
-      return n >= LAST.ordinal()? LAST : values()[n + 1];
+      return n >= LAST.ordinal() ? LAST : values()[n + 1];
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/StorageContainerDatanodeProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/StorageContainerDatanodeProtocolClientSideTranslatorPB.java
@@ -84,11 +84,9 @@ public class StorageContainerDatanodeProtocolClientSideTranslatorPB
    * fail require careful attention. It is strongly advised to relinquish the
    * underlying resources and to internally <em>mark</em> the {@code Closeable}
    * as closed, prior to throwing the {@code IOException}.
-   *
-   * @throws IOException if an I/O error occurs
    */
   @Override
-  public void close() throws IOException {
+  public void close() {
     RPC.stopProxy(rpcProxy);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

EndpointStateMachine.EndPointStates.value is redundant since Java enum already has ordinal().

## What is the link to the Apache JIRA

HDDS-11310

## How was this patch tested?

By existing tests.