### PR TITLE
HDDS-11208. Change RatisBlockOutputStream to use HDDS-11174.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/AbstractCommitWatcher.java
@@ -124,7 +124,6 @@ abstract class AbstractCommitWatcher<BUFFER> {
    *
    * @param commitIndex log index to watch for
    * @return minimum commit index replicated to all nodes
-   * @throws IOException IOException in case watch gets timed out
    */
   CompletableFuture<XceiverClientReply> watchForCommitAsync(long commitIndex) {
     final MemoizedSupplier<CompletableFuture<XceiverClientReply>> supplier

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -487,7 +487,9 @@ public class BlockOutputStream extends OutputStream {
     LOG.debug("Entering watchForCommit commitIndex = {}", commitIndex);
     return sendWatchForCommit(commitIndex)
         .thenAccept(this::checkReply)
-        .exceptionally(e -> { throw new FlushRuntimeException(setIoException(e)); })
+        .exceptionally(e -> {
+          throw new FlushRuntimeException(setIoException(e));
+        })
         .whenComplete((r, e) -> LOG.debug("Leaving watchForCommit commitIndex = {}", commitIndex));
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -442,7 +442,8 @@ public class BlockOutputStream extends OutputStream {
         writeChunk(buffer);
         putBlockFuture = executePutBlock(false, false);
       }
-      CompletableFuture<Void> watchForCommitAsync = watchForCommitAsync(putBlockFuture);
+      CompletableFuture<Void> watchForCommitAsync =
+          putBlockFuture.thenCompose(x -> watchForCommit(x.commitIndex));
       try {
         watchForCommitAsync.get();
       } catch (InterruptedException e) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
@@ -102,8 +102,8 @@ public class RatisBlockOutputStream extends BlockOutputStream
   }
 
   @Override
-  XceiverClientReply sendWatchForCommit(long commitIndex) throws IOException {
-    return commitWatcher.watchForCommit(commitIndex);
+  CompletableFuture<XceiverClientReply> sendWatchForCommit(long commitIndex) {
+    return commitWatcher.watchForCommitAsync(commitIndex);
   }
 
   @Override

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
@@ -102,8 +102,8 @@ public class RatisBlockOutputStream extends BlockOutputStream
   }
 
   @Override
-  CompletableFuture<XceiverClientReply> sendWatchForCommit(long commitIndex) {
-    return commitWatcher.watchForCommitAsync(commitIndex);
+  CompletableFuture<XceiverClientReply> sendWatchForCommit(long index) {
+    return commitWatcher.watchForCommitAsync(index);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HDDS-11174, we change XceiverClientRatis.watchForCommit to async. This JIRA is to further change RatisBlockOutputStream to use it.

## What is the link to the Apache JIRA

HDDS-11208

## How was this patch tested?

By existing tests.