### PR TITLE
HDDS-11587. Ozone Manager not processing file put requests with multi-tenancy enabled

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/RangerClientMultiTenantAccessController.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/RangerClientMultiTenantAccessController.java
@@ -130,9 +130,12 @@ public class RangerClientMultiTenantAccessController implements
 
     LOG.info("authType = {}, login user = {}", authType, usernameOrPrincipal);
 
+    UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
     client = new RangerClient(rangerHttpsAddress,
         authType, usernameOrPrincipal, passwordOrKeytab,
         rangerServiceName, OzoneConsts.OZONE);
+    // set back the expected login user
+    UserGroupInformation.setLoginUser(loginUser);
 
     // Whether or not the Ranger credentials are valid is unknown right after
     // RangerClient initialization here. Because RangerClient does not perform

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/RangerClientMultiTenantAccessController.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/RangerClientMultiTenantAccessController.java
@@ -131,11 +131,14 @@ public class RangerClientMultiTenantAccessController implements
     LOG.info("authType = {}, login user = {}", authType, usernameOrPrincipal);
 
     UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
-    client = new RangerClient(rangerHttpsAddress,
-        authType, usernameOrPrincipal, passwordOrKeytab,
-        rangerServiceName, OzoneConsts.OZONE);
-    // set back the expected login user
-    UserGroupInformation.setLoginUser(loginUser);
+    try {
+      client = new RangerClient(rangerHttpsAddress,
+          authType, usernameOrPrincipal, passwordOrKeytab,
+          rangerServiceName, OzoneConsts.OZONE);
+    } finally {
+      // set back the expected login user
+      UserGroupInformation.setLoginUser(loginUser);
+    }
 
     // Whether or not the Ranger credentials are valid is unknown right after
     // RangerClient initialization here. Because RangerClient does not perform


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the problem that Ozone Manager fail to process write requests while enabling multi-tenancy

The root cause analysis is shared in the https://issues.apache.org/jira/browse/HDDS-11587. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11587

## How was this patch tested?
Tested in a real cluster which reproduced this problem. After the patch, write operations are successfully handled after the kerberos ticket lifetime. 