### PR TITLE
HDDS-11400. Bump org.apache.maven:maven-core from 3.9.8 to 3.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <vault.driver.version>5.1.0</vault.driver.version>
     <native.lib.tmp.dir></native.lib.tmp.dir>
     <properties.maven.plugin.version>1.2.1</properties.maven.plugin.version>
-    <maven.core.version>3.9.8</maven.core.version>
+    <maven.core.version>3.9.9</maven.core.version>
     <snappy-java.version>1.1.10.6</snappy-java.version>
     <hadoop-shaded-guava.version>1.2.0</hadoop-shaded-guava.version>
     <com.nimbusds.nimbus-jose-jwt.version>9.40</com.nimbusds.nimbus-jose-jwt.version>


### PR DESCRIPTION
## Bump org.apache.maven:maven-core from 3.9.8 to 3.9.9

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11400

## How was this patch tested?
