### PR TITLE
HDDS-11558. Make OM client retry idempotent

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -16,13 +16,11 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import com.google.protobuf.ServiceException;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
-import org.apache.hadoop.hdds.scm.ha.SCMRatisResponse;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdfs.LogVerificationAppender;
@@ -74,7 +72,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithStoppedNodes.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.om.ha.OMHAMetrics;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.service.KeyDeletingService;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.security.UserGroupInformation;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -71,7 +71,6 @@ import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.netty.NettyConfigKeys;
 import org.apache.ratis.protocol.ClientId;
-import org.apache.ratis.protocol.ClientInvocationId;
 import org.apache.ratis.protocol.SetConfigurationRequest;
 import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
 import org.apache.ratis.protocol.exceptions.LeaderSteppingDownException;
@@ -88,7 +87,6 @@ import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.RetryCache;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.util.LifeCycle;
@@ -462,49 +460,21 @@ public final class OzoneManagerRatisServer {
    * ratis server.
    */
   private RaftClientRequest createRaftRequestImpl(OMRequest omRequest) {
+    if (!ozoneManager.isTestSecureOmFlag()) {
+      Preconditions.checkArgument(Server.getClientId() != DUMMY_CLIENT_ID);
+      Preconditions.checkArgument(Server.getCallId() != INVALID_CALL_ID);
+    }
     return RaftClientRequest.newBuilder()
-        .setClientId(getClientId())
+        .setClientId(
+            ClientId.valueOf(UUID.nameUUIDFromBytes(Server.getClientId())))
         .setServerId(server.getId())
         .setGroupId(raftGroupId)
-        .setCallId(getCallId())
+        .setCallId(Server.getCallId())
         .setMessage(
             Message.valueOf(
                 OMRatisHelper.convertRequestToByteString(omRequest)))
         .setType(RaftClientRequest.writeRequestType())
         .build();
-  }
-
-  private ClientId getClientId() {
-    final byte[] clientIdBytes = Server.getClientId();
-    if (!ozoneManager.isTestSecureOmFlag()) {
-      Preconditions.checkArgument(clientIdBytes != DUMMY_CLIENT_ID);
-    }
-    return ClientId.valueOf(UUID.nameUUIDFromBytes(clientIdBytes));
-  }
-
-  private long getCallId() {
-    final long callId = Server.getCallId();
-    if (!ozoneManager.isTestSecureOmFlag()) {
-      Preconditions.checkArgument(callId != INVALID_CALL_ID);
-    }
-    return callId;
-  }
-
-  public OMResponse checkRetryCache() throws ServiceException {
-    final ClientInvocationId invocationId = ClientInvocationId.valueOf(getClientId(), getCallId());
-    final RetryCache.Entry cacheEntry = getServerDivision().getRetryCache().getIfPresent(invocationId);
-    if (cacheEntry == null) {
-      return null;  //cache miss
-    }
-    //cache hit
-    try {
-      return getOMResponse(cacheEntry.getReplyFuture().get());
-    } catch (ExecutionException ex) {
-      throw new ServiceException(ex.getMessage(), ex);
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
-      throw new ServiceException(ex.getMessage(), ex);
-    }
   }
 
   /**
@@ -568,10 +538,6 @@ public final class OzoneManagerRatisServer {
       }
     }
 
-    return getOMResponse(reply);
-  }
-
-  private OMResponse getOMResponse(RaftClientReply reply) throws ServiceException {
     try {
       return OMRatisHelper.getOMResponseFromRaftClientReply(reply);
     } catch (IOException ex) {
@@ -581,6 +547,9 @@ public final class OzoneManagerRatisServer {
         throw new ServiceException(ex);
       }
     }
+
+    // TODO: Still need to handle RaftRetry failure exception and
+    //  NotReplicated exception.
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.sun.corba.se.pept.protocol.ClientInvocationInfo;
 import org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -183,9 +183,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
     return response;
   }
 
-  private OMResponse internalProcessRequest(OMRequest request) throws
-      ServiceException {
-    OMClientRequest omClientRequest = null;
+  private OMResponse internalProcessRequest(OMRequest request) throws ServiceException {
     boolean s3Auth = false;
 
     try {
@@ -214,7 +212,16 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
       if (!s3Auth) {
         OzoneManagerRatisUtils.checkLeaderStatus(ozoneManager);
       }
-      OMRequest requestToSubmit;
+
+      // check retry cache
+      final OMResponse cached = omRatisServer.checkRetryCache();
+      if (cached != null) {
+        return cached;
+      }
+
+      // process new request
+      OMClientRequest omClientRequest = null;
+      final OMRequest requestToSubmit;
       try {
         omClientRequest = createClientRequest(request, ozoneManager);
         // TODO: Note: Due to HDDS-6055, createClientRequest() could now
@@ -254,7 +261,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
         return createErrorResponse(request, ex);
       }
 
-      OMResponse response = submitRequestToRatis(requestToSubmit);
+      final OMResponse response = omRatisServer.submitRequest(request);
       if (!response.getSuccess()) {
         omClientRequest.handleRequestFailure(ozoneManager);
       }
@@ -273,14 +280,6 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
   @VisibleForTesting
   public OMRequest getLastRequestToSubmit() {
     return lastRequestToSubmit;
-  }
-
-  /**
-   * Submits request to OM's Ratis server.
-   */
-  private OMResponse submitRequestToRatis(OMRequest request)
-      throws ServiceException {
-    return omRatisServer.submitRequest(request);
   }
 
   private OMResponse submitReadRequestToOM(OMRequest request)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.ozone.util.MetricUtil.captureLatencyNs;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -33,6 +34,7 @@ import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ipc.ProcessingDetails.Timing;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
@@ -40,6 +42,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
 import org.apache.hadoop.ozone.om.helpers.OMAuditLogger;
+import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
@@ -57,7 +60,11 @@ import com.google.protobuf.ProtocolMessageEnum;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.ozone.security.S3SecurityUtil;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.ClientInvocationId;
+import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RetryCache;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.ExitUtils;
 import org.slf4j.Logger;
@@ -222,6 +229,27 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
         //  Added the assertion.
         assert (omClientRequest != null);
         OMClientRequest finalOmClientRequest = omClientRequest;
+
+        ClientInvocationId clientInvocationId = ClientInvocationId.valueOf(
+            ClientId.valueOf(UUID.nameUUIDFromBytes(ProtobufRpcEngine.Server.getClientId())),
+            ProtobufRpcEngine.Server.getCallId());
+        RetryCache.Entry cacheEntry =
+            omRatisServer.getServerDivision().getRetryCache().getIfPresent(clientInvocationId);
+        // if this request has been executed before, return the cached result.
+        if (cacheEntry != null) {
+          if (cacheEntry.getReplyFuture().isDone()) {
+            RaftClientReply raftClientReply;
+            try {
+              raftClientReply = cacheEntry.getReplyFuture().get();
+            } catch (ExecutionException ex) {
+              throw new ServiceException(ex.getMessage(), ex);
+            } catch (InterruptedException ex) {
+              Thread.currentThread().interrupt();
+              throw new ServiceException(ex.getMessage(), ex);
+            }
+            return OMRatisHelper.getOMResponseFromRaftClientReply(raftClientReply);
+          }
+        }
 
         requestToSubmit = preExecute(finalOmClientRequest);
         this.lastRequestToSubmit = requestToSubmit;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -23,7 +23,6 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.ozone.util.MetricUtil.captureLatencyNs;
 
 import java.io.IOException;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -34,7 +33,6 @@ import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ipc.ProcessingDetails.Timing;
-import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMPerformanceMetrics;
@@ -42,7 +40,6 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
 import org.apache.hadoop.ozone.om.helpers.OMAuditLogger;
-import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
@@ -60,11 +57,7 @@ import com.google.protobuf.ProtocolMessageEnum;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.ozone.security.S3SecurityUtil;
-import org.apache.ratis.protocol.ClientId;
-import org.apache.ratis.protocol.ClientInvocationId;
-import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeerId;
-import org.apache.ratis.server.RetryCache;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.ExitUtils;
 import org.slf4j.Logger;
@@ -229,27 +222,6 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
         //  Added the assertion.
         assert (omClientRequest != null);
         OMClientRequest finalOmClientRequest = omClientRequest;
-
-        ClientInvocationId clientInvocationId = ClientInvocationId.valueOf(
-            ClientId.valueOf(UUID.nameUUIDFromBytes(ProtobufRpcEngine.Server.getClientId())),
-            ProtobufRpcEngine.Server.getCallId());
-        RetryCache.Entry cacheEntry =
-            omRatisServer.getServerDivision().getRetryCache().getIfPresent(clientInvocationId);
-        // if this request has been executed before, return the cached result.
-        if (cacheEntry != null) {
-          if (cacheEntry.getReplyFuture().isDone()) {
-            RaftClientReply raftClientReply;
-            try {
-              raftClientReply = cacheEntry.getReplyFuture().get();
-            } catch (ExecutionException ex) {
-              throw new ServiceException(ex.getMessage(), ex);
-            } catch (InterruptedException ex) {
-              Thread.currentThread().interrupt();
-              throw new ServiceException(ex.getMessage(), ex);
-            }
-            return OMRatisHelper.getOMResponseFromRaftClientReply(raftClientReply);
-          }
-        }
 
         requestToSubmit = preExecute(finalOmClientRequest);
         this.lastRequestToSubmit = requestToSubmit;


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11558. HBase RegionServer crashes due to inconsistency caused by Ozone client failover handling

Please describe your PR in detail:
* Please see the jira for the reproduction steps.
* This PR proposes to add a check before OM preExecute() step, such that if OM (inside its Hadoop RPC handler) receives a request that has been executed before, return its cached result.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11558

## How was this patch tested?

The reproduction is complex. It involves pausing multiple OMs in specific lock steps. So I'm not able to write a test. It might be possible to write Docker-based acceptance test to simulate node pause though.
I manually repeated the steps described in the jira several times to confirm the change fixed the problem.