### PR TITLE
HDDS-11456. Require successful dependency/licence checks for acceptance/compile/kubernetes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,8 @@ jobs:
       - build-info
       - build
       - basic
+      - dependency
+      - license
     timeout-minutes: 45
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
@@ -407,6 +409,8 @@ jobs:
       - build-info
       - build
       - basic
+      - dependency
+      - license
     runs-on: ubuntu-20.04
     timeout-minutes: 150
     if: needs.build-info.outputs.needs-compose-tests == 'true'
@@ -454,6 +458,8 @@ jobs:
       - build-info
       - build
       - basic
+      - dependency
+      - license
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     if: needs.build-info.outputs.needs-kubernetes-tests == 'true'

--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -52,7 +52,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -76,7 +76,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=true
 }
@@ -100,7 +100,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=true
 }
@@ -112,7 +112,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -136,7 +136,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -148,7 +148,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -160,7 +160,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -172,7 +172,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -184,7 +184,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -196,7 +196,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -208,7 +208,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=true
 }
@@ -232,7 +232,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -244,7 +244,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -256,7 +256,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -268,7 +268,7 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=false
+  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -330,6 +330,7 @@ function check_needs_compile() {
 
     if [[ ${match_count} != "0" ]]; then
         compile_needed=true
+        dependency_check_needed=true
     fi
 
     start_end::group_end
@@ -519,6 +520,7 @@ function calculate_test_types_to_run() {
         echo "Looks like ${COUNT_CORE_OTHER_CHANGED_FILES} core files changed, running all tests."
         echo
         compose_tests_needed=true
+        dependency_check_needed=true
         integration_tests_needed=true
         kubernetes_tests_needed=true
     else
@@ -526,12 +528,14 @@ function calculate_test_types_to_run() {
         echo
         if [[ ${COUNT_COMPOSE_CHANGED_FILES} != "0" ]] || [[ ${COUNT_ROBOT_CHANGED_FILES} != "0" ]]; then
             compose_tests_needed="true"
+            dependency_check_needed=true
         fi
         if [[ ${COUNT_INTEGRATION_CHANGED_FILES} != "0" ]]; then
             integration_tests_needed="true"
         fi
         if [[ ${COUNT_KUBERNETES_CHANGED_FILES} != "0" ]] || [[ ${COUNT_ROBOT_CHANGED_FILES} != "0" ]]; then
             kubernetes_tests_needed="true"
+            dependency_check_needed=true
         fi
     fi
     start_end::group_end
@@ -589,6 +593,7 @@ get_count_robot_files
 get_count_misc_files
 
 check_needs_build
+check_needs_dependency
 check_needs_compile
 
 # calculate basic checks to run
@@ -596,7 +601,6 @@ BASIC_CHECKS="rat"
 check_needs_author
 check_needs_bats
 check_needs_checkstyle
-check_needs_dependency
 check_needs_docs
 check_needs_findbugs
 check_needs_native


### PR DESCRIPTION
## What changes were proposed in this pull request?

Same as #7192, but also tweak selective checks to trigger `dependency` if any of `acceptance`, `compile` or `kubernetes` is required.  (Because GitHub skips workflow jobs that depend on skipped jobs.)

https://issues.apache.org/jira/browse/HDDS-11456

## How was this patch tested?

Updated bats unit test of the selective check script.

https://github.com/adoroszlai/ozone/actions/runs/10886313446/job/30206027945