### PR TITLE
HDDS-11596. Add Feature Bitmap to OzoneManagerVersion for Compatibility Checks

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -55,9 +55,25 @@ public enum OzoneManagerVersion implements ComponentVersion {
   private static final Map<Integer, OzoneManagerVersion> BY_PROTO_VALUE =
       Arrays.stream(values())
           .collect(toMap(OzoneManagerVersion::toProtoValue, identity()));
-
+  private static final long SUPPORTED_FEATURE_BITMAP = calculateVersionBitmap();
   private final int version;
   private final String description;
+
+  /**
+   * This is limited to 63 because the version bitmap is stored in a `long` type,
+   * which has 64 bits. One bit is reserved for each version number, starting from 0.
+   * Therefore, the highest representable version number is 63.
+   */
+  public static final int MAX_SUPPORTED_VERSION = 63;
+
+  static {
+    for (OzoneManagerVersion version : OzoneManagerVersion.values()) {
+      if (version.toProtoValue() > MAX_SUPPORTED_VERSION) {
+        throw new IllegalStateException(
+                "Version " + version + " exceeds the maximum supported version: " + MAX_SUPPORTED_VERSION);
+      }
+    }
+  }
 
   OzoneManagerVersion(int version, String description) {
     this.version = version;
@@ -81,5 +97,45 @@ public enum OzoneManagerVersion implements ComponentVersion {
   private static OzoneManagerVersion latest() {
     OzoneManagerVersion[] versions = OzoneManagerVersion.values();
     return versions[versions.length - 2];
+  }
+
+  /**
+   * Checks if the given feature version is supported by the OM Service.
+   *
+   * @param omFeatureBitmap The feature bitmap from the remote OM.
+   * @param checkedFeature  The feature to check.
+   * @return true if the feature is supported, false otherwise.
+   */
+  public static boolean isOmFeatureSupported(long omFeatureBitmap, OzoneManagerVersion checkedFeature) {
+    if (checkedFeature.toProtoValue() < 0) {
+      return false;
+    }
+    return (omFeatureBitmap & (1L << checkedFeature .toProtoValue())) != 0;
+  }
+
+  /**
+   * Get the current bitmap representing supported features.
+   *
+   * @return The bitmap of supported features.
+   */
+  public static long getSupportedFeatureBitmap() {
+    return SUPPORTED_FEATURE_BITMAP;
+  }
+
+  /**
+   * Calculate the version bitmap. Each bit position corresponds to a version.
+   * Example: Version 0 -> bit 0, Version 1 -> bit 1, etc.
+   * Note:
+   * - Uses a 64-bit `long`, supporting versions 0 to 63.
+   * - Versions beyond 63 are not supported.
+   */
+  private static long calculateVersionBitmap() {
+    long bitmap = 0L;
+    for (OzoneManagerVersion version : values()) {
+      if (version.version >= 0) { // Ignore FUTURE_VERSION (-1)
+        bitmap |= (1L << version.version);
+      }
+    }
+    return bitmap;
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestComponentVersionInvariants.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestComponentVersionInvariants.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
@@ -92,5 +94,27 @@ public class TestComponentVersionInvariants {
       assertEquals(values[i].toProtoValue(), startValue++);
     }
     assertEquals(values.length, ++startValue);
+  }
+
+  @ParameterizedTest
+  @MethodSource("values")
+  public void testSupportedFeatureBitmapIncludesAllVersions(
+          ComponentVersion[] values) {
+    if (values[0] instanceof OzoneManagerVersion) {
+      long expectedBitmap = 0L;
+      for (ComponentVersion version : values) {
+        int versionValue = version.toProtoValue();
+        if (versionValue >= 0) { // Ignore FUTURE_VERSION (-1)
+          assertTrue(OzoneManagerVersion.isOmFeatureSupported(
+                  OzoneManagerVersion.getSupportedFeatureBitmap(), (OzoneManagerVersion) version));
+          expectedBitmap |= (1L << versionValue);
+        } else {
+          assertFalse(OzoneManagerVersion.isOmFeatureSupported(
+                  OzoneManagerVersion.getSupportedFeatureBitmap(), (OzoneManagerVersion) version));
+        }
+      }
+      assertEquals(expectedBitmap, OzoneManagerVersion.getSupportedFeatureBitmap(),
+              "The SUPPORTED_FEATURE_BITMAP should correctly represent all supported features.");
+    }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ServiceInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ServiceInfo.java
@@ -55,6 +55,11 @@ public final class ServiceInfo {
   private OzoneManagerVersion omVersion;
 
   /**
+   * Bitmap for supported versions.
+   */
+  private long supportedFeatureBitmap;
+
+  /**
    * List of ports the service listens to.
    */
   private Map<ServicePort.Type, Integer> ports;
@@ -72,30 +77,17 @@ public final class ServiceInfo {
    * @param nodeType type of node/service
    * @param hostname hostname of the service
    * @param portList list of ports the service listens to
-   */
-  private ServiceInfo(NodeType nodeType,
-                      String hostname,
-                      List<ServicePort> portList,
-                      OzoneManagerVersion omVersion,
-                      OMRoleInfo omRole) {
-    this(nodeType, hostname, portList, omVersion, omRole, null);
-  }
-
-  /**
-   * Constructs the ServiceInfo for the {@code nodeType}.
-   * @param nodeType type of node/service
-   * @param hostname hostname of the service
-   * @param portList list of ports the service listens to
    * @param omVersion Om Version
    * @param omRole OM role Ino
-   * @param keyProviderUri KMS provider URI
+   * @param serverDefaults server defaults
+   * @param supportedFeatureBitmap bitmap of supported feature
    */
   private ServiceInfo(NodeType nodeType,
                       String hostname,
                       List<ServicePort> portList,
                       OzoneManagerVersion omVersion,
                       OMRoleInfo omRole,
-                      OzoneFsServerDefaults serverDefaults) {
+                      OzoneFsServerDefaults serverDefaults, long supportedFeatureBitmap) {
     Preconditions.checkNotNull(nodeType);
     Preconditions.checkNotNull(hostname);
     this.nodeType = nodeType;
@@ -107,6 +99,7 @@ public final class ServiceInfo {
     }
     this.omRoleInfo = omRole;
     this.serverDefaults = serverDefaults;
+    this.supportedFeatureBitmap = supportedFeatureBitmap;
   }
 
   /**
@@ -203,6 +196,7 @@ public final class ServiceInfo {
     if (serverDefaults != null) {
       builder.setServerDefaults(serverDefaults.getProtobuf());
     }
+    builder.setSupportedFeatureBitmap(supportedFeatureBitmap);
     return builder.build();
   }
 
@@ -220,7 +214,8 @@ public final class ServiceInfo {
         OzoneManagerVersion.fromProtoValue(serviceInfo.getOMVersion()),
         serviceInfo.hasOmRole() ? serviceInfo.getOmRole() : null,
         serviceInfo.hasServerDefaults() ? OzoneFsServerDefaults.getFromProtobuf(
-            serviceInfo.getServerDefaults()) : null);
+            serviceInfo.getServerDefaults()) : null,
+            serviceInfo.getSupportedFeatureBitmap());
   }
 
   /**
@@ -241,6 +236,7 @@ public final class ServiceInfo {
     private List<ServicePort> portList = new ArrayList<>();
     private OMRoleInfo omRoleInfo;
     private OzoneManagerVersion omVersion;
+    private long supportedFeatureBitmap;
     private OzoneFsServerDefaults serverDefaults;
 
     /**
@@ -300,6 +296,11 @@ public final class ServiceInfo {
       return this;
     }
 
+    public Builder setSupportedFeatureBitmap(long featureBitmap) {
+      supportedFeatureBitmap = featureBitmap;
+      return this;
+    }
+
     /**
      * Builds and returns {@link ServiceInfo} with the set values.
      * @return {@link ServiceInfo}
@@ -310,7 +311,8 @@ public final class ServiceInfo {
           portList,
           omVersion,
           omRoleInfo,
-          serverDefaults);
+          serverDefaults,
+          supportedFeatureBitmap);
     }
   }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1638,6 +1638,7 @@ message ServiceInfo {
     optional OMRoleInfo omRole = 4;
     optional int32 OMVersion = 5 [default = 0];
     optional FsServerDefaultsProto serverDefaults = 6;
+    optional uint64 supportedFeatureBitmap = 7;
 }
 
 message MultipartInfoInitiateRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3133,6 +3133,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .setNodeType(HddsProtos.NodeType.OM)
         .setHostname(omRpcAddress.getHostName())
         .setOmVersion(OzoneManagerVersion.CURRENT)
+        .setSupportedFeatureBitmap(OzoneManagerVersion.getSupportedFeatureBitmap())
         .addServicePort(ServicePort.newBuilder()
             .setType(ServicePort.Type.RPC)
             .setValue(omRpcAddress.getPort())
@@ -3182,10 +3183,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         ServiceInfo.Builder peerOmServiceInfoBuilder = ServiceInfo.newBuilder()
             .setNodeType(HddsProtos.NodeType.OM)
             .setHostname(peerNode.getHostName())
-            // For now assume peer is at the same version.
+            // For now assume peer is at the same version and Features
             // This field needs to be fetched from peer when rolling upgrades
             // are implemented.
             .setOmVersion(OzoneManagerVersion.CURRENT)
+            .setSupportedFeatureBitmap(OzoneManagerVersion.getSupportedFeatureBitmap())
             .addServicePort(ServicePort.newBuilder()
                 .setType(ServicePort.Type.RPC)
                 .setValue(peerNode.getRpcPort())

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/ListOpenFilesSubCommand.java
@@ -117,7 +117,8 @@ public class ListOpenFilesSubCommand implements Callable<Void> {
         parent.createOmClient(omServiceId, omHost, false);
     ServiceInfoEx serviceInfoEx = ozoneManagerClient.getServiceInfo();
     final OzoneManagerVersion omVersion = RpcClient.getOmVersion(serviceInfoEx);
-    if (omVersion.compareTo(OzoneManagerVersion.HBASE_SUPPORT) < 0) {
+    final long omSupportedFeatureBitmap = RpcClient.getOMSupportedFeatureBitmap(serviceInfoEx);
+    if (RpcClient.isOmFeatureSupported(omSupportedFeatureBitmap, omVersion, OzoneManagerVersion.HBASE_SUPPORT)) {
       System.err.println("Error: This command requires OzoneManager version "
           + OzoneManagerVersion.HBASE_SUPPORT.name() + " or later.");
       return null;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR introduces "feature bitmap" support in OzoneManagerVersion, enabling the Client check OM feature use the "feature bitmap" instead of the `version` which was the OM latest version.

### Issue
If only the latest `version` is used for feature checks, there is a risk of misjudging compatibility when versions are not sequential. For example, if certain intermediate versions are skipped (e.g., [1, 2, 3, 5]), relying on simple version comparisons might incorrectly assume support for all earlier versions.

We need backport this https://github.com/apache/ozone/pull/7161 patch to ozone-1.4 branch, https://github.com/apache/ozone/pull/7161 introduce the `OzoneManagerVersion#LIGHTWEIGHT_LIST_STATUS(8)`, if we backport the https://github.com/apache/ozone/pull/7161, then the ozone-1.4 OzoneManagerVersion will be [1,2,3,4,8], no the feature [5, 6, 7]. Current logic which base on the latest OzoneManagerVersion#version to judge whether OM support a specific feature, will cause the client think the OM support the features [5, 6, 7], but ozone-1.4 not support.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11596


## How was this patch tested?
Existing tests. Newly added unit test.

