### PR TITLE
HDDS-10479. Add `ozone admin ratis local raftMetaConf` CLI to generate a new raft-meta.conf.

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/RatisCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/RatisCommands.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.ratis;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.OzoneAdmin;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Subcommand for ratis related operations.
+ */
+@CommandLine.Command(
+    name = "ratis",
+    description = "Ratis specific operations",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+@MetaInfServices(SubcommandWithParent.class)
+public class RatisCommands implements Callable<Void>, SubcommandWithParent {
+
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
+  @Override
+  public Void call() throws Exception {
+    GenericCli.missingSubcommand(spec);
+    return null;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return OzoneAdmin.class;
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/local/RatisLocalRaftMetaConfSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/local/RatisLocalRaftMetaConfSubCommand.java
@@ -38,13 +38,13 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Handler to generate a new raft-meta.conf
+ * Handler to generate a new raft-meta.conf.
  */
 @CommandLine.Command(
-   name = "raftMetaConf",
-   description = "Generates a new raft-meta.conf",
-   mixinStandardHelpOptions = true,
-   versionProvider = HddsVersionProvider.class
+    name = "raftMetaConf",
+    description = "Generates a new raft-meta.conf",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
 )
 
 public class RatisLocalRaftMetaConfSubCommand extends ScmSubcommand {
@@ -76,19 +76,19 @@ public class RatisLocalRaftMetaConfSubCommand extends ScmSubcommand {
 
       if (peerIdWithAddressArray.length < 1 || peerIdWithAddressArray.length > 2) {
         System.err.println(
-          "Failed to parse peer's ID and address for: " + idWithAddress + ", from option: -peers " + peers +
-          ". Please provide list of peers in format " +
-          "<[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT>");
+            "Failed to parse peer's ID and address for: " + idWithAddress + ", from option: -peers " + peers +
+            ". Please provide list of peers in format " +
+            "<[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT>");
         return;
       }
 
       InetSocketAddress inetSocketAddress = parseInetSocketAddress(
-        peerIdWithAddressArray[peerIdWithAddressArray.length - 1]);
+          peerIdWithAddressArray[peerIdWithAddressArray.length - 1]);
       String addressString = inetSocketAddress.getHostString() + ":" + inetSocketAddress.getPort();
 
       if (addresses.contains(addressString)) {
         System.err.println("Found duplicated address: " + addressString +
-          ". Please ensure the address of peers have no duplicated value.");
+            ". Please ensure the address of peers have no duplicated value.");
         return;
       }
       addresses.add(addressString);
@@ -99,7 +99,7 @@ public class RatisLocalRaftMetaConfSubCommand extends ScmSubcommand {
 
         if (ids.contains(peerId)) {
           System.err.println("Found duplicated ID: " + peerId +
-            ". Please ensure the ID of peers have no duplicated value.");
+              ". Please ensure the ID of peers have no duplicated value.");
           return;
         }
         ids.add(peerId);
@@ -108,23 +108,23 @@ public class RatisLocalRaftMetaConfSubCommand extends ScmSubcommand {
       }
 
       raftPeerProtos.add(RaftProtos.RaftPeerProto.newBuilder()
-        .setId(ByteString.copyFrom(peerId.getBytes(StandardCharsets.UTF_8)))
-        .setAddress(addressString)
-        .setStartupRole(RaftProtos.RaftPeerRole.FOLLOWER)
-        .build());
+          .setId(ByteString.copyFrom(peerId.getBytes(StandardCharsets.UTF_8)))
+          .setAddress(addressString)
+          .setStartupRole(RaftProtos.RaftPeerRole.FOLLOWER)
+          .build());
     }
 
     try (InputStream in = Files.newInputStream(Paths.get(path, "raft-meta.conf"));
-      OutputStream out = Files.newOutputStream(Paths.get(path, "new-raft-meta.conf"))) {
+        OutputStream out = Files.newOutputStream(Paths.get(path, "new-raft-meta.conf"))) {
 
       long index = RaftProtos.LogEntryProto.newBuilder().mergeFrom(in).build().getIndex();
       System.out.println("Index in the original file is: " + index);
 
       RaftProtos.LogEntryProto newLogEntryProto = RaftProtos.LogEntryProto.newBuilder()
-        .setConfigurationEntry(RaftProtos.RaftConfigurationProto.newBuilder()
-          .addAllPeers(raftPeerProtos).build())
-        .setIndex(index + 1)
-        .build();
+          .setConfigurationEntry(RaftProtos.RaftConfigurationProto.newBuilder()
+            .addAllPeers(raftPeerProtos).build())
+          .setIndex(index + 1)
+          .build();
 
       System.out.println("Generated new LogEntryProto info:\n" + newLogEntryProto);
       newLogEntryProto.writeTo(out);

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/local/RatisLocalRaftMetaConfSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/local/RatisLocalRaftMetaConfSubCommand.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.ratis.local;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Handler to generate a new raft-meta.conf
+ */
+@CommandLine.Command(
+   name = "raftMetaConf",
+   description = "Generates a new raft-meta.conf",
+   mixinStandardHelpOptions = true,
+   versionProvider = HddsVersionProvider.class
+)
+
+public class RatisLocalRaftMetaConfSubCommand extends ScmSubcommand {
+
+  @CommandLine.Option(names = { "-peers" },
+      description = "Provide list of peers in format" +
+        " <[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT>",
+      required = true)
+  private String peers;
+
+  @CommandLine.Option(names = { "-path" },
+      description = "Parent path of raft-meta.conf",
+      required = true)
+  private String path;
+
+  @Override
+  public void execute(ScmClient scmClient) throws IOException {
+    if (peers == null || path == null || peers.isEmpty() || path.isEmpty()) {
+      System.err.println("peers or path cannot be empty.");
+      return;
+    }
+    Set<String> addresses = new HashSet<>();
+    Set<String> ids = new HashSet<>();
+    List<RaftProtos.RaftPeerProto> raftPeerProtos = new ArrayList<>();
+    String[] peerArray = peers.split(",");
+
+    for (String idWithAddress : peerArray) {
+      String[] peerIdWithAddressArray = idWithAddress.split("\\|");
+
+      if (peerIdWithAddressArray.length < 1 || peerIdWithAddressArray.length > 2) {
+        System.err.println(
+          "Failed to parse peer's ID and address for: " + idWithAddress + ", from option: -peers " + peers +
+          ". Please provide list of peers in format " +
+          "<[P0_ID|]P0_HOST:P0_PORT,[P1_ID|]P1_HOST:P1_PORT,[P2_ID|]P2_HOST:P2_PORT>");
+        return;
+      }
+
+      InetSocketAddress inetSocketAddress = parseInetSocketAddress(
+        peerIdWithAddressArray[peerIdWithAddressArray.length - 1]);
+      String addressString = inetSocketAddress.getHostString() + ":" + inetSocketAddress.getPort();
+
+      if (addresses.contains(addressString)) {
+        System.err.println("Found duplicated address: " + addressString +
+          ". Please ensure the address of peers have no duplicated value.");
+        return;
+      }
+      addresses.add(addressString);
+
+      String peerId;
+      if (peerIdWithAddressArray.length == 2) {
+        peerId = RaftPeerId.getRaftPeerId(peerIdWithAddressArray[0]).toString();
+
+        if (ids.contains(peerId)) {
+          System.err.println("Found duplicated ID: " + peerId +
+            ". Please ensure the ID of peers have no duplicated value.");
+          return;
+        }
+        ids.add(peerId);
+      } else {
+        peerId = getPeerId(inetSocketAddress).toString();
+      }
+
+      raftPeerProtos.add(RaftProtos.RaftPeerProto.newBuilder()
+        .setId(ByteString.copyFrom(peerId.getBytes(StandardCharsets.UTF_8)))
+        .setAddress(addressString)
+        .setStartupRole(RaftProtos.RaftPeerRole.FOLLOWER)
+        .build());
+    }
+
+    try (InputStream in = Files.newInputStream(Paths.get(path, "raft-meta.conf"));
+      OutputStream out = Files.newOutputStream(Paths.get(path, "new-raft-meta.conf"))) {
+
+      long index = RaftProtos.LogEntryProto.newBuilder().mergeFrom(in).build().getIndex();
+      System.out.println("Index in the original file is: " + index);
+
+      RaftProtos.LogEntryProto newLogEntryProto = RaftProtos.LogEntryProto.newBuilder()
+        .setConfigurationEntry(RaftProtos.RaftConfigurationProto.newBuilder()
+          .addAllPeers(raftPeerProtos).build())
+        .setIndex(index + 1)
+        .build();
+
+      System.out.println("Generated new LogEntryProto info:\n" + newLogEntryProto);
+      newLogEntryProto.writeTo(out);
+    }
+  }
+
+  public static InetSocketAddress parseInetSocketAddress(String address) {
+    try {
+      final String[] hostPortPair = address.split(":");
+      if (hostPortPair.length < 2) {
+        throw new IllegalArgumentException("Unexpected address format <HOST:PORT>.");
+      }
+      return new InetSocketAddress(hostPortPair[0], Integer.parseInt(hostPortPair[1]));
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to parse the server address parameter \"" + address + "\".", e);
+    }
+  }
+
+  public static RaftPeerId getPeerId(InetSocketAddress address) {
+    return getPeerId(address.getHostString(), address.getPort());
+  }
+
+  public static RaftPeerId getPeerId(String host, int port) {
+    return RaftPeerId.getRaftPeerId(host + "_" + port);
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/local/RatisLocalSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/local/RatisLocalSubCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.ratis.local;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.scm.cli.ratis.RatisCommands;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Subcommand for ratis local related operations.
+ */
+@CommandLine.Command(
+    name = "local",
+    description = "Local operations within Ratis",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+        RatisLocalRaftMetaConfSubCommand.class
+    }
+)
+@MetaInfServices(SubcommandWithParent.class)
+public class RatisLocalSubCommand implements Callable<Void>, SubcommandWithParent {
+
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
+  @Override
+  public Void call() throws Exception {
+    GenericCli.missingSubcommand(spec);
+    return null;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return RatisCommands.class;
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/local/package-info.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/local/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains all of the ratis local related commands.
+ */
+package org.apache.hadoop.hdds.scm.cli.ratis.local;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/package-info.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ratis/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains all of the ratis related scm commands.
+ */
+package org.apache.hadoop.hdds.scm.cli.ratis;

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/ratis/TestRatisLocalRaftMetaConfSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/ratis/TestRatisLocalRaftMetaConfSubCommand.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.ratis;
+
+import org.apache.hadoop.hdds.scm.cli.ratis.local.RatisLocalRaftMetaConfSubCommand;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for RatisLocalRaftMetaConfSubCommand class.
+ */
+public class TestRatisLocalRaftMetaConfSubCommand {
+
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+  private RatisLocalRaftMetaConfSubCommand raftCmd;
+  private ScmClient scmClient;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    raftCmd = new RatisLocalRaftMetaConfSubCommand();
+    System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
+    System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
+
+    scmClient = mock(ScmClient.class);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @Test
+  public void testLocalRaftMetaConfSubcommand(@TempDir Path tempDir) throws IOException {
+    // Set up temporary directory and files
+    Path metadataDir = tempDir.resolve("data/metadata/ratis/test-cluster/current/");
+    Files.createDirectories(metadataDir);
+
+    // Create a dummy raft-meta.conf file using protobuf
+    Path raftMetaConfFile = metadataDir.resolve("raft-meta.conf");
+
+    // Create a LogEntryProto with a dummy index and peer
+    RaftProtos.RaftPeerProto raftPeerProto = RaftProtos.RaftPeerProto.newBuilder()
+      .setId(ByteString.copyFromUtf8("peer1"))
+      .setAddress("localhost:8000")
+      .setStartupRole(RaftProtos.RaftPeerRole.FOLLOWER)
+      .build();
+
+    RaftProtos.LogEntryProto logEntryProto = RaftProtos.LogEntryProto.newBuilder()
+      .setConfigurationEntry(RaftProtos.RaftConfigurationProto.newBuilder()
+        .addPeers(raftPeerProto).build())
+      .setIndex(1)
+      .build();
+
+    // Write the logEntryProto to the raft-meta.conf file
+    try (OutputStream out = Files.newOutputStream(raftMetaConfFile)) {
+      logEntryProto.writeTo(out);
+    }
+
+    CommandLine cmd = new CommandLine(raftCmd);
+    cmd.parseArgs("-peers", "peer1|localhost:8080", "-path", metadataDir.toString());
+
+    raftCmd.execute(scmClient);
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    assertTrue(output.contains("Index in the original file is: 1"));
+    assertTrue(output.contains("Generated new LogEntryProto info"));
+
+    // Verify that the new raft-meta.conf is generated
+    Path newRaftMetaConfFile = metadataDir.resolve("new-raft-meta.conf");
+    assertTrue(Files.exists(newRaftMetaConfFile));
+
+    // Verify content of the newly generated file
+    try (InputStream in = Files.newInputStream(newRaftMetaConfFile)) {
+      RaftProtos.LogEntryProto newLogEntryProto = RaftProtos.LogEntryProto.parseFrom(in);
+      assertEquals(2, newLogEntryProto.getIndex());
+      RaftProtos.RaftPeerProto peerProto = newLogEntryProto.getConfigurationEntry().getPeers(0);
+      assertEquals("peer1", peerProto.getId().toStringUtf8());
+      assertEquals("localhost:8080", peerProto.getAddress());
+      assertEquals(RaftProtos.RaftPeerRole.FOLLOWER, peerProto.getStartupRole());
+    }
+  }
+
+  @Test
+  public void testMissingRequiredArguments() {
+    CommandLine cmd = new CommandLine(raftCmd);
+
+    Exception exception = assertThrows(CommandLine.MissingParameterException.class, () -> {
+      cmd.parseArgs();
+      raftCmd.execute(scmClient);
+    });
+
+    assertEquals("Missing required options: '-peers=<peers>', '-path=<path>'", exception.getMessage());
+  }
+
+  @Test
+  public void testMissingPeersArgument() {
+    CommandLine cmd = new CommandLine(raftCmd);
+
+    Exception exception = assertThrows(CommandLine.MissingParameterException.class, () -> {
+      cmd.parseArgs("-path", "/dummy/path");
+      raftCmd.execute(scmClient);
+    });
+
+    assertEquals("Missing required option: '-peers=<peers>'", exception.getMessage());
+  }
+
+  @Test
+  public void testMissingPathArgument() {
+    CommandLine cmd = new CommandLine(raftCmd);
+
+    Exception exception = assertThrows(CommandLine.MissingParameterException.class, () -> {
+      cmd.parseArgs("-peers", "peer1|localhost:8080");
+      raftCmd.execute(scmClient);
+    });
+
+    assertEquals("Missing required option: '-path=<path>'", exception.getMessage());
+  }
+
+  @Test
+  public void testInvalidPeersFormat() {
+    CommandLine cmd = new CommandLine(raftCmd);
+
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+      cmd.parseArgs("-peers", "peer1|localhost8080", "-path", "/dummy/path"); //invalid peers format (missing ':' separator)
+      raftCmd.execute(scmClient);
+    });
+
+    assertTrue(thrown.getMessage().contains("Failed to parse the server address parameter"));
+  }
+
+  @Test
+  public void testDuplicatePeersAddress() throws IOException {
+    CommandLine cmd = new CommandLine(raftCmd);
+    cmd.parseArgs("-peers", "localhost:8080,localhost:8080", "-path", "/dummy/path");
+    raftCmd.execute(scmClient);
+
+    String errorOutput = errContent.toString(DEFAULT_ENCODING);
+    assertTrue(errorOutput.contains("Found duplicated address"));
+  }
+
+  @Test
+  public void testDuplicatePeersId() throws IOException {
+    CommandLine cmd = new CommandLine(raftCmd);
+    cmd.parseArgs("-peers", "peer1|localhost:8080,peer1|localhost:8081", "-path", "/dummy/path");
+    raftCmd.execute(scmClient);
+
+    String errorOutput = errContent.toString(DEFAULT_ENCODING);
+    assertTrue(errorOutput.contains("Found duplicated ID"));
+  }
+}

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/ratis/TestRatisLocalRaftMetaConfSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/ratis/TestRatisLocalRaftMetaConfSubCommand.java
@@ -36,7 +36,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -78,16 +80,16 @@ public class TestRatisLocalRaftMetaConfSubCommand {
 
     // Create a LogEntryProto with a dummy index and peer
     RaftProtos.RaftPeerProto raftPeerProto = RaftProtos.RaftPeerProto.newBuilder()
-      .setId(ByteString.copyFromUtf8("peer1"))
-      .setAddress("localhost:8000")
-      .setStartupRole(RaftProtos.RaftPeerRole.FOLLOWER)
-      .build();
+        .setId(ByteString.copyFromUtf8("peer1"))
+        .setAddress("localhost:8000")
+        .setStartupRole(RaftProtos.RaftPeerRole.FOLLOWER)
+        .build();
 
     RaftProtos.LogEntryProto logEntryProto = RaftProtos.LogEntryProto.newBuilder()
-      .setConfigurationEntry(RaftProtos.RaftConfigurationProto.newBuilder()
-        .addPeers(raftPeerProto).build())
-      .setIndex(1)
-      .build();
+        .setConfigurationEntry(RaftProtos.RaftConfigurationProto.newBuilder()
+          .addPeers(raftPeerProto).build())
+        .setIndex(1)
+        .build();
 
     // Write the logEntryProto to the raft-meta.conf file
     try (OutputStream out = Files.newOutputStream(raftMetaConfFile)) {
@@ -159,7 +161,8 @@ public class TestRatisLocalRaftMetaConfSubCommand {
     CommandLine cmd = new CommandLine(raftCmd);
 
     IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-      cmd.parseArgs("-peers", "peer1|localhost8080", "-path", "/dummy/path"); //invalid peers format (missing ':' separator)
+      //invalid peers format (missing ':' separator)
+      cmd.parseArgs("-peers", "peer1|localhost8080", "-path", "/dummy/path");
       raftCmd.execute(scmClient);
     });
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added `ozone admin ratis local raftMetaConf` cli option to generate a new raft-meta.conf.
```
ozone admin ratis local raftMetaConf -peers <P0_HOST:P0_PORT,P1_HOST:P1_PORT,P2_HOST:P2_PORT> -path <PARENT_PATH_OF_RAFT_META_CONF>
``` 
Logic implemented by referring to the following ratis shell code - 
https://github.com/apache/ratis/blob/release-3.1.0/ratis-shell/src/main/java/org/apache/ratis/shell/cli/sh/local/RaftMetaConfCommand.java

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10479

## How was this patch tested?
Added unit tests in `TestRatisLocalRaftMetaConfSubCommand`.

Tested the CLI on a docker cluster.
```
bash-4.4$ ozone admin ratis local raftMetaConf -peers "peer1|localhost:8080,peer2|localhost:8081" -path ../.././data/metadata/ratis/bf265839-605b-3f16-9796-c5ba1605619e/current/
Index in the original file is: 0
Generated new LogEntryProto info:
index: 1
configurationEntry {
  peers {
    id: "peer1"
    address: "localhost:8080"
    startupRole: FOLLOWER
  }
  peers {
    id: "peer2"
    address: "localhost:8081"
    startupRole: FOLLOWER
  }
}
```

```
bash-4.4$ ozone admin ratis local raftMetaConf
Missing required options: '-peers=<peers>', '-path=<path>'
```

```
bash-4.4$ ozone admin ratis local raftMetaConf -peers localhost8080
Missing required option: '-path=<path>'
```

```
bash-4.4$ ozone admin ratis local raftMetaConf -peers localhost8080 -path ../.././data/metadata/ratis/bf265839-605b-3f16-9796-c5ba1605619e/current/
Failed to parse the server address parameter "localhost8080".
```

```
bash-4.4$ ozone admin ratis local raftMetaConf -peers localhost:8080,localhost:8080 -path ../.././data/metadata/ratis/bf265839-605b-3f16-9796-c5ba1605619e/current/
Found duplicated address: localhost:8080. Please ensure the address of peers have no duplicated value.
```

```
bash-4.4$ ozone admin ratis local raftMetaConf -peers "peer1|localhost:8080,peer1|localhost:8081" -path ../.././data/metadata/ratis/bf265839-605b-3f16-9796-c5ba1605619e/current/
Found duplicated ID: peer1. Please ensure the ID of peers have no duplicated value.
```