### PR TITLE
HDDS-11420. OM rocksdb manual WAL flush control

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4512,4 +4512,12 @@
       maximum number of buckets across all volumes.
     </description>
   </property>
+  <property>
+    <name>ozone.om.rocksdb.manual.wal.flush</name>
+    <value>false</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      control the manual flush of Rocksdb WAL log when db commit happens.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -420,6 +420,7 @@ public final class DBStoreBuilder {
     // Apply WAL settings.
     dbOptions.setWalTtlSeconds(rocksDBConfiguration.getWalTTL());
     dbOptions.setWalSizeLimitMB(rocksDBConfiguration.getWalSizeLimit());
+    dbOptions.setManualWalFlush(rocksDBConfiguration.getManualWalFlush());
 
     return dbOptions;
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBConfiguration.java
@@ -76,6 +76,13 @@ public class RocksDBConfiguration {
       description = "The lifetime of WAL log files. Default 1200 seconds.")
   private long walTTL = 1200;
 
+  @Config(key = "rocksdb.manual_wal_flush",
+      type = ConfigType.BOOLEAN,
+      defaultValue = "false",
+      tags = {OM, SCM, DATANODE},
+      description = "The disable auto flush for WAL logs.")
+  private boolean manualWalFlush = false;
+
   @Config(key = "rocksdb.WAL_size_limit_MB",
       type = ConfigType.SIZE,
       defaultValue = "0MB",
@@ -139,5 +146,13 @@ public class RocksDBConfiguration {
 
   public int getKeepLogFileNum() {
     return rocksdbKeepLogFileNum;
+  }
+
+  public void setManualWalFlush(boolean bManualWallFlush) {
+    this.manualWalFlush = bManualWallFlush;
+  }
+
+  public boolean getManualWalFlush() {
+    return manualWalFlush;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -623,4 +623,7 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_MAX_BUCKET =
       "ozone.om.max.buckets";
   public static final int OZONE_OM_MAX_BUCKET_DEFAULT = 100000;
+
+  public static final String OZONE_OM_ROCKSDB_MANUAL_WAL_FLUSH = "ozone.om.rocksdb.manual.wal.flush";
+  public static final boolean OZONE_OM_ROCKSDB_MANUAL_WAL_FLUSH_DEFAULT = false;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -109,6 +109,8 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_L
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_MAX_OPEN_FILES_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ROCKSDB_MANUAL_WAL_FLUSH;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ROCKSDB_MANUAL_WAL_FLUSH_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SNAPSHOT_CHECKPOINT_DIR_CREATION_POLL_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
@@ -605,8 +607,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
       throws IOException {
     final int maxFSSnapshots = configuration.getInt(
         OZONE_OM_FS_SNAPSHOT_MAX_LIMIT, OZONE_OM_FS_SNAPSHOT_MAX_LIMIT_DEFAULT);
+    final boolean manualWalFlush = configuration.getBoolean(
+        OZONE_OM_ROCKSDB_MANUAL_WAL_FLUSH, OZONE_OM_ROCKSDB_MANUAL_WAL_FLUSH_DEFAULT);
     RocksDBConfiguration rocksDBConfiguration =
         configuration.getObject(RocksDBConfiguration.class);
+    rocksDBConfiguration.setManualWalFlush(manualWalFlush);
     DBStoreBuilder dbStoreBuilder = DBStoreBuilder.newBuilder(configuration,
         rocksDBConfiguration).setName(dbName)
         .setOpenReadOnly(readOnly)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Capability is added to disable WAL manual flush of rocksdb for OM. There is no change in behavior but added for performance test purpose.
As ratis log itself provide recovery, WAL log provide duplicate mechanism. This is added for planned for Leader Side execution of request as performance optimization.

Parent JIRA:
https://issues.apache.org/jira/browse/HDDS-11415

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11420

## How was this patch tested?

- Existing test scenario