### PR TITLE
HDDS-11494. Improve the duration option of freon

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -290,7 +290,11 @@ public class BaseFreonGenerator {
       //replace environment variables to support multi-node execution
       prefix = resolvePrefix(prefix);
     }
-    if (duration != null && allowDuration()) {
+    if (!allowDuration()) {
+      LOG.warn("--duration is ignored");
+      duration = null;
+    }
+    if (duration != null) {
       durationInSecond = TimeDurationUtil.getTimeDurationHelper(
           "--runtime", duration, TimeUnit.SECONDS);
       if (durationInSecond <= 0) {
@@ -327,7 +331,7 @@ public class BaseFreonGenerator {
     executor = Executors.newFixedThreadPool(threadNo);
     long maxValue;
     LongSupplier supplier;
-    if (duration != null && allowDuration()) {
+    if (duration != null) {
       maxValue = durationInSecond;
       supplier = () -> Duration.between(
           Instant.ofEpochMilli(startTime), Instant.now()).getSeconds();
@@ -561,10 +565,6 @@ public class BaseFreonGenerator {
    */
   public boolean allowDuration() {
     return true;
-  }
-
-  public String getDuration() {
-    return duration;
   }
 
   public MetricRegistry getMetrics() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -189,12 +189,12 @@ public class BaseFreonGenerator {
           completed.set(true);
           break;
         }
-      } else {
-        //in case of an other failed test, we shouldn't execute more tasks.
-        if (counter >= testNo || (!failAtEnd && failureCounter.get() > 0)) {
-          completed.set(true);
-          break;
-        }
+      }
+
+      //in case of an other failed test, we shouldn't execute more tasks.
+      if (counter >= testNo || (!failAtEnd && failureCounter.get() > 0)) {
+        completed.set(true);
+        break;
       }
 
       tryNextTask(provider, counter % testNo);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -189,12 +189,12 @@ public class BaseFreonGenerator {
           completed.set(true);
           break;
         }
-      }
-
-      //in case of an other failed test, we shouldn't execute more tasks.
-      if (counter >= testNo || (!failAtEnd && failureCounter.get() > 0)) {
-        completed.set(true);
-        break;
+      } else {
+        //in case of an other failed test, we shouldn't execute more tasks.
+        if (counter >= testNo || (!failAtEnd && failureCounter.get() > 0)) {
+          completed.set(true);
+          break;
+        }
       }
 
       tryNextTask(provider, counter % testNo);
@@ -290,7 +290,7 @@ public class BaseFreonGenerator {
       //replace environment variables to support multi-node execution
       prefix = resolvePrefix(prefix);
     }
-    if (duration != null) {
+    if (duration != null && allowDuration()) {
       durationInSecond = TimeDurationUtil.getTimeDurationHelper(
           "--runtime", duration, TimeUnit.SECONDS);
       if (durationInSecond <= 0) {
@@ -327,7 +327,7 @@ public class BaseFreonGenerator {
     executor = Executors.newFixedThreadPool(threadNo);
     long maxValue;
     LongSupplier supplier;
-    if (duration != null) {
+    if (duration != null && allowDuration()) {
       maxValue = durationInSecond;
       supplier = () -> Duration.between(
           Instant.ofEpochMilli(startTime), Instant.now()).getSeconds();
@@ -552,6 +552,19 @@ public class BaseFreonGenerator {
 
   public String getPrefix() {
     return prefix;
+  }
+
+  /**
+   * Whether to enable Duration.
+   * If enabled, the command will load the --duration option.
+   * If not enabled, the command will not load the --duration option.
+   */
+  public boolean allowDuration() {
+    return true;
+  }
+
+  public String getDuration() {
+    return duration;
   }
 
   public MetricRegistry getMetrics() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -290,7 +290,7 @@ public class BaseFreonGenerator {
       //replace environment variables to support multi-node execution
       prefix = resolvePrefix(prefix);
     }
-    if (!allowDuration()) {
+    if (duration != null && !allowDuration()) {
       LOG.warn("--duration is ignored");
       duration = null;
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketGenerator.java
@@ -26,8 +26,6 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 
 import com.codahale.metrics.Timer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -42,8 +40,6 @@ import picocli.CommandLine.Option;
     showDefaultValues = true)
 public class OmBucketGenerator extends BaseFreonGenerator
     implements Callable<Void> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(OmBucketGenerator.class);
 
   @Option(names = {"-v", "--volume"},
       description = "Name of the volume which contains the test data. Will be"
@@ -68,9 +64,6 @@ public class OmBucketGenerator extends BaseFreonGenerator
 
   @Override
   public Void call() throws Exception {
-    if (getDuration() != null) {
-      LOG.warn("When running ombg, setting --duration has no effect.");
-    }
 
     init();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketGenerator.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 
 import com.codahale.metrics.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -40,6 +42,8 @@ import picocli.CommandLine.Option;
     showDefaultValues = true)
 public class OmBucketGenerator extends BaseFreonGenerator
     implements Callable<Void> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OmBucketGenerator.class);
 
   @Option(names = {"-v", "--volume"},
       description = "Name of the volume which contains the test data. Will be"
@@ -58,7 +62,15 @@ public class OmBucketGenerator extends BaseFreonGenerator
   private Timer bucketCreationTimer;
 
   @Override
+  public boolean allowDuration() {
+    return false;
+  }
+
+  @Override
   public Void call() throws Exception {
+    if (getDuration() != null) {
+      LOG.warn("When running ombg, setting --duration has no effect.");
+    }
 
     init();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
When running freon, some errors will occur if -duration and -n are set at the same time. The purpose of this PR is to try to fix it.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11494

## How was this patch tested?
ci: https://github.com/jianghuazhu/ozone/actions/runs/11085251713
There should be no errors when testing freon.
`
./bin/ozone freon ombg -v test3 -n 5 --duration 1m
`
Result:
```
SLF4J(W): Class path contains multiple SLF4J providers.
SLF4J(W): Found provider [org.slf4j.reload4j.Reload4jServiceProvider@5c0369c4]
SLF4J(W): Found provider [org.slf4j.simple.SimpleServiceProvider@2be94b0f]
SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J(I): Actual provider is of type [org.slf4j.reload4j.Reload4jServiceProvider@5c0369c4]
2024-09-28 23:54:35,812 [main] INFO impl.MetricsConfig: Loaded properties from hadoop-metrics2.properties
2024-09-28 23:54:35,886 [main] INFO impl.MetricsSystemImpl: Scheduled Metric snapshot period at 10 second(s).
2024-09-28 23:54:35,886 [main] INFO impl.MetricsSystemImpl: ozone-freon metrics system started
2024-09-28 23:54:35,954 [main] INFO freon.BaseFreonGenerator: Executing test with prefix zpwgnyqlzm and number-of-tests 5

 3.33% |████                                                                                                 |  2/60 Time: 0:00:02|  
9/28/24 11:54:38 PM ============================================================

-- Timers ----------------------------------------------------------------------
bucket-create
             count = 5
         mean rate = 7.15 calls/second
     1-minute rate = 0.00 calls/second
     5-minute rate = 0.00 calls/second
    15-minute rate = 0.00 calls/second
               min = 11.53 milliseconds
               max = 14.47 milliseconds
              mean = 13.76 milliseconds
            stddev = 1.12 milliseconds
            median = 14.29 milliseconds
              75% <= 14.31 milliseconds
              95% <= 14.47 milliseconds
              98% <= 14.47 milliseconds
              99% <= 14.47 milliseconds
            99.9% <= 14.47 milliseconds


Total execution time (sec): 2
Failures: 0
Successful executions: 5
```
