### PR TITLE
HDDS-11391. Frequent Ozone DN Crashes During OM + DN Decommission with Freon

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -904,8 +904,6 @@ public class KeyValueHandler extends Handler {
         blockData.setBlockCommitSequenceId(dispatcherContext.getLogIndex());
         boolean eob = writeChunk.getBlock().getEof();
         if (eob) {
-          Preconditions.checkArgument(writeChunk.getBlock().getBlockData().getChunksList().isEmpty(),
-              "Client is not supposed to send empty EC blocks in piggybacking mode.");
           chunkManager.finishWriteChunks(kvContainer, blockData);
         }
         blockManager.putBlock(kvContainer, blockData, eob);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -122,6 +122,7 @@ import static org.apache.hadoop.hdds.scm.utils.ClientCommandsUtils.getReadChunkV
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ContainerDataProto.State.RECOVERING;
 import static org.apache.hadoop.ozone.ClientVersion.EC_REPLICA_INDEX_REQUIRED_IN_BLOCK_REQUEST;
+import static org.apache.hadoop.ozone.OzoneConsts.INCREMENTAL_CHUNK_LIST;
 import static org.apache.hadoop.ozone.container.common.interfaces.Container.ScanResult;
 
 import org.apache.hadoop.util.Time;
@@ -547,9 +548,13 @@ public class KeyValueHandler extends Handler {
 
       boolean endOfBlock = false;
       if (!request.getPutBlock().hasEof() || request.getPutBlock().getEof()) {
-        // in EC, we will be doing empty put block.
-        // So, let's flush only when there are any chunks
-        if (!request.getPutBlock().getBlockData().getChunksList().isEmpty()) {
+        // There are two cases where client sends empty put block with eof.
+        // (1) An EC empty file. In this case, the block/chunk file does not exist,
+        //     so no need to flush/close the file.
+        // (2) Ratis output stream in incremental chunk list mode may send empty put block
+        //     to close the block, in which case we need to flush/close the file.
+        if (!request.getPutBlock().getBlockData().getChunksList().isEmpty() ||
+            blockData.getMetadata().containsKey(INCREMENTAL_CHUNK_LIST)) {
           chunkManager.finishWriteChunks(kvContainer, blockData);
         }
         endOfBlock = true;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -903,6 +903,11 @@ public class KeyValueHandler extends Handler {
         // of order.
         blockData.setBlockCommitSequenceId(dispatcherContext.getLogIndex());
         boolean eob = writeChunk.getBlock().getEof();
+        if (eob) {
+          Preconditions.checkArgument(writeChunk.getBlock().getBlockData().getChunksList().isEmpty(),
+              "Client is not supposed to send empty EC blocks in piggybacking mode.");
+          chunkManager.finishWriteChunks(kvContainer, blockData);
+        }
         blockManager.putBlock(kvContainer, blockData, eob);
         blockDataProto = blockData.getProtoBufMessage();
         final long numBytes = blockDataProto.getSerializedSize();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
@@ -52,7 +52,7 @@ import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersi
  */
 public class ChunkManagerDispatcher implements ChunkManager {
 
-  private static final Logger LOG =
+  static final Logger LOG =
       LoggerFactory.getLogger(ChunkManagerDispatcher.class);
 
   private final Map<ContainerLayoutVersion, ChunkManager> handlers

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
@@ -52,7 +52,7 @@ import static org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersi
  */
 public class ChunkManagerDispatcher implements ChunkManager {
 
-  static final Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(ChunkManagerDispatcher.class);
 
   private final Map<ContainerLayoutVersion, ChunkManager> handlers

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/AbstractTestChunkManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/AbstractTestChunkManager.java
@@ -142,7 +142,12 @@ public abstract class AbstractTestChunkManager {
     try {
       Process process = new ProcessBuilder("fuser", filePath).start();
       try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
-        return reader.readLine() == null;  // If fuser returns no output, the file is not in use
+        String output = reader.readLine();  // If fuser returns no output, the file is not in use
+        if (output == null) {
+          return true;
+        }
+        LOG.debug("File is in use: {}", filePath);
+        return false;
       } finally {
         process.destroy();
       }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/AbstractTestChunkManager.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/AbstractTestChunkManager.java
@@ -148,10 +148,13 @@ public abstract class AbstractTestChunkManager {
     }
   }
 
-  // check that all files under chunk path are closed.
   protected boolean checkChunkFilesClosed() throws IOException {
+    return checkChunkFilesClosed(keyValueContainerData.getChunksPath());
+  }
+
+  // check that all files under chunk path are closed.
+  public static boolean checkChunkFilesClosed(String path) {
     //As in Setup, we try to create container, these paths should exist.
-    String path = keyValueContainerData.getChunksPath();
     assertNotNull(path);
 
     File dir = new File(path);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -239,11 +239,9 @@ public abstract class CommonChunkManagerTestCases extends AbstractTestChunkManag
 
     BlockData blockData = Mockito.mock(BlockData.class);
     when(blockData.getBlockID()).thenReturn(getBlockID());
-
     assertFalse(checkChunkFilesClosed());
 
     chunkManager.finishWriteChunks(getKeyValueContainer(), blockData);
-
     assertTrue(checkChunkFilesClosed());
 
     // THEN

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -239,7 +239,6 @@ public abstract class CommonChunkManagerTestCases extends AbstractTestChunkManag
 
     BlockData blockData = Mockito.mock(BlockData.class);
     when(blockData.getBlockID()).thenReturn(getBlockID());
-    assertFalse(checkChunkFilesClosed());
 
     chunkManager.finishWriteChunks(getKeyValueContainer(), blockData);
     assertTrue(checkChunkFilesClosed());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -39,7 +39,6 @@ import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.COMBIN
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.WRITE_STAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -369,6 +369,9 @@ public class TestHSync {
         // locate the container chunk path on the first DataNode.
         chunkPath = getChunkPathOnDataNode(outputStream);
         assertFalse(AbstractTestChunkManager.checkChunkFilesClosed(chunkPath));
+
+        // TODO: the next assertion will fail if the following line is commented out.
+        outputStream.write(data.getBytes(UTF_8), 0, data.length());
       }
       // After close, the chunk file should be closed.
       assertTrue(AbstractTestChunkManager.checkChunkFilesClosed(chunkPath));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -324,6 +324,8 @@ public class TestHSync {
   }
 
   @Test
+  // Making this the second test to be run to avoid lingering block files from previous tests
+  @Order(2)
   public void testEmptyHsync() throws Exception {
     // Check that deletedTable should not have keys with the same block as in
     // keyTable's when a key is hsync()'ed then close()'d.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -369,14 +369,10 @@ public class TestHSync {
         // locate the container chunk path on the first DataNode.
         chunkPath = getChunkPathOnDataNode(outputStream);
         assertFalse(AbstractTestChunkManager.checkChunkFilesClosed(chunkPath));
-
-        // TODO: the next assertion will fail if the following line is commented out.
-        outputStream.write(data.getBytes(UTF_8), 0, data.length());
       }
       // After close, the chunk file should be closed.
       assertTrue(AbstractTestChunkManager.checkChunkFilesClosed(chunkPath));
     }
-
 
     OzoneManager ozoneManager = cluster.getOzoneManager();
     // Wait for double buffer to trigger all pending addToDBBatch(),


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11391. Frequent Ozone DN Crashes During OM + DN Decommission with Freon

Please describe your PR in detail:
* When in piggyback mode, check if WriteChunk/PutBlock has end of block field toggled. If so, close the corresponding block file open descriptor.
* Added unit test and integration test

TODO:
There is still one corner case not fixed yet: if client does write - hsync and then close (meaning write buffer is emptied), for some reason client doesn't toggle end of block field.
Unfortunately our BlockOutputStream implementation is becoming too complex to understand. Refactoring would be required later.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11391
## How was this patch tested?

Unit tests, integration tests