### PR TITLE
[DO NOT MERGE] Fix the issue that junit5 tests were not executed in CI

### DIFF
--- a/hadoop-hdds/hadoop-dependency-test/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-test/pom.xml
@@ -67,5 +67,15 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <!-- required for Surefire versions before 3.0.0-M5 -->
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithRatis.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine;
 import org.apache.hadoop.ozone.om.ratis.metrics.OzoneManagerStateMachineMetrics;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
@@ -340,9 +341,11 @@ public class TestOzoneRpcClientWithRatis extends TestOzoneRpcClientAbstract {
     omSM.getHandler().setInjector(injector);
     thread1.start();
     thread2.start();
-    GenericTestUtils.waitFor(() -> metrics.getApplyTransactionMapSize() > 0,
-        100, 5000);
-    Thread.sleep(2000);
+    // Wait long enough for createKey's preExecute to finish executing
+    GenericTestUtils.waitFor(() -> {
+      return getCluster().getOzoneManager().getOmServerProtocol().getLastRequestToSubmit().getCmdType().equals(
+          Type.CreateKey);
+    }, 100, 10000);
     injector.resume();
 
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotBackgroundServices.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotBackgroundServices.java
@@ -572,7 +572,7 @@ public class TestSnapshotBackgroundServices {
       } catch (IOException e) {
         Assertions.fail();
       }
-      return snapshotInfo.isSstFiltered();
+      return SstFilteringService.isSstFiltered(ozoneManager.getConfiguration(), snapshotInfo);
     }, 1000, 10000);
   }
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -46,8 +46,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.lock.IOzoneManagerLock;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExpiredMultipartUploadsBucket;
-import org.apache.hadoop.ozone.storage.proto.
-    OzoneManagerStorageProtos.PersistedUserVolumeInfo;
+import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmSnapshotManager.java
@@ -731,6 +731,13 @@ public final class OmSnapshotManager implements AutoCloseable {
         snapshotName + OM_KEY_PREFIX;
   }
 
+  public static Path getSnapshotPath(OMMetadataManager omMetadataManager, SnapshotInfo snapshotInfo) {
+    RDBStore store = (RDBStore) omMetadataManager.getStore();
+    String checkpointPrefix = store.getDbLocation().getName();
+    return Paths.get(store.getSnapshotsParentDir(),
+        checkpointPrefix + snapshotInfo.getCheckpointDir());
+  }
+
   public static String getSnapshotPath(OzoneConfiguration conf,
                                        SnapshotInfo snapshotInfo) {
     return OMStorage.getOmDbDir(conf) +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/snapshot/OMSnapshotPurgeResponse.java
@@ -20,10 +20,11 @@ package org.apache.hadoop.ozone.om.response.snapshot;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.ozone.om.lock.OMLockDetails;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -33,11 +34,11 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.SNAPSHOT_LOCK;
 
 /**
  * Response for OMSnapshotPurgeRequest.
@@ -117,15 +118,24 @@ public class OMSnapshotPurgeResponse extends OMClientResponse {
    */
   private void deleteCheckpointDirectory(OMMetadataManager omMetadataManager,
                                          SnapshotInfo snapshotInfo) {
-    RDBStore store = (RDBStore) omMetadataManager.getStore();
-    String checkpointPrefix = store.getDbLocation().getName();
-    Path snapshotDirPath = Paths.get(store.getSnapshotsParentDir(),
-        checkpointPrefix + snapshotInfo.getCheckpointDir());
-    try {
-      FileUtils.deleteDirectory(snapshotDirPath.toFile());
-    } catch (IOException ex) {
-      LOG.error("Failed to delete snapshot directory {} for snapshot {}",
-          snapshotDirPath, snapshotInfo.getTableKey(), ex);
+    // Acquiring write lock to avoid race condition with sst filtering service which creates a sst filtered file
+    // inside the snapshot directory. Any operation apart which doesn't create/delete files under this snapshot
+    // directory can run in parallel along with this operation.
+    OMLockDetails omLockDetails = omMetadataManager.getLock()
+        .acquireWriteLock(SNAPSHOT_LOCK, snapshotInfo.getVolumeName(), snapshotInfo.getBucketName(),
+            snapshotInfo.getName());
+    boolean acquiredSnapshotLock = omLockDetails.isLockAcquired();
+    if (acquiredSnapshotLock) {
+      Path snapshotDirPath = OmSnapshotManager.getSnapshotPath(omMetadataManager, snapshotInfo);
+      try {
+        FileUtils.deleteDirectory(snapshotDirPath.toFile());
+      } catch (IOException ex) {
+        LOG.error("Failed to delete snapshot directory {} for snapshot {}",
+            snapshotDirPath, snapshotInfo.getTableKey(), ex);
+      } finally {
+        omMetadataManager.getLock().releaseWriteLock(SNAPSHOT_LOCK, snapshotInfo.getVolumeName(),
+            snapshotInfo.getBucketName(), snapshotInfo.getName());
+      }
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.lock.BootstrapStateHandler;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
-import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.OmSnapshot;
 import org.apache.hadoop.ozone.om.OmSnapshotManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -100,7 +99,6 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
   private final long snapshotDeletionPerTask;
   private final int keyLimitPerSnapshot;
   private final int ratisByteLimit;
-  private final boolean isSstFilteringServiceEnabled;
 
   public SnapshotDeletingService(long interval, long serviceTimeout,
       OzoneManager ozoneManager, ScmBlockLocationProtocol scmClient)
@@ -128,8 +126,6 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
     this.keyLimitPerSnapshot = conf.getInt(
         OZONE_SNAPSHOT_KEY_DELETING_LIMIT_PER_TASK,
         OZONE_SNAPSHOT_KEY_DELETING_LIMIT_PER_TASK_DEFAULT);
-
-    this.isSstFilteringServiceEnabled = ((KeyManagerImpl) ozoneManager.getKeyManager()).isSstFilteringSvcEnabled();
   }
 
   private class SnapshotDeletingTask implements BackgroundTask {
@@ -593,8 +589,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
   @VisibleForTesting
   boolean shouldIgnoreSnapshot(SnapshotInfo snapInfo) {
     SnapshotInfo.SnapshotStatus snapshotStatus = snapInfo.getSnapshotStatus();
-    return snapshotStatus != SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED
-        || (isSstFilteringServiceEnabled && !snapInfo.isSstFiltered());
+    return snapshotStatus != SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED;
   }
 
   // TODO: Move this util class.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -100,6 +100,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
   private final long snapshotDeletionPerTask;
   private final int keyLimitPerSnapshot;
   private final int ratisByteLimit;
+  private final boolean isSstFilteringServiceEnabled;
 
   public SnapshotDeletingService(long interval, long serviceTimeout,
       OzoneManager ozoneManager, ScmBlockLocationProtocol scmClient)
@@ -127,6 +128,8 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
     this.keyLimitPerSnapshot = conf.getInt(
         OZONE_SNAPSHOT_KEY_DELETING_LIMIT_PER_TASK,
         OZONE_SNAPSHOT_KEY_DELETING_LIMIT_PER_TASK_DEFAULT);
+
+    this.isSstFilteringServiceEnabled = ((KeyManagerImpl) ozoneManager.getKeyManager()).isSstFilteringSvcEnabled();
   }
 
   private class SnapshotDeletingTask implements BackgroundTask {
@@ -153,12 +156,9 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
 
         while (iterator.hasNext() && snapshotLimit > 0) {
           SnapshotInfo snapInfo = iterator.next().getValue();
-          boolean isSstFilteringServiceEnabled =
-              ((KeyManagerImpl) ozoneManager.getKeyManager())
-                  .isSstFilteringSvcEnabled();
 
           // Only Iterate in deleted snapshot
-          if (shouldIgnoreSnapshot(snapInfo, isSstFilteringServiceEnabled)) {
+          if (shouldIgnoreSnapshot(snapInfo)) {
             continue;
           }
 
@@ -590,10 +590,10 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
     }
   }
 
-  public static boolean shouldIgnoreSnapshot(SnapshotInfo snapInfo,
-      boolean isSstFilteringServiceEnabled) {
+  @VisibleForTesting
+  boolean shouldIgnoreSnapshot(SnapshotInfo snapInfo) {
     SnapshotInfo.SnapshotStatus snapshotStatus = snapInfo.getSnapshotStatus();
-    return !(snapshotStatus == SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED)
+    return snapshotStatus != SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED
         || (isSstFilteringServiceEnabled && !snapInfo.isSstFiltered());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -88,6 +88,9 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
   // always true, only used in tests
   private boolean shouldFlushCache = true;
 
+  private OMRequest lastRequestToSubmit;
+
+
   /**
    * Constructs an instance of the server handler.
    *
@@ -225,6 +228,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
         assert (omClientRequest != null);
         OMClientRequest finalOmClientRequest = omClientRequest;
         requestToSubmit = preExecute(finalOmClientRequest);
+        this.lastRequestToSubmit = requestToSubmit;
       } catch (IOException ex) {
         if (omClientRequest != null) {
           omClientRequest.handleRequestFailure(ozoneManager);
@@ -246,6 +250,11 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
       throws IOException {
     return captureLatencyNs(perfMetrics.getPreExecuteLatencyNs(),
         () -> finalOmClientRequest.preExecute(ozoneManager));
+  }
+
+  @VisibleForTesting
+  public OMRequest getLastRequestToSubmit() {
+    return lastRequestToSubmit;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.ozone.om.service;
+
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
+import org.apache.hadoop.ozone.om.KeyManagerImpl;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.OmSnapshotManager;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.SnapshotChainManager;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Class to unit test SnapshotDeletingService.
+ */
+@ExtendWith(MockitoExtension.class)
+public class TestSnapshotDeletingService {
+  @Mock
+  private OzoneManager ozoneManager;
+  @Mock
+  private KeyManagerImpl keyManager;
+  @Mock
+  private OmSnapshotManager omSnapshotManager;
+  @Mock
+  private SnapshotChainManager chainManager;
+  @Mock
+  private OmMetadataManagerImpl omMetadataManager;
+  @Mock
+  private ScmBlockLocationProtocol scmClient;
+  private final OzoneConfiguration conf = new OzoneConfiguration();;
+  private final long sdsRunInterval = Duration.ofMillis(1000).toMillis();
+  private final  long sdsServiceTimeout = Duration.ofSeconds(10).toMillis();
+
+
+  private static Stream<Arguments> testCasesForIgnoreSnapshotGc() {
+    SnapshotInfo filteredSnapshot = SnapshotInfo.newBuilder().setSstFiltered(true).setName("snap1").build();
+    SnapshotInfo unFilteredSnapshot = SnapshotInfo.newBuilder().setSstFiltered(false).setName("snap1").build();
+    return Stream.of(
+        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, true, false),
+        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true, true),
+        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, true, true),
+        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true, true),
+        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false, false),
+        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false, false),
+        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, false, true),
+        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, false, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCasesForIgnoreSnapshotGc")
+  public void testProcessSnapshotLogicInSDS(SnapshotInfo snapshotInfo,
+                                            SnapshotInfo.SnapshotStatus status,
+                                            boolean sstFilteringServiceEnabled,
+                                            boolean expectedOutcome)
+      throws IOException {
+    Mockito.when(keyManager.isSstFilteringSvcEnabled()).thenReturn(sstFilteringServiceEnabled);
+    Mockito.when(omMetadataManager.getSnapshotChainManager()).thenReturn(chainManager);
+    Mockito.when(ozoneManager.getKeyManager()).thenReturn(keyManager);
+    Mockito.when(ozoneManager.getOmSnapshotManager()).thenReturn(omSnapshotManager);
+    Mockito.when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    Mockito.when(ozoneManager.getConfiguration()).thenReturn(conf);
+
+    SnapshotDeletingService snapshotDeletingService =
+        new SnapshotDeletingService(sdsRunInterval, sdsServiceTimeout, ozoneManager, scmClient);
+
+    snapshotInfo.setSnapshotStatus(status);
+    assertEquals(expectedOutcome, snapshotDeletingService.shouldIgnoreSnapshot(snapshotInfo));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/service/TestSnapshotDeletingService.java
@@ -67,26 +67,23 @@ public class TestSnapshotDeletingService {
     SnapshotInfo filteredSnapshot = SnapshotInfo.newBuilder().setSstFiltered(true).setName("snap1").build();
     SnapshotInfo unFilteredSnapshot = SnapshotInfo.newBuilder().setSstFiltered(false).setName("snap1").build();
     return Stream.of(
-        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, true, false),
-        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true, true),
-        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, true, true),
-        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true, true),
-        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false, false),
-        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false, false),
-        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, false, true),
-        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, false, true));
+        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false),
+        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true),
+        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false),
+        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true),
+        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false),
+        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false),
+        Arguments.of(unFilteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true),
+        Arguments.of(filteredSnapshot, SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true));
   }
 
   @ParameterizedTest
   @MethodSource("testCasesForIgnoreSnapshotGc")
   public void testProcessSnapshotLogicInSDS(SnapshotInfo snapshotInfo,
                                             SnapshotInfo.SnapshotStatus status,
-                                            boolean sstFilteringServiceEnabled,
                                             boolean expectedOutcome)
       throws IOException {
-    Mockito.when(keyManager.isSstFilteringSvcEnabled()).thenReturn(sstFilteringServiceEnabled);
     Mockito.when(omMetadataManager.getSnapshotChainManager()).thenReturn(chainManager);
-    Mockito.when(ozoneManager.getKeyManager()).thenReturn(keyManager);
     Mockito.when(ozoneManager.getOmSnapshotManager()).thenReturn(omSnapshotManager);
     Mockito.when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     Mockito.when(ozoneManager.getConfiguration()).thenReturn(conf);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOmSnapshotUtils.java
@@ -18,21 +18,15 @@
 
 package org.apache.hadoop.ozone.om.snapshot;
 
-import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
-import org.apache.hadoop.ozone.om.service.SnapshotDeletingService;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.ozone.om.snapshot.OmSnapshotUtils.getINode;
@@ -84,42 +78,4 @@ public class TestOmSnapshotUtils {
     assertEquals(tree1Files, tree2Files);
     GenericTestUtils.deleteDirectory(tempDir);
   }
-
-
-  private static Stream<Arguments> testCasesForIgnoreSnapshotGc() {
-    SnapshotInfo filteredSnapshot =
-        SnapshotInfo.newBuilder().setSstFiltered(true).setName("snap1").build();
-    SnapshotInfo unFilteredSnapshot =
-        SnapshotInfo.newBuilder().setSstFiltered(false).setName("snap1")
-            .build();
-    // {IsSnapshotFiltered,isSnapshotDeleted,IsSstServiceEnabled = ShouldIgnore}
-    return Stream.of(Arguments.of(filteredSnapshot,
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, true, false),
-        Arguments.of(filteredSnapshot,
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true, true),
-        Arguments.of(unFilteredSnapshot,
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, true, true),
-        Arguments.of(unFilteredSnapshot,
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, true, true),
-        Arguments.of(filteredSnapshot,
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false, false),
-        Arguments.of(unFilteredSnapshot,
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_DELETED, false, false),
-        Arguments.of(unFilteredSnapshot,
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, false, true),
-        Arguments.of(filteredSnapshot,
-            SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE, false, true));
-  }
-
-  @ParameterizedTest
-  @MethodSource("testCasesForIgnoreSnapshotGc")
-  public void testProcessSnapshotLogicInSDS(SnapshotInfo snapshotInfo,
-      SnapshotInfo.SnapshotStatus status, boolean isSstFilteringSvcEnabled,
-      boolean expectedOutcome) {
-    snapshotInfo.setSnapshotStatus(status);
-    assertEquals(expectedOutcome,
-        SnapshotDeletingService.shouldIgnoreSnapshot(snapshotInfo,
-            isSstFilteringSvcEnabled));
-  }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?


 Fix the issue that junit5 tests were not executed in CI, backport these PR to fix this issue.

HDDS-10059. TestOMRatisSnapshots.testInstallSnapshot should only validate live files. (#6069)
HDDS-10143. Intermittent failure in TestOzoneRpcClientWithRatis.testParallelDeleteBucketAndCreateKey (#6335)
HDDS-11068. Move SstFiltered flag to a file in the snapshot directory (#6965)
HDDS-10218. Speed up TestSstFilteringService (#6196)
HDDS-11084. Read SstFilteringService config only once in SnapshotDeletingService (#6885)
HDDS-10552. Downgrade Surefire to 3.0.0-M4 (#6406)   (re-backport)

## What is the link to the Apache JIRA

Because junit5 dependency `junit-jupiter-engine` was omitted when backporting HDDS-10552 (https://github.com/apache/ozone/pull/6553/commits/6a31ccd5011aad703473e48d7f623f9a6bcbf673). junit5 tests in the ozone-1.4 branch were not executed in CI  (such as: https://github.com/apache/ozone/actions/runs/11085539961). This problem is fixed in this PR.

### Main changes
- HDDS-10059 Add junit5 and junit4 dependencies in `hadoop-dependency-test/pom.xml` (https://github.com/apache/ozone/commit/d88998433c17d8488ece4eca7bc6f2deb2153c57)
- Backport some patches to fix the failed tests.

## How was this patch tested?
https://github.com/xichen01/ozone/actions/runs/11126592655

