### PR TITLE
HDDS-11429. Add lifeline to improve heartbeat report

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -46,6 +46,9 @@ public final class HddsConfigKeys {
       "hdds.command.status.report.interval";
   public static final String HDDS_COMMAND_STATUS_REPORT_INTERVAL_DEFAULT =
       "60s";
+  public static final String HDDS_LIFELINE_REPORT_ENABLE =
+      "hdds.lifeline.report.enable";
+  public static final boolean HDDS_LIFELINE_REPORT_ENABLE_DEFAULT = false;
   public static final String HDDS_CONTAINER_ACTION_MAX_LIMIT =
       "hdds.container.action.max.limit";
   public static final int HDDS_CONTAINER_ACTION_MAX_LIMIT_DEFAULT =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1578,6 +1578,15 @@
       postfix (ns,ms,s,m,h,d)</description>
   </property>
   <property>
+    <name>hdds.lifeline.report.enable</name>
+    <value>false</value>
+    <tag>OZONE, DATANODE, MANAGEMENT</tag>
+    <description>
+      Whether to enable Datanode to send lifeline to SCM and Recon.
+      The default value is false.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.pipeline.destroy.timeout</name>
     <value>66s</value>
     <tag>OZONE, SCM, PIPELINE</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1582,8 +1582,8 @@
     <value>false</value>
     <tag>OZONE, DATANODE, MANAGEMENT</tag>
     <description>
-      Whether to enable Datanode to send lifeline to SCM and Recon.
-      The default value is false.
+      It specifies whether Datanode will send lifeline
+      to SCM and Recon. The default value is false.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -53,6 +53,7 @@ public class EndpointStateMachine
   private EndPointStates state = EndPointStates.FIRST;
   private VersionResponse version;
   private ZonedDateTime lastSuccessfulHeartbeat;
+  private ZonedDateTime lastSuccessfulLifeline;
   private boolean isPassive;
   private final ExecutorService executorService;
 
@@ -300,6 +301,15 @@ public class EndpointStateMachine
   public void setLastSuccessfulHeartbeat(
       ZonedDateTime lastSuccessfulHeartbeat) {
     this.lastSuccessfulHeartbeat = lastSuccessfulHeartbeat;
+  }
+
+  @Override
+  public long getLastSuccessfulLifeline() {
+    return lastSuccessfulLifeline == null ? 0 : lastSuccessfulLifeline.toEpochSecond();
+  }
+
+  public void setLastSuccessfulLifeline(ZonedDateTime lastSuccessfulLifeline) {
+    this.lastSuccessfulLifeline = lastSuccessfulLifeline;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachineMBean.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachineMBean.java
@@ -32,5 +32,7 @@ public interface EndpointStateMachineMBean {
 
   long getLastSuccessfulHeartbeat();
 
+  long getLastSuccessfulLifeline();
+
   String getType();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/LifelineEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/LifelineEndpointTask.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.container.common.states.endpoint;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMLifelineRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVersionProto;
+
+/**
+ * Datanode periodically sends lifeline data to SCM.
+ * This data includes basic node information.
+ */
+public class LifelineEndpointTask implements Runnable {
+
+  public static final Logger LOG = LoggerFactory.getLogger(
+        LifelineEndpointTask.class);
+
+  private final EndpointStateMachine rpcEndpoint;
+  private final DatanodeDetails datanodeDetails;
+  private final OzoneContainer datanodeContainerManager;
+  private final HDDSLayoutVersionManager layoutVersionManager;
+  private final long heartbeatFrequency;
+  private boolean isRunning = false;
+
+  public LifelineEndpointTask(EndpointStateMachine rpcEndpoint,
+      StateContext context, OzoneContainer datanodeContainerManager,
+      DatanodeDetails datanodeDetails) {
+    this.rpcEndpoint = rpcEndpoint;
+    this.layoutVersionManager = context.getParent().getLayoutVersionManager();
+    this.datanodeDetails = datanodeDetails;
+    this.datanodeContainerManager = datanodeContainerManager;
+    if (rpcEndpoint.isPassive()) {
+      heartbeatFrequency = context.getReconHeartbeatFrequency();
+    } else {
+      heartbeatFrequency = context.getHeartbeatFrequency();
+    }
+  }
+
+  @Override
+  public void run() {
+    this.isRunning = true;
+    while (isRunning) {
+      if (rpcEndpoint.getState() == EndpointStateMachine.EndPointStates.SHUTDOWN) {
+        return;
+      }
+
+      if (rpcEndpoint.getState() == EndpointStateMachine.EndPointStates.HEARTBEAT) {
+        SCMLifelineRequestProto.Builder builder = null;
+        try {
+          LayoutVersionProto layoutinfo = toLayoutVersionProto(
+              layoutVersionManager.getMetadataLayoutVersion(),
+              layoutVersionManager.getSoftwareLayoutVersion());
+          NodeReportProto nodeReport = datanodeContainerManager.getNodeReport();
+          builder = SCMLifelineRequestProto.newBuilder()
+              .setDatanodeDetails(datanodeDetails.getProtoBufMessage())
+              .setNodeReport(nodeReport)
+              .setDataNodeLayoutVersion(layoutinfo);
+          SCMLifelineRequestProto lifelineRequest = builder.build();
+          LOG.debug("Sending lifeline message : {}", lifelineRequest);
+          rpcEndpoint.getEndPoint().sendLifeline(lifelineRequest);
+          rpcEndpoint.setLastSuccessfulLifeline(ZonedDateTime.now());
+        } catch (IOException ex) {
+          Preconditions.checkState(builder != null);
+          rpcEndpoint.logIfNeeded(ex);
+        }
+      }
+      try {
+        Thread.sleep(heartbeatFrequency);
+      } catch (InterruptedException e) {
+        this.isRunning = false;
+        Thread.interrupted();
+      }
+    }
+  }
+
+  public void setRunning(boolean isRun) {
+    this.isRunning = isRun;
+  }
+
+  public boolean isRun() {
+    return isRunning;
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/StorageContainerDatanodeProtocol.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/StorageContainerDatanodeProtocol.java
@@ -36,6 +36,9 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.SCMVersionRequestProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.SCMVersionResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMLifelineRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos
+    .SCMLifelineResponseProto;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
@@ -88,5 +91,13 @@ public interface StorageContainerDatanodeProtocol {
       ContainerReportsProto containerReportsRequestProto,
       PipelineReportsProto pipelineReports,
       LayoutVersionProto layoutInfo) throws IOException;
+
+  /**
+   * Used by data node to send a Heartbeat.
+   * @param lifelineRequest Lifeline request containing the message body.
+   * @return Lifeline Response.
+   */
+  SCMLifelineResponseProto sendLifeline(SCMLifelineRequestProto lifelineRequest)
+      throws IOException;
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/StorageContainerNodeProtocol.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/StorageContainerNodeProtocol.java
@@ -88,6 +88,8 @@ public interface StorageContainerNodeProtocol {
   List<SCMCommand> processHeartbeat(DatanodeDetails datanodeDetails,
       CommandQueueReportProto queueReport);
 
+  default void processLifeline(DatanodeDetails datanodeDetails) { }
+
   /**
    * Check if node is registered or not.
    * Return true if Node is registered and false otherwise.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/StorageContainerDatanodeProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/StorageContainerDatanodeProtocolClientSideTranslatorPB.java
@@ -182,11 +182,6 @@ public class StorageContainerDatanodeProtocolClientSideTranslatorPB
         .getRegisterResponse();
   }
 
-  /**
-   * Send by datanode to SCM.
-   * @param lifelineRequest Lifeline request containing the message body.
-   * @return Lifeline Response.
-   */
   @Override
   public SCMLifelineResponseProto sendLifeline(SCMLifelineRequestProto lifelineRequest)
       throws IOException {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/StorageContainerDatanodeProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/StorageContainerDatanodeProtocolClientSideTranslatorPB.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.SCMVersionRequestProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.SCMVersionResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMLifelineRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMLifelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.Type;
 import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtocolTranslator;
@@ -178,5 +180,18 @@ public class StorageContainerDatanodeProtocolClientSideTranslatorPB
     return submitRequest(Type.Register,
         (builder) -> builder.setRegisterRequest(req))
         .getRegisterResponse();
+  }
+
+  /**
+   * Send by datanode to SCM.
+   * @param lifelineRequest Lifeline request containing the message body.
+   * @return Lifeline Response.
+   */
+  @Override
+  public SCMLifelineResponseProto sendLifeline(SCMLifelineRequestProto lifelineRequest)
+      throws IOException {
+    return submitRequest(Type.Lifeline,
+        (builder) -> builder.setLifelineRequest(lifelineRequest))
+            .getLifelineResponse();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/StorageContainerDatanodeProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/StorageContainerDatanodeProtocolServerSideTranslatorPB.java
@@ -118,6 +118,12 @@ public class StorageContainerDatanodeProtocolServerSideTranslatorPB
             .setStatus(Status.OK)
             .setRegisterResponse(register(request.getRegisterRequest()))
             .build();
+      case Lifeline:
+        return SCMDatanodeResponse.newBuilder()
+            .setCmdType(cmdType)
+            .setStatus(Status.OK)
+            .setLifelineResponse(impl.sendLifeline(request.getLifelineRequest()))
+            .build();
       default:
         throw new ServiceException("Unknown command type: " + cmdType);
       }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ScmTestMock.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ScmTestMock.java
@@ -45,6 +45,8 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMLifelineRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMLifelineResponseProto;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.protocol.StorageContainerDatanodeProtocol;
 import org.apache.hadoop.ozone.protocol.VersionResponse;
@@ -66,6 +68,7 @@ public class ScmTestMock implements StorageContainerDatanodeProtocol {
   private AtomicInteger heartbeatCount = new AtomicInteger(0);
   private AtomicInteger rpcCount = new AtomicInteger(0);
   private AtomicInteger containerReportsCount = new AtomicInteger(0);
+  private AtomicInteger lifelineCount = new AtomicInteger(0);
   private String clusterId;
   private String scmId;
 
@@ -305,6 +308,18 @@ public class ScmTestMock implements StorageContainerDatanodeProtocol {
     }
   }
 
+  @Override
+  public SCMLifelineResponseProto sendLifeline(
+      SCMLifelineRequestProto lifelineRequest) throws IOException {
+    rpcCount.incrementAndGet();
+    lifelineCount.incrementAndGet();
+    DatanodeDetailsProto datanodeDetailsProto =
+        lifelineRequest.getDatanodeDetails();
+    updateNodeReport(datanodeDetailsProto, lifelineRequest.getNodeReport());
+    sleepIfNeeded();
+    return SCMLifelineResponseProto.newBuilder().
+        setDatanodeUUID(datanodeDetailsProto.getUuid()).build();
+  }
 
   /**
    * Return the number of StorageReports of a datanode.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
@@ -16,11 +16,19 @@
  */
 package org.apache.hadoop.ozone.container.common.states.datanode;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
 import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_LIFELINE_REPORT_ENABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -31,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointStates.SHUTDOWN;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +47,14 @@ import static org.mockito.Mockito.when;
  * Test class for RunningDatanodeState.
  */
 public class TestRunningDatanodeState {
+
+  private static final InetSocketAddress TEST_SCM_ENDPOINT1 =
+      new InetSocketAddress("test-scm-1", 9861);
+  private static final InetSocketAddress TEST_SCM_ENDPOINT2 =
+      new InetSocketAddress("test-scm-2", 9861);
+  private static final InetSocketAddress TEST_SCM_ENDPOINT3 =
+      new InetSocketAddress("test-scm-3", 9861);
+
   @Test
   public void testAwait() throws InterruptedException {
     SCMConnectionManager connectionManager = mock(SCMConnectionManager.class);
@@ -45,7 +62,7 @@ public class TestRunningDatanodeState {
     when(connectionManager.getValues()).thenReturn(stateMachines);
 
     RunningDatanodeState state =
-        new RunningDatanodeState(null, connectionManager, null);
+        new RunningDatanodeState(new OzoneConfiguration(), connectionManager, null);
 
     int threadPoolSize = 2;
     ExecutorService executorService = Executors.newFixedThreadPool(
@@ -85,5 +102,40 @@ public class TestRunningDatanodeState {
     assertThat(endTime - startTime).isLessThan(500);
 
     executorService.shutdown();
+  }
+
+  @Test
+  public void testLifeline() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(HDDS_LIFELINE_REPORT_ENABLE, true);
+    SCMConnectionManager connectionManager = mock(SCMConnectionManager.class);
+    List<EndpointStateMachine> stateMachines = new ArrayList<>();
+    StorageContainerDatanodeProtocolClientSideTranslatorPB proxy =
+        mock(StorageContainerDatanodeProtocolClientSideTranslatorPB.class);
+    EndpointStateMachine endpointStateMachine1 = mock(EndpointStateMachine.class);
+    when(endpointStateMachine1.getEndPoint()).thenReturn(proxy);
+    when(endpointStateMachine1.getAddress()).thenReturn(TEST_SCM_ENDPOINT1);
+    stateMachines.add(endpointStateMachine1);
+    EndpointStateMachine endpointStateMachine2 = mock(EndpointStateMachine.class);
+    when(endpointStateMachine2.getEndPoint()).thenReturn(proxy);
+    when(endpointStateMachine2.getAddress()).thenReturn(TEST_SCM_ENDPOINT2);
+    stateMachines.add(endpointStateMachine2);
+    EndpointStateMachine endpointStateMachine3 = mock(EndpointStateMachine.class);
+    when(endpointStateMachine3.getEndPoint()).thenReturn(proxy);
+    when(endpointStateMachine3.getAddress()).thenReturn(TEST_SCM_ENDPOINT3);
+    stateMachines.add(endpointStateMachine3);
+
+    when(connectionManager.getValues()).thenReturn(stateMachines);
+    StateContext context = new StateContext(conf,
+        DatanodeStateMachine.DatanodeStates.RUNNING,
+        mock(DatanodeStateMachine.class), "");
+    context.setTermOfLeaderSCM(1);
+    RunningDatanodeState runningDatanodeState =
+        new RunningDatanodeState(conf, connectionManager, context);
+    List<Thread> threads = runningDatanodeState.getLifelineThreads();
+    assertEquals(3, threads.size());
+    for (Thread thread : threads) {
+      assertTrue(thread.isAlive());
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestLifelineEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestLifelineEndpointTask.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.container.common.states.endpoint;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMLifelineRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMLifelineResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_RECON_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class tests the functionality of {@link LifelineEndpointTask}.
+ */
+public class TestLifelineEndpointTask {
+  private static final InetSocketAddress TEST_SCM_ENDPOINT =
+      new InetSocketAddress("test-scm-1", 9861);
+
+  @Test
+  public void testLifelineWithReports() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 1, TimeUnit.SECONDS);
+    conf.setTimeDuration(HDDS_RECON_HEARTBEAT_INTERVAL, 1, TimeUnit.SECONDS);
+    DatanodeStateMachine datanodeStateMachine = mock(DatanodeStateMachine.class);
+
+    when(datanodeStateMachine.getLayoutVersionManager())
+        .thenReturn(new HDDSLayoutVersionManager(maxLayoutVersion()));
+    when(datanodeStateMachine.getContainer())
+        .thenReturn(mock(OzoneContainer.class));
+    when(datanodeStateMachine.getContainer().getNodeReport())
+        .thenReturn(NodeReportProto.getDefaultInstance());
+
+    StateContext context = new StateContext(conf,
+        DatanodeStateMachine.DatanodeStates.RUNNING,
+        datanodeStateMachine, "");
+    StorageContainerDatanodeProtocolClientSideTranslatorPB scm =
+        mock(StorageContainerDatanodeProtocolClientSideTranslatorPB.class);
+    ArgumentCaptor<SCMLifelineRequestProto> argument = ArgumentCaptor
+        .forClass(SCMLifelineRequestProto.class);
+    when(scm.sendLifeline(argument.capture()))
+        .thenAnswer(invocation ->
+        SCMLifelineResponseProto.newBuilder()
+        .setDatanodeUUID(((SCMLifelineRequestProto)invocation.getArgument(0))
+        .getDatanodeDetails().getUuid()).build());
+
+    EndpointStateMachine endpointStateMachine = new EndpointStateMachine(
+        TEST_SCM_ENDPOINT, scm, conf, "");
+    endpointStateMachine.setState(EndpointStateMachine.EndPointStates.HEARTBEAT);
+    LifelineEndpointTask task = getLifelineEndpointTask(endpointStateMachine, context);
+    Thread thread = new Thread(getLifelineEndpointTask(endpointStateMachine, context));
+    thread.start();
+    Thread.sleep(1000);
+    task.setRunning(false);
+    SCMLifelineRequestProto lifeline = argument.getValue();
+    assertTrue(lifeline.hasDatanodeDetails());
+    assertTrue(lifeline.hasNodeReport());
+    assertTrue(lifeline.hasDataNodeLayoutVersion());
+  }
+
+  private LifelineEndpointTask getLifelineEndpointTask(
+      EndpointStateMachine endpointStateMachine, StateContext context) {
+    DatanodeDetails datanodeDetails = DatanodeDetails.newBuilder()
+        .setUuid(UUID.randomUUID()).setHostName("localhost")
+        .setIpAddress("127.0.0.1").build();
+    HDDSLayoutVersionManager layoutVersionManager =
+        mock(HDDSLayoutVersionManager.class);
+    when(layoutVersionManager.getSoftwareLayoutVersion())
+        .thenReturn(maxLayoutVersion());
+    when(layoutVersionManager.getMetadataLayoutVersion())
+        .thenReturn(maxLayoutVersion());
+    return new LifelineEndpointTask(endpointStateMachine, context,
+        context.getParent().getContainer(), datanodeDetails);
+  }
+}

--- a/hadoop-hdds/docs/content/concept/Recon.md
+++ b/hadoop-hdds/docs/content/concept/Recon.md
@@ -70,7 +70,7 @@ further processing by OM db tasks via [Recon Task Framework](#task-framework).
 <br/>
 
 Recon also acts as a passive SCM for datanodes. When Recon is configured in the
-cluster, all the datanodes register with Recon and send heartbeats, container 
+cluster, all the datanodes register with Recon and send heartbeats, lifeline, container 
 reports, incremental container reports etc. to Recon similar to SCM. Recon uses
 all the information it gets from datanodes to construct its own copy of SCM rocks db 
 locally. Recon never sends any command to datanodes in response and just acts as

--- a/hadoop-hdds/docs/content/concept/StorageContainerManager.md
+++ b/hadoop-hdds/docs/content/concept/StorageContainerManager.md
@@ -71,6 +71,9 @@ For a detailed view of Storage Container Manager this section gives a quick over
    * From Datanode to SCM (30 sec by default)
    * Datanodes report the status of containers, node...
    * SCM can add commands to the response
+ * Datanode Lifeline protocol
+   * From Datanode to SCM (30 sec by default)
+   * Datanodes report the status of node
 
 Note: client doesn't connect directly to the SCM
 

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -44,6 +44,7 @@ message SCMDatanodeRequest {
   optional SCMVersionRequestProto getVersionRequest = 3;
   optional SCMRegisterRequestProto registerRequest = 4;
   optional SCMHeartbeatRequestProto sendHeartbeatRequest = 5;
+  optional SCMLifelineRequestProto lifelineRequest = 6;
 }
 
 message SCMDatanodeResponse {
@@ -60,6 +61,7 @@ message SCMDatanodeResponse {
   optional SCMVersionResponseProto getVersionResponse = 6;
   optional SCMRegisteredResponseProto registerResponse = 7;
   optional SCMHeartbeatResponseProto sendHeartbeatResponse = 8;
+  optional SCMLifelineResponseProto lifelineResponse = 9;
 
 }
 
@@ -67,6 +69,7 @@ enum Type {
   GetVersion = 1;
   Register = 2;
   SendHeartbeat = 3;
+  Lifeline = 4;
 }
 
 enum Status {
@@ -155,6 +158,21 @@ message SCMHeartbeatResponseProto {
 
   // Same as term in SCMCommandProto
   optional int64 term = 3;
+}
+
+/**
+ * Generic response that is send to a lifeline request.
+ */
+message SCMLifelineRequestProto {
+  required DatanodeDetailsProto datanodeDetails = 1;
+  optional NodeReportProto nodeReport = 2;
+  optional LayoutVersionProto dataNodeLayoutVersion = 3;
+}
+
+message SCMLifelineResponseProto {
+  required string datanodeUUID = 1;
+  // Same as term in SCMCommandProto
+  optional int64 term = 2;
 }
 
 message SCMNodeAddressList {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -558,6 +558,21 @@ public class SCMNodeManager implements NodeManager {
         != dnDetails.getPersistedOpStateExpiryEpochSec();
   }
 
+  @Override
+  public void processLifeline(DatanodeDetails datanodeDetails) {
+    Preconditions.checkNotNull(datanodeDetails, "Lifeline is missing " +
+        "DatanodeDetails.");
+    try {
+      nodeStateManager.updateLastHeartbeatTime(datanodeDetails);
+      metrics.incNumLifelineProcessed();
+      updateDatanodeOpState(datanodeDetails);
+    } catch (NodeNotFoundException e) {
+      metrics.incNumLifelineProcessingFailed();
+      LOG.error("SCM trying to process lifeline from an " +
+          "unregistered node {}. Ignoring the lifeline.", datanodeDetails);
+    }
+  }
+
   /**
    * This method should only be called when processing the heartbeat.
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
@@ -48,6 +48,8 @@ public final class SCMNodeMetrics implements MetricsSource {
 
   private @Metric MutableCounterLong numHBProcessed;
   private @Metric MutableCounterLong numHBProcessingFailed;
+  private @Metric MutableCounterLong numLifelineProcessed;
+  private @Metric MutableCounterLong numLifelineProcessingFailed;
   private @Metric MutableCounterLong numNodeReportProcessed;
   private @Metric MutableCounterLong numNodeReportProcessingFailed;
   private @Metric MutableCounterLong numNodeCommandQueueReportProcessed;
@@ -97,6 +99,20 @@ public final class SCMNodeMetrics implements MetricsSource {
    */
   void incNumHBProcessingFailed() {
     numHBProcessingFailed.incr();
+  }
+
+  /**
+   * Increments number of lifeline processed count.
+   */
+  void incNumLifelineProcessed() {
+    numLifelineProcessed.incr();
+  }
+
+  /**
+   * Increments number of lifeline processing failed count.
+   */
+  void incNumLifelineProcessingFailed() {
+    numLifelineProcessingFailed.incr();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/ozone/audit/SCMAction.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/ozone/audit/SCMAction.java
@@ -24,6 +24,7 @@ public enum SCMAction implements AuditAction {
   GET_VERSION,
   REGISTER,
   SEND_HEARTBEAT,
+  LIFE_LINE,
   GET_SCM_INFO,
   ALLOCATE_BLOCK,
   DELETE_KEY_BLOCK,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeMetrics.java
@@ -112,6 +112,23 @@ public class TestSCMNodeMetrics {
         "NumHBProcessingFailed");
   }
 
+  @Test
+  public void testLifelineProcessing() {
+    long lifelineProcessed = getCounter("NumLifelineProcessed");
+    createNodeReport();
+    nodeManager.processLifeline(registeredDatanode);
+    assertEquals(lifelineProcessed + 1, getCounter("NumLifelineProcessed"),
+        "NumLifelineProcessed");
+  }
+
+  @Test
+  public void testLifelineProcessingFailure() {
+    long lifelineProcessedFailed = getCounter("NumLifelineProcessingFailed");
+    nodeManager.processLifeline(MockDatanodeDetails.randomDatanodeDetails());
+    assertEquals(lifelineProcessedFailed + 1, getCounter("NumLifelineProcessingFailed"),
+        "NumLifelineProcessingFailed");
+  }
+
   /**
    * Verifies node report processing count.
    *

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -84,7 +85,7 @@ public class ReconNodeManager extends SCMNodeManager {
    * Map that contains mapping between datanodes
    * and their last heartbeat time.
    */
-  private Map<UUID, Long> datanodeHeartbeatMap = new HashMap<>();
+  private Map<UUID, Long> datanodeHeartbeatMap = new ConcurrentHashMap<>();
   private Map<UUID, DatanodeDetails> inMemDatanodeDetails = new HashMap<>();
 
   private long reconDatanodeOutdatedTime;
@@ -253,6 +254,12 @@ public class ReconNodeManager extends SCMNodeManager {
     return cmds.stream()
         .filter(c -> ALLOWED_COMMANDS.contains(c.getType()))
         .collect(toList());
+  }
+
+  @Override
+  public void processLifeline(DatanodeDetails datanodeDetails) {
+    super.processLifeline(datanodeDetails);
+    datanodeHeartbeatMap.put(datanodeDetails.getUuid(), Time.now());
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
In some cases, Datanode will be blocked from reporting heartbeats to SCM, which is very unfriendly. A lifeline mechanism should be designed here to improve the heartbeat reporting between Datanode and SCM, and Datanode and Recon.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11429

## How was this patch tested?
We need to ensure that Datanode normally sends lifelines to SCM/Recon.
When the lifeline is turned on, we can see some phenomena.
Datanode log:
```
2024-09-05 23:56:37,458 [Thread-35] DEBUG org.apache.hadoop.ozone.container.common.states.endpoint.LifelineEndpointTask: Sending lifeline message : datanodeDetails {
  uuid: "e86aabe7-ed94-4f6b-adef-7e0e2d646deb"
  ipAddress: "xx.xx.xx.xx"
  hostName: "xxxxxx"
  ports {
    name: "HTTP"
    value: 9882
  }
  ports {
    name: "CLIENT_RPC"
    value: 19864
  }
  ports {
    name: "REPLICATION"
    value: 9886
  }
  ports {
    name: "RATIS"
    value: 9858
  }
  ports {
    name: "RATIS_ADMIN"
    value: 9857
  }
  ports {
    name: "RATIS_SERVER"
    value: 9856
  }
  ports {
    name: "STANDALONE"
    value: 9859
  }
  networkName: "e86aabe7-ed94-4f6b-adef-7e0e2d646deb"
  networkLocation: "/default-rack"
  persistedOpState: IN_SERVICE
  persistedOpStateExpiry: 0
  currentVersion: 2
  uuid128 {
    mostSigBits: -1699356896767226005
    leastSigBits: -5913369186357973525
  }
}
nodeReport {
  storageReport {
    storageUuid: "DS-2c7b04a0-d430-40db-9716-b4b93d00ea62"
    storageLocation: "/opt/software/ozonedata/hddsdata3"
    capacity: 7998352482304
    scmUsed: 35733504
    remaining: 5541872459776
    storageType: DISK
    failed: false
    committed: 0
    freeSpaceToSpare: 5368709120
  }
  storageReport {
    storageUuid: "DS-32faa23d-a524-45b3-a529-28edafc446e5"
    storageLocation: "/opt/software/ozonedata/hddsdata2"
    capacity: 7998352482304
    scmUsed: 193314816
    remaining: 5541872459776
    storageType: DISK
    failed: false
    committed: 5368707979
    freeSpaceToSpare: 5368709120
  }
  storageReport {
    storageUuid: "DS-4093587b-be27-4c26-a5de-9b3a08c1e3c5"
    storageLocation: "/opt/software/ozonedata/hddsdata1"
    capacity: 7998352482304
    scmUsed: 40685568
    remaining: 5541872459776
    storageType: DISK
    failed: false
    committed: 5368705052
    freeSpaceToSpare: 5368709120
  }
  metadataStorageReport {
    storageLocation: "/opt/software/ozonedata/dn/ratis"
    storageType: DISK
    capacity: 7998626281536
    scmUsed: 12652544
    remaining: 5541872459776
    failed: false
  }
}
dataNodeLayoutVersion {
  metadataLayoutVersion: 8
  softwareLayoutVersion: 8
}
```
SCM log:
```
2024-09-06 01:25:07,048 | INFO  | SCMAudit | user=root | ip=xx.xx.xx.xx | op=LIFE_LINE {datanodeUUID=e86aabe7-ed94-4f6b-adef-7e0e2d646deb} | ret=SUCCESS |
```
Recon log:

```
2024-09-07 15:01:29,746 [IPC Server handler 7 on default port 9891] DEBUG org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolServerSideTranslatorPB: SCMDatanodeProtocol Lifeline request is received
2024-09-07 15:01:29,746 [IPC Server handler 7 on default port 9891] DEBUG org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher: Processing DataNode lifeline. datanodeDetails = e86aabe7-ed94-4f6b-adef-7e0e2d646deb(xxxxxx/xx.xx.xx.xx), layoutVersion = metadataLayoutVersion: 8
softwareLayoutVersion: 8
```
Datanode jmx:
![image](https://github.com/user-attachments/assets/4c65c527-bfc8-4f1a-8d7f-e0e47e98b0e5)

SCM jmx:
![image](https://github.com/user-attachments/assets/bfa45522-d03f-4350-b37b-6899a512f322)

Recon jmx:
![image](https://github.com/user-attachments/assets/c9aa4684-a28b-463b-853c-5758470f5148)
