### PR TITLE
HDDS-11476. Implement lesser/greater operation for --filter option of ldb scan command

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-ldb.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-ldb.robot
@@ -74,7 +74,7 @@ Test ozone debug ldb scan
                         Should not contain      ${output}       dataSize
                         Should not contain      ${output}       keyLocationVersions
 
-Test ozone debug ldb scan with filter option
+Test ozone debug ldb scan with filter option success
     # test filter option with one filter
     ${output} =         Execute                 ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="keyName:equals:testfile2"
                         Should not contain      ${output}       testfile1
@@ -110,12 +110,17 @@ Test ozone debug ldb scan with filter option
                         Should not contain      ${output}       testfile1
                         Should not contain      ${output}       testfile2
                         Should not contain      ${output}       testfile3
+
+Test ozone debug ldb scan with filter option failure
     # test filter option with invalid operator
-    ${output} =         Execute                 ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="dataSize:lesserthan:1200"
-                        Should contain          ${output}           Error: Invalid operator
+    ${output} =         Execute                         ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="dataSize:lesserthan:1200"
+                        Should contain                  ${output}           Error: Invalid operator
     # test filter option with invalid format
     ${output} =         Execute And Ignore Error        ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="dataSize:1200"
                         Should contain                  ${output}           Error: Invalid format
     # test filter option with invalid field
     ${output} =         Execute And Ignore Error        ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="size:equals:1200"
                         Should contain                  ${output}           Error: Invalid field
+    # test filter option for lesser/greater operator on non-numeric field
+    ${output} =         Execute And Ignore Error        ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="keyName:lesser:k1"
+                        Should contain                  ${output}           only on numeric values

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-ldb.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-ldb.robot
@@ -32,10 +32,12 @@ Write keys
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit test user     testuser     testuser.keytab
     Execute             ozone sh volume create ${VOLUME}
     Execute             ozone sh bucket create ${VOLUME}/${BUCKET} -l OBJECT_STORE
-    Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE} bs=100000 count=15
-    Execute             ozone sh key put ${VOLUME}/${BUCKET}/${TESTFILE}1 ${TEMP_DIR}/${TESTFILE}
-    Execute             ozone sh key put ${VOLUME}/${BUCKET}/${TESTFILE}2 ${TEMP_DIR}/${TESTFILE}
-    Execute             ozone sh key put ${VOLUME}/${BUCKET}/${TESTFILE}3 ${TEMP_DIR}/${TESTFILE}
+    Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE}1 bs=100 count=10
+    Execute             ozone sh key put ${VOLUME}/${BUCKET}/${TESTFILE}1 ${TEMP_DIR}/${TESTFILE}1
+    Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE}2 bs=100 count=15
+    Execute             ozone sh key put ${VOLUME}/${BUCKET}/${TESTFILE}2 ${TEMP_DIR}/${TESTFILE}2
+    Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE}3 bs=100 count=20
+    Execute             ozone sh key put ${VOLUME}/${BUCKET}/${TESTFILE}3 ${TEMP_DIR}/${TESTFILE}3
     Execute             ozone sh key addacl -a user:systest:a ${VOLUME}/${BUCKET}/${TESTFILE}3
 
 *** Test Cases ***
@@ -71,6 +73,8 @@ Test ozone debug ldb scan
                         Should not contain      ${output}       objectID
                         Should not contain      ${output}       dataSize
                         Should not contain      ${output}       keyLocationVersions
+
+Test ozone debug ldb scan with filter option
     # test filter option with one filter
     ${output} =         Execute                 ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="keyName:equals:testfile2"
                         Should not contain      ${output}       testfile1
@@ -91,3 +95,27 @@ Test ozone debug ldb scan
                         Should not contain      ${output}       testfile1
                         Should not contain      ${output}       testfile2
                         Should not contain      ${output}       testfile3
+    # test filter option for size > 1200
+    ${output} =         Execute                 ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="dataSize:greater:1200"
+                        Should not contain      ${output}       testfile1
+                        Should contain          ${output}       testfile2
+                        Should contain          ${output}       testfile3
+    # test filter option for size < 1200
+    ${output} =         Execute                 ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="dataSize:lesser:1200"
+                        Should contain          ${output}       testfile1
+                        Should not contain      ${output}       testfile2
+                        Should not contain      ${output}       testfile3
+    # test filter option with no records match both filters
+    ${output} =         Execute                 ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="dataSize:lesser:1200,keyName:equals:testfile2"
+                        Should not contain      ${output}       testfile1
+                        Should not contain      ${output}       testfile2
+                        Should not contain      ${output}       testfile3
+    # test filter option with invalid operator
+    ${output} =         Execute                 ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="dataSize:lesserthan:1200"
+                        Should contain          ${output}           Error: Invalid operator
+    # test filter option with invalid format
+    ${output} =         Execute And Ignore Error        ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="dataSize:1200"
+                        Should contain                  ${output}           Error: Invalid format
+    # test filter option with invalid field
+    ${output} =         Execute And Ignore Error        ozone debug ldb --db=/data/metadata/om.db scan --cf=keyTable --filter="size:equals:1200"
+                        Should contain                  ${output}           Error: Invalid field

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -183,6 +183,30 @@ public class TestLDBCli {
             Named.of("Expect key1-key3", null)
         ),
         Arguments.of(
+            Named.of(KEY_TABLE, Pair.of(KEY_TABLE, false)),
+            Named.of("Default", Pair.of(0, "")),
+            Named.of("Filter dataSize<2000", Arrays.asList("--filter", "dataSize:lesser:2000")),
+            Named.of("Expect key1-key5", Pair.of("key1", "key6"))
+        ),
+        Arguments.of(
+            Named.of(KEY_TABLE, Pair.of(KEY_TABLE, false)),
+            Named.of("Default", Pair.of(0, "")),
+            Named.of("Filter dataSize<500", Arrays.asList("--filter", "dataSize:lesser:500")),
+            Named.of("Expect empty result", null)
+        ),
+        Arguments.of(
+            Named.of(KEY_TABLE, Pair.of(KEY_TABLE, false)),
+            Named.of("Default", Pair.of(0, "")),
+            Named.of("Filter dataSize>500", Arrays.asList("--filter", "dataSize:greater:500")),
+            Named.of("Expect key1-key5", Pair.of("key1", "key6"))
+        ),
+        Arguments.of(
+            Named.of(KEY_TABLE, Pair.of(KEY_TABLE, false)),
+            Named.of("Default", Pair.of(0, "")),
+            Named.of("Filter dataSize>2000", Arrays.asList("--filter", "dataSize:greater:2000")),
+            Named.of("Expect empty result", null)
+        ),
+        Arguments.of(
             Named.of(BLOCK_DATA + " V3", Pair.of(BLOCK_DATA, true)),
             Named.of("Default", Pair.of(0, "")),
             Named.of("V3", Arrays.asList("--dn-schema", "V3")),

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -132,7 +132,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
   @CommandLine.Option(names = {"--filter"},
       description = "Comma-separated list of \"<field>:<operator>:<value>\" where " +
           "<field> is any valid field of the record, " +
-          "<operator> is (EQUALS,MAX or MIN) and " +
+          "<operator> is (EQUALS,LESSER or GREATER) and " +
           "<value> is the value of the field. " +
           "eg.) \"dataSize:equals:1000\" for showing records having the value 1000 for dataSize")
   private String filter;
@@ -261,7 +261,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       logWriter.start();
       processRecords(iterator, dbColumnFamilyDef, logWriter,
           threadPool, schemaV3);
-    } catch (InterruptedException e) {
+    } catch (InterruptedException | IOException e) {
       exception = true;
       Thread.currentThread().interrupt();
     } finally {
@@ -277,7 +277,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
   private void processRecords(ManagedRocksIterator iterator,
                               DBColumnFamilyDefinition dbColumnFamilyDef,
                               LogWriter logWriter, ExecutorService threadPool,
-                              boolean schemaV3) throws InterruptedException {
+                              boolean schemaV3) throws InterruptedException, IOException {
     if (startKey != null) {
       iterator.get().seek(getValueObject(dbColumnFamilyDef, startKey));
     }
@@ -289,29 +289,56 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     long count = 0;
     List<Future<Void>> futures = new ArrayList<>();
     boolean reachedEnd = false;
+
+    Map<String, Filter> fieldsFilterSplitMap = new HashMap<>();
+    if (filter != null) {
+      for (String field : filter.split(",")) {
+        String[] fieldValue = field.split(":");
+        if (fieldValue.length != 3) {
+          err().println("Error: Invalid format for filter \"" + field
+              + "\". Usage: <field>:<operator>:<value>. Ignoring filter passed");
+        } else {
+          Filter filterValue = new Filter(fieldValue[1], fieldValue[2]);
+          if (filterValue.getOperator() == null) {
+            err().println("Error: Invalid format for filter \"" + filterValue
+                + "\". <operator> can be one of [EQUALS,LESSER,GREATER]. Ignoring filter passed");
+          } else {
+            String[] subfields = fieldValue[0].split("\\.");
+            getFilterSplit(Arrays.asList(subfields), fieldsFilterSplitMap, filterValue);
+          }
+        }
+      }
+    }
+
     while (withinLimit(count) && iterator.get().isValid() && !exception && !reachedEnd) {
       // if invalid endKey is given, it is ignored
       if (null != endKey && Arrays.equals(iterator.get().key(), getValueObject(dbColumnFamilyDef, endKey))) {
         reachedEnd = true;
       }
-      batch.add(new ByteArrayKeyValue(
-          iterator.get().key(), iterator.get().value()));
-      iterator.get().next();
-      count++;
-      if (batch.size() >= batchSize) {
-        while (logWriter.getInflightLogCount() > threadCount * 10L
-            && !exception) {
-          // Prevents too many unfinished Tasks from
-          // consuming too much memory.
-          Thread.sleep(100);
+
+      Object o = dbColumnFamilyDef.getValueCodec().fromPersistedFormat(iterator.get().value());
+      if (filter == null ||
+          checkFilteredObject(o, dbColumnFamilyDef.getValueType(), fieldsFilterSplitMap)) {
+        // the record passes the filter
+        batch.add(new ByteArrayKeyValue(
+            iterator.get().key(), iterator.get().value()));
+        count++;
+        if (batch.size() >= batchSize) {
+          while (logWriter.getInflightLogCount() > threadCount * 10L
+              && !exception) {
+            // Prevents too many unfinished Tasks from
+            // consuming too much memory.
+            Thread.sleep(100);
+          }
+          Future<Void> future = threadPool.submit(
+              new Task(dbColumnFamilyDef, batch, logWriter, sequenceId,
+                  withKey, schemaV3, fieldsFilter, filter));
+          futures.add(future);
+          batch = new ArrayList<>(batchSize);
+          sequenceId++;
         }
-        Future<Void> future = threadPool.submit(
-            new Task(dbColumnFamilyDef, batch, logWriter, sequenceId,
-                withKey, schemaV3, fieldsFilter, filter));
-        futures.add(future);
-        batch = new ArrayList<>(batchSize);
-        sequenceId++;
       }
+      iterator.get().next();
     }
     if (!batch.isEmpty()) {
       Future<Void> future = threadPool.submit(new Task(dbColumnFamilyDef,
@@ -326,6 +353,152 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         LOG.error("Task execution failed", e);
       }
     }
+  }
+
+  private void getFilterSplit(List<String> fields, Map<String, Filter> fieldMap, Filter leafValue) throws IOException {
+    int len = fields.size();
+    if (len == 1) {
+      Filter currentValue = fieldMap.get(fields.get(0));
+      if (currentValue != null) {
+        err().println("Cannot pass multiple values for the same field and " +
+            "cannot have filter for both parent and child");
+        throw new IOException("Invalid filter passed");
+      }
+      fieldMap.put(fields.get(0), leafValue);
+    } else {
+      Filter fieldMapGet = fieldMap.computeIfAbsent(fields.get(0), k -> new Filter());
+      if (fieldMapGet.getValue() != null) {
+        err().println("Cannot pass multiple values for the same field and " +
+            "cannot have filter for both parent and child");
+        throw new IOException("Invalid filter passed");
+      }
+      Map<String, Filter> nextLevel = fieldMapGet.getNextLevel();
+      if (nextLevel == null) {
+        fieldMapGet.setNextLevel(new HashMap<>());
+      }
+      getFilterSplit(fields.subList(1, len), fieldMapGet.getNextLevel(), leafValue);
+    }
+  }
+
+  private boolean checkFilteredObject(Object obj, Class<?> clazz, Map<String, Filter> fieldsSplitMap)
+      throws IOException {
+    for (Map.Entry<String, Filter> field : fieldsSplitMap.entrySet()) {
+      try {
+        Field valueClassField = getRequiredFieldFromAllFields(clazz, field.getKey());
+        Object valueObject = valueClassField.get(obj);
+        Filter fieldValue = field.getValue();
+
+        if (valueObject == null) {
+          // there is no such field in the record. This filter will be ignored for the current record.
+          continue;
+        }
+        if (fieldValue == null) {
+          err().println("Malformed filter. Check input");
+          throw new IOException("Invalid filter passed");
+        } else if (fieldValue.getNextLevel() == null) {
+          // reached the end of fields hierarchy, check if they match the filter
+          // Currently, only equals operation is supported
+          try {
+            switch (fieldValue.getOperator()) {
+            case EQUALS:
+              if (!String.valueOf(valueObject).equals(fieldValue.getValue())) {
+                return false;
+              }
+              break;
+            case GREATER:
+              if (Double.parseDouble(String.valueOf(valueObject))
+                  < Double.parseDouble(String.valueOf(fieldValue.getValue()))) {
+                return false;
+              }
+              break;
+            case LESSER:
+              if (Double.parseDouble(String.valueOf(valueObject))
+                  > Double.parseDouble(String.valueOf(fieldValue.getValue()))) {
+                return false;
+              }
+              break;
+            default:
+              err().println("Only EQUALS/LESSER/GREATER operator is supported currently.");
+              throw new IOException("Invalid filter passed");
+            }
+          } catch (NumberFormatException ex) {
+            err().println("LESSER or GREATER operation can be performed only on numeric values.");
+            throw new IOException("Invalid filter passed");
+          }
+        } else {
+          Map<String, Filter> subfields = fieldValue.getNextLevel();
+          if (Collection.class.isAssignableFrom(valueObject.getClass())) {
+            if (!checkFilteredObjectCollection((Collection) valueObject, subfields)) {
+              return false;
+            }
+          } else if (Map.class.isAssignableFrom(valueObject.getClass())) {
+            Map<?, ?> valueObjectMap = (Map<?, ?>) valueObject;
+            boolean flag = false;
+            for (Map.Entry<?, ?> ob : valueObjectMap.entrySet()) {
+              boolean subflag;
+              if (Collection.class.isAssignableFrom(ob.getValue().getClass())) {
+                subflag = checkFilteredObjectCollection((Collection)ob.getValue(), subfields);
+              } else {
+                subflag = checkFilteredObject(ob.getValue(), ob.getValue().getClass(), subfields);
+              }
+              if (subflag) {
+                // atleast one item in the map/list of the record has matched the filter,
+                // so record passes the filter.
+                flag = true;
+                break;
+              }
+            }
+            if (!flag) {
+              // none of the items in the map/list passed the filter => record doesn't pass the filter
+              return false;
+            }
+          } else {
+            if (!checkFilteredObject(valueObject, valueClassField.getType(), subfields)) {
+              return false;
+            }
+          }
+        }
+      } catch (NoSuchFieldException ex) {
+        err().println("ERROR: no such field: " + field);
+        exception = true;
+        return false;
+      } catch (IllegalAccessException e) {
+        err().println("ERROR: Cannot get field from object: " + field);
+        exception = true;
+        return false;
+      } catch (Exception ex) {
+        err().println("ERROR: field: " + field + ", ex: " + ex);
+        exception = true;
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean checkFilteredObjectCollection(Collection<?> valueObject, Map<String, Filter> fields)
+      throws NoSuchFieldException, IllegalAccessException, IOException {
+    for (Object ob : valueObject) {
+      if (checkFilteredObject(ob, ob.getClass(), fields)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static Field getRequiredFieldFromAllFields(Class clazz, String fieldName) throws NoSuchFieldException {
+    List<Field> classFieldList = ValueSchema.getAllFields(clazz);
+    Field classField = null;
+    for (Field f : classFieldList) {
+      if (f.getName().equals(fieldName)) {
+        classField = f;
+        break;
+      }
+    }
+    if (classField == null) {
+      throw new NoSuchFieldException();
+    }
+    classField.setAccessible(true);
+    return classField;
   }
 
   private boolean withinLimit(long i) {
@@ -516,31 +689,6 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       return fieldMap;
     }
 
-    void getFilterSplit(List<String> fields, Map<String, Filter> fieldMap, Filter leafValue) throws IOException {
-      int len = fields.size();
-      if (len == 1) {
-        Filter currentValue = fieldMap.get(fields.get(0));
-        if (currentValue != null) {
-          err().println("Cannot pass multiple values for the same field and " +
-              "cannot have filter for both parent and child");
-          throw new IOException("Invalid filter passed");
-        }
-        fieldMap.put(fields.get(0), leafValue);
-      } else {
-        Filter fieldMapGet = fieldMap.computeIfAbsent(fields.get(0), k -> new Filter());
-        if (fieldMapGet.getValue() != null) {
-          err().println("Cannot pass multiple values for the same field and " +
-              "cannot have filter for both parent and child");
-          throw new IOException("Invalid filter passed");
-        }
-        Map<String, Filter> nextLevel = fieldMapGet.getNextLevel();
-        if (nextLevel == null) {
-          fieldMapGet.setNextLevel(new HashMap<>());
-        }
-        getFilterSplit(fields.subList(1, len), fieldMapGet.getNextLevel(), leafValue);
-      }
-    }
-
     @Override
     public Void call() {
       try {
@@ -551,26 +699,6 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
           for (String field : valueFields.split(",")) {
             String[] subfields = field.split("\\.");
             fieldsSplitMap = getFieldSplit(Arrays.asList(subfields), fieldsSplitMap);
-          }
-        }
-
-        Map<String, Filter> fieldsFilterSplitMap = new HashMap<>();
-        if (valueFilter != null) {
-          for (String field : valueFilter.split(",")) {
-            String[] fieldValue = field.split(":");
-            if (fieldValue.length != 3) {
-              err().println("Error: Invalid format for filter \"" + field
-                  + "\". Usage: <field>:<operator>:<value>. Ignoring filter passed");
-            } else {
-              Filter filter = new Filter(fieldValue[1], fieldValue[2]);
-              if (filter.getOperator() == null) {
-                err().println("Error: Invalid format for filter \"" + filter
-                    + "\". <operator> can be one of [EQUALS,MIN,MAX]. Ignoring filter passed");
-              } else {
-                String[] subfields = fieldValue[0].split("\\.");
-                getFilterSplit(Arrays.asList(subfields), fieldsFilterSplitMap, filter);
-              }
-            }
           }
         }
 
@@ -609,11 +737,6 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
           Object o = dbColumnFamilyDefinition.getValueCodec()
               .fromPersistedFormat(byteArrayKeyValue.getValue());
 
-          if (valueFilter != null &&
-              !checkFilteredObject(o, dbColumnFamilyDefinition.getValueType(), fieldsFilterSplitMap)) {
-            // the record doesn't pass the filter
-            continue;
-          }
           if (valueFields != null) {
             Map<String, Object> filteredValue = new HashMap<>();
             filteredValue.putAll(getFieldsFilteredObject(o, dbColumnFamilyDefinition.getValueType(), fieldsSplitMap));
@@ -630,91 +753,6 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         LOG.error("Exception parse Object", e);
       }
       return null;
-    }
-
-    boolean checkFilteredObject(Object obj, Class<?> clazz, Map<String, Filter> fieldsSplitMap)
-        throws IOException {
-      for (Map.Entry<String, Filter> field : fieldsSplitMap.entrySet()) {
-        try {
-          Field valueClassField = getRequiredFieldFromAllFields(clazz, field.getKey());
-          Object valueObject = valueClassField.get(obj);
-          Filter fieldValue = field.getValue();
-
-          if (valueObject == null) {
-            // there is no such field in the record. This filter will be ignored for the current record.
-            continue;
-          }
-          if (fieldValue == null) {
-            err().println("Malformed filter. Check input");
-            throw new IOException("Invalid filter passed");
-          } else if (fieldValue.getNextLevel() == null) {
-            // reached the end of fields hierarchy, check if they match the filter
-            // Currently, only equals operation is supported
-            if (Filter.FilterOperator.EQUALS.equals(fieldValue.getOperator()) &&
-                !String.valueOf(valueObject).equals(fieldValue.getValue())) {
-              return false;
-            } else if (!Filter.FilterOperator.EQUALS.equals(fieldValue.getOperator())) {
-              err().println("Only EQUALS operator is supported currently.");
-              throw new IOException("Invalid filter passed");
-            }
-          } else {
-            Map<String, Filter> subfields = fieldValue.getNextLevel();
-            if (Collection.class.isAssignableFrom(valueObject.getClass())) {
-              if (!checkFilteredObjectCollection((Collection) valueObject, subfields)) {
-                return false;
-              }
-            } else if (Map.class.isAssignableFrom(valueObject.getClass())) {
-              Map<?, ?> valueObjectMap = (Map<?, ?>) valueObject;
-              boolean flag = false;
-              for (Map.Entry<?, ?> ob : valueObjectMap.entrySet()) {
-                boolean subflag;
-                if (Collection.class.isAssignableFrom(ob.getValue().getClass())) {
-                  subflag = checkFilteredObjectCollection((Collection)ob.getValue(), subfields);
-                } else {
-                  subflag = checkFilteredObject(ob.getValue(), ob.getValue().getClass(), subfields);
-                }
-                if (subflag) {
-                  // atleast one item in the map/list of the record has matched the filter,
-                  // so record passes the filter.
-                  flag = true;
-                  break;
-                }
-              }
-              if (!flag) {
-                // none of the items in the map/list passed the filter => record doesn't pass the filter
-                return false;
-              }
-            } else {
-              if (!checkFilteredObject(valueObject, valueClassField.getType(), subfields)) {
-                return false;
-              }
-            }
-          }
-        } catch (NoSuchFieldException ex) {
-          err().println("ERROR: no such field: " + field);
-          exception = true;
-          return false;
-        } catch (IllegalAccessException e) {
-          err().println("ERROR: Cannot get field from object: " + field);
-          exception = true;
-          return false;
-        } catch (Exception ex) {
-          err().println("ERROR: field: " + field + ", ex: " + ex);
-          exception = true;
-          return false;
-        }
-      }
-      return true;
-    }
-
-    boolean checkFilteredObjectCollection(Collection<?> valueObject, Map<String, Filter> fields)
-        throws NoSuchFieldException, IllegalAccessException, IOException {
-      for (Object ob : valueObject) {
-        if (checkFilteredObject(ob, ob.getClass(), fields)) {
-          return true;
-        }
-      }
-      return false;
     }
 
     Map<String, Object> getFieldsFilteredObject(Object obj, Class<?> clazz, Map<String, Object> fieldsSplitMap) {
@@ -767,22 +805,6 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         subfieldObjectsList.add(subfieldValue);
       }
       return subfieldObjectsList;
-    }
-
-    Field getRequiredFieldFromAllFields(Class clazz, String fieldName) throws NoSuchFieldException {
-      List<Field> classFieldList = ValueSchema.getAllFields(clazz);
-      Field classField = null;
-      for (Field f : classFieldList) {
-        if (f.getName().equals(fieldName)) {
-          classField = f;
-          break;
-        }
-      }
-      if (classField == null) {
-        throw new NoSuchFieldException();
-      }
-      classField.setAccessible(true);
-      return classField;
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -300,7 +300,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         } else {
           Filter filterValue = new Filter(fieldValue[1], fieldValue[2]);
           if (filterValue.getOperator() == null) {
-            err().println("Error: Invalid format for filter \"" + filterValue
+            err().println("Error: Invalid operator for filter \"" + filterValue
                 + "\". <operator> can be one of [EQUALS,LESSER,GREATER]. Ignoring filter passed");
           } else {
             String[] subfields = fieldValue[0].split("\\.");
@@ -380,8 +380,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     }
   }
 
-  private boolean checkFilteredObject(Object obj, Class<?> clazz, Map<String, Filter> fieldsSplitMap)
-      throws IOException {
+  private boolean checkFilteredObject(Object obj, Class<?> clazz, Map<String, Filter> fieldsSplitMap) {
     for (Map.Entry<String, Filter> field : fieldsSplitMap.entrySet()) {
       try {
         Field valueClassField = getRequiredFieldFromAllFields(clazz, field.getKey());
@@ -463,7 +462,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         exception = true;
         return false;
       } catch (IllegalAccessException e) {
-        err().println("ERROR: Cannot get field from object: " + field);
+        err().println("ERROR: Cannot get field \"" + field + "\" from record.");
         exception = true;
         return false;
       } catch (Exception ex) {
@@ -495,6 +494,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       }
     }
     if (classField == null) {
+      err().println("Error: Invalid field \"" + fieldName + "\" passed for filter");
       throw new NoSuchFieldException();
     }
     classField.setAccessible(true);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -332,7 +332,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
           }
           Future<Void> future = threadPool.submit(
               new Task(dbColumnFamilyDef, batch, logWriter, sequenceId,
-                  withKey, schemaV3, fieldsFilter, filter));
+                  withKey, schemaV3, fieldsFilter));
           futures.add(future);
           batch = new ArrayList<>(batchSize);
           sequenceId++;
@@ -342,7 +342,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     }
     if (!batch.isEmpty()) {
       Future<Void> future = threadPool.submit(new Task(dbColumnFamilyDef,
-          batch, logWriter, sequenceId, withKey, schemaV3, fieldsFilter, filter));
+          batch, logWriter, sequenceId, withKey, schemaV3, fieldsFilter));
       futures.add(future);
     }
 
@@ -655,12 +655,11 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     private final boolean withKey;
     private final boolean schemaV3;
     private String valueFields;
-    private String valueFilter;
 
     @SuppressWarnings("checkstyle:parameternumber")
     Task(DBColumnFamilyDefinition dbColumnFamilyDefinition,
          ArrayList<ByteArrayKeyValue> batch, LogWriter logWriter,
-         long sequenceId, boolean withKey, boolean schemaV3, String valueFields, String filter) {
+         long sequenceId, boolean withKey, boolean schemaV3, String valueFields) {
       this.dbColumnFamilyDefinition = dbColumnFamilyDefinition;
       this.batch = batch;
       this.logWriter = logWriter;
@@ -668,7 +667,6 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       this.withKey = withKey;
       this.schemaV3 = schemaV3;
       this.valueFields = valueFields;
-      this.valueFilter = filter;
     }
 
     Map<String, Object> getFieldSplit(List<String> fields, Map<String, Object> fieldMap) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/Filter.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/utils/Filter.java
@@ -82,10 +82,10 @@ public class Filter {
   public FilterOperator getFilterOperator(String op) {
     if (op.equalsIgnoreCase("equals")) {
       return FilterOperator.EQUALS;
-    } else if (op.equalsIgnoreCase("max")) {
-      return FilterOperator.MAX;
-    } else if (op.equalsIgnoreCase("min")) {
-      return FilterOperator.MIN;
+    } else if (op.equalsIgnoreCase("GREATER")) {
+      return FilterOperator.GREATER;
+    } else if (op.equalsIgnoreCase("LESSER")) {
+      return FilterOperator.LESSER;
     } else {
       return null;
     }
@@ -101,7 +101,7 @@ public class Filter {
    */
   public enum FilterOperator {
     EQUALS,
-    MAX,
-    MIN;
+    LESSER,
+    GREATER;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

A --filter option was added recently which selects records that have a given value for a particular field will make debugging easier. (as a part of https://github.com/apache/ozone/pull/7167)
Adding support for lesser/greater than operations will be useful while debugging
For example, if a value has many fields like [name, location->[address, DN, IP], version, lastUpdateTime], 
- using the option "--filter={version:equals:1}" will display records that have the value 1 for version.
- using the option "–filter={lastUpdateTime:greater:1000}" will display the record with lastUpdateTime>1000
- using the option "–filter={lastUpdateTime:lesser:1000}" will display the record with lastUpdateTime<1000

A list of fields along with the value it should be compared to is given to the command, and only those records passing the condition it will be shown.

eg.) ozone debug ldb --db=/data/metadata/om.db scan --cf=volumeTable --filter="usedNamespace:greater:2,adminName:equals:impala" 

In this PR, apart from adding the support for these 2 operations, some code refactoring is also done.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11476

## How was this patch tested?

Added tests in TestLDBCli
Tested locally with a local DB:
```
$ ozone debug ldb --db=/Users/tejaskriya.madhan/ZDump/bigDB/omMBdb/om.db scan --cf=keyTable  -l=3  --filter=dataSize:greater:2 --fields="objectID,updateID,volumeName,bucketName,keyName,dataSize"

{ "/55406660-10tb/ozone-legacy-ec-1st-bucket-55406660/10T-1-terasort-input/part-m-00000": {
  "updateID" : 2363922,
  "bucketName" : "ozone-legacy-ec-1st-bucket-55406660",
  "volumeName" : "55406660-10tb",
  "keyName" : "10T-1-terasort-input/part-m-00000",
  "dataSize" : 108695652200,
  "objectID" : -9223372036253037824
}
, "/55406660-10tb/ozone-legacy-ec-1st-bucket-55406660/10T-1-terasort-input/part-m-00001": {
  "updateID" : 2363776,
  "bucketName" : "ozone-legacy-ec-1st-bucket-55406660",
  "volumeName" : "55406660-10tb",
  "keyName" : "10T-1-terasort-input/part-m-00001",
  "dataSize" : 108695652200,
  "objectID" : -9223372036253027072
}
, "/55406660-10tb/ozone-legacy-ec-1st-bucket-55406660/10T-1-terasort-input/part-m-00002": {
  "updateID" : 2363418,
  "bucketName" : "ozone-legacy-ec-1st-bucket-55406660",
  "volumeName" : "55406660-10tb",
  "keyName" : "10T-1-terasort-input/part-m-00002",
  "dataSize" : 108695652200,
  "objectID" : -9223372036253021440
}
 }


$ ozone debug ldb --db=/Users/tejaskriya.madhan/ZDump/bigDB/omMBdb/om.db scan --cf=keyTable  -l=3  --filter=dataSize:lesser:2 --fields="objectID,updateID,volumeName,bucketName,keyName,dataSize"

{ "/55406660-10tb/ozone-legacy-ec-1st-bucket-55406660/10T-1-terasort-input/": {
  "updateID" : 2350475,
  "bucketName" : "ozone-legacy-ec-1st-bucket-55406660",
  "volumeName" : "55406660-10tb",
  "keyName" : "10T-1-terasort-input/",
  "dataSize" : 0,
  "objectID" : -9223372036253054206
}
, "/55406660-10tb/ozone-legacy-ec-1st-bucket-55406660/10T-1-terasort-input/_SUCCESS": {
  "updateID" : 2364036,
  "bucketName" : "ozone-legacy-ec-1st-bucket-55406660",
  "volumeName" : "55406660-10tb",
  "keyName" : "10T-1-terasort-input/_SUCCESS",
  "dataSize" : 0,
  "objectID" : -9223372036249583104
}
, "/55406660-10tb/ozone-legacy-ec-1st-bucket-55406660/10T-1-terasort-output/": {
  "updateID" : 2365898,
  "bucketName" : "ozone-legacy-ec-1st-bucket-55406660",
  "volumeName" : "55406660-10tb",
  "keyName" : "10T-1-terasort-output/",
  "dataSize" : 0,
  "objectID" : -9223372036249105919
}
 }


$ ozone debug ldb --db=/Users/tejaskriya.madhan/ZDump/bigDB/omMBdb/om.db scan --cf=keyTable  -l=3  --filter=keyName:lesser:2 --fields="objectID,updateID,volumeName,bucketName,keyName,dataSize"

LESSER or GREATER operation can be performed only on numeric values.
ERROR: field: keyName=(LESSER,2,null), ex: java.io.IOException: Invalid filter passed
{  }
Exit code is non-zero. Check the error message above
```
