### PR TITLE
HDDS-11518. Recon OmDB Insights show isKey=true for directories

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightEndpoint.java
@@ -235,6 +235,7 @@ public class OMDBInsightEndpoint {
             continue;
           }
           KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
+          keyEntityInfo.setIsKey(omKeyInfo.isFile());
           keyEntityInfo.setKey(key);
           keyEntityInfo.setPath(omKeyInfo.getKeyName());
           keyEntityInfo.setInStateSince(omKeyInfo.getCreationTime());
@@ -549,6 +550,7 @@ public class OMDBInsightEndpoint {
           continue;
         }
         KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
+        keyEntityInfo.setIsKey(omKeyInfo.isFile());
         keyEntityInfo.setKey(omKeyInfo.getFileName());
         keyEntityInfo.setPath(createPath(omKeyInfo));
         keyEntityInfo.setInStateSince(omKeyInfo.getCreationTime());
@@ -1257,6 +1259,7 @@ public class OMDBInsightEndpoint {
                                                          OmKeyInfo keyInfo) throws IOException {
     KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
     keyEntityInfo.setKey(dbKey); // Set the DB key
+    keyEntityInfo.setIsKey(keyInfo.isFile());
     keyEntityInfo.setPath(ReconUtils.constructFullPath(keyInfo, reconNamespaceSummaryManager,
         omMetadataManager));
     keyEntityInfo.setSize(keyInfo.getDataSize());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightSearchEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/OMDBInsightSearchEndpoint.java
@@ -380,6 +380,7 @@ public class OMDBInsightSearchEndpoint {
                                                          OmKeyInfo keyInfo) {
     KeyEntityInfo keyEntityInfo = new KeyEntityInfo();
     keyEntityInfo.setKey(dbKey); // Set the DB key
+    keyEntityInfo.setIsKey(keyInfo.isFile());
     keyEntityInfo.setPath(keyInfo.getKeyName()); // Assuming path is the same as key name
     keyEntityInfo.setInStateSince(keyInfo.getCreationTime());
     keyEntityInfo.setSize(keyInfo.getDataSize());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
@@ -143,7 +143,7 @@ public class KeyEntityInfo {
     return isKey;
   }
 
-  public void setIsKey(boolean key) {
-    isKey = key;
+  public void setIsKey(boolean isKey) {
+    this.isKey = isKey;
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfo.java
@@ -143,7 +143,7 @@ public class KeyEntityInfo {
     return isKey;
   }
 
-  public void setKey(boolean key) {
+  public void setIsKey(boolean key) {
     isKey = key;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The value of **`isKey`** for the **`keyEntityInfo`** is set to true by default. However, this should not be the case when using this object for deletedDirectories insights. Instead, we need to set the value to match what is present in the **`omKeyInfo`** in the RocksDB table.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11518

## How was this patch tested?

Tested it out manually by creating a deleted directory record and validating in the json response. 

<img width="933" alt="image" src="https://github.com/user-attachments/assets/f621af11-5c18-4d4d-b267-4cf09431b664">
