### PR TITLE
HDDS-11413. PipelineManagerImpl lock optimization reduces AllocateBlock latency

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -176,7 +176,7 @@ public class ContainerManagerImpl implements ContainerManager {
     // Acquire pipeline manager lock, to avoid any updates to pipeline
     // while allocate container happens. This is to avoid scenario like
     // mentioned in HDDS-5655.
-    pipelineManager.acquireReadLock();
+    pipelineManager.acquireReadLock(replicationConfig);
     lock.lock();
     List<Pipeline> pipelines;
     Pipeline pipeline;
@@ -190,7 +190,7 @@ public class ContainerManagerImpl implements ContainerManager {
       }
     } finally {
       lock.unlock();
-      pipelineManager.releaseReadLock();
+      pipelineManager.releaseReadLock(replicationConfig);
     }
 
     if (pipelines.isEmpty()) {
@@ -203,7 +203,7 @@ public class ContainerManagerImpl implements ContainerManager {
             " matching pipeline for replicationConfig: " + replicationConfig
             + ", State:PipelineState.OPEN", e);
       }
-      pipelineManager.acquireReadLock();
+      pipelineManager.acquireReadLock(replicationConfig);
       lock.lock();
       try {
         pipelines = pipelineManager
@@ -218,7 +218,7 @@ public class ContainerManagerImpl implements ContainerManager {
         }
       } finally {
         lock.unlock();
-        pipelineManager.releaseReadLock();
+        pipelineManager.releaseReadLock(replicationConfig);
       }
     }
     return containerInfo;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -207,20 +207,20 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
   /**
    * Acquire read lock.
    */
-  void acquireReadLock();
+  void acquireReadLock(ReplicationConfig replicationConfig);
 
   /**
    * Release read lock.
    */
-  void releaseReadLock();
+  void releaseReadLock(ReplicationConfig replicationConfig);
 
   /**
    * Acquire write lock.
    */
-  void acquireWriteLock();
+  void acquireWriteLock(ReplicationConfig replicationConfig);
 
   /**
    * Release write lock.
    */
-  void releaseWriteLock();
+  void releaseWriteLock(ReplicationConfig replicationConfig);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
@@ -156,13 +156,13 @@ public class WritableRatisContainerProvider
     // Acquire pipeline manager lock, to avoid any updates to pipeline
     // while allocate container happens. This is to avoid scenario like
     // mentioned in HDDS-5655.
-    pipelineManager.acquireReadLock();
+    pipelineManager.acquireReadLock(repConfig);
     try {
       List<Pipeline> availablePipelines = findPipelinesByState(repConfig,
           excludeList, Pipeline.PipelineState.OPEN);
       return selectContainer(availablePipelines, req, owner, excludeList);
     } finally {
-      pipelineManager.releaseReadLock();
+      pipelineManager.releaseReadLock(repConfig);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -332,22 +332,22 @@ public class MockPipelineManager implements PipelineManager {
   }
 
   @Override
-  public void acquireReadLock() {
+  public void acquireReadLock(ReplicationConfig replicationConfig) {
 
   }
 
   @Override
-  public void releaseReadLock() {
+  public void releaseReadLock(ReplicationConfig replicationConfig) {
 
   }
 
   @Override
-  public void acquireWriteLock() {
+  public void acquireWriteLock(ReplicationConfig replicationConfig) {
 
   }
 
   @Override
-  public void releaseWriteLock() {
+  public void releaseWriteLock(ReplicationConfig replicationConfig) {
 
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

PipelineManagerImpl lock optimization reduces AllocateBlock latency


The following are the issues discovered in our production environment:
When applying for a block in the Ratis replica, there may be jitter in the P99 latency due to obtaining a read lock
![image](https://github.com/user-attachments/assets/9a518712-5d2a-45dc-a0f4-483aa3b31495)

The main parts that hold write locks:

```
org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider#allocateContainer
```

![image](https://github.com/user-attachments/assets/776f350e-e0e0-4056-a0d2-aa4e83a37ac1)


EC pipelines are frequently created and closed because there is only one container in each EC pipeline. When the container is full, the creation of new ones will be closed. When creating a pipeline, a write lock at the pipeline manager level will be held, while when applying for a Ratis block, a read lock at the pipeline manager level will be held.

The purpose of this optimization is to unlock. When creating and closing an EC pipeline, only the write lock at the EC pipeline manager level will be held, while when applying for a ratis replica block, only the read lock of the ratis pipeline manager will be held. The two locks will not affect each other.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11413
