### PR TITLE
HDDS-11554. OMDBDefinition should be singleton.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -45,15 +45,12 @@ import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.ozone.compaction.log.CompactionLogEntry;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Class defines the structure and types of the om.db.
  */
-public class OMDBDefinition extends DBDefinition.WithMap {
+public final class OMDBDefinition extends DBDefinition.WithMap {
 
   public static final DBColumnFamilyDefinition<String, RepeatedOmKeyInfo>
             DELETED_TABLE =
@@ -289,20 +286,12 @@ public class OMDBDefinition extends DBDefinition.WithMap {
 
   private static final OMDBDefinition INSTANCE = new OMDBDefinition();
 
-  public static OMDBDefinition getInstance() {
+  public static OMDBDefinition get() {
     return INSTANCE;
   }
 
-  private final List<String> columnFamilyNames = Collections.unmodifiableList(getColumnFamilies().stream()
-        .map(DBColumnFamilyDefinition::getName)
-        .collect(Collectors.toList()));
-
   private OMDBDefinition() {
     super(COLUMN_FAMILIES);
-  }
-
-  public List<String> getColumnFamilyNames() {
-    return columnFamilyNames;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -45,7 +45,10 @@ import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.ozone.compaction.log.CompactionLogEntry;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Class defines the structure and types of the om.db.
@@ -284,8 +287,22 @@ public class OMDBDefinition extends DBDefinition.WithMap {
           USER_TABLE,
           VOLUME_TABLE);
 
-  public OMDBDefinition() {
+  private static final OMDBDefinition INSTANCE = new OMDBDefinition();
+
+  public static OMDBDefinition getInstance() {
+    return INSTANCE;
+  }
+
+  private final List<String> columnFamilyNames = Collections.unmodifiableList(getColumnFamilies().stream()
+        .map(DBColumnFamilyDefinition::getName)
+        .collect(Collectors.toList()));
+
+  private OMDBDefinition() {
     super(COLUMN_FAMILIES);
+  }
+
+  public List<String> getColumnFamilyNames() {
+    return columnFamilyNames;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -478,10 +478,7 @@ public final class OzoneManagerDoubleBuffer {
     if (cleanupTableInfo != null) {
       final List<String> cleanupTables;
       if (cleanupTableInfo.cleanupAll()) {
-        cleanupTables = new OMDBDefinition().getColumnFamilies()
-            .stream()
-            .map(DBColumnFamilyDefinition::getName)
-            .collect(Collectors.toList());
+        cleanupTables = OMDBDefinition.getInstance().getColumnFamilyNames();
       } else {
         cleanupTables = Arrays.asList(cleanupTableInfo.cleanupTables());
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.S3SecretManager;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
@@ -478,7 +477,7 @@ public final class OzoneManagerDoubleBuffer {
     if (cleanupTableInfo != null) {
       final List<String> cleanupTables;
       if (cleanupTableInfo.cleanupAll()) {
-        cleanupTables = OMDBDefinition.getInstance().getColumnFamilyNames();
+        cleanupTables = OMDBDefinition.get().getColumnFamilyNames();
       } else {
         cleanupTables = Arrays.asList(cleanupTableInfo.cleanupTables());
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -439,8 +439,7 @@ public final class OzoneManagerRatisUtils {
    */
   public static TransactionInfo getTrxnInfoFromCheckpoint(
       OzoneConfiguration conf, Path dbPath) throws Exception {
-    return HAUtils
-        .getTrxnInfoFromCheckpoint(conf, dbPath, new OMDBDefinition());
+    return HAUtils.getTrxnInfoFromCheckpoint(conf, dbPath, OMDBDefinition.getInstance());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -439,7 +439,7 @@ public final class OzoneManagerRatisUtils {
    */
   public static TransactionInfo getTrxnInfoFromCheckpoint(
       OzoneConfiguration conf, Path dbPath) throws Exception {
-    return HAUtils.getTrxnInfoFromCheckpoint(conf, dbPath, OMDBDefinition.getInstance());
+    return HAUtils.getTrxnInfoFromCheckpoint(conf, dbPath, OMDBDefinition.get());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
@@ -45,11 +45,10 @@ public class TestOMDBDefinition {
     OzoneConfiguration configuration = new OzoneConfiguration();
     File metaDir = folder.toFile();
     DBStore store = OmMetadataManagerImpl.loadDB(configuration, metaDir);
-    OMDBDefinition dbDef = new OMDBDefinition();
 
     // Get list of tables from DB Definitions
     final Collection<DBColumnFamilyDefinition<?, ?>> columnFamilyDefinitions
-        = dbDef.getColumnFamilies();
+        = OMDBDefinition.getInstance().getColumnFamilies();
     final int countOmDefTables = columnFamilyDefinitions.size();
     ArrayList<String> missingDBDefTables = new ArrayList<>();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
@@ -48,7 +48,7 @@ public class TestOMDBDefinition {
 
     // Get list of tables from DB Definitions
     final Collection<DBColumnFamilyDefinition<?, ?>> columnFamilyDefinitions
-        = OMDBDefinition.getInstance().getColumnFamilies();
+        = OMDBDefinition.get().getColumnFamilies();
     final int countOmDefTables = columnFamilyDefinitions.size();
     ArrayList<String> missingDBDefTables = new ArrayList<>();
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -49,7 +49,7 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
   private OMMetadataManager omMetadataManager;
   private List<OMDBUpdateEvent> omdbUpdateEvents = new ArrayList<>();
   private Map<String, Map<Object, OMDBUpdateEvent>> omdbLatestUpdateEvents = new HashMap<>();
-  private final OMDBDefinition omdbDefinition = OMDBDefinition.getInstance();
+  private final OMDBDefinition omdbDefinition = OMDBDefinition.get();
   private final OmUpdateEventValidator omUpdateEventValidator = new OmUpdateEventValidator(omdbDefinition);
 
   public OMDBUpdatesHandler(OMMetadataManager metadataManager) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -49,14 +49,12 @@ public class OMDBUpdatesHandler extends ManagedWriteBatch.Handler {
   private OMMetadataManager omMetadataManager;
   private List<OMDBUpdateEvent> omdbUpdateEvents = new ArrayList<>();
   private Map<String, Map<Object, OMDBUpdateEvent>> omdbLatestUpdateEvents = new HashMap<>();
-  private OMDBDefinition omdbDefinition;
-  private OmUpdateEventValidator omUpdateEventValidator;
+  private final OMDBDefinition omdbDefinition = OMDBDefinition.getInstance();
+  private final OmUpdateEventValidator omUpdateEventValidator = new OmUpdateEventValidator(omdbDefinition);
 
   public OMDBUpdatesHandler(OMMetadataManager metadataManager) {
     omMetadataManager = metadataManager;
     tablesNames = metadataManager.getStore().getTableNames();
-    omdbDefinition = new OMDBDefinition();
-    omUpdateEventValidator = new OmUpdateEventValidator(omdbDefinition);
   }
 
   @Override

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -68,7 +68,7 @@ public class TestOMDBUpdatesHandler {
 
   private OMMetadataManager omMetadataManager;
   private OMMetadataManager reconOmMetadataManager;
-  private final OMDBDefinition omdbDefinition = OMDBDefinition.getInstance();
+  private final OMDBDefinition omdbDefinition = OMDBDefinition.get();
   private Random random = new Random();
 
   private OzoneConfiguration createNewTestPath(String folderName)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -68,7 +68,7 @@ public class TestOMDBUpdatesHandler {
 
   private OMMetadataManager omMetadataManager;
   private OMMetadataManager reconOmMetadataManager;
-  private OMDBDefinition omdbDefinition = new OMDBDefinition();
+  private final OMDBDefinition omdbDefinition = OMDBDefinition.getInstance();
   private Random random = new Random();
 
   private OzoneConfiguration createNewTestPath(String folderName)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.times;
 public class TestOmUpdateEventValidator {
 
   private OmUpdateEventValidator eventValidator;
-  private OMDBDefinition omdbDefinition;
+  private final OMDBDefinition omdbDefinition = OMDBDefinition.getInstance();
   private OMMetadataManager omMetadataManager;
   private Logger logger;
   @TempDir
@@ -63,11 +63,10 @@ public class TestOmUpdateEventValidator {
   public void setUp() throws IOException {
     omMetadataManager = initializeNewOmMetadataManager(
         temporaryFolder.toFile());
-    omdbDefinition = new OMDBDefinition();
     eventValidator = new OmUpdateEventValidator(omdbDefinition);
     // Create a mock logger
     logger = mock(Logger.class);
-    eventValidator.setLogger(logger);
+    OmUpdateEventValidator.setLogger(logger);
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmUpdateEventValidator.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.times;
 public class TestOmUpdateEventValidator {
 
   private OmUpdateEventValidator eventValidator;
-  private final OMDBDefinition omdbDefinition = OMDBDefinition.getInstance();
+  private final OMDBDefinition omdbDefinition = OMDBDefinition.get();
   private OMMetadataManager omMetadataManager;
   private Logger logger;
   @TempDir

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
@@ -54,11 +54,8 @@ public final class DBDefinitionFactory {
 
   static {
     dbMap = new HashMap<>();
-    Arrays.asList(
-      new SCMDBDefinition(),
-        new OMDBDefinition(),
-        new ReconSCMDBDefinition()
-    ).forEach(dbDefinition -> dbMap.put(dbDefinition.getName(), dbDefinition));
+    Arrays.asList(new SCMDBDefinition(), OMDBDefinition.getInstance(), new ReconSCMDBDefinition())
+        .forEach(dbDefinition -> dbMap.put(dbDefinition.getName(), dbDefinition));
   }
 
   public static DBDefinition getDefinition(String dbName) {
@@ -102,7 +99,7 @@ public final class DBDefinitionFactory {
     if (dbName.startsWith(RECON_CONTAINER_KEY_DB)) {
       return new ReconDBDefinition(dbName);
     } else if (dbName.startsWith(RECON_OM_SNAPSHOT_DB)) {
-      return new OMDBDefinition();
+      return OMDBDefinition.getInstance();
     }
     return null;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
@@ -67,7 +67,7 @@ public final class DBDefinitionFactory {
       dbName = OM_DB_NAME;
     }
     final DBDefinition definition = DB_MAP.get(dbName);
-    return definition != null? definition : getReconDBDefinition(dbName);
+    return definition != null ? definition : getReconDBDefinition(dbName);
   }
 
   public static DBDefinition getDefinition(Path dbPath,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
@@ -20,7 +20,10 @@ package org.apache.hadoop.ozone.debug;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
@@ -48,14 +51,14 @@ public final class DBDefinitionFactory {
   private DBDefinitionFactory() {
   }
 
-  private static HashMap<String, DBDefinition> dbMap;
-
-  private static String dnDBSchemaVersion;
+  private static final AtomicReference<String> DATANODE_DB_SCHEMA_VERSION = new AtomicReference<>();
+  private static final Map<String, DBDefinition> DB_MAP;
 
   static {
-    dbMap = new HashMap<>();
-    Arrays.asList(new SCMDBDefinition(), OMDBDefinition.getInstance(), new ReconSCMDBDefinition())
-        .forEach(dbDefinition -> dbMap.put(dbDefinition.getName(), dbDefinition));
+    final Map<String, DBDefinition> map = new HashMap<>();
+    Arrays.asList(new SCMDBDefinition(), OMDBDefinition.get(), new ReconSCMDBDefinition())
+        .forEach(dbDefinition -> map.put(dbDefinition.getName(), dbDefinition));
+    DB_MAP = Collections.unmodifiableMap(map);
   }
 
   public static DBDefinition getDefinition(String dbName) {
@@ -63,10 +66,8 @@ public final class DBDefinitionFactory {
     if (!dbName.equals(OM_DB_NAME) && dbName.startsWith(OM_DB_NAME)) {
       dbName = OM_DB_NAME;
     }
-    if (dbMap.containsKey(dbName)) {
-      return dbMap.get(dbName);
-    }
-    return getReconDBDefinition(dbName);
+    final DBDefinition definition = DB_MAP.get(dbName);
+    return definition != null? definition : getReconDBDefinition(dbName);
   }
 
   public static DBDefinition getDefinition(Path dbPath,
@@ -80,7 +81,7 @@ public final class DBDefinitionFactory {
     }
     String dbName = fileName.toString();
     if (dbName.endsWith(OzoneConsts.CONTAINER_DB_SUFFIX)) {
-      switch (dnDBSchemaVersion) {
+      switch (DATANODE_DB_SCHEMA_VERSION.get()) {
       case "V1":
         return new DatanodeSchemaOneDBDefinition(
             dbPath.toAbsolutePath().toString(), config);
@@ -99,12 +100,12 @@ public final class DBDefinitionFactory {
     if (dbName.startsWith(RECON_CONTAINER_KEY_DB)) {
       return new ReconDBDefinition(dbName);
     } else if (dbName.startsWith(RECON_OM_SNAPSHOT_DB)) {
-      return OMDBDefinition.getInstance();
+      return OMDBDefinition.get();
     }
     return null;
   }
 
   public static void setDnDBSchemaVersion(String dnDBSchemaVersion) {
-    DBDefinitionFactory.dnDBSchemaVersion = dnDBSchemaVersion;
+    DATANODE_DB_SCHEMA_VERSION.set(dnDBSchemaVersion);
   }
 }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestDBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestDBDefinitionFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.debug;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -43,8 +44,7 @@ public class TestDBDefinitionFactory {
 
   @Test
   public void testGetDefinition() {
-    DBDefinition definition =
-        DBDefinitionFactory.getDefinition(new OMDBDefinition().getName());
+    DBDefinition definition = DBDefinitionFactory.getDefinition(OMDBDefinition.getInstance().getName());
     assertInstanceOf(OMDBDefinition.class, definition);
 
     definition = DBDefinitionFactory.getDefinition(
@@ -62,20 +62,18 @@ public class TestDBDefinitionFactory {
     definition = DBDefinitionFactory.getDefinition(
         RECON_CONTAINER_KEY_DB + "_1");
     assertInstanceOf(ReconDBDefinition.class, definition);
+
     DBDefinitionFactory.setDnDBSchemaVersion("V2");
-    definition =
-        DBDefinitionFactory.getDefinition(Paths.get("/tmp/test-container.db"),
-            new OzoneConfiguration());
+    final Path dbPath = Paths.get("/tmp/test-container.db");
+    definition = DBDefinitionFactory.getDefinition(dbPath, new OzoneConfiguration());
     assertInstanceOf(DatanodeSchemaTwoDBDefinition.class, definition);
+
     DBDefinitionFactory.setDnDBSchemaVersion("V1");
-    definition =
-        DBDefinitionFactory.getDefinition(Paths.get("/tmp/test-container.db"),
-            new OzoneConfiguration());
+    definition = DBDefinitionFactory.getDefinition(dbPath, new OzoneConfiguration());
     assertInstanceOf(DatanodeSchemaOneDBDefinition.class, definition);
+
     DBDefinitionFactory.setDnDBSchemaVersion("V3");
-    definition =
-        DBDefinitionFactory.getDefinition(Paths.get("/tmp/test-container.db"),
-            new OzoneConfiguration());
+    definition = DBDefinitionFactory.getDefinition(dbPath, new OzoneConfiguration());
     assertInstanceOf(DatanodeSchemaThreeDBDefinition.class, definition);
   }
 }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestDBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestDBDefinitionFactory.java
@@ -44,7 +44,7 @@ public class TestDBDefinitionFactory {
 
   @Test
   public void testGetDefinition() {
-    DBDefinition definition = DBDefinitionFactory.getDefinition(OMDBDefinition.getInstance().getName());
+    DBDefinition definition = DBDefinitionFactory.getDefinition(OMDBDefinition.get().getName());
     assertInstanceOf(OMDBDefinition.class, definition);
 
     definition = DBDefinitionFactory.getDefinition(
@@ -65,15 +65,16 @@ public class TestDBDefinitionFactory {
 
     DBDefinitionFactory.setDnDBSchemaVersion("V2");
     final Path dbPath = Paths.get("/tmp/test-container.db");
-    definition = DBDefinitionFactory.getDefinition(dbPath, new OzoneConfiguration());
+    final OzoneConfiguration conf = new OzoneConfiguration();
+    definition = DBDefinitionFactory.getDefinition(dbPath, conf);
     assertInstanceOf(DatanodeSchemaTwoDBDefinition.class, definition);
 
     DBDefinitionFactory.setDnDBSchemaVersion("V1");
-    definition = DBDefinitionFactory.getDefinition(dbPath, new OzoneConfiguration());
+    definition = DBDefinitionFactory.getDefinition(dbPath, conf);
     assertInstanceOf(DatanodeSchemaOneDBDefinition.class, definition);
 
     DBDefinitionFactory.setDnDBSchemaVersion("V3");
-    definition = DBDefinitionFactory.getDefinition(dbPath, new OzoneConfiguration());
+    definition = DBDefinitionFactory.getDefinition(dbPath, conf);
     assertInstanceOf(DatanodeSchemaThreeDBDefinition.class, definition);
   }
 }


### PR DESCRIPTION
## What is the link to the Apache JIRA

HDDS-11554

By definition, OMDBDefinition won't be changed.  It should be a singleton.

## How was this patch tested?

Updating existing tests.