### PR TITLE
HDDS-9781. Limited maxOpenFiles, disabled enableCompactionDag, and createCheckpointDirs when creating OMMetadataManager instance for bootstrapping

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -109,6 +109,8 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_L
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
@@ -388,8 +390,9 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       throws IOException {
     lock = new OmReadOnlyLock();
     omEpoch = 0;
-    setStore(loadDB(conf, dir, name, true,
-        java.util.Optional.of(Boolean.TRUE), Optional.empty()));
+    int maxOpenFiles = conf.getInt(OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES, OZONE_OM_SNAPSHOT_DB_MAX_OPEN_FILES_DEFAULT);
+
+    setStore(loadDB(conf, dir, name, true, Optional.of(Boolean.TRUE), maxOpenFiles, false, false));
     initializeOmTables(CacheType.PARTIAL_CACHE, false);
     perfMetrics = null;
   }
@@ -422,8 +425,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         checkSnapshotDirExist(checkpoint);
       }
       setStore(loadDB(conf, metaDir, dbName, false,
-          java.util.Optional.of(Boolean.TRUE),
-          Optional.of(maxOpenFiles), false, false));
+          java.util.Optional.of(Boolean.TRUE), maxOpenFiles, false, false));
       initializeOmTables(CacheType.PARTIAL_CACHE, false);
     } catch (IOException e) {
       stop();
@@ -565,7 +567,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       int maxOpenFiles = configuration.getInt(OZONE_OM_DB_MAX_OPEN_FILES,
           OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT);
 
-      this.store = loadDB(configuration, metaDir, Optional.of(maxOpenFiles));
+      this.store = loadDB(configuration, metaDir, maxOpenFiles);
 
       initializeOmTables(CacheType.FULL_CACHE, true);
     }
@@ -573,33 +575,15 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     snapshotChainManager = new SnapshotChainManager(this);
   }
 
-  public static DBStore loadDB(OzoneConfiguration configuration, File metaDir)
-      throws IOException {
-    return loadDB(configuration, metaDir, Optional.empty());
-  }
-
-  public static DBStore loadDB(OzoneConfiguration configuration, File metaDir, Optional<Integer> maxOpenFiles)
-      throws IOException {
-    return loadDB(configuration, metaDir, OM_DB_NAME, false,
-        java.util.Optional.empty(), maxOpenFiles, true, true);
-  }
-
-  public static DBStore loadDB(OzoneConfiguration configuration, File metaDir,
-                               String dbName, boolean readOnly,
-                               java.util.Optional<Boolean>
-                                       disableAutoCompaction,
-                               java.util.Optional<Integer> maxOpenFiles)
-          throws IOException {
-    return loadDB(configuration, metaDir, dbName, readOnly,
-        disableAutoCompaction, maxOpenFiles, true, true);
+  public static DBStore loadDB(OzoneConfiguration configuration, File metaDir, int maxOpenFiles) throws IOException {
+    return loadDB(configuration, metaDir, OM_DB_NAME, false, java.util.Optional.empty(), maxOpenFiles, true, true);
   }
 
   @SuppressWarnings("checkstyle:parameternumber")
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir,
                                String dbName, boolean readOnly,
-                               java.util.Optional<Boolean>
-                                   disableAutoCompaction,
-                               java.util.Optional<Integer> maxOpenFiles,
+                               java.util.Optional<Boolean> disableAutoCompaction,
+                               int maxOpenFiles,
                                boolean enableCompactionDag,
                                boolean createCheckpointDirs)
       throws IOException {
@@ -613,10 +597,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
         .setPath(Paths.get(metaDir.getPath()))
         .setMaxFSSnapshots(maxFSSnapshots)
         .setEnableCompactionDag(enableCompactionDag)
-        .setCreateCheckpointDirs(createCheckpointDirs);
+        .setCreateCheckpointDirs(createCheckpointDirs)
+        .setMaxNumberOfOpenFiles(maxOpenFiles);
     disableAutoCompaction.ifPresent(
             dbStoreBuilder::disableDefaultCFAutoCompaction);
-    maxOpenFiles.ifPresent(dbStoreBuilder::setMaxNumberOfOpenFiles);
     return addOMTablesAndCodecs(dbStoreBuilder).build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
@@ -27,13 +27,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
- * Test that all the tables are covered both by OMDBDefinition
- * as well as OmMetadataManagerImpl.
+ * Test that all the tables are covered both by OMDBDefinition and OmMetadataManagerImpl.
  */
 public class TestOMDBDefinition {
 
@@ -41,33 +42,33 @@ public class TestOMDBDefinition {
   private Path folder;
 
   @Test
-  public void testDBDefinition() throws Exception {
+  public void testDBDefinition() throws IOException {
     OzoneConfiguration configuration = new OzoneConfiguration();
     File metaDir = folder.toFile();
-    DBStore store = OmMetadataManagerImpl.loadDB(configuration, metaDir);
     OMDBDefinition dbDef = new OMDBDefinition();
 
     // Get list of tables from DB Definitions
-    final Collection<DBColumnFamilyDefinition<?, ?>> columnFamilyDefinitions
-        = dbDef.getColumnFamilies();
+    final Collection<DBColumnFamilyDefinition<?, ?>> columnFamilyDefinitions = dbDef.getColumnFamilies();
     final int countOmDefTables = columnFamilyDefinitions.size();
-    ArrayList<String> missingDBDefTables = new ArrayList<>();
+    List<String> missingDBDefTables = new ArrayList<>();
 
-    // Get list of tables from the RocksDB Store
-    final Collection<String> missingOmDBTables = new ArrayList<>(store.getTableNames().values());
-    missingOmDBTables.remove("default");
-    int countOmDBTables = missingOmDBTables.size();
-    // Remove the file if it is found in both the datastructures
-    for (DBColumnFamilyDefinition definition : columnFamilyDefinitions) {
-      if (!missingOmDBTables.remove(definition.getName())) {
-        missingDBDefTables.add(definition.getName());
+    try (DBStore store = OmMetadataManagerImpl.loadDB(configuration, metaDir, -1)) {
+      // Get list of tables from the RocksDB Store
+      final Collection<String> missingOmDBTables = new ArrayList<>(store.getTableNames().values());
+      missingOmDBTables.remove("default");
+      int countOmDBTables = missingOmDBTables.size();
+      // Remove the file if it is found in both the datastructures
+      for (DBColumnFamilyDefinition definition : columnFamilyDefinitions) {
+        if (!missingOmDBTables.remove(definition.getName())) {
+          missingDBDefTables.add(definition.getName());
+        }
       }
-    }
 
-    assertEquals(0, missingDBDefTables.size(),
-        "Tables in OmMetadataManagerImpl are:" + missingDBDefTables);
-    assertEquals(0, missingOmDBTables.size(),
-        "Tables missing in OMDBDefinition are:" + missingOmDBTables);
-    assertEquals(countOmDBTables, countOmDefTables);
+      assertEquals(0, missingDBDefTables.size(),
+          "Tables in OmMetadataManagerImpl are:" + missingDBDefTables);
+      assertEquals(0, missingOmDBTables.size(),
+          "Tables missing in OMDBDefinition are:" + missingOmDBTables);
+      assertEquals(countOmDBTables, countOmDefTables);
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
For the OMDBCheckpoint request, a new RocksDB instance is created on the checkpointed dir to verify that all the snapshots have created checkpoint dirs because it is an async process in RocksDB.
When this RocksDB instance is created, it is needed to be created with snapshot's DB's config rather than AFS's DB's config.
This change addresses this concern, limits the number of open files, and does not start background processes like compaction.


## What is the link to the Apache JIRA
HDDS-9781

## How was this patch tested?
Existing test.
