### PR TITLE
HDDS-11285. cli to trigger quota repair and status

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -279,6 +279,8 @@ public final class OmUtils {
     case PrintCompactionLogDag:
     case GetSnapshotInfo:
     case GetServerDefaults:
+    case QuotaRepairStatus:
+    case QuotaRepairTrigger:
       return true;
     case CreateVolume:
     case SetVolumeProperty:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -279,8 +279,8 @@ public final class OmUtils {
     case PrintCompactionLogDag:
     case GetSnapshotInfo:
     case GetServerDefaults:
-    case QuotaRepairStatus:
-    case QuotaRepairTrigger:
+    case GetQuotaRepairStatus:
+    case StartQuotaRepair:
       return true;
     case CreateVolume:
     case SetVolumeProperty:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -1153,4 +1153,17 @@ public interface OzoneManagerProtocol
    * @throws IOException
    */
   OzoneFsServerDefaults getServerDefaults() throws IOException;
+
+  /**
+   * Get status of last triggered quota repair in OM.
+   * @return String
+   * @throws IOException
+   */
+  String getQuotaRepairStatus() throws IOException;
+
+  /**
+   * trigger quota repair in OM.
+   * @throws IOException
+   */
+  void triggerQuotaRepair(List<String> buckets) throws IOException;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -1162,8 +1162,8 @@ public interface OzoneManagerProtocol
   String getQuotaRepairStatus() throws IOException;
 
   /**
-   * trigger quota repair in OM.
+   * start quota repair in OM.
    * @throws IOException
    */
-  void triggerQuotaRepair(List<String> buckets) throws IOException;
+  void startQuotaRepair(List<String> buckets) throws IOException;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2581,25 +2581,25 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
   @Override
   public String getQuotaRepairStatus() throws IOException {
-    OzoneManagerProtocolProtos.QuotaRepairStatusRequest quotaRepairStatusRequest =
-        OzoneManagerProtocolProtos.QuotaRepairStatusRequest.newBuilder()
+    OzoneManagerProtocolProtos.GetQuotaRepairStatusRequest quotaRepairStatusRequest =
+        OzoneManagerProtocolProtos.GetQuotaRepairStatusRequest.newBuilder()
             .build();
 
-    OMRequest omRequest = createOMRequest(Type.QuotaRepairStatus)
-        .setQuotaRepairStatusRequest(quotaRepairStatusRequest).build();
+    OMRequest omRequest = createOMRequest(Type.GetQuotaRepairStatus)
+        .setGetQuotaRepairStatusRequest(quotaRepairStatusRequest).build();
 
-    OzoneManagerProtocolProtos.QuotaRepairStatusResponse quotaRepairStatusResponse
-        = handleError(submitRequest(omRequest)).getQuotaRepairStatusResponse();
+    OzoneManagerProtocolProtos.GetQuotaRepairStatusResponse quotaRepairStatusResponse
+        = handleError(submitRequest(omRequest)).getGetQuotaRepairStatusResponse();
     return quotaRepairStatusResponse.getStatus();
   }
 
   @Override
-  public void triggerQuotaRepair(List<String> buckets) throws IOException {
-    OzoneManagerProtocolProtos.QuotaRepairTriggerRequest quotaRepairTriggerRequest =
-        OzoneManagerProtocolProtos.QuotaRepairTriggerRequest.newBuilder()
+  public void startQuotaRepair(List<String> buckets) throws IOException {
+    OzoneManagerProtocolProtos.StartQuotaRepairRequest startQuotaRepairRequest =
+        OzoneManagerProtocolProtos.StartQuotaRepairRequest.newBuilder()
             .build();
-    OMRequest omRequest = createOMRequest(Type.QuotaRepairTrigger)
-        .setQuotaRepairTriggerRequest(quotaRepairTriggerRequest).build();
+    OMRequest omRequest = createOMRequest(Type.StartQuotaRepair)
+        .setStartQuotaRepairRequest(startQuotaRepairRequest).build();
     handleError(submitRequest(omRequest));
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2600,7 +2600,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             .build();
     OMRequest omRequest = createOMRequest(Type.QuotaRepairTrigger)
         .setQuotaRepairTriggerRequest(quotaRepairTriggerRequest).build();
-    handleError(submitRequest(omRequest)).getQuotaRepairTriggerResponse();
+    handleError(submitRequest(omRequest));
   }
 
   private SafeMode toProtoBuf(SafeModeAction action) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2579,6 +2579,30 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         serverDefaultsResponse.getServerDefaults());
   }
 
+  @Override
+  public String getQuotaRepairStatus() throws IOException {
+    OzoneManagerProtocolProtos.QuotaRepairStatusRequest quotaRepairStatusRequest =
+        OzoneManagerProtocolProtos.QuotaRepairStatusRequest.newBuilder()
+            .build();
+
+    OMRequest omRequest = createOMRequest(Type.QuotaRepairStatus)
+        .setQuotaRepairStatusRequest(quotaRepairStatusRequest).build();
+
+    OzoneManagerProtocolProtos.QuotaRepairStatusResponse quotaRepairStatusResponse
+        = handleError(submitRequest(omRequest)).getQuotaRepairStatusResponse();
+    return quotaRepairStatusResponse.getStatus();
+  }
+
+  @Override
+  public void triggerQuotaRepair(List<String> buckets) throws IOException {
+    OzoneManagerProtocolProtos.QuotaRepairTriggerRequest quotaRepairTriggerRequest =
+        OzoneManagerProtocolProtos.QuotaRepairTriggerRequest.newBuilder()
+            .build();
+    OMRequest omRequest = createOMRequest(Type.QuotaRepairTrigger)
+        .setQuotaRepairTriggerRequest(quotaRepairTriggerRequest).build();
+    handleError(submitRequest(omRequest)).getQuotaRepairTriggerResponse();
+  }
+
   private SafeMode toProtoBuf(SafeModeAction action) {
     switch (action) {
     case ENTER:

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
@@ -22,8 +22,13 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.debug.DBScanner;
 import org.apache.hadoop.ozone.debug.RDBParser;
 import org.apache.hadoop.ozone.om.OMStorage;
+import org.apache.hadoop.ozone.repair.OzoneRepair;
 import org.apache.hadoop.ozone.repair.RDBRepair;
 import org.apache.hadoop.ozone.repair.TransactionInfoRepair;
+import org.apache.hadoop.ozone.repair.quota.QuotaRepair;
+import org.apache.hadoop.ozone.repair.quota.QuotaStatus;
+import org.apache.hadoop.ozone.repair.quota.QuotaTrigger;
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +43,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -130,4 +136,28 @@ public class TestOzoneRepairShell {
     throw new IllegalStateException("Failed to scan and find raft's highest term and index from TransactionInfo table");
   }
 
+  @Test
+  public void testQuotaRepair() throws Exception {
+    CommandLine cmd = new CommandLine(new OzoneRepair()).addSubcommand(new CommandLine(new QuotaRepair())
+        .addSubcommand(new QuotaStatus()).addSubcommand(new QuotaTrigger()));
+
+    String[] args = new String[] {"quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
+    int exitCode = cmd.execute(args);
+    assertEquals(0, exitCode);
+    args = new String[] {"quota", "trigger", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
+    exitCode = cmd.execute(args);
+    assertEquals(0, exitCode);
+    GenericTestUtils.waitFor(() -> {
+      out.reset();
+      // verify quota trigger is completed having non-zero lastRunFinishedTime
+      String[] targs = new String[]{"quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
+      cmd.execute(targs);
+      try {
+        return !out.toString(DEFAULT_ENCODING).contains("\"lastRunFinishedTime\":0");
+      } catch (Exception ex) {
+        // do nothing
+      }
+      return false;
+    }, 1000, 10000);
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
@@ -153,7 +153,7 @@ public class TestOzoneRepairShell {
       String[] targs = new String[]{"quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
       cmd.execute(targs);
       try {
-        return !out.toString(DEFAULT_ENCODING).contains("\"lastRunFinishedTime\":0");
+        return !out.toString(DEFAULT_ENCODING).contains("\"lastRunFinishedTime\":\"\"");
       } catch (Exception ex) {
         // do nothing
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneRepairShell.java
@@ -144,7 +144,7 @@ public class TestOzoneRepairShell {
     String[] args = new String[] {"quota", "status", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
     int exitCode = cmd.execute(args);
     assertEquals(0, exitCode);
-    args = new String[] {"quota", "trigger", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
+    args = new String[] {"quota", "start", "--service-host", conf.get(OZONE_OM_ADDRESS_KEY)};
     exitCode = cmd.execute(args);
     assertEquals(0, exitCode);
     GenericTestUtils.waitFor(() -> {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -151,6 +151,8 @@ enum Type {
   ListOpenFiles = 132;
   QuotaRepair = 133;
   GetServerDefaults = 134;
+  QuotaRepairStatus = 135;
+  QuotaRepairTrigger = 136;
 }
 
 enum SafeMode {
@@ -291,6 +293,8 @@ message OMRequest {
   optional ListOpenFilesRequest             ListOpenFilesRequest           = 130;
   optional QuotaRepairRequest               QuotaRepairRequest             = 131;
   optional ServerDefaultsRequest            ServerDefaultsRequest          = 132;
+  optional QuotaRepairStatusRequest         QuotaRepairStatusRequest       = 133;
+  optional QuotaRepairTriggerRequest        QuotaRepairTriggerRequest      = 134;
 }
 
 message OMResponse {
@@ -419,6 +423,8 @@ message OMResponse {
   optional ListOpenFilesResponse             ListOpenFilesResponse         = 133;
   optional QuotaRepairResponse            QuotaRepairResponse        = 134;
   optional ServerDefaultsResponse            ServerDefaultsResponse        = 135;
+  optional QuotaRepairStatusResponse            QuotaRepairStatusResponse        = 136;
+  optional QuotaRepairTriggerResponse            QuotaRepairTriggerResponse        = 137;
 }
 
 enum Status {
@@ -2224,6 +2230,17 @@ message FsServerDefaultsProto {
 
 message ServerDefaultsResponse {
   required FsServerDefaultsProto serverDefaults = 1;
+}
+
+message QuotaRepairStatusRequest {
+}
+message QuotaRepairStatusResponse {
+    optional string status = 1;
+}
+message QuotaRepairTriggerRequest {
+    repeated string buckets = 1;
+}
+message QuotaRepairTriggerResponse {
 }
 
 message OMLockDetailsProto {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -151,8 +151,8 @@ enum Type {
   ListOpenFiles = 132;
   QuotaRepair = 133;
   GetServerDefaults = 134;
-  QuotaRepairStatus = 135;
-  QuotaRepairTrigger = 136;
+  GetQuotaRepairStatus = 135;
+  StartQuotaRepair = 136;
 }
 
 enum SafeMode {
@@ -293,8 +293,8 @@ message OMRequest {
   optional ListOpenFilesRequest             ListOpenFilesRequest           = 130;
   optional QuotaRepairRequest               QuotaRepairRequest             = 131;
   optional ServerDefaultsRequest            ServerDefaultsRequest          = 132;
-  optional QuotaRepairStatusRequest         QuotaRepairStatusRequest       = 133;
-  optional QuotaRepairTriggerRequest        QuotaRepairTriggerRequest      = 134;
+  optional GetQuotaRepairStatusRequest      GetQuotaRepairStatusRequest    = 133;
+  optional StartQuotaRepairRequest          StartQuotaRepairRequest        = 134;
 }
 
 message OMResponse {
@@ -423,8 +423,8 @@ message OMResponse {
   optional ListOpenFilesResponse             ListOpenFilesResponse         = 133;
   optional QuotaRepairResponse            QuotaRepairResponse        = 134;
   optional ServerDefaultsResponse            ServerDefaultsResponse        = 135;
-  optional QuotaRepairStatusResponse            QuotaRepairStatusResponse        = 136;
-  optional QuotaRepairTriggerResponse            QuotaRepairTriggerResponse        = 137;
+  optional GetQuotaRepairStatusResponse      GetQuotaRepairStatusResponse   = 136;
+  optional StartQuotaRepairResponse          StartQuotaRepairResponse       = 137;
 }
 
 enum Status {
@@ -2232,15 +2232,15 @@ message ServerDefaultsResponse {
   required FsServerDefaultsProto serverDefaults = 1;
 }
 
-message QuotaRepairStatusRequest {
+message GetQuotaRepairStatusRequest {
 }
-message QuotaRepairStatusResponse {
+message GetQuotaRepairStatusResponse {
     optional string status = 1;
 }
-message QuotaRepairTriggerRequest {
+message StartQuotaRepairRequest {
     repeated string buckets = 1;
 }
-message QuotaRepairTriggerResponse {
+message StartQuotaRepairResponse {
 }
 
 message OMLockDetailsProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4759,8 +4759,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-  public void triggerQuotaRepair(List<String> buckets) throws IOException {
-    checkAdminUserPrivilege("trigger quota repair");
+  public void startQuotaRepair(List<String> buckets) throws IOException {
+    checkAdminUserPrivilege("start quota repair");
     new QuotaRepairTask(this).repair(buckets);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4754,11 +4754,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @Override
   public String getQuotaRepairStatus() throws IOException {
+    checkAdminUserPrivilege("quota repair status");
     return QuotaRepairTask.getStatus();
   }
 
   @Override
   public void triggerQuotaRepair(List<String> buckets) throws IOException {
+    checkAdminUserPrivilege("trigger quota repair");
     new QuotaRepairTask(this).repair(buckets);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -106,6 +106,7 @@ import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.s3.S3SecretCacheProvider;
 import org.apache.hadoop.ozone.om.s3.S3SecretStoreProvider;
 import org.apache.hadoop.ozone.om.service.OMRangerBGSyncService;
+import org.apache.hadoop.ozone.om.service.QuotaRepairTask;
 import org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
@@ -4749,6 +4750,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public OzoneFsServerDefaults getServerDefaults() {
     return serverDefaults;
+  }
+
+  @Override
+  public String getQuotaRepairStatus() throws IOException {
+    return QuotaRepairTask.getStatus();
+  }
+
+  @Override
+  public void triggerQuotaRepair(List<String> buckets) throws IOException {
+    new QuotaRepairTask(this).repair(buckets);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
@@ -91,7 +91,7 @@ public class QuotaRepairTask {
     // lock in progress operation and reject any other
     if (!IN_PROGRESS.compareAndSet(false, true)) {
       LOG.info("quota repair task already running");
-      throw new OMException("Operation in progress", OMException.ResultCodes.QUOTA_ERROR);
+      throw new OMException("Quota repair is already running", OMException.ResultCodes.QUOTA_ERROR);
     }
     REPAIR_STATUS.reset(RUN_CNT.get() + 1);
     return CompletableFuture.supplyAsync(() -> repairTask(buckets));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
@@ -184,7 +184,11 @@ public class QuotaRepairTask {
     }
 
     // update volume to support quota
-    builder.setSupportVolumeOldQuota(true);
+    if (buckets.isEmpty()) {
+      builder.setSupportVolumeOldQuota(true);
+    } else {
+      builder.setSupportVolumeOldQuota(false);
+    }
   }
 
   private OzoneManagerProtocolProtos.OMResponse submitRequest(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
@@ -501,8 +501,9 @@ public class QuotaRepairTask {
       }
       Map<String, Object> status = new HashMap<>();
       status.put("taskId", taskId);
-      status.put("lastRunStartTime", lastRunStartTime);
-      status.put("lastRunFinishedTime", lastRunFinishedTime);
+      status.put("lastRunStartTime", lastRunStartTime > 0 ? new java.util.Date(lastRunStartTime).toString() : "");
+      status.put("lastRunFinishedTime", lastRunFinishedTime > 0 ? new java.util.Date(lastRunFinishedTime).toString()
+          : "");
       status.put("errorMsg", errorMsg);
       status.put("bucketCountDiffMap", bucketCountDiffMap);
       try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/QuotaRepairTask.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -74,27 +76,31 @@ public class QuotaRepairTask {
   private static final int TASK_THREAD_CNT = 3;
   private static final AtomicBoolean IN_PROGRESS = new AtomicBoolean(false);
   private static final RepairStatus REPAIR_STATUS = new RepairStatus();
+  private static final AtomicLong RUN_CNT = new AtomicLong(0);
   private final OzoneManager om;
-  private final AtomicLong runCount = new AtomicLong(0);
   private ExecutorService executor;
   public QuotaRepairTask(OzoneManager ozoneManager) {
     this.om = ozoneManager;
   }
 
-  public CompletableFuture<Boolean> repair() throws Exception {
+  public CompletableFuture<Boolean> repair() throws IOException {
+    return repair(Collections.emptyList());
+  }
+
+  public CompletableFuture<Boolean> repair(List<String> buckets) throws IOException {
     // lock in progress operation and reject any other
     if (!IN_PROGRESS.compareAndSet(false, true)) {
       LOG.info("quota repair task already running");
-      return CompletableFuture.supplyAsync(() -> false);
+      throw new OMException("Operation in progress", OMException.ResultCodes.QUOTA_ERROR);
     }
-    REPAIR_STATUS.reset(runCount.get() + 1);
-    return CompletableFuture.supplyAsync(() -> repairTask());
+    REPAIR_STATUS.reset(RUN_CNT.get() + 1);
+    return CompletableFuture.supplyAsync(() -> repairTask(buckets));
   }
 
   public static String getStatus() {
     return REPAIR_STATUS.toString();
   }
-  private boolean repairTask() {
+  private boolean repairTask(List<String> buckets) {
     LOG.info("Starting quota repair task {}", REPAIR_STATUS);
     OMMetadataManager activeMetaManager = null;
     try {
@@ -104,7 +110,7 @@ public class QuotaRepairTask {
           = OzoneManagerProtocolProtos.QuotaRepairRequest.newBuilder();
       // repair active db
       activeMetaManager = createActiveDBCheckpoint(om.getMetadataManager(), om.getConfiguration());
-      repairActiveDb(activeMetaManager, builder);
+      repairActiveDb(activeMetaManager, builder, buckets);
 
       // TODO: repair snapshots for quota
 
@@ -116,12 +122,12 @@ public class QuotaRepairTask {
           .setClientId(clientId.toString())
           .build();
       OzoneManagerProtocolProtos.OMResponse response = submitRequest(omRequest, clientId);
-      if (response != null && !response.getSuccess()) {
+      if (response != null && response.getSuccess()) {
+        REPAIR_STATUS.updateStatus(builder, om.getMetadataManager());
+      } else {
         LOG.error("update quota repair count response failed");
         REPAIR_STATUS.updateStatus("Response for update DB is failed");
         return false;
-      } else {
-        REPAIR_STATUS.updateStatus(builder, om.getMetadataManager());
       }
     } catch (Exception exp) {
       LOG.error("quota repair count failed", exp);
@@ -145,11 +151,15 @@ public class QuotaRepairTask {
 
   private void repairActiveDb(
       OMMetadataManager metadataManager,
-      OzoneManagerProtocolProtos.QuotaRepairRequest.Builder builder) throws Exception {
+      OzoneManagerProtocolProtos.QuotaRepairRequest.Builder builder,
+      List<String> buckets) throws Exception {
     Map<String, OmBucketInfo> nameBucketInfoMap = new HashMap<>();
     Map<String, OmBucketInfo> idBucketInfoMap = new HashMap<>();
     Map<String, OmBucketInfo> oriBucketInfoMap = new HashMap<>();
-    prepareAllBucketInfo(nameBucketInfoMap, idBucketInfoMap, oriBucketInfoMap, metadataManager);
+    prepareAllBucketInfo(nameBucketInfoMap, idBucketInfoMap, oriBucketInfoMap, metadataManager, buckets);
+    if (nameBucketInfoMap.isEmpty()) {
+      throw new OMException("no matching buckets", OMException.ResultCodes.BUCKET_NOT_FOUND);
+    }
 
     repairCount(nameBucketInfoMap, idBucketInfoMap, metadataManager);
 
@@ -178,7 +188,7 @@ public class QuotaRepairTask {
   }
 
   private OzoneManagerProtocolProtos.OMResponse submitRequest(
-      OzoneManagerProtocolProtos.OMRequest omRequest, ClientId clientId) {
+      OzoneManagerProtocolProtos.OMRequest omRequest, ClientId clientId) throws Exception {
     try {
       if (om.isRatisEnabled()) {
         OzoneManagerRatisServer server = om.getOmRatisServer();
@@ -186,19 +196,20 @@ public class QuotaRepairTask {
             .setClientId(clientId)
             .setServerId(om.getOmRatisServer().getRaftPeerId())
             .setGroupId(om.getOmRatisServer().getRaftGroupId())
-            .setCallId(runCount.getAndIncrement())
+            .setCallId(RUN_CNT.getAndIncrement())
             .setMessage(Message.valueOf(OMRatisHelper.convertRequestToByteString(omRequest)))
             .setType(RaftClientRequest.writeRequestType())
             .build();
         return server.submitRequest(omRequest, raftClientRequest);
       } else {
+        RUN_CNT.getAndIncrement();
         return om.getOmServerProtocol().submitRequest(
             null, omRequest);
       }
     } catch (ServiceException e) {
       LOG.error("repair quota count " + omRequest.getCmdType() + " request failed.", e);
+      throw e;
     }
-    return null;
   }
   
   private OMMetadataManager createActiveDBCheckpoint(
@@ -228,22 +239,40 @@ public class QuotaRepairTask {
 
   private void prepareAllBucketInfo(
       Map<String, OmBucketInfo> nameBucketInfoMap, Map<String, OmBucketInfo> idBucketInfoMap,
-      Map<String, OmBucketInfo> oriBucketInfoMap, OMMetadataManager metadataManager) throws IOException {
+      Map<String, OmBucketInfo> oriBucketInfoMap, OMMetadataManager metadataManager,
+      List<String> buckets) throws IOException {
+    if (!buckets.isEmpty()) {
+      for (String bucketkey : buckets) {
+        OmBucketInfo bucketInfo = metadataManager.getBucketTable().get(bucketkey);
+        if (null == bucketInfo) {
+          continue;
+        }
+        populateBucket(nameBucketInfoMap, idBucketInfoMap, oriBucketInfoMap, metadataManager, bucketInfo);
+      }
+      return;
+    }
     try (TableIterator<String, ? extends Table.KeyValue<String, OmBucketInfo>>
              iterator = metadataManager.getBucketTable().iterator()) {
       while (iterator.hasNext()) {
         Table.KeyValue<String, OmBucketInfo> entry = iterator.next();
         OmBucketInfo bucketInfo = entry.getValue();
-        String bucketNameKey = buildNamePath(bucketInfo.getVolumeName(),
-            bucketInfo.getBucketName());
-        oriBucketInfoMap.put(bucketNameKey, bucketInfo.copyObject());
-        bucketInfo.incrUsedNamespace(-bucketInfo.getUsedNamespace());
-        bucketInfo.incrUsedBytes(-bucketInfo.getUsedBytes());
-        nameBucketInfoMap.put(bucketNameKey, bucketInfo);
-        idBucketInfoMap.put(buildIdPath(metadataManager.getVolumeId(bucketInfo.getVolumeName()),
-                bucketInfo.getObjectID()), bucketInfo);
+        populateBucket(nameBucketInfoMap, idBucketInfoMap, oriBucketInfoMap, metadataManager, bucketInfo);
       }
     }
+  }
+
+  private static void populateBucket(
+      Map<String, OmBucketInfo> nameBucketInfoMap, Map<String, OmBucketInfo> idBucketInfoMap,
+      Map<String, OmBucketInfo> oriBucketInfoMap, OMMetadataManager metadataManager,
+      OmBucketInfo bucketInfo) throws IOException {
+    String bucketNameKey = buildNamePath(bucketInfo.getVolumeName(),
+        bucketInfo.getBucketName());
+    oriBucketInfoMap.put(bucketNameKey, bucketInfo.copyObject());
+    bucketInfo.incrUsedNamespace(-bucketInfo.getUsedNamespace());
+    bucketInfo.incrUsedBytes(-bucketInfo.getUsedBytes());
+    nameBucketInfoMap.put(bucketNameKey, bucketInfo);
+    idBucketInfoMap.put(buildIdPath(metadataManager.getVolumeId(bucketInfo.getVolumeName()),
+            bucketInfo.getObjectID()), bucketInfo);
   }
 
   private boolean isChange(OmBucketInfo lBucketInfo, OmBucketInfo rBucketInfo) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -382,15 +382,15 @@ public class OzoneManagerRequestHandler implements RequestHandler {
                 .setServerDefaults(impl.getServerDefaults().getProtobuf())
                 .build());
         break;
-      case QuotaRepairStatus:
-        OzoneManagerProtocolProtos.QuotaRepairStatusResponse quotaRepairStatusRsp =
-            getQuotaRepairStatus(request.getQuotaRepairStatusRequest());
-        responseBuilder.setQuotaRepairStatusResponse(quotaRepairStatusRsp);
+      case GetQuotaRepairStatus:
+        OzoneManagerProtocolProtos.GetQuotaRepairStatusResponse quotaRepairStatusRsp =
+            getQuotaRepairStatus(request.getGetQuotaRepairStatusRequest());
+        responseBuilder.setGetQuotaRepairStatusResponse(quotaRepairStatusRsp);
         break;
-      case QuotaRepairTrigger:
-        OzoneManagerProtocolProtos.QuotaRepairTriggerResponse quotaRepairTriggerRsp =
-            triggerQuotaRepair(request.getQuotaRepairTriggerRequest());
-        responseBuilder.setQuotaRepairTriggerResponse(quotaRepairTriggerRsp);
+      case StartQuotaRepair:
+        OzoneManagerProtocolProtos.StartQuotaRepairResponse startQuotaRepairRsp =
+            startQuotaRepair(request.getStartQuotaRepairRequest());
+        responseBuilder.setStartQuotaRepairResponse(startQuotaRepairRsp);
         break;
       default:
         responseBuilder.setSuccess(false);
@@ -1532,15 +1532,15 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     }
   }
 
-  private OzoneManagerProtocolProtos.QuotaRepairStatusResponse getQuotaRepairStatus(
-      OzoneManagerProtocolProtos.QuotaRepairStatusRequest req) throws IOException {
-    return OzoneManagerProtocolProtos.QuotaRepairStatusResponse.newBuilder()
+  private OzoneManagerProtocolProtos.GetQuotaRepairStatusResponse getQuotaRepairStatus(
+      OzoneManagerProtocolProtos.GetQuotaRepairStatusRequest req) throws IOException {
+    return OzoneManagerProtocolProtos.GetQuotaRepairStatusResponse.newBuilder()
         .setStatus(impl.getQuotaRepairStatus())
         .build();
   }
-  private OzoneManagerProtocolProtos.QuotaRepairTriggerResponse triggerQuotaRepair(
-      OzoneManagerProtocolProtos.QuotaRepairTriggerRequest req) throws IOException {
-    impl.triggerQuotaRepair(req.getBucketsList());
-    return OzoneManagerProtocolProtos.QuotaRepairTriggerResponse.newBuilder().build();
+  private OzoneManagerProtocolProtos.StartQuotaRepairResponse startQuotaRepair(
+      OzoneManagerProtocolProtos.StartQuotaRepairRequest req) throws IOException {
+    impl.startQuotaRepair(req.getBucketsList());
+    return OzoneManagerProtocolProtos.StartQuotaRepairResponse.newBuilder().build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -382,6 +382,16 @@ public class OzoneManagerRequestHandler implements RequestHandler {
                 .setServerDefaults(impl.getServerDefaults().getProtobuf())
                 .build());
         break;
+      case QuotaRepairStatus:
+        OzoneManagerProtocolProtos.QuotaRepairStatusResponse quotaRepairStatusRsp =
+            getQuotaRepairStatus(request.getQuotaRepairStatusRequest());
+        responseBuilder.setQuotaRepairStatusResponse(quotaRepairStatusRsp);
+        break;
+      case QuotaRepairTrigger:
+        OzoneManagerProtocolProtos.QuotaRepairTriggerResponse quotaRepairTriggerRsp =
+            triggerQuotaRepair(request.getQuotaRepairTriggerRequest());
+        responseBuilder.setQuotaRepairTriggerResponse(quotaRepairTriggerRsp);
+        break;
       default:
         responseBuilder.setSuccess(false);
         responseBuilder.setMessage("Unrecognized Command Type: " + cmdType);
@@ -1520,5 +1530,17 @@ public class OzoneManagerRequestHandler implements RequestHandler {
       throw new IllegalArgumentException("Unexpected safe mode action " +
           safeMode);
     }
+  }
+
+  private OzoneManagerProtocolProtos.QuotaRepairStatusResponse getQuotaRepairStatus(
+      OzoneManagerProtocolProtos.QuotaRepairStatusRequest req) throws IOException {
+    return OzoneManagerProtocolProtos.QuotaRepairStatusResponse.newBuilder()
+        .setStatus(impl.getQuotaRepairStatus())
+        .build();
+  }
+  private OzoneManagerProtocolProtos.QuotaRepairTriggerResponse triggerQuotaRepair(
+      OzoneManagerProtocolProtos.QuotaRepairTriggerRequest req) throws IOException {
+    impl.triggerQuotaRepair(req.getBucketsList());
+    return OzoneManagerProtocolProtos.QuotaRepairTriggerResponse.newBuilder().build();
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaRepair.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaRepair.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.repair.quota;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory;
+import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
+import org.apache.hadoop.ozone.repair.OzoneRepair;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ratis.protocol.ClientId;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
+
+/**
+ * Ozone Repair CLI for quota.
+ */
+@CommandLine.Command(name = "quota",
+    description = "Operational tool to repair quota in OM DB.")
+@MetaInfServices(SubcommandWithParent.class)
+public class QuotaRepair implements Callable<Void>, SubcommandWithParent {
+
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
+  @CommandLine.ParentCommand
+  private OzoneRepair parent;
+
+  @Override
+  public Void call() {
+    GenericCli.missingSubcommand(spec);
+    return null;
+  }
+
+  public OzoneManagerProtocolClientSideTranslatorPB createOmClient(
+      String omServiceID,
+      String omHost,
+      boolean forceHA
+  ) throws Exception {
+    OzoneConfiguration conf = parent.getOzoneConf();
+    if (omHost != null && !omHost.isEmpty()) {
+      omServiceID = null;
+      conf.set(OZONE_OM_ADDRESS_KEY, omHost);
+    } else if (omServiceID == null || omServiceID.isEmpty()) {
+      omServiceID = getTheOnlyConfiguredOmServiceIdOrThrow();
+    }
+    RPC.setProtocolEngine(conf, OzoneManagerProtocolPB.class,
+        ProtobufRpcEngine.class);
+    String clientId = ClientId.randomId().toString();
+    if (!forceHA || (forceHA && OmUtils.isOmHAServiceId(conf, omServiceID))) {
+      OmTransport omTransport = new Hadoop3OmTransportFactory()
+          .createOmTransport(conf, getUser(), omServiceID);
+      return new OzoneManagerProtocolClientSideTranslatorPB(omTransport,
+          clientId);
+    } else {
+      throw new OzoneClientException("This command works only on OzoneManager" +
+          " HA cluster. Service ID specified does not match" +
+          " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
+          "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are " +
+          conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + "\n");
+    }
+  }
+
+  private String getTheOnlyConfiguredOmServiceIdOrThrow() {
+    if (getConfiguredServiceIds().size() != 1) {
+      throw new IllegalArgumentException("There is no Ozone Manager service ID "
+          + "specified, but there are either zero, or more than one service ID"
+          + "configured.");
+    }
+    return getConfiguredServiceIds().iterator().next();
+  }
+
+  private Collection<String> getConfiguredServiceIds() {
+    OzoneConfiguration conf = parent.getOzoneConf();
+    Collection<String> omServiceIds =
+        conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
+    return omServiceIds;
+  }
+
+  public UserGroupInformation getUser() throws IOException {
+    return UserGroupInformation.getCurrentUser();
+  }
+
+  protected OzoneRepair getParent() {
+    return parent;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return OzoneRepair.class;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaStatus.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaStatus.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache
+ * License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software
+ * distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.repair.quota;
+
+import java.util.concurrent.Callable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+
+/**
+ * Tool to get status of last triggered quota repair.
+ */
+@CommandLine.Command(
+    name = "status",
+    description = "CLI to get the status of last trigger quota repair if available.",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+@MetaInfServices(SubcommandWithParent.class)
+public class QuotaStatus implements Callable<Void>, SubcommandWithParent  {
+  @CommandLine.Spec
+  private static CommandLine.Model.CommandSpec spec;
+
+  @CommandLine.Option(
+      names = {"--service-id", "--om-service-id"},
+      description = "Ozone Manager Service ID",
+      required = false
+  )
+  private String omServiceId;
+
+  @CommandLine.Option(
+      names = {"--service-host"},
+      description = "Ozone Manager Host. If OM HA is enabled, use --service-id instead. "
+          + "If you must use --service-host with OM HA, this must point directly to the leader OM. "
+          + "This option is required when --service-id is not provided or when HA is not enabled."
+  )
+  private String omHost;
+
+  @CommandLine.ParentCommand
+  private QuotaRepair parent;
+
+  @Override
+  public Void call() throws Exception {
+    OzoneManagerProtocol ozoneManagerClient =
+        parent.createOmClient(omServiceId, omHost, false);
+    System.out.println(ozoneManagerClient.getQuotaRepairStatus());
+    return null;
+  }
+
+  protected QuotaRepair getParent() {
+    return parent;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return QuotaRepair.class;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaStatus.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaStatus.java
@@ -22,7 +22,6 @@
 package org.apache.hadoop.ozone.repair.quota;
 
 import java.util.concurrent.Callable;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaTrigger.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaTrigger.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache
+ * License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software
+ * distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.repair.quota;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+/**
+ * Tool to trigger quota repair.
+ */
+@CommandLine.Command(
+    name = "trigger",
+    description = "CLI to trigger quota repair.",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+@MetaInfServices(SubcommandWithParent.class)
+public class QuotaTrigger implements Callable<Void>, SubcommandWithParent  {
+  @CommandLine.Spec
+  private static CommandLine.Model.CommandSpec spec;
+
+  @CommandLine.ParentCommand
+  private QuotaRepair parent;
+
+  @CommandLine.Option(
+      names = {"--service-id", "--om-service-id"},
+      description = "Ozone Manager Service ID",
+      required = false
+  )
+  private String omServiceId;
+
+  @CommandLine.Option(
+      names = {"--service-host"},
+      description = "Ozone Manager Host. If OM HA is enabled, use --service-id instead. "
+          + "If you must use --service-host with OM HA, this must point directly to the leader OM. "
+          + "This option is required when --service-id is not provided or when HA is not enabled."
+  )
+  private String omHost;
+
+  @CommandLine.Option(names = {"--buckets"},
+      required = false,
+      description = "trigger quota repair for specific buckets. Input will be list of uri separated by comma as" +
+          " /<volume>/<bucket>[,...]")
+  private String buckets;
+
+  @Override
+  public Void call() throws Exception {
+    List<String> bucketList = Collections.emptyList();
+    if (StringUtils.isNotEmpty(buckets)) {
+      bucketList = Arrays.asList(buckets.split(","));
+    }
+    
+    OzoneManagerProtocol ozoneManagerClient =
+        parent.createOmClient(omServiceId, omHost, false);
+    try {
+      ozoneManagerClient.triggerQuotaRepair(bucketList);
+      System.out.println(ozoneManagerClient.getQuotaRepairStatus());
+    } catch (Exception ex) {
+      System.out.println(ex.getMessage());
+    }
+    return null;
+  }
+
+  protected QuotaRepair getParent() {
+    return parent;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return QuotaRepair.class;
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaTrigger.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/QuotaTrigger.java
@@ -36,7 +36,7 @@ import picocli.CommandLine;
  * Tool to trigger quota repair.
  */
 @CommandLine.Command(
-    name = "trigger",
+    name = "start",
     description = "CLI to trigger quota repair.",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
@@ -66,7 +66,7 @@ public class QuotaTrigger implements Callable<Void>, SubcommandWithParent  {
 
   @CommandLine.Option(names = {"--buckets"},
       required = false,
-      description = "trigger quota repair for specific buckets. Input will be list of uri separated by comma as" +
+      description = "start quota repair for specific buckets. Input will be list of uri separated by comma as" +
           " /<volume>/<bucket>[,...]")
   private String buckets;
 
@@ -80,7 +80,7 @@ public class QuotaTrigger implements Callable<Void>, SubcommandWithParent  {
     OzoneManagerProtocol ozoneManagerClient =
         parent.createOmClient(omServiceId, omHost, false);
     try {
-      ozoneManagerClient.triggerQuotaRepair(bucketList);
+      ozoneManagerClient.startQuotaRepair(bucketList);
       System.out.println(ozoneManagerClient.getQuotaRepairStatus());
     } catch (Exception ex) {
       System.out.println(ex.getMessage());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/repair/quota/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Ozone Repair tools.
+ */
+package org.apache.hadoop.ozone.repair.quota;


### PR DESCRIPTION
## What changes were proposed in this pull request?

CLI option to trigger repair and also check status:

```
ozone repair quota status [--service-host=<omHost> ] [--service-id, --om-service-id=<omServiceId>] 

ozone repair quota trigger [--buckets=<buckets>] [--service-host=<omHost>] [--service-id=<omServiceId>]
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11285

## How was this patch tested?

- Unit test case is added

```
./ozone repair quota trigger --service-host=localhost
ATTENTION: Running as user sumitagrawal. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: <supressed>
{"bucketCountDiffMap":{},"lastRunFinishedTime":"","lastRunStartTime":1725511849369,"taskId":1,"errorMsg":""}


./ozone repair quota status --service-host=localhost 
ATTENTION: Running as user sumitagrawal. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: <supressed>
 {"bucketCountDiffMap":{},"lastRunFinishedTime":"Thu Sep 05 10:29:00 IST 2024","lastRunStartTime":"Thu Sep 05 10:28:59 IST 2024","taskId":1,"errorMsg":"BUCKET_NOT_FOUND org.apache.hadoop.ozone.om.exceptions.OMException: no matching buckets"}


./ozone repair quota status --service-host=localhost 
ATTENTION: Running as user sumitagrawal. Make sure this is the same user used to run the Ozone process. Are you sure you want to continue (y/N)? y
Run as user: <supressed>
{"bucketCountDiffMap":{},"lastRunFinishedTime":"Thu Sep 05 10:29:00 IST 2024","lastRunStartTime":"Thu Sep 05 10:28:59 IST 2024","taskId":1,"errorMsg":""}
```
