### PR TITLE
HDDS-11542. Add a new freon subcommand to read random keys

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -42,6 +42,7 @@ import static org.apache.hadoop.hdds.server.http.HttpServer2.setHttpBaseDir;
     description = "Load generator and tester tool for ozone",
     subcommands = {
         RandomKeyGenerator.class,
+        RandomKeyReader.class,
         OzoneClientKeyGenerator.class,
         OzoneClientKeyValidator.class,
         OzoneClientKeyRemover.class,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
@@ -18,6 +18,9 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Reads keys from random volume/bucket pairs
+ */
 @CommandLine.Command(name = "random-key-reader",
         aliases = "rkr",
         description = "Read keys from random volume/buckets",
@@ -30,8 +33,8 @@ public class RandomKeyReader extends BaseFreonGenerator
   )
   private String omServiceID = null;
   private OzoneClient[] ozoneClients;
-  int clientCount;
-  Timer timer;
+  private int clientCount;
+  private Timer timer;
   private AtomicInteger readKeyCount = new AtomicInteger();
 
   public Void call() throws Exception {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
@@ -1,7 +1,7 @@
 package org.apache.hadoop.ozone.freon;
 
 import com.codahale.metrics.Timer;
-import kotlin.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -39,65 +39,88 @@ public class RandomKeyReader extends BaseFreonGenerator
   private int clientCount;
   private Timer timer;
   private AtomicInteger readKeyCount = new AtomicInteger();
+  private ArrayList<Pair<OzoneVolume, OzoneBucket>> volBuckPairs;
 
   @Override
   public Void call() throws Exception {
     init();
+    setupClients();
+    gatherVolumeBucketInfo();
+    runTests(this::readRandomKeys);
+    teardownClients();
+    report();
+    return null;
+  }
+
+  public void init() {
+    super.init();
+    timer = getMetrics().timer("key-read");
+  }
+
+  private void setupClients() throws Exception {
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
     clientCount = getThreadNo();
     ozoneClients = new OzoneClient[clientCount];
     for (int i = 0; i < clientCount; i++) {
       ozoneClients[i] = createOzoneClient(omServiceID, ozoneConfiguration);
     }
-    timer = getMetrics().timer("key-read");
-
-    runTests(this::readRandomKeys);
-    for (int i = 0; i < clientCount; i++) {
-      if (ozoneClients[i] != null) {
-        ozoneClients[i].close();
-      }
-    }
-    String report = "-- Result ----------------------------------------------------------------------\n" +
-            "The number of keys read: "
-            + readKeyCount.get();
-    System.out.println(report);
-    return null;
   }
 
-  // Get volume list,
-  public void readRandomKeys(long count) throws IOException {
-    int clientIndex = (int) (count % clientCount);
-    OzoneClient c = ozoneClients[clientIndex];
-    timer.time(() -> {
-      Iterator<? extends OzoneVolume> vols = null;
-      try {
-        vols = c.getObjectStore().listVolumes("");
-        if (!vols.hasNext()) {
-          throw new RuntimeException("There is no volume.");
-        }
-        ArrayList<Pair<OzoneVolume, OzoneBucket>> volBuckPairs = new ArrayList<>();
-        vols.forEachRemaining(vol ->
-                vol.listBuckets("").forEachRemaining(buck -> {
-                  Pair<OzoneVolume, OzoneBucket> p = new Pair<>(vol, buck);
-                  volBuckPairs.add(p);
-                })
-        );
-        if (volBuckPairs.isEmpty()) {
-          throw new RuntimeException("No bucket exists in any volume. Create a bucket ");
-        }
-        int randomPairInd = new Random().nextInt(volBuckPairs.size());
-        Pair<OzoneVolume, OzoneBucket> pair = volBuckPairs.get(randomPairInd);
-        Iterator<? extends OzoneKey> keyItereator = pair.getSecond().listKeys("", "");
+  private void gatherVolumeBucketInfo() throws IOException {
+    if (ozoneClients.length == 0) {
+      throw new IllegalStateException("No clients available for gathering volume-bucket information.");
+    }
 
-        while (keyItereator.hasNext()) {
-          String keyName = keyItereator.next().getName();
-          OzoneInputStream stream = null;
-          try {
-            stream = pair.getSecond().readKey(keyName);
+    OzoneClient client = ozoneClients[0];
+    Iterator<? extends OzoneVolume> volumes = client.getObjectStore().listVolumes("");
+
+    if (!volumes.hasNext()) {
+      throw new RuntimeException("There is no volume.");
+    }
+
+    volBuckPairs = new ArrayList<>();
+    volumes.forEachRemaining(vol ->
+            vol.listBuckets("").forEachRemaining(buck -> {
+              Pair<OzoneVolume, OzoneBucket> pair = Pair.of(vol, buck);
+              volBuckPairs.add(pair);
+            })
+    );
+
+    if (volBuckPairs.isEmpty()) {
+      throw new RuntimeException("No bucket exists in any volume. Create a bucket.");
+    }
+  }
+
+  private void teardownClients() {
+    for (int i = 0; i < clientCount; i++) {
+      try {
+        if (ozoneClients[i] != null) {
+          ozoneClients[i].close();
+        }
+      } catch (IOException e) {
+        System.err.println("Error while closing client " + i + ": " + e.getMessage());
+      }
+    }
+  }
+
+  private void report() {
+    String report = "-- Result ----------------------------------------------------------------------\n" +
+            "The number of keys read: " + readKeyCount.get();
+    System.out.println(report);
+  }
+
+  public void readRandomKeys(long count) {
+    timer.time(() -> {
+      try {
+        int randomPairIndex = new Random().nextInt(volBuckPairs.size());
+        Pair<OzoneVolume, OzoneBucket> pair = volBuckPairs.get(randomPairIndex);
+        Iterator<? extends OzoneKey> keyIterator = pair.getRight().listKeys("", "");
+
+        while (keyIterator.hasNext()) {
+          String keyName = keyIterator.next().getName();
+          try (OzoneInputStream stream = pair.getRight().readKey(keyName)) {
             IOUtils.consume(stream);
             readKeyCount.incrementAndGet();
-          } catch (IOException e) {
-            throw new RuntimeException(e);
           }
         }
       } catch (IOException e) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
@@ -77,13 +77,9 @@ public class RandomKeyReader extends BaseFreonGenerator
                 if (volBuckPairs.isEmpty()) {
                     throw new RuntimeException("No bucket exists in any volume. Create a bucket ");
                 }
-                Iterator<? extends OzoneKey> keyItereator;
-                Pair<OzoneVolume, OzoneBucket> pair;
-                do {
-                    int randomPairInd = new Random().nextInt(volBuckPairs.size());
-                    pair = volBuckPairs.get(randomPairInd);
-                    keyItereator = pair.getSecond().listKeys("", "");
-                } while (!keyItereator.hasNext());
+                int randomPairInd = new Random().nextInt(volBuckPairs.size());
+                Pair<OzoneVolume, OzoneBucket> pair = volBuckPairs.get(randomPairInd);
+                Iterator<? extends OzoneKey> keyItereator = pair.getSecond().listKeys("", "");;
 
                 while (keyItereator.hasNext()) {
                     String keyName = keyItereator.next().getName();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
@@ -3,6 +3,7 @@ package org.apache.hadoop.ozone.freon;
 import com.codahale.metrics.Timer;
 import kotlin.Pair;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -24,7 +25,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 @CommandLine.Command(name = "random-key-reader",
         aliases = "rkr",
         description = "Read keys from random volume/buckets",
-        mixinStandardHelpOptions = true)
+        versionProvider = HddsVersionProvider.class,
+        mixinStandardHelpOptions = true,
+        showDefaultValues = true)
 public class RandomKeyReader extends BaseFreonGenerator
         implements Callable<Void> {
   @CommandLine.Option(
@@ -37,6 +40,7 @@ public class RandomKeyReader extends BaseFreonGenerator
   private Timer timer;
   private AtomicInteger readKeyCount = new AtomicInteger();
 
+  @Override
   public Void call() throws Exception {
     init();
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Reads keys from random volume/bucket pairs
+ * Reads keys from random volume/bucket pairs.
  */
 @CommandLine.Command(name = "random-key-reader",
         aliases = "rkr",
@@ -53,7 +53,8 @@ public class RandomKeyReader extends BaseFreonGenerator
         ozoneClients[i].close();
       }
     }
-    String report = "The number of keys read: "
+    String report = "-- Result ----------------------------------------------------------------------\n" +
+            "The number of keys read: "
             + readKeyCount.get();
     System.out.println(report);
     return null;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyReader.java
@@ -1,0 +1,99 @@
+package org.apache.hadoop.ozone.freon;
+
+import com.codahale.metrics.Timer;
+import kotlin.Pair;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@CommandLine.Command(name = "random-key-reader",
+    aliases = "rkr",
+    description = "Read keys from random volume/buckets",
+    mixinStandardHelpOptions = true)
+public class RandomKeyReader extends BaseFreonGenerator
+        implements Callable<Void> {
+    @CommandLine.Option(
+            names = "--om-service-id",
+            description = "OM Service ID"
+    )
+    private String omServiceID = null;
+    private OzoneClient[] ozoneClients;
+    int clientCount;
+    Timer timer;
+    AtomicInteger readCount = new AtomicInteger();
+
+    public Void call() throws Exception {
+        init();
+        OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
+        clientCount =  getThreadNo();
+        ozoneClients = new OzoneClient[clientCount];
+        for (int i = 0; i < clientCount; i++) {
+            ozoneClients[i] = createOzoneClient(omServiceID, ozoneConfiguration);
+        }
+        timer = getMetrics().timer("key-read");
+
+        runTests(this::readRandomKeys);
+        for (int i = 0; i < clientCount; i++) {
+            if (ozoneClients[i] != null) {
+                ozoneClients[i].close();
+            }
+        }
+        String report = "The number of keys read: "
+                + readCount.get();
+        System.out.println(report);
+        return null;
+    }
+
+    // Get volume list,
+    public void readRandomKeys(long count) throws IOException {
+        int clientIndex = (int)(count % clientCount);
+        OzoneClient c = ozoneClients[clientIndex];
+        timer.time(() -> {
+            Iterator<? extends OzoneVolume> vols = null;
+            try {
+                vols = c.getObjectStore().listVolumes("");
+                ArrayList<Pair<OzoneVolume, OzoneBucket>> volBuckPairs = new ArrayList<>();
+                vols.forEachRemaining(vol ->
+                    vol.listBuckets("").forEachRemaining(buck -> {
+                        Pair<OzoneVolume, OzoneBucket> p = new Pair<>(vol, buck);
+                        volBuckPairs.add(p);
+                    })
+                );
+                Iterator<? extends OzoneKey> keyItereator;
+                Pair<OzoneVolume, OzoneBucket> pair;
+                do {
+                    int randomPairInd = new Random().nextInt(volBuckPairs.size());
+                    pair = volBuckPairs.get(randomPairInd);
+                    keyItereator = pair.getSecond().listKeys("", "");
+                } while (!keyItereator.hasNext());
+
+                int numOfKeysInBuck = 0;
+                while (keyItereator.hasNext()) {
+                    String keyName = keyItereator.next().getName();
+                    OzoneInputStream stream = null;
+                    try {
+                        stream = pair.getSecond().readKey(keyName);
+                        IOUtils.consume(stream);
+                        numOfKeysInBuck++;
+                        readCount.incrementAndGet();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Background: to measure memory consumption of Ozone, it is important to have a tool to create solely read workload. Existing freon subcommands are not suitable for this case.

I add a new freon subcommand that selects random volume/bucket pairs and read keys from them.
Example command: `ozone freon rkr --duration=10m`
This example reads keys from random volume/bucket pairs for 10 minutes.

At the end it reports the number of keys read and timer report.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11542

## How was this patch tested?
Tested locally. 