### PR TITLE
HDDS-11441. ozone sh key put should only accept positive expectedGeneration

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell_tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell_tests.robot
@@ -56,3 +56,11 @@ Compare Key With Local File with Different File
 Compare Key With Local File if File Does Not Exist
     ${matches} =                Compare Key With Local File     o3://${OM_SERVICE_ID}/vol1/bucket/passwd    /no-such-file
     Should Be Equal             ${matches}     ${FALSE}
+
+Rejects Put Key With Zero Expected Generation
+    ${output} =     Execute and checkrc    ozone sh key put --expectedGeneration 0 o3://${OM_SERVICE_ID}/vol1/bucket/passwd /etc/passwd    255
+    Should Contain    ${output}    must be positive
+
+Rejects Put Key With Negative Expected Generation
+    ${output} =     Execute and checkrc    ozone sh key put --expectedGeneration -1 o3://${OM_SERVICE_ID}/vol1/bucket/passwd /etc/passwd    255
+    Should Contain    ${output}    must be positive


### PR DESCRIPTION
## What changes were proposed in this pull request?

Passing zero or negative `--expectedGeneration` values, `ozone sh key put` performs regular "put key" operation, not atomic rewrite.  To prevent confusion, we should reject such values.  For non-rewrite "put key" the option must be omitted.

https://issues.apache.org/jira/browse/HDDS-11441

## How was this patch tested?

Added Robot test case.

CI:
https://github.com/adoroszlai/ozone/actions/runs/10792841435