### PR TITLE
HDDS-11545. [UI] Add OM and SCM ID information

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.less
@@ -165,3 +165,8 @@ body {
 .pointer {
   cursor: pointer;
 }
+
+.data-container {
+  padding: 24px;
+  height: 80vh;
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.tsx
@@ -72,7 +72,7 @@ class App extends React.Component<Record<string, object>, IAppState> {
               <div style={{ margin: '16px 0', display: 'flex', justifyContent: 'space-between' }}>
                 <Breadcrumbs />
                 <AntDSwitch
-                  // disabled={true}
+                  disabled={true}
                   checkedChildren={<div style={{ paddingLeft: '2px' }}>New UI</div>}
                   onChange={(checked: boolean) => {
                     this.setState({

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/app.tsx
@@ -72,7 +72,7 @@ class App extends React.Component<Record<string, object>, IAppState> {
               <div style={{ margin: '16px 0', display: 'flex', justifyContent: 'space-between' }}>
                 <Breadcrumbs />
                 <AntDSwitch
-                  disabled={true}
+                  // disabled={true}
                   checkedChildren={<div style={{ paddingLeft: '2px' }}>New UI</div>}
                   onChange={(checked: boolean) => {
                     this.setState({

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/buckets/buckets.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/buckets/buckets.tsx
@@ -282,7 +282,7 @@ const Buckets: React.FC<{}> = () => {
           onReload={loadData}
         />
       </div>
-      <div style={{ padding: '24px' }}>
+      <div className='data-container'>
         <div className='content-div'>
           <div className='table-header-section'>
             <div className='table-filter-section'>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/datanodes/datanodes.tsx
@@ -234,7 +234,7 @@ const Datanodes: React.FC<{}> = () => {
           togglePolling={autoReloadHelper.handleAutoReloadToggle}
           onReload={loadData} />
       </div>
-      <div style={{ padding: '24px' }}>
+      <div className='data-container'>
         <div className='content-div'>
           <div className='table-header-section'>
             <div className='table-filter-section'>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/diskUsage/diskUsage.tsx
@@ -103,7 +103,7 @@ const DiskUsage: React.FC<{}> = () => {
       <div className='page-header-v2'>
         Disk Usage
       </div>
-      <div style={{ padding: '24px' }}>
+      <div className='data-container'>
         <Alert
           className='du-alert-message'
           message="Additional block size is added to small entities, for better visibility.

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/overview/overview.tsx
@@ -238,8 +238,8 @@ const Overview: React.FC<{}> = () => {
         deletePendingSummarytotalUnrepSize: deletePendingResponse?.value?.data?.totalUnreplicatedDataSize,
         deletePendingSummarytotalRepSize: deletePendingResponse?.value?.data?.totalReplicatedDataSize,
         deletePendingSummarytotalDeletedKeys: deletePendingResponse?.value?.data?.totalDeletedKeys,
-        scmServiceId: clusterState?.scmServiceId,
-        omServiceId: clusterState?.omServiceId
+        scmServiceId: clusterState?.scmServiceId ?? 'N/A',
+        omServiceId: clusterState?.omServiceId ?? 'N/A'
       });
       setStorageReport({
         ...storageReport,
@@ -345,7 +345,7 @@ const Overview: React.FC<{}> = () => {
           lastUpdatedOMDBDelta={lastUpdatedOMDBDelta} lastUpdatedOMDBFull={lastUpdatedOMDBFull}
           togglePolling={autoReloadHelper.handleAutoReloadToggle} onReload={loadOverviewPageData} omSyncLoad={syncOmData} omStatus={omStatus} />
       </div>
-      <div style={{ padding: '24px' }}>
+      <div className='data-container'>
         <Row
           align='stretch'
           gutter={[
@@ -534,6 +534,15 @@ const Overview: React.FC<{}> = () => {
               linkToUrl='/Om' />
           </Col>
         </Row>
+        <span style={{ paddingLeft: '8px' }}>
+          <span style={{ color: '#6E6E6E' }}>OM ID:&nbsp;</span>
+          {omServiceId}
+        </span>
+        <span style={{ marginLeft: '12px', marginRight: '12px' }}> | </span>
+        <span>
+          <span style={{ color: '#6E6E6E' }}>SCM ID:&nbsp;</span>
+          {scmServiceId}
+        </span>
       </div>
     </>
   );

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/pipelines/pipelines.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/pipelines/pipelines.tsx
@@ -120,7 +120,7 @@ const Pipelines: React.FC<{}> = () => {
           togglePolling={autoReloadHelper.handleAutoReloadToggle}
           onReload={loadData} />
       </div>
-      <div style={{ padding: '24px' }}>
+      <div className='data-container'>
         <div className='content-div'>
           <div className='table-header-section'>
             <div className='table-filter-section'>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/volumes/volumes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/v2/pages/volumes/volumes.tsx
@@ -182,7 +182,7 @@ const Volumes: React.FC<{}> = () => {
           onReload={loadData}
         />
       </div>
-      <div style={{ padding: '24px' }}>
+      <div className='data-container'>
         <div className='content-div'>
           <div className='table-header-section'>
             <div className='table-filter-section'>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-11545. Added OM ID and SCM ID information

Please describe your PR in detail:
* We had a card displaying the OM Id and SCM id in the old UI however the new UI doesn't have this
* As a part of this PR we add a small metadata to the Overview page to display the IDs
* This is helpful in case of running commands or debugging where we can directly get the ID from Recon UI

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11545

## How was this patch tested?
Patch was tested manually.
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/75ac4473-5987-45d8-a2f5-b047b65fbc9a">
