### PR TITLE
HDDS-11580. Validate 'hdds.datanode.dir.du.reserved' property

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.container.common.volume;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageSize;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -222,7 +223,7 @@ public class VolumeUsage {
       if (words.length < 2) {
         LOG.error("Reserved space should be configured in a pair, but current value is {}",
             reserve);
-        continue;
+        throw new ConfigurationException("Reserved space should be configured in a pair");
       }
 
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?
An exception was added to handle cases of severe misconfiguration of the hdds.datanode.dir.du.reserved parameter.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11580

## How was this patch tested?
Build-branch workflow run on the fork.
