### PR TITLE
HDDS-11501. Improve logging in XceiverServerRatis

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -83,6 +83,7 @@ import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -1162,8 +1163,8 @@ public class ContainerStateMachine extends BaseStateMachine {
   }
 
   @Override
-  public void notifyFollowerSlowness(RoleInfoProto roleInfoProto) {
-    ratisServer.handleNodeSlowness(gid, roleInfoProto);
+  public void notifyFollowerSlowness(RoleInfoProto roleInfoProto, RaftPeer follower) {
+    ratisServer.handleFollowerSlowness(gid, roleInfoProto, follower);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -104,6 +104,7 @@ import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.RaftServerRpc;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.TraditionalBinaryPrefix;
@@ -161,19 +162,18 @@ public final class XceiverServerRatis implements XceiverServerSpi {
   private int clientPort;
   private int dataStreamPort;
   private final RaftServer server;
+  private final String name;
   private final List<ThreadPoolExecutor> chunkExecutors;
   private final ContainerDispatcher dispatcher;
   private final ContainerController containerController;
   private final ClientId clientId = ClientId.randomId();
   private final StateContext context;
-  private final long nodeFailureTimeoutMs;
   private boolean isStarted = false;
   private final DatanodeDetails datanodeDetails;
   private final ConfigurationSource conf;
   // TODO: Remove the gids set when Ratis supports an api to query active
   // pipelines
   private final ConcurrentMap<RaftGroupId, ActivePipelineContext> activePipelines = new ConcurrentHashMap<>();
-  private final RaftPeerId raftPeerId;
   // Timeout used while calling submitRequest directly.
   private final long requestTimeout;
   private final boolean shouldDeleteRatisLogDirectory;
@@ -197,14 +197,14 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     this.context = context;
     this.dispatcher = dispatcher;
     this.containerController = containerController;
-    this.raftPeerId = RatisHelper.toRaftPeerId(dd);
     String threadNamePrefix = datanodeDetails.threadNamePrefix();
     chunkExecutors = createChunkExecutors(conf, threadNamePrefix);
-    nodeFailureTimeoutMs = ratisServerConfig.getFollowerSlownessTimeout();
     shouldDeleteRatisLogDirectory =
         ratisServerConfig.shouldDeleteRatisLogDirectory();
 
     RaftProperties serverProperties = newRaftProperties();
+    final RaftPeerId raftPeerId = RatisHelper.toRaftPeerId(dd);
+    this.name = getClass().getSimpleName() + "(" + raftPeerId + ")";
     this.server =
         RaftServer.newBuilder().setServerId(raftPeerId)
             .setProperties(serverProperties)
@@ -474,7 +474,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
     // NOTE : the default value for the retry count in ratis is -1,
     // which means retry indefinitely.
-    int syncTimeoutRetryDefault = (int) nodeFailureTimeoutMs /
+    final int syncTimeoutRetryDefault = (int) ratisServerConfig.getFollowerSlownessTimeout() /
         dataSyncTimeout.toIntExact(TimeUnit.MILLISECONDS);
     int numSyncRetries = conf.getInt(
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_STATEMACHINEDATA_SYNC_RETRIES,
@@ -558,7 +558,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
   @Override
   public void start() throws IOException {
     if (!isStarted) {
-      LOG.info("Starting {} raftPeerId : {}", getClass().getSimpleName(), server.getId());
+      LOG.info("Starting {}", name);
       for (ThreadPoolExecutor executor : chunkExecutors) {
         executor.prestartAllCoreThreads();
       }
@@ -581,11 +581,11 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     }
   }
 
-  private int getRealPort(InetSocketAddress address, Port.Name name) {
+  private int getRealPort(InetSocketAddress address, Port.Name portName) {
     int realPort = address.getPort();
-    datanodeDetails.setPort(DatanodeDetails.newPort(name, realPort));
-    LOG.info("{} raftPeerId : {} is started using port {} for {}",
-        getClass().getSimpleName(), server.getId(), realPort, name);
+    final Port port = DatanodeDetails.newPort(portName, realPort);
+    datanodeDetails.setPort(port);
+    LOG.info("{} is started using port {}", name, port);
     return realPort;
   }
 
@@ -593,7 +593,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
   public void stop() {
     if (isStarted) {
       try {
-        LOG.info("Stopping {} raftPeerId : {}", getClass().getSimpleName(), server.getId());
+        LOG.info("Closing {}", name);
         // shutdown server before the executors as while shutting down,
         // some of the tasks would be executed using the executors.
         server.close();
@@ -602,8 +602,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         }
         isStarted = false;
       } catch (IOException e) {
-        LOG.error("{} raftPeerId : {} Could not be stopped gracefully.",
-            getClass().getSimpleName(), server.getId(), e);
+        LOG.error("Failed to close {}.", name, e);
       }
     }
   }
@@ -707,45 +706,40 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         nextCallId());
   }
 
-  private void handlePipelineFailure(RaftGroupId groupId,
-      RoleInfoProto roleInfoProto) {
-    String msg;
-    UUID datanode = RatisHelper.toDatanodeId(roleInfoProto.getSelf());
-    RaftPeerId id = RaftPeerId.valueOf(roleInfoProto.getSelf().getId());
+  private void handlePipelineFailure(RaftGroupId groupId, RoleInfoProto roleInfoProto, String reason) {
+    final RaftPeerId raftPeerId = RaftPeerId.valueOf(roleInfoProto.getSelf().getId());
+    Preconditions.assertEquals(getServer().getId(), raftPeerId, "raftPeerId");
+    final StringBuilder b = new StringBuilder()
+        .append(name).append(" with datanodeId ").append(RatisHelper.toDatanodeId(raftPeerId))
+        .append("handlePipelineFailure ").append(" for ").append(reason)
+        .append(": ").append(roleInfoProto.getRole())
+        .append(" elapsed time=").append(roleInfoProto.getRoleElapsedTimeMs()).append("ms");
+
     switch (roleInfoProto.getRole()) {
     case CANDIDATE:
-      msg = "Server(DatanodeId=" + datanode + ") is in candidate state for " +
-          roleInfoProto.getCandidateInfo().getLastLeaderElapsedTimeMs() + "ms";
+      final long lastLeaderElapsedTime = roleInfoProto.getCandidateInfo().getLastLeaderElapsedTimeMs();
+      b.append(", lastLeaderElapsedTime=").append(lastLeaderElapsedTime).append("ms");
       break;
     case FOLLOWER:
-      msg = "Server(DatanodeId=" + datanode + ") closes pipeline when installSnapshot from leader " +
-          "because leader snapshot doesn't contain any data to replay, " +
-          "all the log entries prior to the snapshot might have been purged." +
-          "So follower should not try to install snapshot from leader but" +
-          "can close the pipeline here. It's in follower state for " +
-          roleInfoProto.getRoleElapsedTimeMs() + "ms";
+      b.append(", outstandingOp=").append(roleInfoProto.getFollowerInfo().getOutstandingOp());
       break;
     case LEADER:
-      StringBuilder sb = new StringBuilder();
-      sb.append("Server(DatanodeId=" + datanode + ")").append(" has not seen follower/s. Slowness follower:");
-      for (RaftProtos.ServerRpcProto follower : roleInfoProto.getLeaderInfo()
-          .getFollowerInfoList()) {
-        if (follower.getLastRpcElapsedTimeMs() > nodeFailureTimeoutMs) {
-          sb.append(" ").append("Server(DatanodeId=" + RatisHelper.toDatanodeId(follower.getId()) + ")")
-              .append(" for ").append(follower.getLastRpcElapsedTimeMs())
-              .append("ms");
-        }
+      final long followerSlownessTimeoutMs = ratisServerConfig.getFollowerSlownessTimeout();
+      for (RaftProtos.ServerRpcProto follower : roleInfoProto.getLeaderInfo().getFollowerInfoList()) {
+        final long lastRpcElapsedTimeMs = follower.getLastRpcElapsedTimeMs();
+        final boolean slow = lastRpcElapsedTimeMs > followerSlownessTimeoutMs;
+        final RaftPeerId followerId = RaftPeerId.valueOf(follower.getId().getId());
+        b.append("\n  Follower ").append(followerId)
+            .append(" with datanodeId ").append(RatisHelper.toDatanodeId(followerId))
+            .append(" is ").append(slow ? "slow" : " responding")
+            .append(" with lastRpcElapsedTime=").append(lastRpcElapsedTimeMs).append("ms");
       }
-      msg = sb.toString();
       break;
     default:
-      LOG.error("unknown state: {}", roleInfoProto.getRole());
-      throw new IllegalStateException("node" + id + " is in illegal role "
-          + roleInfoProto.getRole());
+      throw new IllegalStateException("Unexpected role " + roleInfoProto.getRole());
     }
 
-    triggerPipelineClose(groupId, msg,
-        ClosePipelineInfo.Reason.PIPELINE_FAILED);
+    triggerPipelineClose(groupId, b.toString(), ClosePipelineInfo.Reason.PIPELINE_FAILED);
   }
 
   private void triggerPipelineClose(RaftGroupId groupId, String detail,
@@ -870,12 +864,12 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     processReply(reply);
   }
 
-  void handleNodeSlowness(RaftGroupId groupId, RoleInfoProto roleInfoProto) {
-    handlePipelineFailure(groupId, roleInfoProto);
+  void handleFollowerSlowness(RaftGroupId groupId, RoleInfoProto roleInfoProto, RaftPeer follower) {
+    handlePipelineFailure(groupId, roleInfoProto, "slow follower " + follower.getId());
   }
 
   void handleNoLeader(RaftGroupId groupId, RoleInfoProto roleInfoProto) {
-    handlePipelineFailure(groupId, roleInfoProto);
+    handlePipelineFailure(groupId, roleInfoProto, "no leader");
   }
 
   void handleApplyTransactionFailure(RaftGroupId groupId,
@@ -902,10 +896,9 @@ public final class XceiverServerRatis implements XceiverServerSpi {
   void handleInstallSnapshotFromLeader(RaftGroupId groupId,
                                        RoleInfoProto roleInfoProto,
                                        TermIndex firstTermIndexInLog) {
-    LOG.warn("Install snapshot notification received from Leader with " +
-        "termIndex: {}, terminating pipeline: {}",
+    LOG.warn("handleInstallSnapshotFromLeader for firstTermIndexInLog={}, terminating pipeline: {}",
         firstTermIndexInLog, groupId);
-    handlePipelineFailure(groupId, roleInfoProto);
+    handlePipelineFailure(groupId, roleInfoProto, "install snapshot notification");
   }
 
   /**
@@ -951,7 +944,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     LOG.info("Leader change notification received for group: {} with new " +
         "leaderId: {}", groupMemberId.getGroupId(), raftPeerId1);
     // Save the reported leader to be sent with the report to SCM
-    boolean leaderForGroup = this.raftPeerId.equals(raftPeerId1);
+    final boolean leaderForGroup = server.getId().equals(raftPeerId1);
     activePipelines.compute(groupMemberId.getGroupId(),
         (key, value) -> value == null ? new ActivePipelineContext(leaderForGroup, false) :
             new ActivePipelineContext(leaderForGroup, value.isPendingClose()));


### PR DESCRIPTION
## What changes were proposed in this pull request?
In XceiverServerRatis, some logs are not clear enough. The purpose of this PR is to try to fix them.
Old log record 1:
```
2024-09-30 00:46:28,733 [973d0e1a-fd90-4d2b-991b-89a92fa7c5e1@group-6FF9AF421BCC->44fd977b-83b9-4753-ba54-52c87024523d-GrpcLogAppender-LogAppenderDaemon] ERROR org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis: pipeline Action CLOSE on pipeline PipelineID=25293fcd-0bf2-4785-b7f8-6ff9af421bcc.Reason : 973d0e1a-fd90-4d2b-991b-89a92fa7c5e1 has not seen follower/s 44fd977b-83b9-4753-ba54-52c87024523d for 94267149ms
```
New log record 1:
```
2024-09-30 14:36:51,515 [main] ERROR ratis.XceiverServerRatis (XceiverServerRatis.java:triggerPipelineClose(777)) - pipeline Action CLOSE on pipeline PipelineID=59064e89-fbd6-470b-a52a-a892f1894967.Reason : Server(DatanodeId=f2e2c2b9-6d81-438f-ad6b-964982fd8e61) has not seen follower/s. Slowness follower: Server(DatanodeId=a559e01c-0b12-48bf-a1ff-7ca41f604c0c) for 600000ms Server(DatanodeId=376707da-c8a8-446e-a778-2607be751d04) for 600000ms
```

Old log record 2:
```
2024-09-30 13:10:34,959 [6183eaf8-9f42-4d35-9cdb-a57250a00d8a-EndpointStateMachineTaskThread-bigdata-pre-hdp01.nmg01/10.77.36.49:9861-0 ] INFO org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis: Starting XceiverServerRatis 6183eaf8-9f42-4d35-9cdb-a57250a00d8a
```
New log record 2:
```
2024-09-30 14:40:37,679 [main] INFO  ratis.XceiverServerRatis (XceiverServerRatis.java:start(561)) - Starting XceiverServerRatis raftPeerId : 7b1168f6-5b60-4ce9-b6e6-75fed6e5be49
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11501

## How was this patch tested?
https://github.com/jianghuazhu/ozone/actions/runs/11101210678
