### PR TITLE
HDDS-10411. Support incremental ChunkBuffer checksum calculation

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -182,8 +182,8 @@ public class OzoneClientConfig {
   // TODO: Re-evaluate if this need to be exposed to end-users at all, e.g. to avoid confusion.
   @Config(key = "chunk.checksum.cache.enabled",
       defaultValue = "true",  // TODO: false by default?
-      description = "Increase client-side chunk checksum calculation efficiency in certain cases " +
-          "by caching previously computed checksums in the same block chunk.",
+      description = "Increase client-side chunk checksum calculation efficiency when incremental chunk list is " +
+          "enabled by caching previously computed checksums in the same block chunk.",
       tags = ConfigTag.CLIENT)
   private boolean chunkChecksumCacheEnabled = true;
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -156,7 +156,7 @@ public class OzoneClientConfig {
       description =
           "Indicates the time duration in seconds a client will wait "
               + "before retrying a read key request on encountering "
-              + "a connectivity excepetion from Datanodes . "
+              + "a connectivity exception from Datanodes. "
               + "By default the interval is 1 second",
       tags = ConfigTag.CLIENT)
   private int readRetryInterval = 1;
@@ -178,7 +178,14 @@ public class OzoneClientConfig {
       tags = { ConfigTag.CLIENT, ConfigTag.CRYPTO_COMPLIANCE })
   private int bytesPerChecksum = 16 * 1024;
 
-  // TODO: Add block chunk checksum cache client option
+  // Client-side block chunk checksum cache config
+  // TODO: Re-evaluate if this need to be exposed to end-users at all, e.g. to avoid confusion.
+  @Config(key = "chunk.checksum.cache.enabled",
+      defaultValue = "true",  // TODO: false by default?
+      description = "Increase client-side chunk checksum calculation efficiency in certain cases " +
+          "by caching previously computed checksums in the same block chunk.",
+      tags = ConfigTag.CLIENT)
+  private boolean chunkChecksumCacheEnabled = true;
 
   @Config(key = "verify.checksum",
       defaultValue = "true",
@@ -449,6 +456,14 @@ public class OzoneClientConfig {
 
   public void setBytesPerChecksum(int bytesPerChecksum) {
     this.bytesPerChecksum = bytesPerChecksum;
+  }
+
+  public boolean isChunkChecksumCacheEnabled() {
+    return chunkChecksumCacheEnabled;
+  }
+
+  public void setChunkChecksumCacheEnabled(boolean chunkChecksumCacheEnabled) {
+    this.chunkChecksumCacheEnabled = chunkChecksumCacheEnabled;
   }
 
   public boolean isChecksumVerify() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -178,6 +178,8 @@ public class OzoneClientConfig {
       tags = { ConfigTag.CLIENT, ConfigTag.CRYPTO_COMPLIANCE })
   private int bytesPerChecksum = 16 * 1024;
 
+  // TODO: Add block chunk checksum cache client option
+
   @Config(key = "verify.checksum",
       defaultValue = "true",
       description = "Ozone client to verify checksum of the checksum "

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -178,15 +178,6 @@ public class OzoneClientConfig {
       tags = { ConfigTag.CLIENT, ConfigTag.CRYPTO_COMPLIANCE })
   private int bytesPerChecksum = 16 * 1024;
 
-  // Client-side block chunk checksum cache config
-  // TODO: Re-evaluate if this need to be exposed to end-users at all, e.g. to avoid confusion.
-  @Config(key = "chunk.checksum.cache.enabled",
-      defaultValue = "true",  // TODO: false by default?
-      description = "Increase client-side chunk checksum calculation efficiency when incremental chunk list is " +
-          "enabled by caching previously computed checksums in the same block chunk.",
-      tags = ConfigTag.CLIENT)
-  private boolean chunkChecksumCacheEnabled = true;
-
   @Config(key = "verify.checksum",
       defaultValue = "true",
       description = "Ozone client to verify checksum of the checksum "
@@ -456,14 +447,6 @@ public class OzoneClientConfig {
 
   public void setBytesPerChecksum(int bytesPerChecksum) {
     this.bytesPerChecksum = bytesPerChecksum;
-  }
-
-  public boolean isChunkChecksumCacheEnabled() {
-    return chunkChecksumCacheEnabled;
-  }
-
-  public void setChunkChecksumCacheEnabled(boolean chunkChecksumCacheEnabled) {
-    this.chunkChecksumCacheEnabled = chunkChecksumCacheEnabled;
   }
 
   public boolean isChecksumVerify() {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -1047,9 +1047,11 @@ public class BlockOutputStream extends OutputStream {
           lastChunkBuffer.capacity() - lastChunkBuffer.position();
       appendLastChunkBuffer(chunk, 0, remainingBufferSize);
       updateBlockDataWithLastChunkBuffer();
-//      checksum.clearChecksumCache();  // New chunk, clear the checksum cache
+
+      // New chunk, need to clear checksum cache
+      checksum.clearChecksumCache();
       // TODO: Can make the cache impl a bit more robust by associating ChecksumCache with ChunkBuffer/ByteBuffer rather
-      //  than the Checksum object.
+      //  than the Checksum object?
       appendLastChunkBuffer(chunk, remainingBufferSize,
           chunk.remaining() - remainingBufferSize);
     }
@@ -1066,10 +1068,10 @@ public class BlockOutputStream extends OutputStream {
     LOG.debug("lastChunkInfo = {}", lastChunkInfo);
     long lastChunkSize = lastChunkInfo.getLen();
     addToBlockData(lastChunkInfo);
-
+    // This sets ByteBuffer limit to capacity, pos to 0. Does NOT erase data
+    // TODO: This could be put inside createChunkInfo() to be more clear.
     lastChunkBuffer.clear();
-    // Clear checksum cache associated with lastChunkBuffer? TODO: Double check
-    checksum.clearChecksumCache();
+
     if (lastChunkSize == config.getStreamBufferSize()) {
       lastChunkOffset += config.getStreamBufferSize();
     } else {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -1045,8 +1045,7 @@ public class BlockOutputStream extends OutputStream {
           lastChunkBuffer.capacity() - lastChunkBuffer.position();
       appendLastChunkBuffer(chunk, 0, remainingBufferSize);
       updateBlockDataWithLastChunkBuffer();
-      // TODO: Can make the cache impl a bit more robust by associating ChecksumCache with ChunkBuffer/ByteBuffer rather
-      //  than the Checksum object?
+      // TODO: Optional refactoring: Can attach ChecksumCache to lastChunkBuffer rather than Checksum
       appendLastChunkBuffer(chunk, remainingBufferSize,
           chunk.remaining() - remainingBufferSize);
     }
@@ -1063,8 +1062,7 @@ public class BlockOutputStream extends OutputStream {
     LOG.debug("lastChunkInfo = {}", lastChunkInfo);
     long lastChunkSize = lastChunkInfo.getLen();
     addToBlockData(lastChunkInfo);
-    // This sets ByteBuffer limit to capacity, pos to 0. Does NOT erase data
-    // TODO: This could be put inside createChunkInfo() to be more clear.
+    // Set ByteBuffer limit to capacity, pos to 0. Does not erase data
     lastChunkBuffer.clear();
 
     if (lastChunkSize == config.getStreamBufferSize()) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -1047,7 +1047,7 @@ public class BlockOutputStream extends OutputStream {
           lastChunkBuffer.capacity() - lastChunkBuffer.position();
       appendLastChunkBuffer(chunk, 0, remainingBufferSize);
       updateBlockDataWithLastChunkBuffer();
-      checksum.clearChecksumCache();  // New chunk, clear the checksum cache
+//      checksum.clearChecksumCache();  // New chunk, clear the checksum cache
       // TODO: Can make the cache impl a bit more robust by associating ChecksumCache with ChunkBuffer/ByteBuffer rather
       //  than the Checksum object.
       appendLastChunkBuffer(chunk, remainingBufferSize,
@@ -1068,8 +1068,8 @@ public class BlockOutputStream extends OutputStream {
     addToBlockData(lastChunkInfo);
 
     lastChunkBuffer.clear();
-    // Clear checksum cache associated with lastChunkBuffer? not the right place. TODO: REMOVE THIS
-//    checksum.clearChecksumCache();
+    // Clear checksum cache associated with lastChunkBuffer? TODO: Double check
+    checksum.clearChecksumCache();
     if (lastChunkSize == config.getStreamBufferSize()) {
       lastChunkOffset += config.getStreamBufferSize();
     } else {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -1047,9 +1047,6 @@ public class BlockOutputStream extends OutputStream {
           lastChunkBuffer.capacity() - lastChunkBuffer.position();
       appendLastChunkBuffer(chunk, 0, remainingBufferSize);
       updateBlockDataWithLastChunkBuffer();
-
-      // New chunk, need to clear checksum cache
-      checksum.clearChecksumCache();
       // TODO: Can make the cache impl a bit more robust by associating ChecksumCache with ChunkBuffer/ByteBuffer rather
       //  than the Checksum object?
       appendLastChunkBuffer(chunk, remainingBufferSize,
@@ -1074,6 +1071,8 @@ public class BlockOutputStream extends OutputStream {
 
     if (lastChunkSize == config.getStreamBufferSize()) {
       lastChunkOffset += config.getStreamBufferSize();
+      // Reached stream buffer size (chunk size), starting new chunk, need to clear checksum cache
+      checksum.clearChecksumCache();
     } else {
       lastChunkBuffer.position((int) lastChunkSize);
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -1040,6 +1040,7 @@ public class BlockOutputStream extends OutputStream {
           lastChunkBuffer.capacity() - lastChunkBuffer.position();
       appendLastChunkBuffer(chunk, 0, remainingBufferSize);
       updateBlockDataWithLastChunkBuffer();
+      checksum.clearChecksumCache();  // New chunk, clear the checksum cache
       appendLastChunkBuffer(chunk, remainingBufferSize,
           chunk.remaining() - remainingBufferSize);
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -102,7 +102,8 @@ public class Checksum {
   private final ChecksumType checksumType;
   private final int bytesPerChecksum;
   /**
-   * TODO: Make sure to clear this cache when a new block chunk is started.
+   * Caches computeChecksum() result when requested.
+   * This must be manually cleared when a new block chunk has been started.
    */
   private final ChecksumCache checksumCache;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
@@ -79,7 +79,7 @@ public class ChecksumCache {
 
     // Start of the checksum index that need to be (re)computed
     final int ciStart = prevChunkLength / bytesPerChecksum;
-    final int ciEnd = currChunkLength / bytesPerChecksum;
+    final int ciEnd = currChunkLength / bytesPerChecksum + (currChunkLength % bytesPerChecksum == 0 ? 0 : 1);
     int i = 0;
     for (ByteBuffer b : data.iterate(bytesPerChecksum)) {
       if (i < ciStart) {
@@ -104,8 +104,8 @@ public class ChecksumCache {
     }
 
     // Sanity check
-    if (i - 1 != ciEnd) {
-      throw new IllegalStateException("Checksum index end does not match expectation");
+    if (i != ciEnd) {
+      throw new IllegalStateException("ChecksumCache: Checksum index end does not match expectation");
     }
 
     // Update last written index

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
@@ -46,6 +46,7 @@ public class ChecksumCache {
   private static final int BLOCK_CHUNK_SIZE = 4 * 1024 * 1024; // 4 MB
 
   public ChecksumCache(int bytesPerChecksum) {
+    LOG.info("Initializing ChecksumCache with bytesPerChecksum = {}", bytesPerChecksum);
     this.prevChunkLength = 0;
     this.bytesPerChecksum = bytesPerChecksum;
     // Set initialCapacity to avoid costly resizes
@@ -93,7 +94,7 @@ public class ChecksumCache {
         continue;
       }
 
-      // i can either point to:
+      // variable i can either point to:
       // 1. the last element in the list -- in which case the checksum needs to be updated
       // 2. one after the last element   -- in which case a new checksum needs to be added
       assert i == checksums.size() - 1 || i == checksums.size();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.common;
+
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Cache previous checksums to avoid recomputing them.
+ * This is a stop-gap solution to reduce checksum calc overhead inside critical section
+ * without having to do a major refactoring/overhaul over protobuf and interfaces.
+ * This is only supposed to be used by BlockOutputStream, for now.
+ * <p>
+ * Each BlockOutputStream has its own Checksum instance.
+ * Each block chunk (4 MB default) is divided into 16 KB (default) each for checksum calculation.
+ * For CRC32/CRC32C, each checksum takes 4 bytes. Thus each block chunk has 4 MB / 16 KB * 4 B = 1 KB of checksum data.
+ */
+public class ChecksumCache {
+  public static final Logger LOG = LoggerFactory.getLogger(ChecksumCache.class);
+
+  private final int bytesPerChecksum;
+  private final List<ByteString> checksums;
+  // Chunk length last time the checksum is computed
+  private int prevChunkLength;
+  // This only serves as a hint for array list initial allocation. The array list will still grow as needed.
+  private static final int BLOCK_CHUNK_SIZE = 4 * 1024 * 1024; // 4 MB
+
+  public ChecksumCache(int bytesPerChecksum) {
+    this.prevChunkLength = 0;
+    this.bytesPerChecksum = bytesPerChecksum;
+    // Set initialCapacity to avoid costly resizes
+    this.checksums = new ArrayList<>(BLOCK_CHUNK_SIZE / bytesPerChecksum);
+  }
+
+  /**
+   * Clear cached checksums. And reset the written index.
+   */
+  public void clear() {
+    prevChunkLength = 0;
+    checksums.clear();
+  }
+
+  public List<ByteString> getChecksums() {
+    return checksums;
+  }
+
+  public List<ByteString> computeChecksum(ChunkBuffer data, Function<ByteBuffer, ByteString> function) {
+    // Indicates how much data the current chunk buffer holds
+    final int currChunkLength = data.limit();
+
+    // Sanity check
+    if (currChunkLength <= prevChunkLength) {
+      // If currChunkLength <= lastChunkLength, it indicates a bug that needs to be addressed.
+      // It means BOS has not properly clear()ed the cache when a new chunk is started in that code path.
+      throw new IllegalArgumentException("ChunkBuffer data limit must be larger than the last time");
+    }
+
+    // One or more checksums need to be computed
+
+    // Start of the checksum index that need to be (re)computed
+    final int ciStart = prevChunkLength / bytesPerChecksum;
+    final int ciEnd = currChunkLength / bytesPerChecksum;
+    int i = 0;
+    for (ByteBuffer b : data.iterate(bytesPerChecksum)) {
+      if (i < ciStart) {
+        i++;
+        continue;
+      }
+
+      // i can either point to:
+      // 1. the last element in the list -- in which case the checksum needs to be updated
+      // 2. one after the last element   -- in which case a new checksum needs to be added
+      assert i == checksums.size() - 1 || i == checksums.size();
+
+      // TODO: Furthermore for CRC32/CRC32C, it can be even more efficient by updating the last checksum byte-by-byte.
+      final ByteString checksum = Checksum.computeChecksum(b, function, bytesPerChecksum);
+      if (i == checksums.size()) {
+        checksums.add(checksum);
+      } else {
+        checksums.set(i, checksum);
+      }
+
+      i++;
+    }
+
+    // Sanity check
+    if (i - 1 != ciEnd) {
+      throw new IllegalStateException("Checksum index end does not match expectation");
+    }
+
+    // Update last written index
+    prevChunkLength = currChunkLength;
+    return checksums;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumCache.java
@@ -68,11 +68,17 @@ public class ChecksumCache {
     // Indicates how much data the current chunk buffer holds
     final int currChunkLength = data.limit();
 
+    if (currChunkLength == prevChunkLength) {
+      LOG.debug("ChunkBuffer data limit same as last time ({}). No new checksums need to be computed", prevChunkLength);
+      return checksums;
+    }
+
     // Sanity check
-    if (currChunkLength <= prevChunkLength) {
+    if (currChunkLength < prevChunkLength) {
       // If currChunkLength <= lastChunkLength, it indicates a bug that needs to be addressed.
       // It means BOS has not properly clear()ed the cache when a new chunk is started in that code path.
-      throw new IllegalArgumentException("ChunkBuffer data limit must be larger than the last time");
+      throw new IllegalArgumentException("ChunkBuffer data limit (" + currChunkLength + ")" +
+          " must not be smaller than last time (" + prevChunkLength + ")");
     }
 
     // One or more checksums need to be computed

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
@@ -39,7 +39,7 @@ public class TestChecksum {
     if (type == null) {
       type = CHECKSUM_TYPE_DEFAULT;
     }
-    return new Checksum(type, BYTES_PER_CHECKSUM);
+    return new Checksum(type, BYTES_PER_CHECKSUM, true);
   }
 
   /**

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
@@ -19,7 +19,10 @@ package org.apache.hadoop.ozone.common;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.ByteBuffer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,25 +38,25 @@ public class TestChecksum {
   private static final ContainerProtos.ChecksumType CHECKSUM_TYPE_DEFAULT =
       ContainerProtos.ChecksumType.SHA256;
 
-  private Checksum getChecksum(ContainerProtos.ChecksumType type) {
+  private Checksum getChecksum(ContainerProtos.ChecksumType type, boolean allowChecksumCache) {
     if (type == null) {
       type = CHECKSUM_TYPE_DEFAULT;
     }
-    return new Checksum(type, BYTES_PER_CHECKSUM, true);
+    return new Checksum(type, BYTES_PER_CHECKSUM, allowChecksumCache);
   }
-
-  // TODO: Parameterize all test cases: useChecksumCache = [true, false]
 
   /**
    * Tests {@link Checksum#verifyChecksum(byte[], ChecksumData)}.
    */
-  @Test
-  public void testVerifyChecksum() throws Exception {
-    Checksum checksum = getChecksum(null);
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testVerifyChecksum(boolean useChecksumCache) throws Exception {
+    Checksum checksum = getChecksum(null, useChecksumCache);
     int dataLen = 55;
     byte[] data = RandomStringUtils.randomAlphabetic(dataLen).getBytes(UTF_8);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(data);
 
-    ChecksumData checksumData = checksum.computeChecksum(data);
+    ChecksumData checksumData = checksum.computeChecksum(byteBuffer, useChecksumCache);
 
     // A checksum is calculate for each bytesPerChecksum number of bytes in
     // the data. Since that value is 10 here and the data length is 55, we
@@ -67,11 +70,13 @@ public class TestChecksum {
   /**
    * Tests that if data is modified, then the checksums should not match.
    */
-  @Test
-  public void testIncorrectChecksum() throws Exception {
-    Checksum checksum = getChecksum(null);
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testIncorrectChecksum(boolean useChecksumCache) throws Exception {
+    Checksum checksum = getChecksum(null, useChecksumCache);
     byte[] data = RandomStringUtils.randomAlphabetic(55).getBytes(UTF_8);
-    ChecksumData originalChecksumData = checksum.computeChecksum(data);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(data);
+    ChecksumData originalChecksumData = checksum.computeChecksum(byteBuffer, useChecksumCache);
 
     // Change the data and check if new checksum matches the original checksum.
     // Modifying one byte of data should be enough for the checksum data to
@@ -85,13 +90,14 @@ public class TestChecksum {
    * Tests that checksum calculated using two different checksumTypes should
    * not match.
    */
-  @Test
-  public void testChecksumMismatchForDifferentChecksumTypes() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testChecksumMismatchForDifferentChecksumTypes(boolean useChecksumCache) {
     // Checksum1 of type SHA-256
-    Checksum checksum1 = getChecksum(null);
+    Checksum checksum1 = getChecksum(null, useChecksumCache);
 
     // Checksum2 of type CRC32
-    Checksum checksum2 = getChecksum(ContainerProtos.ChecksumType.CRC32);
+    Checksum checksum2 = getChecksum(ContainerProtos.ChecksumType.CRC32, useChecksumCache);
 
     // The two checksums should not match as they have different types
     assertNotEquals(checksum1, checksum2, "Checksums should not match for different checksum types");

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
@@ -42,6 +42,8 @@ public class TestChecksum {
     return new Checksum(type, BYTES_PER_CHECKSUM, true);
   }
 
+  // TODO: Parameterize all test cases: useChecksumCache = [true, false]
+
   /**
    * Tests {@link Checksum#verifyChecksum(byte[], ChecksumData)}.
    */

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.common;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
+import org.apache.hadoop.ozone.common.Checksum.Algorithm;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Test class for {@link ChecksumCache}.
+ */
+class TestChecksumCache {
+  public static final Logger LOG = LoggerFactory.getLogger(TestChecksumCache.class);
+
+  @ParameterizedTest
+  @EnumSource(ChecksumType.class)
+  void testComputeChecksum(ChecksumType checksumType) throws Exception {
+    final int bytesPerChecksum = 16;
+    ChecksumCache checksumCache = new ChecksumCache(bytesPerChecksum);
+
+    final int size = 66;
+    byte[] byteArray = new byte[size];
+    // Fill byteArray with bytes from 0 to 127 for deterministic testing
+    for (int i = 0; i < size; i++) {
+      byteArray[i] = (byte) (i % 128);
+    }
+
+    final Function<ByteBuffer, ByteString> function = Algorithm.valueOf(checksumType).newChecksumFunction();
+
+    int i_end = size / bytesPerChecksum + (size % bytesPerChecksum == 0 ? 0 : 1);
+    List<ByteString> lastRes = null;
+    for (int i = 0; i < i_end; i++) {
+      int byteBufferLength = Integer.min(byteArray.length, bytesPerChecksum * (i + 1));
+      ByteBuffer byteBuffer = ByteBuffer.wrap(byteArray, 0, byteBufferLength);
+
+      try (ChunkBuffer chunkBuffer = ChunkBuffer.wrap(byteBuffer.asReadOnlyBuffer())) {
+        List<ByteString> res = checksumCache.computeChecksum(chunkBuffer, function);
+        System.out.println(res);
+        // Verify that every entry in the res list except the last one is the same as the lastRes list
+        if (i > 0) {
+          for (int j = 0; j < res.size() - 1; j++) {
+            Assertions.assertEquals(lastRes.get(j), res.get(j));
+          }
+        }
+        lastRes = res;
+      }
+    }
+
+    // Sanity check
+    checksumCache.clear();
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
@@ -50,9 +50,9 @@ class TestChecksumCache {
 
     final Function<ByteBuffer, ByteString> function = Algorithm.valueOf(checksumType).newChecksumFunction();
 
-    int i_end = size / bytesPerChecksum + (size % bytesPerChecksum == 0 ? 0 : 1);
+    int iEnd = size / bytesPerChecksum + (size % bytesPerChecksum == 0 ? 0 : 1);
     List<ByteString> lastRes = null;
-    for (int i = 0; i < i_end; i++) {
+    for (int i = 0; i < iEnd; i++) {
       int byteBufferLength = Integer.min(byteArray.length, bytesPerChecksum * (i + 1));
       ByteBuffer byteBuffer = ByteBuffer.wrap(byteArray, 0, byteBufferLength);
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumCache.java
@@ -59,7 +59,7 @@ class TestChecksumCache {
       try (ChunkBuffer chunkBuffer = ChunkBuffer.wrap(byteBuffer.asReadOnlyBuffer())) {
         List<ByteString> res = checksumCache.computeChecksum(chunkBuffer, function);
         System.out.println(res);
-        // Verify that every entry in the res list except the last one is the same as the lastRes list
+        // Verify that every entry in the res list except the last one is the same as the one in lastRes list
         if (i > 0) {
           for (int j = 0; j < res.size() - 1; j++) {
             Assertions.assertEquals(lastRes.get(j), res.get(j));

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -560,6 +560,8 @@ public class KeyValueHandler extends Handler {
         endOfBlock = true;
       }
 
+      // Note: checksum held inside blockData. But no extra checksum validation here with handlePutBlock.
+
       long bcsId =
           dispatcherContext == null ? 0 : dispatcherContext.getLogIndex();
       blockData.setBlockCommitSequenceId(bcsId);
@@ -888,6 +890,7 @@ public class KeyValueHandler extends Handler {
       if (isWrite) {
         data =
             ChunkBuffer.wrap(writeChunk.getData().asReadOnlyByteBufferList());
+        // TODO: Can improve checksum validation here. Make this one-shot after protocol change.
         validateChunkChecksumData(data, chunkInfo);
       }
       chunkManager

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestBlockOutputStreamIncrementalPutBlock.java
@@ -74,7 +74,11 @@ public class TestBlockOutputStreamIncrementalPutBlock {
     ((InMemoryConfiguration) config).setBoolean(
         OzoneConfigKeys.OZONE_HBASE_ENHANCEMENTS_ALLOWED, true);
     ((InMemoryConfiguration) config).setBoolean(
+        "ozone.client.hbase.enhancements.allowed", true);
+    ((InMemoryConfiguration) config).setBoolean(
         OzoneConfigKeys.OZONE_FS_HSYNC_ENABLED, true);
+    ((InMemoryConfiguration) config).setInt(
+        "ozone.client.bytes.per.checksum", 8192);
 
     RpcClient rpcClient = new RpcClient(config, null) {
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -84,6 +84,7 @@ import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.common.ChecksumCache;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
 import org.apache.hadoop.ozone.container.keyvalue.impl.AbstractTestChunkManager;
@@ -225,8 +226,8 @@ public class TestHSync {
     GenericTestUtils.setLogLevel(BlockOutputStream.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(BlockInputStream.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(KeyValueHandler.LOG, Level.DEBUG);
-
     GenericTestUtils.setLogLevel(BufferPool.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(ChecksumCache.LOG, Level.DEBUG);
 
     openKeyCleanupService =
         (OpenKeyCleanupService) cluster.getOzoneManager().getKeyManager().getOpenKeyCleanupService();


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem Statement

Currently by default, each 4 MB block chunk is further divided into 16 KB chunks (down from 1 MB, changed in HDDS-10465) for checksum calculation.

The problem is, even with the smaller checksum chunk, clients still calculate the checksum for the whole 4 MB block chunk **from the beginning** every single time:

https://github.com/apache/ozone/blob/e57370124a36315d2be5791753912901f836ccd8/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java#L171-L177

This PR aims to implement a checksum cache to reduce the CPU time spent in critical section for checksum calculation, in hope of greatly improving client hsync throughput when checksum is enabled.

### TODOs

- [x] Add client config key to enable client checksum cache?
- [ ] Thoroughly test all code paths using `Checksum`
- [x] Verify boundary calc in edge cases

### Future Work

There are much more improvements that can be done on optimizing checksum, such as:
1. Even finer-grained incremental checksum calculation.
  - For CRC32/CRC32C, the checksum can be updated on a byte-by-byte basis (rather having to calculate the entire 16 KB)
  - For SHA256 and MD5, the checksum can be updated every 64 bytes (512 bits).
2. Transfer only the unacknowledged checksums to the datanode. Requires proto change.

But those are beyond the scope of this jira and would require major refactoring.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-10411

## How was this patch tested?

- [x] New UT cases to be added