### PR TITLE
HDDS-11519. Clean up unused lines in BlockOutputStream

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -274,16 +274,6 @@ public class BlockInputStream extends BlockExtendedInputStream {
           blockID);
     }
 
-    DatanodeBlockID.Builder blkIDBuilder =
-        DatanodeBlockID.newBuilder().setContainerID(blockID.getContainerID())
-            .setLocalID(blockID.getLocalID())
-            .setBlockCommitSequenceId(blockID.getBlockCommitSequenceId());
-
-    int replicaIndex = pipeline.getReplicaIndex(pipeline.getClosestNode());
-    if (replicaIndex > 0) {
-      blkIDBuilder.setReplicaIndex(replicaIndex);
-    }
-
     GetBlockResponseProto response = ContainerProtocolCalls.getBlock(
         xceiverClient, VALIDATORS, blockID, tokenRef.get(), pipeline.getReplicaIndexes());
     return response.getBlockData();


### PR DESCRIPTION
Please describe your PR in detail:
The variables `blkIDBuilder` and `replicaIndex` are not used anymore in this method.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11519

## How was this patch tested?

CI
https://github.com/Haser0305/ozone/actions/runs/11257303613
