### PR TITLE
HDDS-11407. Use OMLayoutFeature.HBASE_SUPPORT for HSYNC

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -553,7 +553,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
   public static OMRequest disallowHsync(
       OMRequest req, ValidationContext ctx) throws OMException {
     if (!ctx.versionManager()
-        .isAllowed(OMLayoutFeature.HSYNC)) {
+        .isAllowed(OMLayoutFeature.HBASE_SUPPORT)) {
       CommitKeyRequest commitKeyRequest = req.getCommitKeyRequest();
       boolean isHSync = commitKeyRequest.hasHsync() &&
           commitKeyRequest.getHsync();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMLayoutFeature.java
@@ -40,6 +40,7 @@ public enum OMLayoutFeature implements LayoutFeature {
 
   MULTITENANCY_SCHEMA(3, "Multi-Tenancy Schema"),
 
+  @Deprecated
   HSYNC(4, "Support hsync"),
 
   FILESYSTEM_SNAPSHOT(5, "Ozone version supporting snapshot"),


### PR DESCRIPTION
## What changes were proposed in this pull request?
`OMLayoutFeature.HSYNC` was added in 1.4.0 but the HSync feature is disabled in 1.4.0. Later `OMLayoutFeature.HBASE_SUPPORT` was added for the newer HSync APIs and use cases.

Now, we have two layout flags, `OMLayoutFeature.HSync` and `OMLayoutFeature.HBASE_SUPPORT` for HSYNC which creates confusion. This change is to deprecate `OMLayoutFeature.HSync` and use `OMLayoutFeature.HBASE_SUPPORT` for all the HSync use cases.

## What is the link to the Apache JIRA
HDDS-11407.

## How was this patch tested?
Existing tests and more will be added in HDDS-11312
