### PR TITLE
HDDS-11589. ReconSCMDBDefinition should be singleton.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSCMDBDefinition.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSCMDBDefinition.java
@@ -32,25 +32,27 @@ import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 /**
  * Recon SCM db file for ozone.
  */
-public class ReconSCMDBDefinition extends SCMDBDefinition {
+public final class ReconSCMDBDefinition extends SCMDBDefinition {
   private static final Codec<UUID> UUID_CODEC = new DelegatedCodec<>(
       StringCodec.get(), UUID::fromString, UUID::toString,
       UUID.class, DelegatedCodec.CopyType.SHALLOW);
 
   public static final String RECON_SCM_DB_NAME = "recon-scm.db";
 
-  public static final DBColumnFamilyDefinition<UUID, DatanodeDetails>
-      NODES =
-      new DBColumnFamilyDefinition<UUID, DatanodeDetails>(
-          "nodes",
-          UUID_CODEC,
-          DatanodeDetails.getCodec());
+  public static final DBColumnFamilyDefinition<UUID, DatanodeDetails> NODES
+      = new DBColumnFamilyDefinition<>("nodes", UUID_CODEC, DatanodeDetails.getCodec());
 
   private static final Map<String, DBColumnFamilyDefinition<?, ?>>
       COLUMN_FAMILIES = DBColumnFamilyDefinition.newUnmodifiableMap(
           SCMDBDefinition.get().getMap(), NODES);
 
-  public ReconSCMDBDefinition() {
+  private static final ReconSCMDBDefinition INSTANCE = new ReconSCMDBDefinition();
+
+  public static ReconSCMDBDefinition get() {
+    return INSTANCE;
+  }
+
+  private ReconSCMDBDefinition() {
     super(COLUMN_FAMILIES);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -218,8 +218,7 @@ public class ReconStorageContainerManagerFacade
 
     this.scmStorageConfig = new ReconStorageConfig(conf, reconUtils);
     this.clusterMap = new NetworkTopologyImpl(conf);
-    this.dbStore = DBStoreBuilder
-        .createDBStore(ozoneConfiguration, new ReconSCMDBDefinition());
+    this.dbStore = DBStoreBuilder.createDBStore(ozoneConfiguration, ReconSCMDBDefinition.get());
 
     this.scmLayoutVersionManager =
         new HDDSLayoutVersionManager(scmStorageConfig.getLayoutVersion());
@@ -627,8 +626,7 @@ public class ReconStorageContainerManagerFacade
 
   private void initializeNewRdbStore(File dbFile) throws IOException {
     try {
-      DBStore newStore = createDBAndAddSCMTablesAndCodecs(
-          dbFile, new ReconSCMDBDefinition());
+      final DBStore newStore = createDBAndAddSCMTablesAndCodecs(dbFile, ReconSCMDBDefinition.get());
       Table<UUID, DatanodeDetails> nodeTable =
           ReconSCMDBDefinition.NODES.getTable(dbStore);
       Table<UUID, DatanodeDetails> newNodeTable =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
@@ -88,7 +88,7 @@ public class AbstractReconContainerManagerTest {
     conf = new OzoneConfiguration();
     conf.set(OZONE_METADATA_DIRS, tempDir.getAbsolutePath());
     conf.set(OZONE_SCM_NAMES, "localhost");
-    store = DBStoreBuilder.createDBStore(conf, new ReconSCMDBDefinition());
+    store = DBStoreBuilder.createDBStore(conf, ReconSCMDBDefinition.get());
     scmhaManager = SCMHAManagerStub.getInstance(
         true, new SCMHADBTransactionBufferStub(store));
     sequenceIdGen = new SequenceIdGenerator(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
@@ -86,7 +86,7 @@ public class TestReconNodeManager {
     reconStorageConfig = new ReconStorageConfig(conf, reconUtils);
     versionManager = new HDDSLayoutVersionManager(
         reconStorageConfig.getLayoutVersion());
-    store = DBStoreBuilder.createDBStore(conf, new ReconSCMDBDefinition());
+    store = DBStoreBuilder.createDBStore(conf, ReconSCMDBDefinition.get());
     reconContext = new ReconContext(conf, reconUtils);
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -94,7 +94,7 @@ public class TestReconPipelineManager {
         temporaryFolder.toAbsolutePath().toString());
     conf.set(OZONE_SCM_NAMES, "localhost");
     scmStorageConfig = new ReconStorageConfig(conf, new ReconUtils());
-    store = DBStoreBuilder.createDBStore(conf, new ReconSCMDBDefinition());
+    store = DBStoreBuilder.createDBStore(conf, ReconSCMDBDefinition.get());
     scmhaManager = SCMHAManagerStub.getInstance(
         true, new SCMHADBTransactionBufferStub(store));
     scmContext = SCMContext.emptyContext();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
@@ -56,7 +56,7 @@ public final class DBDefinitionFactory {
 
   static {
     final Map<String, DBDefinition> map = new HashMap<>();
-    Arrays.asList(SCMDBDefinition.get(), OMDBDefinition.get(), new ReconSCMDBDefinition())
+    Arrays.asList(SCMDBDefinition.get(), OMDBDefinition.get(), ReconSCMDBDefinition.get())
         .forEach(dbDefinition -> map.put(dbDefinition.getName(), dbDefinition));
     DB_MAP = Collections.unmodifiableMap(map);
   }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestDBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestDBDefinitionFactory.java
@@ -50,8 +50,7 @@ public class TestDBDefinitionFactory {
     definition = DBDefinitionFactory.getDefinition(SCMDBDefinition.get().getName());
     assertInstanceOf(SCMDBDefinition.class, definition);
 
-    definition = DBDefinitionFactory.getDefinition(
-        new ReconSCMDBDefinition().getName());
+    definition = DBDefinitionFactory.getDefinition(ReconSCMDBDefinition.get().getName());
     assertInstanceOf(ReconSCMDBDefinition.class, definition);
 
     definition = DBDefinitionFactory.getDefinition(


### PR DESCRIPTION
## What changes were proposed in this pull request?

By definition, ReconSCMDBDefinition won't be changed. It should be a singleton.

## What is the link to the Apache JIRA

HDDS-11589

## How was this patch tested?

By updating existing tests.