### PR TITLE
HDDS-11419. Fix waitForCheckpointDirectoryExist log message

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBCheckpointUtils.java
@@ -49,7 +49,7 @@ public final class RDBCheckpointUtils {
     final boolean success = RatisHelper.attemptUntilTrue(file::exists, POLL_INTERVAL_DURATION, maxWaitTimeout);
     if (!success) {
       LOG.info("Checkpoint directory: {} didn't get created in {} secs.",
-          maxWaitTimeout.getSeconds(), file.getAbsolutePath());
+          file.getAbsolutePath(), maxWaitTimeout.getSeconds());
     }
     return success;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the waitForCheckpointDirectoryExist helper method prints the log message in reversed order.

Please describe your PR in detail:
* As a part of this PR we are fixing this error message to properly reflect the fields it is logging
* Currently in the message `Checkpoint directory: {} didn't get created in {} secs` the ordering is reversed i.e Checkpoint directory `time` didn't get created in `directoryPath` seconds i.e the fields are flipped
* After this change the message will be proper

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11419

## How was this patch tested?
This patch was tested via Unit tests
