### PR TITLE
HDDS-11536. Bump macOS runner version to macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         include:
           - os: ubuntu-20.04
           - java: 8
-            os: macos-12
+            os: macos-13
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## What changes were proposed in this pull request?

`macos-12` runner is being deprecated, bump to next version: `macos-13`.

https://issues.apache.org/jira/browse/HDDS-11536

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/11194104108