### PR TITLE
HDDS-11574. Ozone client leak in TestS3SDKV1

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -884,7 +884,7 @@ public final class HddsUtils {
    */
   public static void reportLeak(Class<?> clazz, String stackTrace, Logger log) {
     String warning = String.format("%s is not closed properly", clazz.getSimpleName());
-    if (stackTrace != null && LOG.isDebugEnabled()) {
+    if (stackTrace != null && log.isDebugEnabled()) {
       String debugMessage = String.format("%nStackTrace for unclosed instance: %s",
           stackTrace);
       warning = warning.concat(debugMessage);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -430,17 +430,18 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
     byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
 
     OzoneConfiguration conf = cluster.getConf();
-    OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(conf);
-    ObjectStore store = ozoneClient.getObjectStore();
+    try (OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(conf)) {
+      ObjectStore store = ozoneClient.getObjectStore();
 
-    OzoneVolume volume = store.getS3Volume();
-    OzoneBucket bucket = volume.getBucket(bucketName);
+      OzoneVolume volume = store.getS3Volume();
+      OzoneBucket bucket = volume.getBucket(bucketName);
 
-    try (OzoneOutputStream out = bucket.createKey(keyName,
-        valueBytes.length,
-        ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS, ReplicationFactor.ONE),
-        Collections.emptyMap())) {
-      out.write(valueBytes);
+      try (OzoneOutputStream out = bucket.createKey(keyName,
+          valueBytes.length,
+          ReplicationConfig.fromTypeAndFactor(ReplicationType.RATIS, ReplicationFactor.ONE),
+          Collections.emptyMap())) {
+        out.write(valueBytes);
+      }
     }
 
     S3Object s3Object = s3Client.getObject(bucketName, keyName);

--- a/hadoop-ozone/integration-test/src/test/resources/log4j.properties
+++ b/hadoop-ozone/integration-test/src/test/resources/log4j.properties
@@ -21,3 +21,4 @@ log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=ERROR
 log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
 log4j.logger.org.apache.hadoop.hdds.utils.db.managed=TRACE
 log4j.logger.org.apache.hadoop.hdds.utils.db.CodecBuffer=DEBUG
+log4j.logger.org.apache.hadoop.ozone.client.OzoneClientFactory=DEBUG


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fix `OzoneClient` leak in S3G integration test:
https://github.com/apache/ozone/actions/runs/11315912516/attempts/1#summary-31467801190

- `HddsUtils#reportLeak` is supposed to print the leak's stack trace if log level is at least `DEBUG`.  However, it checks the wrong `Logger` instance: `HddsUtils`'s `LOG` instead of the argument `log`.  This method was moved from `ManagedRocksObjectUtils` by HDDS-11543, adding the new parameter, but keeping the `LOG.isDebugEnabled()` check.

- Set `OzoneClientFactory` log level to `DEBUG` in integration tests to get stack trace of `OzoneClient` leaks.

https://issues.apache.org/jira/browse/HDDS-11574

## How was this patch tested?

```
$ mvn -am -pl :ozone-integration-test -Dtest='TestS3SDKV1*' clean test
$ grep 'not closed properly' hadoop-ozone/integration-test/target/surefire-reports/*TestS3SDKV1*-output.txt | wc -l
0
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/11316491577