### PR TITLE
HDDS-10617. Unexpected number of files in ITestS3AContractGetFileStatusV1List

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/s3a-test.sh
@@ -94,10 +94,9 @@ EOF
 
   # Some tests are skipped due to known issues.
   # - ITestS3AContractDistCp: HDDS-10616
-  # - ITestS3AContractGetFileStatusV1List: HDDS-10617
   # - ITestS3AContractRename: HDDS-10665
   mvn -B -V --fail-never --no-transfer-progress \
-    -Dtest='ITestS3AContract*, ITestS3ACommitterMRJob, !ITestS3AContractDistCp, !ITestS3AContractGetFileStatusV1List, !ITestS3AContractRename' \
+    -Dtest='ITestS3AContract*, ITestS3ACommitterMRJob, !ITestS3AContractDistCp, !ITestS3AContractRename' \
     clean test
 
   local target="${RESULT_DIR}/junit/${bucket}/target"

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -69,6 +69,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.hadoop.ozone.OzoneConsts.ETAG;
@@ -219,6 +220,9 @@ public class BucketEndpoint extends EndpointBase {
           !next.getName().startsWith(prefix)) {
         // prefix has delimiter but key don't have
         // example prefix: dir1/ key: dir123
+        continue;
+      }
+      if (startAfter != null && count == 0 && Objects.equals(startAfter, next.getName())) {
         continue;
       }
       String relativeKeyName = next.getName().substring(prefix.length());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix unexpected number of files in S3 status list, caused by including `startAfter` item in each batch (for directories).  Since the test uses page size = 2, each batch had one item from the previous, and only one new item.  This duplicated directory entries in the listing.

https://issues.apache.org/jira/browse/HDDS-10617

## How was this patch tested?

`ITestS3AContractGetFileStatusV1List` is now enabled and passing.

CI:
https://github.com/adoroszlai/ozone/actions/runs/10883581540