### PR TITLE
HDDS-11405. Implement setrep command for Ozone FS.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractOzoneFileSystemTest.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.ozone;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.BlockLocation;
@@ -40,6 +41,7 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -55,6 +57,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -90,6 +93,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -2288,5 +2292,31 @@ abstract class AbstractOzoneFileSystemTest {
     assertEquals(0, f1.length);
     assertEquals(2, f2.length);
     assertEquals(3, f3.length);
+  }
+
+  @Test
+  public void testSetReplication() throws IOException {
+    String testKeyName = "testKey" + RandomStringUtils.randomNumeric(4);
+    Path testKeyPath = new Path("/" + testKeyName);
+    try (OzoneOutputStream outputStream = client.getObjectStore()
+        .getVolume(volumeName).getBucket(bucketName)
+        .createKey(testKeyName, 1,
+            RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
+            new HashMap<>())) {
+      outputStream.write(RandomUtils.nextBytes(1));
+    }
+    OzoneKeyDetails key = getKey(testKeyPath, false);
+    assertEquals(HddsProtos.ReplicationType.RATIS,
+        key.getReplicationConfig().getReplicationType());
+    assertEquals(ReplicationFactor.ONE.toString(),
+        key.getReplicationConfig().getReplication());
+    o3fs.setReplication(testKeyPath, (short) 3);
+    key = getKey(testKeyPath, false);
+    assertEquals(ReplicationFactor.THREE.toString(),
+        key.getReplicationConfig().getReplication());
+    IOException exception = assertThrows(IOException.class,
+        () -> o3fs.setReplication(testKeyPath, (short) 5),
+        "Does not throw IOException");
+    assertTrue(exception.getMessage().contains("not supported"));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -2608,6 +2609,37 @@ abstract class AbstractRootedOzoneFileSystemTest {
     for (String key : fileNames) {
       fs.delete(new Path(base, key));
     }
+  }
+
+  @Test
+  public void testSetReplication() throws IOException {
+    String testKeyName = "testKey" + RandomStringUtils.randomNumeric(4);
+    Path testKeyPath = new Path(bucketPath, testKeyName);
+    OzoneBucket ozoneBucket =
+        objectStore.getVolume(volumeName).getBucket(bucketName);
+    try (OzoneOutputStream outputStream = ozoneBucket.createKey(testKeyName, 1,
+        RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.ONE),
+        new HashMap<>())) {
+      outputStream.write(RandomUtils.nextBytes(1));
+    }
+    OzoneKeyDetails key = getKey(testKeyPath, false);
+    assertEquals(HddsProtos.ReplicationType.RATIS,
+        key.getReplicationConfig().getReplicationType());
+    assertEquals(ReplicationFactor.ONE.toString(),
+        key.getReplicationConfig().getReplication());
+    ofs.setReplication(testKeyPath, (short) 3);
+    key = getKey(testKeyPath, false);
+    assertEquals(ReplicationFactor.THREE.toString(),
+        key.getReplicationConfig().getReplication());
+    IOException exception = assertThrows(IOException.class,
+        () -> ofs.setReplication(testKeyPath, (short) 5),
+        "Does not throw IOException");
+    assertTrue(exception.getMessage().contains("not supported"));
+    exception = assertThrows(IOException.class,
+        () -> ofs.setReplication(testKeyPath, (short) 2),
+        "Does not throw IOException");
+    assertTrue(exception.getMessage().contains("not supported"));
   }
 
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -52,6 +53,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -61,6 +63,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
@@ -83,6 +86,9 @@ import org.apache.hadoop.security.token.Token;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_NOT_FOUND;
@@ -810,5 +816,29 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
 
     return ozoneClient.getProxy().getOzoneManagerClient().setSafeMode(
         action, isChecked);
+  }
+
+  @Override
+  public void setReplication(String key, short replication) throws IOException {
+    OzoneKeyDetails keyDetails = bucket.getKey(key);
+    ReplicationConfig newReplication = OzoneClientUtils
+        .resolveClientSideReplicationConfig(replication, null,
+            null, config);
+    if (newReplication == null) {
+      throw new IOException(
+          "Replication factor of " + replication + " not supported");
+    }
+    if (newReplication.getReplication()
+        .equals(keyDetails.getReplicationConfig().getReplication())) {
+      return;
+    }
+    try (InputStream inputStream = readFile(key);
+        OzoneOutputStream outputStream = bucket.rewriteKey(key,
+            keyDetails.getDataSize(), keyDetails.getGeneration(),
+            newReplication, keyDetails.getMetadata())) {
+      int chunkSize = (int) config.getStorageSize(OZONE_SCM_CHUNK_SIZE_KEY,
+          OZONE_SCM_CHUNK_SIZE_DEFAULT, StorageUnit.BYTES);
+      IOUtils.copyBytes(inputStream, outputStream, chunkSize);
+    }
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -945,6 +945,13 @@ public class BasicOzoneFileSystem extends FileSystem {
   }
 
   @Override
+  public boolean setReplication(Path src, short replication)
+      throws IOException {
+    adapter.setReplication(pathToKey(src), replication);
+    return true;
+  }
+
+  @Override
   public RemoteIterator<LocatedFileStatus> listLocatedStatus(Path f)
       throws IOException {
     incrementCounter(Statistic.INVOCATION_LIST_LOCATED_STATUS);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -60,6 +61,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdfs.protocol.SnapshotDiffReport;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.OmUtils;
@@ -70,6 +72,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.OzoneSnapshot;
 import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
@@ -98,6 +101,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_SNAPSHOT_INDICATOR;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
@@ -390,6 +395,32 @@ public class BasicRootedOzoneClientAdapterImpl
 
   protected void incrementCounter(Statistic objectsRead, long count) {
     //noop: Use RootedOzoneClientAdapterImpl which supports statistics.
+  }
+
+  @Override
+  public void setReplication(String key, short replication) throws IOException {
+    OFSPath ofsPath = new OFSPath(key, config);
+    OzoneBucket bucket = getBucket(ofsPath, false);
+    OzoneKeyDetails keyDetails = bucket.getKey(ofsPath.getKeyName());
+    ReplicationConfig newReplication = OzoneClientUtils
+        .resolveClientSideReplicationConfig(replication, null,
+            null, config);
+    if (newReplication == null) {
+      throw new IOException(
+          "Replication factor of " + replication + " not supported");
+    }
+    if (newReplication.getReplication()
+        .equals(keyDetails.getReplicationConfig().getReplication())) {
+      return;
+    }
+    try (InputStream inputStream = readFile(key);
+        OzoneOutputStream outputStream = bucket.rewriteKey(ofsPath.getKeyName(),
+            keyDetails.getDataSize(), keyDetails.getGeneration(),
+            newReplication, keyDetails.getMetadata())) {
+      int chunkSize = (int) config.getStorageSize(OZONE_SCM_CHUNK_SIZE_KEY,
+          OZONE_SCM_CHUNK_SIZE_DEFAULT, StorageUnit.BYTES);
+      IOUtils.copyBytes(inputStream, outputStream, chunkSize);
+    }
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -599,6 +599,13 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     }
   }
 
+  @Override
+  public boolean setReplication(Path src, short replication)
+      throws IOException {
+    adapterImpl.setReplication(pathToKey(src), replication);
+    return true;
+  }
+
   /**
    * To be used only by recursiveBucketDelete().
    */

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -115,4 +115,6 @@ public interface OzoneClientAdapter {
 
   boolean setSafeMode(SafeModeAction action, boolean isChecked)
       throws IOException;
+
+  void setReplication(String key, short replication) throws IOException;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently this command does not work as on demand changing of replication is not supported in Ozone.
However with the new atomic rewriteKey API , this makes it possible to rewrite key with the new replication and setrep can be implemented using this. This is only for RATIS keys and does not apply for EC keys as there is no point of replication factor in EC keys. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11405

## How was this patch tested?
Unit tests added. Also tested the `ozone fs` shell

```bash
bash-4.4$ ozone sh key info  vol1/buck1/key1 | grep "replicationFactor"
 "replicationFactor" : "ONE",
bash-4.4$ ozone fs -ls ofs://om/vol1/buck1/key1
-rw-rw-rw-   1 hadoop hadoop       4068 2024-09-05 08:36 ofs://om/vol1/buck1/key1
bash-4.4$ ozone fs -setrep -w 3 ofs://om/vol1/buck1/key1
Replication 3 set: ofs://om/vol1/buck1/key1
Waiting for ofs://om/vol1/buck1/key1 ... done
bash-4.4$ ozone sh key info  vol1/buck1/key1   | grep "replicationFactor"
replicationFactor : THREE,
bash-4.4$ ozone fs -setrep -w 2 ofs://om/vol1/buck1/key1
setrep: Replication factor of 2 not supported
```