### PR TITLE
HDDS-11359. Intermittent timeout in TestPipelineManagerMXBean#testPipelineInfo

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -45,6 +47,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 @Timeout(3000)
 public class TestPipelineManagerMXBean {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestPipelineManagerMXBean.class);
   private MiniOzoneCluster cluster;
   private MBeanServer mbs;
 
@@ -78,6 +82,8 @@ public class TestPipelineManagerMXBean {
           final Integer count = entry.getValue();
           final Integer currentCount = getMetricsCount(data, entry.getKey());
           if (currentCount == null || !currentCount.equals(count)) {
+            LOG.error("PipelineState = {}: [currentCount = {}, PipelineCount = {}]",
+                entry.getKey(), currentCount, count);
             return false;
           }
         }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
-import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +38,6 @@ import java.lang.management.ManagementFactory;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 
@@ -68,7 +66,6 @@ public class TestPipelineManagerMXBean {
    *
    * @throws Exception
    */
-  @Flaky("HDDS-11359")
   @Test
   public void testPipelineInfo() throws Exception {
     ObjectName bean = new ObjectName(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
@@ -69,7 +69,7 @@ public class TestPipelineManagerMXBean {
     GenericTestUtils.waitFor(() -> {
       try {
         Map<String, Integer> pipelineStateCount = cluster
-          .getStorageContainerManager().getPipelineManager().getPipelineInfo();
+            .getStorageContainerManager().getPipelineManager().getPipelineInfo();
         final TabularData data = (TabularData) mbs.getAttribute(
             bean, "PipelineInfo");
         for (Map.Entry<String, Integer> entry : pipelineStateCount.entrySet()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.scm.pipeline;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,8 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 @Timeout(3000)
 public class TestPipelineManagerMXBean {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestPipelineManagerMXBean.class);
   private MiniOzoneCluster cluster;
   private MBeanServer mbs;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
@@ -85,7 +85,7 @@ public class TestPipelineManagerMXBean {
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-    }, 500, 3000);
+    }, 500, 12000);
   }
 
   private Integer getMetricsCount(TabularData data, String state) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerMXBean.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Seen in [this run](https://github.com/errose28/ozone/actions/runs/10511037945)

Test set: org.apache.hadoop.hdds.scm.pipeline.TestPipelineManagerMXBean
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 25.984 s <<< FAILURE! - in org.apache.hadoop.hdds.scm.pipeline.TestPipelineManagerMXBean
org.apache.hadoop.hdds.scm.pipeline.TestPipelineManagerMXBean.testPipelineInfo  Time elapsed: 25.927 s  <<< ERROR!
java.util.concurrent.TimeoutException: 
Timed out waiting for condition. Thread diagnostics:
Timestamp: 2024-08-22 04:26:47,454
This previously showed up as an assertion failure until [HDDS-9537](https://issues.apache.org/jira/browse/HDDS-9537) introduced a wait for the condition. It seems the condition is still sometimes not satisfied, but the error now shows up as a timeout.

Please describe your PR in detail:
Get `PipelineInfo` every times until `PipelineInfo` matches data from `MBeanServer`. Otherwise, `PipelineInfo` may be out of date.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11359

## How was this patch tested?

Passed 100*10 iterations after changs:
https://github.com/chungen0126/ozone/actions/runs/10588323726
