### PR TITLE
HDDS-11526. hdds.datanode.metadata.rocksdb.cache.size default value description is wrong

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1570,7 +1570,7 @@
 
   <property>
     <name>hdds.datanode.metadata.rocksdb.cache.size</name>
-    <value>64MB</value>
+    <value>1GB</value>
     <tag>OZONE, DATANODE, MANAGEMENT</tag>
     <description>
         Size of the block metadata cache shared among RocksDB instances on each

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -689,7 +689,7 @@ public class TestKeyValueContainer {
 
     try (DBHandle db = BlockUtils.getDB(keyValueContainerData, CONF)) {
       RDBStore store = (RDBStore) db.getStore().getStore();
-      long defaultCacheSize = 64 * OzoneConsts.MB;
+      long defaultCacheSize = OzoneConsts.GB;
       long cacheSize = Long.parseLong(store
           .getProperty("rocksdb.block-cache-capacity"));
       assertEquals(defaultCacheSize, cacheSize);


### PR DESCRIPTION
## What changes were proposed in this pull request?
The default value of property `hdds.datanode.metadata.rocksdb.cache.size` in ozone-default.xml is corrected to 1GB as per the actual default value used in the code. 

## What is the link to the Apache JIRA
[HDDS-11526](https://issues.apache.org/jira/browse/HDDS-11526)

## How was this patch tested?
Tested using TestKeyValueContainer#testContainerRocksDB.