### PR TITLE
HDDS-11372. No coverage for org.apache.ozone packages

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -33,7 +33,7 @@ source "$SCRIPT_DIR"/testlib.sh
 if [[ "${OZONE_WITH_COVERAGE}" == "true" ]]; then
    java -cp "$PROJECT_DIR"/share/coverage/$(ls "$PROJECT_DIR"/share/coverage | grep test-util):"$PROJECT_DIR"/share/coverage/jacoco-core.jar org.apache.ozone.test.JacocoServer &
    DOCKER_BRIDGE_IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
-   export OZONE_OPTS="-javaagent:share/coverage/jacoco-agent.jar=output=tcpclient,address=$DOCKER_BRIDGE_IP,includes=org.apache.hadoop.ozone.*:org.apache.hadoop.hdds.*:org.apache.hadoop.fs.ozone.*"
+   export OZONE_OPTS="-javaagent:share/coverage/jacoco-agent.jar=output=tcpclient,address=$DOCKER_BRIDGE_IP,includes=org.apache.hadoop.ozone.*:org.apache.hadoop.hdds.*:org.apache.hadoop.fs.ozone.*:org.apache.ozone.*:org.hadoop.ozone.*"
 fi
 
 cd "$SCRIPT_DIR"

--- a/pom.xml
+++ b/pom.xml
@@ -1769,7 +1769,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <goal>prepare-agent</goal>
             </goals>
             <configuration>
-              <includes>org.apache.hadoop.hdds.*,org.apache.hadoop.ozone.*,org.apache.hadoop.fs.ozone.*</includes>
+              <includes>org.apache.hadoop.hdds.*,org.apache.hadoop.ozone.*,org.apache.hadoop.fs.ozone.*,org.apache.ozone.*,org.hadoop.ozone.*</includes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the problem that coverage is not calculated for `org.apache.ozone` and some other packages.

![coverage on `master`](https://github.com/user-attachments/assets/39e04216-b720-424d-bd07-10460ad374ec)

https://issues.apache.org/jira/browse/HDDS-11372

## How was this patch tested?

Tweaked CI workflow to run `coverage` check in my fork (normally it only runs in `apache/ozone` repo).  Verified coverage > 0% for the packages affected.

![coverage with patch](https://github.com/user-attachments/assets/e63950f1-606e-4948-b8a8-82dbaf5379c4)