### PR TITLE
HDDS-11322. [hsync] Block ECKeyOutputStream from calling hsync and hflush

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.client.io;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
@@ -418,6 +419,16 @@ public final class ECKeyOutputStream extends KeyOutputStream
   @Override
   public void flush() {
     LOG.debug("ECKeyOutputStream does not support flush.");
+  }
+
+  @Override
+  public void hflush() {
+    throw new NotImplementedException("ECKeyOutputStream does not support hflush.");
+  }
+
+  @Override
+  public void hsync() {
+    throw new NotImplementedException("ECKeyOutputStream does not support hsync.");
   }
 
   private void closeCurrentStreamEntry()


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ECKeyOutputStream` extends `KeyOutputStream`, but Ozone EC does not support `hsync` (at least for now since it is not implemented) as there are known issues with that, such as HDDS-8932.

This jira prevents `hsync()` and `hflush()` from being called on `ECKeyOutputStream` by throwing `NotImplementedException`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11322

## How was this patch tested?

- Added test case to make sure that invocation of `hsync()` and `hflush()` on `ECKeyOutputStream` throws exception.