### PR TITLE
HDDS-11081. Use thread-local instance of FileSystem in Freon tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -152,10 +152,10 @@ public class TestHadoopDirTreeGenerator {
     Path rootDir = new Path(rootPath.concat("/"));
     // verify root path details
     FileStatus[] fileStatuses = fileSystem.listStatus(rootDir);
+    // verify the num of peer directories, expected span count is 1
+    // as it has only one dir at root.
+    verifyActualSpan(1, fileStatuses);
     for (FileStatus fileStatus : fileStatuses) {
-      // verify the num of peer directories, expected span count is 1
-      // as it has only one dir at root.
-      verifyActualSpan(1, fileStatuses);
       int actualDepth =
           traverseToLeaf(fileSystem, fileStatus.getPath(), 1, depth, span,
               fileCount, StorageSize.parse(perFileSize, StorageUnit.BYTES));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopBaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopBaseFreonGenerator.java
@@ -74,9 +74,9 @@ public abstract class HadoopBaseFreonGenerator extends BaseFreonGenerator {
     return threadLocalFileSystem.get();
   }
 
-  private org.apache.hadoop.fs.FileSystem createFS() {
+  private FileSystem createFS() {
     try {
-      return org.apache.hadoop.fs.FileSystem.get(uri, configuration);
+      return FileSystem.get(uri, configuration);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopBaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopBaseFreonGenerator.java
@@ -44,6 +44,7 @@ public abstract class HadoopBaseFreonGenerator extends BaseFreonGenerator {
 
   @Override
   public void init() {
+    super.init();
     configuration = createOzoneConfiguration();
     uri = URI.create(rootPath);
     String scheme = Optional.ofNullable(uri.getScheme())

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopBaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopBaseFreonGenerator.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.freon;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.util.Optional;
+
+/**
+ * Base class for Freon generator tests that requires  {@link FileSystem} instance.
+ */
+public abstract class HadoopBaseFreonGenerator extends BaseFreonGenerator {
+
+  @Option(names = {"-r", "--rpath", "--path"},
+      description = "Hadoop FS file system path. Use full path.",
+      defaultValue = "o3fs://bucket1.vol1")
+  private String rootPath;
+
+  private final ThreadLocal<FileSystem>  threadLocalFileSystem =
+      ThreadLocal.withInitial(this::createFS);
+
+  private OzoneConfiguration configuration;
+  private URI uri;
+
+  @Override
+  public void init() {
+    configuration = createOzoneConfiguration();
+    uri = URI.create(rootPath);
+    String scheme = Optional.ofNullable(uri.getScheme())
+        .orElseGet(() -> FileSystem.getDefaultUri(configuration)
+            .getScheme());
+    String disableCacheName =
+        String.format("fs.%s.impl.disable.cache", scheme);
+    print("Disabling FS cache: " + disableCacheName);
+    configuration.setBoolean(disableCacheName, true);
+  }
+
+  @Override
+  protected void taskLoopCompleted() {
+    FileSystem fileSystem = threadLocalFileSystem.get();
+    try {
+      fileSystem.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  protected String getRootPath() {
+    return rootPath;
+  }
+
+  protected FileSystem getFileSystem() {
+    return threadLocalFileSystem.get();
+  }
+
+  private org.apache.hadoop.fs.FileSystem createFS() {
+    try {
+      return org.apache.hadoop.fs.FileSystem.get(uri, configuration);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -72,9 +72,7 @@ public class HadoopFsGenerator extends HadoopBaseFreonGenerator
     super.init();
 
     Path file = new Path(getRootPath() + "/" + generateObjectName(0));
-    try (FileSystem fileSystem = getFileSystem()) {
-      fileSystem.mkdirs(file.getParent());
-    }
+    getFileSystem().mkdirs(file.getParent());
 
     contentGenerator =
         new ContentGenerator(fileSize.toBytes(), bufferSize, copyBufferSize,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
@@ -16,13 +16,10 @@
  */
 package org.apache.hadoop.ozone.freon;
 
-import java.net.URI;
 import java.util.concurrent.Callable;
 
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
@@ -41,16 +38,11 @@ import picocli.CommandLine.Option;
     mixinStandardHelpOptions = true,
     showDefaultValues = true)
 @SuppressWarnings("java:S2245") // no need for secure random
-public class HadoopNestedDirGenerator extends BaseFreonGenerator
+public class HadoopNestedDirGenerator extends HadoopBaseFreonGenerator
     implements Callable<Void> {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(HadoopNestedDirGenerator.class);
-
-  @Option(names = {"-r", "--rpath"},
-      description = "Hadoop FS directory system path",
-      defaultValue = "o3fs://bucket2.vol2")
-  private String rootPath;
 
   @Option(names = {"-d", "--depth"},
       description = "Number of directories to be generated recursively",
@@ -70,8 +62,6 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
       defaultValue = "10")
   private int length;
 
-  private FileSystem fileSystem;
-
   @Override
   public Void call() throws Exception {
     String s;
@@ -82,9 +72,7 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
       s = "Invalid span value, span value should be greater or equal to zero!";
       print(s);
     } else {
-      init();
-      OzoneConfiguration configuration = createOzoneConfiguration();
-      fileSystem = FileSystem.get(URI.create(rootPath), configuration);
+      super.init();
       runTests(this::createDir);
     }
     return null;
@@ -109,14 +97,14 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
       dirString = dirString.concat("/").concat(RandomStringUtils.
           randomAlphanumeric(length));
     }
-    Path file = new Path(rootPath.concat("/").concat(dirString));
-    fileSystem.mkdirs(file.getParent());
+    Path file = new Path(getRootPath().concat("/").concat(dirString));
+    getFileSystem().mkdirs(file.getParent());
     String leafDir = dirString.substring(0, dirString.length() - length);
     String tmp = "/0";
     for (int i = 1; i <= span; i++) {
       String childDir = leafDir.concat(Integer.toString(i)).concat(tmp);
-      Path dir = new Path(rootPath.concat("/").concat(childDir));
-      fileSystem.mkdirs(dir.getParent());
+      Path dir = new Path(getRootPath().concat("/").concat(childDir));
+      getFileSystem().mkdirs(dir.getParent());
     }
     String message = "\nSuccessfully created directories. " +
             "Total Directories with level = " + depth + " and span = " + span;


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-4313](https://issues.apache.org/jira/browse/HDDS-4313) uses thread-local instance of FileSystem in HadoopFsGenerator to prevent client contention due to the shared FileSystem instance. We can apply this to other FS freon tests (e.g. HadoopDirTreeGenerator)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11081

## How was this patch tested?

Existing tests.
