### PR TITLE
HDDS-11456. Require successful dependency/licence checks for acceptance/compile/kubernetes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,8 @@ jobs:
       - build-info
       - build
       - basic
+      - dependency
+      - license
     timeout-minutes: 45
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
@@ -407,6 +409,8 @@ jobs:
       - build-info
       - build
       - basic
+      - dependency
+      - license
     runs-on: ubuntu-20.04
     timeout-minutes: 150
     if: needs.build-info.outputs.needs-compose-tests == 'true'
@@ -454,6 +458,8 @@ jobs:
       - build-info
       - build
       - basic
+      - dependency
+      - license
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     if: needs.build-info.outputs.needs-kubernetes-tests == 'true'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Wait for successful dependency and license checks before starting acceptance tests and other checks that also require a build (compile and kubernetes, currently).  Since dependency and license checks are quick, we can delay starting some other checks until their results are known.  This saves quite some worfkflow execution time in the rare case that these checks find any problem.

https://issues.apache.org/jira/browse/HDDS-11456

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/10833842006