### PR TITLE
HDDS-11145. ozone admin om cancelprepare --service-id improvement

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/CancelPrepareSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/CancelPrepareSubCommand.java
@@ -38,7 +38,7 @@ public class CancelPrepareSubCommand implements Callable<Void> {
   @CommandLine.Option(
       names = {"-id", "--service-id"},
       description = "Ozone Manager Service ID",
-      required = true
+      required = false
   )
   private String omServiceId;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
ozone admin om cancelprepare --service-id improvement.

Please describe your PR in detail:
Currently, for ozone admin om cancelprepare command, we need to specify the om service ID as its a mandatory parameter.

```
ozone admin om cancelprepare
Missing required option: '--service-id=<omServiceId>'
Usage: ozone admin om cancelprepare [-hV] -id=<omServiceId>
Cancel prepare state in the OMs.
  -h, --help      Show this help message and exit.
      -id, --service-id=<omServiceId>
                  Ozone Manager Service ID
  -V, --version   Print version information and exit. 
```
The aim is to pick the default om service ID when explicilty not specified. 

## What is the link to the Apache JIRA
[HDDS-11145](https://issues.apache.org/jira/browse/HDDS-11145)

## How was this patch tested?
Tested Manually using CLI

```
ozone admin om cancelprepare
Cancel prepare succeeded, cluster can now accept write requests.

```