### PR TITLE
HDDS-11319. Reduce XceiverClientRatis info log to debug

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -137,7 +137,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
       throw new IllegalArgumentException(watchType + " is not supported. " +
           "Currently only ALL_COMMITTED or MAJORITY_COMMITTED are supported");
     }
-    LOG.info("WatchType {}. Majority {}, ", this.watchType, this.majority);
+    LOG.debug("WatchType {}. Majority {}, ", this.watchType, this.majority);
     if (LOG.isTraceEnabled()) {
       LOG.trace("new XceiverClientRatis for pipeline " + pipeline.getId(),
           new Throwable("TRACE"));


### PR DESCRIPTION
## What changes were proposed in this pull request?
I changed the log level from info to debug in XceiverClientRatis.java to this log message:
`"WatchType {}. Majority {}, ", this.watchType, this.majority)`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11319

## How was this patch tested?
Trivial change