### PR TITLE
HDDS-11438. Ensure DataInputBuffer is closed in OMPBHelper#convert

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -253,7 +253,8 @@ public final class OMPBHelper {
     } catch (IOException e) {
       throw new RuntimeException(e);
     } finally {
-      buffer.close();
+        assert buffer != null;
+        buffer.close();
     }
 
     int offset = Integer.BYTES + Long.BYTES;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -242,19 +242,12 @@ public final class OMPBHelper {
     DataOutputBuffer buf = new DataOutputBuffer();
     checksum.write(buf);
     byte[] bytes = buf.getData();
-    DataInputBuffer buffer = null;
     int bytesPerCRC;
     long crcPerBlock;
-    try {
-      buffer = new DataInputBuffer();
+    try (DataInputBuffer buffer = new DataInputBuffer()) {
       buffer.reset(bytes, 0, bytes.length);
       bytesPerCRC = buffer.readInt();
       crcPerBlock = buffer.readLong();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    } finally {
-      assert buffer != null;
-      buffer.close();
     }
 
     int offset = Integer.BYTES + Long.BYTES;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -253,8 +253,8 @@ public final class OMPBHelper {
     } catch (IOException e) {
       throw new RuntimeException(e);
     } finally {
-        assert buffer != null;
-        buffer.close();
+      assert buffer != null;
+      buffer.close();
     }
 
     int offset = Integer.BYTES + Long.BYTES;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -242,11 +242,19 @@ public final class OMPBHelper {
     DataOutputBuffer buf = new DataOutputBuffer();
     checksum.write(buf);
     byte[] bytes = buf.getData();
-    DataInputBuffer buffer = new DataInputBuffer();
-    buffer.reset(bytes, 0, bytes.length);
-    int bytesPerCRC = buffer.readInt();
-    long crcPerBlock = buffer.readLong();
-    buffer.close();
+    DataInputBuffer buffer = null;
+    int bytesPerCRC;
+    long crcPerBlock;
+    try {
+      buffer = new DataInputBuffer();
+      buffer.reset(bytes, 0, bytes.length);
+      bytesPerCRC = buffer.readInt();
+      crcPerBlock = buffer.readLong();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } finally {
+      buffer.close();
+    }
 
     int offset = Integer.BYTES + Long.BYTES;
     ByteString byteString = ByteString.copyFrom(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Connections, streams, files, and other classes that implement the Closeable interface or its super-interface, AutoCloseable, needs to be closed after use. Further, that close call must be made in a finally block otherwise an exception could keep the call from being made.
This change ensures that the DataInputBuffer and its close call is closed in a finally clause.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11438
## How was this patch tested?
This is a trivial change, so no testing was deemed necessary.
