### PR TITLE
HDDS-11556. Add a getTypeClass method to Codec.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -74,7 +74,8 @@ public class DatanodeDetails extends NodeImpl implements
   private static final Codec<DatanodeDetails> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(ExtendedDatanodeDetailsProto.getDefaultInstance()),
       DatanodeDetails::getFromProtoBuf,
-      DatanodeDetails::getExtendedProtoBufMessage);
+      DatanodeDetails::getExtendedProtoBufMessage,
+      DatanodeDetails.class);
 
   public static Codec<DatanodeDetails> getCodec() {
     return CODEC;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerID.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdds.utils.db.LongCodec;
 public final class ContainerID implements Comparable<ContainerID> {
   private static final Codec<ContainerID> CODEC = new DelegatedCodec<>(
       LongCodec.get(), ContainerID::valueOf, c -> c.id,
-      DelegatedCodec.CopyType.SHALLOW);
+      ContainerID.class, DelegatedCodec.CopyType.SHALLOW);
 
   public static final ContainerID MIN = ContainerID.valueOf(0);
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -46,7 +46,8 @@ public final class ContainerInfo implements Comparable<ContainerInfo> {
   private static final Codec<ContainerInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(HddsProtos.ContainerInfoProto.getDefaultInstance()),
       ContainerInfo::fromProtobuf,
-      ContainerInfo::getProtobuf);
+      ContainerInfo::getProtobuf,
+      ContainerInfo.class);
 
   public static Codec<ContainerInfo> getCodec() {
     return CODEC;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -68,6 +68,7 @@ public final class Pipeline {
       Proto2Codec.get(HddsProtos.Pipeline.getDefaultInstance()),
       Pipeline::getFromProtobufSetCreationTimestamp,
       p -> p.getProtobufMessage(ClientVersion.CURRENT_VERSION),
+      Pipeline.class,
       DelegatedCodec.CopyType.UNSUPPORTED);
 
   public static Codec<Pipeline> getCodec() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 public final class PipelineID {
   private static final Codec<PipelineID> CODEC = new DelegatedCodec<>(
       UuidCodec.get(), PipelineID::valueOf, c -> c.id,
-      DelegatedCodec.CopyType.SHALLOW);
+      PipelineID.class, DelegatedCodec.CopyType.SHALLOW);
 
   public static Codec<PipelineID> getCodec() {
     return CODEC;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/BooleanCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/BooleanCodec.java
@@ -37,6 +37,11 @@ public final class BooleanCodec implements Codec<Boolean> {
   }
 
   @Override
+  public Class<Boolean> getTypeClass() {
+    return Boolean.class;
+  }
+
+  @Override
   public boolean supportCodecBuffer() {
     return true;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -30,6 +30,9 @@ import java.io.IOException;
 public interface Codec<T> {
   byte[] EMPTY_BYTE_ARRAY = {};
 
+  /** @return the class of the {@link T}. */
+  Class<T> getTypeClass();
+
   /**
    * Does this {@link Codec} support the {@link CodecBuffer} methods?
    * If this method returns true, this class must implement both

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DelegatedCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DelegatedCodec.java
@@ -47,6 +47,7 @@ public class DelegatedCodec<T, DELEGATE> implements Codec<T> {
   private final Codec<DELEGATE> delegate;
   private final CheckedFunction<DELEGATE, T, IOException> forward;
   private final CheckedFunction<T, DELEGATE, IOException> backward;
+  private final Class<T> clazz;
   private final CopyType copyType;
 
   /**
@@ -60,18 +61,25 @@ public class DelegatedCodec<T, DELEGATE> implements Codec<T> {
   public DelegatedCodec(Codec<DELEGATE> delegate,
       CheckedFunction<DELEGATE, T, IOException> forward,
       CheckedFunction<T, DELEGATE, IOException> backward,
-      CopyType copyType) {
+      Class<T> clazz, CopyType copyType) {
     this.delegate = delegate;
     this.forward = forward;
     this.backward = backward;
+    this.clazz = clazz;
     this.copyType = copyType;
   }
 
   /** The same as new DelegatedCodec(delegate, forward, backward, DEEP). */
   public DelegatedCodec(Codec<DELEGATE> delegate,
       CheckedFunction<DELEGATE, T, IOException> forward,
-      CheckedFunction<T, DELEGATE, IOException> backward) {
-    this(delegate, forward, backward, CopyType.DEEP);
+      CheckedFunction<T, DELEGATE, IOException> backward,
+      Class<T> clazz) {
+    this(delegate, forward, backward, clazz, CopyType.DEEP);
+  }
+
+  @Override
+  public Class<T> getTypeClass() {
+    return clazz;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
@@ -37,6 +37,11 @@ public final class IntegerCodec implements Codec<Integer> {
   }
 
   @Override
+  public Class<Integer> getTypeClass() {
+    return Integer.class;
+  }
+
+  @Override
   public boolean supportCodecBuffer() {
     return true;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
@@ -34,6 +34,11 @@ public final class LongCodec implements Codec<Long> {
   private LongCodec() { }
 
   @Override
+  public Class<Long> getTypeClass() {
+    return Long.class;
+  }
+
+  @Override
   public boolean supportCodecBuffer() {
     return true;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto2Codec.java
@@ -47,10 +47,17 @@ public final class Proto2Codec<M extends MessageLite>
     return (Codec<T>) codec;
   }
 
+  private final Class<M> clazz;
   private final Parser<M> parser;
 
   private Proto2Codec(M m) {
+    this.clazz = (Class<M>) m.getClass();
     this.parser = (Parser<M>) m.getParserForType();
+  }
+
+  @Override
+  public Class<M> getTypeClass() {
+    return clazz;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto3Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Proto3Codec.java
@@ -47,10 +47,17 @@ public final class Proto3Codec<M extends MessageLite>
     return (Codec<T>) codec;
   }
 
+  private final Class<M> clazz;
   private final Parser<M> parser;
 
   private Proto3Codec(M m) {
+    this.clazz = (Class<M>) m.getClass();
     this.parser = (Parser<M>) m.getParserForType();
+  }
+
+  @Override
+  public Class<M> getTypeClass() {
+    return clazz;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ShortCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ShortCodec.java
@@ -38,6 +38,11 @@ public final class ShortCodec implements Codec<Short> {
   }
 
   @Override
+  public Class<Short> getTypeClass() {
+    return Short.class;
+  }
+
+  @Override
   public boolean supportCodecBuffer() {
     return true;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodecBase.java
@@ -59,6 +59,11 @@ abstract class StringCodecBase implements Codec<String> {
     this.fixedLength = max == encoder.averageBytesPerChar();
   }
 
+  @Override
+  public final Class<String> getTypeClass() {
+    return String.class;
+  }
+
   CharsetEncoder newEncoder() {
     return charset.newEncoder()
         .onMalformedInput(CodingErrorAction.REPORT)

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/UuidCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/UuidCodec.java
@@ -41,6 +41,11 @@ public final class UuidCodec implements Codec<UUID> {
   private UuidCodec() { }
 
   @Override
+  public Class<UUID> getTypeClass() {
+    return UUID.class;
+  }
+
+  @Override
   public boolean supportCodecBuffer() {
     return true;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockData.java
@@ -39,7 +39,8 @@ public class BlockData {
   private static final Codec<BlockData> CODEC = new DelegatedCodec<>(
       Proto3Codec.get(ContainerProtos.BlockData.getDefaultInstance()),
       BlockData::getFromProtoBuf,
-      BlockData::getProtoBufMessage);
+      BlockData::getProtoBufMessage,
+      BlockData.class);
 
   public static Codec<BlockData> getCodec() {
     return CODEC;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfoList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfoList.java
@@ -36,6 +36,7 @@ public class ChunkInfoList {
       Proto3Codec.get(ContainerProtos.ChunkInfoList.getDefaultInstance()),
       ChunkInfoList::getFromProtoBuf,
       ChunkInfoList::getProtoBufMessage,
+      ChunkInfoList.class,
       DelegatedCodec.CopyType.SHALLOW);
 
   public static Codec<ChunkInfoList> getCodec() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneChunkInfoListCodec.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneChunkInfoListCodec.java
@@ -58,6 +58,11 @@ public final class SchemaOneChunkInfoListCodec implements Codec<ChunkInfoList> {
   }
 
   @Override
+  public Class<ChunkInfoList> getTypeClass() {
+    return ChunkInfoList.class;
+  }
+
+  @Override
   public byte[] toPersistedFormat(ChunkInfoList chunkList) {
     return chunkList.getProtoBufMessage().toByteArray();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneKeyCodec.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneKeyCodec.java
@@ -49,6 +49,11 @@ public final class SchemaOneKeyCodec implements Codec<String> {
   }
 
   @Override
+  public Class<String> getTypeClass() {
+    return String.class;
+  }
+
+  @Override
   public byte[] toPersistedFormat(String stringObject) throws IOException {
     try {
       // If the caller's string has no prefix, it should be stored as a long

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/MoveDataNodePair.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/MoveDataNodePair.java
@@ -36,6 +36,7 @@ public class MoveDataNodePair {
       Proto2Codec.get(MoveDataNodePairProto.getDefaultInstance()),
       MoveDataNodePair::getFromProtobuf,
       pair -> pair.getProtobufMessage(ClientVersion.CURRENT_VERSION),
+      MoveDataNodePair.class,
       DelegatedCodec.CopyType.SHALLOW);
 
   public static Codec<MoveDataNodePair> getCodec() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
@@ -39,7 +39,8 @@ public final class CertInfo implements Comparable<CertInfo>, Serializable {
   private static final Codec<CertInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(CertInfoProto.getDefaultInstance()),
       CertInfo::fromProtobuf,
-      CertInfo::getProtobuf);
+      CertInfo::getProtobuf,
+      CertInfo.class);
 
   public static Codec<CertInfo> getCodec() {
     return CODEC;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/TransactionInfo.java
@@ -45,6 +45,7 @@ public final class TransactionInfo implements Comparable<TransactionInfo> {
       StringCodec.get(),
       TransactionInfo::valueOf,
       TransactionInfo::toString,
+      TransactionInfo.class,
       DelegatedCodec.CopyType.SHALLOW);
 
   public static Codec<TransactionInfo> getCodec() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
@@ -34,6 +34,11 @@ public final class ByteArrayCodec implements Codec<byte[]> {
   }
 
   @Override
+  public Class<byte[]> getTypeClass() {
+    return byte[].class;
+  }
+
+  @Override
   public byte[] toPersistedFormat(byte[] bytes) {
     return bytes;
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/ByteStringCodec.java
@@ -35,6 +35,11 @@ public final class ByteStringCodec implements Codec<ByteString> {
   private ByteStringCodec() { }
 
   @Override
+  public Class<ByteString> getTypeClass() {
+    return ByteString.class;
+  }
+
+  @Override
   public boolean supportCodecBuffer() {
     return true;
   }

--- a/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/src/main/java/org/apache/ozone/compaction/log/CompactionLogEntry.java
@@ -38,7 +38,8 @@ public final class CompactionLogEntry implements
   private static final Codec<CompactionLogEntry> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(CompactionLogEntryProto.getDefaultInstance()),
       CompactionLogEntry::getFromProtobuf,
-      CompactionLogEntry::getProtobuf);
+      CompactionLogEntry::getProtobuf,
+      CompactionLogEntry.class);
 
   public static Codec<CompactionLogEntry> getCodec() {
     return CODEC;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/BigIntegerCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/BigIntegerCodec.java
@@ -39,6 +39,11 @@ public final class BigIntegerCodec implements Codec<BigInteger> {
   }
 
   @Override
+  public Class<BigInteger> getTypeClass() {
+    return BigInteger.class;
+  }
+
+  @Override
   public byte[] toPersistedFormat(BigInteger object) throws IOException {
     return object.toByteArray();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/X509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/X509CertificateCodec.java
@@ -52,6 +52,11 @@ public final class X509CertificateCodec implements Codec<X509Certificate> {
   }
 
   @Override
+  public Class<X509Certificate> getTypeClass() {
+    return X509Certificate.class;
+  }
+
+  @Override
   public boolean supportCodecBuffer() {
     return true;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/OldPipelineIDCodecForTesting.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/OldPipelineIDCodecForTesting.java
@@ -30,6 +30,10 @@ import org.apache.hadoop.hdds.utils.db.Codec;
  * Codec to serialize / deserialize PipelineID.
  */
 public class OldPipelineIDCodecForTesting implements Codec<PipelineID> {
+  @Override
+  public Class<PipelineID> getTypeClass() {
+    return PipelineID.class;
+  }
 
   @Override
   public byte[] toPersistedFormat(PipelineID object) throws IOException {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/OldX509CertificateCodecForTesting.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/OldX509CertificateCodecForTesting.java
@@ -46,6 +46,11 @@ public final class OldX509CertificateCodecForTesting
   }
 
   @Override
+  public Class<X509Certificate> getTypeClass() {
+    return X509Certificate.class;
+  }
+
+  @Override
   public byte[] toPersistedFormat(X509Certificate object) throws IOException {
     try {
       return CertificateCodec.getPEMEncodedString(object)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -48,7 +48,8 @@ public final class OmBucketInfo extends WithObjectID implements Auditable, CopyO
   private static final Codec<OmBucketInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(BucketInfo.getDefaultInstance()),
       OmBucketInfo::getFromProtobuf,
-      OmBucketInfo::getProtobuf);
+      OmBucketInfo::getProtobuf,
+      OmBucketInfo.class);
 
   public static Codec<OmBucketInfo> getCodec() {
     return CODEC;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -34,6 +34,7 @@ public final class OmDBAccessIdInfo {
       Proto2Codec.get(ExtendedUserAccessIdInfo.getDefaultInstance()),
       OmDBAccessIdInfo::getFromProtobuf,
       OmDBAccessIdInfo::getProtobuf,
+      OmDBAccessIdInfo.class,
       DelegatedCodec.CopyType.SHALLOW);
 
   public static Codec<OmDBAccessIdInfo> getCodec() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -34,6 +34,7 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
       Proto2Codec.get(TenantState.getDefaultInstance()),
       OmDBTenantState::getFromProtobuf,
       OmDBTenantState::getProtobuf,
+      OmDBTenantState.class,
       DelegatedCodec.CopyType.SHALLOW);
 
   public static Codec<OmDBTenantState> getCodec() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
@@ -33,11 +33,11 @@ import java.util.Set;
  * principal.
  */
 public final class OmDBUserPrincipalInfo {
-  private static final Codec<OmDBUserPrincipalInfo> CODEC
-      = new DelegatedCodec<>(
-          Proto2Codec.get(TenantUserPrincipalInfo.getDefaultInstance()),
-          OmDBUserPrincipalInfo::getFromProtobuf,
-          OmDBUserPrincipalInfo::getProtobuf);
+  private static final Codec<OmDBUserPrincipalInfo> CODEC = new DelegatedCodec<>(
+      Proto2Codec.get(TenantUserPrincipalInfo.getDefaultInstance()),
+      OmDBUserPrincipalInfo::getFromProtobuf,
+      OmDBUserPrincipalInfo::getProtobuf,
+      OmDBUserPrincipalInfo.class);
 
   public static Codec<OmDBUserPrincipalInfo> getCodec() {
     return CODEC;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -40,7 +40,8 @@ public class OmDirectoryInfo extends WithParentObjectId
   private static final Codec<OmDirectoryInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(DirectoryInfo.getDefaultInstance()),
       OmDirectoryInfo::getFromProtobuf,
-      OmDirectoryInfo::getProtobuf);
+      OmDirectoryInfo::getProtobuf,
+      OmDirectoryInfo.class);
 
   public static Codec<OmDirectoryInfo> getCodec() {
     return CODEC;
@@ -219,7 +220,7 @@ public class OmDirectoryInfo extends WithParentObjectId
             .setCreationTime(dirInfo.getCreationTime())
             .setModificationTime(dirInfo.getModificationTime())
             .setAcls(OzoneAclUtil.fromProtobuf(dirInfo.getAclsList()));
-    if (dirInfo.getMetadataList() != null) {
+    if (  dirInfo.getMetadataList() != null) {
       opib.addAllMetadata(KeyValueUtil
               .getFromProtobuf(dirInfo.getMetadataList()));
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -220,7 +220,7 @@ public class OmDirectoryInfo extends WithParentObjectId
             .setCreationTime(dirInfo.getCreationTime())
             .setModificationTime(dirInfo.getModificationTime())
             .setAcls(OzoneAclUtil.fromProtobuf(dirInfo.getAclsList()));
-    if (  dirInfo.getMetadataList() != null) {
+    if (dirInfo.getMetadataList() != null) {
       opib.addAllMetadata(KeyValueUtil
               .getFromProtobuf(dirInfo.getMetadataList()));
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -65,7 +65,8 @@ public final class OmKeyInfo extends WithParentObjectId
     return new DelegatedCodec<>(
         Proto2Codec.get(KeyInfo.getDefaultInstance()),
         OmKeyInfo::getFromProtobuf,
-        k -> k.getProtobuf(ignorePipeline, ClientVersion.CURRENT_VERSION));
+        k -> k.getProtobuf(ignorePipeline, ClientVersion.CURRENT_VERSION),
+        OmKeyInfo.class);
   }
 
   public static Codec<OmKeyInfo> getCodec(boolean ignorePipeline) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
@@ -42,7 +42,8 @@ public final class OmMultipartKeyInfo extends WithObjectID implements CopyObject
   private static final Codec<OmMultipartKeyInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(MultipartKeyInfo.getDefaultInstance()),
       OmMultipartKeyInfo::getFromProto,
-      OmMultipartKeyInfo::getProto);
+      OmMultipartKeyInfo::getProto,
+      OmMultipartKeyInfo.class);
 
   public static Codec<OmMultipartKeyInfo> getCodec() {
     return CODEC;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
@@ -46,7 +46,8 @@ public final class OmVolumeArgs extends WithObjectID
   private static final Codec<OmVolumeArgs> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(VolumeInfo.getDefaultInstance()),
       OmVolumeArgs::getFromProtobuf,
-      OmVolumeArgs::getProtobuf);
+      OmVolumeArgs::getProtobuf,
+      OmVolumeArgs.class);
 
   public static Codec<OmVolumeArgs> getCodec() {
     return CODEC;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -47,7 +47,8 @@ public class RepeatedOmKeyInfo implements CopyObject<RepeatedOmKeyInfo> {
     return new DelegatedCodec<>(
         Proto2Codec.get(RepeatedKeyInfo.getDefaultInstance()),
         RepeatedOmKeyInfo::getFromProto,
-        k -> k.getProto(ignorePipeline, ClientVersion.CURRENT_VERSION));
+        k -> k.getProto(ignorePipeline, ClientVersion.CURRENT_VERSION),
+        RepeatedOmKeyInfo.class);
   }
 
   public static Codec<RepeatedOmKeyInfo> getCodec(boolean ignorePipeline) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
@@ -31,7 +31,8 @@ public final class S3SecretValue {
   private static final Codec<S3SecretValue> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(S3Secret.getDefaultInstance()),
       S3SecretValue::fromProtobuf,
-      S3SecretValue::getProtobuf);
+      S3SecretValue::getProtobuf,
+      S3SecretValue.class);
 
   public static Codec<S3SecretValue> getCodec() {
     return CODEC;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotDiffJob.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotDiffJob.java
@@ -262,6 +262,11 @@ public class SnapshotDiffJob {
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Override
+    public Class<SnapshotDiffJob> getTypeClass() {
+      return SnapshotDiffJob.class;
+    }
+
+    @Override
     public byte[] toPersistedFormat(SnapshotDiffJob object)
         throws IOException {
       return MAPPER.writeValueAsBytes(object);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/SnapshotInfo.java
@@ -56,10 +56,10 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
  */
 public final class SnapshotInfo implements Auditable, CopyObject<SnapshotInfo> {
   private static final Codec<SnapshotInfo> CODEC = new DelegatedCodec<>(
-      Proto2Codec.get(
-          OzoneManagerProtocolProtos.SnapshotInfo.getDefaultInstance()),
+      Proto2Codec.get(OzoneManagerProtocolProtos.SnapshotInfo.getDefaultInstance()),
       SnapshotInfo::getFromProtobuf,
-      SnapshotInfo::getProtobuf);
+      SnapshotInfo::getProtobuf,
+      SnapshotInfo.class);
 
   public static Codec<SnapshotInfo> getCodec() {
     return CODEC;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/snapshot/SnapshotDiffReportOzone.java
@@ -47,6 +47,7 @@ public class SnapshotDiffReportOzone
       Proto2Codec.get(DiffReportEntryProto.getDefaultInstance()),
       SnapshotDiffReportOzone::fromProtobufDiffReportEntry,
       SnapshotDiffReportOzone::toProtobufDiffReportEntry,
+      DiffReportEntry.class,
       DelegatedCodec.CopyType.SHALLOW);
 
   public static Codec<DiffReportEntry> getDiffReportEntryCodec() {

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
@@ -43,6 +43,11 @@ public final class TokenIdentifierCodec implements Codec<OzoneTokenIdentifier> {
   }
 
   @Override
+  public Class<OzoneTokenIdentifier> getTypeClass() {
+    return OzoneTokenIdentifier.class;
+  }
+
+  @Override
   public byte[] toPersistedFormat(OzoneTokenIdentifier object) {
     Preconditions
         .checkNotNull(object, "Null object can't be converted to byte array.");

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -42,7 +42,8 @@ public final class OmPrefixInfo extends WithObjectID implements CopyObject<OmPre
   private static final Codec<OmPrefixInfo> CODEC = new DelegatedCodec<>(
       Proto2Codec.get(PersistedPrefixInfo.getDefaultInstance()),
       OmPrefixInfo::getFromProtobuf,
-      OmPrefixInfo::getProtobuf);
+      OmPrefixInfo::getProtobuf,
+      OmPrefixInfo.class);
 
   public static Codec<OmPrefixInfo> getCodec() {
     return CODEC;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -50,7 +50,7 @@ import java.util.Map;
 /**
  * Class defines the structure and types of the om.db.
  */
-public final class OMDBDefinition extends DBDefinition.WithMap {
+public class OMDBDefinition extends DBDefinition.WithMap {
 
   public static final DBColumnFamilyDefinition<String, RepeatedOmKeyInfo>
             DELETED_TABLE =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -50,7 +50,7 @@ import java.util.Map;
 /**
  * Class defines the structure and types of the om.db.
  */
-public class OMDBDefinition extends DBDefinition.WithMap {
+public final class OMDBDefinition extends DBDefinition.WithMap {
 
   public static final DBColumnFamilyDefinition<String, RepeatedOmKeyInfo>
             DELETED_TABLE =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.S3SecretManager;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.S3SecretManager;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/codec/NSSummaryCodec.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/codec/NSSummaryCodec.java
@@ -59,6 +59,11 @@ public final class NSSummaryCodec implements Codec<NSSummary> {
   }
 
   @Override
+  public Class<NSSummary> getTypeClass() {
+    return NSSummary.class;
+  }
+
+  @Override
   public byte[] toPersistedFormat(NSSummary object) throws IOException {
     Set<Long> childDirs = object.getChildDir();
     String dirName = object.getDirName();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ContainerReplicaHistoryList.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ContainerReplicaHistoryList.java
@@ -34,11 +34,11 @@ import org.apache.hadoop.hdds.utils.db.Proto2Codec;
  * For Recon DB table definition.
  */
 public class ContainerReplicaHistoryList {
-  private static final Codec<ContainerReplicaHistoryList> CODEC
-      = new DelegatedCodec<>(Proto2Codec.get(
-      ContainerReplicaHistoryListProto.getDefaultInstance()),
+  private static final Codec<ContainerReplicaHistoryList> CODEC = new DelegatedCodec<>(
+      Proto2Codec.get(ContainerReplicaHistoryListProto.getDefaultInstance()),
       ContainerReplicaHistoryList::fromProto,
-      ContainerReplicaHistoryList::toProto);
+      ContainerReplicaHistoryList::toProto,
+      ContainerReplicaHistoryList.class);
 
   public static Codec<ContainerReplicaHistoryList> getCodec() {
     return CODEC;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSCMDBDefinition.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSCMDBDefinition.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 public class ReconSCMDBDefinition extends SCMDBDefinition {
   private static final Codec<UUID> UUID_CODEC = new DelegatedCodec<>(
       StringCodec.get(), UUID::fromString, UUID::toString,
-      DelegatedCodec.CopyType.SHALLOW);
+      UUID.class, DelegatedCodec.CopyType.SHALLOW);
 
   public static final String RECON_SCM_DB_NAME = "recon-scm.db";
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerKeyPrefixCodec.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerKeyPrefixCodec.java
@@ -18,9 +18,6 @@
 
 package org.apache.hadoop.ozone.recon.spi.impl;
 
-import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
-
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -30,6 +27,8 @@ import org.apache.hadoop.hdds.utils.db.Codec;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Codec to serialize/deserialize {@link ContainerKeyPrefix}.
@@ -51,8 +50,12 @@ public final class ContainerKeyPrefixCodec
   }
 
   @Override
-  public byte[] toPersistedFormat(ContainerKeyPrefix containerKeyPrefix)
-      throws IOException {
+  public Class<ContainerKeyPrefix> getTypeClass() {
+    return ContainerKeyPrefix.class;
+  }
+
+  @Override
+  public byte[] toPersistedFormat(ContainerKeyPrefix containerKeyPrefix) {
     Preconditions.checkNotNull(containerKeyPrefix,
             "Null object can't be converted to byte array.");
     byte[] containerIdBytes = Longs.toByteArray(containerKeyPrefix
@@ -76,9 +79,7 @@ public final class ContainerKeyPrefixCodec
   }
 
   @Override
-  public ContainerKeyPrefix fromPersistedFormat(byte[] rawData)
-      throws IOException {
-
+  public ContainerKeyPrefix fromPersistedFormat(byte[] rawData) {
     // First 8 bytes is the containerId.
     long containerIdFromDB = ByteBuffer.wrap(ArrayUtils.subarray(
         rawData, 0, Long.BYTES)).getLong();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/KeyPrefixContainerCodec.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/KeyPrefixContainerCodec.java
@@ -24,10 +24,9 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.ozone.recon.api.types.KeyPrefixContainer;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Codec to serialize/deserialize {@link KeyPrefixContainer}.
@@ -49,8 +48,12 @@ public final class KeyPrefixContainerCodec
   private static final String KEY_DELIMITER = "_";
 
   @Override
-  public byte[] toPersistedFormat(KeyPrefixContainer keyPrefixContainer)
-      throws IOException {
+  public Class<KeyPrefixContainer> getTypeClass() {
+    return KeyPrefixContainer.class;
+  }
+
+  @Override
+  public byte[] toPersistedFormat(KeyPrefixContainer keyPrefixContainer) {
     Preconditions.checkNotNull(keyPrefixContainer,
             "Null object can't be converted to byte array.");
     byte[] keyPrefixBytes = keyPrefixContainer.getKeyPrefix().getBytes(UTF_8);
@@ -75,9 +78,7 @@ public final class KeyPrefixContainerCodec
   }
 
   @Override
-  public KeyPrefixContainer fromPersistedFormat(byte[] rawData)
-      throws IOException {
-
+  public KeyPrefixContainer fromPersistedFormat(byte[] rawData) {
     // When reading from byte[], we can always expect to have the key, version
     // and version parts in the byte array.
     byte[] keyBytes = ArrayUtils.subarray(rawData,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
@@ -48,7 +48,7 @@ public final class DBDefinitionFactory {
   private DBDefinitionFactory() {
   }
 
-  private static final HashMap<String, DBDefinition> dbMap;
+  private static HashMap<String, DBDefinition> dbMap;
 
   private static String dnDBSchemaVersion;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
@@ -48,7 +48,7 @@ public final class DBDefinitionFactory {
   private DBDefinitionFactory() {
   }
 
-  private static HashMap<String, DBDefinition> dbMap;
+  private static final HashMap<String, DBDefinition> dbMap;
 
   private static String dnDBSchemaVersion;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Each Codec<T> corresponds to a specific type T.   It is useful to add the following method to Codec.  Then, the DB definition code be simplified; see HDDS-11557.
```java
  /** @return the class of the {@link T}. */
  Class<T> getTypeClass();
```

## What is the link to the Apache JIRA

HDDS-11556

## How was this patch tested?

By existing tests.