### PR TITLE
HDDS-11331. Fix Datanode unable to report for a long time

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.ozone.container.common.states.DatanodeState;
 import org.apache.hadoop.ozone.container.common.states.datanode.InitDatanodeState;
 import org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.CommandStatus;
 import org.apache.hadoop.ozone.protocol.commands.DeleteBlockCommandStatus.DeleteBlockCommandStatusBuilder;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
@@ -550,8 +551,12 @@ public class StateContext {
     if (map == null) {
       return Collections.emptyList();
     }
-    final PipelineReportsProto reports = parentDatanodeStateMachine.
-        getContainer().getPipelineReport();
+    final OzoneContainer ozoneContainer = parentDatanodeStateMachine.
+        getContainer();
+    if (ozoneContainer == null) {
+      return Collections.emptyList();
+    }
+    final PipelineReportsProto reports = ozoneContainer.getPipelineReport();
     return map.getActions(reports.getPipelineReportList(), maxLimit);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -119,7 +119,7 @@ public class StateContext {
   private final Map<InetSocketAddress, List<Message>>
       incrementalReportsQueue;
   private final Map<InetSocketAddress, Queue<ContainerAction>> containerActions;
-  private final Map<InetSocketAddress, ActionMap> pipelineActions;
+  private final Map<InetSocketAddress, PipelineActionMap> pipelineActions;
   private DatanodeStateMachine.DatanodeStates state;
   private boolean shutdownOnError = false;
   private boolean shutdownGracefully = false;
@@ -547,7 +547,7 @@ public class StateContext {
   public List<PipelineAction> getPendingPipelineAction(
       InetSocketAddress endpoint,
       int maxLimit) {
-    final ActionMap map = pipelineActions.get(endpoint);
+    final PipelineActionMap map = pipelineActions.get(endpoint);
     if (map == null) {
       return Collections.emptyList();
     }
@@ -886,7 +886,7 @@ public class StateContext {
     if (!endpoints.contains(endpoint)) {
       this.endpoints.add(endpoint);
       this.containerActions.put(endpoint, new LinkedList<>());
-      this.pipelineActions.put(endpoint, new ActionMap());
+      this.pipelineActions.put(endpoint, new PipelineActionMap());
       this.incrementalReportsQueue.put(endpoint, new LinkedList<>());
       Map<String, AtomicBoolean> mp = new HashMap<>();
       fullReportTypeList.forEach(e -> {
@@ -948,7 +948,7 @@ public class StateContext {
     return threadNamePrefix;
   }
 
-  static class ActionMap {
+  static class PipelineActionMap {
     private final LinkedHashMap<PipelineKey, PipelineAction> map =
         new LinkedHashMap<>();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In some cases, Datanodes were unable to report to the SCM for a long time due to StateContext#pipelineActions being stuck. This PR is intended to try to fix this.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11331

## How was this patch tested?
Need to ensure CI execution is successful.
