### PR TITLE
HDDS-11499. Remove Redundant Code from ECReconstructionCoordinator.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.io.ElasticByteBufferPool;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.io.BlockInputStreamFactory;
 import org.apache.hadoop.ozone.client.io.BlockInputStreamFactoryImpl;
 import org.apache.hadoop.ozone.client.io.ECBlockInputStreamProxy;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -370,7 +370,7 @@ public class ECReconstructionCoordinator implements Closeable {
           .append(" block length: ")
           .append(data.getSize())
           .append(" block group length: ")
-          .append(getBlockDataLength(data))
+          .append(data.getBlockGroupLength())
           .append(" chunk list: \n");
       int cnt = 0;
       for (ContainerProtos.ChunkInfo chunkInfo : data.getChunks()) {
@@ -572,22 +572,12 @@ public class ECReconstructionCoordinator implements Closeable {
         continue;
       }
 
-      long putBlockLen = getBlockDataLength(blockGroup[i]);
+      long putBlockLen = blockGroup[i].getBlockGroupLength();
       // Use safe length is the minimum of the lengths recorded across the
       // stripe
       blockGroupLen = Math.min(putBlockLen, blockGroupLen);
     }
     return blockGroupLen == Long.MAX_VALUE ? 0 : blockGroupLen;
-  }
-
-  private long getBlockDataLength(BlockData blockData) {
-    String lenStr = blockData.getMetadata()
-        .get(OzoneConsts.BLOCK_GROUP_LEN_KEY_IN_PUT_BLOCK);
-    // If we don't have the length, then it indicates a problem with the stripe.
-    // All replica should carry the length, so if it is not there, we return 0,
-    // which will cause us to set the length of the block to zero and not
-    // attempt to reconstruct it.
-    return (lenStr == null) ? 0 : Long.parseLong(lenStr);
   }
 
   public ECReconstructionMetrics getECReconstructionMetrics() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HDDS-10985(#7009), we worked together to improve the issue where EC blocks could not be recovered due to checksum problems. We have deployed it internally, and everything seems to be functioning normally so far.

I found a small improvement that can be optimized, as there is some redundancy in the code.

In HDDS-10985, we extracted `getBlockDataLength` into `BlockData`, allowing us to directly call the internal method in `ECReconstructionCoordinator`.

## What is the link to the Apache JIRA

JIRA: https://issues.apache.org/jira/browse/HDDS-10985

## How was this patch tested?

No Need Unit Test.
