### PR TITLE
HDDS-11312. [hsync] Added upgrade tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
@@ -40,6 +40,7 @@ OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
 OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
+OZONE-SITE.XML_ozone.fs.hsync.enabled=true
 
 # If SCM sends container close commands as part of upgrade finalization while
 # datanodes are doing a leader election, all 3 replicas may end up in the

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-config
@@ -37,6 +37,7 @@ OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
+OZONE-SITE.XML_ozone.fs.hsync.enabled=true
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/om-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/om-ha/docker-config
@@ -32,6 +32,7 @@ OZONE-SITE.XML_ozone.scm.block.client.address=scm
 OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_ozone.http.basedir=/tmp/ozone_http
+OZONE-SITE.XML_ozone.fs.hsync.enabled=true
 
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.5.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.5.0/callback.sh
@@ -27,4 +27,5 @@ with_this_version_pre_finalized() {
 with_this_version_finalized() {
   execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
   execute_robot_test "$SCM" -N "${OUTPUT_NAME}-hsync" debug/ozone-debug-lease-recovery.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-freon-hsync" freon/hsync.robot
 }

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.5.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/callbacks/1.5.0/callback.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$TEST_DIR"/testlib.sh
+
+with_this_version_pre_finalized() {
+  # New layout features were added in this version, so OM and SCM should be pre-finalized.
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include pre-finalized upgrade/check-finalization.robot
+  # Test that HSync is disabled when pre-finalized.
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-hsync" --include pre-finalized-hsync-tests hsync/upgrade-hsync-check.robot
+}
+
+with_this_version_finalized() {
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-check-finalization" --include finalized upgrade/check-finalization.robot
+  execute_robot_test "$SCM" -N "${OUTPUT_NAME}-hsync" debug/ozone-debug-lease-recovery.robot
+}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-lease-recovery.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-lease-recovery.robot
@@ -17,25 +17,18 @@
 Documentation       Test lease recovery of ozone filesystem
 Library             OperatingSystem
 Resource            ../lib/os.robot
+Resource            ../lib/fs.robot
 Resource            ozone-debug.robot
 Test Timeout        5 minute
 Suite Setup         Create volume bucket and put key
 
 *** Variables ***
-${OMSERVICEID}
+${OM_SERVICE_ID}    %{OM_SERVICE_ID}
 ${VOLUME}           lease-recovery-volume
 ${BUCKET}           lease-recovery-bucket
 ${TESTFILE}         testfile22
 
 *** Keywords ***
-Get OM serviceId
-    ${confKey} =        Execute And Ignore Error        ozone getconf confKey ozone.om.service.ids
-    ${result} =         Evaluate                        "Configuration ozone.om.service.ids is missing" in """${confKey}"""
-    IF      ${result} == ${True}
-        Set Suite Variable  ${OMSERVICEID}         om
-    ELSE
-        Set Suite Variable  ${OMSERVICEID}         ${confKey}
-    END
 Create volume bucket and put key
     Execute                 ozone sh volume create /${VOLUME}
     Execute                 ozone sh bucket create /${VOLUME}/${BUCKET}
@@ -44,15 +37,17 @@ Create volume bucket and put key
 
 *** Test Cases ***
 Test ozone debug recover for o3fs
-    Get OM serviceId
-    ${result} =              Execute Lease recovery cli    o3fs://${BUCKET}.${VOLUME}.${OMSERVICEID}/${TESTFILE}
-    Should Contain    ${result}   Lease recovery SUCCEEDED
-    ${result} =              Execute Lease recovery cli    o3fs://${BUCKET}.${VOLUME}.${OMSERVICEID}/randomfile
-    Should Contain    ${result}    not found
+    ${o3fs_path} =     Format FS URL         o3fs    ${VOLUME}    ${BUCKET}    ${TESTFILE}
+    ${result} =        Execute Lease recovery cli    ${o3fs_path}
+                       Should Contain    ${result}   Lease recovery SUCCEEDED
+    ${o3fs_path} =     Format FS URL         o3fs    ${VOLUME}    ${BUCKET}    randomfile
+    ${result} =        Execute Lease recovery cli    ${o3fs_path}
+                       Should Contain    ${result}    not found
 
 Test ozone debug recover for ofs
-    Get OM serviceId
-    ${result} =              Execute Lease recovery cli    ofs://${OMSERVICEID}/${VOLUME}/${BUCKET}/${TESTFILE}
-    Should Contain    ${result}   Lease recovery SUCCEEDED
-    ${result} =              Execute Lease recovery cli    ofs://${OMSERVICEID}/${VOLUME}/${BUCKET}/randomfile
-    Should Contain    ${result}    not found
+    ${ofs_path} =      Format FS URL         ofs     ${VOLUME}    ${BUCKET}    ${TESTFILE}
+    ${result} =        Execute Lease recovery cli    ${ofs_path}
+                       Should Contain    ${result}   Lease recovery SUCCEEDED
+    ${ofs_path} =      Format FS URL         ofs     ${VOLUME}    ${BUCKET}    randomfile
+    ${result} =        Execute Lease recovery cli    ${ofs_path}
+                       Should Contain    ${result}    not found

--- a/hadoop-ozone/dist/src/main/smoketest/freon/hsync.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/hsync.robot
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test HSync via freon CLI.
+Library             OperatingSystem
+Library             String
+Library             BuiltIn
+Resource            ../ozone-lib/freon.robot
+Test Timeout        10 minutes
+Suite Setup         Get OM serviceId
+
+*** Variables ***
+${OMSERVICEID}
+${VOLUME}           hsync-volume
+${BUCKET}           hsync-bucket
+
+*** Keywords ***
+Get OM serviceId
+    ${confKey} =        Execute And Ignore Error        ozone getconf confKey ozone.om.service.ids
+    ${result} =         Evaluate                        "Configuration ozone.om.service.ids is missing" in """${confKey}"""
+    IF      ${result} == ${True}
+        Set Suite Variable  ${OMSERVICEID}         om
+    ELSE
+        Set Suite Variable  ${OMSERVICEID}         ${confKey}
+    END
+
+*** Test Cases ***
+Generate key by HSYNC
+    Freon DFSG    sync=HSYNC    path=ofs://${OMSERVICEID}/${VOLUME}/${BUCKET}
+
+Generate key by HFLUSH
+    Freon DFSG    sync=HFLUSH   path=ofs://${OMSERVICEID}/${VOLUME}/${BUCKET}

--- a/hadoop-ozone/dist/src/main/smoketest/freon/hsync.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/hsync.robot
@@ -19,27 +19,33 @@ Library             OperatingSystem
 Library             String
 Library             BuiltIn
 Resource            ../ozone-lib/freon.robot
+Resource            ../lib/fs.robot
 Test Timeout        10 minutes
-Suite Setup         Get OM serviceId
+Suite Setup         Create volume and bucket
 
 *** Variables ***
-${OMSERVICEID}
+${OM_SERVICE_ID}    %{OM_SERVICE_ID}
 ${VOLUME}           hsync-volume
 ${BUCKET}           hsync-bucket
 
 *** Keywords ***
-Get OM serviceId
-    ${confKey} =        Execute And Ignore Error        ozone getconf confKey ozone.om.service.ids
-    ${result} =         Evaluate                        "Configuration ozone.om.service.ids is missing" in """${confKey}"""
-    IF      ${result} == ${True}
-        Set Suite Variable  ${OMSERVICEID}         om
-    ELSE
-        Set Suite Variable  ${OMSERVICEID}         ${confKey}
-    END
+Create volume and bucket
+    Execute             ozone sh volume create /${volume}
+    Execute             ozone sh bucket create /${volume}/${bucket}
 
 *** Test Cases ***
-Generate key by HSYNC
-    Freon DFSG    sync=HSYNC    path=ofs://${OMSERVICEID}/${VOLUME}/${BUCKET}
+Generate key for o3fs by HSYNC
+    ${path} =     Format FS URL         o3fs     ${VOLUME}    ${BUCKET}
+    Freon DFSG    sync=HSYNC    path=${path}
 
-Generate key by HFLUSH
-    Freon DFSG    sync=HFLUSH   path=ofs://${OMSERVICEID}/${VOLUME}/${BUCKET}
+Generate key for o3fs by HFLUSH
+    ${path} =     Format FS URL         o3fs     ${VOLUME}    ${BUCKET}
+    Freon DFSG    sync=HFLUSH   path=${path}
+
+Generate key for ofs by HSYNC
+    ${path} =     Format FS URL         ofs     ${VOLUME}    ${BUCKET}
+    Freon DFSG    sync=HSYNC    path=${path}
+
+Generate key for ofs by HFLUSH
+    ${path} =     Format FS URL         ofs     ${VOLUME}    ${BUCKET}
+    Freon DFSG    sync=HFLUSH   path=${path}

--- a/hadoop-ozone/dist/src/main/smoketest/hsync/upgrade-hsync-check.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/hsync/upgrade-hsync-check.robot
@@ -36,6 +36,11 @@ Create volume bucket and put key
     Execute             ozone sh bucket create /${volume}/${bucket}
     Execute             ozone sh key put /${volume}/${bucket}/${key} /etc/hosts
 
+Freon DFSG
+    [arguments]    ${prefix}=dfsg    ${n}=1000    ${path}={EMPTY}    ${sync}=HSYNC    ${buffer}=1024    ${copy-buffer}=1024    ${size}=10240
+    ${result} =    Execute and checkrc   ozone freon dfsg -n ${n} --sync ${sync} -s ${size} --path ${path} --buffer ${buffer} --copy-buffer ${copy-buffer} -p ${prefix}    255
+                   Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION
+
 *** Test Cases ***
 Test HSync lease recover prior to finalization
     Create volume bucket and put key
@@ -48,20 +53,16 @@ Test HSync lease recover prior to finalization
 
 Generate key for o3fs by HSYNC prior to finalization
     ${path} =     Format FS URL         o3fs     ${VOLUME}    ${BUCKET}
-    ${result} =   Execute and checkrc   ozone freon dfsg -n 100 --sync HSYNC -s 10240 --path ${path} --buffer 1024 --copy-buffer 1024 -p dfsg
-                  Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION
+    Freon DFSG    sync=HSYNC    path=${path}
 
 Generate key for o3fs by HFLUSH prior to finalization
     ${path} =     Format FS URL         o3fs     ${VOLUME}    ${BUCKET}
-    ${result} =   Execute and checkrc   ozone freon dfsg -n 100 --sync HFLUSH -s 10240 --path ${path} --buffer 1024 --copy-buffer 1024 -p dfsg
-                  Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION
+    Freon DFSG    sync=HFLUSH    path=${path}
 
 Generate key for ofs by HSYNC prior to finalization
     ${path} =     Format FS URL         ofs     ${VOLUME}    ${BUCKET}
-    ${result} =   Execute and checkrc   ozone freon dfsg -n 100 --sync HSYNC -s 10240 --path ${path} --buffer 1024 --copy-buffer 1024 -p dfsg
-                  Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION
+    Freon DFSG    sync=HSYNC    path=${path}
 
 Generate key for ofs by HFLUSH prior to finalization
     ${path} =     Format FS URL         ofs     ${VOLUME}    ${BUCKET}
-    ${result} =   Execute and checkrc   ozone freon dfsg -n 100 --sync HFLUSH -s 10240 --path ${path} --buffer 1024 --copy-buffer 1024 -p dfsg
-                  Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION
+    Freon DFSG    sync=HFLUSH    path=${path}

--- a/hadoop-ozone/dist/src/main/smoketest/hsync/upgrade-hsync-check.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/hsync/upgrade-hsync-check.robot
@@ -37,7 +37,7 @@ Create volume bucket and put key
     Execute             ozone sh key put /${volume}/${bucket}/${key} /etc/hosts
 
 *** Test Cases ***
-Test HSync Prior To Finalization
+Test HSync lease recover prior to finalization
     Create volume bucket and put key
     ${o3fs_path} =  Format FS URL          o3fs     ${VOLUME}    ${BUCKET}    ${KEY}
     ${result} =     Execute and checkrc    ozone debug recover --path=${o3fs_path}    255
@@ -45,3 +45,23 @@ Test HSync Prior To Finalization
     ${ofs_path} =   Format FS URL          ofs      ${VOLUME}    ${BUCKET}    ${KEY}
     ${result} =     Execute and checkrc    ozone debug recover --path=${ofs_path}    255
                     Should contain  ${result}  It belongs to the layout feature HBASE_SUPPORT, whose layout version is 7
+
+Generate key for o3fs by HSYNC prior to finalization
+    ${path} =     Format FS URL         o3fs     ${VOLUME}    ${BUCKET}
+    ${result} =   Execute and checkrc   ozone freon dfsg -n 100 --sync HSYNC -s 10240 --path ${path} --buffer 1024 --copy-buffer 1024 -p dfsg
+                  Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION
+
+Generate key for o3fs by HFLUSH prior to finalization
+    ${path} =     Format FS URL         o3fs     ${VOLUME}    ${BUCKET}
+    ${result} =   Execute and checkrc   ozone freon dfsg -n 100 --sync HFLUSH -s 10240 --path ${path} --buffer 1024 --copy-buffer 1024 -p dfsg
+                  Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION
+
+Generate key for ofs by HSYNC prior to finalization
+    ${path} =     Format FS URL         ofs     ${VOLUME}    ${BUCKET}
+    ${result} =   Execute and checkrc   ozone freon dfsg -n 100 --sync HSYNC -s 10240 --path ${path} --buffer 1024 --copy-buffer 1024 -p dfsg
+                  Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION
+
+Generate key for ofs by HFLUSH prior to finalization
+    ${path} =     Format FS URL         ofs     ${VOLUME}    ${BUCKET}
+    ${result} =   Execute and checkrc   ozone freon dfsg -n 100 --sync HFLUSH -s 10240 --path ${path} --buffer 1024 --copy-buffer 1024 -p dfsg
+                  Should contain   ${result}   NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION

--- a/hadoop-ozone/dist/src/main/smoketest/hsync/upgrade-hsync-check.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/hsync/upgrade-hsync-check.robot
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test HSync during upgrade
+Library             OperatingSystem
+Library             String
+Library             BuiltIn
+Resource            ../commonlib.robot
+Default Tags        pre-finalized-hsync-tests
+Suite Setup         Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
+
+*** Variables ***
+${OMSERVICEID}
+${VOLUME}
+${BUCKET}
+${KEY}
+
+*** Keywords ***
+Get OM serviceId
+    ${confKey} =        Execute And Ignore Error        ozone getconf confKey ozone.om.service.ids
+    ${result} =         Evaluate                        "Configuration ozone.om.service.ids is missing" in """${confKey}"""
+    IF      ${result} == ${True}
+        Set Suite Variable  ${OMSERVICEID}         om
+    ELSE
+        Set Suite Variable  ${OMSERVICEID}         ${confKey}
+    END
+Create volume for upgrade test
+    ${random} =     Generate Random String  5  [LOWER]
+    ${volume} =     Set Variable        vol-${random}
+    ${result} =     Execute             ozone sh volume create /${volume}
+                    Should not contain  ${result}       Failed
+    Set Suite Variable      ${VOLUME}           ${volume}
+
+Create bucket for upgrade test
+    ${random} =     Generate Random String  5  [LOWER]
+    ${bucket} =     Set Variable        buc-${random}
+    ${result} =     Execute             ozone sh bucket create -l FILE_SYSTEM_OPTIMIZED /${volume}/${bucket}
+                    Should not contain  ${result}       Failed
+    Set Suite Variable      ${BUCKET}           ${bucket}
+
+Create key for upgrade test
+    ${random} =     Generate Random String  5  [LOWER]
+    ${key} =        Set Variable        key-${random}
+    ${result} =     Execute             ozone sh key put /${volume}/${bucket}/${key} /etc/hosts
+    Set Suite Variable      ${KEY}          ${key}
+
+*** Test Cases ***
+Test HSync Prior To Finalization
+    Get OM serviceId
+    Create volume for upgrade test
+    Create bucket for upgrade test
+    Create key for upgrade test
+    ${result} =     Execute and checkrc        ozone debug recover --path=ofs://${OMSERVICEID}/${VOLUME}/${BUCKET}/${KEY}    255
+                    Should contain  ${result}  It belongs to the layout feature HBASE_SUPPORT, whose layout version is 7
+    ${result} =     Execute and checkrc        ozone debug recover --path=o3fs://${BUCKET}.${VOLUME}.${OMSERVICEID}/${KEY}    255
+                    Should contain  ${result}  It belongs to the layout feature HBASE_SUPPORT, whose layout version is 7

--- a/hadoop-ozone/dist/src/main/smoketest/ozone-lib/freon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozone-lib/freon.robot
@@ -67,3 +67,9 @@ Freon OMBR
     [arguments]    ${prefix}=ombg    ${n}=1    ${threads}=1    ${args}=${EMPTY}
     ${result} =        Execute          ozone freon ombr ${OM_HA_PARAM} -t ${threads} -n${n} -p ${prefix} ${args}
                        Should contain   ${result}   Successful executions: ${n}
+
+Freon DFSG
+    [arguments]    ${prefix}=dfsg    ${n}=1000    ${path}={EMPTY}    ${threads}=1    ${sync}=HSYNC    ${buffer}=1024    ${copy-buffer}=1024    ${size}=10240    ${args}=${EMPTY}
+    ${result} =    Execute    ozone freon dfsg -n ${n} --sync ${sync} -s ${size} --path ${path} --buffer ${buffer} --copy-buffer ${copy-buffer} -p ${prefix} -t ${threads} ${args}
+                   Should contain   ${result}   Successful executions: ${n}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to add upgrade tests and set the basic framework to add more tests for hsync. 
1. The upgrade tests added are currently using lease recovery API only. We can add other APIs `listOpenFiles`. (I tried to add listOpenFiles API as well but was facing issues when running in a non-HA environment. Will work on that as an improvement.)
2. Added HSync and HFlush tests via freon.

## What is the link to the Apache JIRA
HDDS-11312

## How was this patch tested?
Green CI for acceptance tests in my forked branch: https://github.com/hemantk-12/ozone/actions/runs/10512044391