### PR TITLE
HDDS-11357. Datanode Usageinfo Support Display Pipelines Count.

### DIFF
--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -191,6 +191,7 @@ message DatanodeUsageInfoProto {
     optional int64 containerCount = 5;
     optional int64 committed = 6;
     optional int64 freeSpaceToSpare = 7;
+    optional int64 pipelineCount = 8;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
@@ -32,6 +32,7 @@ public class DatanodeUsageInfo {
   private DatanodeDetails datanodeDetails;
   private SCMNodeStat scmNodeStat;
   private int containerCount;
+  private int pipelineCount;
 
   /**
    * Constructs a DatanodeUsageInfo with DatanodeDetails and SCMNodeStat.
@@ -45,6 +46,7 @@ public class DatanodeUsageInfo {
     this.datanodeDetails = datanodeDetails;
     this.scmNodeStat = scmNodeStat;
     this.containerCount = -1;
+    this.pipelineCount = -1;
   }
 
   /**
@@ -145,6 +147,14 @@ public class DatanodeUsageInfo {
     this.containerCount = containerCount;
   }
 
+  public int getPipelineCount() {
+    return pipelineCount;
+  }
+
+  public void setPipelineCount(int pipelineCount) {
+    this.pipelineCount = pipelineCount;
+  }
+
   /**
    * Gets Comparator that compares two DatanodeUsageInfo on the basis of
    * their utilization values. Utilization is (capacity - remaining) divided
@@ -210,6 +220,7 @@ public class DatanodeUsageInfo {
     }
 
     builder.setContainerCount(containerCount);
+    builder.setPipelineCount(pipelineCount);
     return builder;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -982,6 +982,7 @@ public class SCMNodeManager implements NodeManager {
     DatanodeUsageInfo usageInfo = new DatanodeUsageInfo(dn, stat);
     try {
       usageInfo.setContainerCount(getContainerCount(dn));
+      usageInfo.setPipelineCount(getPipeLineCount(dn));
     } catch (NodeNotFoundException ex) {
       LOG.error("Unknown datanode {}.", dn, ex);
     }
@@ -1608,6 +1609,11 @@ public class SCMNodeManager implements NodeManager {
   public int getContainerCount(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
     return nodeStateManager.getContainerCount(datanodeDetails.getUuid());
+  }
+
+  public int getPipeLineCount(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException {
+    return nodeStateManager.getPipelinesCount(datanodeDetails);
   }
 
   @Override

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
@@ -155,6 +155,8 @@ public class UsageInfoSubcommand extends ScmSubcommand {
         + " B", StringUtils.byteDesc(info.getRemaining()));
     System.out.printf("%-13s: %s %n", "Remaining %",
         PERCENT_FORMAT.format(info.getRemainingRatio()));
+    System.out.printf("%-13s: %d %n", "Pipeline(s)",
+            info.getPipelineCount());
     System.out.printf("%-13s: %d %n", "Container(s)",
             info.getContainerCount());
     System.out.printf("%-24s: %s (%s) %n", "Container Pre-allocated",
@@ -192,6 +194,7 @@ public class UsageInfoSubcommand extends ScmSubcommand {
     private long committed = 0;
     private long freeSpaceToSpare = 0;
     private long containerCount = 0;
+    private long pipelineCount = 0;
 
     DatanodeUsage(HddsProtos.DatanodeUsageInfoProto proto) {
       if (proto.hasNode()) {
@@ -211,6 +214,9 @@ public class UsageInfoSubcommand extends ScmSubcommand {
       }
       if (proto.hasContainerCount()) {
         containerCount = proto.getContainerCount();
+      }
+      if (proto.hasPipelineCount()) {
+        pipelineCount = proto.getPipelineCount();
       }
       if (proto.hasFreeSpaceToSpare()) {
         freeSpaceToSpare = proto.getFreeSpaceToSpare();
@@ -277,5 +283,8 @@ public class UsageInfoSubcommand extends ScmSubcommand {
       return remaining / (double) capacity;
     }
 
+    public long getPipelineCount() {
+      return pipelineCount;
+    }
   }
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestUsageInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestUsageInfoSubcommand.java
@@ -94,6 +94,7 @@ public class TestUsageInfoSubcommand {
     assertEquals(80.00, json.get(0).get("remainingPercent").doubleValue(), 0.001);
 
     assertEquals(5, json.get(0).get("containerCount").longValue());
+    assertEquals(10, json.get(0).get("pipelineCount").longValue());
   }
 
   @Test
@@ -122,6 +123,7 @@ public class TestUsageInfoSubcommand {
     assertThat(output).contains("Remaining    :");
     assertThat(output).contains("Remaining %  :");
     assertThat(output).contains("Container(s) :");
+    assertThat(output).contains("Pipeline(s)  :");
     assertThat(output).contains("Container Pre-allocated :");
     assertThat(output).contains("Remaining Allocatable   :");
     assertThat(output).contains("Free Space To Spare     :");
@@ -135,6 +137,7 @@ public class TestUsageInfoSubcommand {
         .setRemaining(80)
         .setUsed(10)
         .setContainerCount(5)
+        .setPipelineCount(10)
         .build());
     return result;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can use `ozone admin datanode usageinfo` to display the usage information of a datanode. However, this information does not include Pipeline details, which are also crucial for the datanode. It would be useful to include Pipeline information in this display.

The information is displayed as follows:

```
UUID : dd1e5cf2-dtf5-6b35-ade5-ac8589d9eaf5
IP Address : 192.168.0.1
Hostname : localhost-192.168.0.1
Capacity : 100 B (100 B)
Total Used : 20 B (20 B)
Total Used % : 20.00%
Ozone Used : 10 B (10 B)
Ozone Used % : 10.00%
Remaining : 80 B (80 B)
Remaining % : 80.00%
Pipeline(s) : 10
Container(s) : 5
Container Pre-allocated : 0 B (0 B)
Remaining Allocatable : 80 B (80 B)
Free Space To Spare : 0 B (0 B)
```



## What is the link to the Apache JIRA

JIRA: HDDS-11357. Datanode Usageinfo Support Display Pipeline.

## How was this patch tested?

Junit Test & Execute the command manually.
