### PR TITLE
HDDS-3498. Shutdown datanode if address is already in use

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -234,12 +234,14 @@ public class EndpointStateMachine
     }
 
     if (missCounter == 0) {
-      LOG.warn(
-          "Unable to communicate to {} server at {} for past {} seconds.",
-          serverName,
-          getAddress().getHostString() + ":" + getAddress().getPort(),
-          TimeUnit.MILLISECONDS.toSeconds(this.getMissedCount() *
-                  getScmHeartbeatInterval(this.conf)), ex);
+      LOG.error(
+              "Unable to communicate to {} server at {}:{} for past {} seconds.",
+              serverName,
+              address.getAddress(),
+              address.getPort(),
+              TimeUnit.MILLISECONDS.toSeconds(this.getMissedCount() * getScmHeartbeatInterval(this.conf)),
+              ex
+      );
     }
 
     if (LOG.isTraceEnabled()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -107,7 +107,8 @@ public class VersionEndpointTask implements
     } catch (DiskOutOfSpaceException ex) {
       rpcEndPoint.setState(EndpointStateMachine.EndPointStates.SHUTDOWN);
     } catch (IOException ex) {
-      rpcEndPoint.logIfNeeded(ex);
+      LOG.error(ex.getCause().getMessage(), ex);
+      rpcEndPoint.setState(EndpointStateMachine.EndPointStates.SHUTDOWN);
     } finally {
       rpcEndPoint.unlock();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes a bug related to an incomplete datanode process.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3498

## How was this patch tested?
Manual tests using docker-compose, build-branch workflow.
