### PR TITLE
HDDS-11373. Log for EC reconstruction command lists the missing indexes as ASCII control characters

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.ozone.protocol.commands;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.HddsIdFactory;
-import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -140,7 +140,7 @@ public class ReconstructECContainersCommand
             .collect(Collectors.joining(", "))).append("]")
         .append(", targets: ").append(getTargetDatanodes())
         .append(", missingIndexes: ").append(
-            StringUtils.bytes2String(missingContainerIndexes.asReadOnlyByteBuffer()));
+            Arrays.toString(missingContainerIndexes.toByteArray()));
     return sb.toString();
   }
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/protocol/commands/TestReconstructionECContainersCommands.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/protocol/commands/TestReconstructionECContainersCommands.java
@@ -26,10 +26,12 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -53,11 +55,8 @@ public class TestReconstructionECContainersCommands {
 
   @Test
   public void protobufConversion() {
-    final ByteString missingContainerIndexes = Proto2Utils.unsafeByteString(new byte[]{1, 2});
-    List<Long> srcNodesIndexes = new ArrayList<>();
-    for (int i = 0; i < srcNodesIndexes.size(); i++) {
-      srcNodesIndexes.add(i + 1L);
-    }
+    byte[] missingIndexes = {1, 2};
+    final ByteString missingContainerIndexes = Proto2Utils.unsafeByteString(missingIndexes);
     ECReplicationConfig ecReplicationConfig = new ECReplicationConfig(3, 2);
     final List<DatanodeDetails> dnDetails = getDNDetails(5);
 
@@ -70,6 +69,10 @@ public class TestReconstructionECContainersCommands {
     ReconstructECContainersCommand reconstructECContainersCommand =
         new ReconstructECContainersCommand(1L, sources, targets,
             missingContainerIndexes, ecReplicationConfig);
+
+    assertThat(reconstructECContainersCommand.toString())
+        .contains("missingIndexes: " + Arrays.toString(missingIndexes));
+
     StorageContainerDatanodeProtocolProtos.ReconstructECContainersCommandProto
         proto = reconstructECContainersCommand.getProto();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Logs for EC reconstruction command lists the missing indexes as ASCII control characters like `^A ^B`.

Fix by restoring `Arrays.toString` in EC reconstruction command's `toString()`.

https://issues.apache.org/jira/browse/HDDS-11373

## How was this patch tested?

Added assertion in unit test.

CI:
https://github.com/adoroszlai/ozone/actions/runs/10574613444