### PR TITLE
HDDS-11381. Adding logging for sortByDistanceCost in NetworkTopologyImpl

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -789,6 +789,9 @@ public class NetworkTopologyImpl implements NetworkTopology {
       List<N> shuffledNodes =
           new ArrayList<>(nodes.subList(0, activeLen));
       shuffleOperation.accept(shuffledNodes);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Sorted datanodes {}, result: {}", nodes, shuffledNodes);
+      }
       return shuffledNodes;
     }
     // Sort weights for the nodes array
@@ -815,6 +818,9 @@ public class NetworkTopologyImpl implements NetworkTopology {
 
     Preconditions.checkState(ret.size() == activeLen,
         "Wrong number of nodes sorted!");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Sorted datanodes {} for client {}, result: {}", nodes, reader, ret);
+    }
     return ret;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11381. Adding logging for sortByDistanceCost in NetworkTopologyImpl to print sorted datanode list

Please describe your PR in detail:
Context: The sortDatanodes method in the KeyManagerImpl class used to include logging to print the sorted list of datanodes for topology-aware reads. However, as part of the changes introduced in [HDDS-9343](https://issues.apache.org/jira/browse/HDDS-9343), which moved the sortDatanodes logic to the OM (Ozone Manager), this logging was removed.

Action: To reinstate this functionality, add logging to the sortByDistanceCost method—called from the KeyManagerImpl class—to print the sorted list of datanodes. This will help maintain visibility into the datanode sorting process in the new implementation.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11381

## How was this patch tested?
Locally in docker image