### PR TITLE
HDDS-11346. FS CLI gives incorrect recursive volume deletion prompt

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -722,7 +722,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         throw new IOException("Recursive volume delete using " +
             "ofs is not supported. " +
             "Instead use 'ozone sh volume delete -r " +
-            "-id <OM_SERVICE_ID> <Volume_URI>' command");
+            "o3://<OM_SERVICE_ID>/<Volume_URI>' command");
       }
       return deleteVolume(f, ofsPath);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Correct the prompt Ozone CLI gives when trying to recursively delete an Ozone volume.

HDDS-10716 fixed it partially by removing the invalid `-skipTrash` option but didn't fix the `-id` part.

See the JIRA description for more details.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11346

## How was this patch tested?

- Verified manually.