### PR TITLE
[DO NOT MERGE] Backport some fixes and compatibility commits from master to ozone-1.4

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ECBlockOutputStream.java
@@ -38,9 +38,13 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -141,8 +145,34 @@ public class ECBlockOutputStream extends BlockOutputStream {
     }
 
     if (checksumBlockData != null) {
-      List<ChunkInfo> currentChunks = getContainerBlockData().getChunksList();
+
+      // For the same BlockGroupLength, we need to find the larger value of Block DataSize.
+      // This is because we do not send empty chunks to the DataNode, so the larger value is more accurate.
+      Map<Long, Optional<BlockData>> maxDataSizeByGroup = Arrays.stream(blockData)
+          .filter(Objects::nonNull)
+          .collect(Collectors.groupingBy(BlockData::getBlockGroupLength,
+          Collectors.maxBy(Comparator.comparingLong(BlockData::getSize))));
+      BlockData maxBlockData = maxDataSizeByGroup.get(blockGroupLength).get();
+
+      // When calculating the checksum size,
+      // We need to consider both blockGroupLength and the actual size of blockData.
+      //
+      // We use the smaller value to determine the size of the ChunkList.
+      //
+      // 1. In most cases, blockGroupLength is equal to the size of blockData.
+      // 2. Occasionally, blockData is not fully filled; if a chunk is empty,
+      // it is not sent to the DN, resulting in blockData size being smaller than blockGroupLength.
+      // 3. In cases with 'dirty data',
+      // if an error occurs when writing to the EC-Stripe (e.g., DN reports Container Closed),
+      // and the length confirmed with OM is smaller, blockGroupLength may be smaller than blockData size.
+      long blockDataSize = Math.min(maxBlockData.getSize(), blockGroupLength);
+      int chunkSize = (int) Math.ceil(((double) blockDataSize / repConfig.getEcChunkSize()));
       List<ChunkInfo> checksumBlockDataChunks = checksumBlockData.getChunks();
+      if (chunkSize > 0) {
+        checksumBlockDataChunks = checksumBlockData.getChunks().subList(0, chunkSize);
+      }
+
+      List<ChunkInfo> currentChunks = getContainerBlockData().getChunksList();
 
       Preconditions.checkArgument(
           currentChunks.size() == checksumBlockDataChunks.size(),
@@ -268,7 +298,7 @@ public class ECBlockOutputStream extends BlockOutputStream {
         throw ce;
       });
     } catch (IOException | ExecutionException e) {
-      throw new IOException(EXCEPTION_MSG + e.toString(), e);
+      throw new IOException(EXCEPTION_MSG + e, e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       handleInterruptedException(ex, false);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/RatisConfUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/RatisConfUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.conf;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.util.Preconditions;
+import org.apache.ratis.util.SizeInBytes;
+
+/**
+ * Utilities for Ratis configurations.
+ */
+public class RatisConfUtils {
+  /** For {@link GrpcConfigKeys}. */
+  public static class Grpc {
+    /** For setting {@link GrpcConfigKeys#setMessageSizeMax(RaftProperties, SizeInBytes)}. */
+    public static void setMessageSizeMax(RaftProperties properties, int max) {
+      Preconditions.assertTrue(max > 0, () -> "max = " + max + " <= 0");
+
+      final long logAppenderBufferByteLimit = RaftServerConfigKeys.Log.Appender.bufferByteLimit(properties).getSize();
+      Preconditions.assertTrue(max >= logAppenderBufferByteLimit,
+          () -> "max = " + max + " < logAppenderBufferByteLimit = " + logAppenderBufferByteLimit);
+
+      // Need an 1MB gap; see RATIS-2135
+      GrpcConfigKeys.setMessageSizeMax(properties, SizeInBytes.valueOf(max + SizeInBytes.ONE_MB.getSize()));
+    }
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto3Codec;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -295,5 +296,15 @@ public class BlockData {
     blockID.appendTo(sb);
     sb.append(", size=").append(size);
     sb.append("]");
+  }
+
+  public long getBlockGroupLength() {
+    String lenStr = getMetadata()
+        .get(OzoneConsts.BLOCK_GROUP_LEN_KEY_IN_PUT_BLOCK);
+    // If we don't have the length, then it indicates a problem with the stripe.
+    // All replica should carry the length, so if it is not there, we return 0,
+    // which will cause us to set the length of the block to zero and not
+    // attempt to reconstruct it.
+    return (lenStr == null) ? 0 : Long.parseLong(lenStr);
   }
 }

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2097,7 +2097,7 @@
   </property>
 
   <property>
-    <name>ozone.om.ratis.server.leaderelection.pre-vote </name>
+    <name>ozone.om.ratis.server.leaderelection.pre-vote</name>
     <value>true</value>
     <tag>OZONE, OM, RATIS, MANAGEMENT</tag>
     <description>Enable/disable OM HA leader election pre-vote phase.
@@ -2111,6 +2111,15 @@
     <description>The timeout duration for ratis server failure detection,
       once the threshold has reached, the ratis state machine will be informed
       about the failure in the ratis ring.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.om.ratis.server.close.threshold</name>
+    <value>60s</value>
+    <tag>OZONE, OM, RATIS</tag>
+    <description>
+      Raft Server will close if JVM pause longer than the threshold.
     </description>
   </property>
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestRatisConfUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestRatisConfUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.conf;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.util.SizeInBytes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test {@link RatisConfUtils}.
+ */
+public class TestRatisConfUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(TestRatisConfUtils.class);
+
+  @Test
+  void testGrpcSetMessageSizeMax() {
+    final RaftProperties properties = new RaftProperties();
+
+    final int logAppenderBufferByteLimit = 1000;
+
+    // setMessageSizeMax without setBufferByteLimit
+    Assertions.assertThrows(IllegalStateException.class,
+        () -> RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit));
+
+    RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties, SizeInBytes.valueOf(logAppenderBufferByteLimit));
+
+    // setMessageSizeMax with a value smaller than logAppenderBufferByteLimit
+    Assertions.assertThrows(IllegalStateException.class,
+        () -> RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit - 1));
+
+    // setMessageSizeMax with the correct logAppenderBufferByteLimit
+    RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);
+
+    final SizeInBytes max = GrpcConfigKeys.messageSizeMax(properties, LOG::info);
+    Assertions.assertEquals(SizeInBytes.ONE_MB.getSize(), max.getSize() - logAppenderBufferByteLimit);
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -27,6 +27,10 @@ import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Queue;
 import java.util.Set;
+import java.util.Objects;
+import java.util.LinkedHashMap;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -46,6 +50,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Descriptors.Descriptor;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatus.Status;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerAction;
@@ -54,10 +59,12 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineAction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReport;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.ozone.container.common.states.DatanodeState;
 import org.apache.hadoop.ozone.container.common.states.datanode.InitDatanodeState;
 import org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.CommandStatus;
 import org.apache.hadoop.ozone.protocol.commands.DeleteBlockCommandStatus.DeleteBlockCommandStatusBuilder;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
@@ -117,7 +124,7 @@ public class StateContext {
   private final Map<InetSocketAddress, List<Message>>
       incrementalReportsQueue;
   private final Map<InetSocketAddress, Queue<ContainerAction>> containerActions;
-  private final Map<InetSocketAddress, Queue<PipelineAction>> pipelineActions;
+  private final Map<InetSocketAddress, PipelineActionMap> pipelineActions;
   private DatanodeStateMachine.DatanodeStates state;
   private boolean shutdownOnError = false;
   private boolean shutdownGracefully = false;
@@ -182,7 +189,7 @@ public class StateContext {
     crlStatusReport = new AtomicReference<>(); // Certificate Revocation List
     endpoints = new HashSet<>();
     containerActions = new HashMap<>();
-    pipelineActions = new HashMap<>();
+    pipelineActions = new ConcurrentHashMap<>();
     lock = new ReentrantLock();
     stateExecutionCount = new AtomicLong(0);
     threadPoolNotAvailableCount = new AtomicLong(0);
@@ -525,46 +532,15 @@ public class StateContext {
   }
 
   /**
-   * Helper function for addPipelineActionIfAbsent that check if inputs are the
-   * same close pipeline action.
-   *
-   * Important Note: Make sure to double check for correctness before using this
-   * helper function for other purposes!
-   *
-   * @return true if a1 and a2 are the same close pipeline action,
-   *         false otherwise
-   */
-  boolean isSameClosePipelineAction(PipelineAction a1, PipelineAction a2) {
-    return a1.getAction() == a2.getAction()
-        && a1.hasClosePipeline()
-        && a2.hasClosePipeline()
-        && a1.getClosePipeline().getPipelineID()
-        .equals(a2.getClosePipeline().getPipelineID());
-  }
-
-  /**
    * Add PipelineAction to PipelineAction queue if it's not present.
    *
    * @param pipelineAction PipelineAction to be added
    */
   public void addPipelineActionIfAbsent(PipelineAction pipelineAction) {
-    synchronized (pipelineActions) {
-      /**
-       * If pipelineAction queue already contains entry for the pipeline id
-       * with same action, we should just return.
-       * Note: We should not use pipelineActions.contains(pipelineAction) here
-       * as, pipelineAction has a msg string. So even if two msgs differ though
-       * action remains same on the given pipeline, it will end up adding it
-       * multiple times here.
-       */
-      for (InetSocketAddress endpoint : endpoints) {
-        final Queue<PipelineAction> actionsForEndpoint =
-            pipelineActions.get(endpoint);
-        if (actionsForEndpoint.stream().noneMatch(
-            action -> isSameClosePipelineAction(action, pipelineAction))) {
-          actionsForEndpoint.add(pipelineAction);
-        }
-      }
+    // Put only if the pipeline id with the same action is absent.
+    final PipelineKey key = new PipelineKey(pipelineAction);
+    for (InetSocketAddress endpoint : endpoints) {
+      pipelineActions.get(endpoint).putIfAbsent(key, pipelineAction);
     }
   }
 
@@ -577,34 +553,17 @@ public class StateContext {
   public List<PipelineAction> getPendingPipelineAction(
       InetSocketAddress endpoint,
       int maxLimit) {
-    List<PipelineAction> pipelineActionList = new ArrayList<>();
-    List<PipelineAction> persistPipelineAction = new ArrayList<>();
-    synchronized (pipelineActions) {
-      if (!pipelineActions.isEmpty() &&
-          CollectionUtils.isNotEmpty(pipelineActions.get(endpoint))) {
-        Queue<PipelineAction> actionsForEndpoint =
-            this.pipelineActions.get(endpoint);
-        int size = actionsForEndpoint.size();
-        int limit = size > maxLimit ? maxLimit : size;
-        for (int count = 0; count < limit; count++) {
-          // Add closePipeline back to the pipelineAction queue until
-          // pipeline is closed and removed from the DN.
-          PipelineAction action = actionsForEndpoint.poll();
-          if (action.hasClosePipeline()) {
-            if (parentDatanodeStateMachine.getContainer().getPipelineReport()
-                .getPipelineReportList().stream().noneMatch(
-                    report -> action.getClosePipeline().getPipelineID()
-                        .equals(report.getPipelineID()))) {
-              continue;
-            }
-            persistPipelineAction.add(action);
-          }
-          pipelineActionList.add(action);
-        }
-        actionsForEndpoint.addAll(persistPipelineAction);
-      }
-      return pipelineActionList;
+    final PipelineActionMap map = pipelineActions.get(endpoint);
+    if (map == null) {
+      return Collections.emptyList();
     }
+    final OzoneContainer ozoneContainer = parentDatanodeStateMachine.
+        getContainer();
+    if (ozoneContainer == null) {
+      return Collections.emptyList();
+    }
+    final PipelineReportsProto reports = ozoneContainer.getPipelineReport();
+    return map.getActions(reports.getPipelineReportList(), maxLimit);
   }
 
   /**
@@ -922,7 +881,7 @@ public class StateContext {
     if (!endpoints.contains(endpoint)) {
       this.endpoints.add(endpoint);
       this.containerActions.put(endpoint, new LinkedList<>());
-      this.pipelineActions.put(endpoint, new LinkedList<>());
+      this.pipelineActions.put(endpoint, new PipelineActionMap());
       this.incrementalReportsQueue.put(endpoint, new LinkedList<>());
       Map<String, AtomicBoolean> mp = new HashMap<>();
       fullReportTypeList.forEach(e -> {
@@ -987,5 +946,80 @@ public class StateContext {
 
   public String getThreadNamePrefix() {
     return threadNamePrefix;
+  }
+
+  static class PipelineActionMap {
+    private final LinkedHashMap<PipelineKey, PipelineAction> map =
+        new LinkedHashMap<>();
+
+    synchronized int size() {
+      return map.size();
+    }
+
+    synchronized void putIfAbsent(PipelineKey key,
+        PipelineAction pipelineAction) {
+      map.putIfAbsent(key, pipelineAction);
+    }
+
+    synchronized List<PipelineAction> getActions(List<PipelineReport> reports,
+        int max) {
+      if (map.isEmpty()) {
+        return Collections.emptyList();
+      }
+      final List<PipelineAction> pipelineActionList = new ArrayList<>();
+      final int limit = Math.min(map.size(), max);
+      final Iterator<Map.Entry<PipelineKey, PipelineAction>> i =
+          map.entrySet().iterator();
+      for (int count = 0; count < limit && i.hasNext(); count++) {
+        final Map.Entry<PipelineKey, PipelineAction> entry = i.next();
+        final PipelineAction action = entry.getValue();
+        // Add closePipeline back to the pipelineAction queue until
+        // pipeline is closed and removed from the DN.
+        if (action.hasClosePipeline()) {
+          if (reports.stream().noneMatch(entry.getKey()::equalsId)) {
+            // pipeline is removed from the DN, this action is no longer needed.
+            i.remove();
+            continue;
+          }
+          // pipeline is closed but not yet removed from the DN.
+        } else {
+          i.remove();
+        }
+        pipelineActionList.add(action);
+      }
+      // add all
+      return pipelineActionList;
+    }
+  }
+
+  static class PipelineKey {
+    private final HddsProtos.PipelineID pipelineID;
+    private final PipelineAction.Action action;
+
+    PipelineKey(PipelineAction p) {
+      this.pipelineID = p.getClosePipeline().getPipelineID();
+      this.action = p.getAction();
+    }
+
+    boolean equalsId(PipelineReport report) {
+      return pipelineID.equals(report.getPipelineID());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(pipelineID);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if (!(obj instanceof PipelineKey)) {
+        return false;
+      }
+      final PipelineKey that = (PipelineKey) obj;
+      return Objects.equals(this.action, that.action)
+          && Objects.equals(this.pipelineID, that.pipelineID);
+    }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -31,23 +31,6 @@ import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_PREFI
 @ConfigGroup(prefix = HDDS_DATANODE_RATIS_PREFIX_KEY + "."
     + GrpcConfigKeys.PREFIX)
 public class DatanodeRatisGrpcConfig {
-  @Config(key = "message.size.max",
-      defaultValue = "32MB",
-      type = ConfigType.SIZE,
-      tags = {OZONE, CLIENT, PERFORMANCE},
-      description = "Maximum message size allowed to be received by Grpc " +
-          "Channel (Server)."
-  )
-  private int maximumMessageSize = 32 * 1024 * 1024;
-
-  public int getMaximumMessageSize() {
-    return maximumMessageSize;
-  }
-
-  public void setMaximumMessageSize(int maximumMessageSize) {
-    this.maximumMessageSize = maximumMessageSize;
-  }
-
   @Config(key = "flow.control.window",
       defaultValue = "5MB",
       type = ConfigType.SIZE,

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -167,6 +167,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.ha;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.RatisConfUtils;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.ratis.ServerNotLeaderException;
@@ -69,8 +70,9 @@ public final class RatisUtil {
     // TODO: Check the default values.
     final RaftProperties properties = new RaftProperties();
     setRaftStorageDir(properties, conf);
-    setRaftRpcProperties(properties, conf);
-    setRaftLogProperties(properties, conf);
+
+    final int logAppenderBufferByteLimit = setRaftLogProperties(properties, conf);
+    setRaftRpcProperties(properties, conf, logAppenderBufferByteLimit);
     setRaftRetryCacheProperties(properties, conf);
     setRaftSnapshotProperties(properties, conf);
     setRaftLeadElectionProperties(properties, conf);
@@ -100,15 +102,14 @@ public final class RatisUtil {
    * @param ozoneConf ConfigurationSource
    */
   private static void setRaftRpcProperties(final RaftProperties properties,
-      ConfigurationSource ozoneConf) {
+      ConfigurationSource ozoneConf, int logAppenderBufferByteLimit) {
     RatisHelper.setRpcType(properties,
         RpcType.valueOf(ozoneConf.get(ScmConfigKeys.OZONE_SCM_HA_RATIS_RPC_TYPE,
                 ScmConfigKeys.OZONE_SCM_HA_RATIS_RPC_TYPE_DEFAULT)));
     GrpcConfigKeys.Server.setPort(properties, ozoneConf
         .getInt(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY,
             ScmConfigKeys.OZONE_SCM_RATIS_PORT_DEFAULT));
-    GrpcConfigKeys.setMessageSizeMax(properties,
-        SizeInBytes.valueOf("32m"));
+    RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);
     long ratisRequestTimeout = ozoneConf.getTimeDuration(
             ScmConfigKeys.OZONE_SCM_HA_RATIS_REQUEST_TIMEOUT,
             ScmConfigKeys.OZONE_SCM_HA_RATIS_REQUEST_TIMEOUT_DEFAULT,
@@ -161,7 +162,7 @@ public final class RatisUtil {
    * @param properties RaftProperties instance which will be updated
    * @param ozoneConf ConfigurationSource
    */
-  private static void setRaftLogProperties(final RaftProperties properties,
+  private static int setRaftLogProperties(final RaftProperties properties,
       final ConfigurationSource ozoneConf) {
     Log.setSegmentSizeMax(properties, SizeInBytes.valueOf((long)
         ozoneConf.getStorageSize(
@@ -195,6 +196,7 @@ public final class RatisUtil {
             ozoneConf.getInt(ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_PURGE_GAP,
                     ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_PURGE_GAP_DEFAULT));
     Log.setSegmentCacheNumMax(properties, 2);
+    return logAppenderQueueByteLimit;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockedSCM.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/MockedSCM.java
@@ -1,0 +1,318 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+import com.google.protobuf.ByteString;
+import jakarta.annotation.Nonnull;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.PlacementPolicyValidateProxy;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.ContainerReplicaNotFoundException;
+import org.apache.hadoop.hdds.scm.container.MockNodeManager;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementPolicyFactory;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementMetrics;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.ha.SCMService;
+import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
+import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManager;
+import org.apache.hadoop.hdds.scm.ha.StatefulServiceStateManagerImpl;
+import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Class for test used for setting up testable StorageContainerManager.
+ * Provides an access to {@link TestableCluster} and to necessary mocked instances
+ */
+public final class MockedSCM {
+  private final StorageContainerManager scm;
+  private final TestableCluster cluster;
+  private final MockNodeManager mockNodeManager;
+  private MockedReplicationManager mockedReplicaManager;
+  private MoveManager moveManager;
+  private ContainerManager containerManager;
+
+  private MockedPlacementPolicies mockedPlacementPolicies;
+
+  public MockedSCM(@Nonnull TestableCluster testableCluster) {
+    scm = mock(StorageContainerManager.class);
+    cluster = testableCluster;
+    mockNodeManager = new MockNodeManager(cluster.getDatanodeToContainersMap());
+  }
+
+  public void init(@Nonnull ContainerBalancerConfiguration balancerConfig) {
+    init(balancerConfig, new OzoneConfiguration());
+  }
+
+  public void init(@Nonnull ContainerBalancerConfiguration balancerConfig, @Nonnull OzoneConfiguration ozoneCfg) {
+    ozoneCfg.setFromObject(balancerConfig);
+    try {
+      doMock(balancerConfig, ozoneCfg);
+    } catch (IOException | NodeNotFoundException | TimeoutException e) {
+      throw new RuntimeException("Can't initialize TestOzoneHDDS: ", e);
+    }
+  }
+
+  /**
+   * Mock some instances that will be used for MockedStorageContainerManager.
+   */
+  private void doMock(@Nonnull ContainerBalancerConfiguration cfg, @Nonnull OzoneConfiguration ozoneCfg)
+      throws IOException, NodeNotFoundException, TimeoutException {
+    containerManager = mockContainerManager(cluster);
+    mockedReplicaManager = MockedReplicationManager.doMock();
+    moveManager = mockMoveManager();
+    StatefulServiceStateManager stateManager = MockedServiceStateManager.doMock();
+    SCMServiceManager scmServiceManager = mockSCMServiceManger();
+
+    mockedPlacementPolicies = MockedPlacementPolicies.doMock(ozoneCfg, mockNodeManager);
+
+    when(scm.getConfiguration()).then(invocationOnMock -> {
+      ozoneCfg.setFromObject(cfg);
+      return ozoneCfg;
+    });
+    when(scm.getMoveManager()).thenReturn(moveManager);
+    when(scm.getScmNodeManager()).thenReturn(mockNodeManager);
+    when(scm.getContainerManager()).thenReturn(containerManager);
+    when(scm.getReplicationManager()).thenReturn(mockedReplicaManager.manager);
+    when(scm.getContainerPlacementPolicy()).thenReturn(mockedPlacementPolicies.placementPolicy);
+    when(scm.getPlacementPolicyValidateProxy()).thenReturn(mockedPlacementPolicies.validateProxyPolicy);
+    when(scm.getSCMServiceManager()).thenReturn(scmServiceManager);
+    when(scm.getScmContext()).thenReturn(SCMContext.emptyContext());
+    when(scm.getClusterMap()).thenReturn(null);
+    when(scm.getEventQueue()).thenReturn(mock(EventPublisher.class));
+    when(scm.getStatefulServiceStateManager()).thenReturn(stateManager);
+  }
+
+  @Override
+  public String toString() {
+    return cluster.toString();
+  }
+
+  public @Nonnull ContainerBalancerTask startBalancerTask(
+      @Nonnull ContainerBalancer containerBalancer,
+      @Nonnull ContainerBalancerConfiguration config
+  ) {
+    ContainerBalancerTask task = new ContainerBalancerTask(scm, 0, containerBalancer,
+        containerBalancer.getMetrics(), config, false);
+    task.run();
+    return task;
+  }
+
+  public @Nonnull ContainerBalancerTask startBalancerTask(@Nonnull ContainerBalancerConfiguration config) {
+    init(config);
+    return startBalancerTask(new ContainerBalancer(scm), config);
+  }
+
+  public void enableLegacyReplicationManager() {
+    mockedReplicaManager.conf.setEnableLegacy(true);
+  }
+
+  public void disableLegacyReplicationManager() {
+    mockedReplicaManager.conf.setEnableLegacy(false);
+  }
+
+  public @Nonnull MoveManager getMoveManager() {
+    return moveManager;
+  }
+
+  public @Nonnull ReplicationManager getReplicationManager() {
+    return mockedReplicaManager.manager;
+  }
+
+  public @Nonnull MockNodeManager getNodeManager() {
+    return mockNodeManager;
+  }
+
+  public @Nonnull StorageContainerManager getStorageContainerManager() {
+    return scm;
+  }
+
+  public @Nonnull TestableCluster getCluster() {
+    return cluster;
+  }
+
+  public @Nonnull ContainerManager getContainerManager() {
+    return containerManager;
+  }
+
+  public @Nonnull PlacementPolicy getPlacementPolicy() {
+    return mockedPlacementPolicies.placementPolicy;
+  }
+
+  public @Nonnull PlacementPolicy getEcPlacementPolicy() {
+    return mockedPlacementPolicies.ecPlacementPolicy;
+  }
+
+  private static @Nonnull ContainerManager mockContainerManager(@Nonnull TestableCluster cluster)
+      throws ContainerNotFoundException {
+    ContainerManager containerManager = mock(ContainerManager.class);
+    Mockito
+        .when(containerManager.getContainerReplicas(any(ContainerID.class)))
+        .thenAnswer(invocationOnMock -> {
+          ContainerID cid = (ContainerID) invocationOnMock.getArguments()[0];
+          return cluster.getCidToReplicasMap().get(cid);
+        });
+
+    Mockito
+        .when(containerManager.getContainer(any(ContainerID.class)))
+        .thenAnswer(invocationOnMock -> {
+          ContainerID cid = (ContainerID) invocationOnMock.getArguments()[0];
+          return cluster.getCidToInfoMap().get(cid);
+        });
+
+    Mockito
+        .when(containerManager.getContainers())
+        .thenReturn(new ArrayList<>(cluster.getCidToInfoMap().values()));
+    return containerManager;
+  }
+
+  private static @Nonnull SCMServiceManager mockSCMServiceManger() {
+    SCMServiceManager scmServiceManager = mock(SCMServiceManager.class);
+
+    Mockito
+        .doNothing()
+        .when(scmServiceManager)
+        .register(Mockito.any(SCMService.class));
+
+    return scmServiceManager;
+  }
+
+  private static @Nonnull MoveManager mockMoveManager()
+      throws NodeNotFoundException, ContainerReplicaNotFoundException, ContainerNotFoundException {
+    MoveManager moveManager = mock(MoveManager.class);
+    Mockito
+        .when(moveManager.move(
+            any(ContainerID.class),
+            any(DatanodeDetails.class),
+            any(DatanodeDetails.class)))
+        .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+    return moveManager;
+  }
+
+  private static final class MockedReplicationManager {
+    private final ReplicationManager manager;
+    private final ReplicationManager.ReplicationManagerConfiguration conf;
+
+    private MockedReplicationManager() {
+      manager = mock(ReplicationManager.class);
+      conf = new ReplicationManager.ReplicationManagerConfiguration();
+      // Disable LegacyReplicationManager. This means balancer should select RATIS as well as
+      // EC containers for balancing. Also, MoveManager will be used.
+      conf.setEnableLegacy(false);
+    }
+
+    private static @Nonnull MockedReplicationManager doMock()
+        throws NodeNotFoundException, ContainerNotFoundException, TimeoutException {
+      MockedReplicationManager mockedManager = new MockedReplicationManager();
+
+      Mockito
+          .when(mockedManager.manager.getConfig())
+          .thenReturn(mockedManager.conf);
+
+      Mockito
+          .when(mockedManager.manager.isContainerReplicatingOrDeleting(Mockito.any(ContainerID.class)))
+          .thenReturn(false);
+
+      Mockito
+          .when(mockedManager.manager.move(
+              Mockito.any(ContainerID.class),
+              Mockito.any(DatanodeDetails.class),
+              Mockito.any(DatanodeDetails.class)))
+          .thenReturn(CompletableFuture.completedFuture(MoveManager.MoveResult.COMPLETED));
+
+      Mockito
+          .when(mockedManager.manager.getClock())
+          .thenReturn(Clock.system(ZoneId.systemDefault()));
+
+      return mockedManager;
+    }
+  }
+
+  private static final class MockedServiceStateManager {
+    private final Map<String, ByteString> serviceToConfigMap = new HashMap<>();
+    private final StatefulServiceStateManager serviceStateManager = Mockito.mock(StatefulServiceStateManagerImpl.class);
+
+    private static @Nonnull StatefulServiceStateManager doMock() throws IOException {
+      MockedServiceStateManager manager = new MockedServiceStateManager();
+
+      // When StatefulServiceStateManager#saveConfiguration is called, save to in-memory serviceToConfigMap instead.
+      Map<String, ByteString> map = manager.serviceToConfigMap;
+      StatefulServiceStateManager stateManager = manager.serviceStateManager;
+      Mockito
+          .doAnswer(i -> {
+            map.put(i.getArgument(0, String.class), i.getArgument(1, ByteString.class));
+            return null;
+          })
+          .when(stateManager)
+          .saveConfiguration(Mockito.any(String.class), Mockito.any(ByteString.class));
+
+      // When StatefulServiceStateManager#readConfiguration is called, read from serviceToConfigMap instead.
+      Mockito
+          .when(stateManager.readConfiguration(Mockito.anyString()))
+          .thenAnswer(i -> map.get(i.getArgument(0, String.class)));
+      return stateManager;
+    }
+  }
+
+  private static final class MockedPlacementPolicies {
+    private final PlacementPolicy placementPolicy;
+    private final PlacementPolicy ecPlacementPolicy;
+    private final PlacementPolicyValidateProxy validateProxyPolicy;
+
+    private MockedPlacementPolicies(@Nonnull PlacementPolicy placementPolicy, @Nonnull PlacementPolicy ecPolicy) {
+      this.placementPolicy = placementPolicy;
+      ecPlacementPolicy = ecPolicy;
+      validateProxyPolicy = new PlacementPolicyValidateProxy(this.placementPolicy, ecPlacementPolicy);
+    }
+
+    private static @Nonnull MockedPlacementPolicies doMock(
+        @Nonnull OzoneConfiguration ozoneConfig,
+        @Nonnull NodeManager nodeManager
+    ) throws SCMException {
+      NetworkTopology clusterMap = nodeManager.getClusterNetworkTopologyMap();
+      PlacementPolicy policy = ContainerPlacementPolicyFactory.getPolicy(
+          ozoneConfig, nodeManager, clusterMap, true, SCMContainerPlacementMetrics.create());
+      PlacementPolicy ecPolicy = ContainerPlacementPolicyFactory.getECPolicy(
+          ozoneConfig, nodeManager, clusterMap, true, SCMContainerPlacementMetrics.create());
+      return new MockedPlacementPolicies(policy, ecPolicy);
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancerDatanodeNodeLimit.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+import jakarta.annotation.Nonnull;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.event.Level;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ContainerBalancerTask} moved from {@link TestContainerBalancerTask} to run them on clusters
+ * with different datanode count.
+ */
+public class TestContainerBalancerDatanodeNodeLimit {
+  private static final long STORAGE_UNIT = OzoneConsts.GB;
+  private static final int DATANODE_COUNT_LIMIT_FOR_SMALL_CLUSTER = 15;
+
+  @BeforeAll
+  public static void setup() {
+    GenericTestUtils.setLogLevel(ContainerBalancerTask.LOG, Level.DEBUG);
+  }
+
+  private static Stream<Arguments> createMockedSCMs() {
+    return Stream.of(
+        Arguments.of(getMockedSCM(4)),
+        Arguments.of(getMockedSCM(5)),
+        Arguments.of(getMockedSCM(6)),
+        Arguments.of(getMockedSCM(7)),
+        Arguments.of(getMockedSCM(8)),
+        Arguments.of(getMockedSCM(9)),
+        Arguments.of(getMockedSCM(10)),
+        Arguments.of(getMockedSCM(11)),
+        Arguments.of(getMockedSCM(12)),
+        Arguments.of(getMockedSCM(13)),
+        Arguments.of(getMockedSCM(14)),
+        Arguments.of(getMockedSCM(15)),
+        Arguments.of(getMockedSCM(17)),
+        Arguments.of(getMockedSCM(19)),
+        Arguments.of(getMockedSCM(20)),
+        Arguments.of(getMockedSCM(30)));
+  }
+
+  @ParameterizedTest(name = "MockedSCM #{index}: {0}")
+  @MethodSource("createMockedSCMs")
+  public void containerBalancerShouldObeyMaxDatanodesToInvolveLimit(@Nonnull MockedSCM mockedSCM) {
+    ContainerBalancerConfiguration config = new OzoneConfiguration().getObject(ContainerBalancerConfiguration.class);
+    int nodeCount = mockedSCM.getCluster().getNodeCount();
+    if (nodeCount < DATANODE_COUNT_LIMIT_FOR_SMALL_CLUSTER) {
+      config.setMaxDatanodesPercentageToInvolvePerIteration(100);
+    }
+    config.setIterations(1);
+    config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
+
+    ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
+    ContainerBalancerMetrics metrics = task.getMetrics();
+
+    int maxDatanodePercentage = config.getMaxDatanodesPercentageToInvolvePerIteration();
+    int number = maxDatanodePercentage * nodeCount / 100;
+    int datanodesInvolvedPerIteration = task.getCountDatanodesInvolvedPerIteration();
+    assertThat(datanodesInvolvedPerIteration).isGreaterThan(0);
+    assertThat(datanodesInvolvedPerIteration).isLessThanOrEqualTo(number);
+    long numDatanodesInvolvedInLatestIteration = metrics.getNumDatanodesInvolvedInLatestIteration();
+    assertThat(numDatanodesInvolvedInLatestIteration).isGreaterThan(0);
+    assertThat(numDatanodesInvolvedInLatestIteration).isLessThanOrEqualTo(number);
+  }
+
+  @ParameterizedTest(name = "MockedSCM #{index}: {0}")
+  @MethodSource("createMockedSCMs")
+  public void balancerShouldObeyMaxSizeEnteringTargetLimit(@Nonnull MockedSCM mockedSCM) {
+    OzoneConfiguration ozoneConfig = new OzoneConfiguration();
+    ozoneConfig.set("ozone.scm.container.size", "1MB");
+    ContainerBalancerConfiguration config = balancerConfigByOzoneConfig(ozoneConfig);
+    if (mockedSCM.getCluster().getNodeCount() < DATANODE_COUNT_LIMIT_FOR_SMALL_CLUSTER) {
+      config.setMaxDatanodesPercentageToInvolvePerIteration(100);
+    }
+    config.setIterations(1);
+    config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
+    // No containers should be selected when the limit is just 2 MB.
+    config.setMaxSizeEnteringTarget(2 * OzoneConsts.MB);
+
+    ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
+    // Container balancer still has unbalanced nodes due to MaxSizeEnteringTarget limit
+    assertTrue(stillHaveUnbalancedNodes(task));
+    // ContainerToSourceMap is empty due to MaxSizeEnteringTarget limit
+    assertTrue(task.getContainerToSourceMap().isEmpty());
+    // SizeScheduledForMoveInLatestIteration equals to 0 because there are no containers was selected
+    assertEquals(0, task.getSizeScheduledForMoveInLatestIteration());
+
+    // Some containers should be selected when using default values.
+    ContainerBalancerConfiguration balancerConfig = balancerConfigByOzoneConfig(new OzoneConfiguration());
+    if (mockedSCM.getCluster().getNodeCount() < DATANODE_COUNT_LIMIT_FOR_SMALL_CLUSTER) {
+      balancerConfig.setMaxDatanodesPercentageToInvolvePerIteration(100);
+    }
+    balancerConfig.setIterations(1);
+
+    task = mockedSCM.startBalancerTask(balancerConfig);
+    // Balancer should have identified unbalanced nodes.
+    assertTrue(stillHaveUnbalancedNodes(task));
+    // ContainerToSourceMap is not empty due to some containers should be selected
+    assertFalse(task.getContainerToSourceMap().isEmpty());
+    // SizeScheduledForMoveInLatestIteration doesn't equal to 0 because some containers should be selected
+    assertNotEquals(0, task.getSizeScheduledForMoveInLatestIteration());
+  }
+
+  @ParameterizedTest(name = "MockedSCM #{index}: {0}")
+  @MethodSource("createMockedSCMs")
+  public void balancerShouldObeyMaxSizeLeavingSourceLimit(@Nonnull MockedSCM mockedSCM) {
+    OzoneConfiguration ozoneConfig = new OzoneConfiguration();
+    ozoneConfig.set("ozone.scm.container.size", "1MB");
+    ContainerBalancerConfiguration config = balancerConfigByOzoneConfig(ozoneConfig);
+    if (mockedSCM.getCluster().getNodeCount() < DATANODE_COUNT_LIMIT_FOR_SMALL_CLUSTER) {
+      config.setMaxDatanodesPercentageToInvolvePerIteration(100);
+    }
+    config.setIterations(1);
+    config.setMaxSizeEnteringTarget(50 * STORAGE_UNIT);
+    config.setMaxSizeToMovePerIteration(50 * STORAGE_UNIT);
+    // No source containers should be selected when the limit is just 2 MB.
+    config.setMaxSizeLeavingSource(2 * OzoneConsts.MB);
+
+    ContainerBalancerTask task = mockedSCM.startBalancerTask(config);
+    // Container balancer still has unbalanced nodes due to MaxSizeLeavingSource limit
+    assertTrue(stillHaveUnbalancedNodes(task));
+    // ContainerToSourceMap is empty due to MaxSizeLeavingSource limit
+    assertTrue(task.getContainerToSourceMap().isEmpty());
+    // SizeScheduledForMoveInLatestIteration equals to 0 because there are no containers was selected
+    assertEquals(0, task.getSizeScheduledForMoveInLatestIteration());
+
+    // Some containers should be selected when using default values.
+    ContainerBalancerConfiguration newBalancerConfig = balancerConfigByOzoneConfig(new OzoneConfiguration());
+    if (mockedSCM.getCluster().getNodeCount() < DATANODE_COUNT_LIMIT_FOR_SMALL_CLUSTER) {
+      newBalancerConfig.setMaxDatanodesPercentageToInvolvePerIteration(100);
+    }
+    newBalancerConfig.setIterations(1);
+
+    task = mockedSCM.startBalancerTask(newBalancerConfig);
+    // Balancer should have identified unbalanced nodes.
+    assertTrue(stillHaveUnbalancedNodes(task));
+    // ContainerToSourceMap is not empty due to some containers should be selected
+    assertFalse(task.getContainerToSourceMap().isEmpty());
+    // SizeScheduledForMoveInLatestIteration doesn't equal to 0 because some containers should be selected
+    assertNotEquals(0, task.getSizeScheduledForMoveInLatestIteration());
+  }
+
+  private static boolean stillHaveUnbalancedNodes(@Nonnull ContainerBalancerTask task) {
+    return !task.getUnBalancedNodes().isEmpty();
+  }
+
+  public static @Nonnull MockedSCM getMockedSCM(int datanodeCount) {
+    return new MockedSCM(new TestableCluster(datanodeCount, STORAGE_UNIT));
+  }
+
+  private static @Nonnull ContainerBalancerConfiguration balancerConfigByOzoneConfig(
+      @Nonnull OzoneConfiguration ozoneConfiguration
+  ) {
+    return ozoneConfiguration.getObject(ContainerBalancerConfiguration.class);
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestableCluster.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestableCluster.java
@@ -1,0 +1,253 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.balancer;
+
+import jakarta.annotation.Nonnull;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+
+/**
+ * Class is used for creating test cluster with a required number of datanodes.
+ * 1. Fill the cluster by generating some data.
+ * 2. Nodes in the cluster have utilization values determined by generateUtilization method.
+ */
+public final class TestableCluster {
+  static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+  private static final Logger LOG = LoggerFactory.getLogger(TestableCluster.class);
+  private final int nodeCount;
+  private final double[] nodeUtilizationList;
+  private final DatanodeUsageInfo[] nodesInCluster;
+  private final Map<ContainerID, ContainerInfo> cidToInfoMap = new HashMap<>();
+  private final Map<ContainerID, Set<ContainerReplica>> cidToReplicasMap = new HashMap<>();
+  private final Map<DatanodeUsageInfo, Set<ContainerID>> dnUsageToContainersMap = new HashMap<>();
+  private final double averageUtilization;
+
+  TestableCluster(int numberOfNodes, long storageUnit) {
+    nodeCount = numberOfNodes;
+    nodeUtilizationList = createUtilizationList(nodeCount);
+    nodesInCluster = new DatanodeUsageInfo[nodeCount];
+
+    generateData(storageUnit);
+    createReplicasForContainers();
+    long clusterCapacity = 0, clusterUsedSpace = 0;
+
+    // For each node utilization, calculate that datanode's used space and capacity.
+    for (int i = 0; i < nodeUtilizationList.length; i++) {
+      Set<ContainerID> containerIDSet = dnUsageToContainersMap.get(nodesInCluster[i]);
+      long datanodeUsedSpace = 0;
+      for (ContainerID containerID : containerIDSet) {
+        datanodeUsedSpace += cidToInfoMap.get(containerID).getUsedBytes();
+      }
+      // Use node utilization and used space to determine node capacity.
+      long datanodeCapacity = (nodeUtilizationList[i] == 0)
+          ? storageUnit * RANDOM.nextInt(10, 60)
+          : (long) (datanodeUsedSpace / nodeUtilizationList[i]);
+
+      SCMNodeStat stat = new SCMNodeStat(datanodeCapacity, datanodeUsedSpace,
+          datanodeCapacity - datanodeUsedSpace, 0,
+          datanodeCapacity - datanodeUsedSpace - 1);
+      nodesInCluster[i].setScmNodeStat(stat);
+      clusterUsedSpace += datanodeUsedSpace;
+      clusterCapacity += datanodeCapacity;
+    }
+
+    averageUtilization = (double) clusterUsedSpace / clusterCapacity;
+  }
+
+  @Override
+  public String toString() {
+    return "cluster of " + nodeCount + " nodes";
+  }
+
+  @Nonnull Map<DatanodeUsageInfo, Set<ContainerID>> getDatanodeToContainersMap() {
+    return dnUsageToContainersMap;
+  }
+
+  @Nonnull Map<ContainerID, ContainerInfo> getCidToInfoMap() {
+    return cidToInfoMap;
+  }
+
+  int getNodeCount() {
+    return nodeCount;
+  }
+
+  double getAverageUtilization() {
+    return averageUtilization;
+  }
+
+  @Nonnull DatanodeUsageInfo[] getNodesInCluster() {
+    return nodesInCluster;
+  }
+
+  double[] getNodeUtilizationList() {
+    return nodeUtilizationList;
+  }
+
+  @Nonnull Map<ContainerID, Set<ContainerReplica>> getCidToReplicasMap() {
+    return cidToReplicasMap;
+  }
+
+  /**
+   * Determines unBalanced nodes, that is, over and under utilized nodes,
+   * according to the generated utilization values for nodes and the threshold.
+   *
+   * @param threshold a percentage in the range 0 to 100
+   * @return list of DatanodeUsageInfo containing the expected(correct) unBalanced nodes.
+   */
+  @Nonnull List<DatanodeUsageInfo> getUnBalancedNodes(double threshold) {
+    threshold /= 100;
+    double lowerLimit = averageUtilization - threshold;
+    double upperLimit = averageUtilization + threshold;
+
+    // Use node utilization to determine over and under utilized nodes.
+    List<DatanodeUsageInfo> expectedUnBalancedNodes = new ArrayList<>();
+    for (int i = 0; i < nodeCount; i++) {
+      double nodeUtilization = nodeUtilizationList[i];
+      if (nodeUtilization < lowerLimit || nodeUtilization > upperLimit) {
+        expectedUnBalancedNodes.add(nodesInCluster[i]);
+      }
+    }
+    return expectedUnBalancedNodes;
+  }
+
+  /**
+   * Create some datanodes and containers for each node.
+   */
+  private void generateData(long storageUnit) {
+    // Create datanodes and add containers to them.
+    for (int i = 0; i < nodeCount; i++) {
+      DatanodeUsageInfo usageInfo =
+          new DatanodeUsageInfo(MockDatanodeDetails.randomDatanodeDetails(), new SCMNodeStat());
+      nodesInCluster[i] = usageInfo;
+
+      // Create containers with varying used space.
+      Set<ContainerID> containerIDSet = new HashSet<>();
+      int sizeMultiple = 0;
+      for (int j = 0; j < i; j++) {
+        sizeMultiple %= 5;
+        sizeMultiple++;
+        ContainerInfo container = createContainer((long) i * i + j, storageUnit * sizeMultiple);
+
+        cidToInfoMap.put(container.containerID(), container);
+        containerIDSet.add(container.containerID());
+
+        // Create initial replica for this container and add it.
+        Set<ContainerReplica> containerReplicaSet = new HashSet<>();
+        containerReplicaSet.add(
+            createReplica(container.containerID(), usageInfo.getDatanodeDetails(), container.getUsedBytes()));
+        cidToReplicasMap.put(container.containerID(), containerReplicaSet);
+      }
+      dnUsageToContainersMap.put(usageInfo, containerIDSet);
+    }
+  }
+
+  private @Nonnull ContainerInfo createContainer(long id, long usedBytes) {
+    ContainerInfo.Builder builder = new ContainerInfo.Builder()
+        .setContainerID(id)
+        .setState(HddsProtos.LifeCycleState.CLOSED)
+        .setOwner("TestContainerBalancer")
+        .setUsedBytes(usedBytes);
+
+    // Make it a RATIS container if id is even, else make it an EC container.
+    ReplicationConfig config = (id % 2 == 0)
+        ? RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE)
+        : new ECReplicationConfig(3, 2);
+
+    builder.setReplicationConfig(config);
+    return builder.build();
+  }
+
+  /**
+   * Create the required number of replicas for each container. Note that one replica already exists and
+   * nodes with utilization value 0 should not have any replicas.
+   */
+  private void createReplicasForContainers() {
+    for (ContainerInfo container : cidToInfoMap.values()) {
+      // One replica already exists; create the remaining ones.
+      ReplicationConfig replicationConfig = container.getReplicationConfig();
+      ContainerID key = container.containerID();
+      for (int i = 0; i < replicationConfig.getRequiredNodes() - 1; i++) {
+        // Randomly pick a datanode for this replica.
+        int dnIndex = RANDOM.nextInt(0, nodeCount);
+        // Don't put replicas in DNs that are supposed to have 0 utilization.
+        if (Math.abs(nodeUtilizationList[dnIndex] - 0.0d) > 0.00001) {
+          DatanodeDetails node = nodesInCluster[dnIndex].getDatanodeDetails();
+          Set<ContainerReplica> replicas = cidToReplicasMap.get(key);
+          replicas.add(createReplica(key, node, container.getUsedBytes()));
+          cidToReplicasMap.put(key, replicas);
+          dnUsageToContainersMap.get(nodesInCluster[dnIndex]).add(key);
+        }
+      }
+    }
+  }
+
+  /**
+   * Generates a range of equally spaced utilization(that is, used / capacity) values from 0 to 1.
+   *
+   * @param count Number of values to generate. Count must be greater than or equal to 1.
+   * @return double array of node utilization values
+   * @throws IllegalArgumentException If the value of the parameter count is less than 1.
+   */
+  private static double[] createUtilizationList(int count) throws IllegalArgumentException {
+    if (count < 1) {
+      LOG.warn("The value of argument count is {}. However, count must be greater than 0.", count);
+      throw new IllegalArgumentException();
+    }
+    double[] result = new double[count];
+    for (int i = 0; i < count; i++) {
+      result[i] = (i / (double) count);
+    }
+    return result;
+  }
+
+  private @Nonnull ContainerReplica createReplica(
+      @Nonnull ContainerID containerID,
+      @Nonnull DatanodeDetails datanodeDetails,
+      long usedBytes
+  ) {
+    return ContainerReplica.newBuilder()
+        .setContainerID(containerID)
+        .setContainerState(ContainerReplicaProto.State.CLOSED)
+        .setDatanodeDetails(datanodeDetails)
+        .setOriginNodeId(datanodeDetails.getUuid())
+        .setSequenceId(1000L)
+        .setBytesUsed(usedBytes)
+        .build();
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -247,6 +247,10 @@ public final class OMConfigKeys {
   public static final boolean
       OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT = true;
 
+  public static final String OZONE_OM_RATIS_SERVER_CLOSE_THRESHOLD_KEY =
+      "ozone.om.ratis.server.close.threshold";
+  public static final TimeDuration OZONE_OM_RATIS_SERVER_CLOSE_THRESHOLD_DEFAULT =
+      TimeDuration.valueOf(60, TimeUnit.SECONDS);
 
   // OM SnapshotProvider configurations
   public static final String OZONE_OM_RATIS_SNAPSHOT_DIR =

--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/.env
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HDDS_VERSION=${hdds.version}
+OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
+OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-compose.yaml
@@ -1,0 +1,179 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.8"
+
+# reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
+x-common-config:
+  &common-config
+   image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
+   volumes:
+      - ../..:/opt/hadoop
+   env_file:
+      - docker-config
+
+x-replication:
+  &replication
+   OZONE-SITE.XML_ozone.server.default.replication: ${OZONE_REPLICATION_FACTOR:-3}
+
+services:
+   datanode1:
+      <<: *common-config
+      ports:
+         - 19864
+         - 9882
+      environment:
+         <<: *replication
+      command: ["ozone","datanode"]
+      volumes:
+         - tmpfs1:/data
+         - ../..:/opt/hadoop
+   datanode2:
+      <<: *common-config
+      ports:
+         - 19864
+         - 9882
+      environment:
+         <<: *replication
+      command: [ "ozone","datanode" ]
+      volumes:
+         - tmpfs2:/data
+         - ../..:/opt/hadoop
+   datanode3:
+      <<: *common-config
+      ports:
+         - 19864
+         - 9882
+      environment:
+         <<: *replication
+      command: [ "ozone","datanode" ]
+      volumes:
+         - tmpfs3:/data
+         - ../..:/opt/hadoop
+   datanode4:
+      <<: *common-config
+      ports:
+         - 19864
+         - 9882
+      environment:
+         <<: *replication
+      command: [ "ozone","datanode" ]
+      volumes:
+         - tmpfs4:/data
+         - ../..:/opt/hadoop
+   om1:
+      <<: *common-config
+      environment:
+         WAITFOR: scm3:9894
+         ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+         <<: *replication
+      ports:
+         - 9874:9874
+         - 9862
+      hostname: om1
+      command: ["ozone","om"]
+   om2:
+      <<: *common-config
+      environment:
+         WAITFOR: scm3:9894
+         ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+         <<: *replication
+      ports:
+         - 9874
+         - 9862
+      hostname: om2
+      command: ["ozone","om"]
+   om3:
+      <<: *common-config
+      environment:
+         WAITFOR: scm3:9894
+         ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+         <<: *replication
+      ports:
+         - 9874
+         - 9862
+      hostname: om3
+      command: ["ozone","om"]
+   scm1:
+      <<: *common-config
+      ports:
+         - 9876:9876
+      environment:
+         ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
+         OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
+         <<: *replication
+      command: ["ozone","scm"]
+   scm2:
+      <<: *common-config
+      ports:
+         - 9876
+      environment:
+         WAITFOR: scm1:9894
+         ENSURE_SCM_BOOTSTRAPPED: /data/metadata/scm/current/VERSION
+         OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
+         <<: *replication
+      command: ["ozone","scm"]
+   scm3:
+      <<: *common-config
+      ports:
+         - 9876
+      environment:
+         WAITFOR: scm2:9894
+         ENSURE_SCM_BOOTSTRAPPED: /data/metadata/scm/current/VERSION
+         OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
+         <<: *replication
+      command: ["ozone","scm"]
+   httpfs:
+      <<: *common-config
+      environment:
+         OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
+         <<: *replication
+      ports:
+         - 14000:14000
+      command: [ "ozone","httpfs" ]
+   s3g:
+      <<: *common-config
+      environment:
+         OZONE_OPTS:
+         <<: *replication
+      ports:
+         - 9878:9878
+      command: ["ozone","s3g"]
+volumes:
+   tmpfs1:
+      driver: local
+      driver_opts:
+         o: "size=1g,uid=1000"
+         device: tmpfs
+         type: tmpfs
+   tmpfs2:
+      driver: local
+      driver_opts:
+         o: "size=1g,uid=2000"
+         device: tmpfs
+         type: tmpfs
+   tmpfs3:
+      driver: local
+      driver_opts:
+         o: "size=1g,uid=3000"
+         device: tmpfs
+         type: tmpfs
+   tmpfs4:
+      driver: local
+      driver_opts:
+         o: "size=1g,uid=4000"
+         device: tmpfs
+         type: tmpfs

--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/docker-config
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For HttpFS service it is required to enable proxying users.
+CORE-SITE.XML_hadoop.proxyuser.hadoop.hosts=*
+CORE-SITE.XML_hadoop.proxyuser.hadoop.groups=*
+
+CORE-SITE.XML_fs.defaultFS=ofs://om/
+CORE-SITE.XML_fs.trash.interval=1
+
+OZONE-SITE.XML_ozone.om.service.ids=om
+OZONE-SITE.XML_ozone.om.nodes.om=om1,om2,om3
+OZONE-SITE.XML_ozone.om.address.om.om1=om1
+OZONE-SITE.XML_ozone.om.address.om.om2=om2
+OZONE-SITE.XML_ozone.om.address.om.om3=om3
+OZONE-SITE.XML_ozone.om.ratis.enable=true
+
+OZONE-SITE.XML_ozone.scm.service.ids=scmservice
+OZONE-SITE.XML_ozone.scm.nodes.scmservice=scm1,scm2,scm3
+OZONE-SITE.XML_ozone.scm.address.scmservice.scm1=scm1
+OZONE-SITE.XML_ozone.scm.address.scmservice.scm2=scm2
+OZONE-SITE.XML_ozone.scm.address.scmservice.scm3=scm3
+OZONE-SITE.XML_ozone.scm.ratis.enable=true
+OZONE-SITE.XML_ozone.scm.datanode.id.dir=/data
+OZONE-SITE.XML_ozone.scm.container.size=100MB
+OZONE-SITE.XML_ozone.scm.block.size=20MB
+OZONE-SITE.XML_ozone.scm.datanode.ratis.volume.free-space.min=10MB
+OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
+OZONE-SITE.XML_hdds.node.report.interval=20s
+OZONE-SITE.XML_hdds.heartbeat.interval=20s
+OZONE-SITE.XML_hdds.datanode.du.refresh.period=20s
+OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
+OZONE-SITE.XML_hdds.datanode.volume.min.free.space=100MB
+OZONE-SITE.XML_ozone.scm.pipeline.creation.auto.factor.one=false
+OZONE-SITE.XML_ozone.datanode.pipeline.limit=1
+OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.scm.primordial.node.id=scm1
+OZONE-SITE.XML_hdds.container.report.interval=30s
+OZONE-SITE.XML_ozone.om.s3.grpc.server_enabled=true
+OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
+OZONE-SITE.XML_ozone.recon.address=recon:9891
+OZONE-SITE.XML_ozone.recon.http-address=0.0.0.0:9888
+OZONE-SITE.XML_ozone.recon.https-address=0.0.0.0:9889
+OZONE-SITE.XML_dfs.container.ratis.datastream.enabled=true
+
+OZONE_CONF_DIR=/etc/hadoop
+OZONE_LOG_DIR=/var/log/hadoop
+
+no_proxy=om1,om2,om3,scm,s3g,recon,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-balancer/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-balancer/test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#suite:balancer
+
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
+export OM_SERVICE_ID="om"
+export OM=om1
+export SCM=scm1
+export OZONE_REPLICATION_FACTOR=3
+
+# shellcheck source=/dev/null
+source "$COMPOSE_DIR/../testlib.sh"
+
+# We need 4 dataNodes in this tests
+start_docker_env 4
+
+execute_robot_test ${OM} balancer/testBalancer.robot

--- a/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/balancer/testBalancer.robot
@@ -1,0 +1,143 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoketest ozone cluster startup
+Library             OperatingSystem
+Library             Collections
+Resource            ../commonlib.robot
+Resource            ../ozone-lib/shell.robot
+
+Test Timeout        20 minutes
+
+*** Variables ***
+${SECURITY_ENABLED}                 false
+${HOST}                             datanode1
+${VOLUME}                           volume1
+${BUCKET}                           bucket1
+${SIZE}                             104857600
+
+
+** Keywords ***
+Prepare For Tests
+    Execute             dd if=/dev/urandom of=/tmp/100mb bs=1048576 count=100
+    Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit test user    testuser    testuser.keytab
+    Execute                 ozone sh volume create /${VOLUME}
+    Execute                 ozone sh bucket create /${VOLUME}/${BUCKET}
+
+
+Datanode In Maintenance Mode
+    ${result} =             Execute                         ozone admin datanode maintenance ${HOST}
+                            Should Contain                  ${result}             Entering maintenance mode on datanode
+    ${result} =             Execute                         ozone admin datanode list | grep "Operational State:*"
+                            Wait Until Keyword Succeeds      30sec   5sec    Should contain   ${result}   ENTERING_MAINTENANCE
+                            Wait Until Keyword Succeeds      3min    10sec   Related pipelines are closed
+                            Sleep                   60000ms
+
+Related pipelines are closed
+    ${result} =         Execute          ozone admin datanode list | awk -v RS= '{$1=$1}1'|grep MAINT | sed -e 's/^.*pipelines: \\(.*\\)$/\\1/'
+                        Should Contain Any   ${result}   CLOSED   No related pipelines or the node is not in Healthy state.
+
+Datanode Recommission
+    ${result} =             Execute                         ozone admin datanode recommission ${HOST}
+                            Should Contain                  ${result}             Started recommissioning datanode
+                            Wait Until Keyword Succeeds      1min    10sec    Datanode Recommission is Finished
+                            Sleep                   300000ms
+
+Datanode Recommission is Finished
+    ${result} =             Execute                         ozone admin datanode list | grep "Operational State:*"
+                            Should Not Contain   ${result}   ENTERING_MAINTENANCE
+
+Run Container Balancer
+    ${result} =             Execute                         ozone admin containerbalancer start -t 1 -d 100 -i 1
+                            Should Contain                  ${result}             Container Balancer started successfully.
+    ${result} =             Execute                         ozone admin containerbalancer status
+                            Should Contain                  ${result}             ContainerBalancer is Running.
+                            Wait Until Keyword Succeeds      3min    10sec    ContainerBalancer is Not Running
+                            Sleep                   60000ms
+
+ContainerBalancer is Not Running
+    ${result} =         Execute          ozone admin containerbalancer status
+                        Should contain   ${result}   ContainerBalancer is Not Running.
+
+Create Multiple Keys
+    [arguments]             ${NUM_KEYS}
+    ${file} =    Set Variable    /tmp/100mb
+    FOR     ${INDEX}        IN RANGE                ${NUM_KEYS}
+            ${fileName} =           Set Variable            file-${INDEX}.txt
+            ${key} =    Set Variable    /${VOLUME}/${BUCKET}/${fileName}
+            LOG             ${fileName}
+            Create Key    ${key}    ${file}
+            Key Should Match Local File    ${key}      ${file}
+    END
+
+Datanode Usageinfo
+    [arguments]             ${uuid}
+    ${result} =             Execute               ozone admin datanode usageinfo --uuid=${uuid}
+                            Should Contain                  ${result}             Ozone Used
+
+Get Uuid
+    ${result} =             Execute          ozone admin datanode list | awk -v RS= '{$1=$1}1'| grep ${HOST} | sed -e 's/Datanode: //'|sed -e 's/ .*$//'
+    [return]          ${result}
+
+Close All Containers
+    FOR     ${INDEX}    IN RANGE    15
+        ${container} =      Execute          ozone admin container list --state OPEN | jq -r 'select(.replicationConfig.replicationFactor == "THREE") | .containerID' | head -1
+        EXIT FOR LOOP IF    "${container}" == ""
+                            Execute          ozone admin container close "${container}"
+        ${output} =         Execute          ozone admin container info "${container}"
+                            Should contain   ${output}   CLOS
+    END
+    Wait until keyword succeeds    3min    10sec    All container is closed
+
+All container is closed
+    ${output} =         Execute          ozone admin container list --state OPEN
+                        Should Be Empty   ${output}
+
+Get Datanode Ozone Used Bytes Info
+    [arguments]             ${uuid}
+    ${output} =    Execute    export DATANODES=$(ozone admin datanode list --json) && for datanode in $(echo "$\{DATANODES\}" | jq -r '.[].datanodeDetails.uuid'); do ozone admin datanode usageinfo --uuid=$\{datanode\} --json | jq '{(.[0].datanodeDetails.uuid) : .[0].ozoneUsed}'; done | jq -s add
+    ${result} =    Execute    echo '${output}' | jq '. | to_entries | .[] | select(.key == "${uuid}") | .value'
+    [return]          ${result}
+
+** Test Cases ***
+Verify Container Balancer for RATIS containers
+    Prepare For Tests
+
+    Datanode In Maintenance Mode
+
+    ${uuid} =                   Get Uuid
+    Datanode Usageinfo          ${uuid}
+
+    Create Multiple Keys          3
+
+    Close All Containers
+
+    ${datanodeOzoneUsedBytesInfo} =    Get Datanode Ozone Used Bytes Info          ${uuid}
+    Should Be True    ${datanodeOzoneUsedBytesInfo} < ${SIZE}
+
+    Datanode Recommission
+
+    Run Container Balancer
+
+    ${datanodeOzoneUsedBytesInfoAfterContainerBalancing} =    Get Datanode Ozone Used Bytes Info          ${uuid}
+    Should Not Be Equal As Integers     ${datanodeOzoneUsedBytesInfo}    ${datanodeOzoneUsedBytesInfoAfterContainerBalancing}
+    Should Be True    ${datanodeOzoneUsedBytesInfoAfterContainerBalancing} < ${SIZE} * 3.5
+    Should Be True    ${datanodeOzoneUsedBytesInfoAfterContainerBalancing} > ${SIZE} * 3
+
+
+
+
+

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.SecretKeyTestClient;
+import org.apache.hadoop.ozone.client.io.BlockOutputStreamEntry;
 import org.apache.hadoop.ozone.client.io.InsufficientLocationsException;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
@@ -85,6 +86,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
@@ -101,6 +103,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -114,6 +117,8 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.READ;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.WRITE;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.newWriteChunkRequestBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * This class tests container commands on EC containers.
@@ -612,30 +617,33 @@ public class TestContainerCommandsEC {
 
   @ParameterizedTest
   @MethodSource("recoverableMissingIndexes")
-  void testECReconstructionCoordinatorWith(List<Integer> missingIndexes)
+  void testECReconstructionCoordinatorWith(List<Integer> missingIndexes, boolean triggerRetry)
       throws Exception {
-    testECReconstructionCoordinator(missingIndexes, 3);
+    testECReconstructionCoordinator(missingIndexes, 3, triggerRetry);
   }
 
   @ParameterizedTest
   @MethodSource("recoverableMissingIndexes")
-  void testECReconstructionCoordinatorWithPartialStripe(List<Integer> missingIndexes)
-      throws Exception {
-    testECReconstructionCoordinator(missingIndexes, 1);
+  void testECReconstructionCoordinatorWithPartialStripe(List<Integer> missingIndexes,
+      boolean triggerRetry) throws Exception {
+    testECReconstructionCoordinator(missingIndexes, 1, triggerRetry);
   }
 
   @ParameterizedTest
   @MethodSource("recoverableMissingIndexes")
-  void testECReconstructionCoordinatorWithFullAndPartialStripe(List<Integer> missingIndexes)
-      throws Exception {
-    testECReconstructionCoordinator(missingIndexes, 4);
+  void testECReconstructionCoordinatorWithFullAndPartialStripe(List<Integer> missingIndexes,
+      boolean triggerRetry) throws Exception {
+    testECReconstructionCoordinator(missingIndexes, 4, triggerRetry);
   }
 
-  static Stream<List<Integer>> recoverableMissingIndexes() {
-    return Stream
-        .concat(IntStream.rangeClosed(1, 5).mapToObj(ImmutableList::of), Stream
-            .of(ImmutableList.of(2, 3), ImmutableList.of(2, 4),
-                ImmutableList.of(3, 5), ImmutableList.of(4, 5)));
+  static Stream<Arguments> recoverableMissingIndexes() {
+    Stream<Arguments> args = IntStream.rangeClosed(1, 5).mapToObj(i -> arguments(ImmutableList.of(i), true));
+    Stream<Arguments> args1 = IntStream.rangeClosed(1, 5).mapToObj(i -> arguments(ImmutableList.of(i), false));
+    Stream<Arguments> args2 =  Stream.of(arguments(ImmutableList.of(2, 3), true),
+        arguments(ImmutableList.of(2, 4), true), arguments(ImmutableList.of(3, 5), true));
+    Stream<Arguments> args3 =  Stream.of(arguments(ImmutableList.of(2, 3), false),
+        arguments(ImmutableList.of(2, 4), false), arguments(ImmutableList.of(3, 5), false));
+    return Stream.concat(Stream.concat(args, args1), Stream.concat(args2, args3));
   }
 
   /**
@@ -646,7 +654,7 @@ public class TestContainerCommandsEC {
   public void testECReconstructionCoordinatorWithMissingIndexes135() {
     InsufficientLocationsException exception =
         Assert.assertThrows(InsufficientLocationsException.class, () -> {
-          testECReconstructionCoordinator(ImmutableList.of(1, 3, 5), 3);
+          testECReconstructionCoordinator(ImmutableList.of(1, 3, 5), 3, false);
         });
 
     String expectedMessage =
@@ -657,7 +665,7 @@ public class TestContainerCommandsEC {
   }
 
   private void testECReconstructionCoordinator(List<Integer> missingIndexes,
-      int numInputChunks) throws Exception {
+      int numInputChunks, boolean triggerRetry) throws Exception {
     ObjectStore objectStore = rpcClient.getObjectStore();
     String keyString = UUID.randomUUID().toString();
     String volumeName = UUID.randomUUID().toString();
@@ -666,7 +674,7 @@ public class TestContainerCommandsEC {
     objectStore.getVolume(volumeName).createBucket(bucketName);
     OzoneVolume volume = objectStore.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    createKeyAndWriteData(keyString, bucket, numInputChunks);
+    createKeyAndWriteData(keyString, bucket, numInputChunks, triggerRetry);
 
     try (
         XceiverClientManager xceiverClientManager =
@@ -778,7 +786,7 @@ public class TestContainerCommandsEC {
                           .getReplicationConfig(), cToken);
           Assert.assertEquals(blockDataArrList.get(i).length,
               reconstructedBlockData.length);
-          checkBlockData(blockDataArrList.get(i), reconstructedBlockData);
+          checkBlockDataWithRetry(blockDataArrList.get(i), reconstructedBlockData, triggerRetry);
           XceiverClientSpi client = xceiverClientManager.acquireClient(
               newTargetPipeline);
           try {
@@ -799,7 +807,7 @@ public class TestContainerCommandsEC {
   }
 
   private void createKeyAndWriteData(String keyString, OzoneBucket bucket,
-      int numChunks) throws IOException {
+      int numChunks, boolean triggerRetry) throws IOException {
     for (int i = 0; i < numChunks; i++) {
       inputChunks[i] = getBytesWith(i + 1, EC_CHUNK_SIZE);
     }
@@ -808,9 +816,46 @@ public class TestContainerCommandsEC {
         new HashMap<>())) {
       Assert.assertTrue(out.getOutputStream() instanceof KeyOutputStream);
       for (int i = 0; i < numChunks; i++) {
+        // We generally wait until the data is written to the last chunk
+        // before attempting to trigger CloseContainer.
+        // We use an asynchronous approach for this trigger,
+        // aiming to ensure that closing the container does not interfere with the write operation.
+        // However, this process often needs to be executed multiple times before it takes effect.
+        if (i == numChunks - 1 && triggerRetry) {
+          triggerRetryByCloseContainer(out);
+        }
         out.write(inputChunks[i]);
       }
     }
+  }
+
+  private void triggerRetryByCloseContainer(OzoneOutputStream out) {
+    CompletableFuture.runAsync(() -> {
+      BlockOutputStreamEntry blockOutputStreamEntry = out.getKeyOutputStream().getStreamEntries().get(0);
+      BlockID entryBlockID = blockOutputStreamEntry.getBlockID();
+      long entryContainerID = entryBlockID.getContainerID();
+      Pipeline entryPipeline = blockOutputStreamEntry.getPipeline();
+      Map<DatanodeDetails, Integer> replicaIndexes = entryPipeline.getReplicaIndexes();
+      try {
+        for (Map.Entry<DatanodeDetails, Integer> entry : replicaIndexes.entrySet()) {
+          DatanodeDetails key = entry.getKey();
+          Integer value = entry.getValue();
+          XceiverClientManager xceiverClientManager = new XceiverClientManager(config);
+          Token<ContainerTokenIdentifier> cToken = containerTokenGenerator
+              .generateToken(ANY_USER, ContainerID.valueOf(entryContainerID));
+          XceiverClientSpi client = xceiverClientManager.acquireClient(
+              createSingleNodePipeline(entryPipeline, key, value));
+          try {
+            ContainerProtocolCalls.closeContainer(client, entryContainerID, cToken.encodeToUrlString());
+          } finally {
+            xceiverClientManager.releaseClient(client, false);
+          }
+          break;
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
   }
 
   @Test
@@ -825,7 +870,7 @@ public class TestContainerCommandsEC {
     objectStore.getVolume(volumeName).createBucket(bucketName);
     OzoneVolume volume = objectStore.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
-    createKeyAndWriteData(keyString, bucket, 3);
+    createKeyAndWriteData(keyString, bucket, 3, false);
 
     OzoneKeyDetails key = bucket.getKey(keyString);
     long conID = key.getOzoneKeyLocations().get(0).getContainerID();
@@ -899,6 +944,25 @@ public class TestContainerCommandsEC {
         HddsProtos.LifeCycleEvent.CLOSE);
   }
 
+  private void checkBlockDataWithRetry(
+      org.apache.hadoop.ozone.container.common.helpers.BlockData[] blockData,
+      org.apache.hadoop.ozone.container.common.helpers.BlockData[]
+      reconstructedBlockData, boolean triggerRetry) {
+    if (triggerRetry) {
+      for (int i = 0; i < reconstructedBlockData.length; i++) {
+        assertEquals(blockData[i].getBlockID(), reconstructedBlockData[i].getBlockID());
+        List<ContainerProtos.ChunkInfo> oldBlockDataChunks = blockData[i].getChunks();
+        List<ContainerProtos.ChunkInfo> newBlockDataChunks = reconstructedBlockData[i].getChunks();
+        for (int j = 0; j < newBlockDataChunks.size(); j++) {
+          ContainerProtos.ChunkInfo chunkInfo = oldBlockDataChunks.get(j);
+          assertEquals(chunkInfo, newBlockDataChunks.get(j));
+        }
+      }
+      return;
+    }
+    checkBlockData(blockData, reconstructedBlockData);
+  }
+
   private void checkBlockData(
       org.apache.hadoop.ozone.container.common.helpers.BlockData[] blockData,
       org.apache.hadoop.ozone.container.common.helpers.BlockData[]
@@ -967,8 +1031,7 @@ public class TestContainerCommandsEC {
         out.write(values[i]);
       }
     }
-//    List<ContainerID> containerIDs =
-//        new ArrayList<>(scm.getContainerManager().getContainerIDs());
+
     List<ContainerID> containerIDs =
             scm.getContainerManager().getContainers()
                     .stream()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHASnapshot.java
@@ -21,31 +21,41 @@ package org.apache.hadoop.ozone.om;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.IOUtils;
+import org.apache.hadoop.hdds.utils.db.RDBCheckpointUtils;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse;
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.OmSnapshotManager.getSnapshotPath;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.DONE;
 import static org.apache.hadoop.ozone.snapshot.SnapshotDiffResponse.JobStatus.IN_PROGRESS;
 import static org.awaitility.Awaitility.await;
@@ -72,6 +82,8 @@ public class TestOzoneManagerHASnapshot {
     String clusterId = UUID.randomUUID().toString();
     String scmId = UUID.randomUUID().toString();
     conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
+    conf.setTimeDuration(OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 1, TimeUnit.SECONDS);
+    conf.setTimeDuration(OzoneConfigKeys.OZONE_SNAPSHOT_DELETING_SERVICE_INTERVAL, 1, TimeUnit.SECONDS);
 
     cluster = (MiniOzoneHAClusterImpl) MiniOzoneCluster.newOMHABuilder(conf)
         .setClusterId(clusterId)
@@ -270,5 +282,98 @@ public class TestOzoneManagerHASnapshot {
     try (OzoneOutputStream fileKey = bucket.createKey(keyName, value.length)) {
       fileKey.write(value);
     }
+  }
+
+  /**
+   * This is to simulate HDDS-11152 scenario. In which a follower's doubleBuffer is lagging and accumulates purgeKey
+   * and purgeSnapshot in same batch.
+   */
+  @Test
+  public void testKeyAndSnapshotDeletionService() throws IOException, InterruptedException, TimeoutException {
+    OzoneManager omLeader = cluster.getOMLeader();
+    OzoneManager omFollower;
+
+    if (omLeader != cluster.getOzoneManager(0)) {
+      omFollower = cluster.getOzoneManager(0);
+    } else {
+      omFollower = cluster.getOzoneManager(1);
+    }
+
+    int numKeys = 5;
+    List<String> keys = new ArrayList<>();
+    for (int i = 0; i < numKeys; i++) {
+      String keyName = "key-" + RandomStringUtils.randomNumeric(10);
+      createFileKey(ozoneBucket, keyName);
+      keys.add(keyName);
+    }
+
+    // Stop the key deletion service so that deleted keys get trapped in the snapshots.
+    omLeader.getKeyManager().getDeletingService().suspend();
+    // Stop the snapshot deletion service so that deleted keys get trapped in the snapshots.
+    omLeader.getKeyManager().getSnapshotDeletingService().suspend();
+
+    // Delete half of the keys
+    for (int i = 0; i < numKeys / 2; i++) {
+      ozoneBucket.deleteKey(keys.get(i));
+    }
+
+    String snapshotName = "snap-" + RandomStringUtils.randomNumeric(10);
+    createSnapshot(volumeName, bucketName, snapshotName);
+
+    store.deleteSnapshot(volumeName, bucketName, snapshotName);
+
+    // Pause double buffer on follower node to accumulate all the key purge, snapshot delete and purge transactions.
+    omFollower.getOmRatisServer().getOmStateMachine().getOzoneManagerDoubleBuffer().stopDaemon();
+
+    long keyDeleteServiceCount = omLeader.getKeyManager().getDeletingService().getRunCount().get();
+    omLeader.getKeyManager().getDeletingService().resume();
+
+    GenericTestUtils.waitFor(
+        () -> omLeader.getKeyManager().getDeletingService().getRunCount().get() > keyDeleteServiceCount,
+        1000, 60000);
+
+    long snapshotDeleteServiceCount = omLeader.getKeyManager().getSnapshotDeletingService().getRunCount().get();
+    omLeader.getKeyManager().getSnapshotDeletingService().resume();
+
+    GenericTestUtils.waitFor(
+        () -> omLeader.getKeyManager().getSnapshotDeletingService().getRunCount().get() > snapshotDeleteServiceCount,
+        1000, 60000);
+
+    String tableKey = SnapshotInfo.getTableKey(volumeName, bucketName, snapshotName);
+    checkSnapshotIsPurgedFromDB(omLeader, tableKey);
+
+    // Resume the DoubleBuffer and flush the pending transactions.
+    OzoneManagerDoubleBuffer omDoubleBuffer =
+        omFollower.getOmRatisServer().getOmStateMachine().getOzoneManagerDoubleBuffer();
+    omDoubleBuffer.resume();
+    CompletableFuture.supplyAsync(() -> {
+      omDoubleBuffer.flushTransactions();
+      return null;
+    });
+    omDoubleBuffer.awaitFlush();
+    checkSnapshotIsPurgedFromDB(omFollower, tableKey);
+  }
+
+  private void createSnapshot(String volName, String buckName, String snapName) throws IOException {
+    store.createSnapshot(volName, buckName, snapName);
+
+    String tableKey = SnapshotInfo.getTableKey(volName, buckName, snapName);
+    SnapshotInfo snapshotInfo = SnapshotUtils.getSnapshotInfo(cluster.getOMLeader(), tableKey);
+    String fileName = getSnapshotPath(cluster.getOMLeader().getConfiguration(), snapshotInfo);
+    File snapshotDir = new File(fileName);
+    if (!RDBCheckpointUtils.waitForCheckpointDirectoryExist(snapshotDir)) {
+      throw new IOException("Snapshot directory doesn't exist");
+    }
+  }
+
+  private void checkSnapshotIsPurgedFromDB(OzoneManager ozoneManager, String snapshotTableKey)
+      throws InterruptedException, TimeoutException {
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return ozoneManager.getMetadataManager().getSnapshotInfoTable().get(snapshotTableKey) == null;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 1000, 60000);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshot.java
@@ -205,11 +205,7 @@ public abstract class TestOmSnapshot {
     conf.setBoolean(OZONE_OM_ENABLE_FILESYSTEM_PATHS, enabledFileSystemPaths);
     conf.set(OZONE_DEFAULT_BUCKET_LAYOUT, bucketLayout.name());
     conf.setBoolean(OZONE_OM_SNAPSHOT_FORCE_FULL_DIFF, forceFullSnapshotDiff);
-    conf.setBoolean(OZONE_OM_SNAPSHOT_DIFF_DISABLE_NATIVE_LIBS,
-        disableNativeDiff);
-    conf.setBoolean(OZONE_OM_ENABLE_FILESYSTEM_PATHS, enabledFileSystemPaths);
-    conf.set(OZONE_DEFAULT_BUCKET_LAYOUT, bucketLayout.name());
-    conf.setBoolean(OZONE_OM_SNAPSHOT_FORCE_FULL_DIFF, forceFullSnapshotDiff);
+    conf.setBoolean(OZONE_OM_SNAPSHOT_DIFF_DISABLE_NATIVE_LIBS, disableNativeDiff);
     conf.setEnum(HDDS_DB_PROFILE, DBProfile.TEST);
     // Enable filesystem snapshot feature for the test regardless of the default
     conf.setBoolean(OMConfigKeys.OZONE_FILESYSTEM_SNAPSHOT_ENABLED_KEY, true);
@@ -1487,10 +1483,8 @@ public abstract class TestOmSnapshot {
     String toSnapshotTableKey =
         SnapshotInfo.getTableKey(volumeName, bucketName, toSnapName);
 
-    UUID fromSnapshotID = ozoneManager.getOmSnapshotManager()
-        .getSnapshotInfo(fromSnapshotTableKey).getSnapshotId();
-    UUID toSnapshotID = ozoneManager.getOmSnapshotManager()
-        .getSnapshotInfo(toSnapshotTableKey).getSnapshotId();
+    UUID fromSnapshotID = SnapshotUtils.getSnapshotInfo(ozoneManager, fromSnapshotTableKey).getSnapshotId();
+    UUID toSnapshotID = SnapshotUtils.getSnapshotInfo(ozoneManager, toSnapshotTableKey).getSnapshotId();
 
     // Construct SnapshotDiffJob table key.
     String snapDiffJobKey = fromSnapshotID + DELIMITER + toSnapshotID;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
@@ -72,8 +72,8 @@ public class TestReconTasks {
     taskConfig.setMissingContainerTaskInterval(Duration.ofSeconds(15));
     conf.setFromObject(taskConfig);
 
-    conf.set("ozone.scm.stale.node.interval", "10s");
-    conf.set("ozone.scm.dead.node.interval", "20s");
+    conf.set("ozone.scm.stale.node.interval", "6s");
+    conf.set("ozone.scm.dead.node.interval", "10s");
     cluster =  MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1)
         .includeRecon(true).build();
     cluster.waitForClusterToBeReady();
@@ -100,9 +100,6 @@ public class TestReconTasks {
         RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE), "admin");
     final ContainerInfo container2 = scmContainerManager.allocateContainer(
-        RatisReplicationConfig.getInstance(
-            HddsProtos.ReplicationFactor.ONE), "admin");
-    reconContainerManager.allocateContainer(
         RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE), "admin");
     scmContainerManager.updateContainerState(container1.containerID(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSecretKeysApi.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSecretKeysApi.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.tag.Flaky;
 import org.apache.ratis.util.ExitUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -192,6 +193,7 @@ public final class TestSecretKeysApi {
    * Test secret key apis in happy case.
    */
   @Test
+  @Flaky("HDDS-8900")
   public void testSecretKeyApiSuccess() throws Exception {
     enableBlockToken();
     // set a low rotation period, of 1s, expiry is 3s, expect 3 active keys

--- a/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
+++ b/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
@@ -54,7 +54,7 @@
   <property>
     <name>hdds.container.ratis.log.appender.queue.byte-limit
 </name>
-    <value>8MB</value>
+    <value>32MB</value>
   </property>
   <property>
     <name>ozone.om.ratis.log.appender.queue.byte-limit</name>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -97,6 +97,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_DB_
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_REPORT_MAX_PAGE_SIZE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_DIFF_REPORT_MAX_PAGE_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_SNAPSHOT_ERROR;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotDiffManager.getSnapshotRootPath;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.checkSnapshotActive;
 import static org.apache.hadoop.ozone.om.snapshot.SnapshotUtils.dropColumnFamilyHandle;
@@ -691,19 +692,38 @@ public final class OmSnapshotManager implements AutoCloseable {
   }
 
   /**
-   * Returns true if the snapshot is in given status.
-   * @param key DB snapshot table key
-   * @param status SnapshotStatus
-   * @return true if the snapshot is in given status, false otherwise
+   * Returns OmSnapshot object and skips active check.
+   * This should only be used for API calls initiated by background service e.g. purgeKeys, purgeSnapshot,
+   * snapshotMoveDeletedKeys, and SetSnapshotProperty.
    */
-  public boolean isSnapshotStatus(String key,
-                                  SnapshotInfo.SnapshotStatus status)
-      throws IOException {
-    return getSnapshotInfo(key).getSnapshotStatus().equals(status);
+  public ReferenceCounted<OmSnapshot> getSnapshot(UUID snapshotId) throws IOException {
+    return snapshotCache.get(snapshotId);
   }
 
-  public SnapshotInfo getSnapshotInfo(String key) throws IOException {
-    return SnapshotUtils.getSnapshotInfo(ozoneManager, key);
+  /**
+   * Returns snapshotInfo from cache if it is present in cache, otherwise it checks RocksDB and return value from there.
+   * #################################################
+   * NOTE: THIS SHOULD BE USED BY SNAPSHOT CACHE ONLY.
+   * #################################################
+   * Sometimes, the follower OM node may be lagging that it gets purgeKeys or snapshotMoveDeletedKeys from a Snapshot,
+   * and purgeSnapshot for the same Snapshot one after another. And purgeSnapshot's validateAndUpdateCache gets
+   * executed before doubleBuffer flushes purgeKeys or snapshotMoveDeletedKeys from that Snapshot.
+   * This should not be a case on the leader node because SnapshotDeletingService checks that deletedTable and
+   * deletedDirectoryTable in DB don't have entries for the bucket before it sends a purgeSnapshot on a snapshot.
+   * If that happens, and we just look into the cache, the addToBatch operation will fail when it tries to open
+   * the DB and purgeKeys from the Snapshot because snapshot is already purged from the SnapshotInfoTable cache.
+   * Hence, it is needed to look into the table to make sure that snapshot exists somewhere either in cache or in DB.
+   */
+  private SnapshotInfo getSnapshotInfo(String snapshotKey) throws IOException {
+    SnapshotInfo snapshotInfo = ozoneManager.getMetadataManager().getSnapshotInfoTable().get(snapshotKey);
+
+    if (snapshotInfo == null) {
+      snapshotInfo = ozoneManager.getMetadataManager().getSnapshotInfoTable().getSkipCache(snapshotKey);
+    }
+    if (snapshotInfo == null) {
+      throw new OMException("Snapshot '" + snapshotKey + "' is not found.", INVALID_SNAPSHOT_ERROR);
+    }
+    return snapshotInfo;
   }
 
   public static String getSnapshotPrefix(String snapshotName) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -354,13 +354,16 @@ public class SnapshotChainManager {
   public synchronized boolean deleteSnapshot(SnapshotInfo snapshotInfo)
       throws IOException {
     validateSnapshotChain();
-    boolean status = deleteSnapshotGlobal(snapshotInfo.getSnapshotId()) &&
-        deleteSnapshotPath(snapshotInfo.getSnapshotPath(),
-            snapshotInfo.getSnapshotId());
-    if (status) {
-      snapshotIdToTableKey.remove(snapshotInfo.getSnapshotId());
-    }
-    return status;
+    return deleteSnapshotGlobal(snapshotInfo.getSnapshotId()) &&
+        deleteSnapshotPath(snapshotInfo.getSnapshotPath(), snapshotInfo.getSnapshotId());
+  }
+
+  /**
+   * Remove the snapshot from snapshotIdToSnapshotTableKey map.
+   */
+  public synchronized void removeFromSnapshotIdToTable(UUID snapshotId) throws IOException {
+    validateSnapshotChain();
+    snapshotIdToTableKey.remove(snapshotId);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -599,10 +599,9 @@ public final class OzoneManagerRatisServer {
   public static RaftProperties newRaftProperties(ConfigurationSource conf,
       int port, String ratisStorageDir) {
     // Set RPC type
-    final String rpcType = conf.get(
+    final RpcType rpc = SupportedRpcType.valueOfIgnoreCase(conf.get(
         OMConfigKeys.OZONE_OM_RATIS_RPC_TYPE_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_RPC_TYPE_DEFAULT);
-    final RpcType rpc = SupportedRpcType.valueOfIgnoreCase(rpcType);
+        OMConfigKeys.OZONE_OM_RATIS_RPC_TYPE_DEFAULT));
     final RaftProperties properties = RatisHelper.newRaftProperties(rpc);
 
     // Set the ratis port number
@@ -613,8 +612,7 @@ public final class OzoneManagerRatisServer {
     }
 
     // Set Ratis storage directory
-    RaftServerConfigKeys.setStorageDir(properties,
-        Collections.singletonList(new File(ratisStorageDir)));
+    RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(new File(ratisStorageDir)));
 
     final int logAppenderQueueByteLimit = (int) conf.getStorageSize(
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
@@ -641,58 +639,46 @@ public final class OzoneManagerRatisServer {
 
   private static void setRaftLeaderElectionProperties(RaftProperties properties, ConfigurationSource conf) {
     // Disable/enable the pre vote feature in Ratis
-    RaftServerConfigKeys.LeaderElection.setPreVote(properties,
-        conf.getBoolean(OMConfigKeys.OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE,
-            OMConfigKeys.OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT));
+    RaftServerConfigKeys.LeaderElection.setPreVote(properties, conf.getBoolean(
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE,
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT));
   }
 
   private static void setRaftLogProperties(RaftProperties properties,
       int logAppenderQueueByteLimit, ConfigurationSource conf) {
     // Set RAFT segment size
-    final long raftSegmentSize = (long) conf.getStorageSize(
+    RaftServerConfigKeys.Log.setSegmentSizeMax(properties, SizeInBytes.valueOf((long) conf.getStorageSize(
         OMConfigKeys.OZONE_OM_RATIS_SEGMENT_SIZE_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_SEGMENT_SIZE_DEFAULT,
-        StorageUnit.BYTES);
-    RaftServerConfigKeys.Log.setSegmentSizeMax(properties,
-        SizeInBytes.valueOf(raftSegmentSize));
+        OMConfigKeys.OZONE_OM_RATIS_SEGMENT_SIZE_DEFAULT, StorageUnit.BYTES)));
 
     // Set to enable RAFT to purge logs up to Snapshot Index
-    RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties,
-        conf.getBoolean(
-          OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX,
-          OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX_DEFAULT
-        )
-    );
+    RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, conf.getBoolean(
+        OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX,
+        OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_UPTO_SNAPSHOT_INDEX_DEFAULT));
+
     // Set number of last RAFT logs to not be purged
-    RaftServerConfigKeys.Log.setPurgePreservationLogNum(properties,
-        conf.getLong(
-          OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM,
-          OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_DEFAULT
-        )
-    );
+    RaftServerConfigKeys.Log.setPurgePreservationLogNum(properties, conf.getLong(
+        OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM,
+        OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_DEFAULT));
 
     // Set RAFT segment pre-allocated size
-    final long raftSegmentPreallocatedSize = (long) conf.getStorageSize(
+    RaftServerConfigKeys.Log.setPreallocatedSize(properties, SizeInBytes.valueOf((long) conf.getStorageSize(
         OMConfigKeys.OZONE_OM_RATIS_SEGMENT_PREALLOCATED_SIZE_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_SEGMENT_PREALLOCATED_SIZE_DEFAULT,
-        StorageUnit.BYTES);
-    int logAppenderQueueNumElements = conf.getInt(
+        OMConfigKeys.OZONE_OM_RATIS_SEGMENT_PREALLOCATED_SIZE_DEFAULT, StorageUnit.BYTES)));
+
+    // Set RAFT buffer element limit
+    RaftServerConfigKeys.Log.Appender.setBufferElementLimit(properties, conf.getInt(
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS,
-        OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS_DEFAULT);
-    RaftServerConfigKeys.Log.Appender.setBufferElementLimit(properties,
-        logAppenderQueueNumElements);
-    RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties,
-        SizeInBytes.valueOf(logAppenderQueueByteLimit));
-    RaftServerConfigKeys.Log.setWriteBufferSize(properties,
-        SizeInBytes.valueOf(logAppenderQueueByteLimit + 8));
-    RaftServerConfigKeys.Log.setPreallocatedSize(properties,
-        SizeInBytes.valueOf(raftSegmentPreallocatedSize));
-    RaftServerConfigKeys.Log.Appender.setInstallSnapshotEnabled(properties,
-        false);
-    final int logPurgeGap = conf.getInt(
+        OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS_DEFAULT));
+
+    RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties, SizeInBytes.valueOf(logAppenderQueueByteLimit));
+    RaftServerConfigKeys.Log.setWriteBufferSize(properties, SizeInBytes.valueOf(logAppenderQueueByteLimit + 8));
+    RaftServerConfigKeys.Log.Appender.setInstallSnapshotEnabled(properties, false);
+
+    RaftServerConfigKeys.Log.setPurgeGap(properties, conf.getInt(
         OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_GAP,
-        OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_GAP_DEFAULT);
-    RaftServerConfigKeys.Log.setPurgeGap(properties, logPurgeGap);
+        OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_GAP_DEFAULT));
+
     // Set the number of maximum cached segments
     RaftServerConfigKeys.Log.setSegmentCacheNumMax(properties, 2);
   }
@@ -700,69 +686,46 @@ public final class OzoneManagerRatisServer {
   private static void setGrpcConfig(RaftProperties properties, int logAppenderQueueByteLimit) {
     // For grpc set the maximum message size
     // TODO: calculate the optimal max message size
-    GrpcConfigKeys.setMessageSizeMax(properties,
-        SizeInBytes.valueOf(logAppenderQueueByteLimit));
+    GrpcConfigKeys.setMessageSizeMax(properties, SizeInBytes.valueOf(logAppenderQueueByteLimit));
   }
 
   private static void setRaftRpcProperties(RaftProperties properties, ConfigurationSource conf) {
     // Set the server request timeout
-    TimeUnit serverRequestTimeoutUnit =
-        OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT.getUnit();
-    long serverRequestTimeoutDuration = conf.getTimeDuration(
+    TimeUnit serverRequestTimeoutUnit = OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT.getUnit();
+    final TimeDuration serverRequestTimeout = TimeDuration.valueOf(conf.getTimeDuration(
         OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT
-            .getDuration(), serverRequestTimeoutUnit);
-    final TimeDuration serverRequestTimeout = TimeDuration.valueOf(
-        serverRequestTimeoutDuration, serverRequestTimeoutUnit);
-    RaftServerConfigKeys.Rpc.setRequestTimeout(properties,
-        serverRequestTimeout);
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT.getDuration(), serverRequestTimeoutUnit),
+        serverRequestTimeoutUnit);
+    RaftServerConfigKeys.Rpc.setRequestTimeout(properties, serverRequestTimeout);
 
     // Set the server min and max timeout
-    TimeUnit serverMinTimeoutUnit =
-        OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT.getUnit();
-    long serverMinTimeoutDuration = conf.getTimeDuration(
+    TimeUnit serverMinTimeoutUnit = OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT.getUnit();
+    final TimeDuration serverMinTimeout = TimeDuration.valueOf(conf.getTimeDuration(
         OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT
-            .getDuration(), serverMinTimeoutUnit);
-    final TimeDuration serverMinTimeout = TimeDuration.valueOf(
-        serverMinTimeoutDuration, serverMinTimeoutUnit);
-    long serverMaxTimeoutDuration =
-        serverMinTimeout.toLong(TimeUnit.MILLISECONDS) + 200;
-    final TimeDuration serverMaxTimeout = TimeDuration.valueOf(
-        serverMaxTimeoutDuration, TimeUnit.MILLISECONDS);
-    RaftServerConfigKeys.Rpc.setTimeoutMin(properties,
-        serverMinTimeout);
-    RaftServerConfigKeys.Rpc.setTimeoutMax(properties,
-        serverMaxTimeout);
+        OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT.getDuration(), serverMinTimeoutUnit),
+        serverMinTimeoutUnit);
+    final TimeDuration serverMaxTimeout = serverMinTimeout.add(200, TimeUnit.MILLISECONDS);
+    RaftServerConfigKeys.Rpc.setTimeoutMin(properties, serverMinTimeout);
+    RaftServerConfigKeys.Rpc.setTimeoutMax(properties, serverMaxTimeout);
 
     // Set the server Rpc slowness timeout and Notification noLeader timeout
-    TimeUnit nodeFailureTimeoutUnit =
-        OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT
-            .getUnit();
-    long nodeFailureTimeoutDuration = conf.getTimeDuration(
+    TimeUnit nodeFailureTimeoutUnit = OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT.getUnit();
+    final TimeDuration nodeFailureTimeout = TimeDuration.valueOf(conf.getTimeDuration(
         OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT
-            .getDuration(), nodeFailureTimeoutUnit);
-    final TimeDuration nodeFailureTimeout = TimeDuration.valueOf(
-        nodeFailureTimeoutDuration, nodeFailureTimeoutUnit);
-    RaftServerConfigKeys.Notification.setNoLeaderTimeout(properties,
-        nodeFailureTimeout);
-    RaftServerConfigKeys.Rpc.setSlownessTimeout(properties,
-        nodeFailureTimeout);
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT.getDuration(), nodeFailureTimeoutUnit),
+        nodeFailureTimeoutUnit);
+    RaftServerConfigKeys.Notification.setNoLeaderTimeout(properties, nodeFailureTimeout);
+    RaftServerConfigKeys.Rpc.setSlownessTimeout(properties, nodeFailureTimeout);
   }
 
   private static void setRaftRetryCacheProperties(RaftProperties properties, ConfigurationSource conf) {
     // Set timeout for server retry cache entry
-    TimeUnit retryCacheTimeoutUnit = OMConfigKeys
-        .OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DEFAULT.getUnit();
-    long retryCacheTimeoutDuration = conf.getTimeDuration(
+    TimeUnit retryCacheTimeoutUnit = OMConfigKeys.OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DEFAULT.getUnit();
+    final TimeDuration retryCacheTimeout = TimeDuration.valueOf(conf.getTimeDuration(
         OMConfigKeys.OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DEFAULT
-            .getDuration(), retryCacheTimeoutUnit);
-    final TimeDuration retryCacheTimeout = TimeDuration.valueOf(
-        retryCacheTimeoutDuration, retryCacheTimeoutUnit);
-    RaftServerConfigKeys.RetryCache.setExpiryTime(properties,
-        retryCacheTimeout);
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DEFAULT.getDuration(), retryCacheTimeoutUnit),
+        retryCacheTimeoutUnit);
+    RaftServerConfigKeys.RetryCache.setExpiryTime(properties, retryCacheTimeout);
   }
 
   private static void setRaftSnapshotProperties(RaftProperties properties, ConfigurationSource conf) {
@@ -775,15 +738,11 @@ public final class OzoneManagerRatisServer {
     // The transaction info value in OM DB is used as
     // snapshot value after restart.
 
-    RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(
-        properties, true);
+    RaftServerConfigKeys.Snapshot.setAutoTriggerEnabled(properties, true);
 
-    long snapshotAutoTriggerThreshold = conf.getLong(
+    RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(properties, conf.getLong(
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_DEFAULT);
-
-    RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(properties,
-        snapshotAutoTriggerThreshold);
+        OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_DEFAULT));
   }
 
   private static void setRaftCloseThreshold(RaftProperties properties, ConfigurationSource conf) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -596,8 +596,6 @@ public final class OzoneManagerRatisServer {
     }
   }
 
-  //TODO simplify it to make it shorter
-  @SuppressWarnings("methodlength")
   public static RaftProperties newRaftProperties(ConfigurationSource conf,
       int port, String ratisStorageDir) {
     // Set RPC type
@@ -617,11 +615,39 @@ public final class OzoneManagerRatisServer {
     // Set Ratis storage directory
     RaftServerConfigKeys.setStorageDir(properties,
         Collections.singletonList(new File(ratisStorageDir)));
+
+    final int logAppenderQueueByteLimit = (int) conf.getStorageSize(
+        OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
+        OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT, StorageUnit.BYTES);
+
+    // For grpc config
+    setGrpcConfig(properties, logAppenderQueueByteLimit);
+
+    setRaftLeaderElectionProperties(properties, conf);
+
+    setRaftLogProperties(properties, logAppenderQueueByteLimit, conf);
+
+    setRaftRpcProperties(properties, conf);
+
+    setRaftRetryCacheProperties(properties, conf);
+
+    setRaftSnapshotProperties(properties, conf);
+
+    setRaftCloseThreshold(properties, conf);
+
+    getOMHAConfigs(conf).forEach(properties::set);
+    return properties;
+  }
+
+  private static void setRaftLeaderElectionProperties(RaftProperties properties, ConfigurationSource conf) {
     // Disable/enable the pre vote feature in Ratis
     RaftServerConfigKeys.LeaderElection.setPreVote(properties,
         conf.getBoolean(OMConfigKeys.OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE,
             OMConfigKeys.OZONE_OM_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT));
+  }
 
+  private static void setRaftLogProperties(RaftProperties properties,
+      int logAppenderQueueByteLimit, ConfigurationSource conf) {
     // Set RAFT segment size
     final long raftSegmentSize = (long) conf.getStorageSize(
         OMConfigKeys.OZONE_OM_RATIS_SEGMENT_SIZE_KEY,
@@ -653,10 +679,6 @@ public final class OzoneManagerRatisServer {
     int logAppenderQueueNumElements = conf.getInt(
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS,
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_NUM_ELEMENTS_DEFAULT);
-    final int logAppenderQueueByteLimit = (int) conf.getStorageSize(
-        OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
-        OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
-        StorageUnit.BYTES);
     RaftServerConfigKeys.Log.Appender.setBufferElementLimit(properties,
         logAppenderQueueNumElements);
     RaftServerConfigKeys.Log.Appender.setBufferByteLimit(properties,
@@ -671,12 +693,18 @@ public final class OzoneManagerRatisServer {
         OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_GAP,
         OMConfigKeys.OZONE_OM_RATIS_LOG_PURGE_GAP_DEFAULT);
     RaftServerConfigKeys.Log.setPurgeGap(properties, logPurgeGap);
+    // Set the number of maximum cached segments
+    RaftServerConfigKeys.Log.setSegmentCacheNumMax(properties, 2);
+  }
 
+  private static void setGrpcConfig(RaftProperties properties, int logAppenderQueueByteLimit) {
     // For grpc set the maximum message size
     // TODO: calculate the optimal max message size
     GrpcConfigKeys.setMessageSizeMax(properties,
         SizeInBytes.valueOf(logAppenderQueueByteLimit));
+  }
 
+  private static void setRaftRpcProperties(RaftProperties properties, ConfigurationSource conf) {
     // Set the server request timeout
     TimeUnit serverRequestTimeoutUnit =
         OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT.getUnit();
@@ -688,18 +716,6 @@ public final class OzoneManagerRatisServer {
         serverRequestTimeoutDuration, serverRequestTimeoutUnit);
     RaftServerConfigKeys.Rpc.setRequestTimeout(properties,
         serverRequestTimeout);
-
-    // Set timeout for server retry cache entry
-    TimeUnit retryCacheTimeoutUnit = OMConfigKeys
-        .OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DEFAULT.getUnit();
-    long retryCacheTimeoutDuration = conf.getTimeDuration(
-        OMConfigKeys.OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DEFAULT
-            .getDuration(), retryCacheTimeoutUnit);
-    final TimeDuration retryCacheTimeout = TimeDuration.valueOf(
-        retryCacheTimeoutDuration, retryCacheTimeoutUnit);
-    RaftServerConfigKeys.RetryCache.setExpiryTime(properties,
-        retryCacheTimeout);
 
     // Set the server min and max timeout
     TimeUnit serverMinTimeoutUnit =
@@ -719,11 +735,7 @@ public final class OzoneManagerRatisServer {
     RaftServerConfigKeys.Rpc.setTimeoutMax(properties,
         serverMaxTimeout);
 
-    // Set the number of maximum cached segments
-    RaftServerConfigKeys.Log.setSegmentCacheNumMax(properties, 2);
-
-    // TODO: set max write buffer size
-
+    // Set the server Rpc slowness timeout and Notification noLeader timeout
     TimeUnit nodeFailureTimeoutUnit =
         OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT
             .getUnit();
@@ -737,7 +749,23 @@ public final class OzoneManagerRatisServer {
         nodeFailureTimeout);
     RaftServerConfigKeys.Rpc.setSlownessTimeout(properties,
         nodeFailureTimeout);
+  }
 
+  private static void setRaftRetryCacheProperties(RaftProperties properties, ConfigurationSource conf) {
+    // Set timeout for server retry cache entry
+    TimeUnit retryCacheTimeoutUnit = OMConfigKeys
+        .OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DEFAULT.getUnit();
+    long retryCacheTimeoutDuration = conf.getTimeDuration(
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_KEY,
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_RETRY_CACHE_TIMEOUT_DEFAULT
+            .getDuration(), retryCacheTimeoutUnit);
+    final TimeDuration retryCacheTimeout = TimeDuration.valueOf(
+        retryCacheTimeoutDuration, retryCacheTimeoutUnit);
+    RaftServerConfigKeys.RetryCache.setExpiryTime(properties,
+        retryCacheTimeout);
+  }
+
+  private static void setRaftSnapshotProperties(RaftProperties properties, ConfigurationSource conf) {
     // Set auto trigger snapshot. We don't need to configure auto trigger
     // threshold in OM, as last applied index is flushed during double buffer
     // flush automatically. (But added this property internally, so that this
@@ -756,9 +784,17 @@ public final class OzoneManagerRatisServer {
 
     RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(properties,
         snapshotAutoTriggerThreshold);
+  }
 
-    getOMHAConfigs(conf).forEach(properties::set);
-    return properties;
+  private static void setRaftCloseThreshold(RaftProperties properties, ConfigurationSource conf) {
+    // Set RAFT server close threshold
+    TimeUnit closeThresholdUnit = OMConfigKeys.OZONE_OM_RATIS_SERVER_CLOSE_THRESHOLD_DEFAULT.getUnit();
+    final int closeThreshold = (int) TimeDuration.valueOf(conf.getTimeDuration(
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_CLOSE_THRESHOLD_KEY,
+        OMConfigKeys.OZONE_OM_RATIS_SERVER_CLOSE_THRESHOLD_DEFAULT.getDuration(), closeThresholdUnit),
+        closeThresholdUnit).toLong(TimeUnit.SECONDS);
+    // TODO: update to new api setCloseThreshold(RaftProperties, TimeDuration) if available
+    RaftServerConfigKeys.setCloseThreshold(properties, closeThreshold);
   }
 
   private static Map<String, String> getOMHAConfigs(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.RatisConfUtils;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.security.SecurityConfig;
@@ -614,16 +615,15 @@ public final class OzoneManagerRatisServer {
     // Set Ratis storage directory
     RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(new File(ratisStorageDir)));
 
-    final int logAppenderQueueByteLimit = (int) conf.getStorageSize(
+    final int logAppenderBufferByteLimit = (int) conf.getStorageSize(
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT,
         OMConfigKeys.OZONE_OM_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT, StorageUnit.BYTES);
+    setRaftLogProperties(properties, logAppenderBufferByteLimit, conf);
 
     // For grpc config
-    setGrpcConfig(properties, logAppenderQueueByteLimit);
+    RatisConfUtils.Grpc.setMessageSizeMax(properties, logAppenderBufferByteLimit);
 
     setRaftLeaderElectionProperties(properties, conf);
-
-    setRaftLogProperties(properties, logAppenderQueueByteLimit, conf);
 
     setRaftRpcProperties(properties, conf);
 
@@ -681,12 +681,6 @@ public final class OzoneManagerRatisServer {
 
     // Set the number of maximum cached segments
     RaftServerConfigKeys.Log.setSegmentCacheNumMax(properties, 2);
-  }
-
-  private static void setGrpcConfig(RaftProperties properties, int logAppenderQueueByteLimit) {
-    // For grpc set the maximum message size
-    // TODO: calculate the optimal max message size
-    GrpcConfigKeys.setMessageSizeMax(properties, SizeInBytes.valueOf(logAppenderQueueByteLimit));
   }
 
   private static void setRaftRpcProperties(RaftProperties properties, ConfigurationSource conf) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMDirectoriesPurgeRequestWithFSO.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -69,9 +70,7 @@ public class OMDirectoriesPurgeRequestWithFSO extends OMKeyRequest {
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
     try {
       if (fromSnapshot != null) {
-        fromSnapshotInfo = ozoneManager.getMetadataManager()
-            .getSnapshotInfoTable()
-            .get(fromSnapshot);
+        fromSnapshotInfo = SnapshotUtils.getSnapshotInfo(ozoneManager, fromSnapshot);
       }
 
       for (OzoneManagerProtocolProtos.PurgePathRequest path : purgeRequests) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -74,14 +75,12 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
     try {
       SnapshotInfo fromSnapshotInfo = null;
       if (fromSnapshot != null) {
-        fromSnapshotInfo = ozoneManager.getMetadataManager()
-            .getSnapshotInfoTable().get(fromSnapshot);
+        fromSnapshotInfo = SnapshotUtils.getSnapshotInfo(ozoneManager, fromSnapshot);
       }
       omClientResponse = new OMKeyPurgeResponse(omResponse.build(),
           keysToBePurgedList, fromSnapshotInfo, keysToUpdateList);
     } catch (IOException ex) {
-      omClientResponse = new OMKeyPurgeResponse(
-          createErrorOMResponse(omResponse, ex));
+      omClientResponse = new OMKeyPurgeResponse(createErrorOMResponse(omResponse, ex));
     }
 
     return omClientResponse;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotMoveDeletedKeysRequest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.snapshot;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
-import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
@@ -60,7 +59,6 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
   @DisallowedUntilLayoutVersion(FILESYSTEM_SNAPSHOT)
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
       long trxnLogIndex) {
-    OmSnapshotManager omSnapshotManager = ozoneManager.getOmSnapshotManager();
     OmMetadataManagerImpl omMetadataManager = (OmMetadataManagerImpl)
         ozoneManager.getMetadataManager();
     SnapshotChainManager snapshotChainManager =
@@ -78,8 +76,10 @@ public class OMSnapshotMoveDeletedKeysRequest extends OMClientRequest {
     OzoneManagerProtocolProtos.OMResponse.Builder omResponse =
         OmResponseUtil.getOMResponseBuilder(getOmRequest());
     try {
-      nextSnapshot = SnapshotUtils.getNextActiveSnapshot(fromSnapshot,
-          snapshotChainManager, omSnapshotManager);
+      // Check the snapshot exists.
+      SnapshotUtils.getSnapshotInfo(ozoneManager, fromSnapshot.getTableKey());
+
+      nextSnapshot = SnapshotUtils.getNextActiveSnapshot(fromSnapshot, snapshotChainManager, ozoneManager);
 
       // Get next non-deleted snapshot.
       List<SnapshotMoveKeyInfos> nextDBKeysList =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
+import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -53,6 +54,13 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
 
   private static final Logger LOG = LoggerFactory.getLogger(OMSnapshotPurgeRequest.class);
 
+  /**
+   * This map contains up to date snapshotInfo and works as a local cache for OMSnapshotPurgeRequest.
+   * Since purge and other updates happen in sequence inside validateAndUpdateCache, we can get updated snapshotInfo
+   * from this map rather than getting form snapshotInfoTable which creates a deep copy for every get call.
+   */
+  private final Map<String, SnapshotInfo> updatedSnapshotInfos = new HashMap<>();
+
   public OMSnapshotPurgeRequest(OMRequest omRequest) {
     super(omRequest);
   }
@@ -78,9 +86,6 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
     try {
       List<String> snapshotDbKeys = snapshotPurgeRequest
           .getSnapshotDBKeysList();
-      Map<String, SnapshotInfo> updatedSnapInfos = new HashMap<>();
-      Map<String, SnapshotInfo> updatedPathPreviousAndGlobalSnapshots =
-          new HashMap<>();
 
       // Each snapshot purge operation does three things:
       //  1. Update the deep clean flag for the next active snapshot (So that it can be
@@ -90,7 +95,7 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
       // There is no need to take lock for snapshot purge as of now. We can simply rely on OMStateMachine
       // because it executes transaction sequentially.
       for (String snapTableKey : snapshotDbKeys) {
-        SnapshotInfo fromSnapshot = omMetadataManager.getSnapshotInfoTable().get(snapTableKey);
+        SnapshotInfo fromSnapshot = getUpdatedSnapshotInfo(snapTableKey, omMetadataManager);
         if (fromSnapshot == null) {
           // Snapshot may have been purged in the previous iteration of SnapshotDeletingService.
           LOG.warn("The snapshot {} is not longer in snapshot table, It maybe removed in the previous " +
@@ -102,10 +107,9 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
             SnapshotUtils.getNextActiveSnapshot(fromSnapshot, snapshotChainManager, omSnapshotManager);
 
         // Step 1: Update the deep clean flag for the next active snapshot
-        updateSnapshotInfoAndCache(nextSnapshot, omMetadataManager, trxnLogIndex, updatedSnapInfos);
+        updateSnapshotInfoAndCache(nextSnapshot, omMetadataManager, trxnLogIndex);
         // Step 2: Update the snapshot chain.
-        updateSnapshotChainAndCache(omMetadataManager, fromSnapshot, trxnLogIndex,
-            updatedPathPreviousAndGlobalSnapshots);
+        updateSnapshotChainAndCache(omMetadataManager, fromSnapshot, trxnLogIndex);
         // Remove and close snapshot's RocksDB instance from SnapshotCache.
         omSnapshotManager.invalidateCacheEntry(fromSnapshot.getSnapshotId());
         // Step 3: Purge the snapshot from SnapshotInfoTable cache.
@@ -113,14 +117,11 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
             .addCacheEntry(new CacheKey<>(fromSnapshot.getTableKey()), CacheValue.get(trxnLogIndex));
       }
 
-      omClientResponse = new OMSnapshotPurgeResponse(omResponse.build(),
-          snapshotDbKeys, updatedSnapInfos,
-          updatedPathPreviousAndGlobalSnapshots);
+      omClientResponse = new OMSnapshotPurgeResponse(omResponse.build(), snapshotDbKeys, updatedSnapshotInfos);
 
       omMetrics.incNumSnapshotPurges();
-      LOG.info("Successfully executed snapshotPurgeRequest: {{}} along with updating deep clean flags for " +
-              "snapshots: {} and global and previous for snapshots:{}.",
-          snapshotPurgeRequest, updatedSnapInfos.keySet(), updatedPathPreviousAndGlobalSnapshots.keySet());
+      LOG.info("Successfully executed snapshotPurgeRequest: {{}} along with updating snapshots:{}.",
+          snapshotPurgeRequest, updatedSnapshotInfos);
     } catch (IOException ex) {
       omClientResponse = new OMSnapshotPurgeResponse(
           createErrorOMResponse(omResponse, ex));
@@ -131,9 +132,8 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
     return omClientResponse;
   }
 
-  private void updateSnapshotInfoAndCache(SnapshotInfo snapInfo,
-      OmMetadataManagerImpl omMetadataManager, long trxnLogIndex,
-                                          Map<String, SnapshotInfo> updatedSnapInfos) throws IOException {
+  private void updateSnapshotInfoAndCache(SnapshotInfo snapInfo, OmMetadataManagerImpl omMetadataManager,
+                                          long trxnLogIndex) throws IOException {
     if (snapInfo != null) {
       // Setting next snapshot deep clean to false, Since the
       // current snapshot is deleted. We can potentially
@@ -143,7 +143,7 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
       // Update table cache first
       omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(snapInfo.getTableKey()),
           CacheValue.get(trxnLogIndex, snapInfo));
-      updatedSnapInfos.put(snapInfo.getTableKey(), snapInfo);
+      updatedSnapshotInfos.put(snapInfo.getTableKey(), snapInfo);
     }
   }
 
@@ -156,8 +156,7 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
   private void updateSnapshotChainAndCache(
       OmMetadataManagerImpl metadataManager,
       SnapshotInfo snapInfo,
-      long trxnLogIndex,
-      Map<String, SnapshotInfo> updatedPathPreviousAndGlobalSnapshots
+      long trxnLogIndex
   ) throws IOException {
     if (snapInfo == null) {
       return;
@@ -196,43 +195,36 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
     }
 
     SnapshotInfo nextPathSnapInfo =
-        nextPathSnapshotKey != null ? metadataManager.getSnapshotInfoTable().get(nextPathSnapshotKey) : null;
+        nextPathSnapshotKey != null ? getUpdatedSnapshotInfo(nextPathSnapshotKey, metadataManager) : null;
 
-    SnapshotInfo nextGlobalSnapInfo =
-        nextGlobalSnapshotKey != null ? metadataManager.getSnapshotInfoTable().get(nextGlobalSnapshotKey) : null;
-
-    // Updates next path snapshot's previous snapshot ID
     if (nextPathSnapInfo != null) {
       nextPathSnapInfo.setPathPreviousSnapshotId(snapInfo.getPathPreviousSnapshotId());
       metadataManager.getSnapshotInfoTable().addCacheEntry(
           new CacheKey<>(nextPathSnapInfo.getTableKey()),
           CacheValue.get(trxnLogIndex, nextPathSnapInfo));
-      updatedPathPreviousAndGlobalSnapshots
-          .put(nextPathSnapInfo.getTableKey(), nextPathSnapInfo);
     }
 
-    // Updates next global snapshot's previous snapshot ID
-    // If both next global and path snapshot are same, it may overwrite
-    // nextPathSnapInfo.setPathPreviousSnapshotID(), adding this check
-    // will prevent it.
-    if (nextGlobalSnapInfo != null && nextPathSnapInfo != null &&
-        nextGlobalSnapInfo.getSnapshotId().equals(nextPathSnapInfo.getSnapshotId())) {
-      nextPathSnapInfo.setGlobalPreviousSnapshotId(snapInfo.getGlobalPreviousSnapshotId());
-      metadataManager.getSnapshotInfoTable().addCacheEntry(
-          new CacheKey<>(nextPathSnapInfo.getTableKey()),
-          CacheValue.get(trxnLogIndex, nextPathSnapInfo));
-      updatedPathPreviousAndGlobalSnapshots
-          .put(nextPathSnapInfo.getTableKey(), nextPathSnapInfo);
-    } else if (nextGlobalSnapInfo != null) {
-      nextGlobalSnapInfo.setGlobalPreviousSnapshotId(
-          snapInfo.getGlobalPreviousSnapshotId());
+    SnapshotInfo nextGlobalSnapInfo =
+        nextGlobalSnapshotKey != null ? getUpdatedSnapshotInfo(nextGlobalSnapshotKey, metadataManager) : null;
+
+    if (nextGlobalSnapInfo != null) {
+      nextGlobalSnapInfo.setGlobalPreviousSnapshotId(snapInfo.getGlobalPreviousSnapshotId());
       metadataManager.getSnapshotInfoTable().addCacheEntry(
           new CacheKey<>(nextGlobalSnapInfo.getTableKey()),
           CacheValue.get(trxnLogIndex, nextGlobalSnapInfo));
-      updatedPathPreviousAndGlobalSnapshots
-          .put(nextGlobalSnapInfo.getTableKey(), nextGlobalSnapInfo);
     }
 
     snapshotChainManager.deleteSnapshot(snapInfo);
+  }
+
+  private SnapshotInfo getUpdatedSnapshotInfo(String snapshotTableKey, OMMetadataManager omMetadataManager)
+      throws IOException {
+    SnapshotInfo snapshotInfo = updatedSnapshotInfos.get(snapshotTableKey);
+
+    if (snapshotInfo == null) {
+      snapshotInfo = omMetadataManager.getSnapshotInfoTable().get(snapshotTableKey);
+      updatedSnapshotInfos.put(snapshotTableKey, snapshotInfo);
+    }
+    return snapshotInfo;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotPurgeRequest.java
@@ -19,10 +19,7 @@
 
 package org.apache.hadoop.ozone.om.request.snapshot;
 
-import org.apache.commons.lang3.tuple.Triple;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
-import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -43,14 +40,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.UUID;
-
-import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.SNAPSHOT_LOCK;
 
 /**
  * Handles OMSnapshotPurge Request.
@@ -90,62 +83,34 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
           new HashMap<>();
 
       // Each snapshot purge operation does three things:
-      //  1. Update the snapshot chain,
-      //  2. Update the deep clean flag for the next active snapshot (So that it can be
+      //  1. Update the deep clean flag for the next active snapshot (So that it can be
       //     deep cleaned by the KeyDeletingService in the next run),
+      //  2. Update the snapshot chain,
       //  3. Finally, purge the snapshot.
-      // All of these steps have to be performed only when it acquires all the necessary
-      // locks (lock on the snapshot to be purged, lock on the next active snapshot, and
-      // lock on the next path and global previous snapshots). Ideally, there is no need
-      // for locks for snapshot purge and can rely on OMStateMachine because OMStateMachine
-      // is going to process each request sequentially.
-      //
-      // But there is a problem with that. After filtering unnecessary SST files for a snapshot,
-      // SstFilteringService updates that snapshot's SstFilter flag. SstFilteringService cannot
-      // use SetSnapshotProperty API because it runs on each OM independently and One OM does
-      // not know if the snapshot has been filtered on the other OM in HA environment.
-      //
-      // If locks are not taken snapshot purge and SstFilteringService will cause a race condition
-      // and override one's update with another.
+      // There is no need to take lock for snapshot purge as of now. We can simply rely on OMStateMachine
+      // because it executes transaction sequentially.
       for (String snapTableKey : snapshotDbKeys) {
-        // To acquire all the locks, a set is maintained which is keyed by snapshotTableKey.
-        // snapshotTableKey is nothing but /volumeName/bucketName/snapshotName.
-        // Once all the locks are acquired, it performs the three steps mentioned above and
-        // release all the locks after that.
-        Set<Triple<String, String, String>> lockSet = new HashSet<>(4, 1);
-        try {
-          if (omMetadataManager.getSnapshotInfoTable().get(snapTableKey) == null) {
-            // Snapshot may have been purged in the previous iteration of SnapshotDeletingService.
-            LOG.warn("The snapshot {} is not longer in snapshot table, It maybe removed in the previous " +
-                "Snapshot purge request.", snapTableKey);
-            continue;
-          }
-
-          acquireLock(lockSet, snapTableKey, omMetadataManager);
-          SnapshotInfo fromSnapshot = omMetadataManager.getSnapshotInfoTable().get(snapTableKey);
-
-          SnapshotInfo nextSnapshot =
-              SnapshotUtils.getNextActiveSnapshot(fromSnapshot, snapshotChainManager, omSnapshotManager);
-
-          if (nextSnapshot != null) {
-            acquireLock(lockSet, nextSnapshot.getTableKey(), omMetadataManager);
-          }
-
-          // Update the chain first so that it has all the necessary locks before updating deep clean.
-          updateSnapshotChainAndCache(lockSet, omMetadataManager, fromSnapshot, trxnLogIndex,
-              updatedPathPreviousAndGlobalSnapshots);
-          updateSnapshotInfoAndCache(nextSnapshot, omMetadataManager, trxnLogIndex, updatedSnapInfos);
-          // Remove and close snapshot's RocksDB instance from SnapshotCache.
-          omSnapshotManager.invalidateCacheEntry(fromSnapshot.getSnapshotId());
-            // Update SnapshotInfoTable cache.
-          omMetadataManager.getSnapshotInfoTable()
-              .addCacheEntry(new CacheKey<>(fromSnapshot.getTableKey()), CacheValue.get(trxnLogIndex));
-        } finally {
-          for (Triple<String, String, String> lockKey: lockSet) {
-            omMetadataManager.getLock()
-                .releaseWriteLock(SNAPSHOT_LOCK, lockKey.getLeft(), lockKey.getMiddle(), lockKey.getRight());
-          }
+        SnapshotInfo fromSnapshot = omMetadataManager.getSnapshotInfoTable().get(snapTableKey);
+        if (fromSnapshot == null) {
+          // Snapshot may have been purged in the previous iteration of SnapshotDeletingService.
+          LOG.warn("The snapshot {} is not longer in snapshot table, It maybe removed in the previous " +
+              "Snapshot purge request.", snapTableKey);
+          continue;
         }
+
+        SnapshotInfo nextSnapshot =
+            SnapshotUtils.getNextActiveSnapshot(fromSnapshot, snapshotChainManager, omSnapshotManager);
+
+        // Step 1: Update the deep clean flag for the next active snapshot
+        updateSnapshotInfoAndCache(nextSnapshot, omMetadataManager, trxnLogIndex, updatedSnapInfos);
+        // Step 2: Update the snapshot chain.
+        updateSnapshotChainAndCache(omMetadataManager, fromSnapshot, trxnLogIndex,
+            updatedPathPreviousAndGlobalSnapshots);
+        // Remove and close snapshot's RocksDB instance from SnapshotCache.
+        omSnapshotManager.invalidateCacheEntry(fromSnapshot.getSnapshotId());
+        // Step 3: Purge the snapshot from SnapshotInfoTable cache.
+        omMetadataManager.getSnapshotInfoTable()
+            .addCacheEntry(new CacheKey<>(fromSnapshot.getTableKey()), CacheValue.get(trxnLogIndex));
       }
 
       omClientResponse = new OMSnapshotPurgeResponse(omResponse.build(),
@@ -166,41 +131,19 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
     return omClientResponse;
   }
 
-  private void acquireLock(Set<Triple<String, String, String>> lockSet, String snapshotTableKey,
-                           OMMetadataManager omMetadataManager) throws IOException {
-    SnapshotInfo snapshotInfo = omMetadataManager.getSnapshotInfoTable().get(snapshotTableKey);
-
-    // It should not be the case that lock is required for non-existing snapshot.
-    if (snapshotInfo == null) {
-      LOG.error("Snapshot: '{}' doesn't not exist in snapshot table.", snapshotTableKey);
-      throw new OMException("Snapshot: '{" + snapshotTableKey + "}' doesn't not exist in snapshot table.",
-          OMException.ResultCodes.FILE_NOT_FOUND);
-    }
-    Triple<String, String, String> lockKey = Triple.of(snapshotInfo.getVolumeName(), snapshotInfo.getBucketName(),
-        snapshotInfo.getName());
-    if (!lockSet.contains(lockKey)) {
-      mergeOmLockDetails(omMetadataManager.getLock()
-          .acquireWriteLock(SNAPSHOT_LOCK, lockKey.getLeft(), lockKey.getMiddle(), lockKey.getRight()));
-      lockSet.add(lockKey);
-    }
-  }
-
   private void updateSnapshotInfoAndCache(SnapshotInfo snapInfo,
       OmMetadataManagerImpl omMetadataManager, long trxnLogIndex,
-      Map<String, SnapshotInfo> updatedSnapInfos) throws IOException {
+                                          Map<String, SnapshotInfo> updatedSnapInfos) throws IOException {
     if (snapInfo != null) {
-      // Fetch the latest value again after acquiring lock.
-      SnapshotInfo updatedSnapshotInfo = omMetadataManager.getSnapshotInfoTable().get(snapInfo.getTableKey());
-
       // Setting next snapshot deep clean to false, Since the
       // current snapshot is deleted. We can potentially
       // reclaim more keys in the next snapshot.
-      updatedSnapshotInfo.setDeepClean(false);
+      snapInfo.setDeepClean(false);
 
       // Update table cache first
-      omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(updatedSnapshotInfo.getTableKey()),
-          CacheValue.get(trxnLogIndex, updatedSnapshotInfo));
-      updatedSnapInfos.put(updatedSnapshotInfo.getTableKey(), updatedSnapshotInfo);
+      omMetadataManager.getSnapshotInfoTable().addCacheEntry(new CacheKey<>(snapInfo.getTableKey()),
+          CacheValue.get(trxnLogIndex, snapInfo));
+      updatedSnapInfos.put(snapInfo.getTableKey(), snapInfo);
     }
   }
 
@@ -211,7 +154,6 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
    * update in DB.
    */
   private void updateSnapshotChainAndCache(
-      Set<Triple<String, String, String>> lockSet,
       OmMetadataManagerImpl metadataManager,
       SnapshotInfo snapInfo,
       long trxnLogIndex,
@@ -245,18 +187,12 @@ public class OMSnapshotPurgeRequest extends OMClientRequest {
           snapInfo.getSnapshotPath(), snapInfo.getSnapshotId());
       nextPathSnapshotKey = snapshotChainManager
           .getTableKey(nextPathSnapshotId);
-
-      // Acquire lock from the snapshot
-      acquireLock(lockSet, nextPathSnapshotKey, metadataManager);
     }
 
     String nextGlobalSnapshotKey = null;
     if (hasNextGlobalSnapshot) {
       UUID nextGlobalSnapshotId = snapshotChainManager.nextGlobalSnapshot(snapInfo.getSnapshotId());
       nextGlobalSnapshotKey = snapshotChainManager.getTableKey(nextGlobalSnapshotId);
-
-      // Acquire lock from the snapshot
-      acquireLock(lockSet, nextGlobalSnapshotKey, metadataManager);
     }
 
     SnapshotInfo nextPathSnapInfo =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/snapshot/OMSnapshotSetPropertyRequest.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_NOT_FOUND;
-import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.SNAPSHOT_LOCK;
 
 /**
  * Updates the exclusive size of the snapshot.
@@ -55,7 +54,7 @@ public class OMSnapshotSetPropertyRequest extends OMClientRequest {
       long trxnLogIndex) {
     OMMetrics omMetrics = ozoneManager.getMetrics();
 
-    OMClientResponse omClientResponse = null;
+    OMClientResponse omClientResponse;
     OMMetadataManager metadataManager = ozoneManager.getMetadataManager();
 
     OzoneManagerProtocolProtos.OMResponse.Builder omResponse =
@@ -63,32 +62,15 @@ public class OMSnapshotSetPropertyRequest extends OMClientRequest {
     OzoneManagerProtocolProtos.SetSnapshotPropertyRequest
         setSnapshotPropertyRequest = getOmRequest()
         .getSetSnapshotPropertyRequest();
-    SnapshotInfo updatedSnapInfo = null;
 
     String snapshotKey = setSnapshotPropertyRequest.getSnapshotKey();
-    boolean acquiredSnapshotLock = false;
-    String volumeName = null;
-    String bucketName = null;
-    String snapshotName = null;
 
     try {
-      SnapshotInfo snapshotInfo = metadataManager.getSnapshotInfoTable().get(snapshotKey);
-      if (snapshotInfo == null) {
+      SnapshotInfo updatedSnapInfo = metadataManager.getSnapshotInfoTable().get(snapshotKey);
+      if (updatedSnapInfo == null) {
         LOG.error("Snapshot: '{}' doesn't not exist in snapshot table.", snapshotKey);
         throw new OMException("Snapshot: '{" + snapshotKey + "}' doesn't not exist in snapshot table.", FILE_NOT_FOUND);
       }
-
-      volumeName = snapshotInfo.getVolumeName();
-      bucketName = snapshotInfo.getBucketName();
-      snapshotName = snapshotInfo.getName();
-
-      mergeOmLockDetails(metadataManager.getLock()
-          .acquireWriteLock(SNAPSHOT_LOCK, volumeName, bucketName, snapshotName));
-
-      acquiredSnapshotLock = getOmLockDetails().isLockAcquired();
-
-      updatedSnapInfo = metadataManager.getSnapshotInfoTable()
-          .get(snapshotKey);
 
 
       if (setSnapshotPropertyRequest.hasDeepCleanedDeletedDir()) {
@@ -126,14 +108,6 @@ public class OMSnapshotSetPropertyRequest extends OMClientRequest {
           createErrorOMResponse(omResponse, ex));
       omMetrics.incNumSnapshotSetPropertyFails();
       LOG.error("Failed to execute snapshotSetPropertyRequest: {{}}.", setSnapshotPropertyRequest, ex);
-    } finally {
-      if (acquiredSnapshotLock) {
-        mergeOmLockDetails(metadataManager.getLock()
-            .releaseWriteLock(SNAPSHOT_LOCK, volumeName, bucketName, snapshotName));
-      }
-      if (omClientResponse != null) {
-        omClientResponse.setOmLockDetails(getOmLockDetails());
-      }
     }
 
     return omClientResponse;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMDirectoriesPurgeResponseWithFSO.java
@@ -84,10 +84,7 @@ public class OMDirectoriesPurgeResponseWithFSO extends OmKeyResponse {
               .getOzoneManager().getOmSnapshotManager();
 
       try (ReferenceCounted<OmSnapshot>
-          rcFromSnapshotInfo = omSnapshotManager.getSnapshot(
-              fromSnapshotInfo.getVolumeName(),
-              fromSnapshotInfo.getBucketName(),
-              fromSnapshotInfo.getName())) {
+          rcFromSnapshotInfo = omSnapshotManager.getSnapshot(fromSnapshotInfo.getSnapshotId())) {
         OmSnapshot fromSnapshot = rcFromSnapshotInfo.get();
         DBStore fromSnapshotStore = fromSnapshot.getMetadataManager()
             .getStore();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
@@ -75,18 +75,13 @@ public class OMKeyPurgeResponse extends OmKeyResponse {
 
     if (fromSnapshot != null) {
       OmSnapshotManager omSnapshotManager =
-          ((OmMetadataManagerImpl) omMetadataManager)
-              .getOzoneManager().getOmSnapshotManager();
+          ((OmMetadataManagerImpl) omMetadataManager).getOzoneManager().getOmSnapshotManager();
 
       try (ReferenceCounted<OmSnapshot> rcOmFromSnapshot =
-          omSnapshotManager.getSnapshot(
-              fromSnapshot.getVolumeName(),
-              fromSnapshot.getBucketName(),
-              fromSnapshot.getName())) {
+          omSnapshotManager.getSnapshot(fromSnapshot.getSnapshotId())) {
 
         OmSnapshot fromOmSnapshot = rcOmFromSnapshot.get();
-        DBStore fromSnapshotStore =
-            fromOmSnapshot.getMetadataManager().getStore();
+        DBStore fromSnapshotStore = fromOmSnapshot.getMetadataManager().getStore();
         // Init Batch Operation for snapshot db.
         try (BatchOperation writeBatch =
             fromSnapshotStore.initBatchOperation()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotMoveDeletedKeysResponse.java
@@ -91,19 +91,13 @@ public class OMSnapshotMoveDeletedKeysResponse extends OMClientResponse {
             .getOzoneManager().getOmSnapshotManager();
 
     try (ReferenceCounted<OmSnapshot> rcOmFromSnapshot =
-        omSnapshotManager.getSnapshot(
-            fromSnapshot.getVolumeName(),
-            fromSnapshot.getBucketName(),
-            fromSnapshot.getName())) {
+        omSnapshotManager.getSnapshot(fromSnapshot.getSnapshotId())) {
 
       OmSnapshot fromOmSnapshot = rcOmFromSnapshot.get();
 
       if (nextSnapshot != null) {
         try (ReferenceCounted<OmSnapshot>
-            rcOmNextSnapshot = omSnapshotManager.getSnapshot(
-                nextSnapshot.getVolumeName(),
-                nextSnapshot.getBucketName(),
-                nextSnapshot.getName())) {
+            rcOmNextSnapshot = omSnapshotManager.getSnapshot(nextSnapshot.getSnapshotId())) {
 
           OmSnapshot nextOmSnapshot = rcOmNextSnapshot.get();
           RDBStore nextSnapshotStore =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
@@ -89,8 +89,15 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
         continue;
       }
 
+      // Remove and close snapshot's RocksDB instance from SnapshotCache.
+      ((OmMetadataManagerImpl) omMetadataManager).getOzoneManager().getOmSnapshotManager()
+          .invalidateCacheEntry(snapshotInfo.getSnapshotId());
+      // Remove the snapshot from snapshotId to snapshotTableKey map.
+      ((OmMetadataManagerImpl) omMetadataManager).getSnapshotChainManager()
+          .removeFromSnapshotIdToTable(snapshotInfo.getSnapshotId());
       // Delete Snapshot checkpoint directory.
       deleteCheckpointDirectory(omMetadataManager, snapshotInfo);
+      // Delete snapshotInfo from the table.
       omMetadataManager.getSnapshotInfoTable().deleteWithBatch(batchOperation, dbKey);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
@@ -48,18 +48,15 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
       LoggerFactory.getLogger(OMSnapshotPurgeResponse.class);
   private final List<String> snapshotDbKeys;
   private final Map<String, SnapshotInfo> updatedSnapInfos;
-  private final Map<String, SnapshotInfo> updatedPreviousAndGlobalSnapInfos;
 
   public OMSnapshotPurgeResponse(
       @Nonnull OMResponse omResponse,
       @Nonnull List<String> snapshotDbKeys,
-      Map<String, SnapshotInfo> updatedSnapInfos,
-      Map<String, SnapshotInfo> updatedPreviousAndGlobalSnapInfos
+      Map<String, SnapshotInfo> updatedSnapInfos
   ) {
     super(omResponse);
     this.snapshotDbKeys = snapshotDbKeys;
     this.updatedSnapInfos = updatedSnapInfos;
-    this.updatedPreviousAndGlobalSnapInfos = updatedPreviousAndGlobalSnapInfos;
   }
 
   /**
@@ -71,7 +68,6 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
     checkStatusNotOK();
     this.snapshotDbKeys = null;
     this.updatedSnapInfos = null;
-    this.updatedPreviousAndGlobalSnapInfos = null;
   }
 
   @Override
@@ -81,8 +77,6 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
     OmMetadataManagerImpl metadataManager = (OmMetadataManagerImpl)
         omMetadataManager;
     updateSnapInfo(metadataManager, batchOperation, updatedSnapInfos);
-    updateSnapInfo(metadataManager, batchOperation,
-        updatedPreviousAndGlobalSnapInfos);
     for (String dbKey: snapshotDbKeys) {
       // Skip the cache here because snapshot is purged from cache in OMSnapshotPurgeRequest.
       SnapshotInfo snapshotInfo = omMetadataManager

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
@@ -80,9 +80,9 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
 
     OmMetadataManagerImpl metadataManager = (OmMetadataManagerImpl)
         omMetadataManager;
+    updateSnapInfo(metadataManager, batchOperation, updatedSnapInfos);
     updateSnapInfo(metadataManager, batchOperation,
         updatedPreviousAndGlobalSnapInfos);
-    updateSnapInfo(metadataManager, batchOperation, updatedSnapInfos);
     for (String dbKey: snapshotDbKeys) {
       // Skip the cache here because snapshot is purged from cache in OMSnapshotPurgeRequest.
       SnapshotInfo snapshotInfo = omMetadataManager

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.lock.BootstrapStateHandler;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
@@ -39,6 +38,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.snapshot.SnapshotUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeletedKeys;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -576,8 +576,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     return cLimit + increment >= maxLimit;
   }
 
-  protected SnapshotInfo getPreviousActiveSnapshot(SnapshotInfo snapInfo,
-      SnapshotChainManager chainManager, OmSnapshotManager omSnapshotManager)
+  protected SnapshotInfo getPreviousActiveSnapshot(SnapshotInfo snapInfo, SnapshotChainManager chainManager)
       throws IOException {
     SnapshotInfo currSnapInfo = snapInfo;
     while (chainManager.hasPreviousPathSnapshot(
@@ -586,7 +585,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
       UUID prevPathSnapshot = chainManager.previousPathSnapshot(
           currSnapInfo.getSnapshotPath(), currSnapInfo.getSnapshotId());
       String tableKey = chainManager.getTableKey(prevPathSnapshot);
-      SnapshotInfo prevSnapInfo = omSnapshotManager.getSnapshotInfo(tableKey);
+      SnapshotInfo prevSnapInfo = SnapshotUtils.getSnapshotInfo(ozoneManager, tableKey);
       if (prevSnapInfo.getSnapshotStatus() ==
           SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE) {
         return prevSnapInfo;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -289,13 +289,11 @@ public class KeyDeletingService extends AbstractKeyDeletingService {
             }
 
             String snapshotBucketKey = dbBucketKey + OzoneConsts.OM_KEY_PREFIX;
-            SnapshotInfo previousSnapshot = getPreviousActiveSnapshot(
-                currSnapInfo, snapChainManager, omSnapshotManager);
+            SnapshotInfo previousSnapshot = getPreviousActiveSnapshot(currSnapInfo, snapChainManager);
             SnapshotInfo previousToPrevSnapshot = null;
 
             if (previousSnapshot != null) {
-              previousToPrevSnapshot = getPreviousActiveSnapshot(
-                  previousSnapshot, snapChainManager, omSnapshotManager);
+              previousToPrevSnapshot = getPreviousActiveSnapshot(previousSnapshot, snapChainManager);
             }
 
             Table<String, OmKeyInfo> previousKeyTable = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -211,8 +211,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
           }
 
           //TODO: [SNAPSHOT] Add lock to deletedTable and Active DB.
-          SnapshotInfo previousSnapshot = getPreviousActiveSnapshot(
-              snapInfo, chainManager, omSnapshotManager);
+          SnapshotInfo previousSnapshot = getPreviousActiveSnapshot(snapInfo, chainManager);
           Table<String, OmKeyInfo> previousKeyTable = null;
           Table<String, OmDirectoryInfo> previousDirTable = null;
           OmSnapshot omPreviousSnapshot = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDirectoryCleaningService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDirectoryCleaningService.java
@@ -176,8 +176,7 @@ public class SnapshotDirectoryCleaningService
                   "unexpected state.");
             }
 
-            SnapshotInfo previousSnapshot = getPreviousActiveSnapshot(
-                currSnapInfo, snapChainManager, omSnapshotManager);
+            SnapshotInfo previousSnapshot = getPreviousActiveSnapshot(currSnapInfo, snapChainManager);
             SnapshotInfo previousToPrevSnapshot = null;
 
             Table<String, OmKeyInfo> previousKeyTable = null;
@@ -194,8 +193,7 @@ public class SnapshotDirectoryCleaningService
                   .getKeyTable(bucketInfo.getBucketLayout());
               prevRenamedTable = omPreviousSnapshot
                   .getMetadataManager().getSnapshotRenamedTable();
-              previousToPrevSnapshot = getPreviousActiveSnapshot(
-                  previousSnapshot, snapChainManager, omSnapshotManager);
+              previousToPrevSnapshot = getPreviousActiveSnapshot(previousSnapshot, snapChainManager);
             }
 
             Table<String, OmKeyInfo> previousToPrevKeyTable = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotUtils.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.snapshot;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRocksDB;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
-import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.SnapshotChainManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -143,7 +142,7 @@ public final class SnapshotUtils {
    * Get the next non deleted snapshot in the snapshot chain.
    */
   public static SnapshotInfo getNextActiveSnapshot(SnapshotInfo snapInfo,
-      SnapshotChainManager chainManager, OmSnapshotManager omSnapshotManager)
+      SnapshotChainManager chainManager, OzoneManager ozoneManager)
       throws IOException {
 
     // If the snapshot is deleted in the previous run, then the in-memory
@@ -162,8 +161,7 @@ public final class SnapshotUtils {
                 snapInfo.getSnapshotPath(), snapInfo.getSnapshotId());
 
         String tableKey = chainManager.getTableKey(nextPathSnapshot);
-        SnapshotInfo nextSnapshotInfo =
-            omSnapshotManager.getSnapshotInfo(tableKey);
+        SnapshotInfo nextSnapshotInfo = getSnapshotInfo(ozoneManager, tableKey);
 
         if (nextSnapshotInfo.getSnapshotStatus().equals(
             SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE)) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -209,17 +209,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
           deletedKey));
     }
 
-    SnapshotInfo fromSnapshotInfo = new SnapshotInfo.Builder()
-        .setVolumeName(volumeName)
-        .setBucketName(bucketName)
-        .setName("snap1")
-        .build();
-
-    ReferenceCounted<OmSnapshot> rcOmSnapshot =
-        ozoneManager.getOmSnapshotManager().getSnapshot(
-            fromSnapshotInfo.getVolumeName(),
-            fromSnapshotInfo.getBucketName(),
-            fromSnapshotInfo.getName());
+    ReferenceCounted<OmSnapshot> rcOmSnapshot = ozoneManager.getOmSnapshotManager()
+        .getSnapshot(snapInfo.getVolumeName(), snapInfo.getBucketName(), snapInfo.getName());
     OmSnapshot omSnapshot = rcOmSnapshot.get();
 
     // The keys should be present in the snapshot's deletedTable
@@ -247,8 +238,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     try (BatchOperation batchOperation =
         omMetadataManager.getStore().initBatchOperation()) {
 
-      OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(
-          omResponse, deletedKeyNames, fromSnapshotInfo, null);
+      OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(omResponse, deletedKeyNames, snapInfo, null);
       omKeyPurgeResponse.addToDBBatch(omMetadataManager, batchOperation);
 
       // Do manual commit and see whether addToBatch is successful or not.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDiffManager.java
@@ -361,7 +361,6 @@ public class TestSnapshotDiffManager {
 
     omSnapshotManager = mock(OmSnapshotManager.class);
     when(ozoneManager.getOmSnapshotManager()).thenReturn(omSnapshotManager);
-    when(omSnapshotManager.isSnapshotStatus(any(), any())).thenReturn(true);
     SnapshotCache snapshotCache = new SnapshotCache(mockCacheLoader(), 10, omMetrics, 0);
 
     when(omSnapshotManager.getActiveSnapshot(anyString(), anyString(), anyString()))

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -51,7 +51,8 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     UNDER_REPLICATED,
     OVER_REPLICATED,
     MIS_REPLICATED,
-    ALL_REPLICAS_UNHEALTHY
+    ALL_REPLICAS_UNHEALTHY,
+    NEGATIVE_SIZE // Added new state to track containers with negative sizes
   }
 
   private static final String CONTAINER_ID = "container_id";

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ContainerSchemaDefinition.java
@@ -51,7 +51,7 @@ public class ContainerSchemaDefinition implements ReconSchemaDefinition {
     UNDER_REPLICATED,
     OVER_REPLICATED,
     MIS_REPLICATED,
-    ALL_REPLICAS_UNHEALTHY,
+    ALL_REPLICAS_BAD,
     NEGATIVE_SIZE // Added new state to track containers with negative sizes
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
@@ -51,6 +51,12 @@ public class UnhealthyContainersResponse {
   private long misReplicatedCount = 0;
 
   /**
+   * Total count of containers with negative size.
+   */
+  @JsonProperty("negativeSizeCount")
+  private long negativeSizeCount = 0;
+
+  /**
    * A collection of unhealthy containers.
    */
   @JsonProperty("containers")
@@ -73,6 +79,9 @@ public class UnhealthyContainersResponse {
     } else if (state.equals(
         UnHealthyContainerStates.MIS_REPLICATED.toString())) {
       this.misReplicatedCount = count;
+    } else if (state.equals(
+        UnHealthyContainerStates.NEGATIVE_SIZE.toString())) {
+      this.negativeSizeCount = count;
     }
   }
 
@@ -90,6 +99,10 @@ public class UnhealthyContainersResponse {
 
   public long getMisReplicatedCount() {
     return misReplicatedCount;
+  }
+
+  public long getNegativeSizeCount() {
+    return negativeSizeCount;
   }
 
   public Collection<UnhealthyContainerMetadata> getContainers() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerHealthSchemaManager.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.recon.persistence;
 
 import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.UNDER_REPLICATED;
-import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_UNHEALTHY;
+import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_BAD;
 import static org.hadoop.ozone.recon.schema.tables.UnhealthyContainersTable.UNHEALTHY_CONTAINERS;
 import static org.jooq.impl.DSL.count;
 
@@ -71,7 +71,7 @@ public class ContainerHealthSchemaManager {
     SelectQuery<Record> query = dslContext.selectQuery();
     query.addFrom(UNHEALTHY_CONTAINERS);
     if (state != null) {
-      if (state.equals(ALL_REPLICAS_UNHEALTHY)) {
+      if (state.equals(ALL_REPLICAS_BAD)) {
         query.addConditions(UNHEALTHY_CONTAINERS.CONTAINER_STATE
             .eq(UNDER_REPLICATED.toString()));
         query.addConditions(UNHEALTHY_CONTAINERS.ACTUAL_REPLICA_COUNT.eq(0));

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -855,10 +855,12 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     ContainerInfo omContainerInfo1 = mock(ContainerInfo.class);
     given(omContainerInfo1.containerID()).willReturn(new ContainerID(1));
     given(omContainerInfo1.getUsedBytes()).willReturn(1500000000L); // 1.5GB
+    given(omContainerInfo1.getState()).willReturn(LifeCycleState.OPEN);
 
     ContainerInfo omContainerInfo2 = mock(ContainerInfo.class);
     given(omContainerInfo2.containerID()).willReturn(new ContainerID(2));
     given(omContainerInfo2.getUsedBytes()).willReturn(2500000000L); // 2.5GB
+    given(omContainerInfo2.getState()).willReturn(LifeCycleState.OPEN);
 
     // Create a list of container info objects
     List<ContainerInfo> containers = new ArrayList<>();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -96,7 +96,8 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     List<ContainerInfo> mockContainers = getMockContainers(7);
     when(scmMock.getScmServiceProvider()).thenReturn(scmClientMock);
     when(scmMock.getContainerManager()).thenReturn(containerManagerMock);
-    when(containerManagerMock.getContainers()).thenReturn(mockContainers);
+    when(containerManagerMock.getContainers(any(ContainerID.class),
+        anyInt())).thenReturn(mockContainers);
     for (ContainerInfo c : mockContainers) {
       when(containerManagerMock.getContainer(c.containerID())).thenReturn(c);
       when(scmClientMock.getContainerWithPipeline(c.getContainerID()))
@@ -151,7 +152,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
             reconTaskStatusDao, containerHealthSchemaManager,
             placementMock, reconTaskConfig, reconContainerMetadataManager);
     containerHealthTask.start();
-    LambdaTestUtils.await(6000, 1000, () ->
+    LambdaTestUtils.await(60000, 1000, () ->
         (unHealthyContainersTableHandle.count() == 6));
     UnhealthyContainers rec =
         unHealthyContainersTableHandle.fetchByContainerId(1L).get(0);
@@ -268,7 +269,8 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     List<ContainerInfo> mockContainers = getMockContainers(3);
     when(scmMock.getScmServiceProvider()).thenReturn(scmClientMock);
     when(scmMock.getContainerManager()).thenReturn(containerManagerMock);
-    when(containerManagerMock.getContainers()).thenReturn(mockContainers);
+    when(containerManagerMock.getContainers(any(ContainerID.class),
+        anyInt())).thenReturn(mockContainers);
     for (ContainerInfo c : mockContainers) {
       when(containerManagerMock.getContainer(c.containerID())).thenReturn(c);
       when(scmClientMock.getContainerWithPipeline(c.getContainerID()))

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -18,9 +18,12 @@
 
 package org.apache.hadoop.ozone.recon.fsck;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates.ALL_REPLICAS_UNHEALTHY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -333,6 +336,64 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     Assertions.assertTrue(taskStatus.getLastUpdatedTimestamp() >
         currentTime);
   }
+
+  @Test
+  public void testNegativeSizeContainers() throws Exception {
+    // Setup mock objects and test environment
+    UnhealthyContainersDao unhealthyContainersDao =
+        getDao(UnhealthyContainersDao.class);
+    ContainerHealthSchemaManager containerHealthSchemaManager =
+        new ContainerHealthSchemaManager(
+            getSchemaDefinition(ContainerSchemaDefinition.class),
+            unhealthyContainersDao);
+    ReconStorageContainerManagerFacade scmMock =
+        mock(ReconStorageContainerManagerFacade.class);
+    ContainerManager containerManagerMock = mock(ContainerManager.class);
+    StorageContainerServiceProvider scmClientMock =
+        mock(StorageContainerServiceProvider.class);
+    ReconContainerMetadataManager reconContainerMetadataManager =
+        mock(ReconContainerMetadataManager.class);
+    MockPlacementPolicy placementMock = new MockPlacementPolicy();
+
+    // Mock container info setup
+    List<ContainerInfo> mockContainers = getMockContainers(3);
+    when(scmMock.getContainerManager()).thenReturn(containerManagerMock);
+    when(scmMock.getScmServiceProvider()).thenReturn(scmClientMock);
+    when(containerManagerMock.getContainers(any(ContainerID.class),
+        anyInt())).thenReturn(mockContainers);
+    for (ContainerInfo c : mockContainers) {
+      when(containerManagerMock.getContainer(
+          c.containerID())).thenReturn(c);
+      when(scmClientMock.getContainerWithPipeline(
+          c.getContainerID())).thenReturn(new ContainerWithPipeline(c, null));
+      when(containerManagerMock.getContainer(c.containerID())
+          .getUsedBytes()).thenReturn(Long.valueOf(-10));
+    }
+
+    // Verify the table is initially empty
+    assertThat(unhealthyContainersDao.findAll()).isEmpty();
+
+    // Setup and start the container health task
+    ReconTaskStatusDao reconTaskStatusDao = getDao(ReconTaskStatusDao.class);
+    ReconTaskConfig reconTaskConfig = new ReconTaskConfig();
+    reconTaskConfig.setMissingContainerTaskInterval(Duration.ofSeconds(2));
+    ContainerHealthTask containerHealthTask = new ContainerHealthTask(
+        scmMock.getContainerManager(), scmMock.getScmServiceProvider(),
+        reconTaskStatusDao,
+        containerHealthSchemaManager, placementMock, reconTaskConfig,
+        reconContainerMetadataManager);
+    containerHealthTask.start();
+
+    // Wait for the task to identify unhealthy containers
+    LambdaTestUtils.await(6000, 1000,
+        () -> unhealthyContainersDao.count() == 3);
+
+    // Assert that all unhealthy containers have been identified as NEGATIVE_SIZE states
+    List<UnhealthyContainers> negativeSizeContainers =
+        unhealthyContainersDao.fetchByContainerState("NEGATIVE_SIZE");
+    assertThat(negativeSizeContainers).hasSize(3);
+  }
+
 
   private Set<ContainerReplica> getMockReplicas(
       long containerId, State...states) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerSizeCountTask.java
@@ -18,6 +18,11 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.DELETED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.QUASI_CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.CLOSING;
 import static org.hadoop.ozone.recon.schema.tables.ContainerCountBySizeTable.CONTAINER_COUNT_BY_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
@@ -80,18 +85,21 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
   @Test
   public void testProcess() {
     // mock a container with invalid used bytes
-    final ContainerInfo omContainerInfo0 = mock(ContainerInfo.class);
+    ContainerInfo omContainerInfo0 = mock(ContainerInfo.class);
     given(omContainerInfo0.containerID()).willReturn(new ContainerID(0));
     given(omContainerInfo0.getUsedBytes()).willReturn(-1L);
+    given(omContainerInfo0.getState()).willReturn(OPEN);
 
     // Write 2 keys
     ContainerInfo omContainerInfo1 = mock(ContainerInfo.class);
     given(omContainerInfo1.containerID()).willReturn(new ContainerID(1));
     given(omContainerInfo1.getUsedBytes()).willReturn(1500000000L); // 1.5GB
+    given(omContainerInfo1.getState()).willReturn(CLOSED);
 
     ContainerInfo omContainerInfo2 = mock(ContainerInfo.class);
     given(omContainerInfo2.containerID()).willReturn(new ContainerID(2));
     given(omContainerInfo2.getUsedBytes()).willReturn(2500000000L); // 2.5GB
+    given(omContainerInfo2.getState()).willReturn(CLOSING);
 
     // mock getContainers method to return a list of containers
     List<ContainerInfo> containers = new ArrayList<>();
@@ -101,8 +109,8 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
 
     task.process(containers);
 
-    // Verify 2 containers are in correct bins.
-    assertEquals(2, containerCountBySizeDao.count());
+    // Verify 3 containers are in correct bins.
+    assertEquals(3, containerCountBySizeDao.count());
 
     // container size upper bound for
     // 1500000000L (1.5GB) is 2147483648L = 2^31 = 2GB (next highest power of 2)
@@ -120,10 +128,11 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
         containerCountBySizeDao.findById(recordToFind.value1()).getCount()
             .longValue());
 
-    // Add a new key
+    // Add a new container
     ContainerInfo omContainerInfo3 = mock(ContainerInfo.class);
     given(omContainerInfo3.containerID()).willReturn(new ContainerID(3));
     given(omContainerInfo3.getUsedBytes()).willReturn(1000000000L); // 1GB
+    given(omContainerInfo3.getState()).willReturn(QUASI_CLOSED);
     containers.add(omContainerInfo3);
 
     // Update existing key.
@@ -133,7 +142,7 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
     task.process(containers);
 
     // Total size groups added to the database
-    assertEquals(4, containerCountBySizeDao.count());
+    assertEquals(5, containerCountBySizeDao.count());
 
     // Check whether container size upper bound for
     // 50000L is 536870912L = 2^29 = 512MB (next highest power of 2)
@@ -160,4 +169,59 @@ public class TestContainerSizeCountTask extends AbstractReconSqlDBTest {
         .getCount()
         .longValue());
   }
+
+  @Test
+  public void testProcessDeletedAndNegativeSizedContainers() {
+    // Create a list of containers, including one that is deleted
+    ContainerInfo omContainerInfo1 = mock(ContainerInfo.class);
+    given(omContainerInfo1.containerID()).willReturn(new ContainerID(1));
+    given(omContainerInfo1.getUsedBytes()).willReturn(1500000000L); // 1.5GB
+    given(omContainerInfo1.getState()).willReturn(OPEN);
+
+    ContainerInfo omContainerInfo2 = mock(ContainerInfo.class);
+    given(omContainerInfo2.containerID()).willReturn(new ContainerID(2));
+    given(omContainerInfo2.getUsedBytes()).willReturn(2500000000L); // 2.5GB
+    given(omContainerInfo2.getState()).willReturn(CLOSED);
+
+    ContainerInfo omContainerInfoDeleted = mock(ContainerInfo.class);
+    given(omContainerInfoDeleted.containerID()).willReturn(new ContainerID(3));
+    given(omContainerInfoDeleted.getUsedBytes()).willReturn(1000000000L);
+    given(omContainerInfoDeleted.getState()).willReturn(DELETED); // 1GB
+
+    // Create a mock container with negative size
+    final ContainerInfo negativeSizeContainer = mock(ContainerInfo.class);
+    given(negativeSizeContainer.containerID()).willReturn(new ContainerID(0));
+    given(negativeSizeContainer.getUsedBytes()).willReturn(-1L);
+    given(negativeSizeContainer.getState()).willReturn(OPEN);
+
+    // Create a mock container with negative size and DELETE state
+    final ContainerInfo negativeSizeDeletedContainer =
+        mock(ContainerInfo.class);
+    given(negativeSizeDeletedContainer.containerID()).willReturn(
+        new ContainerID(0));
+    given(negativeSizeDeletedContainer.getUsedBytes()).willReturn(-1L);
+    given(negativeSizeDeletedContainer.getState()).willReturn(DELETED);
+
+    // Create a mock container with id 1 and updated size of 1GB from 1.5GB
+    final ContainerInfo validSizeContainer = mock(ContainerInfo.class);
+    given(validSizeContainer.containerID()).willReturn(new ContainerID(1));
+    given(validSizeContainer.getUsedBytes()).willReturn(1000000000L); // 1GB
+    given(validSizeContainer.getState()).willReturn(CLOSED);
+
+    // Mock getContainers method to return a list of containers including
+    // both valid and invalid ones
+    List<ContainerInfo> containers = new ArrayList<>();
+    containers.add(omContainerInfo1);
+    containers.add(omContainerInfo2);
+    containers.add(omContainerInfoDeleted);
+    containers.add(negativeSizeContainer);
+    containers.add(negativeSizeDeletedContainer);
+    containers.add(validSizeContainer);
+
+    task.process(containers);
+
+    // Verify that only the valid containers are counted
+    assertEquals(3, containerCountBySizeDao.count());
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <okhttp3.version>4.12.0</okhttp3.version>
     <stax2.version>4.2.2</stax2.version>
     <jakarta.inject.version>2.6.1</jakarta.inject.version>
-    <jakarta.annotation.version>1.3.5</jakarta.annotation.version>
+    <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
     <joda.time.version>2.12.5</joda.time.version>
 
     <compile-testing.version>0.19</compile-testing.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Backport the following commit from master to ozone-1.4 for 1.4.1. Including some bug fixes and necessary dependencies.

HDDS-8900. Mark TestSecretKeysApi#testSecretKeyApiSuccess as flaky
HDDS-10985. EC Reconstruction failed because the size of currentChunks was not equal to checksumBlockDataChunks. (#7009)
HDDS-11375. DN startup fails due to illegal configuration of raft.grpc.message.size.max (#7128)
~~HDDS-11350. NullPointerException thrown on checking container balancer status (#7134)~~
~~HDDS-11120. Rich rebalancing status info (#6911)~~
HDDS-9889. Refactor tests related to dynamical adaptation for datanode limits in ContainerBalancer (#5758)
HDDS-10612. Add Robot test to verify Container Balancer for RATIS containers (#6457)
HDDS-11331. Fix Datanode unable to report for a long time (#7090)
HDDS-11320. Update OM, SCM, Datanode conf for RATIS-2135. (#7080)
HDDS-10773. Simplify OM RaftProperties formatting (#6605)
HDDS-10761. Add raft close threshold config to OM RaftProperties (#6594)
HDDS-11309. Increase CONTAINER_STATE Column Length in UNHEALTHY_CONTAINERS to Avoid Truncation (#7071)
HDDS-10293. IllegalArgumentException: containerSize Negative (#6178)
HDDS-9819. Recon - Potential memory overflow in Container Health Task. (#5841)
HDDS-11209. Avoid insufficient EC pipelines in the container pipeline cache (#6974)
HDDS-11152. OMDoubleBuffer error when handling snapshot's background operations (#7112)
HDDS-9198. Maintain local cache in OMSnapshotPurgeRequest to get updated snapshotInfo and pass the same to OMSnapshotPurgeResponse (#7045)
HDDS-11137. Removed locks from SnapshotPurge and SnapshotSetProperty APIs. (#7018)

## How was this patch tested?

https://github.com/xichen01/ozone/actions/runs/10927685549

