### PR TITLE
HDDS-11538. Let coverage report link to java sources

### DIFF
--- a/hadoop-ozone/dev-support/checks/coverage.sh
+++ b/hadoop-ozone/dev-support/checks/coverage.sh
@@ -53,4 +53,5 @@ find target/coverage-classes -type d \( -name proto -or -name proto3 -or -name g
   | xargs rm -rf
 
 #generate the reports
-jacoco report "$REPORT_DIR/jacoco-all.exec" --classfiles target/coverage-classes --html "$REPORT_DIR/all" --xml "$REPORT_DIR/all.xml"
+src=$(find hadoop-* -path '*/src/main/java' | sed 's/^/--sourcefiles /g' | xargs echo)
+jacoco report "$REPORT_DIR/jacoco-all.exec" $src --classfiles target/coverage-classes --html "$REPORT_DIR/all" --xml "$REPORT_DIR/all.xml"


### PR DESCRIPTION
## What changes were proposed in this pull request?

JaCoCo can show java sources in the coverage report, we only need to let it know where to find the source files.

![1_master](https://github.com/user-attachments/assets/ca98d0c9-4ffa-4f3e-9fa9-5f9f8a061bbd)

https://issues.apache.org/jira/browse/HDDS-11538

## How was this patch tested?

![2_patch 1](https://github.com/user-attachments/assets/f4f9d908-04d1-4f0e-8116-5ee280c292ce)
![2_patch 2](https://github.com/user-attachments/assets/40d35d1c-73c2-4330-afea-ef6efde7b60a)

CI:
https://github.com/adoroszlai/ozone/actions/runs/11200444704