### PR TITLE
HDDS-11333. Avoid hard-coded current version in upgrade/xcompat tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -35,7 +35,7 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-export OZONE_CURRENT_VERSION=1.5.0
+export OZONE_CURRENT_VERSION="${ozone.version}"
 run_test ha non-rolling-upgrade 1.4.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.3.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.2.1 "$OZONE_CURRENT_VERSION"

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -21,7 +21,7 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 basename=$(basename ${COMPOSE_DIR})
 
-current_version=1.5.0
+current_version="${ozone.version}"
 old_versions="1.0.0 1.1.0 1.2.1 1.3.0 1.4.0" # container is needed for each version in clients.yaml
 
 # shellcheck source=hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -77,7 +77,8 @@ test_cross_compatibility() {
 
 test_ec_cross_compatibility() {
   echo "Running Erasure Coded storage backward compatibility tests."
-  local cluster_versions_with_ec="1.3.0 1.4.0"
+  # local cluster_versions_with_ec="1.3.0 1.4.0 ${current_version}"
+  local cluster_versions_with_ec="${current_version}" # until HDDS-11334
   local non_ec_client_versions="1.0.0 1.1.0 1.2.1"
 
   for cluster_version in ${cluster_versions_with_ec}; do


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace hard-coded version number for current in upgrade and xcompat tests.

Only run EC compatibility test for current version.  Previously it was executed twice, once for both 1.3.0 and 1.4.0, but `new-cluster.yaml` ignores the version number.  EC test is to be improved in HDDS-11334 to cover multiple versions.

https://issues.apache.org/jira/browse/HDDS-11333

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/10430533094