### PR TITLE
HDDS-11502. Class path contains multiple SLF4J providers

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -459,7 +459,6 @@ MIT
    org.kohsuke.metainf-services:metainf-services
    org.slf4j:slf4j-api
    org.slf4j:slf4j-reload4j
-   org.slf4j:slf4j-simple
 
 
 Public Domain

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -265,7 +265,6 @@ share/ozone/lib/simpleclient_dropwizard.jar
 share/ozone/lib/simpleclient.jar
 share/ozone/lib/slf4j-api.jar
 share/ozone/lib/slf4j-reload4j.jar
-share/ozone/lib/slf4j-simple.jar
 share/ozone/lib/snakeyaml.jar
 share/ozone/lib/snappy-java.jar
 share/ozone/lib/spring-beans.jar

--- a/pom.xml
+++ b/pom.xml
@@ -762,6 +762,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.apache.ratis</groupId>
         <artifactId>ratis-shell</artifactId>
         <version>${ratis.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix warning from SLF4J caused by having multiple providers on the classpath:

```
$ ozone freon ockg -n1 -t1
SLF4J(W): Class path contains multiple SLF4J providers.
SLF4J(W): Found provider [org.slf4j.reload4j.Reload4jServiceProvider@2133c8f8]
SLF4J(W): Found provider [org.slf4j.simple.SimpleServiceProvider@43a25848]
SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J(I): Actual provider is of type [org.slf4j.reload4j.Reload4jServiceProvider@2133c8f8]
...
```

https://issues.apache.org/jira/browse/HDDS-11502

## How was this patch tested?

Verified no warnings from SLF4J:

```
$ ozone freon ockg -n1 -t1
...
Successful executions: 1
```

Also checked `ozone ratis` commands:

```
$ ozone ratis group info -peers localhost:9894
group id: 9d149523-fe70-4ebc-a766-179bbc41e231
leader info: c00def7a-fede-45a6-acfe-c09f0a0b1e07(e8b8adcf6a83:9894)

[server {
  id: "c00def7a-fede-45a6-acfe-c09f0a0b1e07"
  address: "e8b8adcf6a83:9894"
  startupRole: FOLLOWER
}
commitIndex: 18
]
...
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/11105179309