### PR TITLE
HDDS-11527. Avoid unnecessary duplicate build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,11 +259,11 @@ jobs:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
-      - name: Setup java 8
+      - name: Setup java ${{ env.TEST_JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: ${{ env.TEST_JAVA_VERSION }}
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh ${{ inputs.ratis_args }}
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ on:
         required: false
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
-  TEST_JAVA_VERSION: 17 # preferred version
+  # Minimum required Java version for running Ozone is defined in pom.xml (javac.version).
+  TEST_JAVA_VERSION: 17 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   OZONE_WITH_COVERAGE: ${{ github.event_name == 'push' }}
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ on:
         required: false
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
-  BUILD_JAVA_VERSION: 8 # minimum version
   TEST_JAVA_VERSION: 17 # preferred version
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
   OZONE_WITH_COVERAGE: ${{ github.event_name == 'push' }}
@@ -106,7 +105,7 @@ jobs:
     if: needs.build-info.outputs.needs-build == 'true'
     strategy:
       matrix:
-        java: [ 8, 17 ]
+        java: [ 17 ]
       fail-fast: false
     steps:
       - name: Checkout project
@@ -150,21 +149,19 @@ jobs:
       - name: Store binaries for tests
         uses: actions/upload-artifact@v4
         with:
-          name: ozone-bin-${{ matrix.java }}
+          name: ozone-bin
           path: |
             hadoop-ozone/dist/target/ozone-*.tar.gz
             !hadoop-ozone/dist/target/ozone-*-src.tar.gz
           retention-days: 1
       - name: Store source tarball for compilation
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.java == env.BUILD_JAVA_VERSION }}
         with:
           name: ozone-src
           path: hadoop-ozone/dist/target/ozone-*-src.tar.gz
           retention-days: 1
       - name: Store Maven repo for tests
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.java == env.BUILD_JAVA_VERSION }}
         with:
           name: ozone-repo
           path: |
@@ -348,7 +345,7 @@ jobs:
       - name: Download compiled Ozone binaries
         uses: actions/download-artifact@v4
         with:
-          name: ozone-bin-${{ env.BUILD_JAVA_VERSION }}
+          name: ozone-bin
       - name: Untar binaries
         run: |
           mkdir dist
@@ -425,14 +422,8 @@ jobs:
           ref: ${{ needs.build-info.outputs.sha }}
       - name: Download compiled Ozone binaries
         uses: actions/download-artifact@v4
-        if: ${{ matrix.suite }} == 'MR' # until HDDS-11053 is fixed
         with:
-          name: ozone-bin-${{ env.BUILD_JAVA_VERSION }}
-      - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v4
-        if: ${{ matrix.suite }} != 'MR'
-        with:
-          name: ozone-bin-${{ env.TEST_JAVA_VERSION }}
+          name: ozone-bin
       - name: Untar binaries
         run: |
           mkdir -p hadoop-ozone/dist/target
@@ -475,7 +466,7 @@ jobs:
       - name: Download compiled Ozone binaries
         uses: actions/download-artifact@v4
         with:
-          name: ozone-bin-${{ env.BUILD_JAVA_VERSION }}
+          name: ozone-bin
       - name: Untar binaries
         run: |
           mkdir -p hadoop-ozone/dist/target
@@ -596,7 +587,7 @@ jobs:
       - name: Untar binaries
         run: |
           mkdir -p hadoop-ozone/dist/target
-          tar xzvf target/artifacts/ozone-bin-${{ env.TEST_JAVA_VERSION }}/ozone*.tar.gz -C hadoop-ozone/dist/target
+          tar xzvf target/artifacts/ozone-bin/ozone*.tar.gz -C hadoop-ozone/dist/target
       - name: Setup java ${{ env.TEST_JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     if: needs.build-info.outputs.needs-build == 'true'
-    strategy:
-      matrix:
-        java: [ 17 ]
-      fail-fast: false
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -141,7 +137,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.java }}
+          java-version: ${{ env.TEST_JAVA_VERSION }}
       - name: Run a full build
         run: hadoop-ozone/dev-support/checks/build.sh -Pdist -Psrc -Dmaven.javadoc.skip=true ${{ inputs.ratis_args }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
-      - name: Setup java
+      - name: Setup java ${{ env.TEST_JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -210,7 +210,7 @@ jobs:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
-      - name: Setup java
+      - name: Setup java ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -259,7 +259,7 @@ jobs:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
-      - name: Setup java
+      - name: Setup java 8
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -307,7 +307,7 @@ jobs:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
-      - name: Setup java
+      - name: Setup java 8
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,11 @@ jobs:
           name: ozone-repo
           path: |
             ~/.m2/repository/org/apache/ozone
+      - name: Setup java ${{ env.TEST_JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.TEST_JAVA_VERSION }}
       - name: Execute tests
         run: |
           hadoop-ozone/dev-support/checks/${{ github.job }}.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,11 +259,11 @@ jobs:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
-      - name: Setup java ${{ env.TEST_JAVA_VERSION }}
+      - name: Setup java 8
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: ${{ env.TEST_JAVA_VERSION }}
+          java-version: 8
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh ${{ inputs.ratis_args }}
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,11 +307,11 @@ jobs:
           name: ratis-jars
           path: |
             ~/.m2/repository/org/apache/ratis
-      - name: Setup java 8
+      - name: Setup java ${{ env.TEST_JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: ${{ env.TEST_JAVA_VERSION }}
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ github.job }}.sh ${{ inputs.ratis_args }}
         continue-on-error: true


### PR DESCRIPTION
## What changes were proposed in this pull request?

After HDDS-11046, CI workflow builds Ozone with both Java 8 and 17.  Both target Java 8 (create classfiles usable in JDK 8), so there is no difference at runtime.  This PR removes the Java 8 build.

Also:
- use `TEST_JAVA_VERSION` where possible (`basic` check cannot use it, because SpotBugs 3 does not work with Java 17, while SpotBugs 4 reports many new issues)
- include Java version in "Setup java" step name
- add comment about different Java versions

https://issues.apache.org/jira/browse/HDDS-11527

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/11175653923