### PR TITLE
HDDS-11369. [hsync] Remove KeyOutputStreamSemaphore logs

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
@@ -32,6 +32,7 @@ public class KeyOutputStreamSemaphore {
   private final Semaphore requestSemaphore;
 
   KeyOutputStreamSemaphore(int maxConcurrentWritePerKey) {
+    LOG.debug("Initializing semaphore with maxConcurrentWritePerKey = {}", maxConcurrentWritePerKey);
     if (maxConcurrentWritePerKey > 0) {
       requestSemaphore = new Semaphore(maxConcurrentWritePerKey);
     } else if (maxConcurrentWritePerKey == 0) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
@@ -32,7 +32,6 @@ public class KeyOutputStreamSemaphore {
   private final Semaphore requestSemaphore;
 
   KeyOutputStreamSemaphore(int maxConcurrentWritePerKey) {
-    LOG.info("Initializing semaphore with maxConcurrentWritePerKey = {}", maxConcurrentWritePerKey);
     if (maxConcurrentWritePerKey > 0) {
       requestSemaphore = new Semaphore(maxConcurrentWritePerKey);
     } else if (maxConcurrentWritePerKey == 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Seeing these log messages in the console running freon tool

2024-08-23 23:18:37,432 [pool-2-thread-9] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
2024-08-23 23:18:37,432 [pool-2-thread-8] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
2024-08-23 23:18:37,432 [pool-2-thread-2] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
2024-08-23 23:18:37,432 [pool-2-thread-4] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
2024-08-23 23:18:37,432 [pool-2-thread-1] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
2024-08-23 23:18:37,432 [pool-2-thread-3] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
2024-08-23 23:18:37,432 [pool-2-thread-7] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
2024-08-23 23:18:37,432 [pool-2-thread-5] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
2024-08-23 23:18:37,432 [pool-2-thread-10] INFO io.KeyOutputStreamSemaphore: Initializing semaphore with maxConcurrentWritePerKey = 1
Remove these log messages to keep console output tidy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11369

## How was this patch tested?

CI:
https://github.com/chungen0126/ozone/actions/runs/10626544862
