### PR TITLE
HDDS-11480. Refactor OM volume response tests

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.om.response.volume;
 
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -40,7 +42,8 @@ public class TestOMVolumeCreateResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
-
+    OMMetadataManager omMetadataManager = getOmMetadataManager();
+    BatchOperation batchOperation = getBatchOperation();
     String volumeName = UUID.randomUUID().toString();
     String userName = "user1";
     PersistedUserVolumeInfo volumeList = PersistedUserVolumeInfo.newBuilder()
@@ -78,7 +81,8 @@ public class TestOMVolumeCreateResponse extends TestOMVolumeResponse {
 
   @Test
   void testAddToDBBatchNoOp() throws Exception {
-
+    OMMetadataManager omMetadataManager = getOmMetadataManager();
+    BatchOperation batchOperation = getBatchOperation();
     OMResponse omResponse = OMResponse.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.CreateVolume)
         .setStatus(OzoneManagerProtocolProtos.Status.VOLUME_ALREADY_EXISTS)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
@@ -18,10 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.volume;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -31,13 +27,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.storage.proto.
     OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.util.Time;
-import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,29 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * This class tests OMVolumeCreateResponse.
  */
-public class TestOMVolumeCreateResponse {
-
-  @TempDir
-  private Path folder;
-
-  private OMMetadataManager omMetadataManager;
-  private BatchOperation batchOperation;
-
-  @BeforeEach
-  public void setup() throws Exception {
-    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.toAbsolutePath().toString());
-    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
-    batchOperation = omMetadataManager.getStore().initBatchOperation();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    if (batchOperation != null) {
-      batchOperation.close();
-    }
-  }
+public class TestOMVolumeCreateResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
@@ -79,10 +48,10 @@ public class TestOMVolumeCreateResponse {
         .addVolumeNames(volumeName).build();
 
     OMResponse omResponse = OMResponse.newBuilder()
-            .setCmdType(OzoneManagerProtocolProtos.Type.CreateVolume)
-            .setStatus(OzoneManagerProtocolProtos.Status.OK)
-            .setSuccess(true)
-            .setCreateVolumeResponse(CreateVolumeResponse.getDefaultInstance())
+        .setCmdType(OzoneManagerProtocolProtos.Type.CreateVolume)
+        .setStatus(OzoneManagerProtocolProtos.Status.OK)
+        .setSuccess(true)
+        .setCreateVolumeResponse(CreateVolumeResponse.getDefaultInstance())
         .build();
 
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
@@ -125,6 +94,4 @@ public class TestOMVolumeCreateResponse {
     assertEquals(0, omMetadataManager.countRowsInTable(
         omMetadataManager.getVolumeTable()));
   }
-
-
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
@@ -18,10 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.volume;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -30,14 +26,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.util.Time;
-import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.util.UUID;
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -45,33 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * This class tests OMVolumeCreateResponse.
  */
-public class TestOMVolumeDeleteResponse {
-
-  @TempDir
-  private Path folder;
-
-  private OMMetadataManager omMetadataManager;
-  private BatchOperation batchOperation;
-
-  @BeforeEach
-  public void setup() throws Exception {
-    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.toAbsolutePath().toString());
-    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
-    batchOperation = omMetadataManager.getStore().initBatchOperation();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    if (batchOperation != null) {
-      batchOperation.close();
-    }
-  }
+public class TestOMVolumeDeleteResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
-
     String volumeName = UUID.randomUUID().toString();
     String userName = "user1";
     PersistedUserVolumeInfo volumeList = PersistedUserVolumeInfo.newBuilder()
@@ -95,7 +63,7 @@ public class TestOMVolumeDeleteResponse {
     // As we are deleting updated volume list should be empty.
     PersistedUserVolumeInfo updatedVolumeList =
         PersistedUserVolumeInfo.newBuilder()
-        .setObjectID(1).setUpdateID(1).build();
+            .setObjectID(1).setUpdateID(1).build();
     OMVolumeDeleteResponse omVolumeDeleteResponse =
         new OMVolumeDeleteResponse(omResponse, volumeName, userName,
             updatedVolumeList);
@@ -107,7 +75,7 @@ public class TestOMVolumeDeleteResponse {
     omMetadataManager.getStore().commitBatchOperation(batchOperation);
 
     assertNull(omMetadataManager.getVolumeTable().get(
-            omMetadataManager.getVolumeKey(volumeName)));
+        omMetadataManager.getVolumeKey(volumeName)));
 
     assertNull(omMetadataManager.getUserTable().get(
         omMetadataManager.getUserKey(userName)));
@@ -127,5 +95,4 @@ public class TestOMVolumeDeleteResponse {
         omResponse);
     assertDoesNotThrow(() -> omVolumeDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation));
   }
-
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.om.response.volume;
 
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -40,6 +42,8 @@ public class TestOMVolumeDeleteResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
+    OMMetadataManager omMetadataManager = getOmMetadataManager();
+    BatchOperation batchOperation = getBatchOperation();
     String volumeName = UUID.randomUUID().toString();
     String userName = "user1";
     PersistedUserVolumeInfo volumeList = PersistedUserVolumeInfo.newBuilder()
@@ -83,7 +87,8 @@ public class TestOMVolumeDeleteResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatchNoOp() {
-
+    OMMetadataManager omMetadataManager = getOmMetadataManager();
+    BatchOperation batchOperation = getBatchOperation();
     OMResponse omResponse = OMResponse.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.DeleteVolume)
         .setStatus(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeResponse.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.om.response.volume;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -11,12 +29,15 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 
+/**
+ * Base test class for OM volume response.
+ */
 public class TestOMVolumeResponse {
   @TempDir
   private Path folder;
 
-  protected OMMetadataManager omMetadataManager;
-  protected BatchOperation batchOperation;
+  private OMMetadataManager omMetadataManager;
+  private BatchOperation batchOperation;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -32,5 +53,12 @@ public class TestOMVolumeResponse {
     if (batchOperation != null) {
       batchOperation.close();
     }
+  }
+
+  protected OMMetadataManager getOmMetadataManager() {
+    return omMetadataManager;
+  }
+  protected BatchOperation getBatchOperation() {
+    return batchOperation;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeResponse.java
@@ -1,0 +1,36 @@
+package org.apache.hadoop.ozone.om.response.volume;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+public class TestOMVolumeResponse {
+  @TempDir
+  private Path folder;
+
+  protected OMMetadataManager omMetadataManager;
+  protected BatchOperation batchOperation;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
+        folder.toAbsolutePath().toString());
+    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
+    batchOperation = omMetadataManager.getStore().initBatchOperation();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (batchOperation != null) {
+      batchOperation.close();
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.om.response.volume;
 
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -40,7 +42,8 @@ public class TestOMVolumeSetOwnerResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
-
+    OMMetadataManager omMetadataManager = getOmMetadataManager();
+    BatchOperation batchOperation = getBatchOperation();
     String volumeName = UUID.randomUUID().toString();
     String oldOwner = "user1";
     PersistedUserVolumeInfo volumeList = PersistedUserVolumeInfo.newBuilder()
@@ -106,7 +109,8 @@ public class TestOMVolumeSetOwnerResponse extends TestOMVolumeResponse {
 
   @Test
   void testAddToDBBatchNoOp() throws Exception {
-
+    OMMetadataManager omMetadataManager = getOmMetadataManager();
+    BatchOperation batchOperation = getBatchOperation();
     OMResponse omResponse = OMResponse.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.SetVolumeProperty)
         .setStatus(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -18,10 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.volume;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -30,14 +26,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.util.Time;
-import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,30 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * This class tests OMVolumeCreateResponse.
  */
-public class TestOMVolumeSetOwnerResponse {
-
-  @TempDir
-  private Path folder;
-
-  private OMMetadataManager omMetadataManager;
-  private BatchOperation batchOperation;
-
-  @BeforeEach
-  public void setup() throws Exception {
-    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.toAbsolutePath().toString());
-    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
-    batchOperation = omMetadataManager.getStore().initBatchOperation();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    if (batchOperation != null) {
-      batchOperation.close();
-    }
-  }
-
+public class TestOMVolumeSetOwnerResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
@@ -94,25 +62,24 @@ public class TestOMVolumeSetOwnerResponse {
         new OMVolumeCreateResponse(omResponse, omVolumeArgs, volumeList);
 
 
-
     String newOwner = "user2";
     PersistedUserVolumeInfo newOwnerVolumeList =
         PersistedUserVolumeInfo.newBuilder()
-        .setObjectID(1)
-        .setUpdateID(1)
-        .addVolumeNames(volumeName).build();
+            .setObjectID(1)
+            .setUpdateID(1)
+            .addVolumeNames(volumeName).build();
     PersistedUserVolumeInfo oldOwnerVolumeList =
         PersistedUserVolumeInfo.newBuilder()
-        .setObjectID(2)
-        .setUpdateID(2)
-        .build();
+            .setObjectID(2)
+            .setUpdateID(2)
+            .build();
     OmVolumeArgs newOwnerVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(newOwner).setAdminName(newOwner)
         .setVolume(volumeName).setCreationTime(omVolumeArgs.getCreationTime())
         .build();
 
     OMVolumeSetOwnerResponse omVolumeSetOwnerResponse =
-        new OMVolumeSetOwnerResponse(omResponse, oldOwner,  oldOwnerVolumeList,
+        new OMVolumeSetOwnerResponse(omResponse, oldOwner, oldOwnerVolumeList,
             newOwnerVolumeList, newOwnerVolumeArgs);
 
     omVolumeCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
@@ -155,6 +122,4 @@ public class TestOMVolumeSetOwnerResponse {
     assertEquals(0, omMetadataManager.countRowsInTable(
         omMetadataManager.getVolumeTable()));
   }
-
-
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.om.response.volume;
 
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -39,7 +41,8 @@ public class TestOMVolumeSetQuotaResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
-
+    OMMetadataManager omMetadataManager = getOmMetadataManager();
+    BatchOperation batchOperation = getBatchOperation();
     String volumeName = UUID.randomUUID().toString();
     String userName = "user1";
 
@@ -75,7 +78,8 @@ public class TestOMVolumeSetQuotaResponse extends TestOMVolumeResponse {
 
   @Test
   void testAddToDBBatchNoOp() throws Exception {
-
+    OMMetadataManager omMetadataManager = getOmMetadataManager();
+    BatchOperation batchOperation = getBatchOperation();
     OMResponse omResponse = OMResponse.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.CreateVolume)
         .setStatus(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
@@ -18,10 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.volume;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -29,14 +25,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.util.Time;
-import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,30 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * This class tests OMVolumeCreateResponse.
  */
-public class TestOMVolumeSetQuotaResponse {
-
-  @TempDir
-  private Path folder;
-
-  private OMMetadataManager omMetadataManager;
-  private BatchOperation batchOperation;
-
-  @BeforeEach
-  public void setup() throws Exception {
-    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
-        folder.toAbsolutePath().toString());
-    omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration, null);
-    batchOperation = omMetadataManager.getStore().initBatchOperation();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    if (batchOperation != null) {
-      batchOperation.close();
-    }
-  }
-
+public class TestOMVolumeSetQuotaResponse extends TestOMVolumeResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
@@ -123,6 +91,4 @@ public class TestOMVolumeSetQuotaResponse {
     assertEquals(0, omMetadataManager.countRowsInTable(
         omMetadataManager.getVolumeTable()));
   }
-
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR extracts the bootstrap methods (`setup()`, `tearDown()`) used in the following OM volume response tests to reduce redundant code by allowing the tests to inherit from a superclass:

- TestOMVolumeCreateResponse
- TestOMVolumeDeleteResponse
- TestOMVolumeSetOwnerResponse
- TestOMVolumeSetQuotaResponse

## What is the link to the Apache JIRA

[HDDS-11480. Refactor OM volume response tests](https://issues.apache.org/jira/browse/HDDS-11480)

## How was this patch tested?

- Pass all unit test