### PR TITLE
HDDS-11483. Make s3g object get and put operation buffer configurable

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3469,9 +3469,9 @@
   <property>
     <name>ozone.s3g.client.buffer.size</name>
     <tag>OZONE, S3GATEWAY</tag>
-    <value>4KB</value>
+    <value>1MB</value>
     <description>
-      The size of the buffer which is for read block. (4KB by default).
+      The size of the buffer which is for read block. (1MB by default).
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3469,9 +3469,9 @@
   <property>
     <name>ozone.s3g.client.buffer.size</name>
     <tag>OZONE, S3GATEWAY</tag>
-    <value>1MB</value>
+    <value>4MB</value>
     <description>
-      The size of the buffer which is for read block. (1MB by default).
+      The size of the buffer which is for read block. (4MB by default).
     </description>
   </property>
   <property>

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
@@ -56,7 +56,7 @@ public final class S3GatewayConfigKeys {
   public static final String OZONE_S3G_CLIENT_BUFFER_SIZE_KEY =
       "ozone.s3g.client.buffer.size";
   public static final String OZONE_S3G_CLIENT_BUFFER_SIZE_DEFAULT =
-      "1MB";
+      "4MB";
 
   // S3G kerberos, principal config
   public static final String OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY =

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
@@ -56,7 +56,7 @@ public final class S3GatewayConfigKeys {
   public static final String OZONE_S3G_CLIENT_BUFFER_SIZE_KEY =
       "ozone.s3g.client.buffer.size";
   public static final String OZONE_S3G_CLIENT_BUFFER_SIZE_DEFAULT =
-      "4KB";
+      "1MB";
 
   // S3G kerberos, principal config
   public static final String OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY =

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -320,7 +320,7 @@ public class ObjectEndpoint extends EndpointBase {
           long metadataLatencyNs =
               getMetrics().updatePutKeyMetadataStats(startNanos);
           perf.appendMetaLatencyNanos(metadataLatencyNs);
-          int bufferLength = length < bufferSize? (int) length: bufferSize;
+          int bufferLength = length < bufferSize ? (int) length : bufferSize;
           putLength = IOUtils.copy(digestInputStream, output, bufferLength);
           eTag = DatatypeConverter.printHexBinary(
                   digestInputStream.getMessageDigest().digest())
@@ -444,7 +444,7 @@ public class ObjectEndpoint extends EndpointBase {
       if (rangeHeaderVal == null || rangeHeader.isReadFull()) {
         StreamingOutput output = dest -> {
           try (OzoneInputStream key = keyDetails.getContent()) {
-            int bufferLength = keyDetails.getDataSize() < bufferSize? (int) keyDetails.getDataSize(): bufferSize;
+            int bufferLength = keyDetails.getDataSize() < bufferSize ? (int) keyDetails.getDataSize() : bufferSize;
             long readLength = IOUtils.copy(key, dest, bufferLength);
             getMetrics().incGetKeySuccessLength(readLength);
             perf.appendSizeBytes(readLength);
@@ -468,7 +468,7 @@ public class ObjectEndpoint extends EndpointBase {
         StreamingOutput output = dest -> {
           try (OzoneInputStream ozoneInputStream = keyDetails.getContent()) {
             ozoneInputStream.seek(startOffset);
-            int bufferLength = copyLength < bufferSize? (int) copyLength: bufferSize;
+            int bufferLength = copyLength < bufferSize ? (int) copyLength : bufferSize;
             long readLength = IOUtils.copyLarge(ozoneInputStream, dest, 0,
                 copyLength, new byte[bufferLength]);
             getMetrics().incGetKeySuccessLength(readLength);
@@ -999,7 +999,7 @@ public class ObjectEndpoint extends EndpointBase {
                     partNumber, uploadID)) {
               metadataLatencyNs =
                   getMetrics().updateCopyKeyMetadataStats(startNanos);
-              int bufferLength = length < bufferSize? (int) length: bufferSize;
+              int bufferLength = length < bufferSize ? (int) length : bufferSize;
               copyLength = IOUtils.copyLarge(
                   sourceObject, ozoneOutputStream, 0, length, new byte[bufferLength]);
               ozoneOutputStream.getMetadata()
@@ -1012,7 +1012,7 @@ public class ObjectEndpoint extends EndpointBase {
                     partNumber, uploadID)) {
               metadataLatencyNs =
                   getMetrics().updateCopyKeyMetadataStats(startNanos);
-              int bufferLength = length < bufferSize? (int) length: bufferSize;
+              int bufferLength = length < bufferSize ? (int) length : bufferSize;
               copyLength = IOUtils.copy(sourceObject, ozoneOutputStream, bufferLength);
               ozoneOutputStream.getMetadata()
                   .putAll(sourceKeyDetails.getMetadata());
@@ -1029,7 +1029,7 @@ public class ObjectEndpoint extends EndpointBase {
                 partNumber, uploadID)) {
           metadataLatencyNs =
               getMetrics().updatePutKeyMetadataStats(startNanos);
-          int bufferLength = length < bufferSize? (int) length: bufferSize;
+          int bufferLength = length < bufferSize ? (int) length : bufferSize;
           putLength = IOUtils.copy(digestInputStream, ozoneOutputStream, bufferLength);
           byte[] digest = digestInputStream.getMessageDigest().digest();
           ozoneOutputStream.getMetadata()
@@ -1184,7 +1184,7 @@ public class ObjectEndpoint extends EndpointBase {
         long metadataLatencyNs =
             getMetrics().updateCopyKeyMetadataStats(startNanos);
         perf.appendMetaLatencyNanos(metadataLatencyNs);
-        int bufferLength = srcKeyLen < bufferSize? (int) srcKeyLen: bufferSize;
+        int bufferLength = srcKeyLen < bufferSize ? (int) srcKeyLen : bufferSize;
         copyLength = IOUtils.copy(src, dest, bufferLength);
         String eTag = DatatypeConverter.printHexBinary(src.getMessageDigest().digest()).toLowerCase();
         dest.getMetadata().put(ETAG, eTag);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -51,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
@@ -234,7 +235,7 @@ public class TestPartUpload {
     try (MockedStatic<IOUtils> mocked = mockStatic(IOUtils.class)) {
       // Add the mocked methods only during the copy request
       when(objectEndpoint.getMessageDigestInstance()).thenReturn(messageDigest);
-      mocked.when(() -> IOUtils.copyLarge(any(InputStream.class), any(OutputStream.class)))
+      mocked.when(() -> IOUtils.copy(any(InputStream.class), any(OutputStream.class), anyInt()))
           .thenThrow(IOException.class);
 
       String content = "Multipart Upload";


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. make s3g object read/write buffer configurable
2. change ozone.s3g.client.buffer.size default value from 4KB to 1MB

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11483


## How was this patch tested?
wrap get benchmark test
1. before the patch, ozone.client.bytes.per.checksum = 16KB, s3 get buffer size 8KB

```
[root@vc0616 systest]# warp get --warp-client=vc0616.halxg.cloudera.com --host=localhost:9879 --tls --autoterm --insecure --access-key=$AWS_ACCESS_KEY_ID --secret-key=$AWS_SECRET_ACCESS_KEY --obj.size=20mb --concurrent=20 --bucket=bucket-20-24 --objects 10000 --duration=5m
warp: Running benchmark on all clients...                                                                                                                                                                                                                  
warp: Benchmark data written to "warp-remote-2024-09-20[053918]-cTQe.csv.zst"                                                                                                                                                                              

----------------------------------------
Operation: PUT. Concurrency: 20
* Average: 358.85 MiB/s, 18.81 obj/s

Throughput, split into 104 x 5s:
 * Fastest: 452.0MiB/s, 23.70 obj/s
 * 50% Median: 360.3MiB/s, 18.89 obj/s
 * Slowest: 267.6MiB/s, 14.03 obj/s

----------------------------------------
Operation: GET. Concurrency: 20
* Average: 224.64 MiB/s, 11.78 obj/s

Throughput, split into 294 x 1s:
 * Fastest: 262.4MiB/s, 13.76 obj/s
 * 50% Median: 230.3MiB/s, 12.08 obj/s
 * Slowest: 49.0MiB/s, 2.57 obj/s
warp: Cleanup done. 
```

2. with the patch,  ozone.client.bytes.per.checksum = 16KB, s3 get buffer size 1MB

```
[root@vc0616 systest]# warp get --warp-client=vc0616.halxg.cloudera.com --host=localhost:9879 --tls --autoterm --insecure --access-key=$AWS_ACCESS_KEY_ID --secret-key=$AWS_SECRET_ACCESS_KEY --obj.size=20mb --concurrent=20 --bucket=bucket-24-10-56 --objects 10000 --duration=5m
warp: Running benchmark on all clients...                                                                                                                                                                                                                    

warp: Benchmark data written to "warp-remote-2024-09-23[201117]-qHUD.csv.zst"                                                                                                                                                                                

----------------------------------------
Operation: PUT. Concurrency: 20
* Average: 349.16 MiB/s, 18.31 obj/s

Throughput, split into 107 x 5s:
 * Fastest: 441.5MiB/s, 23.15 obj/s
 * 50% Median: 351.3MiB/s, 18.42 obj/s
 * Slowest: 259.9MiB/s, 13.63 obj/s

----------------------------------------
Operation: GET. Concurrency: 20
* Average: 1002.26 MiB/s, 52.55 obj/s

Throughput, split into 297 x 1s:
 * Fastest: 1064.7MiB/s, 55.82 obj/s
 * 50% Median: 1041.5MiB/s, 54.60 obj/s
 * Slowest: 59.2MiB/s, 3.10 obj/s
warp: Cleanup done.  
```

```
3.  ozone.client.bytes.per.checksum = 1MB, s3 get buffer size 8KB
[root@vc0616 systest]# warp get --warp-client=vc0616.halxg.cloudera.com --host=localhost:9879 --tls --autoterm --insecure --access-key=$AWS_ACCESS_KEY_ID --secret-key=$AWS_SECRET_ACCESS_KEY --obj.size=20mb --concurrent=20 --bucket=bucket-19-23 --objects 10000 --duration=5m
warp: Client 10.17.212.26:7761: Requested stage prepare start...                                                                                                                                                                                           
warp: Benchmark data written to "warp-remote-2024-09-20[044056]-999v.csv.zst"                                                                                                                                                                              

----------------------------------------
Operation: PUT. Concurrency: 20
* Average: 371.36 MiB/s, 19.47 obj/s

Throughput, split into 100 x 5s:
 * Fastest: 433.5MiB/s, 22.73 obj/s
 * 50% Median: 378.1MiB/s, 19.82 obj/s
 * Slowest: 255.2MiB/s, 13.38 obj/s

----------------------------------------
Operation: GET. Concurrency: 20
* Average: 980.89 MiB/s, 51.43 obj/s

Throughput, split into 298 x 1s:
 * Fastest: 1093.4MiB/s, 57.33 obj/s
 * 50% Median: 1040.7MiB/s, 54.56 obj/s
 * Slowest: 31.8MiB/s, 1.67 obj/s
warp: Cleanup done.    
```   

heap space consideration
 - according to this [link](https://support.sonatype.com/hc/en-us/articles/360000744687-Understanding-Eclipse-Jetty-9-4-Thread-Allocation), the max threads of jetty is 200.  So there is max 200 get/put requests handled concurrently, each request by default 1MB, totally 200MB, which I think is acceptable. 