### PR TITLE
HDDS-11320. Update OM, SCM, Datanode conf for RATIS-2135.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/RatisConfUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/RatisConfUtils.java
@@ -30,15 +30,15 @@ public class RatisConfUtils {
   /** For {@link GrpcConfigKeys}. */
   public static class Grpc {
     /** For setting {@link GrpcConfigKeys#setMessageSizeMax(RaftProperties, SizeInBytes)}. */
-    public static void setMessageSizeMax(RaftProperties properties, int logAppenderBufferByteLimit) {
-      Preconditions.assertTrue(logAppenderBufferByteLimit > 0,
-          () -> "logAppenderBufferByteLimit = " + logAppenderBufferByteLimit + " <= 0");
-      Preconditions.assertSame(RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties).getSize(),
-          logAppenderBufferByteLimit, "logAppenderBufferByteLimit");
+    public static void setMessageSizeMax(RaftProperties properties, int max) {
+      Preconditions.assertTrue(max > 0, () -> "max = " + max + " <= 0");
+
+      final long logAppenderBufferByteLimit = RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties).getSize();
+      Preconditions.assertTrue(max >= logAppenderBufferByteLimit,
+          () -> "max = " + max + " < logAppenderBufferByteLimit = " + logAppenderBufferByteLimit);
 
       // Need an 1MB gap; see RATIS-2135
-      final long max = SizeInBytes.ONE_MB.getSize() + logAppenderBufferByteLimit;
-      GrpcConfigKeys.setMessageSizeMax(properties, SizeInBytes.valueOf(max));
+      GrpcConfigKeys.setMessageSizeMax(properties, SizeInBytes.valueOf(max + SizeInBytes.ONE_MB.getSize()));
     }
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/RatisConfUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/RatisConfUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.conf;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.util.Preconditions;
+import org.apache.ratis.util.SizeInBytes;
+
+/**
+ * Utilities for Ratis configurations.
+ */
+public class RatisConfUtils {
+  /** For {@link GrpcConfigKeys}. */
+  public static class Grpc {
+    /** For setting {@link GrpcConfigKeys#setMessageSizeMax(RaftProperties, SizeInBytes)}. */
+    public static void setMessageSizeMax(RaftProperties properties, int logAppenderBufferByteLimit) {
+      Preconditions.assertTrue(logAppenderBufferByteLimit > 0,
+          () -> "logAppenderBufferByteLimit = " + logAppenderBufferByteLimit + " <= 0");
+      Preconditions.assertSame(RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties).getSize(),
+          logAppenderBufferByteLimit, "logAppenderBufferByteLimit");
+
+      // Need an 1MB gap; see RATIS-2135
+      final long max = SizeInBytes.ONE_MB.getSize() + logAppenderBufferByteLimit;
+      GrpcConfigKeys.setMessageSizeMax(properties, SizeInBytes.valueOf(max));
+    }
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestRatisConfUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestRatisConfUtils.java
@@ -44,9 +44,9 @@ public class TestRatisConfUtils {
 
     RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties, SizeInBytes.valueOf(logAppenderBufferByteLimit));
 
-    // setMessageSizeMax with a different logAppenderBufferByteLimit
+    // setMessageSizeMax with a value smaller than logAppenderBufferByteLimit
     Assertions.assertThrows(IllegalStateException.class,
-        () -> RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit + 1));
+        () -> RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit - 1));
 
     // setMessageSizeMax with the correct logAppenderBufferByteLimit
     RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestRatisConfUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestRatisConfUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.conf;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.util.SizeInBytes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test {@link RatisConfUtils}.
+ */
+public class TestRatisConfUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(TestRatisConfUtils.class);
+
+  @Test
+  void testGrpcSetMessageSizeMax() {
+    final RaftProperties properties = new RaftProperties();
+
+    final int logAppenderBufferByteLimit = 1000;
+
+    // setMessageSizeMax without setBufferByteLimit
+    Assertions.assertThrows(IllegalStateException.class,
+        () -> RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit));
+
+    RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties, SizeInBytes.valueOf(logAppenderBufferByteLimit));
+
+    // setMessageSizeMax with a different logAppenderBufferByteLimit
+    Assertions.assertThrows(IllegalStateException.class,
+        () -> RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit + 1));
+
+    // setMessageSizeMax with the correct logAppenderBufferByteLimit
+    RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);
+
+    final SizeInBytes max = GrpcConfigKeys.messageSizeMax(properties, LOG::info);
+    Assertions.assertEquals(SizeInBytes.ONE_MB.getSize(), max.getSize() - logAppenderBufferByteLimit);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -283,7 +283,8 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     final int logAppenderBufferByteLimit = setRaftSegmentAndWriteBufferSize(properties);
 
     // set grpc message size max
-    RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);
+    final int max = Math.max(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE, logAppenderBufferByteLimit);
+    RatisConfUtils.Grpc.setMessageSizeMax(properties, max);
 
     // set raft segment pre-allocated size
     setRaftSegmentPreallocatedSize(properties);
@@ -422,9 +423,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
         HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
         StorageUnit.BYTES);
-    assertTrue(logAppenderQueueByteLimit >= OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE,
-        () -> HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT + " = " + logAppenderQueueByteLimit
-            + " must be >= OZONE_SCM_CHUNK_MAX_SIZE (=" + OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE);
 
     final long raftSegmentSize = (long) conf.getStorageSize(
         HDDS_CONTAINER_RATIS_SEGMENT_SIZE_KEY,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.DatanodeVersion;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
+import org.apache.hadoop.hdds.conf.RatisConfUtils;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -279,11 +280,13 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     final RpcType rpc = setRpcType(properties);
 
     // set raft segment size
-    setRaftSegmentAndWriteBufferSize(properties);
+    final int logAppenderBufferByteLimit = setRaftSegmentAndWriteBufferSize(properties);
+
+    // set grpc message size max
+    RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);
 
     // set raft segment pre-allocated size
-    final long raftSegmentPreallocatedSize =
-        setRaftSegmentPreallocatedSize(properties);
+    setRaftSegmentPreallocatedSize(properties);
 
     // setup ratis stream if datastream is enabled
     if (streamEnable) {
@@ -313,11 +316,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     storageDirPaths.forEach(d -> storageDirs.add(new File(d)));
 
     RaftServerConfigKeys.setStorageDir(properties, storageDirs);
-
-    // For grpc set the maximum message size
-    GrpcConfigKeys.setMessageSizeMax(properties,
-        SizeInBytes.valueOf(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE
-                + raftSegmentPreallocatedSize));
 
     // Set the ratis port number
     if (rpc == SupportedRpcType.GRPC) {
@@ -407,17 +405,16 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         .setExpiryTime(properties, retryCacheTimeout);
   }
 
-  private long setRaftSegmentPreallocatedSize(RaftProperties properties) {
+  private void setRaftSegmentPreallocatedSize(RaftProperties properties) {
     final long raftSegmentPreallocatedSize = (long) conf.getStorageSize(
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_SEGMENT_PREALLOCATED_SIZE_KEY,
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_SEGMENT_PREALLOCATED_SIZE_DEFAULT,
         StorageUnit.BYTES);
     RaftServerConfigKeys.Log.setPreallocatedSize(properties,
         SizeInBytes.valueOf(raftSegmentPreallocatedSize));
-    return raftSegmentPreallocatedSize;
   }
 
-  private void setRaftSegmentAndWriteBufferSize(RaftProperties properties) {
+  private int setRaftSegmentAndWriteBufferSize(RaftProperties properties) {
     final int logAppenderQueueNumElements = conf.getInt(
         HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS,
         HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS_DEFAULT);
@@ -425,6 +422,9 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
         HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
         StorageUnit.BYTES);
+    assertTrue(logAppenderQueueByteLimit >= OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE,
+        () -> HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT + " = " + logAppenderQueueByteLimit
+            + " must be >= OZONE_SCM_CHUNK_MAX_SIZE (=" + OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE);
 
     final long raftSegmentSize = (long) conf.getStorageSize(
         HDDS_CONTAINER_RATIS_SEGMENT_SIZE_KEY,
@@ -446,6 +446,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         SizeInBytes.valueOf(raftSegmentSize));
     RaftServerConfigKeys.Log.setWriteBufferSize(properties,
         SizeInBytes.valueOf(raftSegmentBufferSize));
+    return logAppenderQueueByteLimit;
   }
 
   private void setStateMachineDataConfigurations(RaftProperties properties) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.ha;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.RatisConfUtils;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.ratis.ServerNotLeaderException;
@@ -69,8 +70,9 @@ public final class RatisUtil {
     // TODO: Check the default values.
     final RaftProperties properties = new RaftProperties();
     setRaftStorageDir(properties, conf);
-    setRaftRpcProperties(properties, conf);
-    setRaftLogProperties(properties, conf);
+
+    final int logAppenderBufferByteLimit = setRaftLogProperties(properties, conf);
+    setRaftRpcProperties(properties, conf, logAppenderBufferByteLimit);
     setRaftRetryCacheProperties(properties, conf);
     setRaftSnapshotProperties(properties, conf);
     setRaftLeadElectionProperties(properties, conf);
@@ -100,15 +102,14 @@ public final class RatisUtil {
    * @param ozoneConf ConfigurationSource
    */
   private static void setRaftRpcProperties(final RaftProperties properties,
-      ConfigurationSource ozoneConf) {
+      ConfigurationSource ozoneConf, int logAppenderBufferByteLimit) {
     RatisHelper.setRpcType(properties,
         RpcType.valueOf(ozoneConf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_RPC_TYPE,
                 ScmConfigKeys.OZONE_SCM_HA_RATIS_RPC_TYPE_DEFAULT)));
     GrpcConfigKeys.Server.setPort(properties, ozoneConf
         .getInt(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY,
             ScmConfigKeys.OZONE_SCM_RATIS_PORT_DEFAULT));
-    GrpcConfigKeys.setMessageSizeMax(properties,
-        SizeInBytes.valueOf("32m"));
+    RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);
     long ratisRequestTimeout = ozoneConf.getTimeDuration(
             ScmConfigKeys.OZONE_SCM_HA_RATIS_REQUEST_TIMEOUT,
             ScmConfigKeys.OZONE_SCM_HA_RATIS_REQUEST_TIMEOUT_DEFAULT,
@@ -161,7 +162,7 @@ public final class RatisUtil {
    * @param properties RaftProperties instance which will be updated
    * @param ozoneConf ConfigurationSource
    */
-  private static void setRaftLogProperties(final RaftProperties properties,
+  private static int setRaftLogProperties(final RaftProperties properties,
       final ConfigurationSource ozoneConf) {
     Log.setSegmentSizeMax(properties, SizeInBytes.valueOf((long)
         ozoneConf.getStorageSize(
@@ -195,6 +196,7 @@ public final class RatisUtil {
             ozoneConf.getInt(ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_PURGE_GAP,
                     ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_PURGE_GAP_DEFAULT));
     Log.setSegmentCacheNumMax(properties, 2);
+    return logAppenderQueueByteLimit;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.RatisConfUtils;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.security.SecurityConfig;
@@ -624,16 +625,15 @@ public final class OzoneManagerRatisServer {
     // Set Ratis storage directory
     RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(new File(ratisStorageDir)));
 
-    final int logAppenderQueueByteLimit = (int) conf.getStorageSize(
+    final int logAppenderBufferByteLimit = (int) conf.getStorageSize(
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT, StorageUnit.BYTES);
+    setRaftLogProperties(properties, logAppenderBufferByteLimit, conf);
 
     // For grpc config
-    setGrpcConfig(properties, logAppenderQueueByteLimit);
+    RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);
 
     setRaftLeaderElectionProperties(properties, conf);
-
-    setRaftLogProperties(properties, logAppenderQueueByteLimit, conf);
 
     setRaftRpcProperties(properties, conf);
 
@@ -691,12 +691,6 @@ public final class OzoneManagerRatisServer {
 
     // Set the number of maximum cached segments
     RaftServerConfigKeys.Log.setSegmentCacheNumMax(properties, 2);
-  }
-
-  private static void setGrpcConfig(RaftProperties properties, int logAppenderQueueByteLimit) {
-    // For grpc set the maximum message size
-    // TODO: calculate the optimal max message size
-    GrpcConfigKeys.setMessageSizeMax(properties, SizeInBytes.valueOf(logAppenderQueueByteLimit));
   }
 
   private static void setRaftRpcProperties(RaftProperties properties, ConfigurationSource conf) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to a bug, [RATIS-2135](https://issues.apache.org/jira/browse/RATIS-2135) requires
- raft.grpc.message.size.max

to be 1MB larger than

- raft.server.log.appender.buffer.byte-limit

We must change the OM, SCM and Datanode conf accordingly.

## What is the link to the Apache JIRA

HDDS-11320

## How was this patch tested?

A new unit test.