### PR TITLE
HDDS-11354. Intermittent failure in TestOzoneManagerSnapshotAcl#testLookupKeyWithNotAllowedUserForPrefixAcl

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -217,8 +217,8 @@ public final class OzoneManagerDoubleBuffer {
   }
 
   public OzoneManagerDoubleBuffer start() {
-    daemon.start();
     isRunning.set(true);
+    daemon.start();
     return this;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
TestOzoneManagerSnapshotAcl#testLookupKeyWithNotAllowedUserForPrefixAcl failed in [this run](https://github.com/errose28/ozone/actions/runs/10478142479/attempts/1)

Please describe your PR in detail:
Sometimes `OzoneManagerDoubleBuffer` doesn't work. Therefore, OM failed to create snapshot.
Set `isRunning` to true before starting `OzoneManagerDoubleBuffer`. 
This is necessary because, if `OzoneManagerDoubleBuffer#flushTransactions` runs while `isRunning` is false, it wil not flush any buffers, as shown below.

```
  /**
   * Runs in a background thread and batches the transaction in currentBuffer
   * and commit to DB.
   */
  @VisibleForTesting
  public void flushTransactions() {
    while (isRunning.get() && canFlush()) {        // it won't go into the while loop if isRunning is false
      flushCurrentBuffer();
    }
  }
  ```

## What is the link to the Apache JIRA

[HDDS-11354](https://issues.apache.org/jira/browse/HDDS-11354)

## How was this patch tested?

Test 100*10 times and pass:
https://github.com/chungen0126/ozone/actions/runs/10878894979
