### PR TITLE
HDDS-11547. Make MAVEN_OPTS optional

### DIFF
--- a/hadoop-ozone/dev-support/checks/build.sh
+++ b/hadoop-ozone/dev-support/checks/build.sh
@@ -26,7 +26,7 @@ else
   MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"
 fi
 
-export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
+export MAVEN_OPTS="-Xmx4096m ${MAVEN_OPTS:-}"
 echo "${MAVEN_OPTIONS}"
 mvn ${MAVEN_OPTIONS} clean install "$@"
 exit $?

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -30,7 +30,7 @@ if [[ ${ITERATIONS} -le 0 ]]; then
   ITERATIONS=1
 fi
 
-export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
+export MAVEN_OPTS="-Xmx4096m ${MAVEN_OPTS:-}"
 MAVEN_OPTIONS="-B -V -Dskip.npx -Dskip.installnpx -Dnative.lib.tmp.dir=/tmp --no-transfer-progress"
 
 if [[ "${OZONE_WITH_COVERAGE}" != "true" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

`junit.sh` fails if `MAVEN_OPTS` is not set: the script enables `nounset` (fail on unset variables), but references `MAVEN_OPTS` without providing default value.

https://issues.apache.org/jira/browse/HDDS-11547

## How was this patch tested?

```
$ unset MAVEN_OPTS
$ ./hadoop-ozone/dev-support/checks/junit.sh
Apache Maven 3.6.3
Maven home: /usr/share/maven
Java version: 1.8.0_422, vendor: Private Build, runtime: /usr/lib/jvm/java-8-openjdk-amd64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-45-generic", arch: "amd64", family: "unix"
[INFO] Scanning for projects...
...
```