### PR TITLE
HDDS-11566. Replication tasks add transferredBytes and queuedTime metrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
@@ -71,15 +71,12 @@ public class ECReconstructionCoordinatorTask
     // respective container. HDDS-6582
     // 5. Close/finalize the recovered containers.
     long start = Time.monotonicNow();
-
-    LOG.info("{}", this);
-
     try {
       reconstructionCoordinator.reconstructECContainerGroup(
           reconstructionCommandInfo.getContainerID(),
           reconstructionCommandInfo.getEcReplicationConfig(),
           reconstructionCommandInfo.getSourceNodeMap(),
-          reconstructionCommandInfo.getTargetNodeMap());
+          reconstructionCommandInfo.getTargetNodeMap(), this);
       long elapsed = Time.monotonicNow() - start;
       setStatus(Status.DONE);
       LOG.info("{} in {} ms", this, elapsed);
@@ -88,6 +85,7 @@ public class ECReconstructionCoordinatorTask
       setStatus(Status.FAILED);
       LOG.warn("{} after {} ms", this, elapsed, e);
     }
+    LOG.info("{}", this);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -68,6 +68,9 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
         .addGauge(Interns.info("numQueuedReplications",
             "Number of replications in queue"),
             supervisor.getReplicationQueuedCount())
+        .addGauge(Interns.info("timeQueued",
+            "Time Queue waiting"),
+            supervisor.getQueuedTime())
         .addGauge(Interns.info("numRequestedReplications",
             "Number of requested replications"),
             supervisor.getReplicationRequestCount())
@@ -86,7 +89,10 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
             supervisor.getReplicationSkippedCount())
         .addGauge(Interns.info("maxReplicationStreams", "Maximum number of "
             + "concurrent replication tasks which can run simultaneously"),
-            supervisor.getMaxReplicationStreams());
+            supervisor.getMaxReplicationStreams())
+        .addGauge(Interns.info("bytesTransferred",
+            "Number of bytes transferred while replication"),
+            supervisor.getTransferredBytes());
 
     Map<String, String> metricsMap = ReplicationSupervisor.getMetricsMap();
     if (!metricsMap.isEmpty()) {
@@ -110,7 +116,13 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
                   supervisor.getReplicationSkippedCount(metricsName))
               .addGauge(Interns.info("numQueued" + metricsName,
                   "Number of " + descriptionSegment + " in queue"),
-                  supervisor.getReplicationQueuedCount(metricsName));
+                  supervisor.getReplicationQueuedCount(metricsName))
+              .addGauge(Interns.info("timeQueued" + metricsName,
+                  "Time Queue waiting" + descriptionSegment),
+                  supervisor.getQueuedTime(metricsName))
+              .addGauge(Interns.info("bytesTransferred" + metricsName,
+                  "Number of " + descriptionSegment + " bytes transferred"),
+                  supervisor.getTransferredBytes(metricsName));
         }
       });
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -22,20 +22,18 @@ import java.util.Objects;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The task to download a container from the sources.
  */
 public class ReplicationTask extends AbstractReplicationTask {
+  private static final Logger LOG = LoggerFactory.getLogger(ReplicationTask.class);
 
   private final ReplicateContainerCommand cmd;
   private final ContainerReplicator replicator;
   private final String debugString;
-
-  /**
-   * Counter for the transferred bytes.
-   */
-  private long transferredBytes;
 
   public ReplicationTask(ReplicateContainerCommand cmd,
                          ContainerReplicator replicator) {
@@ -106,23 +104,6 @@ public class ReplicationTask extends AbstractReplicationTask {
     return debugString;
   }
 
-  @Override
-  public String toString() {
-    String str = super.toString();
-    if (transferredBytes > 0) {
-      str += ", transferred " + transferredBytes + " bytes";
-    }
-    return str;
-  }
-
-  public long getTransferredBytes() {
-    return transferredBytes;
-  }
-
-  public void setTransferredBytes(long transferredBytes) {
-    this.transferredBytes = transferredBytes;
-  }
-
   DatanodeDetails getTarget() {
     return cmd.getTargetDatanode();
   }
@@ -130,5 +111,6 @@ public class ReplicationTask extends AbstractReplicationTask {
   @Override
   public void runTask() {
     replicator.replicate(this);
+    LOG.info("{}", this);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestECContainerRecovery.java
@@ -330,7 +330,7 @@ public class TestECContainerRecovery {
         invocation.callRealMethod();
         return null;
       }).when(coordinator).reconstructECBlockGroup(any(), any(),
-              any(), any());
+              any(), any(), any());
     }
 
     // Shutting down DN triggers close pipeline and close container.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added transferredBytes and queuedTime metrics for replication tasks, including ec reconstruction and container replication.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11566

## How was this patch tested?
ci: 
https://github.com/jianghuazhu/ozone/actions/runs/11310889447

datanode jmx: 
![image](https://github.com/user-attachments/assets/b1ca8618-88be-4b64-a1ff-7830e2e331c5)
![image](https://github.com/user-attachments/assets/6c93c78c-aeb7-44b0-b9d2-09b7dff39308)


