### PR TITLE
HDDS-11535. Incomplete SCM roles table header

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -1001,6 +1001,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         .setClusterId(scmInfo.getClusterId())
         .setScmId(scmInfo.getScmId())
         .addAllPeerRoles(scmInfo.getRatisPeerRoles())
+        .setScmRatisEnabled(scmInfo.getScmRatisEnabled())
         .build();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some column headers are missing from SCM roles table header:

```
$ cd hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/ozone
$ OZONE_DATANODES=3 ./run.sh -d
$ docker-compose exec scm bash
bash-4.4$ ozone admin scm roles
f27d293bb5b5:9894:LEADER:833027d4-771b-4793-9e6d-024cc4a1bc7b:172.30.0.2
bash-4.4$ ozone admin scm roles --table
+----------------------------------------------------------------------------------+
|                         Storage Container Manager Roles                          |
+--------------+------+
|  Host Name   | Port |
+--------------+------+
| f27d293bb5b5 | 9894 | LEADER | 833027d4-771b-4793-9e6d-024cc4a1bc7b | 172.30.0.2 |
+--------------+------+--------+--------------------------------------+------------+
```

https://issues.apache.org/jira/browse/HDDS-11535

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/ozone
$ OZONE_DATANODES=3 ./run.sh -d
$ docker-compose exec scm bash
bash-4.4$ ozone admin scm roles
d973c629bf53:9894:LEADER:83cd8776-103d-4c5f-98bc-a2a5a7ee1618:172.31.0.4
bash-4.4$ ozone admin scm roles --table
+------------------------------------------------------------------------------------------+
|                             Storage Container Manager Roles                              |
+--------------+------------+--------+--------------------------------------+--------------+
|  Host Name   | Ratis Port |  Role  |               Node ID                | Host Address |
+--------------+------------+--------+--------------------------------------+--------------+
| d973c629bf53 |    9894    | LEADER | 83cd8776-103d-4c5f-98bc-a2a5a7ee1618 |  172.31.0.4  |
+--------------+------------+--------+--------------------------------------+--------------+
```

https://github.com/adoroszlai/ozone/actions/runs/11192740026