### PR TITLE
HDDS-11340. Avoid extra PubBlock call when a full block is closed

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -94,6 +94,9 @@ public class BlockOutputStream extends OutputStream {
       KeyValue.newBuilder().setKey(FULL_CHUNK).build();
 
   private AtomicReference<BlockID> blockID;
+  // planned block full size
+  private long blockSize;
+  private boolean eofSent = false;
   private final AtomicReference<ChunkInfo> previousChunkInfo
       = new AtomicReference<>();
 
@@ -164,6 +167,7 @@ public class BlockOutputStream extends OutputStream {
   @SuppressWarnings("checkstyle:ParameterNumber")
   public BlockOutputStream(
       BlockID blockID,
+      long blockSize,
       XceiverClientFactory xceiverClientManager,
       Pipeline pipeline,
       BufferPool bufferPool,
@@ -175,6 +179,7 @@ public class BlockOutputStream extends OutputStream {
     this.xceiverClientFactory = xceiverClientManager;
     this.config = config;
     this.blockID = new AtomicReference<>(blockID);
+    this.blockSize = blockSize;
     replicationIndex = pipeline.getReplicaIndex(pipeline.getClosestNode());
     KeyValue keyValue =
         KeyValue.newBuilder().setKey("TYPE").setValue("KEY").build();
@@ -530,7 +535,7 @@ public class BlockOutputStream extends OutputStream {
     final XceiverClientReply asyncReply;
     try {
       BlockData blockData = containerBlockData.build();
-      LOG.debug("sending PutBlock {}", blockData);
+      LOG.debug("sending PutBlock {} flushPos {}", blockData, flushPos);
 
       if (config.getIncrementalChunkList()) {
         // remove any chunks in the containerBlockData list.
@@ -538,7 +543,9 @@ public class BlockOutputStream extends OutputStream {
         containerBlockData.clearChunks();
       }
 
-      asyncReply = putBlockAsync(xceiverClient, blockData, close, tokenString);
+      // if block is full, send the eof
+      boolean isBlockFull = (blockSize != -1 && flushPos == blockSize);
+      asyncReply = putBlockAsync(xceiverClient, blockData, close || isBlockFull, tokenString);
       CompletableFuture<ContainerCommandResponseProto> future = asyncReply.getResponse();
       flushFuture = future.thenApplyAsync(e -> {
         try {
@@ -550,6 +557,7 @@ public class BlockOutputStream extends OutputStream {
         if (getIoException() == null && !force) {
           handleSuccessfulPutBlock(e.getPutBlock().getCommittedBlockLength(),
               asyncReply, flushPos, byteBufferList);
+          eofSent = close || isBlockFull;
         }
         return e;
       }, responseExecutor).exceptionally(e -> {
@@ -690,7 +698,7 @@ public class BlockOutputStream extends OutputStream {
       // There're no pending written data, but there're uncommitted data.
       updatePutBlockLength();
       putBlockResultFuture = executePutBlock(close, false);
-    } else if (close) {
+    } else if (close && !eofSent) {
       // forcing an "empty" putBlock if stream is being closed without new
       // data since latest flush - we need to send the "EOF" flag
       updatePutBlockLength();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -80,7 +80,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
       ContainerClientMetrics clientMetrics, StreamBufferArgs streamBufferArgs,
       Supplier<ExecutorService> executorServiceSupplier
   ) throws IOException {
-    super(blockID, xceiverClientManager,
+    super(blockID, -1, xceiverClientManager,
         pipeline, bufferPool, config, token, clientMetrics, streamBufferArgs, executorServiceSupplier);
     // In EC stream, there will be only one node in pipeline.
     this.datanodeDetails = pipeline.getClosestNode();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/RatisBlockOutputStream.java
@@ -72,6 +72,7 @@ public class RatisBlockOutputStream extends BlockOutputStream
   @SuppressWarnings("checkstyle:ParameterNumber")
   public RatisBlockOutputStream(
       BlockID blockID,
+      long blockSize,
       XceiverClientFactory xceiverClientManager,
       Pipeline pipeline,
       BufferPool bufferPool,
@@ -80,7 +81,7 @@ public class RatisBlockOutputStream extends BlockOutputStream
       ContainerClientMetrics clientMetrics, StreamBufferArgs streamBufferArgs,
       Supplier<ExecutorService> blockOutputStreamResourceProvider
   ) throws IOException {
-    super(blockID, xceiverClientManager, pipeline,
+    super(blockID, blockSize, xceiverClientManager, pipeline,
         bufferPool, config, token, clientMetrics, streamBufferArgs, blockOutputStreamResourceProvider);
     this.commitWatcher = new CommitWatcher(bufferPool, getXceiverClient());
   }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockOutputStreamCorrectness.java
@@ -174,6 +174,7 @@ class TestBlockOutputStreamCorrectness {
 
     return new RatisBlockOutputStream(
         new BlockID(1L, 1L),
+        -1,
         xcm,
         pipeline,
         bufferPool,

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -108,7 +108,7 @@ public class BlockOutputStreamEntry extends OutputStream {
    * @throws IOException
    */
   void createOutputStream() throws IOException {
-    outputStream = new RatisBlockOutputStream(blockID, xceiverClientManager,
+    outputStream = new RatisBlockOutputStream(blockID, length, xceiverClientManager,
         pipeline, bufferPool, config, token, clientMetrics, streamBufferArgs,
         executorServiceSupplier);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, for every client side buffer flush size(32MB default), there will be a putBlock call to DN to persist the block metadata.  For a 128MB block, there will be 4 putBlock calls during the data write, and one extra putBlock at the end when this block is closed due to full.  This last putBlock will add the flag "eof" in the request to indicate that this block is completed. 
This task aims to remove this last putBlock call in case this block is a full block when block close is called. 


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11340

## How was this patch tested?

Existing test cases, plus manual audit log verification. Before the patch, here are the audit logs, the block size 32MB. 
```
2024-08-19 21:29:26,396 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=0, size=4194304, stage=WRITE_DATA} | ret=null | perf={preOpLatencyMs=19, opLatencyMs=32} |
2024-08-19 21:29:26,397 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=4194304, size=4194304, stage=WRITE_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=1} |  
2024-08-19 21:29:26,418 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=0, size=4194304, stage=COMMIT_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=0} |  
2024-08-19 21:29:26,422 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=4194304, size=4194304, stage=COMMIT_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=0} |
2024-08-19 21:29:26,436 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=8388608, size=4194304, stage=WRITE_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=2} |
2024-08-19 21:29:26,439 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=8388608, size=4194304, stage=COMMIT_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=0} |
2024-08-19 21:29:26,465 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=12582912, size=4194304, stage=WRITE_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=1} |
2024-08-19 21:29:26,467 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=12582912, size=4194304, stage=COMMIT_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=0} |
2024-08-19 21:29:26,477 | INFO  | DNAudit | user=null | ip=null | op=PUT_BLOCK {blockData=[blockId=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: null, size=16777216]} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=7} |
2024-08-19 21:29:26,483 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=16777216, size=4194304, stage=WRITE_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=2} |
2024-08-19 21:29:26,484 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=16777216, size=4194304, stage=COMMIT_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=0} |
2024-08-19 21:29:26,500 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=20971520, size=4194304, stage=WRITE_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=1} |
2024-08-19 21:29:26,504 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=20971520, size=4194304, stage=COMMIT_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=0} |
2024-08-19 21:29:26,524 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=25165824, size=4194304, stage=WRITE_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=1} |
2024-08-19 21:29:26,526 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=25165824, size=4194304, stage=COMMIT_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=0} |
2024-08-19 21:29:26,539 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=29360128, size=4194304, stage=WRITE_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=1} |
2024-08-19 21:29:26,545 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: 0, offset=29360128, size=4194304, stage=COMMIT_DATA} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=0} |
2024-08-19 21:29:26,551 | INFO  | DNAudit | user=null | ip=null | op=PUT_BLOCK {blockData=[blockId=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: null, size=33554432]} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=2} |
2024-08-19 21:29:26,576 | INFO  | DNAudit | user=null | ip=null | op=PUT_BLOCK {blockData=[blockId=conID: 2001 locID: 113750153625602004 bcsId: 0 replicaIndex: null, size=33554432]} | ret=null | perf={preOpLatencyMs=0, opLatencyMs=4} |
```

after the patch
```
2024-08-19 22:08:28,508 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240420885044, opLatencyMs=28845125} |
2024-08-19 22:08:28,512 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240452817194, opLatencyMs=1545333} |
2024-08-19 22:08:28,514 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240454482485, opLatencyMs=2044583} |
2024-08-19 22:08:28,522 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240462158935, opLatencyMs=1801875} |
2024-08-19 22:08:28,522 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240464377266, opLatencyMs=52292} |
2024-08-19 22:08:28,525 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240467488055, opLatencyMs=61125} |
2024-08-19 22:08:28,526 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240468259054, opLatencyMs=86708} |
2024-08-19 22:08:28,527 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240468926345, opLatencyMs=34291} |
2024-08-19 22:08:28,537 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240476854462, opLatencyMs=2298291} |
2024-08-19 22:08:28,538 | INFO  | DNAudit | user=null | ip=null | op=PUT_BLOCK {blockData=[blockId=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: null, size=16777216]} | ret=null | perf={preOpLatencyMs=-561240470193760, opLatencyMs=9853542} |
2024-08-19 22:08:28,538 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240480741874, opLatencyMs=54167} |
2024-08-19 22:08:28,551 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240491555406, opLatencyMs=1393083} |
2024-08-19 22:08:28,552 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240494505445, opLatencyMs=62625} |
2024-08-19 22:08:28,566 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240506190266, opLatencyMs=1912792} |
2024-08-19 22:08:28,568 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240510633054, opLatencyMs=72541} |
2024-08-19 22:08:28,578 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240518328587, opLatencyMs=1434459} |
2024-08-19 22:08:28,579 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240521221084, opLatencyMs=61167} |
2024-08-19 22:08:28,581 | INFO  | DNAudit | user=null | ip=null | op=PUT_BLOCK {blockData=[blockId=conID: 2004 locID: 113750153625602007 bcsId: 0 replicaIndex: null, size=33554432]} | ret=null | perf={preOpLatencyMs=-561240521807333, opLatencyMs=1738125} |
2024-08-19 22:08:28,613 | INFO  | DNAudit | user=null | ip=null | op=WRITE_CHUNK {blockData=conID: 2005 locID: 113750153625602008 bcsId: 0 replicaIndex: 0, blockDataSize=4194304} | ret=null | perf={preOpLatencyMs=-561240549952095, opLatencyMs=5258083} |
```