### PR TITLE
HDDS-11403. PartialTableCache optimize for cleanup

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -518,17 +518,22 @@ public class TestTableCache {
 
     tableCache.evictCache(epochs);
 
-    assertEquals(2, tableCache.size());
     if (cacheType == TableCache.CacheType.FULL_CACHE) {
+      assertEquals(2, tableCache.size());
       // no deleted entries
       assertEquals(0, tableCache.getEpochEntries().size());
-    } else {
-      assertEquals(2, tableCache.getEpochEntries().size());
-    }
 
-    assertNotNull(tableCache.get(new CacheKey<>(Long.toString(0))));
-    assertEquals(2,
-        tableCache.get(new CacheKey<>(Long.toString(0))).getEpoch());
+      assertNotNull(tableCache.get(new CacheKey<>(Long.toString(0))));
+      assertEquals(2,
+          tableCache.get(new CacheKey<>(Long.toString(0))).getEpoch());
+    } else {
+      // only key 1 with epoch 4 will remain
+      assertEquals(1, tableCache.size());
+      assertEquals(1, tableCache.getEpochEntries().size());
+
+      // since all epoch till 3 cleared, key 0 will not be there in partial table
+      assertNull(tableCache.get(new CacheKey<>(Long.toString(0))));
+    }
 
     assertNotNull(tableCache.get(new CacheKey<>(Long.toString(1))));
     assertEquals(4,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -133,6 +133,9 @@ public final class OmKeyInfo extends WithParentObjectId
     this.ownerName = b.ownerName;
     this.tags = b.tags;
     this.expectedDataGeneration = b.expectedDataGeneration;
+    if (null == this.fileName) {
+      this.fileName = OzoneFSUtils.getFileName(this.keyName);
+    }
   }
 
   public String getVolumeName() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -4281,6 +4281,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     omMetadataManager.getKeyTable(getBucketLayout())
         .put(omMetadataManager.getOzoneKey(volumeName, bucketName, keyName),
             omKeyInfo);
+    omMetadataManager.getKeyTable(getBucketLayout())
+        .addCacheEntry(omMetadataManager.getOzoneKey(volumeName, bucketName, keyName),
+            omKeyInfo, -1);
 
     //Step 5
     key = bucket.getKey(keyName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

PartialTableCache optimize for cleanup involves,
- cleanup all previous epoch with latest epoch (no need validation for epoch in sequence)
- Timer based cleanup instead of triggering cleanup for every task (which may lead to add task in worker queue)

This optimization is done with similar approach [HDDS-11201](https://issues.apache.org/jira/browse/HDDS-11201), where FullTableCache is handled (where faced memory issue).

Also fix,
- When delay in cache cleanup, fileStatus returns cache entry, and OMKeyInfo is missing fileName. This is re-created when reading from DB while build, but missing when build via user input. This difference in behavior is fixed.
- Also test case failing when delay in cache cleanup, as db updated directly but cache have old entry.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11403

## How was this patch tested?

- UT case updated for impact
- Running existing testcases for impact
