### PR TITLE
HDDS-11380. Fixing the error message of node decommission to be more comprehensive

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -431,8 +431,9 @@ public class NodeDecommissionManager {
           int reqNodes = cif.getReplicationConfig().getRequiredNodes();
           if ((inServiceTotal - numDecom) < reqNodes) {
             String errorMsg = "Insufficient nodes. Tried to decommission " + dns.size() +
-                " nodes of which " + numDecom + " nodes were valid. Cluster has " + inServiceTotal +
-                " IN-SERVICE nodes, " + reqNodes + " of which are required for minimum replication. ";
+                " nodes out of " + inServiceTotal + " IN-SERVICE nodes. Cannot decommission because we need " +
+                (reqNodes - (inServiceTotal - numDecom)) + " more IN-SERVICE nodes " +
+                "to maintain replication factor. ";
             LOG.info(errorMsg + "Failing due to datanode : {}, container : {}", dn, cid);
             errors.add(new DatanodeAdminError("AllHosts", errorMsg));
             return false;
@@ -595,8 +596,9 @@ public class NodeDecommissionManager {
           }
           if ((inServiceTotal - numMaintenance) < minInService) {
             String errorMsg = "Insufficient nodes. Tried to start maintenance for " + dns.size() +
-                " nodes of which " + numMaintenance + " nodes were valid. Cluster has " + inServiceTotal +
-                " IN-SERVICE nodes, " + minInService + " of which are required for minimum replication. ";
+                " nodes out of " + inServiceTotal + " IN-SERVICE nodes. Cannot enter maintenance mode because " +
+                "we need " + (minInService - (inServiceTotal - numMaintenance)) +
+                " more IN-SERVICE nodes to maintain minimum replication. ";
             LOG.info(errorMsg + "Failing due to datanode : {}, container : {}", dn, cid);
             errors.add(new DatanodeAdminError("AllHosts", errorMsg));
             return false;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -435,7 +435,7 @@ public class NodeDecommissionManager {
             int unHealthyTotal = nodeManager.getAllNodes().size() - inServiceTotal;
             String errorMsg = "Insufficient nodes. Tried to decommission " + dns.size() +
                 " nodes out of " + inServiceTotal + " IN-SERVICE HEALTHY and " + unHealthyTotal +
-                " UNHEALTHY nodes. Cannot decommission as a minimum of " + reqNodes +
+                " not IN-SERVICE or not HEALTHY nodes. Cannot decommission as a minimum of " + reqNodes +
                 " IN-SERVICE HEALTHY nodes are required to maintain replication after decommission. ";
             LOG.info(errorMsg + "Failing due to datanode : {}, container : {}", dn, cid);
             errors.add(new DatanodeAdminError("AllHosts", errorMsg));
@@ -603,7 +603,7 @@ public class NodeDecommissionManager {
             int unHealthyTotal = nodeManager.getAllNodes().size() - inServiceTotal;
             String errorMsg = "Insufficient nodes. Tried to start maintenance for " + dns.size() +
                 " nodes out of " + inServiceTotal + " IN-SERVICE HEALTHY and " + unHealthyTotal +
-                " UNHEALTHY nodes. Cannot enter maintenance mode as a minimum of " + minInService +
+                " not IN-SERVICE or not HEALTHY nodes. Cannot enter maintenance mode as a minimum of " + minInService +
                 " IN-SERVICE HEALTHY nodes are required to maintain replication after maintenance. ";
             LOG.info(errorMsg + "Failing due to datanode : {}, container : {}", dn, cid);
             errors.add(new DatanodeAdminError("AllHosts", errorMsg));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -440,6 +440,10 @@ public class TestNodeDecommissionManager {
     error = decom.decommissionNodes(Arrays.asList(dns.get(1).getIpAddress(),
         dns.get(2).getIpAddress(), dns.get(3).getIpAddress(), dns.get(4).getIpAddress()), false);
     assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    String errorMsg = String.format("%d IN-SERVICE HEALTHY and %d not IN-SERVICE or not HEALTHY nodes.", 5, 0);
+    assertTrue(error.get(0).getError().contains(errorMsg));
+    errorMsg = String.format("Cannot decommission as a minimum of %d IN-SERVICE HEALTHY nodes are required", 3);
+    assertTrue(error.get(0).getError().contains(errorMsg));
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
@@ -489,6 +493,10 @@ public class TestNodeDecommissionManager {
 
     error = decom.decommissionNodes(Arrays.asList(dns.get(1).getIpAddress()), false);
     assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    String errorMsg = String.format("%d IN-SERVICE HEALTHY and %d not IN-SERVICE or not HEALTHY nodes.", 5, 0);
+    assertTrue(error.get(0).getError().contains(errorMsg));
+    errorMsg = String.format("Cannot decommission as a minimum of %d IN-SERVICE HEALTHY nodes are required", 5);
+    assertTrue(error.get(0).getError().contains(errorMsg));
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     error = decom.decommissionNodes(Arrays.asList(dns.get(1).getIpAddress()), true);
@@ -537,6 +545,10 @@ public class TestNodeDecommissionManager {
 
     error = decom.decommissionNodes(Arrays.asList(dns.get(1).getIpAddress()), false);
     assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    String errorMsg = String.format("%d IN-SERVICE HEALTHY and %d not IN-SERVICE or not HEALTHY nodes.", 5, 0);
+    assertTrue(error.get(0).getError().contains(errorMsg));
+    errorMsg = String.format("Cannot decommission as a minimum of %d IN-SERVICE HEALTHY nodes are required", 5);
+    assertTrue(error.get(0).getError().contains(errorMsg));
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     error = decom.decommissionNodes(Arrays.asList(dns.get(1).getIpAddress()), true);
@@ -637,6 +649,7 @@ public class TestNodeDecommissionManager {
     error = decom.decommissionNodes(Arrays.asList(dns.get(0).getIpAddress(),
         dns.get(1).getIpAddress(), dns.get(2).getIpAddress()), false);
     assertFalse(error.get(0).getHostname().contains("AllHosts"));
+    assertTrue(error.get(0).getError().contains("The host was not found in SCM"));
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
@@ -673,6 +686,11 @@ public class TestNodeDecommissionManager {
     error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(),
         dns.get(2).getIpAddress(), dns.get(3).getIpAddress(), dns.get(4).getIpAddress()), 100, false);
     assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    String errorMsg = String.format("%d IN-SERVICE HEALTHY and %d not IN-SERVICE or not HEALTHY nodes.", 5, 0);
+    assertTrue(error.get(0).getError().contains(errorMsg));
+    errorMsg = String.format("Cannot enter maintenance mode as a minimum of %d IN-SERVICE HEALTHY nodes are required",
+        2);
+    assertTrue(error.get(0).getError().contains(errorMsg));
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
@@ -768,6 +786,11 @@ public class TestNodeDecommissionManager {
     error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress(), dns.get(2).getIpAddress()),
         100, false);
     assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    String errorMsg = String.format("%d IN-SERVICE HEALTHY and %d not IN-SERVICE or not HEALTHY nodes.", 5, 0);
+    assertTrue(error.get(0).getError().contains(errorMsg));
+    errorMsg = String.format("Cannot enter maintenance mode as a minimum of %d IN-SERVICE HEALTHY nodes are required",
+        4);
+    assertTrue(error.get(0).getError().contains(errorMsg));
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
@@ -869,6 +892,11 @@ public class TestNodeDecommissionManager {
     // it should not be allowed as for EC, maintenance.remaining.redundancy is 2 => 3+2=5 DNs are required
     error = decom.startMaintenanceNodes(Arrays.asList(dns.get(1).getIpAddress()), 100, false);
     assertTrue(error.get(0).getHostname().contains("AllHosts"));
+    String errorMsg = String.format("%d IN-SERVICE HEALTHY and %d not IN-SERVICE or not HEALTHY nodes.", 5, 0);
+    assertTrue(error.get(0).getError().contains(errorMsg));
+    errorMsg = String.format("Cannot enter maintenance mode as a minimum of %d IN-SERVICE HEALTHY nodes are required",
+        5);
+    assertTrue(error.get(0).getError().contains(errorMsg));
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11380. Fixing the error message of node decommission to be more comprehensive

Please describe your PR in detail:
Right now, when decommissioning fails quickly due to in-sufficient nodes, the error message says

> Insufficient nodes. Tried to decommission 1 nodes of which 1 nodes were valid. Cluster has 3 IN-SERVICE nodes, 3 of which are required for minimum replication.

This does not clearly explain, how many nodes are required for the decommission to proceed. So in this PR we will be changing the above message to clearly define how many more IN-SERVICE nodes are needed for decommissioning to proceed.

>  Insufficient nodes. Tried to decommission 2 nodes out of 4 IN-SERVICE HEALTHY and 1 UNHEALTHY nodes. Cannot decommission as a minimum of 3 IN-SERVICE HEALTHY nodes are required to maintain replication after decommission.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11380 

## How was this patch tested?

Ran the existing tests in TestNodeDecommissionManager.java
Also tested locally in docker

sh-4.4$ ozone admin datanode decommission ozone-datanode-4 ozone-datanode-5
Started decommissioning datanode(s):
ozone-datanode-4
ozone-datanode-5
Error: AllHosts: Insufficient nodes. Tried to decommission 2 nodes out of 3 IN-SERVICE HEALTHY and 2 not IN-SERVICE or not HEALTHY nodes. Cannot decommission as a minimum of 3 IN-SERVICE HEALTHY nodes are required to maintain replication after decommission. 
Some nodes could not enter the decommission workflow

sh-4.4$ ozone admin datanode maintenance ozone-datanode-2 ozone-datanode-4 ozone-datanode-5
Entering maintenance mode on datanode(s):
ozone-datanode-2
ozone-datanode-4
ozone-datanode-5
Error: AllHosts: Insufficient nodes. Tried to start maintenance for 3 nodes out of 3 IN-SERVICE HEALTHY and 2 not IN-SERVICE or not HEALTHY nodes. Cannot enter maintenance mode as a minimum of 2 IN-SERVICE HEALTHY nodes are required to maintain replication after maintenance. 
Some nodes could not start the maintenance workflow
