### PR TITLE
HDDS-11220. Reproduction test case for [HBase Replication] RS down due to "ManagedChannelOrphanWrapper: Previous channel was not shutdown properly"

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestHSync.java
@@ -417,6 +417,44 @@ public class TestHSync {
     return chunkPath;
   }
 
+  @Test
+  public void testHSyncSeek() throws Exception {
+    // Set the fs.defaultFS
+    final String rootPath = String.format("%s://%s.%s/",
+        OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
+    CONF.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    final String dir = OZONE_ROOT + bucket.getVolumeName()
+        + OZONE_URI_DELIMITER + bucket.getName();
+    final Path key1 = new Path(dir, "key-hsync-seek");
+
+    final byte[] data = new byte[1024];
+    final byte[] buffer = new byte[1024];
+    ThreadLocalRandom.current().nextBytes(data);
+    try (FileSystem fs = FileSystem.get(CONF)) {
+      // Create key1
+      try (FSDataOutputStream os = fs.create(key1, true)) {
+        os.write(data, 0, 1);
+        // the first hsync will update the correct length in the key info at OM
+        os.hsync();
+        os.write(data, 0, data.length);
+        os.hsync(); // the second hsync will not update the length at OM
+        try (FSDataInputStream in = fs.open(key1)) {
+          // the actual key length is 1025, but the length in OM is 1
+          in.seek(2);
+          final int n = in.read(buffer, 1, buffer.length-1);
+          // expect to read 1023 bytes
+          assertEquals(buffer.length - 1, n);
+          for (int i = 1; i < buffer.length; i++) {
+            assertEquals(data[i], buffer[i], "expected at i=" + i);
+          }
+        }
+      } finally {
+        fs.delete(key1, false);
+      }
+    }
+  }
+
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   public void testO3fsHSync(boolean incrementalChunkList) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11220. Reproduction test case for [HBase Replication] RS down due to "ManagedChannelOrphanWrapper: Previous channel was not shutdown properly"

Please describe your PR in detail:
* An input stream for an open file will not be able to seek/read to its latest length.
* Unlike HDFS where NameNode gets the latest block length of an open file via DataNode block reports, Ozone OM/SCM aren't aware of the length.
* An input stream that seeks immediately after instantiation doesn't know the actual length.
* This bug was found when enabling HBase to HBase replication between two Ozone storage clusters.
* Here is a reproduction test case. A full fix will be added later.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11220

## How was this patch tested?

Unit test, and also plan to verify the fix on a HBase/Ozone cluster.