### PR TITLE
HDDS-11551. Provide details about integration check failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,7 +549,11 @@ jobs:
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
       - name: Summary of failures
-        run: hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
+        run: |
+          if [[ -s "target/${{ github.job }}/summary.md" ]]; then
+            cat target/${{ github.job }}/summary.md >> $GITHUB_STEP_SUMMARY
+          fi
+          hadoop-ozone/dev-support/checks/_summary.sh target/${{ github.job }}/summary.txt
         if: ${{ !cancelled() }}
       - name: Archive build results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What changes were proposed in this pull request?

Even if all tests pass, integration check may fail if it detects a leak (HDDS-8261).  Tests may also crash.

With this change, CI will list failed, crashed and leaking integration tests separately to help understand CI results ([example](https://github.com/adoroszlai/ozone/actions/runs/11261798708/attempts/1#summary-31316050194)).

https://issues.apache.org/jira/browse/HDDS-11551

## How was this patch tested?

Temporarily added a test with failure and enabled a test with leak.

CI:
https://github.com/adoroszlai/ozone/actions/runs/11261977076