### PR TITLE
HDDS-11318. Add versionsBackup to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ target
 build
 dependency-reduced-pom.xml
 make-build-debug
+*.versionsBackup
 
 # Filesystem contract test options and credentials
 auth-keys.xml


### PR DESCRIPTION
## What changes were proposed in this pull request?
When executing `mvn versions:set,` all versionsBackup files are shown, which should be hidden. The purpose of this PR is to solve this.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11318

## How was this patch tested?
After adding this pr, the versionsBackup file will not be displayed again when executing `mvn versions:set` again.
`mvn versions:set -DnewVersion=1.5.1`
`
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   hadoop-hdds/annotations/pom.xml
	modified:   hadoop-hdds/client/pom.xml
	modified:   hadoop-hdds/common/pom.xml
	modified:   hadoop-hdds/config/pom.xml
	modified:   hadoop-hdds/container-service/pom.xml
	modified:   hadoop-hdds/crypto-api/pom.xml
	modified:   hadoop-hdds/crypto-default/pom.xml
	modified:   hadoop-hdds/docs/pom.xml
	modified:   hadoop-hdds/erasurecode/pom.xml
	modified:   hadoop-hdds/framework/pom.xml
	modified:   hadoop-hdds/hadoop-dependency-client/pom.xml
	modified:   hadoop-hdds/hadoop-dependency-server/pom.xml
	modified:   hadoop-hdds/hadoop-dependency-test/pom.xml
	modified:   hadoop-hdds/interface-admin/pom.xml
	modified:   hadoop-hdds/interface-client/pom.xml
	modified:   hadoop-hdds/interface-server/pom.xml
	modified:   hadoop-hdds/managed-rocksdb/pom.xml
	modified:   hadoop-hdds/pom.xml
	modified:   hadoop-hdds/rocks-native/pom.xml
	modified:   hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
	modified:   hadoop-hdds/server-scm/pom.xml
	modified:   hadoop-hdds/test-utils/pom.xml
	modified:   hadoop-hdds/tools/pom.xml
	modified:   hadoop-ozone/client/pom.xml
	modified:   hadoop-ozone/common/pom.xml
	modified:   hadoop-ozone/csi/pom.xml
	modified:   hadoop-ozone/datanode/pom.xml
	modified:   hadoop-ozone/dist/pom.xml
	modified:   hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
	modified:   hadoop-ozone/fault-injection-test/network-tests/pom.xml
	modified:   hadoop-ozone/fault-injection-test/pom.xml
	modified:   hadoop-ozone/httpfsgateway/pom.xml
	modified:   hadoop-ozone/insight/pom.xml
	modified:   hadoop-ozone/integration-test/pom.xml
	modified:   hadoop-ozone/interface-client/pom.xml
	modified:   hadoop-ozone/interface-storage/pom.xml
	modified:   hadoop-ozone/ozone-manager/pom.xml
	modified:   hadoop-ozone/ozonefs-common/pom.xml
	modified:   hadoop-ozone/ozonefs-hadoop2/pom.xml
	modified:   hadoop-ozone/ozonefs-hadoop3-client/pom.xml
	modified:   hadoop-ozone/ozonefs-hadoop3/pom.xml
	modified:   hadoop-ozone/ozonefs-shaded/pom.xml
	modified:   hadoop-ozone/ozonefs/pom.xml
	modified:   hadoop-ozone/pom.xml
	modified:   hadoop-ozone/recon-codegen/pom.xml
	modified:   hadoop-ozone/recon/pom.xml
	modified:   hadoop-ozone/s3-secret-store/pom.xml
	modified:   hadoop-ozone/s3gateway/pom.xml
	modified:   hadoop-ozone/tools/pom.xml
	modified:   pom.xml

no changes added to commit (use "git add" and/or "git commit -a")
`