### PR TITLE
HDDS-11570. Fix HDDS Docs Build fail with Hugo v0.135.0

### DIFF
--- a/hadoop-hdds/docs/content/feature/Quota.md
+++ b/hadoop-hdds/docs/content/feature/Quota.md
@@ -1,6 +1,6 @@
 ---
 title: "Quota in Ozone"
-date: "2020-October-22"
+date: "2020-10-22"
 weight: 4
 summary: Quota in Ozone
 icon: user

--- a/hadoop-hdds/docs/content/feature/Quota.zh.md
+++ b/hadoop-hdds/docs/content/feature/Quota.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Ozone 中的配额"
-date: "2020-October-22"
+date: "2020-10-22"
 weight: 4
 summary: Ozone中的配额
 icon: user

--- a/hadoop-hdds/docs/content/security/GDPR.md
+++ b/hadoop-hdds/docs/content/security/GDPR.md
@@ -1,6 +1,6 @@
 ---
 title: "GDPR in Ozone"
-date: "2019-September-17"
+date: "2019-09-17"
 weight: 3
 icon: user
 menu:

--- a/hadoop-hdds/docs/content/security/GDPR.zh.md
+++ b/hadoop-hdds/docs/content/security/GDPR.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Ozone 中的 GDPR"
-date: "2019-September-17"
+date: "2019-09-17"
 weight: 3
 summary: Ozone 中的 GDPR
 menu:

--- a/hadoop-hdds/docs/content/security/SecureOzone.md
+++ b/hadoop-hdds/docs/content/security/SecureOzone.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing Ozone"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: Overview of Ozone security concepts and steps to secure Ozone Manager and SCM.
 weight: 1
 menu:

--- a/hadoop-hdds/docs/content/security/SecureOzone.zh.md
+++ b/hadoop-hdds/docs/content/security/SecureOzone.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "安全化 Ozone"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: 简要介绍 Ozone 中的安全概念以及安全化 OM 和 SCM 的步骤。
 weight: 1
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringDatanodes.md
+++ b/hadoop-hdds/docs/content/security/SecuringDatanodes.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing Datanodes"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 3
 menu:
    main:

--- a/hadoop-hdds/docs/content/security/SecuringDatanodes.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringDatanodes.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "安全化 Datanode"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 3
 menu:
   main:

--- a/hadoop-hdds/docs/content/security/SecuringOzoneHTTP.md
+++ b/hadoop-hdds/docs/content/security/SecuringOzoneHTTP.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing HTTP"
-date: "2020-June-17"
+date: "2020-06-17"
 summary: Secure HTTP web-consoles for Ozone services 
 weight: 4
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringOzoneHTTP.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringOzoneHTTP.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "安全化 HTTP"
-date: "2020-June-17"
+date: "2020-06-17"
 summary: 安全化 Ozone 服务的 HTTP 网络控制台
 weight: 4
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringS3.md
+++ b/hadoop-hdds/docs/content/security/SecuringS3.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing S3"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: Ozone supports S3 protocol, and uses AWS Signature Version 4 protocol which allows a seamless S3 experience.
 weight: 5
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringS3.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringS3.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "安全化 S3"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: Ozone 支持 S3 协议，并使用 AWS Signature Version 4 protocol which allows a seamless S3
  experience.
 weight: 5

--- a/hadoop-hdds/docs/content/security/SecuringTDE.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.md
@@ -1,6 +1,6 @@
 ---
 title: "Transparent Data Encryption"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: TDE allows data on the disks to be encrypted-at-rest and automatically decrypted during access. 
 weight: 2
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "透明数据加密"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: 透明数据加密（Transparent Data Encryption，TDE）以密文形式在磁盘上保存数据，但可以在用户访问的时候自动进行解密。
 weight: 2
 menu:

--- a/hadoop-hdds/docs/content/security/SecurityAcls.md
+++ b/hadoop-hdds/docs/content/security/SecurityAcls.md
@@ -1,6 +1,6 @@
 ---
 title: "Ozone ACLs"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 6
 menu:
    main:

--- a/hadoop-hdds/docs/content/security/SecurityAcls.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityAcls.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Ozone 访问控制列表"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 6
 menu:
    main:

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache Ranger"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 7
 menu:
    main:

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache Ranger"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 7
 menu:
    main:


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pull request fixes the Hadoop HDDS docs build issue encountered with Hugo v0.135.0 on an M1 Max MacBook Pro.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11570

## How was this patch tested?

The issue was reproduced by building Ozone with the following command on an M1 Max MacBook Pro:

```bash
mvn clean install -DskipTests -Dos.arch=x86_64
```

The Hugo version used was v0.135:

```
hugo version
hugo v0.135.0-f30603c47f5205e30ef83c70419f57d7eb7175ab darwin/arm64 BuildDate=2024-09-27T13:17:08Z VendorInfo=gohugoio
```

The Maven build failed specifically at the hadoop-hdds-docs module with the following error:

```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.4.1:exec (default) on project hdds-docs: Command execution failed.: Process exited with an error: 1 (Exit value: 1) -> [Help 1]
```


