### PR TITLE
HDDS-11375. DN startup fails due to illegal configuration of raft.grpc.message.size.max

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -31,23 +31,6 @@ import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_PREFI
 @ConfigGroup(prefix = HDDS_DATANODE_RATIS_PREFIX_KEY + "."
     + GrpcConfigKeys.PREFIX)
 public class DatanodeRatisGrpcConfig {
-  @Config(key = "message.size.max",
-      defaultValue = "32MB",
-      type = ConfigType.SIZE,
-      tags = {OZONE, CLIENT, PERFORMANCE},
-      description = "Maximum message size allowed to be received by Grpc " +
-          "Channel (Server)."
-  )
-  private int maximumMessageSize = 32 * 1024 * 1024;
-
-  public int getMaximumMessageSize() {
-    return maximumMessageSize;
-  }
-
-  public void setMaximumMessageSize(int maximumMessageSize) {
-    this.maximumMessageSize = maximumMessageSize;
-  }
-
   @Config(key = "flow.control.window",
       defaultValue = "5MB",
       type = ConfigType.SIZE,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -36,10 +36,7 @@ public class DatanodeRatisGrpcConfig {
       type = ConfigType.SIZE,
       tags = {OZONE, CLIENT, PERFORMANCE},
       description = "Maximum message size allowed to be received by Grpc " +
-          "Channel (Server). This value must be at least 1MB greater than " +
-          "the log appender buffer byte limit, " +
-          "hdds.container.ratis.log.appender.queue.byte-limit, which is 32MB by default +" +
-          ". This is to avoid the issue mentioned in RATIS-2135."
+          "Channel (Server)."
   )
   private int maximumMessageSize = 33 * 1024 * 1024;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -32,13 +32,13 @@ import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_PREFI
     + GrpcConfigKeys.PREFIX)
 public class DatanodeRatisGrpcConfig {
   @Config(key = "message.size.max",
-      defaultValue = "33MB",
+      defaultValue = "32MB",
       type = ConfigType.SIZE,
       tags = {OZONE, CLIENT, PERFORMANCE},
       description = "Maximum message size allowed to be received by Grpc " +
           "Channel (Server)."
   )
-  private int maximumMessageSize = 33 * 1024 * 1024;
+  private int maximumMessageSize = 32 * 1024 * 1024;
 
   public int getMaximumMessageSize() {
     return maximumMessageSize;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -32,13 +32,13 @@ import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_PREFI
     + GrpcConfigKeys.PREFIX)
 public class DatanodeRatisGrpcConfig {
   @Config(key = "message.size.max",
-      defaultValue = "32MB",
+      defaultValue = "33MB",
       type = ConfigType.SIZE,
       tags = {OZONE, CLIENT, PERFORMANCE},
       description = "Maximum message size allowed to be received by Grpc " +
           "Channel (Server)."
   )
-  private int maximumMessageSize = 32 * 1024 * 1024;
+  private int maximumMessageSize = 33 * 1024 * 1024;
 
   public int getMaximumMessageSize() {
     return maximumMessageSize;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -36,7 +36,10 @@ public class DatanodeRatisGrpcConfig {
       type = ConfigType.SIZE,
       tags = {OZONE, CLIENT, PERFORMANCE},
       description = "Maximum message size allowed to be received by Grpc " +
-          "Channel (Server)."
+          "Channel (Server). This value must be at least 1MB greater than " +
+          "the log appender buffer byte limit, " +
+          "hdds.container.ratis.log.appender.queue.byte-limit, which is 32MB by default +" +
+          ". This is to avoid the issue mentioned in RATIS-2135."
   )
   private int maximumMessageSize = 33 * 1024 * 1024;
 

--- a/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
+++ b/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
@@ -84,7 +84,7 @@
   <property>
     <name>hdds.container.ratis.log.appender.queue.byte-limit
 </name>
-    <value>8MB</value>
+    <value>32MB</value>
   </property>
   <property>
     <name>ozone.om.ratis.log.appender.queue.byte-limit</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11375. DN Startup fails with "RuntimeException: Can't start the HDDS datanode plugin"

Please describe your PR in detail:
* Remove the predefined hdds.ratis.raft.grpc.message.size, because its value of 32MB is not large enough. We should simply remove it and let it be calculated as hdds.container.ratis.log.appender.queue.byte-limit + 1MB.
* Update hdds.container.ratis.log.appender.queue.byte-limit to 32MB in the integration test so that integration tests can reproduce the bug.

Note: HDDS-11320 did update hdds.ratis.raft.grpc.message.size to be hdds.container.ratis.log.appender.queue.byte-limit + 1MB, but later it got override here: https://github.com/apache/ozone/blob/master/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java#L370

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11375

## How was this patch tested?

https://github.com/jojochuang/ozone/actions/runs/10588626984
without removing hdds.ratis.raft.grpc.message.size, TestMiniOzoneCluster using Ratis master branch fails with the exact same error.

https://github.com/jojochuang/ozone/actions/runs/10589356146
Running TestMiniOzoneCluster using the fix and Ratis master branch does not fail.