### PR TITLE
HDDS-11468. Enabled DB sync button

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -76,10 +76,11 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
       );
 
     const lastUpdatedDeltaFullText = lastUpdatedOMDBDelta === 0 || lastUpdatedOMDBDelta === undefined || lastUpdatedOMDBFull === 0 || lastUpdatedOMDBFull === undefined ? '' :
+      //omSyncLoad should be clickable at all times. If the response from the dbsync is false it will show DB update is already running else show triggered sync
       (
         <>
           &nbsp; | DB Synced at {lastUpdatedDeltaFullToolTip}
-          &nbsp;<Button shape='circle' icon={<PlayCircleOutlined />} size='small' loading={isLoading} onClick={omSyncLoad} disabled={omStatus === '' ? false : true} />
+          &nbsp;<Button shape='circle' icon={<PlayCircleOutlined />} size='small' loading={isLoading} onClick={omSyncLoad} />
         </>
       );
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11468. Enabled DB sync button

Please describe your PR in detail:
* Currently the OM status gets initialized to empty string on component mount. This will cause the disabled status to evaluate to false. But upon clicking the button, the state gets updated and hence the disabled status evaluates to true.
* When we refresh the page, this state is again reset and the button gets enabled again.
* The backend will always provide a boolean response and we do not need to check for the empty string
* In such a scenario even after the initial load we should not disable the button and rather only check the response from backend.
* This PR makes the change by removing the disable flag allowing the user to click even after the sync.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11468

## How was this patch tested?
Patch was tested manually and verified behaviour.