### PR TITLE
HDDS-11586. Remove duplicate OzoneManagerProtocolServerSideTranslatorPB#OM_REQUESTS_PACKAGE

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -69,7 +69,6 @@ import org.slf4j.LoggerFactory;
  */
 public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerProtocolPB {
   private static final Logger LOG = LoggerFactory .getLogger(OzoneManagerProtocolServerSideTranslatorPB.class);
-  private static final String OM_REQUESTS_PACKAGE = "org.apache.hadoop.ozone";
 
   private final OzoneManagerRatisServer omRatisServer;
   private final RequestHandler handler;
@@ -123,7 +122,6 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
 
     // TODO: make this injectable for testing...
     this.requestValidations = new RequestValidations()
-        .fromPackage(OM_REQUESTS_PACKAGE)
         .withinContext(ValidationContext.of(ozoneManager.getVersionManager(), ozoneManager.getMetadataManager()))
         .load();
   }
@@ -214,8 +212,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
         //  return null, which triggered the findbugs warning.
         //  Added the assertion.
         assert (omClientRequest != null);
-        OMClientRequest finalOmClientRequest = omClientRequest;
-        requestToSubmit = preExecute(finalOmClientRequest);
+        requestToSubmit = preExecute(omClientRequest);
         this.lastRequestToSubmit = requestToSubmit;
       } catch (IOException ex) {
         if (omClientRequest != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The same validation package is defined in OzoneManagerProtocolServerSideTranslatorPB and RequestValidations, so you only need to keep one of them.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11586

## How was this patch tested?
ci: 
https://github.com/jianghuazhu/ozone/actions/runs/11345726134
