### PR TITLE
HDDS-11557. Simplify DBColumnFamilyDefinition.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -51,27 +51,21 @@ public class DatanodeSchemaOneDBDefinition
       BLOCK_DATA =
       new DBColumnFamilyDefinition<>(
           StringUtils.bytes2String(DEFAULT_COLUMN_FAMILY),
-          String.class,
           SchemaOneKeyCodec.get(),
-          BlockData.class,
           BlockData.getCodec());
 
   public static final DBColumnFamilyDefinition<String, Long>
         METADATA =
         new DBColumnFamilyDefinition<>(
             StringUtils.bytes2String(DEFAULT_COLUMN_FAMILY),
-            String.class,
             SchemaOneKeyCodec.get(),
-            Long.class,
             LongCodec.get());
 
   public static final DBColumnFamilyDefinition<String, ChunkInfoList>
         DELETED_BLOCKS =
         new DBColumnFamilyDefinition<>(
             StringUtils.bytes2String(DEFAULT_COLUMN_FAMILY),
-            String.class,
             SchemaOneKeyCodec.get(),
-            ChunkInfoList.class,
             SchemaOneChunkInfoListCodec.get());
 
   private static final Map<String, List<DBColumnFamilyDefinition<?, ?>>>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaThreeDBDefinition.java
@@ -59,45 +59,35 @@ public class DatanodeSchemaThreeDBDefinition
       BLOCK_DATA =
       new DBColumnFamilyDefinition<>(
           "block_data",
-          String.class,
           FixedLengthStringCodec.get(),
-          BlockData.class,
           BlockData.getCodec());
 
   public static final DBColumnFamilyDefinition<String, Long>
       METADATA =
       new DBColumnFamilyDefinition<>(
           "metadata",
-          String.class,
           FixedLengthStringCodec.get(),
-          Long.class,
           LongCodec.get());
 
   public static final DBColumnFamilyDefinition<String, DeletedBlocksTransaction>
       DELETE_TRANSACTION =
       new DBColumnFamilyDefinition<>(
           "delete_txns",
-          String.class,
           FixedLengthStringCodec.get(),
-          DeletedBlocksTransaction.class,
           Proto2Codec.get(DeletedBlocksTransaction.getDefaultInstance()));
 
   public static final DBColumnFamilyDefinition<String, Long>
       FINALIZE_BLOCKS =
       new DBColumnFamilyDefinition<>(
           "finalize_blocks",
-          String.class,
           FixedLengthStringCodec.get(),
-          Long.class,
           LongCodec.get());
 
   public static final DBColumnFamilyDefinition<String, BlockData>
       LAST_CHUNK_INFO =
       new DBColumnFamilyDefinition<>(
           "last_chunk_info",
-          String.class,
           FixedLengthStringCodec.get(),
-          BlockData.class,
           BlockData.getCodec());
 
   private static String separator = "";

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.hdds.utils.db.FixedLengthStringCodec;
@@ -44,45 +43,35 @@ public class DatanodeSchemaTwoDBDefinition
           BLOCK_DATA =
           new DBColumnFamilyDefinition<>(
                   "block_data",
-                  String.class,
                   StringCodec.get(),
-                  BlockData.class,
                   BlockData.getCodec());
 
   public static final DBColumnFamilyDefinition<String, Long>
           METADATA =
           new DBColumnFamilyDefinition<>(
           "metadata",
-          String.class,
           StringCodec.get(),
-          Long.class,
           LongCodec.get());
 
   public static final DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
       DELETE_TRANSACTION =
       new DBColumnFamilyDefinition<>(
           "delete_txns",
-          Long.class,
           LongCodec.get(),
-          StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction.class,
           Proto2Codec.get(DeletedBlocksTransaction.getDefaultInstance()));
 
   public static final DBColumnFamilyDefinition<String, Long>
       FINALIZE_BLOCKS =
       new DBColumnFamilyDefinition<>(
           "finalize_blocks",
-          String.class,
           FixedLengthStringCodec.get(),
-          Long.class,
           LongCodec.get());
 
   public static final DBColumnFamilyDefinition<String, BlockData>
       LAST_CHUNK_INFO =
       new DBColumnFamilyDefinition<>(
           "last_chunk_info",
-          String.class,
           FixedLengthStringCodec.get(),
-          BlockData.class,
           BlockData.getCodec());
 
   public DatanodeSchemaTwoDBDefinition(String dbPath,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBColumnFamilyDefinition.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBColumnFamilyDefinition.java
@@ -54,32 +54,21 @@ public class DBColumnFamilyDefinition<KEY, VALUE> {
 
   private final String tableName;
 
-  private final Class<KEY> keyType;
-
   private final Codec<KEY> keyCodec;
-
-  private final Class<VALUE> valueType;
 
   private final Codec<VALUE> valueCodec;
 
-  private ManagedColumnFamilyOptions cfOptions;
+  private volatile ManagedColumnFamilyOptions cfOptions;
 
-  public DBColumnFamilyDefinition(
-      String tableName,
-      Class<KEY> keyType,
-      Codec<KEY> keyCodec,
-      Class<VALUE> valueType,
-      Codec<VALUE> valueCodec) {
+  public DBColumnFamilyDefinition(String tableName, Codec<KEY> keyCodec, Codec<VALUE> valueCodec) {
     this.tableName = tableName;
-    this.keyType = keyType;
     this.keyCodec = keyCodec;
-    this.valueType = valueType;
     this.valueCodec = valueCodec;
     this.cfOptions = null;
   }
 
   public Table<KEY, VALUE> getTable(DBStore db) throws IOException {
-    return db.getTable(tableName, keyType, valueType);
+    return db.getTable(tableName, getKeyType(), getValueType());
   }
 
   public String getName() {
@@ -87,7 +76,7 @@ public class DBColumnFamilyDefinition<KEY, VALUE> {
   }
 
   public Class<KEY> getKeyType() {
-    return keyType;
+    return keyCodec.getTypeClass();
   }
 
   public Codec<KEY> getKeyCodec() {
@@ -95,7 +84,7 @@ public class DBColumnFamilyDefinition<KEY, VALUE> {
   }
 
   public Class<VALUE> getValueType() {
-    return valueType;
+    return valueCodec.getTypeClass();
   }
 
   public Codec<VALUE> getValueCodec() {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestDBStoreBuilder.java
@@ -179,7 +179,7 @@ public class TestDBStoreBuilder {
     String sampleTableName = "sampleTable";
     final DBColumnFamilyDefinition<String, Long> sampleTable =
         new DBColumnFamilyDefinition<>(sampleTableName,
-            String.class, StringCodec.get(), Long.class, LongCodec.get());
+            StringCodec.get(), LongCodec.get());
     final DBDefinition sampleDB = new DBDefinition.WithMap(
         DBColumnFamilyDefinition.newUnmodifiableMap(sampleTable)) {
       {
@@ -250,8 +250,8 @@ public class TestDBStoreBuilder {
 
     String sampleTableName = "sampleTable";
     final DBColumnFamilyDefinition<String, Long> sampleTable =
-        new DBColumnFamilyDefinition<>(sampleTableName, String.class,
-            StringCodec.get(), Long.class, LongCodec.get());
+        new DBColumnFamilyDefinition<>(sampleTableName,
+            StringCodec.get(), LongCodec.get());
     final DBDefinition sampleDB = new DBDefinition.WithMap(
         DBColumnFamilyDefinition.newUnmodifiableMap(sampleTable)) {
       @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -53,63 +53,49 @@ public class SCMDBDefinition extends DBDefinition.WithMap {
       DELETED_BLOCKS =
       new DBColumnFamilyDefinition<>(
           "deletedBlocks",
-          Long.class,
           LongCodec.get(),
-          DeletedBlocksTransaction.class,
           Proto2Codec.get(DeletedBlocksTransaction.getDefaultInstance()));
 
   public static final DBColumnFamilyDefinition<BigInteger, X509Certificate>
       VALID_CERTS =
       new DBColumnFamilyDefinition<>(
           "validCerts",
-          BigInteger.class,
           BigIntegerCodec.get(),
-          X509Certificate.class,
           X509CertificateCodec.get());
 
   public static final DBColumnFamilyDefinition<BigInteger, X509Certificate>
       VALID_SCM_CERTS =
       new DBColumnFamilyDefinition<>(
           "validSCMCerts",
-          BigInteger.class,
           BigIntegerCodec.get(),
-          X509Certificate.class,
           X509CertificateCodec.get());
 
   public static final DBColumnFamilyDefinition<PipelineID, Pipeline>
       PIPELINES =
       new DBColumnFamilyDefinition<>(
           "pipelines",
-          PipelineID.class,
           PipelineID.getCodec(),
-          Pipeline.class,
           Pipeline.getCodec());
 
   public static final DBColumnFamilyDefinition<ContainerID, ContainerInfo>
       CONTAINERS =
       new DBColumnFamilyDefinition<>(
           "containers",
-          ContainerID.class,
           ContainerID.getCodec(),
-          ContainerInfo.class,
           ContainerInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, TransactionInfo>
       TRANSACTIONINFO =
       new DBColumnFamilyDefinition<>(
           "scmTransactionInfos",
-          String.class,
           StringCodec.get(),
-          TransactionInfo.class,
           TransactionInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, Long>
       SEQUENCE_ID =
       new DBColumnFamilyDefinition<>(
           "sequenceId",
-          String.class,
           StringCodec.get(),
-          Long.class,
           LongCodec.get());
 
   public static final DBColumnFamilyDefinition<ContainerID,
@@ -117,9 +103,7 @@ public class SCMDBDefinition extends DBDefinition.WithMap {
       MOVE =
       new DBColumnFamilyDefinition<>(
           "move",
-          ContainerID.class,
           ContainerID.getCodec(),
-          MoveDataNodePair.class,
           MoveDataNodePair.getCodec());
 
   /**
@@ -129,18 +113,14 @@ public class SCMDBDefinition extends DBDefinition.WithMap {
   public static final DBColumnFamilyDefinition<String, String>
       META = new DBColumnFamilyDefinition<>(
           "meta",
-          String.class,
           StringCodec.get(),
-          String.class,
           StringCodec.get());
 
   public static final DBColumnFamilyDefinition<String, ByteString>
       STATEFUL_SERVICE_CONFIG =
       new DBColumnFamilyDefinition<>(
           "statefulServiceConfig",
-          String.class,
           StringCodec.get(),
-          ByteString.class,
           ByteStringCodec.get());
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -56,139 +56,109 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
             DELETED_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.DELETED_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    RepeatedOmKeyInfo.class,
                     RepeatedOmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, PersistedUserVolumeInfo>
       USER_TABLE = new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.USER_TABLE,
-          String.class,
           StringCodec.get(),
-          PersistedUserVolumeInfo.class,
           Proto2Codec.get(PersistedUserVolumeInfo.getDefaultInstance()));
 
   public static final DBColumnFamilyDefinition<String, OmVolumeArgs>
             VOLUME_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.VOLUME_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    OmVolumeArgs.class,
                     OmVolumeArgs.getCodec());
 
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
             OPEN_KEY_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.OPEN_KEY_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    OmKeyInfo.class,
                     OmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
             KEY_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.KEY_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    OmKeyInfo.class,
                     OmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, OmBucketInfo>
             BUCKET_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.BUCKET_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    OmBucketInfo.class,
                     OmBucketInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, OmMultipartKeyInfo>
             MULTIPART_INFO_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.MULTIPARTINFO_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    OmMultipartKeyInfo.class,
                     OmMultipartKeyInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, OmPrefixInfo>
             PREFIX_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.PREFIX_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    OmPrefixInfo.class,
                     OmPrefixInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<OzoneTokenIdentifier, Long>
             DTOKEN_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.DELEGATION_TOKEN_TABLE,
-                    OzoneTokenIdentifier.class,
                     TokenIdentifierCodec.get(),
-                    Long.class,
                     LongCodec.get());
 
   public static final DBColumnFamilyDefinition<String, S3SecretValue>
             S3_SECRET_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.S3_SECRET_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    S3SecretValue.class,
                     S3SecretValue.getCodec());
 
   public static final DBColumnFamilyDefinition<String, TransactionInfo>
             TRANSACTION_INFO_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TRANSACTION_INFO_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    TransactionInfo.class,
                     TransactionInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, OmDirectoryInfo>
             DIRECTORY_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.DIRECTORY_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    OmDirectoryInfo.class,
                     OmDirectoryInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
             FILE_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.FILE_TABLE,
-                    String.class,
                     StringCodec.get(),
-                    OmKeyInfo.class,
                     OmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
             OPEN_FILE_TABLE =
             new DBColumnFamilyDefinition<>(
                   OmMetadataManagerImpl.OPEN_FILE_TABLE,
-                  String.class,
                   StringCodec.get(),
-                  OmKeyInfo.class,
                   OmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
       DELETED_DIR_TABLE =
       new DBColumnFamilyDefinition<>(OmMetadataManagerImpl.DELETED_DIR_TABLE,
-          String.class, StringCodec.get(), OmKeyInfo.class,
+          StringCodec.get(),
           OmKeyInfo.getCodec(true));
 
   public static final DBColumnFamilyDefinition<String, String>
       META_TABLE = new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.META_TABLE,
-          String.class,
           StringCodec.get(),
-          String.class,
           StringCodec.get());
 
   // Tables for multi-tenancy
@@ -197,27 +167,26 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
             TENANT_ACCESS_ID_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TENANT_ACCESS_ID_TABLE,
-                    String.class,  // accessId
+                    // accessId
                     StringCodec.get(),
-                    OmDBAccessIdInfo.class,  // tenantId, secret, principal
+                    // tenantId, secret, principal
                     OmDBAccessIdInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, OmDBUserPrincipalInfo>
             PRINCIPAL_TO_ACCESS_IDS_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.PRINCIPAL_TO_ACCESS_IDS_TABLE,
-                    String.class,  // User principal
+                    // User principal
                     StringCodec.get(),
-                    OmDBUserPrincipalInfo.class,  // List of accessIds
+                    // List of accessIds
                     OmDBUserPrincipalInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, OmDBTenantState>
             TENANT_STATE_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TENANT_STATE_TABLE,
-                    String.class,  // tenantId (tenant name)
+                    // tenantId (tenant name)
                     StringCodec.get(),
-                    OmDBTenantState.class,
                     OmDBTenantState.getCodec());
 
   // End tables for S3 multi-tenancy
@@ -226,18 +195,15 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
       SNAPSHOT_INFO_TABLE =
       new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.SNAPSHOT_INFO_TABLE,
-          String.class,  // snapshot path
+          // snapshot path
           StringCodec.get(),
-          SnapshotInfo.class,
           SnapshotInfo.getCodec());
 
   public static final DBColumnFamilyDefinition<String, CompactionLogEntry>
       COMPACTION_LOG_TABLE =
       new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.COMPACTION_LOG_TABLE,
-          String.class,
           StringCodec.get(),
-          CompactionLogEntry.class,
           CompactionLogEntry.getCodec());
 
   /**
@@ -254,9 +220,9 @@ public final class OMDBDefinition extends DBDefinition.WithMap {
       SNAPSHOT_RENAMED_TABLE =
       new DBColumnFamilyDefinition<>(
           OmMetadataManagerImpl.SNAPSHOT_RENAMED_TABLE,
-          String.class,  // /volumeName/bucketName/objectID
+          // /volumeName/bucketName/objectID
           StringCodec.get(),
-          String.class, // path to key in prev snapshot's key(file)/dir Table.
+          // path to key in prev snapshot's key(file)/dir Table.
           StringCodec.get());
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSCMDBDefinition.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSCMDBDefinition.java
@@ -43,9 +43,7 @@ public class ReconSCMDBDefinition extends SCMDBDefinition {
       NODES =
       new DBColumnFamilyDefinition<UUID, DatanodeDetails>(
           "nodes",
-          UUID.class,
           UUID_CODEC,
-          DatanodeDetails.class,
           DatanodeDetails.getCodec());
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconDBDefinition.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconDBDefinition.java
@@ -46,44 +46,34 @@ public class ReconDBDefinition extends DBDefinition.WithMap {
       CONTAINER_KEY =
       new DBColumnFamilyDefinition<>(
           "containerKeyTable",
-          ContainerKeyPrefix.class,
           ContainerKeyPrefixCodec.get(),
-          Integer.class,
           IntegerCodec.get());
 
   public static final DBColumnFamilyDefinition<KeyPrefixContainer, Integer>
       KEY_CONTAINER =
       new DBColumnFamilyDefinition<>(
           "keyContainerTable",
-          KeyPrefixContainer.class,
           KeyPrefixContainerCodec.get(),
-          Integer.class,
           IntegerCodec.get());
 
   public static final DBColumnFamilyDefinition<Long, Long>
       CONTAINER_KEY_COUNT =
       new DBColumnFamilyDefinition<>(
           "containerKeyCountTable",
-          Long.class,
           LongCodec.get(),
-          Long.class,
           LongCodec.get());
 
   public static final DBColumnFamilyDefinition
       <Long, ContainerReplicaHistoryList> REPLICA_HISTORY =
       new DBColumnFamilyDefinition<Long, ContainerReplicaHistoryList>(
           "replica_history",
-          Long.class,
           LongCodec.get(),
-          ContainerReplicaHistoryList.class,
           ContainerReplicaHistoryList.getCodec());
 
   public static final DBColumnFamilyDefinition<Long, NSSummary>
       NAMESPACE_SUMMARY = new DBColumnFamilyDefinition<Long, NSSummary>(
           "namespaceSummaryTable",
-          Long.class,
           LongCodec.get(),
-          NSSummary.class,
           NSSummaryCodec.get());
 
   // Container Replica History with bcsId tracking.
@@ -91,9 +81,7 @@ public class ReconDBDefinition extends DBDefinition.WithMap {
       <Long, ContainerReplicaHistoryList> REPLICA_HISTORY_V2 =
       new DBColumnFamilyDefinition<Long, ContainerReplicaHistoryList>(
           "replica_history_v2",
-          Long.class,
           LongCodec.get(),
-          ContainerReplicaHistoryList.class,
           ContainerReplicaHistoryList.getCodec());
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>


### PR DESCRIPTION
## What changes were proposed in this pull request?

```java
//DBColumnFamilyDefinition.java
  private final Class<KEY> keyType;

  private final Codec<KEY> keyCodec;

  private final Class<VALUE> valueType;

  private final Codec<VALUE> valueCodec;
```
The `keyType` and `valueType` fields above can be removed from `DBColumnFamilyDefinition` after HDDS-11556.

## What is the link to the Apache JIRA

HDDS-11557

## How was this patch tested?

By existing tests.