### PR TITLE
HDDS-11458. Selective checks: trigger checkstyle for properties file changes

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -429,3 +429,15 @@ load bats-assert/load.bash
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
+
+@test "properties file in resources" {
+  run dev-support/ci/selective_ci_checks.sh 71b8bdd8becf72d6f7d4e7986895504b8259b3e5
+
+  assert_output -p 'basic-checks=["rat","checkstyle","native"]'
+  assert_output -p needs-build=false
+  assert_output -p needs-compile=false
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-dependency-check=false
+  assert_output -p needs-integration-tests=true
+  assert_output -p needs-kubernetes-tests=false
+}

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -373,6 +373,7 @@ function check_needs_checkstyle() {
         "^hadoop-hdds/dev-support/checkstyle"
         "pom.xml"
         "src/..../java"
+        "src/..../resources/.*\.properties"
     )
     local ignore_array=(
         "^hadoop-ozone/dist"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Checkstyle applies some of its checks to properties files in `src/.../resources` directory.  However, checkstyle is run for PRs only if some Java files are changed (or checkstyle config itself).  Thus CI may fail to catch some checkstyle violation in properties files.

https://issues.apache.org/jira/browse/HDDS-11458

## How was this patch tested?

Added test case for selective checks using the following commit:

```
commit 71b8bdd8becf72d6f7d4e7986895504b8259b3e5
...

    HDDS-4794. No appenders could be found for logger - in tests (#1896)

 hadoop-hdds/client/src/test/resources/log4j.properties            |  2 +-
 hadoop-hdds/common/src/test/resources/log4j.properties            |  2 +-
 hadoop-hdds/container-service/src/test/resources/log4j.properties |  2 +-
 hadoop-hdds/framework/src/test/resources/log4j.properties         | 23 +++++++++++++++++++++++
 hadoop-ozone/insight/src/test/resources/log4j.properties          | 23 +++++++++++++++++++++++
 hadoop-ozone/tools/src/test/resources/log4j.properties            | 23 +++++++++++++++++++++++
 6 files changed, 72 insertions(+), 3 deletions(-)
```