### PR TITLE
HDDS-11473. Clean up files created after TestKeyValueHandlerWithUnhealthyContainer#testMarkContainerUnhealthyInFailedVolume

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
@@ -35,12 +35,14 @@ import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
@@ -71,6 +73,9 @@ import static org.mockito.Mockito.when;
 public class TestKeyValueHandlerWithUnhealthyContainer {
   public static final Logger LOG = LoggerFactory.getLogger(
       TestKeyValueHandlerWithUnhealthyContainer.class);
+
+  @TempDir
+  private File tempDir;
 
   private IncrementalReportSender<Container> mockIcrSender;
 
@@ -220,6 +225,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
     KeyValueContainerData mockContainerData = mock(KeyValueContainerData.class);
     HddsVolume mockVolume = mock(HddsVolume.class);
     when(mockContainerData.getVolume()).thenReturn(mockVolume);
+    when(mockContainerData.getMetadataPath()).thenReturn(tempDir.getAbsolutePath());
     KeyValueContainer container = new KeyValueContainer(
         mockContainerData, new OzoneConfiguration());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please describe your PR in detail:
After running `
TestKeyValueHandlerWithUnhealthyContainer#testMarkContainerUnhealthyInFailedVolume`, it generate files.
It is better to move them to the `TempDir`, and make sure the project is clean after running tests.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11473

## How was this patch tested?

CI:
https://github.com/chungen0126/ozone/actions/runs/10938671361