### PR TITLE
HDDS-11475. EC: Verify EC reconstruction correctness on DN

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -207,6 +207,14 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private long excludeNodesExpiryTime = 10 * 60 * 1000;
 
+  @Config(key = "ec.reconstruct.validation",
+      defaultValue = "false",
+      description = "The flag whether to validate that EC reconstruction tasks " +
+          "reconstruct target containers correctly. When validation fails, " +
+          "reconstruction tasks will fail.",
+      tags = ConfigTag.CLIENT)
+  private boolean ecReconstructValidation = false;
+
   @Config(key = "ec.reconstruct.stripe.read.pool.limit",
       defaultValue = "30",
       description = "Thread pool max size for parallelly read" +
@@ -491,6 +499,14 @@ public class OzoneClientConfig {
       return ChecksumCombineMode.valueOf(
           ChecksumCombineMode.COMPOSITE_CRC.name());
     }
+  }
+
+  public void setEcReconstructValidation(boolean ecReconstructValidation) {
+    this.ecReconstructValidation = ecReconstructValidation;
+  }
+
+  public boolean isEcReconstructValidation() {
+    return ecReconstructValidation;
   }
 
   public void setEcReconstructStripeReadPoolLimit(int poolLimit) {

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedStripeInputStream.java
@@ -813,6 +813,7 @@ public class TestECBlockReconstructedStripeInputStream {
       BlockLocationInfo keyInfo) {
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
     clientConfig.setChecksumVerify(true);
+    clientConfig.setEcReconstructValidation(true);
     return new ECBlockReconstructedStripeInputStream(repConfig, keyInfo,
         null, null, streamFactory, bufferPool, ecReconstructExecutor,
         clientConfig);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.security.token.Token;
+import org.apache.ozone.erasurecode.rawcoder.InvalidDecodingException;
 import org.apache.ratis.util.MemoizedSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -319,6 +320,9 @@ public class ECReconstructionCoordinator implements Closeable {
               // lengths etc.
               logBlockGroupDetails(blockLocationInfo, repConfig,
                   blockDataGroup);
+              if (e instanceof InvalidDecodingException) {
+                getECReconstructionMetrics().incrECInvalidReconstructionTasks();
+              }
               throw e;
             }
             // TODO: can be submitted in parallel

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionMetrics.java
@@ -39,6 +39,8 @@ public final class ECReconstructionMetrics {
   private @Metric MutableCounterLong blockGroupReconstructionFailsTotal;
   private @Metric MutableCounterLong reconstructionTotal;
   private @Metric MutableCounterLong reconstructionFailsTotal;
+  @Metric("Count of erasure coding invalidated reconstruction tasks")
+  private MutableCounterLong ecInvalidReconstructionTasks;
 
   private ECReconstructionMetrics() {
   }
@@ -76,5 +78,13 @@ public final class ECReconstructionMetrics {
 
   public long getBlockGroupReconstructionTotal() {
     return blockGroupReconstructionTotal.value();
+  }
+
+  public void incrECInvalidReconstructionTasks() {
+    ecInvalidReconstructionTasks.incr();
+  }
+
+  public long getECInvalidReconstructionTasks() {
+    return ecInvalidReconstructionTasks.value();
   }
 }

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/DecodingValidator.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/DecodingValidator.java
@@ -1,0 +1,171 @@
+package org.apache.ozone.erasurecode.rawcoder;
+
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.ozone.erasurecode.ECChunk;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class DecodingValidator {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DecodingValidator.class.getName());
+  private final RawErasureDecoder decoder;
+  private ByteBuffer buffer;
+  private int[] newValidIndexes;
+  private int newErasedIndex;
+
+  public DecodingValidator(RawErasureDecoder decoder) {
+    this.decoder = decoder;
+  }
+
+  /**
+   * Validate outputs decoded from inputs, by decoding an input back from
+   * the outputs and comparing it with the original one.
+   *
+   * For instance, in RS (6, 3), let (d0, d1, d2, d3, d4, d5) be sources
+   * and (p0, p1, p2) be parities, and assume
+   *  inputs = [d0, null (d1), d2, d3, d4, d5, null (p0), p1, null (p2)];
+   *  erasedIndexes = [1, 6];
+   *  outputs = [d1, p0].
+   * Then
+   *  1. Create new inputs, erasedIndexes and outputs for validation so that
+   *     the inputs could contain the decoded outputs, and decode them:
+   *      newInputs = [d1, d2, d3, d4, d5, p0]
+   *      newErasedIndexes = [0]
+   *      newOutputs = [d0']
+   *  2. Compare d0 and d0'. The comparison will fail with high probability
+   *     when the initial outputs are wrong.
+   *
+   * Note that the input buffers' positions must be the ones where data are
+   * read: If the input buffers have been processed by a decoder, the buffers'
+   * positions must be reset before being passed into this method.
+   *
+   * This method does not change outputs and erasedIndexes.
+   *
+   * @param inputs input buffers used for decoding. The buffers' position
+   *               are moved to the end after this method.
+   * @param erasedIndexes indexes of erased units used for decoding
+   * @param outputs decoded output buffers, which are ready to be read after
+   *                the call
+   * @throws IOException
+   */
+  public void validate(ByteBuffer[] inputs, int[] erasedIndexes,
+                       ByteBuffer[] outputs) throws IOException {
+    markBuffers(outputs);
+
+    try {
+      ByteBuffer validInput = CoderUtil.findFirstValidInput(inputs);
+      boolean isDirect = validInput.isDirect();
+      int capacity = validInput.capacity();
+      int remaining = validInput.remaining();
+
+      // Init buffer
+      if (buffer == null || buffer.isDirect() != isDirect
+          || buffer.capacity() < remaining) {
+        buffer = allocateBuffer(isDirect, capacity);
+      }
+      buffer.clear().limit(remaining);
+
+      // Create newInputs and newErasedIndex for validation
+      ByteBuffer[] newInputs = new ByteBuffer[inputs.length];
+      int count = 0;
+      for (int i = 0; i < erasedIndexes.length; i++) {
+        newInputs[erasedIndexes[i]] = outputs[i];
+        count++;
+      }
+      newErasedIndex = -1;
+      boolean selected = false;
+      int numValidIndexes = CoderUtil.getValidIndexes(inputs).length;
+      for (int i = 0; i < newInputs.length; i++) {
+        if (count == numValidIndexes) {
+          break;
+        } else if (!selected && inputs[i] != null) {
+          newErasedIndex = i;
+          newInputs[i] = null;
+          selected = true;
+        } else if (newInputs[i] == null) {
+          newInputs[i] = inputs[i];
+          if (inputs[i] != null) {
+            count++;
+          }
+        }
+      }
+
+      // Keep it for testing
+      newValidIndexes = CoderUtil.getValidIndexes(newInputs);
+
+      decoder.decode(newInputs, new int[]{newErasedIndex},
+          new ByteBuffer[]{buffer});
+
+      if (!buffer.equals(inputs[newErasedIndex])) {
+        throw new InvalidDecodingException("Failed to validate decoding");
+      }
+      LOG.debug("Success to validate decoding.");
+    } finally {
+      toLimits(inputs);
+      resetBuffers(outputs);
+    }
+  }
+
+  /**
+   *  Validate outputs decoded from inputs, by decoding an input back from
+   *  those outputs and comparing it with the original one.
+   * @param inputs input buffers used for decoding
+   * @param erasedIndexes indexes of erased units used for decoding
+   * @param outputs decoded output buffers
+   * @throws IOException
+   */
+  public void validate(ECChunk[] inputs, int[] erasedIndexes, ECChunk[] outputs)
+      throws IOException {
+    ByteBuffer[] newInputs = CoderUtil.toBuffers(inputs);
+    ByteBuffer[] newOutputs = CoderUtil.toBuffers(outputs);
+    validate(newInputs, erasedIndexes, newOutputs);
+  }
+
+  private ByteBuffer allocateBuffer(boolean direct, int capacity) {
+    if (direct) {
+      buffer = ByteBuffer.allocateDirect(capacity);
+    } else {
+      buffer = ByteBuffer.allocate(capacity);
+    }
+    return buffer;
+  }
+
+  private static void markBuffers(ByteBuffer[] buffers) {
+    for (ByteBuffer buffer: buffers) {
+      if (buffer != null) {
+        buffer.mark();
+      }
+    }
+  }
+
+  private static void resetBuffers(ByteBuffer[] buffers) {
+    for (ByteBuffer buffer: buffers) {
+      if (buffer != null) {
+        buffer.reset();
+      }
+    }
+  }
+
+  private static void toLimits(ByteBuffer[] buffers) {
+    for (ByteBuffer buffer: buffers) {
+      if (buffer != null) {
+        buffer.position(buffer.limit());
+      }
+    }
+  }
+
+  @VisibleForTesting
+  protected int[] getNewValidIndexes() {
+    return newValidIndexes;
+  }
+
+  @VisibleForTesting
+  protected int getNewErasedIndex() {
+    return newErasedIndex;
+  }
+}

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/DecodingValidator.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/DecodingValidator.java
@@ -2,6 +2,7 @@ package org.apache.ozone.erasurecode.rawcoder;
 
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.ozone.erasurecode.ECChunk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +10,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+/**
+ * A utility class to validate decoding.
+ */
+@InterfaceAudience.Private
 public class DecodingValidator {
 
   private static final Logger LOG =

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/InvalidDecodingException.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/InvalidDecodingException.java
@@ -24,8 +24,7 @@ import java.io.IOException;
  * Thrown for invalid decoding.
  */
 
-public class InvalidDecodingException
-    extends IOException {
+public class InvalidDecodingException extends IOException {
   private static final long serialVersionUID = 0L;
 
   public InvalidDecodingException(String description) {

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/InvalidDecodingException.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/InvalidDecodingException.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+
+import java.io.IOException;
+
+/**
+ * Thrown for invalid decoding.
+ */
+
+public class InvalidDecodingException
+    extends IOException {
+  private static final long serialVersionUID = 0L;
+
+  public InvalidDecodingException(String description) {
+    super(description);
+  }
+}

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/TestCoderBase.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/TestCoderBase.java
@@ -519,4 +519,16 @@ public abstract class TestCoderBase {
       buffer.position(buffer.position() + 1);
     }
   }
+
+  /**
+   * Pollute some chunk.
+   * @param chunks
+   */
+  protected void polluteSomeChunk(ECChunk[] chunks) {
+    int idx = new Random().nextInt(chunks.length);
+    ByteBuffer buffer = chunks[idx].getBuffer();
+    buffer.mark();
+    buffer.put((byte) ((buffer.get(buffer.position()) + 1)));
+    buffer.reset();
+  }
 }

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestDecodingValidator.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestDecodingValidator.java
@@ -182,7 +182,8 @@ public class TestDecodingValidator extends TestRawCoderBase {
   @ParameterizedTest
   @MethodSource("data")
   public void testValidateWithBadDecoding(Class<? extends RawErasureCoderFactory> factoryClass, int numDataUnits,
-                                          int numParityUnits, int[] erasedDataIndexes, int[] erasedParityIndexes) throws IOException {
+                                          int numParityUnits, int[] erasedDataIndexes,
+                                          int[] erasedParityIndexes) throws IOException {
     checkNative(factoryClass);
     this.encoderFactoryClass = factoryClass;
     this.decoderFactoryClass = factoryClass;

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestDecodingValidator.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestDecodingValidator.java
@@ -1,0 +1,274 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.ozone.erasurecode.ECChunk;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * Test {@link DecodingValidator} under various decoders.
+ */
+public class TestDecodingValidator extends TestRawCoderBase {
+
+  private DecodingValidator validator;
+
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(RSRawErasureCoderFactory.class, 6, 3, new int[]{1}, new int[]{}),
+        Arguments.of(RSRawErasureCoderFactory.class, 6, 3, new int[]{3}, new int[]{0}),
+        Arguments.of(RSRawErasureCoderFactory.class, 6, 3, new int[]{2, 4}, new int[]{1}),
+        Arguments.of(NativeRSRawErasureCoderFactory.class, 6, 3, new int[]{0}, new int[]{}),
+        Arguments.of(XORRawErasureCoderFactory.class, 10, 1, new int[]{0}, new int[]{}),
+        Arguments.of(NativeXORRawErasureCoderFactory.class, 10, 1, new int[]{0}, new int[]{})
+    );
+  }
+
+  @BeforeEach
+  public void setup() {
+    setAllowDump(false);
+  }
+
+  /**
+   * Test if the same validator can process direct and non-direct buffers.
+   */
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidate(Class<? extends RawErasureCoderFactory> factoryClass, int numDataUnits,
+                           int numParityUnits, int[] erasedDataIndexes, int[] erasedParityIndexes) {
+    checkNative(factoryClass);
+    this.encoderFactoryClass = factoryClass;
+    this.decoderFactoryClass = factoryClass;
+    prepare(null, numDataUnits, numParityUnits, erasedDataIndexes,
+        erasedParityIndexes);
+    testValidate(true);
+    testValidate(false);
+  }
+
+  /**
+   * Test if the same validator can process variable width of data for
+   * inputs and outputs.
+   */
+  protected void testValidate(boolean usingDirectBuffer) {
+    this.usingDirectBuffer = usingDirectBuffer;
+    prepareCoders(false);
+    prepareValidator(false);
+
+    performTestValidate(baseChunkSize);
+    performTestValidate(baseChunkSize - 17);
+    performTestValidate(baseChunkSize + 18);
+  }
+
+  protected void prepareValidator(boolean recreate) {
+    if (validator == null || recreate) {
+      validator = new DecodingValidator(decoder);
+    }
+  }
+
+  protected void performTestValidate(int chunkSize) {
+    setChunkSize(chunkSize);
+    prepareBufferAllocator(false);
+
+    // encode
+    ECChunk[] dataChunks = prepareDataChunksForEncoding();
+    ECChunk[] parityChunks = prepareParityChunksForEncoding();
+    ECChunk[] clonedDataChunks = cloneChunksWithData(dataChunks);
+    try {
+      encoder.encode(dataChunks, parityChunks);
+    } catch (Exception e) {
+      Assertions.fail("Should not get Exception: " + e.getMessage());
+    }
+
+    // decode
+    backupAndEraseChunks(clonedDataChunks, parityChunks);
+    ECChunk[] inputChunks =
+        prepareInputChunksForDecoding(clonedDataChunks, parityChunks);
+    markChunks(inputChunks);
+    ensureOnlyLeastRequiredChunks(inputChunks);
+    ECChunk[] recoveredChunks = prepareOutputChunksForDecoding();
+    int[] erasedIndexes = getErasedIndexesForDecoding();
+    try {
+      decoder.decode(inputChunks, erasedIndexes, recoveredChunks);
+    } catch (Exception e) {
+      Assertions.fail("Should not get Exception: " + e.getMessage());
+    }
+
+    // validate
+    restoreChunksFromMark(inputChunks);
+    ECChunk[] clonedInputChunks = cloneChunksWithData(inputChunks);
+    ECChunk[] clonedRecoveredChunks = cloneChunksWithData(recoveredChunks);
+    int[] clonedErasedIndexes = erasedIndexes.clone();
+
+    try {
+      validator.validate(clonedInputChunks, clonedErasedIndexes,
+          clonedRecoveredChunks);
+    } catch (Exception e) {
+      Assertions.fail("Should not get Exception: " + e.getMessage());
+    }
+
+    // Check if input buffers' positions are moved to the end
+    verifyBufferPositionAtEnd(clonedInputChunks);
+
+    // Check if validator does not change recovered chunks and erased indexes
+    verifyChunksEqual(recoveredChunks, clonedRecoveredChunks);
+    Assertions.assertArrayEquals(erasedIndexes, clonedErasedIndexes,
+        "Erased indexes should not be changed");
+
+    // Check if validator uses correct indexes for validation
+    List<Integer> validIndexesList =
+        IntStream.of(CoderUtil.getValidIndexes(inputChunks)).boxed()
+            .collect(Collectors.toList());
+    List<Integer> newValidIndexesList =
+        IntStream.of(validator.getNewValidIndexes()).boxed()
+            .collect(Collectors.toList());
+    List<Integer> erasedIndexesList =
+        IntStream.of(erasedIndexes).boxed().collect(Collectors.toList());
+    int newErasedIndex = validator.getNewErasedIndex();
+    assertTrue(
+        newValidIndexesList.containsAll(erasedIndexesList),
+        "Valid indexes for validation should contain"
+            + " erased indexes for decoding");
+    assertTrue(
+        validIndexesList.contains(newErasedIndex),
+        "An erased index for validation should be contained"
+            + " in valid indexes for decoding");
+    Assertions.assertFalse(
+        newValidIndexesList.contains(newErasedIndex),
+        "An erased index for validation should not be contained"
+            + " in valid indexes for validation");
+  }
+
+  private void verifyChunksEqual(ECChunk[] chunks1, ECChunk[] chunks2) {
+    boolean result = Arrays.deepEquals(toArrays(chunks1), toArrays(chunks2));
+    assertTrue(result, "Recovered chunks should not be changed");
+  }
+
+  /**
+   * Test if validator throws {@link InvalidDecodingException} when
+   * a decoded output buffer is polluted.
+   */
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testValidateWithBadDecoding(Class<? extends RawErasureCoderFactory> factoryClass, int numDataUnits,
+                                          int numParityUnits, int[] erasedDataIndexes, int[] erasedParityIndexes) throws IOException {
+    checkNative(factoryClass);
+    this.encoderFactoryClass = factoryClass;
+    this.decoderFactoryClass = factoryClass;
+    prepare(null, numDataUnits, numParityUnits, erasedDataIndexes,
+        erasedParityIndexes);
+    this.usingDirectBuffer = true;
+    prepareCoders(true);
+    prepareValidator(true);
+    prepareBufferAllocator(false);
+
+    // encode
+    ECChunk[] dataChunks = prepareDataChunksForEncoding();
+    ECChunk[] parityChunks = prepareParityChunksForEncoding();
+    ECChunk[] clonedDataChunks = cloneChunksWithData(dataChunks);
+    try {
+      encoder.encode(dataChunks, parityChunks);
+    } catch (Exception e) {
+      Assertions.fail("Should not get Exception: " + e.getMessage());
+    }
+
+    // decode
+    backupAndEraseChunks(clonedDataChunks, parityChunks);
+    ECChunk[] inputChunks =
+        prepareInputChunksForDecoding(clonedDataChunks, parityChunks);
+    markChunks(inputChunks);
+    ensureOnlyLeastRequiredChunks(inputChunks);
+    ECChunk[] recoveredChunks = prepareOutputChunksForDecoding();
+    int[] erasedIndexes = getErasedIndexesForDecoding();
+    try {
+      decoder.decode(inputChunks, erasedIndexes, recoveredChunks);
+    } catch (Exception e) {
+      Assertions.fail("Should not get Exception: " + e.getMessage());
+    }
+
+    // validate
+    restoreChunksFromMark(inputChunks);
+    polluteSomeChunk(recoveredChunks);
+    try {
+      validator.validate(inputChunks, erasedIndexes, recoveredChunks);
+      Assertions.fail("Validation should fail due to bad decoding");
+    } catch (InvalidDecodingException e) {
+      String expected = "Failed to validate decoding";
+      assertThat(e).hasMessageContaining(expected);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testIdempotentReleases(Class<? extends RawErasureCoderFactory> factoryClass) {
+    checkNative(factoryClass);
+    this.encoderFactoryClass = factoryClass;
+    this.decoderFactoryClass = factoryClass;
+    prepareCoders(true);
+
+    for (int i = 0; i < 3; i++) {
+      encoder.release();
+      decoder.release();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testCodingWithErasingTooMany(Class<? extends RawErasureCoderFactory> factoryClass) {
+    checkNative(factoryClass);
+    this.encoderFactoryClass = factoryClass;
+    this.decoderFactoryClass = factoryClass;
+    assertThrows(Exception.class, () -> testCoding(true), "Decoding test erasing too many should fail");
+    assertThrows(Exception.class, () -> testCoding(false), "Decoding test erasing too many should fail");
+  }
+
+  @Override
+  @Disabled
+  public void testIdempotentReleases() {
+    // just override and ignore this test for we have a parameterized one.
+  }
+
+  @Override
+  @Disabled
+  public void testCodingWithErasingTooMany() {
+    // just override and ignore this test for we have a parameterized one.
+  }
+
+  private void checkNative(Class<? extends RawErasureCoderFactory> factoryClass) {
+    if (factoryClass == NativeRSRawErasureCoderFactory.class ||
+        factoryClass == NativeXORRawErasureCoderFactory.class) {
+      Assumptions.assumeTrue(ErasureCodeNative.isNativeCodeLoaded());
+    }
+  }
+}

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestRawCoderBase.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestRawCoderBase.java
@@ -34,16 +34,20 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @SuppressWarnings("checkstyle:VisibilityModifier")
 public abstract class TestRawCoderBase extends TestCoderBase {
-  private final Class<? extends RawErasureCoderFactory> encoderFactoryClass;
-  private final Class<? extends RawErasureCoderFactory> decoderFactoryClass;
-  private RawErasureEncoder encoder;
-  private RawErasureDecoder decoder;
+  protected Class<? extends RawErasureCoderFactory> encoderFactoryClass;
+  protected Class<? extends RawErasureCoderFactory> decoderFactoryClass;
+  protected RawErasureEncoder encoder;
+  protected RawErasureDecoder decoder;
 
   public TestRawCoderBase(
       Class<? extends RawErasureCoderFactory> encoderFactoryClass,
       Class<? extends RawErasureCoderFactory> decoderFactoryClass) {
     this.encoderFactoryClass = encoderFactoryClass;
     this.decoderFactoryClass = decoderFactoryClass;
+  }
+
+  public TestRawCoderBase() {
+
   }
 
   /**
@@ -319,7 +323,7 @@ public abstract class TestRawCoderBase extends TestCoderBase {
     verifyBufferPositionAtEnd(inputChunks);
   }
 
-  private void verifyBufferPositionAtEnd(ECChunk[] inputChunks) {
+  void verifyBufferPositionAtEnd(ECChunk[] inputChunks) {
     for (ECChunk chunk : inputChunks) {
       if (chunk != null) {
         assertEquals(0, chunk.getBuffer().remaining());


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDFS-15759](https://issues.apache.org/jira/browse/HDFS-15759) shows a good way to prevent potential EC reconstruction correctness on datanode, so maybe we can adapt it to Ozone. 

```
To prevent further data corruption issues, this feature proposes a simple and effective way to verify
EC reconstruction correctness on DataNode at each reconstruction process.

It verifies correctness of outputs decoded from inputs as follows:
1. Decoding an input with the outputs;
2. Compare the decoded input with the original input.

For instance, in RS-6-3, assume that outputs [d1, p1] are decoded from inputs [d0, d2, d3, d4, d5, p0]. 
Then the verification is done by decoding d0 from [d1, d2, d3, d4, d5, p1], and comparing the original
and decoded data of d0.

When an EC reconstruction task goes wrong, the comparison will fail with high probability.
Then the task will also fail and be retried by NameNode.
The next reconstruction will succeed if the condition triggered the failure is gone.
```

Now this PR has worked over 3 months on our clusters.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11475

## How was this patch tested?

Unit tests and online tests.