### PR TITLE
HDDS-11325. (addendum) Intermittent failure in TestBlockOutputStreamWithFailures#testContainerClose

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.TestHelper;
 
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
@@ -662,7 +661,6 @@ class TestBlockOutputStream {
 
   @ParameterizedTest
   @MethodSource("clientParameters")
-  @Flaky("HDDS-11325")
   void testWriteMoreThanMaxFlushSize(boolean flushDelay, boolean enablePiggybacking) throws Exception {
     OzoneClientConfig config = newClientConfig(cluster.getConf(), flushDelay, enablePiggybacking);
     try (OzoneClient client = newClient(cluster.getConf(), config)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -51,8 +51,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.ratis.protocol.exceptions.GroupMismatchException;
 import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,12 +70,12 @@ class TestBlockOutputStreamWithFailures {
 
   private MiniOzoneCluster cluster;
 
-  @BeforeAll
+  @BeforeEach
   void init() throws Exception {
     cluster = createCluster();
   }
 
-  @AfterAll
+  @AfterEach
   void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -442,7 +442,8 @@ class TestBlockOutputStreamWithFailures {
         assertInstanceOf(RatisBlockOutputStream.class,
             keyOutputStream.getStreamEntries().get(0).getOutputStream());
 
-    assertEquals(2, blockOutputStream.getBufferPool().getSize());
+    assertThat(blockOutputStream.getBufferPool().getSize())
+        .isLessThanOrEqualTo(2);
     assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
 
     assertEquals(0, blockOutputStream.getTotalDataFlushedLength());
@@ -455,7 +456,8 @@ class TestBlockOutputStreamWithFailures {
     // Since the data in the buffer is already flushed, flush here will have
     // no impact on the counters and data structures
 
-    assertEquals(2, blockOutputStream.getBufferPool().getSize());
+    assertThat(blockOutputStream.getBufferPool().getSize())
+        .isLessThanOrEqualTo(2);
     assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
 
     assertEquals(dataLength, blockOutputStream.getTotalDataFlushedLength());
@@ -506,9 +508,10 @@ class TestBlockOutputStreamWithFailures {
             keyOutputStream.getStreamEntries().get(0).getOutputStream());
 
     // we have just written data more than flush Size(2 chunks), at this time
-    // buffer pool will have 4 buffers allocated worth of chunk size
+    // buffer pool will have up to 4 buffers allocated worth of chunk size
 
-    assertEquals(4, blockOutputStream.getBufferPool().getSize());
+    assertThat(blockOutputStream.getBufferPool().getSize())
+        .isLessThanOrEqualTo(4);
     // writtenDataLength as well flushedDataLength will be updated here
     assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
 
@@ -531,7 +534,8 @@ class TestBlockOutputStreamWithFailures {
     // Since the data in the buffer is already flushed, flush here will have
     // no impact on the counters and data structures
 
-    assertEquals(4, blockOutputStream.getBufferPool().getSize());
+    assertThat(blockOutputStream.getBufferPool().getSize())
+        .isLessThanOrEqualTo(4);
     assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
 
     assertEquals(dataLength, blockOutputStream.getTotalDataFlushedLength());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -51,8 +51,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.ratis.protocol.exceptions.GroupMismatchException;
 import org.apache.ratis.protocol.exceptions.RaftRetryFailureException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,12 +70,12 @@ class TestBlockOutputStreamWithFailures {
 
   private MiniOzoneCluster cluster;
 
-  @BeforeEach
+  @BeforeAll
   void init() throws Exception {
     cluster = createCluster();
   }
 
-  @AfterEach
+  @AfterAll
   void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -93,7 +93,6 @@ class TestBlockOutputStreamWithFailures {
 
   @ParameterizedTest
   @MethodSource("clientParameters")
-  @Flaky("HDDS-11325")
   void testContainerClose(boolean flushDelay, boolean enablePiggybacking) throws Exception {
     OzoneClientConfig config = newClientConfig(cluster.getConf(), flushDelay, enablePiggybacking);
     try (OzoneClient client = newClient(cluster.getConf(), config)) {
@@ -386,7 +385,8 @@ class TestBlockOutputStreamWithFailures {
         assertInstanceOf(RatisBlockOutputStream.class,
             keyOutputStream.getStreamEntries().get(0).getOutputStream());
 
-    assertEquals(4, blockOutputStream.getBufferPool().getSize());
+    assertThat(blockOutputStream.getBufferPool().getSize())
+        .isLessThanOrEqualTo(4);
     assertEquals(dataLength, blockOutputStream.getWrittenDataLength());
 
     assertEquals(400, blockOutputStream.getTotalDataFlushedLength());


### PR DESCRIPTION
## What changes were proposed in this pull request?
 HDDS-11325. (addendum) Intermittent failure in TestBlockOutputStreamWithFailures#testContainerClose

Please describe your PR in detail:
1. Removed \@Flaky annotation  from TestBlockOutputStreamWithFailures#testContainerClose and TestBlockOutputStream#testWriteMoreThanMaxFlushSize
2. Relaxed the assertions in the test to match the current behavior.
3. Verified there's no longer intermittent test failures in TestBlockOutputStreamWithFailures#testContainerClose and TestBlockOutputStream#testWriteMoreThanMaxFlushSize

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11325

## How was this patch tested?

Flaky-test-check:

https://github.com/jojochuang/ozone/actions/runs/10532241331
TestBlockOutputStream#testWriteMoreThanMaxFlushSize[HDDS-11325-take2]-10x10 

https://github.com/jojochuang/ozone/actions/runs/10565349000
TestBlockOutputStreamWithFailures#testContainerClose[HDDS-11325-take2]-10x10 


