### PR TITLE
HDDS-11181. Cleanup of unnecessary try-catch block.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -2117,12 +2117,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setGetFileStatusRequest(req)
         .build();
 
-    final GetFileStatusResponse resp;
-    try {
-      resp = handleError(submitRequest(omRequest)).getGetFileStatusResponse();
-    } catch (IOException e) {
-      throw e;
-    }
+    final GetFileStatusResponse resp = handleError(submitRequest(omRequest))
+        .getGetFileStatusResponse();
     return OzoneFileStatus.getFromProtobuf(resp.getStatus());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerUtils.java
@@ -164,12 +164,8 @@ public final class OzoneManagerUtils {
        * buck-src has the actual BucketLayout that will be used by the
        * links.
        */
-      try {
-        return resolveBucketInfoLink(metadataManager,
-            buckInfo.getSourceVolume(), buckInfo.getSourceBucket(), visited);
-      } catch (IOException e) {
-        throw e;
-      }
+      return resolveBucketInfoLink(metadataManager, buckInfo.getSourceVolume(),
+          buckInfo.getSourceBucket(), visited);
     }
     return buckInfo;
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
@@ -154,8 +154,6 @@ public final class OzoneClientCache {
         }
       } catch (CertificateException ce) {
         throw new IOException(ce);
-      } catch (IOException e) {
-        throw e;
       } finally {
         if (certClient != null) {
           certClient.close();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -355,11 +355,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
     // wait until all keys are added or exception occurred.
     while ((numberOfKeysAdded.get() != totalKeyCount)
            && exception == null) {
-      try {
-        Thread.sleep(CHECK_INTERVAL_MILLIS);
-      } catch (InterruptedException e) {
-        throw e;
-      }
+      Thread.sleep(CHECK_INTERVAL_MILLIS);
     }
     executor.shutdown();
     executor.awaitTermination(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
@@ -373,11 +369,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
 
     if (validateExecutor != null) {
       while (!validationQueue.isEmpty()) {
-        try {
-          Thread.sleep(CHECK_INTERVAL_MILLIS);
-        } catch (InterruptedException e) {
-          throw e;
-        }
+        Thread.sleep(CHECK_INTERVAL_MILLIS);
       }
       validateExecutor.shutdown();
       validateExecutor.awaitTermination(Integer.MAX_VALUE,
@@ -421,11 +413,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
       // wait until all Buckets are cleaned or exception occurred.
       while ((numberOfBucketsCleaned.get() != totalBucketCount)
           && exception == null) {
-        try {
-          Thread.sleep(CHECK_INTERVAL_MILLIS);
-        } catch (InterruptedException e) {
-          throw e;
-        }
+        Thread.sleep(CHECK_INTERVAL_MILLIS);
       }
     } catch (InterruptedException e) {
       LOG.error("Failed to wait until all Buckets are cleaned", e);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/DeleteVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/DeleteVolumeHandler.java
@@ -227,11 +227,7 @@ public class DeleteVolumeHandler extends VolumeHandler {
       // wait until all Buckets are cleaned or exception occurred.
       while (numberOfBucketsCleaned.get() != totalBucketCount
           && exception == null) {
-        try {
-          Thread.sleep(100);
-        } catch (InterruptedException e) {
-          throw e;
-        }
+        Thread.sleep(100);
       }
     } catch (InterruptedException e) {
       LOG.error("Failed to wait until all Buckets are cleaned", e);


### PR DESCRIPTION
## Cleanup of unnecessary try-catch block

In the following places, the catch block catching exception is re-throwing the same exception without performing any other action. In such cases there is no need to catch the exception.


## HDDS-11181


## How was this patch tested?
As this PR doesn't change anything functionally, existing tests are enough to test this patch.