### PR TITLE
HDDS-11500. Fix RootCARotationManager cancelling wrong task in notifyStatusChanged.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/security/RootCARotationManager.java
@@ -188,7 +188,7 @@ public class RootCARotationManager extends StatefulService {
           waitAckTask.cancel(true);
         }
         if (waitAckTimeoutTask != null) {
-          waitAckTask.cancel(true);
+          waitAckTimeoutTask.cancel(true);
         }
         if (clearPostProcessingTask != null) {
           clearPostProcessingTask.cancel(true);


### PR DESCRIPTION
In root ca rotation the improper task is cancelled when the state of the leader SCM changes. This patch fixes a trivial oversight in that.

[HDDS-11500](https://issues.apache.org/jira/browse/HDDS-11500)

Green CI: https://github.com/Galsza/ozone/actions/runs/11093492542