### PR TITLE
HDDS-11349. Add NullPointer handling when volume/bucket tables are not initialized

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -173,7 +173,9 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
 
     // If the table is not yet initialized, i.e. it is null
     // Return empty list as response
-    if (volumeTable == null) return result;
+    if (volumeTable == null) {
+      return result;
+    }
 
     try (TableIterator<String, ? extends Table.KeyValue<String, OmVolumeArgs>>
                  iterator = volumeTable.iterator()) {
@@ -304,7 +306,9 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
     Table<String, OmBucketInfo> bucketTable = getBucketTable();
     // If the table is not yet initialized, i.e. it is null
     // Return empty list as response
-    if (bucketTable == null) return result;
+    if (bucketTable == null) {
+      return result;
+    }
 
     try (TableIterator<String, ? extends Table.KeyValue<String, OmBucketInfo>>
              iterator = bucketTable.iterator()) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -169,8 +169,14 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
     // Unlike in {@link OmMetadataManagerImpl}, the volumes are queried directly
     // from the volume table (not through cache) since Recon does not use
     // Table cache.
+    Table<String, OmVolumeArgs>  volumeTable = getVolumeTable();
+
+    // If the table is not yet initialized, i.e. it is null
+    // Return empty list as response
+    if (volumeTable == null) return result;
+
     try (TableIterator<String, ? extends Table.KeyValue<String, OmVolumeArgs>>
-             iterator = getVolumeTable().iterator()) {
+                 iterator = volumeTable.iterator()) {
 
       while (iterator.hasNext() && result.size() < maxKeys) {
         Table.KeyValue<String, OmVolumeArgs> kv = iterator.next();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -302,6 +302,9 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
 
     int currentCount = 0;
     Table<String, OmBucketInfo> bucketTable = getBucketTable();
+    // If the table is not yet initialized, i.e. it is null
+    // Return empty list as response
+    if (bucketTable == null) return result;
 
     try (TableIterator<String, ? extends Table.KeyValue<String, OmBucketInfo>>
              iterator = bucketTable.iterator()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11349. Add NullPointer handling when volume/bucket tables are not initialized

Please describe your PR in detail:
* Currently if we call the /volumes API while the Volumes table is being initialized it returns a 500 error.
* This PR will add the handling of this scenario
* After this change, if we call `/volumes` or `/buckets` endpoint before the table is completely initialized, it will return
```
{
  totalCount: 0,
  volumes: []
}
```
```
{
buckets: []
totalCount: 0
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11349

## How was this patch tested?
It was tested using unit tests and also manually verifying the response is properly returned.
<img width="909" alt="Screenshot 2024-08-21 at 12 45 17" src="https://github.com/user-attachments/assets/ce580b71-6069-4b24-b3f9-f82cedba0d3a">

<img width="922" alt="Screenshot 2024-08-21 at 12 45 26" src="https://github.com/user-attachments/assets/50c5dac5-d98c-4901-8969-cf6988d3fea6">
