### PR TITLE
HDDS-11498. Improve SCM deletion efficiency.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -354,10 +354,11 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       DeletedContainerBlocksSummary summary =
           DeletedContainerBlocksSummary.getFrom(containerBlocks);
       LOG.info("Summary of deleting container blocks, numOfTransactions={}, "
-              + "numOfContainers={}, numOfBlocks={}",
+              + "numOfContainers={}, numOfBlocks={}, commandId={}.",
           summary.getNumOfTxs(),
           summary.getNumOfContainers(),
-          summary.getNumOfBlocks());
+          summary.getNumOfBlocks(),
+          cmd.getCmd().getId());
       if (LOG.isDebugEnabled()) {
         LOG.debug("Start to delete container blocks, TXIDs={}",
             summary.getTxIDSummary());
@@ -384,7 +385,8 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
           LOG.debug("Sending following block deletion ACK to SCM");
           for (DeleteBlockTransactionResult result : blockDeletionACK
               .getResultsList()) {
-            LOG.debug("{} : {}", result.getTxID(), result.getSuccess());
+            LOG.debug("TxId = {} : ContainerId = {} : {}",
+                result.getTxID(), result.getContainerID(), result.getSuccess());
           }
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
@@ -47,7 +47,8 @@ class DatanodeDeletedBlockTransactions {
     blocksDeleted += tx.getLocalIDCount();
     if (SCMBlockDeletingService.LOG.isDebugEnabled()) {
       SCMBlockDeletingService.LOG
-          .debug("Transaction added: {} <- TX({})", dnID, tx.getTxID());
+          .debug("Transaction added: {} <- TX({}), DN {} <- blocksDeleted Add {}.",
+          dnID, tx.getTxID(), dnID, tx.getLocalIDCount());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -291,7 +291,6 @@ public class DeletedBlockLogImpl
       if (!transactionStatusManager.isDuplication(
           details, updatedTxn.getTxID(), commandStatus)) {
         transactions.addTransactionToDN(details.getUuid(), updatedTxn);
-        metrics.setNumBlockDeletionTransactionDataNodes(dnList.size());
         metrics.incrProcessedTransaction();
       }
     }
@@ -322,7 +321,6 @@ public class DeletedBlockLogImpl
         DatanodeDetails dnDetail = replica.getDatanodeDetails();
         LOG.debug("Skip Container = {}, because DN = {} is not in dnList.",
             containerId, dnDetail.getUuid());
-        metrics.incrSkippedTransaction();
         return true;
       }
     }
@@ -374,10 +372,12 @@ public class DeletedBlockLogImpl
                   .getContainerReplicas(
                       ContainerID.valueOf(txn.getContainerID()));
               if (checkInadequateReplica(replicas, txn, dnList)) {
+                metrics.incrSkippedTransaction();
                 continue;
               }
               getTransaction(
                   txn, transactions, dnList, replicas, commandStatus);
+              metrics.setNumBlockDeletionTransactionDataNodes(dnList.size());
             }
           } catch (ContainerNotFoundException ex) {
             LOG.warn("Container: {} was not found for the transaction: {}.", id, txn);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -290,7 +290,8 @@ public class DeletedBlockLogImpl
     // We have made an improvement here, and we expect that all replicas
     // of the Container being sent will be included in the dnList.
     // This change benefits ACK confirmation and improves deletion speed.
-    // The principle behind it is that DN can receive the command to delete a certain Container at the same time and provide
+    // The principle behind it is that
+    // DN can receive the command to delete a certain Container at the same time and provide
     // feedback to SCM at roughly the same time.
     // This avoids the issue of deletion blocking,
     // where some replicas of a Container are deleted while others do not receive the delete command.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -311,7 +311,6 @@ public class DeletedBlockLogImpl
       if (!transactionStatusManager.isDuplication(
           details, updatedTxn.getTxID(), commandStatus)) {
         transactions.addTransactionToDN(details.getUuid(), updatedTxn);
-        metrics.incrProcessedTransaction();
       }
     }
   }
@@ -374,6 +373,7 @@ public class DeletedBlockLogImpl
                 continue;
               }
               metrics.setNumBlockDeletionTransactionDataNodes(dnList.size());
+              metrics.incrProcessedTransaction();
               getTransaction(
                   txn, transactions, dnList, replicas, commandStatus);
             }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -299,20 +299,19 @@ public class DeletedBlockLogImpl
       DatanodeDetails datanodeDetails = replica.getDatanodeDetails();
       if (!dnList.contains(datanodeDetails)) {
         DatanodeDetails dnDetail = replica.getDatanodeDetails();
-        LOG.debug("Skip Container = {}, because DN= {} is not in dnList.",
+        LOG.debug("Skip Container = {}, because DN = {} is not in dnList.",
             containerId, dnDetail.getUuid());
+        metrics.incrSkippedTransaction();
         return;
       }
     }
 
     for (ContainerReplica replica : replicas) {
       DatanodeDetails details = replica.getDatanodeDetails();
-      if (!dnList.contains(details)) {
-        continue;
-      }
       if (!transactionStatusManager.isDuplication(
           details, updatedTxn.getTxID(), commandStatus)) {
         transactions.addTransactionToDN(details.getUuid(), updatedTxn);
+        metrics.incrProcessedTransaction();
       }
     }
   }
@@ -374,6 +373,7 @@ public class DeletedBlockLogImpl
               if (checkInadequateReplica(replicas, txn)) {
                 continue;
               }
+              metrics.setNumBlockDeletionTransactionDataNodes(dnList.size());
               getTransaction(
                   txn, transactions, dnList, replicas, commandStatus);
             }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto.DeleteBlockTransactionResult;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.command.CommandStatusReportHandler.DeleteBlockStatus;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -203,9 +203,10 @@ public class SCMBlockDeletingService extends BackgroundService
             }
           }
           LOG.info("Totally added {} blocks to be deleted for"
-                  + " {} datanodes, task elapsed time: {}ms",
+                  + " {} datanodes / {} totalnodes, task elapsed time: {}ms",
               transactions.getBlocksDeleted(),
               transactions.getDatanodeTransactionMap().size(),
+              included.size(),
               Time.monotonicNow() - startTime);
           deletedBlockLog.incrementCount(new ArrayList<>(processedTxIDs));
         } catch (NotLeaderException nle) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
 /**
  * Metrics related to Block Deleting Service running in SCM.
@@ -75,6 +76,15 @@ public final class ScmBlockDeletingServiceMetrics {
 
   @Metric(about = "The number of created txs which are added into DB.")
   private MutableCounterLong numBlockDeletionTransactionCreated;
+
+  @Metric(about = "The number of skipped transactions")
+  private MutableCounterLong numSkippedTransactions;
+
+  @Metric(about = "The number of processed transactions")
+  private MutableCounterLong numProcessedTransactions;
+
+  @Metric(about = "The number of dataNodes of delete transactions.")
+  private MutableGaugeLong numBlockDeletionTransactionDataNodes;
 
   private ScmBlockDeletingServiceMetrics() {
   }
@@ -130,6 +140,18 @@ public final class ScmBlockDeletingServiceMetrics {
     this.numBlockDeletionTransactionCreated.incr(count);
   }
 
+  public void incrSkippedTransaction() {
+    this.numSkippedTransactions.incr();
+  }
+
+  public void incrProcessedTransaction() {
+    this.numProcessedTransactions.incr();
+  }
+
+  public void setNumBlockDeletionTransactionDataNodes(long dataNodes) {
+    this.numBlockDeletionTransactionDataNodes.set(dataNodes);
+  }
+
   public long getNumBlockDeletionCommandSent() {
     return numBlockDeletionCommandSent.value();
   }
@@ -160,6 +182,18 @@ public final class ScmBlockDeletingServiceMetrics {
 
   public long getNumBlockDeletionTransactionCreated() {
     return numBlockDeletionTransactionCreated.value();
+  }
+
+  public long getNumSkippedTransactions() {
+    return numSkippedTransactions.value();
+  }
+
+  public long getNumProcessedTransactions() {
+    return numProcessedTransactions.value();
+  }
+
+  public long getNumBlockDeletionTransactionDataNodes() {
+    return numBlockDeletionTransactionDataNodes.value();
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

> Background

During our use of deletion, I noticed that it can be very slow, especially after we switched to the EC policy.

Our Ozone01 cluster currently has about 1K machines. Initially, we chose to use a `Ratis-3Replica` strategy, but for cost 
considerations, we gradually switched to the `EC-6-3` strategy in July.

The following chart shows the deletion speed for `Ratis-3Replica` .

![image](https://github.com/user-attachments/assets/6da0b823-254e-4ea3-b91d-5675640dea0d)

The following chart shows the deletion speed for `EC-6-3`.

![image](https://github.com/user-attachments/assets/0d0c688b-5a09-4aa9-9b02-2b9f0880f795)

By reviewing the code and analyzing the logs, we found that the following situation can cause deletion to be very slow. We will illustrate this with an example.

> Example

We want to delete data from an EC container with ContainerId = 1000. Since it is EC-6-3, there are 9 replicas (DN1, DN2, DN3, ... DN9).

Before deletion, we first select a batch of DNs; at this time, we may only select DN1 to DN6. We then send the deletion command to these 6 DNs, and the command executes normally, successfully deleting 6 blocks. However, if DN7 to DN9 are not selected, our deletion process will get stuck.

I came up with a possible solution to eliminate this stuck situation. We require that all replicas of the container to be deleted must be present in the selected DN list simultaneously. Otherwise, we will skip that container.

```
private void getTransaction(DeletedBlocksTransaction tx,
      DatanodeDeletedBlockTransactions transactions,
      Set<DatanodeDetails> dnList, Set<ContainerReplica> replicas,
      Map<UUID, Map<Long, CmdStatus>> commandStatus) {
    DeletedBlocksTransaction updatedTxn =
        DeletedBlocksTransaction.newBuilder(tx)
            .setCount(transactionStatusManager.getOrDefaultRetryCount(
              tx.getTxID(), 0))
            .build();
    
     // Requiring that replicas must be present in the DN list simultaneously ensures that the deletion commands for all 
     // replicas of the same container can be issued at once, avoiding situations where some replicas of the container are 
     // deleted while others are not.
    for (ContainerReplica replica : replicas) {
      DatanodeDetails datanodeDetails = replica.getDatanodeDetails();
      if (!dnList.contains(datanodeDetails)) {
        return;
      }
    }

    for (ContainerReplica replica : replicas) {
      DatanodeDetails details = replica.getDatanodeDetails();
      if (!dnList.contains(details)) {
        continue;
      }
      if (!transactionStatusManager.isDuplication(
          details, updatedTxn.getTxID(), commandStatus)) {
        transactions.addTransactionToDN(details.getUuid(), updatedTxn);
      }
    }
  }
```
> Internal deployment results.

We rolled out this improvement internally in the SCM around 7 PM on September 26th, and we observed a significant enhancement in deletion efficiency, with 50 million blocks being fully processed within 5 hours.

The core aspect of this improvement is to ensure that all DNs within the same container receive the delete command simultaneously. When they send their ACKs, they can reach the SCM at approximately the same time, which facilitates the confirmation of block deletions.

![image](https://github.com/user-attachments/assets/fa31de60-6491-44db-85f6-8df7d56120b2)


## What is the link to the Apache JIRA

JIRA: HDDS-11498. Improve SCM deletion efficiency.

## How was this patch tested?

Production environment validation.
