### PR TITLE
HDDS-11327. [hsync] Revert config default ozone.fs.hsync.enabled to false

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -126,7 +126,7 @@ public final class OzoneConfigKeys {
   public static final String OZONE_FS_HSYNC_ENABLED
       = "ozone.fs.hsync.enabled";
   public static final boolean OZONE_FS_HSYNC_ENABLED_DEFAULT
-      = true;
+      = false;
 
   /**
    * hsync lease soft limit.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4213,7 +4213,7 @@
 
   <property>
     <name>ozone.fs.hsync.enabled</name>
-    <value>true</value>
+    <value>false</value>
     <tag>OZONE, CLIENT</tag>
     <description>
       Enable hsync/hflush. By default they are disabled.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -173,7 +173,6 @@ public class TestHSync {
     // Reduce KeyDeletingService interval
     CONF.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
     CONF.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
-    CONF.setBoolean("ozone.fs.hsync.enabled", true);
     CONF.setBoolean("ozone.client.incremental.chunk.list", true);
     CONF.setBoolean("ozone.client.stream.putblock.piggybacking", true);
     CONF.setTimeDuration(OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_INTERVAL,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -173,6 +173,7 @@ public class TestHSync {
     // Reduce KeyDeletingService interval
     CONF.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
     CONF.setTimeDuration(OZONE_DIR_DELETING_SERVICE_INTERVAL, 100, TimeUnit.MILLISECONDS);
+    CONF.setBoolean("ozone.fs.hsync.enabled", true);
     CONF.setBoolean("ozone.client.incremental.chunk.list", true);
     CONF.setBoolean("ozone.client.stream.putblock.piggybacking", true);
     CONF.setTimeDuration(OZONE_OM_OPEN_KEY_CLEANUP_SERVICE_INTERVAL,


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone.fs.hsync.enabled` was initially added in HDDS-8302 with default value of `false`. The config is used to control whether the hsync feature (implemented for HBase support for the most part) would be enabled on both OM side and client side.

But the default was later flipped to `true` in HDDS-10252. We need to:

1. Switch the default back to `false`
2. Ensure this doesn't break any existing tests et al..

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11327

## How was this patch tested?

- Existing tests should all pass.