### PR TITLE
HDDS-11390. Removed hsync and hflush capability check in ContentGenerator

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -23,9 +23,7 @@ import java.nio.charset.StandardCharsets;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
-import org.apache.hadoop.fs.impl.StoreImplementationUtils;
 import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 
 /**
@@ -109,20 +107,17 @@ public class ContentGenerator {
       // noop
       break;
     case HFLUSH:
-      if (StoreImplementationUtils.hasCapability(
-          outputStream, StreamCapabilities.HSYNC)) {
-        ((Syncable)outputStream).hflush();
+      if (outputStream instanceof Syncable) {
+        ((Syncable) outputStream).hflush();
       }
       break;
     case HSYNC:
-      if (StoreImplementationUtils.hasCapability(
-          outputStream, StreamCapabilities.HSYNC)) {
-        ((Syncable)outputStream).hsync();
+      if (outputStream instanceof Syncable) {
+        ((Syncable) outputStream).hsync();
       }
       break;
     default:
-      throw new IllegalArgumentException("Unsupported sync option"
-          + flushOrSync);
+      throw new IllegalArgumentException("Unsupported sync option" + flushOrSync);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, there is a precautionary hsync and hflush capability check in ContentGenerator which is unnecessary. Because it should be based on feature flag and API implementation as in [OzoneOutputStream](https://github.com/apache/ozone/blob/877504aee1a5a23eeaa097e159b033018af66c86/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneOutputStream.java#L108-L123).
This change is to remove the check and just rely on the feature flag and client.

## What is the link to the Apache JIRA
HDDS-11390

## How was this patch tested?
Exiting unit tests and more in HDDS-11312
