### PR TITLE
HDDS-11376. Improve ReplicationSupervisor to record replication metrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
@@ -47,6 +47,16 @@ public class ECReconstructionCoordinatorTask
   }
 
   @Override
+  public String getMetricName() {
+    return "ECReconstructions";
+  }
+
+  @Override
+  public String getMetricDescriptionSegment() {
+    return "EC reconstructions";
+  }
+
+  @Override
   public void runTask() {
     // Implement the coordinator logic to handle a container group
     // reconstruction.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -71,13 +71,9 @@ public abstract class AbstractReplicationTask {
     queued = Instant.now(clock);
   }
   
-  protected String getMetricName() {
-    return "";
-  }
+  protected abstract String getMetricName();
 
-  protected String getMetricDescriptionSegment() {
-    return "";
-  }
+  protected abstract String getMetricDescriptionSegment();
 
   public long getContainerId() {
     return containerId;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/AbstractReplicationTask.java
@@ -70,6 +70,14 @@ public abstract class AbstractReplicationTask {
     this.term = term;
     queued = Instant.now(clock);
   }
+  
+  protected String getMetricName() {
+    return "";
+  }
+
+  protected String getMetricDescriptionSegment() {
+    return "";
+  }
 
   public long getContainerId() {
     return containerId;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -77,8 +77,7 @@ public final class ReplicationSupervisor {
   private final Map<String, AtomicLong> timeoutCounter = new ConcurrentHashMap<>();
   private final Map<String, AtomicLong> skippedCounter = new ConcurrentHashMap<>();
 
-  @SuppressWarnings({"checkstyle:VisibilityModifier", "checkstyle:StaticVariableName"})
-  public static Map<String, String> METRICS_MAP = new HashMap<>();
+  public static final Map<String, String> metricsMap = new HashMap<>();
 
   /**
    * A set of container IDs that are currently being downloaded
@@ -232,7 +231,7 @@ public final class ReplicationSupervisor {
           failureCounter.put(task.getMetricName(), new AtomicLong(0));
           timeoutCounter.put(task.getMetricName(), new AtomicLong(0));
           skippedCounter.put(task.getMetricName(), new AtomicLong(0));
-          METRICS_MAP.put(task.getMetricName(), task.getMetricDescriptionSegment());
+          metricsMap.put(task.getMetricName(), task.getMetricDescriptionSegment());
         }
       }
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.PriorityBlockingQueue;
@@ -77,7 +78,11 @@ public final class ReplicationSupervisor {
   private final Map<String, AtomicLong> timeoutCounter = new ConcurrentHashMap<>();
   private final Map<String, AtomicLong> skippedCounter = new ConcurrentHashMap<>();
 
-  public static final Map<String, String> METRICS_MAP = new HashMap<>();
+  private static final Map<String, String> METRICS_MAP;
+
+  static {
+    METRICS_MAP = new HashMap<>();
+  }
 
   /**
    * A set of container IDs that are currently being downloaded
@@ -188,6 +193,10 @@ public final class ReplicationSupervisor {
 
   public static Builder newBuilder() {
     return new Builder();
+  }
+
+  public static Map<String, String> getMetricsMap() {
+    return Collections.unmodifiableMap(METRICS_MAP);
   }
 
   private ReplicationSupervisor(StateContext context, ExecutorService executor,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -468,12 +468,11 @@ public final class ReplicationSupervisor {
   }
 
   private long getCount(Map<String, AtomicLong> counter) {
-    if (counter.isEmpty()) {
-      return 0;
+    long total = 0;
+    for (Map.Entry<String, AtomicLong> entry : counter.entrySet()) {
+      total += entry.getValue().get();
     }
-    AtomicLong total = new AtomicLong(0);
-    counter.forEach((key, value) -> total.addAndGet(value.get()));
-    return total.get();
+    return total;
   }
 
   public long getReplicationSuccessCount() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -472,9 +472,7 @@ public final class ReplicationSupervisor {
       return 0;
     }
     AtomicLong total = new AtomicLong(0);
-    counter.forEach((key, value) -> {
-      total.set(total.get() + value.get());
-    });
+    counter.forEach((key, value) -> total.addAndGet(value.get()));
     return total.get();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -77,7 +77,7 @@ public final class ReplicationSupervisor {
   private final Map<String, AtomicLong> timeoutCounter = new ConcurrentHashMap<>();
   private final Map<String, AtomicLong> skippedCounter = new ConcurrentHashMap<>();
 
-  public static final Map<String, String> metricsMap = new HashMap<>();
+  public static final Map<String, String> METRICS_MAP = new HashMap<>();
 
   /**
    * A set of container IDs that are currently being downloaded
@@ -231,7 +231,7 @@ public final class ReplicationSupervisor {
           failureCounter.put(task.getMetricName(), new AtomicLong(0));
           timeoutCounter.put(task.getMetricName(), new AtomicLong(0));
           skippedCounter.put(task.getMetricName(), new AtomicLong(0));
-          metricsMap.put(task.getMetricName(), task.getMetricDescriptionSegment());
+          METRICS_MAP.put(task.getMetricName(), task.getMetricDescriptionSegment());
         }
       }
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinatorTask;
 
 import java.util.Map;
 
@@ -72,54 +71,45 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
         .addGauge(Interns.info("numRequestedReplications",
             "Number of requested replications"),
             supervisor.getReplicationRequestCount())
-        .addGauge(Interns.info("numRequestedECReconstructions",
-            "Number of requested EC reconstructions"),
-            supervisor.getReplicationRequestCount(ECReconstructionCoordinatorTask.class))
-        .addGauge(Interns.info("numRequestedContainerReplications",
-            "Number of requested container replications"),
-            supervisor.getReplicationRequestCount(ReplicationTask.class))
         .addGauge(Interns.info("numSuccessReplications",
             "Number of successful replications"),
             supervisor.getReplicationSuccessCount())
-        .addGauge(Interns.info("numSuccessECReconstructions",
-            "Number of successful EC reconstructions"),
-            supervisor.getReplicationSuccessCount(ECReconstructionCoordinatorTask.class))
-        .addGauge(Interns.info("numSuccessContainerReplications",
-            "Number of successful container replications"),
-            supervisor.getReplicationSuccessCount(ReplicationTask.class))
         .addGauge(Interns.info("numFailureReplications",
             "Number of failure replications"),
             supervisor.getReplicationFailureCount())
-        .addGauge(Interns.info("numFailureECReconstructions",
-            "Number of failure EC reconstructions"),
-            supervisor.getReplicationFailureCount(ECReconstructionCoordinatorTask.class))
-        .addGauge(Interns.info("numFailureContainerReplications",
-            "Number of failure container replications"),
-            supervisor.getReplicationFailureCount(ReplicationTask.class))
         .addGauge(Interns.info("numTimeoutReplications",
             "Number of replication requests timed out before being processed"),
             supervisor.getReplicationTimeoutCount())
-        .addGauge(Interns.info("numTimeoutECReconstructions",
-            "Number of EC reconstructions timed out before being processed"),
-            supervisor.getReplicationTimeoutCount(ECReconstructionCoordinatorTask.class))
-        .addGauge(Interns.info("numTimeoutContainerReplications",
-            "Number of container replications timed out before being processed"),
-            supervisor.getReplicationTimeoutCount(ReplicationTask.class))
         .addGauge(Interns.info("numSkippedReplications",
             "Number of replication requests skipped as the container is "
             + "already present"),
             supervisor.getReplicationSkippedCount())
-        .addGauge(Interns.info("numSkippedECReconstructions",
-            "Number of EC reconstructions skipped as the container is "
-            + "already present"),
-            supervisor.getReplicationSkippedCount(ECReconstructionCoordinatorTask.class))
-        .addGauge(Interns.info("numSkippedContainerReplications",
-            "Number of container replications skipped as the container is "
-            + "already present"),
-            supervisor.getReplicationSkippedCount(ReplicationTask.class))
         .addGauge(Interns.info("maxReplicationStreams", "Maximum number of "
             + "concurrent replication tasks which can run simultaneously"),
             supervisor.getMaxReplicationStreams());
+
+    if (!ReplicationSupervisor.METRICS_MAP.isEmpty()) {
+      ReplicationSupervisor.METRICS_MAP.forEach((metricsName, descriptionSegment) -> {
+        if (!metricsName.equals("")) {
+          builder.addGauge(Interns.info("numRequested" + metricsName,
+              "Number of requested " + descriptionSegment),
+                  supervisor.getReplicationRequestCount(metricsName))
+              .addGauge(Interns.info("numSuccess" + metricsName,
+                  "Number of successful " + descriptionSegment),
+                  supervisor.getReplicationSuccessCount(metricsName))
+              .addGauge(Interns.info("numFailure" + metricsName,
+                  "Number of failure " + descriptionSegment),
+                  supervisor.getReplicationFailureCount(metricsName))
+              .addGauge(Interns.info("numTimeout" + metricsName,
+                  "Number of " + descriptionSegment + " timed out before being processed"),
+                  supervisor.getReplicationTimeoutCount(metricsName))
+              .addGauge(Interns.info("numSkipped" + metricsName,
+                  "Number of " + descriptionSegment + " skipped as the container is "
+                  + "already present"),
+                  supervisor.getReplicationSkippedCount(metricsName));
+        }
+      });
+    }
 
     Map<String, Integer> tasks = supervisor.getInFlightReplicationSummary();
     for (Map.Entry<String, Integer> entry : tasks.entrySet()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -88,8 +88,9 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
             + "concurrent replication tasks which can run simultaneously"),
             supervisor.getMaxReplicationStreams());
 
-    if (!ReplicationSupervisor.METRICS_MAP.isEmpty()) {
-      ReplicationSupervisor.METRICS_MAP.forEach((metricsName, descriptionSegment) -> {
+    Map<String, String> metricsMap = ReplicationSupervisor.getMetricsMap();
+    if (!metricsMap.isEmpty()) {
+      metricsMap.forEach((metricsName, descriptionSegment) -> {
         if (!metricsName.equals("")) {
           builder.addGauge(Interns.info("numRequested" + metricsName,
               "Number of requested " + descriptionSegment),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinatorTask;
 
 import java.util.Map;
 
@@ -71,12 +72,45 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
         .addGauge(Interns.info("numRequestedReplications",
             "Number of requested replications"),
             supervisor.getReplicationRequestCount())
+        .addGauge(Interns.info("numSuccessReplications",
+            "Number of successful replications"),
+            supervisor.getReplicationSuccessCount())
+        .addGauge(Interns.info("numSuccessECReconstructions",
+            "Number of successful EC reconstructions"),
+            supervisor.getReplicationSuccessCount(ECReconstructionCoordinatorTask.class))
+        .addGauge(Interns.info("numSuccessContainerReplications",
+            "Number of successful container replications"),
+            supervisor.getReplicationSuccessCount(ReplicationTask.class))
+        .addGauge(Interns.info("numFailureReplications",
+            "Number of failure replications"),
+            supervisor.getReplicationFailureCount())
+        .addGauge(Interns.info("numFailureECReconstructions",
+            "Number of failure EC reconstructions"),
+            supervisor.getReplicationFailureCount(ECReconstructionCoordinatorTask.class))
+        .addGauge(Interns.info("numFailureContainerReplications",
+            "Number of failure container replications"),
+            supervisor.getReplicationFailureCount(ReplicationTask.class))
         .addGauge(Interns.info("numTimeoutReplications",
             "Number of replication requests timed out before being processed"),
             supervisor.getReplicationTimeoutCount())
+        .addGauge(Interns.info("numTimeoutECReconstructions",
+            "Number of EC reconstructions timed out before being processed"),
+            supervisor.getReplicationTimeoutCount(ECReconstructionCoordinatorTask.class))
+        .addGauge(Interns.info("numTimeoutContainerReplications",
+            "Number of container replications timed out before being processed"),
+            supervisor.getReplicationTimeoutCount(ReplicationTask.class))
         .addGauge(Interns.info("numSkippedReplications",
             "Number of replication requests skipped as the container is "
-            + "already present"), supervisor.getReplicationSkippedCount())
+            + "already present"),
+            supervisor.getReplicationSkippedCount())
+        .addGauge(Interns.info("numSkippedECReconstructions",
+            "Number of EC reconstructions skipped as the container is "
+            + "already present"),
+            supervisor.getReplicationSkippedCount(ECReconstructionCoordinatorTask.class))
+        .addGauge(Interns.info("numSkippedContainerReplications",
+            "Number of container replications skipped as the container is "
+            + "already present"),
+            supervisor.getReplicationSkippedCount(ReplicationTask.class))
         .addGauge(Interns.info("maxReplicationStreams", "Maximum number of "
             + "concurrent replication tasks which can run simultaneously"),
             supervisor.getMaxReplicationStreams());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -88,8 +88,8 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
             + "concurrent replication tasks which can run simultaneously"),
             supervisor.getMaxReplicationStreams());
 
-    if (!ReplicationSupervisor.METRICS_MAP.isEmpty()) {
-      ReplicationSupervisor.METRICS_MAP.forEach((metricsName, descriptionSegment) -> {
+    if (!ReplicationSupervisor.metricsMap.isEmpty()) {
+      ReplicationSupervisor.metricsMap.forEach((metricsName, descriptionSegment) -> {
         if (!metricsName.equals("")) {
           builder.addGauge(Interns.info("numRequested" + metricsName,
               "Number of requested " + descriptionSegment),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -72,6 +72,12 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
         .addGauge(Interns.info("numRequestedReplications",
             "Number of requested replications"),
             supervisor.getReplicationRequestCount())
+        .addGauge(Interns.info("numRequestedECReconstructions",
+            "Number of requested EC reconstructions"),
+            supervisor.getReplicationRequestCount(ECReconstructionCoordinatorTask.class))
+        .addGauge(Interns.info("numRequestedContainerReplications",
+            "Number of requested container replications"),
+            supervisor.getReplicationRequestCount(ReplicationTask.class))
         .addGauge(Interns.info("numSuccessReplications",
             "Number of successful replications"),
             supervisor.getReplicationSuccessCount())

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -88,8 +88,8 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
             + "concurrent replication tasks which can run simultaneously"),
             supervisor.getMaxReplicationStreams());
 
-    if (!ReplicationSupervisor.metricsMap.isEmpty()) {
-      ReplicationSupervisor.metricsMap.forEach((metricsName, descriptionSegment) -> {
+    if (!ReplicationSupervisor.METRICS_MAP.isEmpty()) {
+      ReplicationSupervisor.METRICS_MAP.forEach((metricsName, descriptionSegment) -> {
         if (!metricsName.equals("")) {
           builder.addGauge(Interns.info("numRequested" + metricsName,
               "Number of requested " + descriptionSegment),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -66,6 +66,16 @@ public class ReplicationTask extends AbstractReplicationTask {
   }
 
   @Override
+  public String getMetricName() {
+    return "ContainerReplications";
+  }
+
+  @Override
+  public String getMetricDescriptionSegment() {
+    return "container replications";
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -586,6 +586,16 @@ public class TestReplicationSupervisor {
     }
 
     @Override
+    protected String getMetricName() {
+      return "Blockings";
+    }
+
+    @Override
+    protected String getMetricDescriptionSegment() {
+      return "blockings";
+    }
+
+    @Override
     public void runTask() {
       runningLatch.countDown();
       assertDoesNotThrow(() -> waitForCompleteLatch.await(),
@@ -609,6 +619,16 @@ public class TestReplicationSupervisor {
       this.name = name;
       this.completeLatch = completeLatch;
       setPriority(priority);
+    }
+
+    @Override
+    protected String getMetricName() {
+      return "Ordereds";
+    }
+
+    @Override
+    protected String getMetricDescriptionSegment() {
+      return "ordereds";
     }
 
     @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -467,6 +467,11 @@ public class TestReplicationSupervisor {
       assertEquals(1, replicationSupervisor.getReplicationTimeoutCount());
       assertEquals(1, replicationSupervisor.getReplicationTimeoutCount(
           ReplicationTask.class));
+      assertEquals(5, replicationSupervisor.getReplicationRequestCount());
+      assertEquals(5, replicationSupervisor.getReplicationRequestCount(
+          ReplicationTask.class));
+      assertEquals(0, replicationSupervisor.getReplicationRequestCount(
+          ECReconstructionCoordinatorTask.class));
 
       assertEquals(2, ecReconstructionSupervisor.getReplicationSuccessCount());
       assertEquals(2, ecReconstructionSupervisor.getReplicationSuccessCount(
@@ -477,6 +482,11 @@ public class TestReplicationSupervisor {
       assertEquals(2, ecReconstructionSupervisor.getReplicationFailureCount());
       assertEquals(2, ecReconstructionSupervisor.getReplicationFailureCount(
           ECReconstructionCoordinatorTask.class));
+      assertEquals(5, ecReconstructionSupervisor.getReplicationRequestCount());
+      assertEquals(5, ecReconstructionSupervisor.getReplicationRequestCount(
+          ECReconstructionCoordinatorTask.class));
+      assertEquals(0, ecReconstructionSupervisor.getReplicationRequestCount(
+          ReplicationTask.class));
 
       MetricsCollectorImpl replicationMetricsCollector = new MetricsCollectorImpl();
       replicationMetrics.getMetrics(replicationMetricsCollector, true);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -705,7 +705,7 @@ public class TestReplicationSupervisor {
     private final OzoneConfiguration conf = new OzoneConfiguration();
     private final ReplicationSupervisor supervisor;
 
-    public FakeECReconstructionCoordinator(ConfigurationSource conf,
+    FakeECReconstructionCoordinator(ConfigurationSource conf,
         CertificateClient certificateClient, SecretKeySignerClient secretKeyClient,
         StateContext context, ECReconstructionMetrics metrics, String threadNamePrefix,
         ReplicationSupervisor supervisor)

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.SortedMap;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CountDownLatch;
@@ -46,6 +47,8 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ReplicationCommandPriority;
+import org.apache.hadoop.hdds.security.symmetric.SecretKeySignerClient;
+import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.metrics2.impl.MetricsCollectorImpl;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
@@ -55,7 +58,9 @@ import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCommandInfo;
+import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinatorTask;
+import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionMetrics;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -109,6 +114,8 @@ public class TestReplicationSupervisor {
   };
   private final AtomicReference<ContainerReplicator> replicatorRef =
       new AtomicReference<>();
+  private final AtomicReference<ECReconstructionCoordinator> ecReplicatorRef =
+      new AtomicReference<>();
 
   private ContainerSet set;
 
@@ -135,6 +142,7 @@ public class TestReplicationSupervisor {
   @AfterEach
   public void cleanup() {
     replicatorRef.set(null);
+    ecReplicatorRef.set(null);
   }
 
   @ContainerLayoutTestInfo.ContainerTest
@@ -395,6 +403,97 @@ public class TestReplicationSupervisor {
   }
 
   @ContainerLayoutTestInfo.ContainerTest
+  public void testMultipleReplication(ContainerLayoutVersion layout,
+      @TempDir File tempFile) throws IOException {
+    this.layoutVersion = layout;
+    OzoneConfiguration conf = new OzoneConfiguration();
+    // GIVEN
+    ReplicationSupervisor replicationSupervisor =
+        supervisorWithReplicator(FakeReplicator::new);
+    ReplicationSupervisor ecReconstructionSupervisor = supervisorWithECReconstruction();
+    ReplicationSupervisorMetrics replicationMetrics =
+        ReplicationSupervisorMetrics.create(replicationSupervisor);
+    ReplicationSupervisorMetrics ecReconstructionMetrics =
+        ReplicationSupervisorMetrics.create(ecReconstructionSupervisor);
+    try {
+      //WHEN
+      replicationSupervisor.addTask(createTask(1L));
+      ecReconstructionSupervisor.addTask(createECTaskWithCoordinator(2L));
+      replicationSupervisor.addTask(createTask(1L));
+      replicationSupervisor.addTask(createTask(3L));
+      ecReconstructionSupervisor.addTask(createECTaskWithCoordinator(4L));
+
+      SimpleContainerDownloader moc = mock(SimpleContainerDownloader.class);
+      Path res = Paths.get("file:/tmp/no-such-file");
+      when(moc.getContainerDataFromReplicas(anyLong(), anyList(),
+          any(Path.class), any())).thenReturn(res);
+
+      final String testDir = tempFile.getPath();
+      MutableVolumeSet volumeSet = mock(MutableVolumeSet.class);
+      when(volumeSet.getVolumesList()).thenReturn(singletonList(
+          new HddsVolume.Builder(testDir).conf(conf).build()));
+      ContainerController mockedCC = mock(ContainerController.class);
+      ContainerImporter importer = new ContainerImporter(conf, set, mockedCC, volumeSet);
+      ContainerReplicator replicator = new DownloadAndImportReplicator(
+          conf, set, importer, moc);
+      replicatorRef.set(replicator);
+      replicationSupervisor.addTask(createTask(5L));
+
+      ReplicateContainerCommand cmd1 = createCommand(6L);
+      cmd1.setDeadline(clock.millis() + 10000);
+      ReplicationTask task1 = new ReplicationTask(cmd1, replicatorRef.get());
+      clock.fastForward(15000);
+      replicationSupervisor.addTask(task1);
+
+      ReconstructECContainersCommand cmd2 = createReconstructionCmd(7L);
+      cmd2.setDeadline(clock.millis() + 10000);
+      ECReconstructionCoordinatorTask task2 = new ECReconstructionCoordinatorTask(
+          ecReplicatorRef.get(), new ECReconstructionCommandInfo(cmd2));
+      clock.fastForward(15000);
+      ecReconstructionSupervisor.addTask(task2);
+      ecReconstructionSupervisor.addTask(createECTask(8L));
+      ecReconstructionSupervisor.addTask(createECTask(9L));
+
+      //THEN
+      assertEquals(2, replicationSupervisor.getReplicationSuccessCount());
+      assertEquals(2, replicationSupervisor.getReplicationSuccessCount(
+          ReplicationTask.class));
+      assertEquals(1, replicationSupervisor.getReplicationFailureCount());
+      assertEquals(1, replicationSupervisor.getReplicationFailureCount(
+          ReplicationTask.class));
+      assertEquals(1, replicationSupervisor.getReplicationSkippedCount());
+      assertEquals(1, replicationSupervisor.getReplicationSkippedCount(
+          ReplicationTask.class));
+      assertEquals(1, replicationSupervisor.getReplicationTimeoutCount());
+      assertEquals(1, replicationSupervisor.getReplicationTimeoutCount(
+          ReplicationTask.class));
+
+      assertEquals(2, ecReconstructionSupervisor.getReplicationSuccessCount());
+      assertEquals(2, ecReconstructionSupervisor.getReplicationSuccessCount(
+          ECReconstructionCoordinatorTask.class));
+      assertEquals(1, ecReconstructionSupervisor.getReplicationTimeoutCount());
+      assertEquals(1, ecReconstructionSupervisor.getReplicationTimeoutCount(
+          ECReconstructionCoordinatorTask.class));
+      assertEquals(2, ecReconstructionSupervisor.getReplicationFailureCount());
+      assertEquals(2, ecReconstructionSupervisor.getReplicationFailureCount(
+          ECReconstructionCoordinatorTask.class));
+
+      MetricsCollectorImpl replicationMetricsCollector = new MetricsCollectorImpl();
+      replicationMetrics.getMetrics(replicationMetricsCollector, true);
+      assertEquals(1, replicationMetricsCollector.getRecords().size());
+
+      MetricsCollectorImpl ecReconstructionMetricsCollector = new MetricsCollectorImpl();
+      ecReconstructionMetrics.getMetrics(ecReconstructionMetricsCollector, true);
+      assertEquals(1, ecReconstructionMetricsCollector.getRecords().size());
+    } finally {
+      replicationMetrics.unRegister();
+      ecReconstructionMetrics.unRegister();
+      replicationSupervisor.stop();
+      ecReconstructionSupervisor.stop();
+    }
+  }
+
+  @ContainerLayoutTestInfo.ContainerTest
   public void testPriorityOrdering(ContainerLayoutVersion layout)
       throws InterruptedException {
     this.layoutVersion = layout;
@@ -531,6 +630,22 @@ public class TestReplicationSupervisor {
     return supervisor;
   }
 
+  private ReplicationSupervisor supervisorWithECReconstruction() throws IOException {
+    ConfigurationSource conf = new OzoneConfiguration();
+    ExecutorService executor = newDirectExecutorService();
+    ReplicationServer.ReplicationConfig repConf =
+        conf.getObject(ReplicationServer.ReplicationConfig.class);
+    ReplicationSupervisor supervisor = ReplicationSupervisor.newBuilder()
+        .stateContext(context).replicationConfig(repConf).executor(executor)
+        .clock(clock).build();
+
+    FakeECReconstructionCoordinator coordinator = new FakeECReconstructionCoordinator(
+        new OzoneConfiguration(), null, null, context,
+        ECReconstructionMetrics.create(), "", supervisor);
+    ecReplicatorRef.set(coordinator);
+    return supervisor;
+  }
+
   private ReplicationTask createTask(long containerId) {
     ReplicateContainerCommand cmd = createCommand(containerId);
     return new ReplicationTask(cmd, replicatorRef.get());
@@ -538,7 +653,13 @@ public class TestReplicationSupervisor {
 
   private ECReconstructionCoordinatorTask createECTask(long containerId) {
     return new ECReconstructionCoordinatorTask(null,
-        createReconstructionCmd(containerId));
+        createReconstructionCmdInfo(containerId));
+  }
+
+  private ECReconstructionCoordinatorTask createECTaskWithCoordinator(long containerId) {
+    ECReconstructionCommandInfo ecReconstructionCommandInfo = createReconstructionCmdInfo(containerId);
+    return new ECReconstructionCoordinatorTask(ecReplicatorRef.get(),
+        ecReconstructionCommandInfo);
   }
 
   private static ReplicateContainerCommand createCommand(long containerId) {
@@ -548,18 +669,20 @@ public class TestReplicationSupervisor {
     return cmd;
   }
 
-  private static ECReconstructionCommandInfo createReconstructionCmd(
+  private static ECReconstructionCommandInfo createReconstructionCmdInfo(
       long containerId) {
-    List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex> sources
-        = new ArrayList<>();
-    sources.add(new ReconstructECContainersCommand
-        .DatanodeDetailsAndReplicaIndex(
-            MockDatanodeDetails.randomDatanodeDetails(), 1));
-    sources.add(new ReconstructECContainersCommand
-        .DatanodeDetailsAndReplicaIndex(
+    return new ECReconstructionCommandInfo(createReconstructionCmd(containerId));
+  }
+
+  private static ReconstructECContainersCommand createReconstructionCmd(
+      long containerId) {
+    List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex> sources =
+        new ArrayList<>();
+    sources.add(new ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex(
+        MockDatanodeDetails.randomDatanodeDetails(), 1));
+    sources.add(new ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex(
         MockDatanodeDetails.randomDatanodeDetails(), 2));
-    sources.add(new ReconstructECContainersCommand
-        .DatanodeDetailsAndReplicaIndex(
+    sources.add(new ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex(
         MockDatanodeDetails.randomDatanodeDetails(), 3));
 
     byte[] missingIndexes = new byte[1];
@@ -567,14 +690,44 @@ public class TestReplicationSupervisor {
 
     List<DatanodeDetails> target = singletonList(
         MockDatanodeDetails.randomDatanodeDetails());
-    ReconstructECContainersCommand cmd =
-        new ReconstructECContainersCommand(containerId,
-            sources,
-            target,
-            Proto2Utils.unsafeByteString(missingIndexes),
-            new ECReplicationConfig(3, 2));
+    ReconstructECContainersCommand cmd = new ReconstructECContainersCommand(containerId, sources, target,
+        Proto2Utils.unsafeByteString(missingIndexes),
+        new ECReplicationConfig(3, 2));
+    cmd.setTerm(CURRENT_TERM);
+    return cmd;
+  }
 
-    return new ECReconstructionCommandInfo(cmd);
+  /**
+   * A fake coordinator that simulates successful reconstruction of ec containers.
+   */
+  private class FakeECReconstructionCoordinator extends ECReconstructionCoordinator {
+
+    private final OzoneConfiguration conf = new OzoneConfiguration();
+    private final ReplicationSupervisor supervisor;
+
+    public FakeECReconstructionCoordinator(ConfigurationSource conf,
+        CertificateClient certificateClient, SecretKeySignerClient secretKeyClient,
+        StateContext context, ECReconstructionMetrics metrics, String threadNamePrefix,
+        ReplicationSupervisor supervisor)
+            throws IOException {
+      super(conf, certificateClient, secretKeyClient, context, metrics, threadNamePrefix);
+      this.supervisor = supervisor;
+    }
+
+    @Override
+    public void reconstructECContainerGroup(long containerID,
+        ECReplicationConfig repConfig, SortedMap<Integer, DatanodeDetails> sourceNodeMap,
+        SortedMap<Integer, DatanodeDetails> targetNodeMap) {
+      assertEquals(1, supervisor.getTotalInFlightReplications());
+
+      KeyValueContainerData kvcd = new KeyValueContainerData(
+          containerID, layoutVersion, 100L,
+          UUID.randomUUID().toString(), UUID.randomUUID().toString());
+      KeyValueContainer kvc = new KeyValueContainer(kvcd, conf);
+      assertDoesNotThrow(() -> {
+        set.addContainer(kvc);
+      });
+    }
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -457,36 +457,36 @@ public class TestReplicationSupervisor {
       //THEN
       assertEquals(2, replicationSupervisor.getReplicationSuccessCount());
       assertEquals(2, replicationSupervisor.getReplicationSuccessCount(
-          ReplicationTask.class));
+          task1.getMetricName()));
       assertEquals(1, replicationSupervisor.getReplicationFailureCount());
       assertEquals(1, replicationSupervisor.getReplicationFailureCount(
-          ReplicationTask.class));
+          task1.getMetricName()));
       assertEquals(1, replicationSupervisor.getReplicationSkippedCount());
       assertEquals(1, replicationSupervisor.getReplicationSkippedCount(
-          ReplicationTask.class));
+          task1.getMetricName()));
       assertEquals(1, replicationSupervisor.getReplicationTimeoutCount());
       assertEquals(1, replicationSupervisor.getReplicationTimeoutCount(
-          ReplicationTask.class));
+          task1.getMetricName()));
       assertEquals(5, replicationSupervisor.getReplicationRequestCount());
       assertEquals(5, replicationSupervisor.getReplicationRequestCount(
-          ReplicationTask.class));
+          task1.getMetricName()));
       assertEquals(0, replicationSupervisor.getReplicationRequestCount(
-          ECReconstructionCoordinatorTask.class));
+          task2.getMetricName()));
 
       assertEquals(2, ecReconstructionSupervisor.getReplicationSuccessCount());
       assertEquals(2, ecReconstructionSupervisor.getReplicationSuccessCount(
-          ECReconstructionCoordinatorTask.class));
+          task2.getMetricName()));
       assertEquals(1, ecReconstructionSupervisor.getReplicationTimeoutCount());
       assertEquals(1, ecReconstructionSupervisor.getReplicationTimeoutCount(
-          ECReconstructionCoordinatorTask.class));
+          task2.getMetricName()));
       assertEquals(2, ecReconstructionSupervisor.getReplicationFailureCount());
       assertEquals(2, ecReconstructionSupervisor.getReplicationFailureCount(
-          ECReconstructionCoordinatorTask.class));
+          task2.getMetricName()));
       assertEquals(5, ecReconstructionSupervisor.getReplicationRequestCount());
       assertEquals(5, ecReconstructionSupervisor.getReplicationRequestCount(
-          ECReconstructionCoordinatorTask.class));
+          task2.getMetricName()));
       assertEquals(0, ecReconstructionSupervisor.getReplicationRequestCount(
-          ReplicationTask.class));
+          task1.getMetricName()));
 
       MetricsCollectorImpl replicationMetricsCollector = new MetricsCollectorImpl();
       replicationMetrics.getMetrics(replicationMetricsCollector, true);


### PR DESCRIPTION
## What changes were proposed in this pull request?
When datanode executes ReplicateContainerCommand and ReconstructECContainersCommand, they are all done by ReplicationSupervisor. We should record more detailed metrics.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11376

## How was this patch tested?
When we open the jmx connection of Datanode, we will see the newly added metrics.
Old jmx:
![image](https://github.com/user-attachments/assets/56ecc804-49f4-42e9-a43a-18f2adb2cbd1)

New jmx:
![image](https://github.com/user-attachments/assets/39f55a81-a817-4e21-8b76-8f7a5e97b0a4)

