### PR TITLE
HDDS-11457. Internal error on S3 CompleteMultipartUpload if parts are not specified

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -107,6 +107,11 @@ Test Multipart Upload Complete
     ${part2Md5Sum} =    Execute                       md5sum /tmp/part2 | awk '{print $1}'
                         Should Be Equal As Strings    ${eTag2}  ${part2Md5Sum}
 
+#complete multipart upload without any parts
+    ${result} =         Execute AWSS3APICli and checkrc    complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/multipartKey1    255
+                        Should contain    ${result}    InvalidRequest
+                        Should contain    ${result}    must specify at least one part
+
 #complete multipart upload
     ${result} =                 Execute AWSS3APICli           complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --multipart-upload 'Parts=[{ETag=${eTag1},PartNumber=1},{ETag=${eTag2},PartNumber=2}]'
                                 Should contain                ${result}    ${BUCKET}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AuthorizationFilter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AuthorizationFilter.java
@@ -19,11 +19,9 @@ package org.apache.hadoop.ozone.s3;
 
 import javax.annotation.Priority;
 import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -41,6 +39,7 @@ import java.io.IOException;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ACCESS_DENIED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.S3_AUTHINFO_CREATION_ERROR;
+import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
 /**
  * Filter used to construct string to sign from unfiltered request.
@@ -116,10 +115,4 @@ public class AuthorizationFilter implements ContainerRequestFilter {
     return signatureInfo;
   }
 
-  private WebApplicationException wrapOS3Exception(OS3Exception os3Exception) {
-    return new WebApplicationException(os3Exception.getErrorMessage(),
-        os3Exception,
-        Response.status(os3Exception.getHttpCode())
-            .entity(os3Exception.toXml()).build());
-  }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
@@ -34,7 +34,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import javax.ws.rs.ext.Provider;
 
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
+import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
 /**
  * Custom unmarshaller to read CompleteMultipartUploadRequest wo namespace.
@@ -69,6 +71,10 @@ public class CompleteMultipartUploadRequestUnmarshaller
       MultivaluedMap<String, String> multivaluedMap,
       InputStream inputStream) throws IOException, WebApplicationException {
     try {
+      if (inputStream.available() == 0) {
+        throw wrapOS3Exception(INVALID_REQUEST.withMessage("You must specify at least one part"));
+      }
+
       XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
       UnmarshallerHandler unmarshallerHandler =
           context.createUnmarshaller().getUnmarshallerHandler();
@@ -78,8 +84,11 @@ public class CompleteMultipartUploadRequestUnmarshaller
       filter.setParent(xmlReader);
       filter.parse(new InputSource(inputStream));
       return (CompleteMultipartUploadRequest) unmarshallerHandler.getResult();
+    } catch (WebApplicationException e) {
+      throw e;
     } catch (Exception e) {
-      throw new WebApplicationException("Can't parse request body to XML.", e);
+      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
     }
   }
+
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequestUnmarshaller.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
@@ -33,6 +32,9 @@ import java.lang.reflect.Type;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
+
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
 /**
  * Custom unmarshaller to read MultiDeleteRequest w/wo namespace.
@@ -78,7 +80,7 @@ public class MultiDeleteRequestUnmarshaller
       filter.parse(new InputSource(entityStream));
       return (MultiDeleteRequest) unmarshallerHandler.getResult();
     } catch (Exception e) {
-      throw new WebApplicationException("Can't parse request body to XML.", e);
+      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
     }
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/PutBucketAclRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/PutBucketAclRequestUnmarshaller.java
@@ -34,7 +34,9 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
+import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
 /**
  * Custom unmarshaller to read PutBucketAclRequest wo namespace.
@@ -79,7 +81,7 @@ public class PutBucketAclRequestUnmarshaller
       filter.parse(new InputSource(inputStream));
       return (S3BucketAcl)(unmarshallerHandler.getResult());
     } catch (Exception e) {
-      throw new WebApplicationException("Can't parse request body to XML.", e);
+      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
     }
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/OS3Exception.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/OS3Exception.java
@@ -158,4 +158,9 @@ public class OS3Exception extends Exception {
         this.getErrorMessage(), this.getResource(),
         this.getRequestId());
   }
+
+  /** Create a copy with specific message. */
+  public OS3Exception withMessage(String message) {
+    return new OS3Exception(code, message, httpCode);
+  }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Utils.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -115,5 +117,12 @@ public final class S3Utils {
     } catch (IllegalArgumentException ex) {
       throw newError(INVALID_ARGUMENT, storageType, ex);
     }
+  }
+
+  public static WebApplicationException wrapOS3Exception(OS3Exception ex) {
+    return new WebApplicationException(ex.getErrorMessage(), ex,
+        Response.status(ex.getHttpCode())
+            .entity(ex.toXml())
+            .build());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When submitting `CompleteMultipartUpload` request without parts, `CompleteMultipartUploadRequestUnmarshaller` encounters `SAXParseException`, which it converts to error response with the default `500 Internal Server Error` code.  We can use the more specific `InvalidRequest` code instead.  Similar problem is fixed in two other unmarshallers.  Additionally, we can avoid the `SAXParseException` by checking for empty input and returning more specific error message (`You must specify at least one part`) for empty `CompleteMultipartUpload` request.

https://issues.apache.org/jira/browse/HDDS-11457

## How was this patch tested?

Tweaked existing robot test to verify this case.

CI:
https://github.com/adoroszlai/ozone/actions/runs/10846339715