### PR TITLE
HDDS-11486. SnapshotDiffManager prints ERROR for NativeLibraryNotLoadedException

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -284,7 +284,8 @@ public class SnapshotDiffManager implements AutoCloseable {
       try {
         return ManagedRawSSTFileReader.loadLibrary();
       } catch (NativeLibraryNotLoadedException e) {
-        LOG.error("Native Library for raw sst file reading loading failed.", e);
+        LOG.warn("Native Library for raw sst file reading loading failed." +
+            " Fallback to Handling raw sst file by deltas", e);
         return false;
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -285,7 +285,7 @@ public class SnapshotDiffManager implements AutoCloseable {
         return ManagedRawSSTFileReader.loadLibrary();
       } catch (NativeLibraryNotLoadedException e) {
         LOG.warn("Native Library for raw sst file reading loading failed." +
-            " Fallback to Handling raw sst file by deltas");
+            " Fallback to Handling raw sst file by deltas. {}", e.getMessage());
         return false;
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -285,7 +285,7 @@ public class SnapshotDiffManager implements AutoCloseable {
         return ManagedRawSSTFileReader.loadLibrary();
       } catch (NativeLibraryNotLoadedException e) {
         LOG.warn("Native Library for raw sst file reading loading failed." +
-            " Fallback to Handling raw sst file by deltas. {}", e.getMessage());
+            " Fallback to performing a full diff instead. {}", e.getMessage());
         return false;
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/SnapshotDiffManager.java
@@ -285,7 +285,7 @@ public class SnapshotDiffManager implements AutoCloseable {
         return ManagedRawSSTFileReader.loadLibrary();
       } catch (NativeLibraryNotLoadedException e) {
         LOG.warn("Native Library for raw sst file reading loading failed." +
-            " Fallback to Handling raw sst file by deltas", e);
+            " Fallback to Handling raw sst file by deltas");
         return false;
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Not sure how important of the NativeLibraryNotLoadedException. Keep seeing the following ERROR in the OM log. If it is important, it should throw the exception out and stop OM; otherwise, change it to WARN and consider not printing the stack trace.

```
024-09-24 23:02:20,241 ERROR [main]-org.apache.hadoop.ozone.om.snapshot.SnapshotDiffManager: Native Library for raw sst file reading loading failed.
org.apache.hadoop.hdds.utils.NativeLibraryNotLoadedException: Unable to load library ozone_rocksdb_tools from both java.library.path & resource file libozone_rocksdb_tools.so from jar.
        at org.apache.hadoop.hdds.utils.db.managed.ManagedRawSSTFileReader.loadLibrary(ManagedRawSSTFileReader.java:40)
        at org.apache.hadoop.ozone.om.snapshot.SnapshotDiffManager.initNativeLibraryForEfficientDiff(SnapshotDiffManager.java:292)
        at org.apache.hadoop.ozone.om.snapshot.SnapshotDiffManager.<init>(SnapshotDiffManager.java:266)
        at org.apache.hadoop.ozone.om.OmSnapshotManager.<init>(OmSnapshotManager.java:278)
        at org.apache.hadoop.ozone.om.OzoneManager.instantiateServices(OzoneManager.java:847)
        at org.apache.hadoop.ozone.om.OzoneManager.<init>(OzoneManager.java:674)
        at org.apache.hadoop.ozone.om.OzoneManager.createOm(OzoneManager.java:759)
        at org.apache.hadoop.ozone.om.OzoneManagerStarter$OMStarterHelper.start(OzoneManagerStarter.java:189)
        at org.apache.hadoop.ozone.om.OzoneManagerStarter.startOm(OzoneManagerStarter.java:86)
        at org.apache.hadoop.ozone.om.OzoneManagerStarter.call(OzoneManagerStarter.java:74)
        at org.apache.hadoop.hdds.cli.GenericCli.call(GenericCli.java:38)
        ...
        at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:91)
        at org.apache.hadoop.ozone.om.OzoneManagerStarter.main(OzoneManagerStarter.java:58)
```

Please describe your PR in detail:

Using native libs to read raw sst file is set by default. If the native libs were not loaded, `SnapshotDiffManager`  handles deltas instead.  I think log warn message is fine, since `SnapshotDiffManager sill works.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11486

## How was this patch tested?

CI: 
https://github.com/chungen0126/ozone/actions/runs/11253054528
