### PR TITLE
HDDS-11585. Add DN Ratis log purge parameters to close pipeline with slow follower

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -105,11 +105,19 @@ public final class ScmConfigKeys {
       "hdds.container.ratis.log.appender.queue.byte-limit";
   public static final String
       HDDS_CONTAINER_RATIS_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT = "32MB";
+
   public static final String HDDS_CONTAINER_RATIS_LOG_PURGE_GAP =
       "hdds.container.ratis.log.purge.gap";
   // TODO: Set to 1024 once RATIS issue around purge is fixed.
   public static final int HDDS_CONTAINER_RATIS_LOG_PURGE_GAP_DEFAULT =
       1000000;
+  public static final String HDDS_RATIS_LOG_PURGE_UPTO_INDEX_KEY =
+      "hdds.ratis.log.purge.upto.snapshot.index";
+  public static final boolean HDDS_RATIS_LOG_PURGE_UPTO_INDEX_DEFAULT = true;
+  public static final String HDDS_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_KEY =
+      "hdds.ratis.log.purge.preservation.log.num";
+  public static final long HDDS_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_DEFAULT = 1000000;
+
   public static final String HDDS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT =
       "hdds.container.ratis.leader.pending.bytes.limit";
   public static final String

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -432,6 +432,14 @@ public final class OzoneConfigKeys {
       ScmConfigKeys.HDDS_RATIS_SNAPSHOT_THRESHOLD_KEY;
   public static final long HDDS_RATIS_SNAPSHOT_THRESHOLD_DEFAULT =
       ScmConfigKeys.HDDS_RATIS_SNAPSHOT_THRESHOLD_DEFAULT;
+  public static final String HDDS_RATIS_LOG_PURGE_UPTO_INDEX_KEY =
+      ScmConfigKeys.HDDS_RATIS_LOG_PURGE_UPTO_INDEX_KEY;
+  public static final boolean HDDS_RATIS_LOG_PURGE_UPTO_INDEX_DEFAULT =
+      ScmConfigKeys.HDDS_RATIS_LOG_PURGE_UPTO_INDEX_DEFAULT;
+  public static final String HDDS_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_KEY =
+      ScmConfigKeys.HDDS_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_KEY;
+  public static final long HDDS_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_DEFAULT =
+      ScmConfigKeys.HDDS_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_DEFAULT;
 
   public static final String HDDS_DATANODE_PLUGINS_KEY =
       "hdds.datanode.plugins";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -279,10 +279,30 @@
   </property>
   <property>
     <name>hdds.ratis.snapshot.threshold</name>
-    <value>10000</value>
+    <value>100000</value>
     <tag>OZONE, RATIS</tag>
     <description>Number of transactions after which a ratis snapshot should be
       taken.
+    </description>
+  </property>
+  <property>
+    <name>hdds.ratis.log.purge.upto.snapshot.index</name>
+    <value>true</value>
+    <tag>OZONE, RATIS</tag>
+    <description>
+      Enable/disable Raft server to purge its log up to the snapshot index
+      after taking snapshot.
+    </description>
+  </property>
+  <property>
+    <name>hdds.ratis.log.purge.preservation.log.num</name>
+    <value>1000000</value>
+    <tag>OZONE, RATIS</tag>
+    <description>
+      The number of latest Raft logs to not be purged after taking snapshot.
+      In Ratis write pipeline, when hdds.ratis.log.purge.upto.snapshot.index is set in datanodes,
+      this configuration set how far behind the "slow" follower log index compared to the leader
+      before the pipeline is eligible be closed due to the notifyInstallSnapshot mechanism.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -357,6 +357,16 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_LOG_PURGE_GAP,
         OzoneConfigKeys.HDDS_CONTAINER_RATIS_LOG_PURGE_GAP_DEFAULT);
     RaftServerConfigKeys.Log.setPurgeGap(properties, purgeGap);
+    boolean purgeUpToSnapshotIndex =
+        conf.getBoolean(OzoneConfigKeys.HDDS_RATIS_LOG_PURGE_UPTO_INDEX_KEY,
+            OzoneConfigKeys.HDDS_RATIS_LOG_PURGE_UPTO_INDEX_DEFAULT);
+    long purgePreservationLogNum =
+        conf.getLong(OzoneConfigKeys.HDDS_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_KEY,
+            OzoneConfigKeys.HDDS_RATIS_LOG_PURGE_PRESERVATION_LOG_NUM_DEFAULT);
+    RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(
+        properties, purgeUpToSnapshotIndex);
+    RaftServerConfigKeys.Log.setPurgePreservationLogNum(
+        properties, purgePreservationLogNum);
 
     //Set the number of Snapshots Retained.
     RatisServerConfiguration ratisServerConfiguration =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone Ratis pipeline seem to have an indirect mechanism to detect follower with lagging index (i.e. "slow follower") through the notifyInstallSnapshot mechanism (since installSnapshot is always disabled).

The idea is that if the leader already purge the logs up to the snapshot index, and the leader's first index is higher than the slow follower's next index (i.e. the log to replicate to slow follower has been purged), the leader will send the notifyInstallSnapshot request to follower and the follower will call StateMachine#notifyInstallSnapshotFromLeader API. 

Datanode implementation of notifyInstallSnapshotFromLeader is to close the pipeline. This indirectly acts as an automatic "slow follower detector" which might be helpful since by default will watch for ALL_COMMITTED (i.e. log index needs to be replicated in all DNs) and will increase write latency considerably.

See the figure in the ticket, we can see follower index lag that causes prolonged cluster write degradation that required administrator to close the pipeline manually. Even after the difference of the log index between leader and follower reaches > 1 million, the pipeline is not automatically closed. 

The root cause is because raft.server.log.purge.upto.snapshot.index defaults to false. This means that the leader will not purge the logs until it has been replicated to the slow follower. Therefore, the notifyInstallSnapshot mechanism will never be triggered.

Just like [HDDS-8131](https://issues.apache.org/jira/browse/HDDS-8131), I propose to make raft.server.log.purge.upto.snapshot.index and raft.server.log.purge.preservation.log.num to be configurable. The configuration will be set to
- raft.server.log.purge.upto.snapshot.index = true
- raft.server.log.purge.preservation.log.num = <SLOW_FOLLOWER_THRESHOLD> (can be discussed)

Other snapshot configurations such might need to be revisited
- raft.server.snapshot.auto.trigger.threshold (hdds.ratis.snapshot.threshold) = default is 100,000
- raft.server.log.purge.gap (hdds.container.ratis.log.purge.gap) = default is 1,000,000
  - This might be too large, we can reduce it to something like 100,000

Alternatively, a more precise and straightforward way is to implement https://issues.apache.org/jira/browse/RATIS-2156.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11585

## How was this patch tested?

Existing tests.

Clean CI: https://github.com/ivandika3/ozone/actions/runs/11358581639