### PR TITLE
HDDS-11504. Update Ratis to 3.1.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- HDDS Rocks Native dependency version-->
     <hdds.rocks.native.version>${hdds.version}</hdds.rocks.native.version>
     <!-- Apache Ratis version -->
-    <ratis.version>3.1.0</ratis.version>
+    <ratis.version>3.1.1</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>1.0.6</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11504. Update Ratis to 3.1.1.

Please describe your PR in detail:
* Update Ratis version from 3.1.0 to 3.1.1, which contains a lot of important bug fixes.
* IMO the most critical bug fixes for Ozone are 

1.  [RATIS-2135](https://issues.apache.org/jira/browse/RATIS-2135),
2. Revert of [RATIS-2099](https://issues.apache.org/jira/browse/RATIS-2099) and
3. Revert of [RATIS-1983](https://issues.apache.org/jira/browse/RATIS-1983).

We found Ozone were experiencing errors, slower (10%) and went out of memory under stress.

Commit diff: 
https://github.com/apache/ratis/compare/ratis-3.1.0...ratis-3.1.1

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11504

## How was this patch tested?

Existing unit test. 