### PR TITLE
HDDS-11482. EC Checksum throws IllegalArgumentException because the buffer limit is negative

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECBlockChecksumComputer.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECBlockChecksumComputer.java
@@ -72,15 +72,13 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
   private void computeMd5Crc() {
     Preconditions.checkArgument(chunkInfoList.size() > 0);
 
-    final ContainerProtos.ChunkInfo firstChunkInfo = chunkInfoList.get(0);
-    long chunkSize = firstChunkInfo.getLen();
-    long bytesPerCrc = firstChunkInfo.getChecksumData().getBytesPerChecksum();
-    // Total parity checksum bytes per stripe to remove
-    int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
-
     final MessageDigest digester = MD5Hash.getDigester();
 
     for (ContainerProtos.ChunkInfo chunkInfo : chunkInfoList) {
+      long chunkSize = chunkInfo.getLen();
+      long bytesPerCrc = chunkInfo.getChecksumData().getBytesPerChecksum();
+      // Total parity checksum bytes per stripe to remove
+      int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
       ByteString stripeChecksum = chunkInfo.getStripeChecksum();
 
       Preconditions.checkNotNull(stripeChecksum);
@@ -121,66 +119,40 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
 
     // Bytes required to create a CRC
     long bytesPerCrc = firstChunkInfo.getChecksumData().getBytesPerChecksum();
-    long chunkSize = firstChunkInfo.getLen();
-
-    //When EC chunk size is not a multiple of ozone.client.bytes.per.checksum
-    // (default = 16KB) the last checksum in an EC chunk is only generated for
-    // offset.
-    long bytesPerCrcOffset = chunkSize % bytesPerCrc;
-
     long keySize = keyInfo.getDataSize();
-    // Total parity checksum bytes per stripe to remove
-    int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
-
-    // Number of checksum per chunk, Eg: 2MB EC chunk will
-    // have 2 checksum per chunk.
-    int numChecksumPerChunk = (int)
-        (Math.ceil((double) chunkSize / bytesPerCrc));
 
     CrcComposer blockCrcComposer =
         CrcComposer.newCrcComposer(dataChecksumType, bytesPerCrc);
 
     for (ContainerProtos.ChunkInfo chunkInfo : chunkInfoList) {
       ByteString stripeChecksum = chunkInfo.getStripeChecksum();
+      long chunkSize = chunkInfo.getLen();
+
+      // Total parity checksum bytes per stripe to remove
+      int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
 
       Preconditions.checkNotNull(stripeChecksum);
       final int checksumSize = stripeChecksum.size();
       Preconditions.checkArgument(checksumSize % 4 == 0,
           "Checksum Bytes size does not match");
-      CrcComposer chunkCrcComposer =
-          CrcComposer.newCrcComposer(dataChecksumType, bytesPerCrc);
 
       // Limit parity bytes as they do not contribute to fileChecksum
       final ByteBuffer byteWrap = stripeChecksum.asReadOnlyByteBuffer();
       byteWrap.limit(checksumSize - parityBytes);
 
-      long chunkOffsetIndex = 1;
       while (byteWrap.hasRemaining()) {
-
-        /*
-        When chunk size is not a multiple of bytes.per.crc we get an offset.
-        For eg, RS-3-2-1524k is not a multiple of 1MB. So two checksums are
-        generated 1st checksum for 1024k bytes and 2nd checksum for 500k bytes.
-        When we reach the 2nd Checksum we need to modify the bytesPerCrc as in
-        this case 500k is the bytes for which the checksum is generated.
-        */
-        long currentChunkOffset = Long.MAX_VALUE;
-        if ((chunkOffsetIndex % numChecksumPerChunk == 0)
-            && (bytesPerCrcOffset > 0)) {
-          currentChunkOffset = bytesPerCrcOffset;
+        // Here Math.min in mainly required for last stripe's last chunk. The last chunk of the last stripe can be
+        // less than the chunkSize, chunkSize is only calculated from each stripe's first chunk. This would be fine
+        // for rest of the stripe because all the chunks are of the same size. But for the last stripe we don't know
+        // the exact size of the last chunk. So we calculate it with the of keySize. If the key size is smaller
+        // than the chunk size, then we know it is the last stripe' last chunk.
+        long remainingChunkSize = Math.min(keySize, chunkSize);
+        while (byteWrap.hasRemaining() && remainingChunkSize > 0) {
+          final int checksumData = byteWrap.getInt();
+          blockCrcComposer.update(checksumData, Math.min(bytesPerCrc, remainingChunkSize));
+          remainingChunkSize -= bytesPerCrc;
         }
-
-        final int checksumDataCrc = byteWrap.getInt();
-        //To handle last chunk when it size is lower than 1524K in the case
-        // of rs-3-2-1524k.
-        long chunkSizePerChecksum = Math.min(Math.min(keySize, bytesPerCrc),
-            currentChunkOffset);
-        chunkCrcComposer.update(checksumDataCrc, chunkSizePerChecksum);
-
-        int chunkChecksumCrc = CrcUtil.readInt(chunkCrcComposer.digest(), 0);
-        blockCrcComposer.update(chunkChecksumCrc, chunkSizePerChecksum);
-        keySize -= Math.min(bytesPerCrc, currentChunkOffset);
-        ++chunkOffsetIndex;
+        keySize -= chunkSize;
       }
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -102,7 +102,7 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
     setBytesPerCRC(bytesPerChecksum);
 
     ByteBuffer blockChecksumByteBuffer =
-        getBlockChecksumFromChunkChecksums(chunkInfos);
+        getBlockChecksumFromChunkChecksums(chunkInfos, keyLocationInfo.getLength());
     String blockChecksumForDebug =
         populateBlockChecksumBuf(blockChecksumByteBuffer);
 
@@ -140,10 +140,11 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
   }
 
   private ByteBuffer getBlockChecksumFromChunkChecksums(
-      List<ContainerProtos.ChunkInfo> chunkInfos) throws IOException {
+      List<ContainerProtos.ChunkInfo> chunkInfos,
+      long blockLength) throws IOException {
 
     AbstractBlockChecksumComputer blockChecksumComputer =
-        new ECBlockChecksumComputer(chunkInfos, getKeyInfo());
+        new ECBlockChecksumComputer(chunkInfos, getKeyInfo(), blockLength);
     blockChecksumComputer.compute(getCombineMode());
 
     return blockChecksumComputer.getOutByteBuffer();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileChecksum.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.fs.ozone;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileSystem;
@@ -53,7 +54,9 @@ import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.TestDataUtil.createBucket;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -68,11 +71,11 @@ public class TestOzoneFileChecksum {
       true, false
   };
 
-  private static final int[] DATA_SIZES_1 = DoubleStream.of(0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9)
+  private static final int[] DATA_SIZES_1 = DoubleStream.of(0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10)
       .mapToInt(mb -> (int) (1024 * 1024 * mb) + 510000)
       .toArray();
 
-  private static final int[] DATA_SIZES_2 = DoubleStream.of(0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9)
+  private static final int[] DATA_SIZES_2 = DoubleStream.of(0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10)
       .mapToInt(mb -> (int) (1024 * 1024 * mb) + 820000)
       .toArray();
 
@@ -90,6 +93,8 @@ public class TestOzoneFileChecksum {
   void setup() throws IOException,
       InterruptedException, TimeoutException {
     conf = new OzoneConfiguration();
+    conf.setStorageSize(OZONE_SCM_CHUNK_SIZE_KEY, 1024 * 1024, StorageUnit.BYTES);
+    conf.setStorageSize(OZONE_SCM_BLOCK_SIZE, 2 * 1024 * 1024, StorageUnit.BYTES);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(5)
         .build();


### PR DESCRIPTION
## What changes were proposed in this pull request?
The parity checksum bytes calculation for the EC stripe checksum should be based on each stripe's first chunk's length. But right now it is calculated only on the first stripe's chunk length which results in incorrect results and, in many cases causes the byte buffer limit to become negative. Further, the checksum calculation has been simplified in this patch.

The checksum calculation for the last stripe is a little tricky, We have two cases for it.

1. If the last stripe has only one chunk at replica index 1, we can get the chunk length to calculate checksum. 
2. If the last stripe has more than one chunk, Then the last chunk will be partial. 

For EC, We store the stripe checksum for the entire stripe in replica index 1 and the parity blocks. We use this stripe checksum to calculate the checksum during reading. The chunks we get during checksum calculation will always be from replica index 1 or parity blocks. And the chunk length will always be the stripe's first chunk's length. 

Hence, we don't get the length of the last chunk which may be partial in most of the cases. We calculate the last chunk's size from the block size.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11482

## How was this patch tested?
Updated the existing test. 
Test fails without the fix:https://github.com/aswinshakil/ozone/actions/runs/11002573679/job/30550687378
Test passed with the fix: https://github.com/aswinshakil/ozone/actions/runs/11002650413/job/30551032116