### PR TITLE
HDDS-11309. Increase CONTAINER_STATE Column Length in UNHEALTHY_CONTAINERS to Avoid Truncation

### DIFF
--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -80,7 +80,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
   private void createUnhealthyContainersTable() {
     dslContext.createTableIfNotExists(UNHEALTHY_CONTAINERS_TABLE_NAME)
         .column(CONTAINER_ID, SQLDataType.BIGINT.nullable(false))
-        .column(CONTAINER_STATE, SQLDataType.VARCHAR(16).nullable(false))
+        .column(CONTAINER_STATE, SQLDataType.VARCHAR(40).nullable(false))
         .column("in_state_since", SQLDataType.BIGINT.nullable(false))
         .column("expected_replica_count", SQLDataType.INTEGER.nullable(false))
         .column("actual_replica_count", SQLDataType.INTEGER.nullable(false))

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -51,7 +51,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     UNDER_REPLICATED,
     OVER_REPLICATED,
     MIS_REPLICATED,
-    ALL_REPLICAS_UNHEALTHY,
+    ALL_REPLICAS_BAD,
     NEGATIVE_SIZE // Added new state to track containers with negative sizes
   }
 
@@ -80,7 +80,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
   private void createUnhealthyContainersTable() {
     dslContext.createTableIfNotExists(UNHEALTHY_CONTAINERS_TABLE_NAME)
         .column(CONTAINER_ID, SQLDataType.BIGINT.nullable(false))
-        .column(CONTAINER_STATE, SQLDataType.VARCHAR(40).nullable(false))
+        .column(CONTAINER_STATE, SQLDataType.VARCHAR(16).nullable(false))
         .column("in_state_since", SQLDataType.BIGINT.nullable(false))
         .column("expected_replica_count", SQLDataType.INTEGER.nullable(false))
         .column("actual_replica_count", SQLDataType.INTEGER.nullable(false))

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.recon.persistence;
 
 import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.UNDER_REPLICATED;
-import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_UNHEALTHY;
+import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_BAD;
 import static org.hadoop.ozone.recon.schema.tables.UnhealthyContainersTable.UNHEALTHY_CONTAINERS;
 import static org.jooq.impl.DSL.count;
 
@@ -76,7 +76,7 @@ public class ContainerHealthSchemaManager {
     SelectQuery<Record> query = dslContext.selectQuery();
     query.addFrom(UNHEALTHY_CONTAINERS);
     if (state != null) {
-      if (state.equals(ALL_REPLICAS_UNHEALTHY)) {
+      if (state.equals(ALL_REPLICAS_BAD)) {
         query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_STATE
             .eq(UNDER_REPLICATED.toString()));
         query.addConditions(UNHEALTHY_CONTAINERS.ACTUAL_REPLICA_COUNT.eq(0));

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -22,9 +22,10 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_BAD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
@@ -399,6 +400,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     // Iterate through each state in the UnHealthyContainerStates enum
     for (ContainerSchemaDefinition.UnHealthyContainerStates state :
         ContainerSchemaDefinition.UnHealthyContainerStates.values()) {
+
       // Create a dummy UnhealthyContainer record with the current state
       UnhealthyContainers unhealthyContainer = new UnhealthyContainers();
       unhealthyContainer.setContainerId(state.ordinal() + 1L);
@@ -425,6 +427,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
         break;
 
       case MIS_REPLICATED:
+      case NEGATIVE_SIZE:
         unhealthyContainer.setExpectedReplicaCount(3);
         unhealthyContainer.setActualReplicaCount(3);
         unhealthyContainer.setReplicaDelta(0);
@@ -436,11 +439,8 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
         unhealthyContainer.setReplicaDelta(3);
         break;
 
-      case NEGATIVE_SIZE:
-        unhealthyContainer.setExpectedReplicaCount(3);
-        unhealthyContainer.setActualReplicaCount(3);
-        unhealthyContainer.setReplicaDelta(0);
-        break;
+      default:
+        fail("Unhandled state: " + state.name() + ". Please add this state to the switch case.");
       }
 
       unhealthyContainer.setContainerState(state.name());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -21,7 +21,9 @@ package org.apache.hadoop.ozone.recon.fsck;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_UNHEALTHY;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
@@ -29,7 +31,13 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicatedReplicationConfig;
@@ -60,15 +68,12 @@ import org.hadoop.ozone.recon.schema.tables.daos.UnhealthyContainersDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.ReconTaskStatus;
 import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class to test a single run of the Container Health Task.
  */
 public class TestContainerHealthTask extends AbstractReconSqlDBTest {
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestContainerHealthTask.class);
+
   public TestContainerHealthTask() {
     super();
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -20,10 +20,11 @@ package org.apache.hadoop.ozone.recon.fsck;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_UNHEALTHY;
+import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_BAD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
@@ -200,7 +201,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
 
     List<UnhealthyContainers> unhealthyContainers =
         containerHealthSchemaManager.getUnhealthyContainers(
-            ALL_REPLICAS_UNHEALTHY, 0, Integer.MAX_VALUE);
+            ALL_REPLICAS_BAD, 0, Integer.MAX_VALUE);
     assertEquals(1, unhealthyContainers.size());
     assertEquals(2L,
         unhealthyContainers.get(0).getContainerId().longValue());
@@ -387,7 +388,6 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
 
   @Test
   public void testAllContainerStateInsertions() {
-    // Set up DAOs and Schema Manager
     UnhealthyContainersDao unHealthyContainersTableHandle =
         getDao(UnhealthyContainersDao.class);
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -401,10 +401,48 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
         ContainerSchemaDefinition.UnHealthyContainerStates.values()) {
       // Create a dummy UnhealthyContainer record with the current state
       UnhealthyContainers unhealthyContainer = new UnhealthyContainers();
-      unhealthyContainer.setContainerId(state.ordinal() + 1L); // Ensure unique ID for each state
-      unhealthyContainer.setExpectedReplicaCount(3);
-      unhealthyContainer.setActualReplicaCount(1);
-      unhealthyContainer.setReplicaDelta(2);
+      unhealthyContainer.setContainerId(state.ordinal() + 1L);
+
+      // Set replica counts based on the state
+      switch (state) {
+      case MISSING:
+      case EMPTY_MISSING:
+        unhealthyContainer.setExpectedReplicaCount(3);
+        unhealthyContainer.setActualReplicaCount(0);
+        unhealthyContainer.setReplicaDelta(3);
+        break;
+
+      case UNDER_REPLICATED:
+        unhealthyContainer.setExpectedReplicaCount(3);
+        unhealthyContainer.setActualReplicaCount(1);
+        unhealthyContainer.setReplicaDelta(2);
+        break;
+
+      case OVER_REPLICATED:
+        unhealthyContainer.setExpectedReplicaCount(3);
+        unhealthyContainer.setActualReplicaCount(4);
+        unhealthyContainer.setReplicaDelta(-1);
+        break;
+
+      case MIS_REPLICATED:
+        unhealthyContainer.setExpectedReplicaCount(3);
+        unhealthyContainer.setActualReplicaCount(3);
+        unhealthyContainer.setReplicaDelta(0);
+        break;
+
+      case ALL_REPLICAS_BAD:
+        unhealthyContainer.setExpectedReplicaCount(3);
+        unhealthyContainer.setActualReplicaCount(0);
+        unhealthyContainer.setReplicaDelta(3);
+        break;
+
+      case NEGATIVE_SIZE:
+        unhealthyContainer.setExpectedReplicaCount(3);
+        unhealthyContainer.setActualReplicaCount(3);
+        unhealthyContainer.setReplicaDelta(0);
+        break;
+      }
+
       unhealthyContainer.setContainerState(state.name());
       unhealthyContainer.setInStateSince(System.currentTimeMillis());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
### Problem 
During the execution of the `ContainerHealthTask`, it was discovered that the length of the `CONTAINER_STATE` column in the `UNHEALTHY_CONTAINERS` table is insufficient to store some of the enum values defined in UnHealthyContainerStates. Specifically, the `ALL_REPLICAS_UNHEALTHY` state, which has a length of 21 characters, exceeds the current `VARCHAR(16)` limit set for the `CONTAINER_STATE` column.
When attempting to insert a record with the `ALL_REPLICAS_UNHEALTHY` state into the `UNHEALTHY_CONTAINERS` table, a truncation error is thrown:
```
org.jooq.exception.DataAccessException: SQL [insert into "UNHEALTHY_CONTAINERS" ("container_id", "container_state", "in_state_since", "expected_replica_count", "actual_replica_count", "replica_delta", "reason") values ...]; A truncation error was encountered trying to shrink VARCHAR 'ALL_REPLICAS_UNHEALTHY' to length 16. 
```
This issue affects the functionality of the ContainerHealthTask and prevents it from correctly recording certain unhealthy container states.
### Solution
Changed the state name ALL_REPLICAS_UNHEALTHY to ALL_REPLICAS_BAD so as to match 16 characters, and add a test to ensure all UnHealthyContainerStates enum values insert without truncation errors.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11309

## How was this patch tested?

UT