### PR TITLE
HDDS-11325. Intermittent failure in TestBlockOutputStreamWithFailures#testContainerClose

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -700,7 +700,8 @@ class TestBlockOutputStream {
           assertInstanceOf(RatisBlockOutputStream.class,
               keyOutputStream.getStreamEntries().get(0).getOutputStream());
 
-      assertEquals(4, blockOutputStream.getBufferPool().getSize());
+      assertThat(blockOutputStream.getBufferPool().getSize())
+          .isLessThanOrEqualTo(4);
       // writtenDataLength as well flushedDataLength will be updated here
       assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -730,7 +730,8 @@ class TestBlockOutputStream {
       // Since the data in the buffer is already flushed, flush here will have
       // no impact on the counters and data structures
 
-      assertEquals(4, blockOutputStream.getBufferPool().getSize());
+      assertThat(blockOutputStream.getBufferPool().getSize())
+          .isLessThanOrEqualTo(4);
       assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
       // dataLength > MAX_FLUSH_SIZE
       assertEquals(flushDelay ? MAX_FLUSH_SIZE : dataLength,


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11325. Intermittent failure in TestBlockOutputStreamWithFailures#testContainerClose

Please describe your PR in detail:
The assertion assumes the buffer pool is allocated 4 buffers.

After [HDDS-9844](https://issues.apache.org/jira/browse/HDDS-9844), the block output stream buffer allocation becomes asynchronous and it's possible to allocate fewer buffers than before, because some response already come back and the associated buffer can be reused.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11325

## How was this patch tested?

Unit test change only.