### PR TITLE
HDDS-11392. ChecksumByteBufferImpl's static initializer fails with java 17+

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/JavaUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/JavaUtils.java
@@ -30,11 +30,23 @@ public final class JavaUtils {
    * is equal or greater than the parameter.
    *
    * @param version 8, 9, 10 etc.
-   * @return comparison with system property, always true for 8
+   * @return comparison with system property, always true for any int up to 8
    */
   public static boolean isJavaVersionAtLeast(int version) {
     return JAVA_SPEC_VER >= version;
   }
+
+  /**
+   * Query to see if major version of Java specification of the system
+   * is equal or less than the parameter.
+   *
+   * @param version 8, 9, 10 etc.
+   * @return comparison with system property
+   */
+  public static boolean isJavaVersionAtMost(int version) {
+    return JAVA_SPEC_VER <= version;
+  }
+
 
   /**
    * Private constructor.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumByteBufferImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumByteBufferImpl.java
@@ -44,12 +44,14 @@ public class ChecksumByteBufferImpl implements ChecksumByteBuffer {
 
   static {
     Field f = null;
-    try {
-      f = ByteBuffer.class
-          .getDeclaredField("isReadOnly");
-      f.setAccessible(true);
-    } catch (NoSuchFieldException e) {
-      LOG.error("No isReadOnly field in ByteBuffer", e);
+    if (JavaUtils.isJavaVersionAtMost(8)) {
+      try {
+        f = ByteBuffer.class
+            .getDeclaredField("isReadOnly");
+        f.setAccessible(true);
+      } catch (NoSuchFieldException e) {
+        LOG.error("No isReadOnly field in ByteBuffer", e);
+      }
     }
     IS_READY_ONLY_FIELD = f;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
During our internal testing we ran into an exception with Java 17 that originates in ChecksumByteBufferImpl.
The exception:

<pre>java.lang.reflect.InaccessibleObjectException: Unable to make field boolean java.nio.ByteBuffer.isReadOnly accessible: module java.base does not "opens java.nio" to unnamed module @46d56d67
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at org.apache.hadoop.ozone.common.ChecksumByteBufferImpl.<clinit>(ChecksumByteBufferImpl.java:51)</pre>

The code has a TODO comment later on:
<pre>
  // TODO - when we eventually move to a minimum Java version >= 9 this method
  //        should be refactored to simply call checksum.update(buffer), as the
  //        Checksum interface has been enhanced to allow this since Java 9.
</pre>

Based on the todo the PR proposes to set the field accessible only if we are running on Java 8, and use the Java 9 based solution for anything above Java9 until the update method is there.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11392

## How was this patch tested?
I tested with different vm versions (8, 9, 11, 17, 22) based on a simple method that calls ChecksumByteBufferFactory.crc32Impl().
The original code fails with an error with 17 and 22, while gives a warning about the setAccessible call with 9 and 11, while the patched version does not give a warning, and works without any problem on all versions including Java 8.