### PR TITLE
HDDS-11440. Add a lastTransactionInfo field in SnapshotInfo to check for transactions in flight on the snapshot

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java
@@ -162,7 +162,16 @@ public final class TransactionInfo implements Comparable<TransactionInfo> {
    */
   public static TransactionInfo readTransactionInfo(
       DBStoreHAManager metadataManager) throws IOException {
-    return metadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
+    return readTransactionInfo(metadataManager, false);
+  }
+
+  /**
+   * Return transaction info persisted in OM DB skipping cache.
+   */
+  public static TransactionInfo readTransactionInfo(
+      DBStoreHAManager metadataManager, boolean skipCache) throws IOException {
+    return skipCache ? metadataManager.getTransactionInfoTable().getSkipCache(TRANSACTION_INFO_KEY) :
+        metadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
   }
 
   public SnapshotInfo toSnapshotInfo() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java
@@ -170,6 +170,10 @@ public final class TransactionInfo implements Comparable<TransactionInfo> {
     return ByteString.copyFrom(getCodec().toPersistedFormat(this));
   }
 
+  public static TransactionInfo fromByteString(ByteString byteString) throws IOException {
+    return byteString == null ? null : getCodec().fromPersistedFormat(byteString.toByteArray());
+  }
+
   public SnapshotInfo toSnapshotInfo() {
     return snapshotInfo;
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
+import com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
@@ -162,16 +163,11 @@ public final class TransactionInfo implements Comparable<TransactionInfo> {
    */
   public static TransactionInfo readTransactionInfo(
       DBStoreHAManager metadataManager) throws IOException {
-    return readTransactionInfo(metadataManager, false);
+    return metadataManager.getTransactionInfoTable().getSkipCache(TRANSACTION_INFO_KEY);
   }
 
-  /**
-   * Return transaction info persisted in OM DB skipping cache.
-   */
-  public static TransactionInfo readTransactionInfo(
-      DBStoreHAManager metadataManager, boolean skipCache) throws IOException {
-    return skipCache ? metadataManager.getTransactionInfoTable().getSkipCache(TRANSACTION_INFO_KEY) :
-        metadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
+  public ByteString toByteString() throws IOException {
+    return ByteString.copyFrom(getCodec().toPersistedFormat(this));
   }
 
   public SnapshotInfo toSnapshotInfo() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -417,11 +417,6 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
       return this;
     }
 
-    public Builder setLastTransactionInfo(byte[] lastTransactionInfo) {
-      this.lastTransactionInfo = lastTransactionInfo == null ? null : ByteString.copyFrom(lastTransactionInfo);
-      return this;
-    }
-
     public Builder setLastTransactionInfo(ByteString lastTransactionInfo) {
       this.lastTransactionInfo = lastTransactionInfo;
       return this;
@@ -534,7 +529,7 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     }
 
     if (snapshotInfoProto.hasLastTransactionInfo()) {
-      osib.setLastTransactionInfo(snapshotInfoProto.getLastTransactionInfo().toByteArray());
+      osib.setLastTransactionInfo(snapshotInfoProto.getLastTransactionInfo());
     }
 
     osib.setSnapshotPath(snapshotInfoProto.getSnapshotPath())
@@ -633,8 +628,8 @@ public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
     return lastTransactionInfo;
   }
 
-  public void setLastTransactionInfo(byte[] lastTransactionInfo) {
-    this.lastTransactionInfo = lastTransactionInfo == null ? null : ByteString.copyFrom(lastTransactionInfo);
+  public void setLastTransactionInfo(ByteString lastTransactionInfo) {
+    this.lastTransactionInfo = lastTransactionInfo;
   }
 
   /**

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -886,6 +886,7 @@ message SnapshotInfo {
   optional uint64 exclusiveReplicatedSize = 18;
   // note: shared sizes can be calculated from: referenced - exclusive
   optional bool deepCleanedDeletedDir = 19;
+  optional bytes lastTransactionInfo = 20;
 }
 
 message SnapshotDiffJobProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -41,6 +41,7 @@ import com.google.common.cache.RemovalListener;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
@@ -673,6 +674,40 @@ public final class OmSnapshotManager implements AutoCloseable {
     // retrieve the snapshot from the cache
     return snapshotCache.get(snapshotInfo.getSnapshotId());
   }
+
+  /**
+   * Checks if the last transaction performed on the snapshot has been flushed to disk.
+   * @param metadataManager Metadatamanager of Active OM.
+   * @param snapshotTableKey table key corresponding to snapshot in snapshotInfoTable.
+   * @return True if the changes have been flushed to DB otherwise false
+   * @throws IOException
+   */
+  public static boolean areSnapshotChangesFlushedToDB(OMMetadataManager metadataManager, String snapshotTableKey)
+      throws IOException {
+    // Need this info from cache since the snapshot could have been updated only on cache and not on disk.
+    SnapshotInfo snapshotInfo = metadataManager.getSnapshotInfoTable().get(snapshotTableKey);
+    return areSnapshotChangesFlushedToDB(metadataManager, snapshotInfo);
+  }
+
+  /**
+   * Checks if the last transaction performed on the snapshot has been flushed to disk.
+   * @param metadataManager Metadatamanager of Active OM.
+   * @param snapshotInfo table key corresponding to snapshot in snapshotInfoTable, this should be a value from cache
+   *                     and not from disk.
+   * @return True if the changes have been flushed to DB otherwise false
+   * @throws IOException
+   */
+  public static boolean areSnapshotChangesFlushedToDB(OMMetadataManager metadataManager, SnapshotInfo snapshotInfo)
+      throws IOException {
+    if (snapshotInfo != null) {
+      TransactionInfo snapshotTransactionInfo = snapshotInfo.getLastTransactionInfo() != null ?
+          TransactionInfo.getCodec().fromPersistedFormat(snapshotInfo.getLastTransactionInfo().toByteArray()) : null;
+      TransactionInfo omTransactionInfo = TransactionInfo.readTransactionInfo(metadataManager, true);
+      return snapshotTransactionInfo == null || omTransactionInfo.compareTo(snapshotTransactionInfo) >= 0;
+    }
+    return false;
+  }
+
 
   /**
    * Returns OmSnapshot object and skips active check.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -694,7 +694,8 @@ public final class OmSnapshotManager implements AutoCloseable {
    * @param metadataManager Metadatamanager of Active OM.
    * @param snapshotInfo table key corresponding to snapshot in snapshotInfoTable, this should be a value from cache
    *                     and not from disk.
-   * @return True if the changes have been flushed to DB otherwise false
+   * @return True if the changes have been flushed to DB otherwise false. It would return true if the snapshot
+   * provided is null meaning the snapshot doesn't exist.
    * @throws IOException
    */
   public static boolean areSnapshotChangesFlushedToDB(OMMetadataManager metadataManager, SnapshotInfo snapshotInfo)
@@ -703,9 +704,10 @@ public final class OmSnapshotManager implements AutoCloseable {
       TransactionInfo snapshotTransactionInfo = snapshotInfo.getLastTransactionInfo() != null ?
           TransactionInfo.fromByteString(snapshotInfo.getLastTransactionInfo()) : null;
       TransactionInfo omTransactionInfo = TransactionInfo.readTransactionInfo(metadataManager);
+      // If transactionInfo field is null then return true to keep things backward compatible.
       return snapshotTransactionInfo == null || omTransactionInfo.compareTo(snapshotTransactionInfo) >= 0;
     }
-    return false;
+    return true;
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -692,8 +692,7 @@ public final class OmSnapshotManager implements AutoCloseable {
   /**
    * Checks if the last transaction performed on the snapshot has been flushed to disk.
    * @param metadataManager Metadatamanager of Active OM.
-   * @param snapshotInfo table key corresponding to snapshot in snapshotInfoTable, this should be a value from cache
-   *                     and not from disk.
+   * @param snapshotInfo SnapshotInfo value.
    * @return True if the changes have been flushed to DB otherwise false. It would return true if the snapshot
    * provided is null meaning the snapshot doesn't exist.
    * @throws IOException

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -702,7 +702,7 @@ public final class OmSnapshotManager implements AutoCloseable {
     if (snapshotInfo != null) {
       TransactionInfo snapshotTransactionInfo = snapshotInfo.getLastTransactionInfo() != null ?
           TransactionInfo.getCodec().fromPersistedFormat(snapshotInfo.getLastTransactionInfo().toByteArray()) : null;
-      TransactionInfo omTransactionInfo = TransactionInfo.readTransactionInfo(metadataManager, true);
+      TransactionInfo omTransactionInfo = TransactionInfo.readTransactionInfo(metadataManager);
       return snapshotTransactionInfo == null || omTransactionInfo.compareTo(snapshotTransactionInfo) >= 0;
     }
     return false;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -701,7 +701,7 @@ public final class OmSnapshotManager implements AutoCloseable {
       throws IOException {
     if (snapshotInfo != null) {
       TransactionInfo snapshotTransactionInfo = snapshotInfo.getLastTransactionInfo() != null ?
-          TransactionInfo.getCodec().fromPersistedFormat(snapshotInfo.getLastTransactionInfo().toByteArray()) : null;
+          TransactionInfo.fromByteString(snapshotInfo.getLastTransactionInfo()) : null;
       TransactionInfo omTransactionInfo = TransactionInfo.readTransactionInfo(metadataManager);
       return snapshotTransactionInfo == null || omTransactionInfo.compareTo(snapshotTransactionInfo) >= 0;
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -150,7 +151,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
         }
       }
       if (fromSnapshotInfo != null) {
-        SnapshotUtils.setTransactionInfoInSnapshot(fromSnapshotInfo, termIndex);
+        fromSnapshotInfo.setLastTransactionInfo(TransactionInfo.valueOf(termIndex).toByteString());
         omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(fromSnapshotInfo.getTableKey()),
             CacheValue.get(termIndex.getIndex(), fromSnapshotInfo));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMDirectoriesPurgeResponseWithFSO;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
 import static org.apache.hadoop.ozone.OzoneConsts.DELETED_HSYNC_KEY;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
@@ -70,8 +71,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
     Map<Pair<String, String>, OmBucketInfo> volBucketInfoMap = new HashMap<>();
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
     Map<String, OmKeyInfo> openKeyInfoMap = new HashMap<>();
-    OzoneManagerProtocolProtos.OMResponse.Builder omResponse =
-        OmResponseUtil.getOMResponseBuilder(getOmRequest());
+
     OMMetrics omMetrics = ozoneManager.getMetrics();
     try {
       if (fromSnapshot != null) {
@@ -169,6 +169,8 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
       }
     }
 
+    OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
+        getOmRequest());
     OMClientResponse omClientResponse = new OMDirectoriesPurgeResponseWithFSO(
         omResponse.build(), purgeRequests, ozoneManager.isRatisEnabled(),
             getBucketLayout(), volBucketInfoMap, fromSnapshotInfo, openKeyInfoMap);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -87,7 +88,7 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
     // services.
     try {
       if (fromSnapshotInfo != null) {
-        SnapshotUtils.setTransactionInfoInSnapshot(fromSnapshotInfo, termIndex);
+        fromSnapshotInfo.setLastTransactionInfo(TransactionInfo.valueOf(termIndex).toByteString());
         omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(fromSnapshotInfo.getTableKey()),
             CacheValue.get(termIndex.getIndex(), fromSnapshotInfo));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -61,6 +64,7 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
     String fromSnapshot = purgeKeysRequest.hasSnapshotTableKey() ?
         purgeKeysRequest.getSnapshotTableKey() : null;
     List<String> keysToBePurgedList = new ArrayList<>();
+    OmMetadataManagerImpl omMetadataManager = (OmMetadataManagerImpl) ozoneManager.getMetadataManager();
 
     OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
         getOmRequest());
@@ -71,17 +75,27 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
         keysToBePurgedList.add(deletedKey);
       }
     }
+    final SnapshotInfo fromSnapshotInfo;
 
     try {
-      SnapshotInfo fromSnapshotInfo = null;
-      if (fromSnapshot != null) {
-        fromSnapshotInfo = SnapshotUtils.getSnapshotInfo(ozoneManager, fromSnapshot);
-      }
-      omClientResponse = new OMKeyPurgeResponse(omResponse.build(),
-          keysToBePurgedList, fromSnapshotInfo, keysToUpdateList);
+      fromSnapshotInfo = fromSnapshot == null ? null : SnapshotUtils.getSnapshotInfo(ozoneManager, fromSnapshot);
     } catch (IOException ex) {
-      omClientResponse = new OMKeyPurgeResponse(createErrorOMResponse(omResponse, ex));
+      return new OMKeyPurgeResponse(createErrorOMResponse(omResponse, ex));
     }
+
+    // Setting transaction info for snapshot, this is to prevent duplicate purge requests to OM from background
+    // services.
+    try {
+      if (fromSnapshotInfo != null) {
+        SnapshotUtils.setTransactionInfoInSnapshot(fromSnapshotInfo, termIndex);
+        omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(fromSnapshotInfo.getTableKey()),
+            CacheValue.get(termIndex.getIndex(), fromSnapshotInfo));
+      }
+    } catch (IOException e) {
+      return new OMKeyPurgeResponse(createErrorOMResponse(omResponse, e));
+    }
+    omClientResponse = new OMKeyPurgeResponse(omResponse.build(), keysToBePurgedList, fromSnapshotInfo,
+        keysToUpdateList);
 
     return omClientResponse;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.ozone.om.request.snapshot;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -167,7 +167,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
           ((RDBStore) omMetadataManager.getStore()).getDb()
               .getLatestSequenceNumber();
       snapshotInfo.setDbTxSequenceNumber(dbLatestSequenceNumber);
-      SnapshotUtils.setTransactionInfoInSnapshot(snapshotInfo, termIndex);
+      snapshotInfo.setLastTransactionInfo(TransactionInfo.valueOf(termIndex).toByteString());
       // Snapshot referenced size should be bucket's used bytes
       OmBucketInfo omBucketInfo =
           getBucketInfo(omMetadataManager, volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotCreateRequest.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.request.snapshot;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -166,7 +167,7 @@ public class OMSnapshotCreateRequest extends OMClientRequest {
           ((RDBStore) omMetadataManager.getStore()).getDb()
               .getLatestSequenceNumber();
       snapshotInfo.setDbTxSequenceNumber(dbLatestSequenceNumber);
-
+      SnapshotUtils.setTransactionInfoInSnapshot(snapshotInfo, termIndex);
       // Snapshot referenced size should be bucket's used bytes
       OmBucketInfo omBucketInfo =
           getBucketInfo(omMetadataManager, volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.ozone.om.request.snapshot;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -90,11 +91,11 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
       List<String> movedDirs = moveDeletedKeysRequest.getDeletedDirsToMoveList();
 
       // Update lastTransactionInfo for fromSnapshot and the nextSnapshot.
-      SnapshotUtils.setTransactionInfoInSnapshot(fromSnapshot, termIndex);
+      fromSnapshot.setLastTransactionInfo(TransactionInfo.valueOf(termIndex).toByteString());
       omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(fromSnapshot.getTableKey()),
           CacheValue.get(termIndex.getIndex(), fromSnapshot));
       if (nextSnapshot != null) {
-        SnapshotUtils.setTransactionInfoInSnapshot(nextSnapshot, termIndex);
+        nextSnapshot.setLastTransactionInfo(TransactionInfo.valueOf(termIndex).toByteString());
         omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(nextSnapshot.getTableKey()),
             CacheValue.get(termIndex.getIndex(), nextSnapshot));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
@@ -20,6 +20,8 @@
 package org.apache.hadoop.ozone.om.request.snapshot;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -82,15 +84,20 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
       nextSnapshot = SnapshotUtils.getNextActiveSnapshot(fromSnapshot, snapshotChainManager, ozoneManager);
 
       // Get next non-deleted snapshot.
-      List<SnapshotMoveKeyInfos> nextDBKeysList =
-          moveDeletedKeysRequest.getNextDBKeysList();
-      List<SnapshotMoveKeyInfos> reclaimKeysList =
-          moveDeletedKeysRequest.getReclaimKeysList();
-      List<HddsProtos.KeyValue> renamedKeysList =
-          moveDeletedKeysRequest.getRenamedKeysList();
-      List<String> movedDirs =
-          moveDeletedKeysRequest.getDeletedDirsToMoveList();
+      List<SnapshotMoveKeyInfos> nextDBKeysList = moveDeletedKeysRequest.getNextDBKeysList();
+      List<SnapshotMoveKeyInfos> reclaimKeysList = moveDeletedKeysRequest.getReclaimKeysList();
+      List<HddsProtos.KeyValue> renamedKeysList = moveDeletedKeysRequest.getRenamedKeysList();
+      List<String> movedDirs = moveDeletedKeysRequest.getDeletedDirsToMoveList();
 
+      // Update lastTransactionInfo for fromSnapshot and the nextSnapshot.
+      SnapshotUtils.setTransactionInfoInSnapshot(fromSnapshot, termIndex);
+      omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(fromSnapshot.getTableKey()),
+          CacheValue.get(termIndex.getIndex(), fromSnapshot));
+      if (nextSnapshot != null) {
+        SnapshotUtils.setTransactionInfoInSnapshot(nextSnapshot, termIndex);
+        omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(nextSnapshot.getTableKey()),
+            CacheValue.get(termIndex.getIndex(), nextSnapshot));
+      }
       omClientResponse = new OMSnapshotMoveDeletedKeysResponse(
           omResponse.build(), fromSnapshot, nextSnapshot,
           nextDBKeysList, reclaimKeysList, renamedKeysList, movedDirs);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -117,7 +118,7 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
       }
 
       for (SnapshotInfo snapshotInfo : updatedSnapshotInfos.values()) {
-        SnapshotUtils.setTransactionInfoInSnapshot(snapshotInfo, termIndex);
+        snapshotInfo.setLastTransactionInfo(TransactionInfo.valueOf(termIndex).toByteString());
         omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(snapshotInfo.getTableKey()),
             CacheValue.get(termIndex.getIndex(), snapshotInfo));
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -110,9 +110,16 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
         updateSnapshotInfoAndCache(nextSnapshot, omMetadataManager, trxnLogIndex);
         // Step 2: Update the snapshot chain.
         updateSnapshotChainAndCache(omMetadataManager, fromSnapshot, trxnLogIndex);
-        // Step 3: Purge the snapshot from SnapshotInfoTable cache.
+        // Step 3: Purge the snapshot from SnapshotInfoTable cache and also remove from the map.
         omMetadataManager.getSnapshotInfoTable()
             .addCacheEntry(new CacheKey<>(fromSnapshot.getTableKey()), CacheValue.get(trxnLogIndex));
+        updatedSnapshotInfos.remove(fromSnapshot.getTableKey());
+      }
+
+      for (SnapshotInfo snapshotInfo : updatedSnapshotInfos.values()) {
+        SnapshotUtils.setTransactionInfoInSnapshot(snapshotInfo, termIndex);
+        omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(snapshotInfo.getTableKey()),
+            CacheValue.get(termIndex.getIndex(), snapshotInfo));
       }
 
       omClientResponse = new OMSnapshotPurgeResponse(omResponse.build(), snapshotDbKeys, updatedSnapshotInfos);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
@@ -48,12 +48,13 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_DIR_TABLE
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DIRECTORY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE;
 
 /**
  * Response for {@link OMDirectoriesPurgeRequestWithFSO} request.
  */
 @CleanupTableInfo(cleanupTables = {DELETED_TABLE, DELETED_DIR_TABLE,
-    DIRECTORY_TABLE, FILE_TABLE})
+    DIRECTORY_TABLE, FILE_TABLE, SNAPSHOT_INFO_TABLE})
 public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoriesPurgeResponseWithFSO.class);
@@ -97,6 +98,7 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
           fromSnapshotStore.commitBatchOperation(writeBatch);
         }
       }
+      metadataManager.getSnapshotInfoTable().putWithBatch(batchOp, fromSnapshotInfo.getTableKey(), fromSnapshotInfo);
     } else {
       processPaths(metadataManager, batchOp);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
@@ -39,12 +39,13 @@ import java.util.List;
 import jakarta.annotation.Nonnull;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE;
 import static org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotMoveDeletedKeysResponse.createRepeatedOmKeyInfo;
 
 /**
  * Response for {@link OMKeyPurgeRequest} request.
  */
-@CleanupTableInfo(cleanupTables = {DELETED_TABLE})
+@CleanupTableInfo(cleanupTables = {DELETED_TABLE, SNAPSHOT_INFO_TABLE})
 public class OMKeyPurgeResponse extends OmKeyResponse {
   private List<String> purgeKeyList;
   private SnapshotInfo fromSnapshot;
@@ -90,6 +91,7 @@ public class OMKeyPurgeResponse extends OmKeyResponse {
           fromSnapshotStore.commitBatchOperation(writeBatch);
         }
       }
+      omMetadataManager.getSnapshotInfoTable().putWithBatch(batchOperation, fromSnapshot.getTableKey(), fromSnapshot);
     } else {
       processKeys(batchOperation, omMetadataManager);
       processKeysToUpdate(batchOperation, omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
@@ -133,6 +133,11 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
       }
     }
 
+    // Flush snapshot info to rocksDB.
+    omMetadataManager.getSnapshotInfoTable().putWithBatch(batchOperation, fromSnapshot.getTableKey(), fromSnapshot);
+    if (nextSnapshot != null) {
+      omMetadataManager.getSnapshotInfoTable().putWithBatch(batchOperation, nextSnapshot.getTableKey(), nextSnapshot);
+    }
   }
 
   private void deleteDirsFromSnapshot(BatchOperation batchOp,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -145,7 +145,7 @@ public final class SnapshotUtils {
    */
   public static void setTransactionInfoInSnapshot(SnapshotInfo snapshot, TermIndex termIndex) throws IOException {
     TransactionInfo transactionInfo = TransactionInfo.valueOf(termIndex);
-    snapshot.setLastTransactionInfo(TransactionInfo.getCodec().toPersistedFormat(transactionInfo));
+    snapshot.setLastTransactionInfo(transactionInfo.toByteString());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.snapshot;
 
-import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -27,7 +26,6 @@ import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus;
-import org.apache.ratis.server.protocol.TermIndex;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
@@ -138,14 +136,6 @@ public final class SnapshotUtils {
           "Snapshot with table key '" + snapInfo.getTableKey() +
           "' is no longer active", FILE_NOT_FOUND);
     }
-  }
-
-  /**
-   * Set transactionInfo in snapshotInfo.
-   */
-  public static void setTransactionInfoInSnapshot(SnapshotInfo snapshot, TermIndex termIndex) throws IOException {
-    TransactionInfo transactionInfo = TransactionInfo.valueOf(termIndex);
-    snapshot.setLastTransactionInfo(transactionInfo.toByteString());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.snapshot;
 
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -26,6 +27,7 @@ import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus;
+import org.apache.ratis.server.protocol.TermIndex;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
@@ -136,6 +138,14 @@ public final class SnapshotUtils {
           "Snapshot with table key '" + snapInfo.getTableKey() +
           "' is no longer active", FILE_NOT_FOUND);
     }
+  }
+
+  /**
+   * Set transactionInfo in snapshotInfo.
+   */
+  public static void setTransactionInfoInSnapshot(SnapshotInfo snapshot, TermIndex termIndex) throws IOException {
+    TransactionInfo transactionInfo = TransactionInfo.valueOf(termIndex);
+    snapshot.setLastTransactionInfo(TransactionInfo.getCodec().toPersistedFormat(transactionInfo));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMDirectoriesPurgeRequestAndResponse.java
@@ -26,18 +26,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.key.OMDirectoriesPurgeResponseWithFSO;
 import org.apache.hadoop.ozone.om.response.key.OMKeyPurgeResponse;
+import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import jakarta.annotation.Nonnull;
@@ -109,7 +114,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
    * Create OMRequest which encapsulates DeleteKeyRequest.
    * @return OMRequest
    */
-  private OMRequest createPurgeKeysRequest(String purgeDeletedDir,
+  private OMRequest createPurgeKeysRequest(String fromSnapshot, String purgeDeletedDir,
       List<OmKeyInfo> keyList, OmBucketInfo bucketInfo) throws IOException {
     List<OzoneManagerProtocolProtos.PurgePathRequest> purgePathRequestList
         = new ArrayList<>();
@@ -127,7 +132,9 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     OzoneManagerProtocolProtos.PurgeDirectoriesRequest.Builder purgeDirRequest =
         OzoneManagerProtocolProtos.PurgeDirectoriesRequest.newBuilder();
     purgeDirRequest.addAllDeletedPath(purgePathRequestList);
-
+    if (fromSnapshot != null) {
+      purgeDirRequest.setSnapshotTableKey(fromSnapshot);
+    }
     OzoneManagerProtocolProtos.OMRequest omRequest =
         OzoneManagerProtocolProtos.OMRequest.newBuilder()
             .setCmdType(OzoneManagerProtocolProtos.Type.PurgeDirectories)
@@ -138,8 +145,7 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
   }
   private OzoneManagerProtocolProtos.PurgePathRequest wrapPurgeRequest(
       final long volumeId, final long bucketId, final String purgeDeletedDir,
-       final List<OmKeyInfo> purgeDeletedFiles,
-      final List<OmKeyInfo> markDirsAsDeleted) {
+      final List<OmKeyInfo> purgeDeletedFiles, final List<OmKeyInfo> markDirsAsDeleted) {
     // Put all keys to be purged in a list
     OzoneManagerProtocolProtos.PurgePathRequest.Builder purgePathsRequest
         = OzoneManagerProtocolProtos.PurgePathRequest.newBuilder();
@@ -182,13 +188,13 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     // Create and Delete keys. The keys should be moved to DeletedKeys table
     List<OmKeyInfo> deletedKeyInfos = createAndDeleteKeys(1, null);
     // The keys should be present in the DeletedKeys table before purging
-    List<String> deletedKeyNames = validateDeletedKeysTable(deletedKeyInfos);
+    List<String> deletedKeyNames = validateDeletedKeysTable(omMetadataManager, deletedKeyInfos, true);
 
     // Create PurgeKeysRequest to purge the deleted keys
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().get(
         bucketKey);
-    OMRequest omRequest = createPurgeKeysRequest(
+    OMRequest omRequest = createPurgeKeysRequest(null,
         null, deletedKeyInfos, omBucketInfo);
     OMRequest preExecutedRequest = preExecute(omRequest);
     OMDirectoriesPurgeRequestWithFSO omKeyPurgeRequest =
@@ -205,7 +211,59 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     performBatchOperationCommit(omClientResponse);
 
     // The keys should exist in the DeletedKeys table after dir delete
-    validateDeletedKeys(deletedKeyNames);
+    validateDeletedKeys(omMetadataManager, deletedKeyNames);
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheSnapshotLastTransactionInfoUpdated() throws Exception {
+    // Create and Delete keys. The keys should be moved to DeletedKeys table
+    List<OmKeyInfo> deletedKeyInfos = createAndDeleteKeys(1, null);
+    // The keys should be present in the DeletedKeys table before purging
+    List<String> deletedKeyNames = validateDeletedKeysTable(omMetadataManager, deletedKeyInfos, true);
+
+    String snapshotName = "snap1";
+    SnapshotInfo snapshotInfo = createSnapshot(snapshotName);
+    ReferenceCounted<OmSnapshot> rcOmSnapshot = ozoneManager.getOmSnapshotManager()
+        .getSnapshot(snapshotInfo.getVolumeName(), snapshotInfo.getBucketName(), snapshotInfo.getName());
+    // Keys should be present in snapshot
+    validateDeletedKeysTable(rcOmSnapshot.get().getMetadataManager(), deletedKeyInfos, true);
+    // keys should have been moved from AOS
+    validateDeletedKeysTable(omMetadataManager, deletedKeyInfos, false);
+
+    // Create PurgeKeysRequest to purge the deleted keys
+    assertEquals(snapshotInfo.getLastTransactionInfo(),
+        TransactionInfo.valueOf(TransactionInfo.getTermIndex(1L)).toByteString());
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().get(
+        bucketKey);
+    OMRequest omRequest = createPurgeKeysRequest(snapshotInfo.getTableKey(),
+        null, deletedKeyInfos, omBucketInfo);
+    OMRequest preExecutedRequest = preExecute(omRequest);
+    OMDirectoriesPurgeRequestWithFSO omKeyPurgeRequest =
+        new OMDirectoriesPurgeRequestWithFSO(preExecutedRequest);
+
+    assertEquals(1000L * deletedKeyNames.size(), omBucketInfo.getUsedBytes());
+    OMDirectoriesPurgeResponseWithFSO omClientResponse
+        = (OMDirectoriesPurgeResponseWithFSO) omKeyPurgeRequest
+        .validateAndUpdateCache(ozoneManager, 100L);
+
+    SnapshotInfo snapshotInfoOnDisk = omMetadataManager.getSnapshotInfoTable().getSkipCache(snapshotInfo.getTableKey());
+    SnapshotInfo updatedSnapshotInfo = omMetadataManager.getSnapshotInfoTable().get(snapshotInfo.getTableKey());
+
+    assertEquals(snapshotInfoOnDisk, snapshotInfo);
+    snapshotInfo.setLastTransactionInfo(TransactionInfo.valueOf(TransactionInfo.getTermIndex(100L))
+        .toByteString());
+    assertEquals(snapshotInfo, updatedSnapshotInfo);
+    omBucketInfo = omMetadataManager.getBucketTable().get(bucketKey);
+    assertEquals(0L * deletedKeyNames.size(), omBucketInfo.getUsedBytes());
+
+    performBatchOperationCommit(omClientResponse);
+
+    // The keys should exist in the DeletedKeys table after dir delete
+    validateDeletedKeys(rcOmSnapshot.get().getMetadataManager(), deletedKeyNames);
+    snapshotInfoOnDisk = omMetadataManager.getSnapshotInfoTable().getSkipCache(snapshotInfo.getTableKey());
+    assertEquals(snapshotInfo, snapshotInfoOnDisk);
+    rcOmSnapshot.close();
   }
 
   @Test
@@ -214,13 +272,13 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     // Create and Delete keys. The keys should be moved to DeletedKeys table
     List<OmKeyInfo> deletedKeyInfos = createAndDeleteKeys(1, null);
     // The keys should be present in the DeletedKeys table before purging
-    List<String> deletedKeyNames = validateDeletedKeysTable(deletedKeyInfos);
+    List<String> deletedKeyNames = validateDeletedKeysTable(omMetadataManager, deletedKeyInfos, true);
 
     // Create PurgeKeysRequest to purge the deleted keys
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable().get(
         bucketKey);
-    OMRequest omRequest = createPurgeKeysRequest(
+    OMRequest omRequest = createPurgeKeysRequest(null,
         null, deletedKeyInfos, omBucketInfo);
     OMRequest preExecutedRequest = preExecute(omRequest);
     OMDirectoriesPurgeRequestWithFSO omKeyPurgeRequest =
@@ -258,35 +316,32 @@ public class TestOMDirectoriesPurgeRequestAndResponse extends TestOMKeyRequest {
     performBatchOperationCommit(omClientResponse);
 
     // The keys should exist in the DeletedKeys table after dir delete
-    validateDeletedKeys(deletedKeyNames);
+    validateDeletedKeys(omMetadataManager, deletedKeyNames);
   }
 
-  private void performBatchOperationCommit(
-      OMDirectoriesPurgeResponseWithFSO omClientResponse) throws IOException {
+  private void performBatchOperationCommit(OMDirectoriesPurgeResponseWithFSO omClientResponse) throws IOException {
     try (BatchOperation batchOperation =
              omMetadataManager.getStore().initBatchOperation()) {
-
       omClientResponse.addToDBBatch(omMetadataManager, batchOperation);
-
       // Do manual commit and see whether addToBatch is successful or not.
       omMetadataManager.getStore().commitBatchOperation(batchOperation);
     }
   }
 
   @Nonnull
-  private List<String> validateDeletedKeysTable(
-      List<OmKeyInfo> deletedKeyInfos) throws IOException {
+  private List<String> validateDeletedKeysTable(OMMetadataManager omMetadataManager,
+      List<OmKeyInfo> deletedKeyInfos, boolean keyExists) throws IOException {
     List<String> deletedKeyNames = new ArrayList<>();
     for (OmKeyInfo deletedKey : deletedKeyInfos) {
       String keyName = omMetadataManager.getOzoneKey(deletedKey.getVolumeName(),
           deletedKey.getBucketName(), deletedKey.getKeyName());
-      assertTrue(omMetadataManager.getDeletedTable().isExist(keyName));
+      assertEquals(omMetadataManager.getDeletedTable().isExist(keyName), keyExists);
       deletedKeyNames.add(keyName);
     }
     return deletedKeyNames;
   }
 
-  private void validateDeletedKeys(
+  private void validateDeletedKeys(OMMetadataManager omMetadataManager,
       List<String> deletedKeyNames) throws IOException {
     for (String deletedKey : deletedKeyNames) {
       assertTrue(omMetadataManager.getDeletedTable().isExist(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -23,12 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotCreateRequest;
-import org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest;
-import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotCreateResponse;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.junit.jupiter.api.Test;
 
@@ -42,12 +40,10 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link OMKeyPurgeRequest} and {@link OMKeyPurgeResponse}.
@@ -115,35 +111,6 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
         .build();
   }
 
-  /**
-   * Create snapshot and checkpoint directory.
-   */
-  private SnapshotInfo createSnapshot(String snapshotName) throws Exception {
-    when(ozoneManager.isAdmin(any())).thenReturn(true);
-    BatchOperation batchOperation = omMetadataManager.getStore()
-        .initBatchOperation();
-    OMRequest omRequest = OMRequestTestUtils
-        .createSnapshotRequest(volumeName, bucketName, snapshotName);
-    // Pre-Execute OMSnapshotCreateRequest.
-    OMSnapshotCreateRequest omSnapshotCreateRequest =
-        TestOMSnapshotCreateRequest.doPreExecute(omRequest, ozoneManager);
-
-    // validateAndUpdateCache OMSnapshotCreateResponse.
-    OMSnapshotCreateResponse omClientResponse = (OMSnapshotCreateResponse)
-        omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 1L);
-    // Add to batch and commit to DB.
-    omClientResponse.addToDBBatch(omMetadataManager, batchOperation);
-    omMetadataManager.getStore().commitBatchOperation(batchOperation);
-    batchOperation.close();
-
-    String key = SnapshotInfo.getTableKey(volumeName,
-        bucketName, snapshotName);
-    SnapshotInfo snapshotInfo =
-        omMetadataManager.getSnapshotInfoTable().get(key);
-    assertNotNull(snapshotInfo);
-    return snapshotInfo;
-  }
-
   private OMRequest preExecute(OMRequest originalOmRequest) throws IOException {
     OMKeyPurgeRequest omKeyPurgeRequest =
         new OMKeyPurgeRequest(originalOmRequest);
@@ -205,6 +172,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     List<String> deletedKeyNames = createAndDeleteKeys(1, null);
 
     SnapshotInfo snapInfo = createSnapshot("snap1");
+    assertEquals(snapInfo.getLastTransactionInfo(),
+        TransactionInfo.valueOf(TransactionInfo.getTermIndex(1L)).toByteString());
     // The keys should be not present in the active Db's deletedTable
     for (String deletedKey : deletedKeyNames) {
       assertFalse(omMetadataManager.getDeletedTable().isExist(deletedKey));
@@ -230,6 +199,12 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
 
     omKeyPurgeRequest.validateAndUpdateCache(ozoneManager, 100L);
 
+    SnapshotInfo snapshotInfoOnDisk = omMetadataManager.getSnapshotInfoTable().getSkipCache(snapInfo.getTableKey());
+    SnapshotInfo updatedSnapshotInfo = omMetadataManager.getSnapshotInfoTable().get(snapInfo.getTableKey());
+    assertEquals(snapshotInfoOnDisk, snapInfo);
+    snapInfo.setLastTransactionInfo(TransactionInfo.valueOf(TransactionInfo.getTermIndex(100L))
+        .toByteString());
+    assertEquals(snapInfo, updatedSnapshotInfo);
     OMResponse omResponse = OMResponse.newBuilder()
         .setPurgeKeysResponse(PurgeKeysResponse.getDefaultInstance())
         .setCmdType(Type.PurgeKeys)
@@ -245,7 +220,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
       // Do manual commit and see whether addToBatch is successful or not.
       omMetadataManager.getStore().commitBatchOperation(batchOperation);
     }
-
+    snapshotInfoOnDisk = omMetadataManager.getSnapshotInfoTable().getSkipCache(snapInfo.getTableKey());
+    assertEquals(snapshotInfoOnDisk, snapInfo);
     // The keys should not exist in the DeletedKeys table
     for (String deletedKey : deletedKeyNames) {
       assertFalse(omSnapshot.getMetadataManager()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.IOmMetadataReader;
 import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
@@ -43,9 +44,15 @@ import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.request.snapshot.OMSnapshotCreateRequest;
+import org.apache.hadoop.ozone.om.request.snapshot.TestOMSnapshotCreateRequest;
+import org.apache.hadoop.ozone.om.response.snapshot.OMSnapshotCreateResponse;
 import org.apache.hadoop.ozone.om.snapshot.ReferenceCounted;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -236,7 +243,7 @@ public class TestOMKeyRequest {
         .thenReturn(bucket);
     when(ozoneManager.resolveBucketLink(any(Pair.class)))
         .thenReturn(bucket);
-    OmSnapshotManager omSnapshotManager = new OmSnapshotManager(ozoneManager);
+    OmSnapshotManager omSnapshotManager = Mockito.spy(new OmSnapshotManager(ozoneManager));
     when(ozoneManager.getOmSnapshotManager())
         .thenReturn(omSnapshotManager);
 
@@ -284,4 +291,34 @@ public class TestOMKeyRequest {
     omMetrics.unRegister();
     framework().clearInlineMocks();
   }
+
+  /**
+   * Create snapshot and checkpoint directory.
+   */
+  protected SnapshotInfo createSnapshot(String snapshotName) throws Exception {
+    when(ozoneManager.isAdmin(any())).thenReturn(true);
+    BatchOperation batchOperation = omMetadataManager.getStore()
+        .initBatchOperation();
+    OzoneManagerProtocolProtos.OMRequest omRequest = OMRequestTestUtils
+        .createSnapshotRequest(volumeName, bucketName, snapshotName);
+    // Pre-Execute OMSnapshotCreateRequest.
+    OMSnapshotCreateRequest omSnapshotCreateRequest =
+        TestOMSnapshotCreateRequest.doPreExecute(omRequest, ozoneManager);
+
+    // validateAndUpdateCache OMSnapshotCreateResponse.
+    OMSnapshotCreateResponse omClientResponse = (OMSnapshotCreateResponse)
+        omSnapshotCreateRequest.validateAndUpdateCache(ozoneManager, 1L);
+    // Add to batch and commit to DB.
+    omClientResponse.addToDBBatch(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+    batchOperation.close();
+
+    String key = SnapshotInfo.getTableKey(volumeName,
+        bucketName, snapshotName);
+    SnapshotInfo snapshotInfo =
+        omMetadataManager.getSnapshotInfoTable().get(key);
+    assertNotNull(snapshotInfo);
+    return snapshotInfo;
+  }
+
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/snapshot/TestOMSnapshotCreateRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.snapshot;
 
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -229,7 +230,8 @@ public class TestOMSnapshotCreateRequest {
         omMetadataManager.getSnapshotInfoTable().get(key);
     assertNotNull(snapshotInfoInCache);
     assertEquals(snapshotInfoFromProto, snapshotInfoInCache);
-
+    assertEquals(snapshotInfoInCache.getLastTransactionInfo(),
+        TransactionInfo.valueOf(TransactionInfo.getTermIndex(1L)).toByteString());
     assertEquals(0, omMetrics.getNumSnapshotCreateFails());
     assertEquals(1, omMetrics.getNumSnapshotActive());
     assertEquals(1, omMetrics.getNumSnapshotCreates());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/snapshot/TestOMSnapshotCreateResponse.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -98,7 +99,8 @@ public class TestOMSnapshotCreateResponse {
         snapshotName,
         snapshotId,
         Time.now());
-
+    snapshotInfo.setLastTransactionInfo(
+        TransactionInfo.valueOf(TransactionInfo.getTermIndex(1L)).toByteString());
     // confirm table is empty
     assertEquals(0, omMetadataManager
         .countRowsInTable(omMetadataManager.getSnapshotInfoTable()));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotInfo.java
@@ -135,7 +135,7 @@ public class TestSnapshotInfo {
     // Checking if changes have been flushed when lastTransactionInfo is null
     assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, info));
     TermIndex termIndex = TermIndex.valueOf(1, 1);
-    SnapshotUtils.setTransactionInfoInSnapshot(info, termIndex);
+    info.setLastTransactionInfo(TransactionInfo.valueOf(termIndex).toByteString());
     // Checking if changes to snapshot object has been updated but not updated on cache or disk.
     assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, EXPECTED_SNAPSHOT_KEY));
     snapshotInfo.addCacheEntry(new CacheKey<>(EXPECTED_SNAPSHOT_KEY), CacheValue.get(termIndex.getIndex(), info));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotInfo.java
@@ -19,12 +19,18 @@
 package org.apache.hadoop.ozone.om.snapshot;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo.SnapshotStatus;
 import org.apache.hadoop.util.Time;
+import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -113,5 +119,43 @@ public class TestSnapshotInfo {
     info.setSstFiltered(true);
     snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, info);
     assertTrue(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).isSstFiltered());
+  }
+
+  @Test
+  public void testLastTransactionInfo() throws Exception {
+    Table<String, SnapshotInfo> snapshotInfo =
+        omMetadataManager.getSnapshotInfoTable();
+    SnapshotInfo info = createSnapshotInfo();
+    snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, info);
+    assertEquals(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).getLastTransactionInfo(), null);
+    omMetadataManager.getTransactionInfoTable().put(OzoneConsts.TRANSACTION_INFO_KEY, TransactionInfo.valueOf(0, 0));
+    // Checking if changes have been flushed when lastTransactionInfo is null
+    assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, info));
+    TermIndex termIndex = TermIndex.valueOf(1, 1);
+    SnapshotUtils.setTransactionInfoInSnapshot(info, termIndex);
+    // Checking if changes to snapshot object has been updated but not updated on cache or disk.
+    assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, EXPECTED_SNAPSHOT_KEY));
+    snapshotInfo.addCacheEntry(new CacheKey<>(EXPECTED_SNAPSHOT_KEY), CacheValue.get(termIndex.getIndex(), info));
+
+    assertEquals(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).getLastTransactionInfo(), info.getLastTransactionInfo());
+
+    // Checking if changes have not been flushed when snapshot last transaction info is behind OmTransactionTable value.
+    assertFalse(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, EXPECTED_SNAPSHOT_KEY));
+    omMetadataManager.getTransactionInfoTable().addCacheEntry(new CacheKey<>(OzoneConsts.TRANSACTION_INFO_KEY),
+        CacheValue.get(termIndex.getIndex(), TransactionInfo.valueOf(1, 1)));
+    assertFalse(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, EXPECTED_SNAPSHOT_KEY));
+
+    // Checking changes are flushed when transaction is equal.
+    omMetadataManager.getTransactionInfoTable().put(OzoneConsts.TRANSACTION_INFO_KEY,
+        TransactionInfo.valueOf(1, 1));
+
+
+    assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, EXPECTED_SNAPSHOT_KEY));
+    // Checking changes are flushed when transactionIndex is greater .
+    omMetadataManager.getTransactionInfoTable().put(OzoneConsts.TRANSACTION_INFO_KEY, TransactionInfo.valueOf(1, 2));
+    assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, EXPECTED_SNAPSHOT_KEY));
+    // Checking changes are flushed when both term & transactionIndex is greater.
+    omMetadataManager.getTransactionInfoTable().put(OzoneConsts.TRANSACTION_INFO_KEY, TransactionInfo.valueOf(2, 2));
+    assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, EXPECTED_SNAPSHOT_KEY));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotInfo.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -127,7 +128,9 @@ public class TestSnapshotInfo {
         omMetadataManager.getSnapshotInfoTable();
     SnapshotInfo info = createSnapshotInfo();
     snapshotInfo.put(EXPECTED_SNAPSHOT_KEY, info);
-    assertEquals(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).getLastTransactionInfo(), null);
+    assertNull(snapshotInfo.get(EXPECTED_SNAPSHOT_KEY).getLastTransactionInfo());
+    // checking if true value is returned when snapshot is null.
+    assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, (SnapshotInfo)null));
     omMetadataManager.getTransactionInfoTable().put(OzoneConsts.TRANSACTION_INFO_KEY, TransactionInfo.valueOf(0, 0));
     // Checking if changes have been flushed when lastTransactionInfo is null
     assertTrue(OmSnapshotManager.areSnapshotChangesFlushedToDB(omMetadataManager, info));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a lastTransactionInfo field in SnapshotInfo to check for transactions in flight on the snapshot. This field can be compared against OMTransactionInfo table value to see if all transactions have been flushed to disk. We need this since all tables don't have a cache which could lead to wrong results when an iterator is initialized by a background service if all the transactions haven't been flushed to disk.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11440

## How was this patch tested?
Added unit test to test serialization and deserialization and also testing the allied util functions.