### PR TITLE
HDDS-11417. Refactor SCMSecurityProtocol to return X509Certificates instead of Strings

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -259,10 +259,14 @@ public class CertificateCodec {
    * Gets a certificate path from the specified pem encoded String.
    */
   public static CertPath getCertPathFromPemEncodedString(
-      String pemString) throws CertificateException {
+      String pemString) throws IOException {
     // ByteArrayInputStream.close(), which is a noop, can be safely ignored.
-    return generateCertPathFromInputStream(
-        new ByteArrayInputStream(pemString.getBytes(DEFAULT_CHARSET)));
+    try {
+      return generateCertPathFromInputStream(
+          new ByteArrayInputStream(pemString.getBytes(DEFAULT_CHARSET)));
+    } catch (CertificateException e) {
+      throw new IOException(e);
+    }
   }
 
   private CertPath getCertPath(Path path, String fileName) throws IOException,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -333,8 +333,8 @@ public class TestHddsSecureDatanodeInit {
     when(scmClient.getDataNodeCertificateChain(any(), anyString()))
         .thenReturn(responseProto);
 
-    List<String> rootCaList = new ArrayList<>();
-    rootCaList.add(pemCert);
+    List<X509Certificate> rootCaList = new ArrayList<>();
+    rootCaList.add(newCert);
     when(scmClient.getAllRootCaCertificates()).thenReturn(rootCaList);
     // check that new cert ID should not equal to current cert ID
     String certId = newCert.getSerialNumber().toString();
@@ -356,7 +356,7 @@ public class TestHddsSecureDatanodeInit {
 
     // test the second time certificate rotation, generate a new cert
     newCert = generateX509Cert(null, null, Duration.ofSeconds(CERT_LIFETIME));
-    rootCaList.remove(pemCert);
+    rootCaList.remove(newCert);
     pemCert = CertificateCodec.getPEMEncodedString(newCert);
     responseProto = SCMSecurityProtocolProtos.SCMGetCertResponseProto
         .newBuilder().setResponseCode(SCMSecurityProtocolProtos
@@ -367,7 +367,7 @@ public class TestHddsSecureDatanodeInit {
         .build();
     when(scmClient.getDataNodeCertificateChain(any(), anyString()))
         .thenReturn(responseProto);
-    rootCaList.add(pemCert);
+    rootCaList.add(newCert);
     when(scmClient.getAllRootCaCertificates()).thenReturn(rootCaList);
     String certId2 = newCert.getSerialNumber().toString();
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -111,12 +111,12 @@ public interface SCMSecurityProtocol {
   /**
    * Get list of certificates meet the query criteria.
    *
-   * @param type            - node type: OM/SCM/DN.
-   * @param startSerialId   - start certificate serial id.
-   * @param count           - max number of certificates returned in a batch.
+   * @param type          - node type: OM/SCM/DN.
+   * @param startSerialId - start certificate serial id.
+   * @param count         - max number of certificates returned in a batch.
    * @return list of PEM encoded certificate strings.
    */
-  List<String> listCertificate(HddsProtos.NodeType type, long startSerialId, int count) throws IOException;
+  List<X509Certificate> listCertificate(HddsProtos.NodeType type, long startSerialId, int count) throws IOException;
 
   /**
    * Get Root CA certificate.
@@ -143,7 +143,7 @@ public interface SCMSecurityProtocol {
    *
    * @throws IOException
    */
-  List<String> listCACertificate() throws IOException;
+  List<X509Certificate> listCACertificate() throws IOException;
 
   /**
    * Get SCM signed certificate.
@@ -169,5 +169,5 @@ public interface SCMSecurityProtocol {
    * @return list of the removed certificates
    * @throws IOException
    */
-  List<String> removeExpiredCertificates() throws IOException;
+  List<X509Certificate> removeExpiredCertificates() throws IOException;
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.hdds.protocol;
 
 import java.io.IOException;
+import java.security.cert.CertPath;
 import java.util.List;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -49,19 +50,19 @@ public interface SCMSecurityProtocol {
    * @param certSignReq     - Certificate signing request.
    * @return byte[]         - SCM signed certificate.
    */
-  String getDataNodeCertificate(
+  CertPath getDataNodeCertificate(
       DatanodeDetailsProto dataNodeDetails,
       String certSignReq) throws IOException;
 
   /**
    * Get SCM signed certificate for OM.
    *
-   * @param omDetails       - DataNode Details.
-   * @param certSignReq     - Certificate signing request.
+   * @param omDetails   - DataNode Details.
+   * @param certSignReq - Certificate signing request.
    * @return String         - pem encoded SCM signed
-   *                          certificate.
+   * certificate.
    */
-  String getOMCertificate(OzoneManagerDetailsProto omDetails,
+  CertPath getOMCertificate(OzoneManagerDetailsProto omDetails,
       String certSignReq) throws IOException;
 
 
@@ -73,7 +74,7 @@ public interface SCMSecurityProtocol {
    * @return String         - pem encoded SCM signed
    *                          certificate.
    */
-  String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
+  CertPath getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq) throws IOException;
 
   /**
@@ -85,7 +86,7 @@ public interface SCMSecurityProtocol {
    * @return String         - pem encoded SCM signed
    *                          certificate.
    */
-  String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
+  CertPath getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq, boolean isRenew) throws IOException;
 
   /**
@@ -151,7 +152,7 @@ public interface SCMSecurityProtocol {
    * @return String      - pem encoded SCM signed
    * certificate.
    */
-  String getCertificate(NodeDetailsProto nodeDetails,
+  CertPath getCertificate(NodeDetailsProto nodeDetails,
       String certSignReq) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -106,7 +106,7 @@ public interface SCMSecurityProtocol {
    *
    * @return String         - pem encoded CA certificate.
    */
-  String getCACertificate() throws IOException;
+  CertPath getCACertificate() throws IOException;
 
   /**
    * Get list of certificates meet the query criteria.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -162,7 +162,7 @@ public interface SCMSecurityProtocol {
    *
    * @return String     - pem encoded list of root CA certificates
    */
-  List<String> getAllRootCaCertificates() throws IOException;
+  List<X509Certificate> getAllRootCaCertificates() throws IOException;
 
   /**
    * Remove all expired certificates from the SCM metadata store.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.hdds.protocol;
 
 import java.io.IOException;
 import java.security.cert.CertPath;
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -93,12 +94,12 @@ public interface SCMSecurityProtocol {
    * Get SCM signed certificate for given certificate serial id if it exists.
    * Throws exception if it's not found.
    *
-   * @param certSerialId    - Certificate serial id.
+   * @param certSerialId - Certificate serial id.
    * @return String         - pem encoded SCM signed
-   *                          certificate with given cert id if it
-   *                          exists.
+   * certificate with given cert id if it
+   * exists.
    */
-  String getCertificate(String certSerialId) throws IOException;
+  X509Certificate getCertificate(String certSerialId) throws IOException;
 
   /**
    * Get CA certificate.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -120,10 +120,11 @@ public interface SCMSecurityProtocol {
 
   /**
    * Get Root CA certificate.
+   *
    * @return
    * @throws IOException
    */
-  String getRootCACertificate() throws IOException;
+  X509Certificate getRootCACertificate() throws IOException;
 
   /**
    * Returns all the individual SCM CA's along with Root CA.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -388,13 +388,14 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
   }
 
   @Override
-  public List<String> getAllRootCaCertificates() throws IOException {
+  public List<X509Certificate> getAllRootCaCertificates() throws IOException {
     SCMGetAllRootCaCertificatesRequestProto protoIns =
         SCMGetAllRootCaCertificatesRequestProto.getDefaultInstance();
-    return submitRequest(Type.GetAllRootCaCertificates,
+    List<String> encodedRootCerts = submitRequest(Type.GetAllRootCaCertificates,
         builder -> builder.setGetAllRootCaCertificatesRequestProto(protoIns))
         .getAllRootCaCertificatesResponseProto()
         .getAllX509RootCaCertificatesList();
+    return OzoneSecurityUtil.convertToX509(encodedRootCerts);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -357,12 +357,13 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
   }
 
   @Override
-  public String getRootCACertificate() throws IOException {
+  public X509Certificate getRootCACertificate() throws IOException {
     SCMGetCACertificateRequestProto protoIns = SCMGetCACertificateRequestProto
         .getDefaultInstance();
-    return submitRequest(Type.GetRootCACertificate,
+    String encodedRootCert = submitRequest(Type.GetRootCACertificate,
         builder -> builder.setGetCACertificateRequest(protoIns))
         .getGetCertResponseProto().getX509RootCACertificate();
+    return CertificateCodec.getX509Certificate(encodedRootCert, CertificateCodec::toIOException);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.hdds.protocolPB;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.security.cert.CertPath;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -46,6 +47,7 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMRemove
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.Type;
 import org.apache.hadoop.hdds.scm.proxy.SCMSecurityProtocolFailoverProxyProvider;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
@@ -141,10 +143,11 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
    * @return byte[]         - SCM signed certificate.
    */
   @Override
-  public String getDataNodeCertificate(DatanodeDetailsProto dataNodeDetails,
+  public CertPath getDataNodeCertificate(DatanodeDetailsProto dataNodeDetails,
       String certSignReq) throws IOException {
-    return getDataNodeCertificateChain(dataNodeDetails, certSignReq)
-        .getX509Certificate();
+    return CertificateCodec.getCertPathFromPemEncodedString(getDataNodeCertificateChain(dataNodeDetails, certSignReq)
+        .getX509Certificate());
+
   }
 
   /**
@@ -155,39 +158,40 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
    * @return byte[]         - SCM signed certificate.
    */
   @Override
-  public String getOMCertificate(OzoneManagerDetailsProto omDetails,
+  public CertPath getOMCertificate(OzoneManagerDetailsProto omDetails,
       String certSignReq) throws IOException {
-    return getOMCertChain(omDetails, certSignReq).getX509Certificate();
+    return CertificateCodec.getCertPathFromPemEncodedString(
+        getOMCertChain(omDetails, certSignReq).getX509Certificate());
   }
 
   /**
    * Get SCM signed certificate.
    *
    * @param nodeDetails - Node Details.
-   * @param certSignReq  - Certificate signing request.
+   * @param certSignReq - Certificate signing request.
    * @return String      - pem encoded SCM signed
-   *                         certificate.
+   * certificate.
    */
   @Override
-  public String getCertificate(NodeDetailsProto nodeDetails,
+  public CertPath getCertificate(NodeDetailsProto nodeDetails,
       String certSignReq) throws IOException {
-    return getCertificateChain(nodeDetails, certSignReq)
-        .getX509Certificate();
+    return CertificateCodec.getCertPathFromPemEncodedString(getCertificateChain(nodeDetails, certSignReq)
+        .getX509Certificate());
   }
 
   /**
    * Get signed certificate for SCM node.
    *
-   * @param scmNodeDetails  - SCM Node Details.
-   * @param certSignReq     - Certificate signing request.
+   * @param scmNodeDetails - SCM Node Details.
+   * @param certSignReq    - Certificate signing request.
    * @return String         - pem encoded SCM signed
-   *                          certificate.
+   * certificate.
    */
   @Override
-  public String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
+  public CertPath getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq) throws IOException {
-    return getSCMCertChain(scmNodeDetails, certSignReq, false)
-        .getX509Certificate();
+    return CertificateCodec.getCertPathFromPemEncodedString(getSCMCertChain(scmNodeDetails, certSignReq, false)
+        .getX509Certificate());
   }
 
   /**
@@ -199,10 +203,10 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
    * @return String         - pem encoded SCM signed
    *                          certificate.
    */
-  public String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
+  public CertPath getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq, boolean renew) throws IOException {
-    return getSCMCertChain(scmNodeDetails, certSignReq, renew)
-        .getX509Certificate();
+    return CertificateCodec.getCertPathFromPemEncodedString(getSCMCertChain(scmNodeDetails, certSignReq, renew)
+        .getX509Certificate());
   }
 
   /**
@@ -282,9 +286,10 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
             .setCSR(certSignReq)
             .setDatanodeDetails(dnDetails)
             .build();
-    return submitRequest(Type.GetDataNodeCertificate,
-        builder -> builder.setGetDataNodeCertRequest(request))
-        .getGetCertResponseProto();
+    return
+        submitRequest(Type.GetDataNodeCertificate,
+            builder -> builder.setGetDataNodeCertRequest(request))
+            .getGetCertResponseProto();
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -321,8 +321,8 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
    * @return serial   - Root certificate.
    */
   @Override
-  public String getCACertificate() throws IOException {
-    return getCACert().getX509Certificate();
+  public CertPath getCACertificate() throws IOException {
+    return CertificateCodec.getCertPathFromPemEncodedString(getCACert().getX509Certificate());
   }
 
   public SCMGetCertResponseProto getCACert() throws IOException {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.protocolPB;
 import java.io.Closeable;
 import java.io.IOException;
 import java.security.cert.CertPath;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -259,15 +260,16 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
    * @return string         - pem encoded certificate.
    */
   @Override
-  public String getCertificate(String certSerialId) throws IOException {
+  public X509Certificate getCertificate(String certSerialId) throws IOException {
     SCMGetCertificateRequestProto request = SCMGetCertificateRequestProto
         .newBuilder()
         .setCertSerialId(certSerialId)
         .build();
-    return submitRequest(Type.GetCertificate,
+    String encodedCertificate = submitRequest(Type.GetCertificate,
         builder -> builder.setGetCertificateRequest(request))
         .getGetCertResponseProto()
         .getX509Certificate();
+    return CertificateCodec.getX509Certificate(encodedCertificate, CertificateCodec::toIOException);
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.ipc.RPC;
 
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
 
 /**
  * This class is the client-side translator that forwards requests for
@@ -341,7 +342,7 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
    * @throws IOException
    */
   @Override
-  public List<String> listCertificate(HddsProtos.NodeType role,
+  public List<X509Certificate> listCertificate(HddsProtos.NodeType role,
       long startSerialId, int count) throws IOException {
     SCMListCertificateRequestProto protoIns = SCMListCertificateRequestProto
         .newBuilder()
@@ -349,9 +350,10 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
         .setStartCertId(startSerialId)
         .setCount(count)
         .build();
-    return submitRequest(Type.ListCertificate,
+    List<String> encodedCertList = submitRequest(Type.ListCertificate,
         builder -> builder.setListCertificateRequest(protoIns))
         .getListCertificateResponseProto().getCertificatesList();
+    return OzoneSecurityUtil.convertToX509(encodedCertList);
   }
 
   @Override
@@ -364,12 +366,14 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
   }
 
   @Override
-  public List<String> listCACertificate() throws IOException {
+  public List<X509Certificate> listCACertificate() throws IOException {
     SCMListCACertificateRequestProto proto =
         SCMListCACertificateRequestProto.getDefaultInstance();
-    return submitRequest(Type.ListCACertificate,
+
+    List<String> encodedCertList = submitRequest(Type.ListCACertificate,
         builder -> builder.setListCACertificateRequestProto(proto))
         .getListCertificateResponseProto().getCertificatesList();
+    return OzoneSecurityUtil.convertToX509(encodedCertList);
   }
 
   /**
@@ -393,12 +397,13 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
   }
 
   @Override
-  public List<String> removeExpiredCertificates() throws IOException {
+  public List<X509Certificate> removeExpiredCertificates() throws IOException {
     SCMRemoveExpiredCertificatesRequestProto protoIns =
         SCMRemoveExpiredCertificatesRequestProto.getDefaultInstance();
-    return submitRequest(Type.RemoveExpiredCertificates,
+    List<String> encodedCertList = submitRequest(Type.RemoveExpiredCertificates,
         builder -> builder.setRemoveExpiredCertificatesRequestProto(protoIns))
         .getRemoveExpiredCertificatesResponseProto()
         .getRemovedExpiredCertificatesList();
+    return OzoneSecurityUtil.convertToX509(encodedCertList);
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -476,7 +476,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     getLogger().info("Getting certificate with certSerialId:{}.",
         certId);
     try {
-      String pemEncodedCert = getScmSecureClient().getCertificate(certId);
+      X509Certificate certFromScm = getScmSecureClient().getCertificate(certId);
+      String pemEncodedCert = CertificateCodec.getPEMEncodedString(certFromScm);
       this.storeCertificate(pemEncodedCert, CAType.NONE);
       return CertificateCodec.getX509Certificate(pemEncodedCert);
     } catch (Exception e) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -622,7 +622,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
           rootCaCertificates.add(cert);
         }
       }
-    } catch (IOException | java.security.cert.CertificateException e) {
+    } catch (IOException e) {
       throw new CertificateException("Error while storing certificate.", e,
           CERTIFICATE_ERROR);
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -1331,9 +1331,9 @@ public abstract class DefaultCertificateClient implements CertificateClient {
 
   private void getAndStoreAllRootCAs(CertificateCodec certCodec, boolean renew)
       throws IOException {
-    List<String> rootCAPems = scmSecurityClient.getAllRootCaCertificates();
-    for (String rootCAPem : rootCAPems) {
-      storeCertificate(rootCAPem, CAType.ROOT, certCodec,
+    List<X509Certificate> rootCaCerts = scmSecurityClient.getAllRootCaCertificates();
+    for (X509Certificate rootCAPem : rootCaCerts) {
+      storeCertificate(CertificateCodec.getPEMEncodedString(rootCAPem), CAType.ROOT, certCodec,
           false, !renew);
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/RootCaRotationPoller.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.security.x509.certificate.client;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.SecurityConfig;
-import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,12 +81,8 @@ public class RootCaRotationPoller implements Runnable, Closeable {
    */
   void pollRootCas() {
     try {
-      List<String> pemEncodedRootCaList =
-          scmSecureClient.getAllRootCaCertificates();
-      List<X509Certificate> rootCAsFromSCM =
-          OzoneSecurityUtil.convertToX509(pemEncodedRootCaList);
-      List<X509Certificate> scmCertsWithoutKnownCerts
-          = new ArrayList<>(rootCAsFromSCM);
+      List<X509Certificate> rootCAsFromSCM = scmSecureClient.getAllRootCaCertificates();
+      List<X509Certificate> scmCertsWithoutKnownCerts = new ArrayList<>(rootCAsFromSCM);
       scmCertsWithoutKnownCerts.removeAll(knownRootCerts);
       if (scmCertsWithoutKnownCerts.isEmpty()) {
         return;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hdds.security.x509.certificate.authority.profile.PKIPro
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -236,14 +235,11 @@ public class SCMCertificateClient extends DefaultCertificateClient {
         // In case root CA certificate is rotated during this SCM is offline
         // period, fetch the new root CA list from leader SCM and refresh ratis
         // server's tlsConfig.
-        List<String> rootCAPems = scmSecureClient.getAllRootCaCertificates();
-
+        List<X509Certificate> rootCAsFromLeaderSCM = scmSecureClient.getAllRootCaCertificates();
         // SCM certificate client currently sets root CA as CA cert
         Set<X509Certificate> certList = getAllRootCaCerts();
         certList = certList.isEmpty() ? getAllCaCerts() : certList;
 
-        List<X509Certificate> rootCAsFromLeaderSCM =
-            OzoneSecurityUtil.convertToX509(rootCAPems);
         rootCAsFromLeaderSCM.removeAll(certList);
 
         if (rootCAsFromLeaderSCM.isEmpty()) {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestRootCaRotationPoller.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestRootCaRotationPoller.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.security.x509.certificate.client;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.SecurityConfig;
-import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.SelfSignedCertificate;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ozone.test.GenericTestUtils;
@@ -77,8 +76,8 @@ public class TestRootCaRotationPoller {
         LocalDateTime.now(), Duration.ofSeconds(50));
     HashSet<X509Certificate> knownCerts = new HashSet<>();
     knownCerts.add(knownCert);
-    List<String> certsFromScm = new ArrayList<>();
-    certsFromScm.add(CertificateCodec.getPEMEncodedString(knownCert));
+    List<X509Certificate> certsFromScm = new ArrayList<>();
+    certsFromScm.add(knownCert);
     RootCaRotationPoller poller = new RootCaRotationPoller(secConf,
         knownCerts, scmSecurityClient, "");
     //When the scm returns the same set of root ca certificates, and they poll
@@ -111,9 +110,9 @@ public class TestRootCaRotationPoller {
         LocalDateTime.now(), Duration.ofSeconds(50));
     HashSet<X509Certificate> knownCerts = new HashSet<>();
     knownCerts.add(knownCert);
-    List<String> certsFromScm = new ArrayList<>();
-    certsFromScm.add(CertificateCodec.getPEMEncodedString(knownCert));
-    certsFromScm.add(CertificateCodec.getPEMEncodedString(newRootCa));
+    List<X509Certificate> certsFromScm = new ArrayList<>();
+    certsFromScm.add(knownCert);
+    certsFromScm.add(newRootCa);
     RootCaRotationPoller poller = new RootCaRotationPoller(secConf,
         knownCerts, scmSecurityClient, "");
     //when the scm returns the unknown certificate to the poller
@@ -144,13 +143,12 @@ public class TestRootCaRotationPoller {
         LocalDateTime.now(), Duration.ofSeconds(50));
     HashSet<X509Certificate> knownCerts = new HashSet<>();
     knownCerts.add(knownCert);
-    List<String> certsFromScm = new ArrayList<>();
-    certsFromScm.add(CertificateCodec.getPEMEncodedString(knownCert));
-    certsFromScm.add(CertificateCodec.getPEMEncodedString(newRootCa));
+    List<X509Certificate> certsFromScm = new ArrayList<>();
+    certsFromScm.add(knownCert);
+    certsFromScm.add(newRootCa);
     RootCaRotationPoller poller = new RootCaRotationPoller(secConf,
         knownCerts, scmSecurityClient, "");
-    when(scmSecurityClient.getAllRootCaCertificates())
-        .thenReturn(certsFromScm);
+    when(scmSecurityClient.getAllRootCaCertificates()).thenReturn(certsFromScm);
     CompletableFuture<Void> processingResult = new CompletableFuture<>();
     //When encountering an error for the first run:
     AtomicInteger runNumber = new AtomicInteger(1);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -248,13 +248,14 @@ public class SCMSecurityProtocolServerSideTranslatorPB
     }
     CertPath certificate = impl.getSCMCertificate(request.getScmDetails(),
         request.getCSR(), request.hasRenew() && request.getRenew());
+    String encodedRootCert = CertificateCodec.getPEMEncodedString(impl.getRootCACertificate());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()
             .setResponseCode(ResponseCode.success)
             .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
-            .setX509CACertificate(impl.getRootCACertificate())
-            .setX509RootCACertificate(impl.getRootCACertificate());
+            .setX509CACertificate(encodedRootCert)
+            .setX509RootCACertificate(encodedRootCert);
 
     return builder.build();
 
@@ -328,7 +329,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
     if (scm.getScmStorageConfig().checkPrimarySCMIdInitialized()) {
       throw createNotHAException();
     }
-    String rootCACertificate = impl.getRootCACertificate();
+    String rootCACertificate = CertificateCodec.getPEMEncodedString(impl.getRootCACertificate());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()
@@ -376,7 +377,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
   private void setRootCAIfNeeded(SCMGetCertResponseProto.Builder builder)
       throws IOException {
     if (scm.getScmStorageConfig().checkPrimarySCMIdInitialized()) {
-      builder.setX509RootCACertificate(impl.getRootCACertificate());
+      builder.setX509RootCACertificate(CertificateCodec.getPEMEncodedString(impl.getRootCACertificate()));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.hdds.scm.protocol;
 
 import java.io.IOException;
+import java.security.cert.CertPath;
 import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
@@ -39,6 +40,7 @@ import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolPB;
 import org.apache.hadoop.hdds.scm.ha.RatisUtil;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 
@@ -191,14 +193,14 @@ public class SCMSecurityProtocolServerSideTranslatorPB
       SCMGetDataNodeCertRequestProto request)
       throws IOException {
 
-    String certificate = impl
+    CertPath certificate = impl
         .getDataNodeCertificate(request.getDatanodeDetails(),
             request.getCSR());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()
             .setResponseCode(ResponseCode.success)
-            .setX509Certificate(certificate)
+            .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
             .setX509CACertificate(impl.getCACertificate());
     setRootCAIfNeeded(builder);
 
@@ -214,14 +216,14 @@ public class SCMSecurityProtocolServerSideTranslatorPB
    */
   public SCMGetCertResponseProto getCertificate(
       SCMGetCertRequestProto request) throws IOException {
-    String certificate = impl
+    CertPath certificate = impl
         .getCertificate(request.getNodeDetails(),
             request.getCSR());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()
             .setResponseCode(ResponseCode.success)
-            .setX509Certificate(certificate)
+            .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
             .setX509CACertificate(impl.getCACertificate());
     setRootCAIfNeeded(builder);
 
@@ -242,13 +244,13 @@ public class SCMSecurityProtocolServerSideTranslatorPB
     if (!scm.getScmStorageConfig().isSCMHAEnabled()) {
       throw createNotHAException();
     }
-    String certificate = impl.getSCMCertificate(request.getScmDetails(),
+    CertPath certificate = impl.getSCMCertificate(request.getScmDetails(),
         request.getCSR(), request.hasRenew() && request.getRenew());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()
             .setResponseCode(ResponseCode.success)
-            .setX509Certificate(certificate)
+            .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
             .setX509CACertificate(impl.getRootCACertificate())
             .setX509RootCACertificate(impl.getRootCACertificate());
 
@@ -264,14 +266,14 @@ public class SCMSecurityProtocolServerSideTranslatorPB
    */
   public SCMGetCertResponseProto getOMCertificate(
       SCMGetOMCertRequestProto request) throws IOException {
-    String certificate = impl
+    CertPath certificate = impl
         .getOMCertificate(request.getOmDetails(),
             request.getCSR());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()
             .setResponseCode(ResponseCode.success)
-            .setX509Certificate(certificate)
+            .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
             .setX509CACertificate(impl.getCACertificate());
     setRootCAIfNeeded(builder);
     return builder.build();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -202,7 +202,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .newBuilder()
             .setResponseCode(ResponseCode.success)
             .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
-            .setX509CACertificate(impl.getCACertificate());
+            .setX509CACertificate(CertificateCodec.getPEMEncodedString(impl.getCACertificate()));
     setRootCAIfNeeded(builder);
 
     return builder.build();
@@ -225,7 +225,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .newBuilder()
             .setResponseCode(ResponseCode.success)
             .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
-            .setX509CACertificate(impl.getCACertificate());
+            .setX509CACertificate(CertificateCodec.getPEMEncodedString(impl.getCACertificate()));
     setRootCAIfNeeded(builder);
 
     return builder.build();
@@ -275,7 +275,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .newBuilder()
             .setResponseCode(ResponseCode.success)
             .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
-            .setX509CACertificate(impl.getCACertificate());
+            .setX509CACertificate(CertificateCodec.getPEMEncodedString(impl.getCACertificate()));
     setRootCAIfNeeded(builder);
     return builder.build();
 
@@ -298,13 +298,13 @@ public class SCMSecurityProtocolServerSideTranslatorPB
       SCMSecurityProtocolProtos.SCMGetCACertificateRequestProto request)
       throws IOException {
 
-    String certificate = impl.getCACertificate();
+    CertPath certificate = impl.getCACertificate();
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()
             .setResponseCode(ResponseCode.success)
-            .setX509Certificate(certificate)
-            .setX509CACertificate(certificate);
+            .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate))
+            .setX509CACertificate(CertificateCodec.getPEMEncodedString(certificate));
     setRootCAIfNeeded(builder);
     return builder.build();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.hdds.scm.protocol;
 
 import java.io.IOException;
 import java.security.cert.CertPath;
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
@@ -283,12 +284,12 @@ public class SCMSecurityProtocolServerSideTranslatorPB
   public SCMGetCertResponseProto getCertificate(
       SCMGetCertificateRequestProto request) throws IOException {
 
-    String certificate = impl.getCertificate(request.getCertSerialId());
+    X509Certificate certificate = impl.getCertificate(request.getCertSerialId());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()
             .setResponseCode(ResponseCode.success)
-            .setX509Certificate(certificate);
+            .setX509Certificate(CertificateCodec.getPEMEncodedString(certificate));
     return builder.build();
 
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -370,7 +370,7 @@ public class SCMSecurityProtocolServerSideTranslatorPB
   public SCMGetAllRootCaCertificatesResponseProto getAllRootCa()
       throws IOException {
     return SCMGetAllRootCaCertificatesResponseProto.newBuilder()
-        .addAllAllX509RootCaCertificates(impl.getAllRootCaCertificates())
+        .addAllAllX509RootCaCertificates(convertCertListToEncodedList(impl.getAllRootCaCertificates()))
         .build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -392,14 +392,14 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
    * @return string         - pem encoded SCM signed certificate.
    */
   @Override
-  public String getCertificate(String certSerialId) throws IOException {
+  public X509Certificate getCertificate(String certSerialId) throws IOException {
     LOGGER.debug("Getting certificate with certificate serial id {}",
         certSerialId);
     try {
       X509Certificate certificate =
           scmCertificateServer.getCertificate(certSerialId);
       if (certificate != null) {
-        return getPEMEncodedString(certificate);
+        return certificate;
       }
     } catch (CertificateException e) {
       throw new SCMSecurityException("getCertificate operation failed. ", e,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -181,7 +181,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
    * @return String         - SCM signed pem encoded certificate.
    */
   @Override
-  public String getDataNodeCertificate(
+  public CertPath getDataNodeCertificate(
       DatanodeDetailsProto dnDetails, String certSignReq) throws IOException {
     LOGGER.info("Processing CSR for dn {}, UUID: {}", dnDetails.getHostName(),
         dnDetails.getUuid());
@@ -195,7 +195,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
   }
 
   @Override
-  public String getCertificate(
+  public CertPath getCertificate(
       NodeDetailsProto nodeDetails,
       String certSignReq) throws IOException {
     LOGGER.info("Processing CSR for {} {}, UUID: {}",
@@ -276,7 +276,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
    * @return String         - SCM signed pem encoded certificate.
    */
   @Override
-  public String getOMCertificate(OzoneManagerDetailsProto omDetails,
+  public CertPath getOMCertificate(OzoneManagerDetailsProto omDetails,
       String certSignReq) throws IOException {
     LOGGER.info("Processing CSR for om {}, UUID: {}", omDetails.getHostName(),
         omDetails.getUuid());
@@ -292,12 +292,12 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
   /**
    * Get signed certificate for SCM Node.
    *
-   * @param scmNodeDetails   - SCM Node Details.
-   * @param certSignReq      - Certificate signing request.
+   * @param scmNodeDetails - SCM Node Details.
+   * @param certSignReq    - Certificate signing request.
    * @return String          - SCM signed pem encoded certificate.
    */
   @Override
-  public String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
+  public CertPath getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq) throws IOException {
     return getSCMCertificate(scmNodeDetails, certSignReq, false);
   }
@@ -311,7 +311,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
    * @return String          - SCM signed pem encoded certificate.
    */
   @Override
-  public String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
+  public CertPath getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq, boolean isRenew) throws IOException {
     Objects.requireNonNull(scmNodeDetails);
     // Check clusterID
@@ -333,13 +333,14 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
   }
 
   /**
-   *  Request certificate for the specified role.
+   * Request certificate for the specified role.
+   *
    * @param certSignReq - Certificate signing request.
-   * @param nodeType - role OM/SCM/DATANODE
+   * @param nodeType    - role OM/SCM/DATANODE
    * @return String         - SCM signed pem encoded certificate.
    * @throws IOException
    */
-  private synchronized String getEncodedCertToString(String certSignReq,
+  private synchronized CertPath getEncodedCertToString(String certSignReq,
       NodeType nodeType) throws IOException {
     Future<CertPath> future;
     PKCS10CertificationRequest csr = getCertificationRequest(certSignReq);
@@ -351,7 +352,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
           KERBEROS_TRUSTED, nodeType, getNextCertificateId());
     }
     try {
-      return getPEMEncodedString(future.get());
+      return future.get();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw generateException(e, nodeType);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -82,7 +82,6 @@ import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.Err
 import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.GET_CA_CERT_FAILED;
 import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.GET_CERTIFICATE_FAILED;
 import static org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateApprover.ApprovalType.KERBEROS_TRUSTED;
-import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateSignRequest.getCertificationRequest;
 
 /**
@@ -254,17 +253,12 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
   }
 
   @Override
-  public synchronized List<String> getAllRootCaCertificates()
-      throws IOException {
-    List<String> pemEncodedList = new ArrayList<>();
-    Set<X509Certificate> certList =
+  public synchronized List<X509Certificate> getAllRootCaCertificates() {
+    Set<X509Certificate> certSet =
         scmCertificateClient.getAllRootCaCerts().size() == 0 ?
             scmCertificateClient.getAllCaCerts() :
             scmCertificateClient.getAllRootCaCerts();
-    for (X509Certificate cert : certList) {
-      pemEncodedList.add(getPEMEncodedString(cert));
-    }
-    return pemEncodedList;
+    return new ArrayList<>(certSet);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -416,11 +416,10 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
    * @return string         - Root certificate.
    */
   @Override
-  public String getCACertificate() throws IOException {
+  public CertPath getCACertificate() throws IOException {
     LOGGER.debug("Getting CA certificate.");
     try {
-      return getPEMEncodedString(
-          scmCertificateServer.getCaCertPath());
+      return scmCertificateServer.getCaCertPath();
     } catch (CertificateException e) {
       throw new SCMSecurityException("getRootCertificate operation failed. ",
           e, GET_CA_CERT_FAILED);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -434,24 +434,14 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
    * @throws IOException
    */
   @Override
-  public List<String> listCertificate(NodeType role,
+  public List<X509Certificate> listCertificate(NodeType role,
       long startSerialId, int count) throws IOException {
-    List<X509Certificate> certificates = scmCertificateServer.listCertificate(role, startSerialId, count);
-    List<String> results = new ArrayList<>(certificates.size());
-    for (X509Certificate cert : certificates) {
-      try {
-        String certStr = getPEMEncodedString(cert);
-        results.add(certStr);
-      } catch (SCMSecurityException e) {
-        throw new SCMSecurityException("listCertificate operation failed.", e, e.getErrorCode());
-      }
-    }
-    return results;
+    return scmCertificateServer.listCertificate(role, startSerialId, count);
   }
 
   @Override
-  public List<String> listCACertificate() throws IOException {
-    List<String> caCerts =
+  public List<X509Certificate> listCACertificate() throws IOException {
+    List<X509Certificate> caCerts =
         listCertificate(NodeType.SCM, 0, 10);
     return caCerts;
   }
@@ -474,14 +464,9 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
   }
 
   @Override
-  public List<String> removeExpiredCertificates() throws IOException {
+  public List<X509Certificate> removeExpiredCertificates() throws IOException {
     storageContainerManager.checkAdminAccess(getRpcRemoteUser(), false);
-    List<String> pemEncodedCerts = new ArrayList<>();
-    for (X509Certificate cert : storageContainerManager.getCertificateStore()
-        .removeAllExpiredCertificates()) {
-      pemEncodedCerts.add(CertificateCodec.getPEMEncodedString(cert));
-    }
-    return pemEncodedCerts;
+    return storageContainerManager.getCertificateStore().removeAllExpiredCertificates();
   }
 
   private String getNextCertificateId() throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateServer;
-import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
@@ -447,20 +446,17 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol,
   }
 
   @Override
-  public synchronized String getRootCACertificate() throws IOException {
+  public synchronized X509Certificate getRootCACertificate() throws IOException {
     LOGGER.debug("Getting Root CA certificate.");
     if (rootCertificateServer != null) {
       try {
-        return CertificateCodec.getPEMEncodedString(
-            rootCertificateServer.getCACertificate());
+        return rootCertificateServer.getCACertificate();
       } catch (CertificateException e) {
         LOGGER.error("Failed to get root CA certificate", e);
         throw new IOException("Failed to get root CA certificate", e);
       }
     }
-
-    return CertificateCodec.getPEMEncodedString(
-        scmCertificateClient.getCACertificate());
+    return scmCertificateClient.getCACertificate();
   }
 
   @Override

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/CleanExpiredCertsSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/CleanExpiredCertsSubcommand.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 /**
@@ -36,7 +37,7 @@ public class CleanExpiredCertsSubcommand extends ScmCertSubcommand {
 
   @Override
   protected void execute(SCMSecurityProtocol client) throws IOException {
-    List<String> pemEncodedCerts = client.removeExpiredCertificates();
+    List<X509Certificate> pemEncodedCerts = client.removeExpiredCertificates();
     System.out.println("List of removed expired certificates:");
     printCertList(pemEncodedCerts);
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
@@ -18,14 +18,12 @@
 package org.apache.hadoop.hdds.scm.cli.cert;
 
 import java.io.IOException;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 
-import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
@@ -45,19 +45,13 @@ class InfoSubcommand extends ScmCertSubcommand {
 
   @Override
   public void execute(SCMSecurityProtocol client) throws IOException {
-    final String certPemStr =
+    final X509Certificate certificate =
         client.getCertificate(serialId);
-    Preconditions.checkNotNull(certPemStr,
+    Preconditions.checkNotNull(certificate,
         "Certificate can't be found");
 
     // Print container report info.
     System.out.printf("Certificate id: %s%n", serialId);
-    try {
-      X509Certificate cert = CertificateCodec.getX509Certificate(certPemStr);
-      System.out.println(cert);
-    } catch (CertificateException ex) {
-      System.err.println("Failed to get certificate id " + serialId);
-      throw new IOException("Fail to get certificate id " + serialId, ex);
-    }
+    System.out.println(certificate);
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -20,9 +20,11 @@ package org.apache.hadoop.hdds.scm.cli.cert;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -97,7 +99,11 @@ public class ListSubcommand extends ScmCertSubcommand {
 
     if (json) {
       err.println("Certificate list:(BatchSize=" + count + ", CertCount=" + certPemList.size() + ")");
-      System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(certPemList));
+      ArrayList<Certificate> certificates =
+          certPemList.stream()
+              .map(Certificate::new)
+              .collect(Collectors.toCollection(ArrayList::new));
+      System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(certificates));
       return;
     }
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -19,9 +19,7 @@ package org.apache.hadoop.hdds.scm.cli.cert;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +32,6 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Visibility;
@@ -91,7 +88,7 @@ public class ListSubcommand extends ScmCertSubcommand {
   @Override
   protected void execute(SCMSecurityProtocol client) throws IOException {
     HddsProtos.NodeType nodeType = parseCertRole(role);
-    List<String> certPemList = client.listCertificate(nodeType, startSerialId, count);
+    List<X509Certificate> certPemList = client.listCertificate(nodeType, startSerialId, count);
     if (count == certPemList.size()) {
       err.println("The certificate list could be longer than the batch size: "
           + count + ". Please use the \"-c\" option to see more" +
@@ -100,18 +97,7 @@ public class ListSubcommand extends ScmCertSubcommand {
 
     if (json) {
       err.println("Certificate list:(BatchSize=" + count + ", CertCount=" + certPemList.size() + ")");
-      List<Certificate> certList = new ArrayList<>();
-      for (String certPemStr : certPemList) {
-        try {
-          X509Certificate cert =
-              CertificateCodec.getX509Certificate(certPemStr);
-          certList.add(new Certificate(cert));
-        } catch (CertificateException ex) {
-          err.println("Failed to parse certificate.");
-        }
-      }
-      System.out.println(
-          JsonUtils.toJsonStringWithDefaultPrettyPrinter(certList));
+      System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(certPemList));
       return;
     }
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ScmCertSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ScmCertSubcommand.java
@@ -19,11 +19,9 @@ package org.apache.hadoop.hdds.scm.cli.cert;
 
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.scm.cli.ScmOption;
-import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import picocli.CommandLine;
 
 import java.io.IOException;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -38,20 +36,15 @@ public abstract class ScmCertSubcommand implements Callable<Void> {
 
   private static final String OUTPUT_FORMAT = "%-17s %-30s %-30s %-110s %-110s%n";
 
-  protected void printCertList(List<String> pemEncodedCerts) {
-    if (pemEncodedCerts.isEmpty()) {
+  protected void printCertList(List<X509Certificate> certList) {
+    if (certList.isEmpty()) {
       System.out.println("No certificates to list");
       return;
     }
     System.out.printf(OUTPUT_FORMAT, "SerialNumber", "Valid From",
         "Expiry", "Subject", "Issuer");
-    for (String certPemStr : pemEncodedCerts) {
-      try {
-        X509Certificate cert = CertificateCodec.getX509Certificate(certPemStr);
-        printCert(cert);
-      } catch (CertificateException e) {
-        System.err.println("Failed to parse certificate: " + e.getMessage());
-      }
+    for (X509Certificate certificate : certList) {
+      printCert(certificate);
     }
   }
 

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/cert/TestCleanExpiredCertsSubcommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/cert/TestCleanExpiredCertsSubcommand.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import static org.apache.hadoop.hdds.security.x509.CertificateTestUtils.createSelfSignedCert;
 
 import org.apache.hadoop.hdds.security.x509.CertificateTestUtils;
-import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,8 +70,8 @@ class TestCleanExpiredCertsSubcommand {
     cmd = new CleanExpiredCertsSubcommand();
     KeyPair keyPair = CertificateTestUtils.aKeyPair(new OzoneConfiguration());
     X509Certificate cert = createSelfSignedCert(keyPair, "aCert");
-    ArrayList<String> certPemList = new ArrayList<>();
-    certPemList.add(CertificateCodec.getPEMEncodedString(cert));
+    ArrayList<X509Certificate> certPemList = new ArrayList<>();
+    certPemList.add(cert);
     when(scmSecurityProtocolMock.removeExpiredCertificates())
         .thenReturn(certPemList);
     cmd.execute(scmSecurityProtocolMock);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
+import java.security.cert.CertPath;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
@@ -375,7 +376,7 @@ final class TestSecureOzoneCluster {
       try (SCMSecurityProtocolClientSideTranslatorPB securityClient =
           getScmSecurityClient(conf, ugi)) {
         assertNotNull(securityClient);
-        String caCert = securityClient.getCACertificate();
+        CertPath caCert = securityClient.getCACertificate();
         assertNotNull(caCert);
         // Get some random certificate, used serial id 100 which will be
         // unavailable as our serial id is time stamp. Serial id 1 is root CA,
@@ -927,10 +928,8 @@ final class TestSecureOzoneCluster {
           .contains("Successfully stored OM signed certificate");
       X509Certificate certificate = om.getCertificateClient().getCertificate();
       validateCertificate(certificate);
-      String pemEncodedCACert =
-          scm.getSecurityProtocolServer().getCACertificate();
-      X509Certificate caCert =
-          CertificateCodec.getX509Certificate(pemEncodedCACert);
+      CertPath pemEncodedCACert = scm.getSecurityProtocolServer().getCACertificate();
+      X509Certificate caCert = (X509Certificate) pemEncodedCACert.getCertificates().get(0);
       X509Certificate caCertStored = om.getCertificateClient()
           .getCertificate(caCert.getSerialNumber().toString());
       assertEquals(caCert, caCertStored);


### PR DESCRIPTION
## What changes were proposed in this pull request?
SCMSecurityProtocol consistently returns encoded versions of certificates which causes this encoding to spread around the code.

With the ongoing crypto-compliance efforts it's best to limit the places that use BouncyCastle dependencies. With this refactor it's ensured that only the proto layer translators use it on SCM side.

An additional later benefit of this pull request is that the CAServer can eventually implement the SCMSecurityProtocol, which will be useful when the default certificate server is separated to root and sub ca servers.

[HDDS-11417](https://issues.apache.org/jira/browse/HDDS-11417)

## How was this patch tested?

No functional changes in code, existing CI runs should suffice.
Here is a CI run from my fork that uses the same changeset (Although different branch because the Jira ticket was created later)
https://github.com/Galsza/ozone/actions/runs/10699894112