### PR TITLE
[DO NOT MERGE] Backport some fixes and compatibility commits from master to ozone-1.4 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         include:
           - os: ubuntu-20.04
           - java: 8
-            os: macos-12
+            os: macos-13
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -170,13 +170,13 @@ public class OzoneClientConfig {
   private String checksumType = ChecksumType.CRC32.name();
 
   @Config(key = "bytes.per.checksum",
-      defaultValue = "1MB",
+      defaultValue = "16KB",
       type = ConfigType.SIZE,
       description = "Checksum will be computed for every bytes per checksum "
           + "number of bytes and stored sequentially. The minimum value for "
-          + "this config is 16KB.",
+          + "this config is 8KB.",
       tags = ConfigTag.CLIENT)
-  private int bytesPerChecksum = 1024 * 1024;
+  private int bytesPerChecksum = 16 * 1024;
 
   @Config(key = "verify.checksum",
       defaultValue = "true",

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -149,7 +149,8 @@ public final class XceiverClientRatis extends XceiverClientSpi {
     } else {
       stream = commitInfoProtos.stream().map(proto -> commitInfoMap
           .computeIfPresent(RatisHelper.toDatanodeId(proto.getServer()),
-              (address, index) -> proto.getCommitIndex()));
+              (address, index) -> proto.getCommitIndex()))
+          .filter(Objects::nonNull);
     }
     return stream.mapToLong(Long::longValue).min().orElse(0);
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -458,7 +458,7 @@ public final class OzoneConfigKeys {
       "hdds.datanode.replication.work.dir";
 
 
-  public static final int OZONE_CLIENT_BYTES_PER_CHECKSUM_MIN_SIZE = 16 * 1024;
+  public static final int OZONE_CLIENT_BYTES_PER_CHECKSUM_MIN_SIZE = 8 * 1024;
 
   public static final String OZONE_CLIENT_READ_TIMEOUT
           = "ozone.client.read.timeout";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
@@ -61,6 +61,7 @@ public class ChunkBufferImplWithByteBufferList implements ChunkBuffer {
 
   private void findCurrent() {
     boolean found = false;
+    limitPrecedingCurrent = 0;
     for (int i = 0; i < buffers.size(); i++) {
       final ByteBuffer buf = buffers.get(i);
       final int pos = buf.position();
@@ -185,6 +186,8 @@ public class ChunkBufferImplWithByteBufferList implements ChunkBuffer {
    */
   @Override
   public Iterable<ByteBuffer> iterate(int bufferSize) {
+    Preconditions.checkArgument(bufferSize > 0);
+
     return () -> new Iterator<ByteBuffer>() {
       @Override
       public boolean hasNext() {
@@ -198,10 +201,40 @@ public class ChunkBufferImplWithByteBufferList implements ChunkBuffer {
         }
         findCurrent();
         ByteBuffer current = buffers.get(currentIndex);
-        final ByteBuffer duplicated = current.duplicate();
-        duplicated.limit(current.limit());
-        current.position(current.limit());
-        return duplicated;
+
+        // If current buffer has enough space or it's the last one, return it.
+        if (current.remaining() >= bufferSize || currentIndex == buffers.size() - 1) {
+          final ByteBuffer duplicated = current.duplicate();
+          int duplicatedLimit = Math.min(current.position() + bufferSize, current.limit());
+          duplicated.limit(duplicatedLimit);
+          duplicated.position(current.position());
+
+          current.position(duplicatedLimit);
+          return duplicated;
+        }
+
+        // Otherwise, create a new buffer.
+        int newBufferSize = Math.min(bufferSize, remaining());
+        ByteBuffer allocated = ByteBuffer.allocate(newBufferSize);
+        int remainingToFill = allocated.remaining();
+
+        while (remainingToFill > 0) {
+          final ByteBuffer b = current();
+          int bytes = Math.min(b.remaining(), remainingToFill);
+          b.limit(b.position() + bytes);
+          allocated.put(b);
+          remainingToFill -= bytes;
+          advanceCurrent();
+        }
+
+        allocated.flip();
+
+        // Up-to-date current.
+        current = buffers.get(currentIndex);
+        // Reset
+        current.limit(current.capacity());
+
+        return allocated;
       }
     };
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBufferImplWithByteBufferList.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBufferImplWithByteBufferList.java
@@ -67,6 +67,76 @@ public class TestChunkBufferImplWithByteBufferList {
     assertThrows(IllegalArgumentException.class, () -> ChunkBuffer.wrap(list));
   }
 
+  @Test
+  public void testIterateSmallerOverSingleChunk() {
+    ChunkBuffer subject = ChunkBuffer.wrap(ImmutableList.of(ByteBuffer.allocate(100)));
+
+    assertEquals(0, subject.position());
+    assertEquals(100, subject.remaining());
+    assertEquals(100, subject.limit());
+
+    subject.iterate(25).forEach(buffer -> assertEquals(25, buffer.remaining()));
+
+    assertEquals(100, subject.position());
+    assertEquals(0, subject.remaining());
+    assertEquals(100, subject.limit());
+  }
+
+  @Test
+  public void testIterateOverMultipleChunksFitChunkSize() {
+    ByteBuffer b1 = ByteBuffer.allocate(100);
+    ByteBuffer b2 = ByteBuffer.allocate(100);
+    ByteBuffer b3 = ByteBuffer.allocate(100);
+    ChunkBuffer subject = ChunkBuffer.wrap(ImmutableList.of(b1, b2, b3));
+
+    assertEquals(0, subject.position());
+    assertEquals(300, subject.remaining());
+    assertEquals(300, subject.limit());
+
+    subject.iterate(100).forEach(buffer -> assertEquals(100, buffer.remaining()));
+
+    assertEquals(300, subject.position());
+    assertEquals(0, subject.remaining());
+    assertEquals(300, subject.limit());
+  }
+
+  @Test
+  public void testIterateOverMultipleChunksSmallerChunks() {
+    ByteBuffer b1 = ByteBuffer.allocate(100);
+    ByteBuffer b2 = ByteBuffer.allocate(100);
+    ByteBuffer b3 = ByteBuffer.allocate(100);
+    ChunkBuffer subject = ChunkBuffer.wrap(ImmutableList.of(b1, b2, b3));
+
+    assertEquals(0, subject.position());
+    assertEquals(300, subject.remaining());
+    assertEquals(300, subject.limit());
+
+    subject.iterate(50).forEach(buffer -> assertEquals(50, buffer.remaining()));
+
+    assertEquals(300, subject.position());
+    assertEquals(0, subject.remaining());
+    assertEquals(300, subject.limit());
+  }
+
+  @Test
+  public void testIterateOverMultipleChunksBiggerChunks() {
+    ByteBuffer b1 = ByteBuffer.allocate(100);
+    ByteBuffer b2 = ByteBuffer.allocate(100);
+    ByteBuffer b3 = ByteBuffer.allocate(100);
+    ByteBuffer b4 = ByteBuffer.allocate(100);
+    ChunkBuffer subject = ChunkBuffer.wrap(ImmutableList.of(b1, b2, b3, b4));
+
+    assertEquals(0, subject.position());
+    assertEquals(400, subject.remaining());
+    assertEquals(400, subject.limit());
+
+    subject.iterate(200).forEach(buffer -> assertEquals(200, buffer.remaining()));
+
+    assertEquals(400, subject.position());
+    assertEquals(0, subject.remaining());
+    assertEquals(400, subject.limit());
+  }
+
   private static void assertEmpty(ChunkBuffer subject) {
     assertEquals(0, subject.position());
     assertEquals(0, subject.remaining());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -354,10 +354,11 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       DeletedContainerBlocksSummary summary =
           DeletedContainerBlocksSummary.getFrom(containerBlocks);
       LOG.info("Summary of deleting container blocks, numOfTransactions={}, "
-              + "numOfContainers={}, numOfBlocks={}",
+              + "numOfContainers={}, numOfBlocks={}, commandId={}.",
           summary.getNumOfTxs(),
           summary.getNumOfContainers(),
-          summary.getNumOfBlocks());
+          summary.getNumOfBlocks(),
+          cmd.getCmd().getId());
       if (LOG.isDebugEnabled()) {
         LOG.debug("Start to delete container blocks, TXIDs={}",
             summary.getTxIDSummary());
@@ -384,7 +385,8 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
           LOG.debug("Sending following block deletion ACK to SCM");
           for (DeleteBlockTransactionResult result : blockDeletionACK
               .getResultsList()) {
-            LOG.debug("{} : {}", result.getTxID(), result.getSuccess());
+            LOG.debug("TxId = {} : ContainerId = {} : {}",
+                result.getTxID(), result.getContainerID(), result.getSuccess());
           }
         }
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerCheck.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.container.keyvalue;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdfs.util.Canceler;
@@ -43,7 +44,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.Arrays;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.slf4j.Logger;
@@ -404,8 +404,8 @@ public class KeyValueContainerCheck {
                   " for block %s",
                   ChunkInfo.getFromProtoBuf(chunk),
                   i,
-                  Arrays.toString(expected.toByteArray()),
-                  Arrays.toString(actual.toByteArray()),
+                  StringUtils.bytes2Hex(expected.asReadOnlyByteBuffer()),
+                  StringUtils.bytes2Hex(actual.asReadOnlyByteBuffer()),
                   block.getBlockID());
           return ScanResult.unhealthy(
               ScanResult.FailureType.CORRUPT_CHUNK, chunkFile,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
@@ -126,7 +126,7 @@ public interface ChunkManager {
     } else {
       // Set buffer capacity to checksum boundary size so that each buffer
       // corresponds to one checksum. If checksum is NONE, then set buffer
-      // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 64KB).
+      // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 1MB).
       ChecksumData checksumData = chunkInfo.getChecksumData();
 
       if (checksumData != null) {

--- a/hadoop-hdds/docs/content/feature/Quota.md
+++ b/hadoop-hdds/docs/content/feature/Quota.md
@@ -1,6 +1,6 @@
 ---
 title: "Quota in Ozone"
-date: "2020-October-22"
+date: "2020-10-22"
 weight: 4
 summary: Quota in Ozone
 icon: user

--- a/hadoop-hdds/docs/content/feature/Quota.zh.md
+++ b/hadoop-hdds/docs/content/feature/Quota.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Ozone 中的配额"
-date: "2020-October-22"
+date: "2020-10-22"
 weight: 4
 summary: Ozone中的配额
 icon: user

--- a/hadoop-hdds/docs/content/security/GDPR.md
+++ b/hadoop-hdds/docs/content/security/GDPR.md
@@ -1,6 +1,6 @@
 ---
 title: "GDPR in Ozone"
-date: "2019-September-17"
+date: "2019-09-17"
 weight: 3
 icon: user
 menu:

--- a/hadoop-hdds/docs/content/security/GDPR.zh.md
+++ b/hadoop-hdds/docs/content/security/GDPR.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Ozone 中的 GDPR"
-date: "2019-September-17"
+date: "2019-09-17"
 weight: 3
 summary: Ozone 中的 GDPR
 menu:

--- a/hadoop-hdds/docs/content/security/SecureOzone.md
+++ b/hadoop-hdds/docs/content/security/SecureOzone.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing Ozone"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: Overview of Ozone security concepts and steps to secure Ozone Manager and SCM.
 weight: 1
 menu:

--- a/hadoop-hdds/docs/content/security/SecureOzone.zh.md
+++ b/hadoop-hdds/docs/content/security/SecureOzone.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "安全化 Ozone"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: 简要介绍 Ozone 中的安全概念以及安全化 OM 和 SCM 的步骤。
 weight: 1
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringDatanodes.md
+++ b/hadoop-hdds/docs/content/security/SecuringDatanodes.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing Datanodes"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 3
 menu:
    main:

--- a/hadoop-hdds/docs/content/security/SecuringDatanodes.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringDatanodes.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "安全化 Datanode"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 3
 menu:
   main:

--- a/hadoop-hdds/docs/content/security/SecuringOzoneHTTP.md
+++ b/hadoop-hdds/docs/content/security/SecuringOzoneHTTP.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing HTTP"
-date: "2020-June-17"
+date: "2020-06-17"
 summary: Secure HTTP web-consoles for Ozone services 
 weight: 4
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringS3.md
+++ b/hadoop-hdds/docs/content/security/SecuringS3.md
@@ -1,6 +1,6 @@
 ---
 title: "Securing S3"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: Ozone supports S3 protocol, and uses AWS Signature Version 4 protocol which allows a seamless S3 experience.
 weight: 5
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringS3.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringS3.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "安全化 S3"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: Ozone 支持 S3 协议，并使用 AWS Signature Version 4 protocol which allows a seamless S3
  experience.
 weight: 5

--- a/hadoop-hdds/docs/content/security/SecuringTDE.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.md
@@ -1,6 +1,6 @@
 ---
 title: "Transparent Data Encryption"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: TDE allows data on the disks to be encrypted-at-rest and automatically decrypted during access. 
 weight: 2
 menu:

--- a/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "透明数据加密"
-date: "2019-April-03"
+date: "2019-04-03"
 summary: 透明数据加密（Transparent Data Encryption，TDE）以密文形式在磁盘上保存数据，但可以在用户访问的时候自动进行解密。
 weight: 2
 menu:

--- a/hadoop-hdds/docs/content/security/SecurityAcls.md
+++ b/hadoop-hdds/docs/content/security/SecurityAcls.md
@@ -1,6 +1,6 @@
 ---
 title: "Ozone ACLs"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 6
 menu:
    main:

--- a/hadoop-hdds/docs/content/security/SecurityAcls.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityAcls.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Ozone 访问控制列表"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 6
 menu:
    main:

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache Ranger"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 7
 menu:
    main:

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Apache Ranger"
-date: "2019-April-03"
+date: "2019-04-03"
 weight: 7
 menu:
    main:

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
@@ -47,7 +47,8 @@ class DatanodeDeletedBlockTransactions {
     blocksDeleted += tx.getLocalIDCount();
     if (SCMBlockDeletingService.LOG.isDebugEnabled()) {
       SCMBlockDeletingService.LOG
-          .debug("Transaction added: {} <- TX({})", dnID, tx.getTxID());
+          .debug("Transaction added: {} <- TX({}), DN {} <- blocksDeleted Add {}.",
+          dnID, tx.getTxID(), dnID, tx.getLocalIDCount());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerBlocksDeletionACKProto.DeleteBlockTransactionResult;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.command.CommandStatusReportHandler.DeleteBlockStatus;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -204,20 +203,6 @@ public class DeletedBlockLogImpl
         .build();
   }
 
-  private boolean isTransactionFailed(DeleteBlockTransactionResult result) {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(
-          "Got block deletion ACK from datanode, TXIDs={}, " + "success={}",
-          result.getTxID(), result.getSuccess());
-    }
-    if (!result.getSuccess()) {
-      LOG.warn("Got failed ACK for TXID={}, prepare to resend the "
-          + "TX in next interval", result.getTxID());
-      return true;
-    }
-    return false;
-  }
-
   @Override
   public int getNumOfValidTransactions() throws IOException {
     lock.lock();
@@ -304,26 +289,46 @@ public class DeletedBlockLogImpl
             .setCount(transactionStatusManager.getOrDefaultRetryCount(
               tx.getTxID(), 0))
             .build();
+
     for (ContainerReplica replica : replicas) {
       DatanodeDetails details = replica.getDatanodeDetails();
-      if (!dnList.contains(details)) {
-        continue;
-      }
       if (!transactionStatusManager.isDuplication(
           details, updatedTxn.getTxID(), commandStatus)) {
         transactions.addTransactionToDN(details.getUuid(), updatedTxn);
+        metrics.incrProcessedTransaction();
       }
     }
   }
 
   private Boolean checkInadequateReplica(Set<ContainerReplica> replicas,
-      DeletedBlocksTransaction txn) throws ContainerNotFoundException {
+      DeletedBlocksTransaction txn,
+      Set<DatanodeDetails> dnList) throws ContainerNotFoundException {
     ContainerInfo containerInfo = containerManager
         .getContainer(ContainerID.valueOf(txn.getContainerID()));
     ReplicationManager replicationManager =
         scmContext.getScm().getReplicationManager();
     ContainerHealthResult result = replicationManager
         .getContainerReplicationHealth(containerInfo, replicas);
+
+    // We have made an improvement here, and we expect that all replicas
+    // of the Container being sent will be included in the dnList.
+    // This change benefits ACK confirmation and improves deletion speed.
+    // The principle behind it is that
+    // DN can receive the command to delete a certain Container at the same time and provide
+    // feedback to SCM at roughly the same time.
+    // This avoids the issue of deletion blocking,
+    // where some replicas of a Container are deleted while others do not receive the delete command.
+    long containerId = txn.getContainerID();
+    for (ContainerReplica replica : replicas) {
+      DatanodeDetails datanodeDetails = replica.getDatanodeDetails();
+      if (!dnList.contains(datanodeDetails)) {
+        DatanodeDetails dnDetail = replica.getDatanodeDetails();
+        LOG.debug("Skip Container = {}, because DN = {} is not in dnList.",
+            containerId, dnDetail.getUuid());
+        return true;
+      }
+    }
+
     return result.getHealthState() != ContainerHealthResult.HealthState.HEALTHY;
   }
 
@@ -349,6 +354,7 @@ public class DeletedBlockLogImpl
                 .getCommandStatusByTxId(dnList.stream().
                 map(DatanodeDetails::getUuid).collect(Collectors.toSet()));
         ArrayList<Long> txIDs = new ArrayList<>();
+        metrics.setNumBlockDeletionTransactionDataNodes(dnList.size());
         // Here takes block replica count as the threshold to avoid the case
         // that part of replicas committed the TXN and recorded in the
         // SCMDeletedBlockTransactionStatusManager, while they are counted
@@ -362,23 +368,25 @@ public class DeletedBlockLogImpl
             // HDDS-7126. When container is under replicated, it is possible
             // that container is deleted, but transactions are not deleted.
             if (containerManager.getContainer(id).isDeleted()) {
-              LOG.warn("Container: " + id + " was deleted for the " +
-                  "transaction: " + txn);
+              LOG.warn("Container: {} was deleted for the " +
+                  "transaction: {}.", id, txn);
               txIDs.add(txn.getTxID());
             } else if (txn.getCount() > -1 && txn.getCount() <= maxRetry
                 && !containerManager.getContainer(id).isOpen()) {
               Set<ContainerReplica> replicas = containerManager
                   .getContainerReplicas(
                       ContainerID.valueOf(txn.getContainerID()));
-              if (checkInadequateReplica(replicas, txn)) {
+              if (checkInadequateReplica(replicas, txn, dnList)) {
+                metrics.incrSkippedTransaction();
                 continue;
               }
               getTransaction(
                   txn, transactions, dnList, replicas, commandStatus);
+            } else if (txn.getCount() >= maxRetry || containerManager.getContainer(id).isOpen()) {
+              metrics.incrSkippedTransaction();
             }
           } catch (ContainerNotFoundException ex) {
-            LOG.warn("Container: " + id + " was not found for the transaction: "
-                + txn);
+            LOG.warn("Container: {} was not found for the transaction: {}.", id, txn);
             txIDs.add(txn.getTxID());
           }
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -203,9 +203,10 @@ public class SCMBlockDeletingService extends BackgroundService
             }
           }
           LOG.info("Totally added {} blocks to be deleted for"
-                  + " {} datanodes, task elapsed time: {}ms",
+                  + " {} datanodes / {} totalnodes, task elapsed time: {}ms",
               transactions.getBlocksDeleted(),
               transactions.getDatanodeTransactionMap().size(),
+              included.size(),
               Time.monotonicNow() - startTime);
           deletedBlockLog.incrementCount(new ArrayList<>(processedTxIDs));
         } catch (NotLeaderException nle) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 
 /**
  * Metrics related to Block Deleting Service running in SCM.
@@ -75,6 +76,15 @@ public final class ScmBlockDeletingServiceMetrics {
 
   @Metric(about = "The number of created txs which are added into DB.")
   private MutableCounterLong numBlockDeletionTransactionCreated;
+
+  @Metric(about = "The number of skipped transactions")
+  private MutableCounterLong numSkippedTransactions;
+
+  @Metric(about = "The number of processed transactions")
+  private MutableCounterLong numProcessedTransactions;
+
+  @Metric(about = "The number of dataNodes of delete transactions.")
+  private MutableGaugeLong numBlockDeletionTransactionDataNodes;
 
   private ScmBlockDeletingServiceMetrics() {
   }
@@ -130,6 +140,18 @@ public final class ScmBlockDeletingServiceMetrics {
     this.numBlockDeletionTransactionCreated.incr(count);
   }
 
+  public void incrSkippedTransaction() {
+    this.numSkippedTransactions.incr();
+  }
+
+  public void incrProcessedTransaction() {
+    this.numProcessedTransactions.incr();
+  }
+
+  public void setNumBlockDeletionTransactionDataNodes(long dataNodes) {
+    this.numBlockDeletionTransactionDataNodes.set(dataNodes);
+  }
+
   public long getNumBlockDeletionCommandSent() {
     return numBlockDeletionCommandSent.value();
   }
@@ -160,6 +182,18 @@ public final class ScmBlockDeletingServiceMetrics {
 
   public long getNumBlockDeletionTransactionCreated() {
     return numBlockDeletionTransactionCreated.value();
+  }
+
+  public long getNumSkippedTransactions() {
+    return numSkippedTransactions.value();
+  }
+
+  public long getNumProcessedTransactions() {
+    return numProcessedTransactions.value();
+  }
+
+  public long getNumBlockDeletionTransactionDataNodes() {
+    return numBlockDeletionTransactionDataNodes.value();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -349,8 +349,18 @@ public class AbstractContainerReportHandler {
       break;
     case DELETING:
       /*
-       * The container is under deleting. do nothing.
+      HDDS-11136: If a DELETING container has a non-empty CLOSED replica, the container should be moved back to CLOSED
+      state.
        */
+      boolean replicaStateAllowed = replica.getState() == State.CLOSED;
+      boolean replicaNotEmpty = replica.hasIsEmpty() && !replica.getIsEmpty();
+      if (replicaStateAllowed && replicaNotEmpty) {
+        logger.info("Moving DELETING container {} to CLOSED state, datanode {} reported replica with state={}, " +
+            "isEmpty={} and keyCount={}.", containerId, datanode.getHostName(), replica.getState(), false,
+            replica.getKeyCount());
+        containerManager.transitionDeletingToClosedState(containerId);
+      }
+
       break;
     case DELETED:
       /*

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -132,6 +132,16 @@ public interface ContainerManager extends Closeable {
       throws IOException, InvalidStateTransitionException;
 
   /**
+   * Bypasses the container state machine to change a container's state from DELETING to CLOSED. This API was
+   * introduced to fix a bug (HDDS-11136), and should be used with care otherwise.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/HDDS-11136">HDDS-11136</a>
+   * @param containerID id of the container to transition
+   * @throws IOException
+   */
+  void transitionDeletingToClosedState(ContainerID containerID) throws IOException;
+
+  /**
    * Returns the latest list of replicas for given containerId.
    *
    * @param containerID Container ID

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -283,6 +283,21 @@ public class ContainerManagerImpl implements ContainerManager {
   }
 
   @Override
+  public void transitionDeletingToClosedState(ContainerID containerID) throws IOException {
+    HddsProtos.ContainerID proto = containerID.getProtobuf();
+    lock.lock();
+    try {
+      if (containerExist(containerID)) {
+        containerStateManager.transitionDeletingToClosedState(proto);
+      } else {
+        throwContainerNotFoundException(containerID);
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
   public Set<ContainerReplica> getContainerReplicas(final ContainerID id)
       throws ContainerNotFoundException {
     return Optional.ofNullable(containerStateManager

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -151,6 +151,18 @@ public interface ContainerStateManager {
                             HddsProtos.LifeCycleEvent event)
       throws IOException, InvalidStateTransitionException;
 
+
+  /**
+   * Bypasses the container state machine to change a container's state from DELETING to CLOSED. This API was
+   * introduced to fix a bug (HDDS-11136), and should be used with care otherwise.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/HDDS-11136">HDDS-11136</a>
+   * @param id id of the container to transition
+   * @throws IOException
+   */
+  @Replicate
+  void transitionDeletingToClosedState(HddsProtos.ContainerID id) throws IOException;
+
   /**
    *
    */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisResponse.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisResponse.java
@@ -17,12 +17,13 @@
 
 package org.apache.hadoop.hdds.scm.ha;
 
-import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.SCMRatisResponseProto;
 import org.apache.hadoop.hdds.scm.ha.io.CodecFactory;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.com.google.protobuf.UnsafeByteOperations;
 
 /**
  * Represents the response from RatisServer.
@@ -72,13 +73,11 @@ public final class SCMRatisResponse {
     }
 
     final Class<?> type = result.getClass();
-    final ByteString value = CodecFactory.getCodec(type).serialize(result);
-
     final SCMRatisResponseProto response = SCMRatisResponseProto.newBuilder()
-        .setType(type.getName()).setValue(value).build();
-    return Message.valueOf(
-        org.apache.ratis.thirdparty.com.google.protobuf.ByteString.copyFrom(
-            response.toByteArray()));
+        .setType(type.getName())
+        .setValue(CodecFactory.getCodec(type).serialize(result))
+        .build();
+    return Message.valueOf(UnsafeByteOperations.unsafeWrap(response.toByteString().asReadOnlyByteBuffer()));
   }
 
   public static SCMRatisResponse decode(RaftClientReply reply)
@@ -87,14 +86,13 @@ public final class SCMRatisResponse {
       return new SCMRatisResponse(reply.getException());
     }
 
-    final byte[] response = reply.getMessage().getContent().toByteArray();
+    final ByteString response = reply.getMessage().getContent();
 
-    if (response.length == 0) {
+    if (response.isEmpty()) {
       return new SCMRatisResponse();
     }
 
-    final SCMRatisResponseProto responseProto = SCMRatisResponseProto
-        .parseFrom(response);
+    final SCMRatisResponseProto responseProto = SCMRatisResponseProto.parseFrom(response.toByteArray());
 
     try {
       final Class<?> type = ReflectionUtil.getClass(responseProto.getType());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.apache.hadoop.hdds.scm.HddsTestUtils.getContainerReports;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getECContainer;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getReplicas;
@@ -102,7 +103,6 @@ public class TestContainerReportHandler {
     dbStore = DBStoreBuilder.createDBStore(
         conf, new SCMDBDefinition());
     scmhaManager = SCMHAManagerStub.getInstance(true);
-    nodeManager = new MockNodeManager(true, 10);
     pipelineManager =
         new MockPipelineManager(dbStore, scmhaManager, nodeManager);
     containerStateManager = ContainerStateManagerImpl.newBuilder()
@@ -153,6 +153,10 @@ public class TestContainerReportHandler {
     }).when(containerManager).removeContainerReplica(
         Mockito.any(ContainerID.class), Mockito.any(ContainerReplica.class));
 
+    Mockito.doAnswer(invocation -> {
+      containerStateManager.transitionDeletingToClosedState(((ContainerID) invocation.getArgument(0)).getProtobuf());
+      return null;
+    }).when(containerManager).transitionDeletingToClosedState(Mockito.any(ContainerID.class));
   }
 
   @AfterEach
@@ -449,6 +453,107 @@ public class TestContainerReportHandler {
     // index is 9, container should transition to CLOSED
     Assertions.assertEquals(LifeCycleState.CLOSED,
         containerManager.getContainer(container2.containerID()).getState());
+  }
+
+  /**
+   * Tests that a DELETING RATIS container transitions to CLOSED if a non-empty CLOSED replica is reported. It does not
+   * transition if a non-empty CLOSING replica is reported.
+   */
+  @Test
+  public void ratisContainerShouldTransitionFromDeletingToClosedWhenNonEmptyClosedReplica() throws IOException {
+    ContainerInfo container = getContainer(LifeCycleState.DELETING);
+    containerStateManager.addContainer(container.getProtobuf());
+
+    // set up a non-empty CLOSED replica
+    DatanodeDetails dnWithClosedReplica = nodeManager.getNodes(NodeStatus.inServiceHealthy()).get(0);
+    ContainerReplicaProto.Builder builder = ContainerReplicaProto.newBuilder();
+    ContainerReplicaProto closedReplica = builder.setContainerID(container.getContainerID())
+        .setIsEmpty(false)
+        .setState(ContainerReplicaProto.State.CLOSED)
+        .setKeyCount(0)
+        .setBlockCommitSequenceId(123)
+        .setOriginNodeId(dnWithClosedReplica.getUuidString()).build();
+
+    // set up a non-empty CLOSING replica
+    DatanodeDetails dnWithClosingReplica = nodeManager.getNodes(NodeStatus.inServiceHealthy()).get(1);
+    ContainerReplicaProto closingReplica = builder.setState(ContainerReplicaProto.State.CLOSING)
+        .setOriginNodeId(dnWithClosingReplica.getUuidString()).build();
+
+    // should not transition on processing the CLOSING replica's report
+    ContainerReportHandler containerReportHandler = new ContainerReportHandler(nodeManager, containerManager);
+    ContainerReportsProto closingContainerReport = getContainerReports(closingReplica);
+    containerReportHandler
+        .onMessage(new ContainerReportFromDatanode(dnWithClosingReplica, closingContainerReport), publisher);
+
+    assertEquals(LifeCycleState.DELETING, containerStateManager.getContainer(container.containerID()).getState());
+
+    // should transition on processing the CLOSED replica's report
+    ContainerReportsProto closedContainerReport = getContainerReports(closedReplica);
+    containerReportHandler
+        .onMessage(new ContainerReportFromDatanode(dnWithClosedReplica, closedContainerReport), publisher);
+    assertEquals(LifeCycleState.CLOSED, containerStateManager.getContainer(container.containerID()).getState());
+  }
+
+  @Test
+  public void ratisContainerShouldNotTransitionFromDeletingToClosedWhenEmptyClosedReplica() throws IOException {
+    ContainerInfo container = getContainer(LifeCycleState.DELETING);
+    containerStateManager.addContainer(container.getProtobuf());
+
+    // set up an empty CLOSED replica
+    DatanodeDetails dnWithClosedReplica = nodeManager.getNodes(NodeStatus.inServiceHealthy()).get(0);
+    ContainerReplicaProto.Builder builder = ContainerReplicaProto.newBuilder();
+    ContainerReplicaProto closedReplica = builder.setContainerID(container.getContainerID())
+        .setIsEmpty(true)
+        .setState(ContainerReplicaProto.State.CLOSED)
+        .setKeyCount(0)
+        .setBlockCommitSequenceId(123)
+        .setOriginNodeId(dnWithClosedReplica.getUuidString()).build();
+
+    ContainerReportHandler containerReportHandler = new ContainerReportHandler(nodeManager, containerManager);
+    ContainerReportsProto closedContainerReport = getContainerReports(closedReplica);
+    containerReportHandler
+        .onMessage(new ContainerReportFromDatanode(dnWithClosedReplica, closedContainerReport), publisher);
+    assertEquals(LifeCycleState.DELETING, containerStateManager.getContainer(container.containerID()).getState());
+  }
+
+  /**
+   * Tests that a DELETING EC container transitions to CLOSED if a non-empty CLOSED replica is reported. It does not
+   * transition if a non-empty CLOSING (or any other state) replica is reported.
+   */
+  @Test
+  public void ecContainerShouldTransitionFromDeletingToClosedWhenNonEmptyClosedReplica() throws IOException {
+    ContainerInfo container = getECContainer(LifeCycleState.DELETING, PipelineID.randomId(),
+        new ECReplicationConfig(6, 3));
+    containerStateManager.addContainer(container.getProtobuf());
+
+    // set up a non-empty CLOSED replica
+    DatanodeDetails dnWithClosedReplica = nodeManager.getNodes(NodeStatus.inServiceHealthy()).get(0);
+    ContainerReplicaProto.Builder builder = ContainerReplicaProto.newBuilder();
+    ContainerReplicaProto closedReplica = builder.setContainerID(container.getContainerID())
+        .setIsEmpty(false)
+        .setState(ContainerReplicaProto.State.CLOSED)
+        .setKeyCount(0)
+        .setBlockCommitSequenceId(0)
+        .setReplicaIndex(1)
+        .setOriginNodeId(dnWithClosedReplica.getUuidString()).build();
+
+    // set up a non-empty CLOSING replica
+    DatanodeDetails dnWithClosingReplica = nodeManager.getNodes(NodeStatus.inServiceHealthy()).get(1);
+    ContainerReplicaProto closingReplica = builder.setState(ContainerReplicaProto.State.CLOSING).setReplicaIndex(2)
+        .setOriginNodeId(dnWithClosingReplica.getUuidString()).build();
+
+    // should not transition on processing the CLOSING replica's report
+    ContainerReportHandler containerReportHandler = new ContainerReportHandler(nodeManager, containerManager);
+    ContainerReportsProto closingContainerReport = getContainerReports(closingReplica);
+    containerReportHandler
+        .onMessage(new ContainerReportFromDatanode(dnWithClosingReplica, closingContainerReport), publisher);
+    assertEquals(LifeCycleState.DELETING, containerStateManager.getContainer(container.containerID()).getState());
+
+    // should transition on processing the CLOSED replica's report
+    ContainerReportsProto closedContainerReport = getContainerReports(closedReplica);
+    containerReportHandler
+        .onMessage(new ContainerReportFromDatanode(dnWithClosedReplica, closedContainerReport), publisher);
+    assertEquals(LifeCycleState.CLOSED, containerStateManager.getContainer(container.containerID()).getState());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 
+import org.apache.hadoop.hdds.scm.container.common.helpers.InvalidContainerStateException;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaPendingOps;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
@@ -53,6 +54,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 /**
@@ -151,6 +154,47 @@ public class TestContainerStateManager {
 
     Assertions.assertEquals(2, replicas.size());
     Assertions.assertEquals(3, c1.getReplicationConfig().getRequiredNodes());
+  }
+
+  @Test
+  public void testTransitionDeletingToClosedState() throws IOException {
+    HddsProtos.ContainerInfoProto.Builder builder = HddsProtos.ContainerInfoProto.newBuilder();
+    builder.setContainerID(1)
+        .setState(HddsProtos.LifeCycleState.DELETING)
+        .setUsedBytes(0)
+        .setNumberOfKeys(0)
+        .setOwner("root")
+        .setReplicationType(HddsProtos.ReplicationType.RATIS)
+        .setReplicationFactor(ReplicationFactor.THREE);
+
+    HddsProtos.ContainerInfoProto container = builder.build();
+    HddsProtos.ContainerID cid = HddsProtos.ContainerID.newBuilder().setId(container.getContainerID()).build();
+    containerStateManager.addContainer(container);
+    containerStateManager.transitionDeletingToClosedState(cid);
+    Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSED,
+            containerStateManager.getContainer(ContainerID.getFromProtobuf(cid)).getState());
+  }
+
+  @Test
+  public void testTransitionDeletingToClosedStateAllowsOnlyDeletingContainer() throws IOException {
+    HddsProtos.ContainerInfoProto.Builder builder = HddsProtos.ContainerInfoProto.newBuilder();
+    builder.setContainerID(1)
+        .setState(HddsProtos.LifeCycleState.QUASI_CLOSED)
+        .setUsedBytes(0)
+        .setNumberOfKeys(0)
+        .setOwner("root")
+        .setReplicationType(HddsProtos.ReplicationType.RATIS)
+        .setReplicationFactor(ReplicationFactor.THREE);
+
+    HddsProtos.ContainerInfoProto container = builder.build();
+    HddsProtos.ContainerID cid = HddsProtos.ContainerID.newBuilder().setId(container.getContainerID()).build();
+    containerStateManager.addContainer(container);
+    try {
+      containerStateManager.transitionDeletingToClosedState(cid);
+      fail("Was expecting an Exception, but did not catch any.");
+    } catch (IOException e) {
+      assertInstanceOf(InvalidContainerStateException.class, e.getCause().getCause());
+    }
   }
 
   private void addReplica(ContainerInfo cont, DatanodeDetails node) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECBlockChecksumComputer.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECBlockChecksumComputer.java
@@ -121,12 +121,10 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
 
     // Bytes required to create a CRC
     long bytesPerCrc = firstChunkInfo.getChecksumData().getBytesPerChecksum();
-    ECReplicationConfig replicationConfig =
-        (ECReplicationConfig) keyInfo.getReplicationConfig();
-    long chunkSize = replicationConfig.getEcChunkSize();
+    long chunkSize = firstChunkInfo.getLen();
 
     //When EC chunk size is not a multiple of ozone.client.bytes.per.checksum
-    // (default = 1MB) the last checksum in an EC chunk is only generated for
+    // (default = 16KB) the last checksum in an EC chunk is only generated for
     // offset.
     long bytesPerCrcOffset = chunkSize % bytesPerCrc;
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECBlockChecksumComputer.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECBlockChecksumComputer.java
@@ -45,12 +45,14 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
 
   private final List<ContainerProtos.ChunkInfo> chunkInfoList;
   private final OmKeyInfo keyInfo;
+  private final long blockLength;
 
 
   public ECBlockChecksumComputer(
-      List<ContainerProtos.ChunkInfo> chunkInfoList, OmKeyInfo keyInfo) {
+      List<ContainerProtos.ChunkInfo> chunkInfoList, OmKeyInfo keyInfo, long blockLength) {
     this.chunkInfoList = chunkInfoList;
     this.keyInfo = keyInfo;
+    this.blockLength = blockLength;
   }
 
   @Override
@@ -72,15 +74,13 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
   private void computeMd5Crc() {
     Preconditions.checkArgument(chunkInfoList.size() > 0);
 
-    final ContainerProtos.ChunkInfo firstChunkInfo = chunkInfoList.get(0);
-    long chunkSize = firstChunkInfo.getLen();
-    long bytesPerCrc = firstChunkInfo.getChecksumData().getBytesPerChecksum();
-    // Total parity checksum bytes per stripe to remove
-    int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
-
     final MessageDigest digester = MD5Hash.getDigester();
 
     for (ContainerProtos.ChunkInfo chunkInfo : chunkInfoList) {
+      long chunkSize = chunkInfo.getLen();
+      long bytesPerCrc = chunkInfo.getChecksumData().getBytesPerChecksum();
+      // Total parity checksum bytes per stripe to remove
+      int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
       ByteString stripeChecksum = chunkInfo.getStripeChecksum();
 
       Preconditions.checkNotNull(stripeChecksum);
@@ -121,66 +121,40 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
 
     // Bytes required to create a CRC
     long bytesPerCrc = firstChunkInfo.getChecksumData().getBytesPerChecksum();
-    long chunkSize = firstChunkInfo.getLen();
-
-    //When EC chunk size is not a multiple of ozone.client.bytes.per.checksum
-    // (default = 16KB) the last checksum in an EC chunk is only generated for
-    // offset.
-    long bytesPerCrcOffset = chunkSize % bytesPerCrc;
-
-    long keySize = keyInfo.getDataSize();
-    // Total parity checksum bytes per stripe to remove
-    int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
-
-    // Number of checksum per chunk, Eg: 2MB EC chunk will
-    // have 2 checksum per chunk.
-    int numChecksumPerChunk = (int)
-        (Math.ceil((double) chunkSize / bytesPerCrc));
+    long blockSize = blockLength;
 
     CrcComposer blockCrcComposer =
         CrcComposer.newCrcComposer(dataChecksumType, bytesPerCrc);
 
     for (ContainerProtos.ChunkInfo chunkInfo : chunkInfoList) {
       ByteString stripeChecksum = chunkInfo.getStripeChecksum();
+      long chunkSize = chunkInfo.getLen();
+
+      // Total parity checksum bytes per stripe to remove
+      int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
 
       Preconditions.checkNotNull(stripeChecksum);
       final int checksumSize = stripeChecksum.size();
       Preconditions.checkArgument(checksumSize % 4 == 0,
           "Checksum Bytes size does not match");
-      CrcComposer chunkCrcComposer =
-          CrcComposer.newCrcComposer(dataChecksumType, bytesPerCrc);
 
       // Limit parity bytes as they do not contribute to fileChecksum
       final ByteBuffer byteWrap = stripeChecksum.asReadOnlyByteBuffer();
       byteWrap.limit(checksumSize - parityBytes);
 
-      long chunkOffsetIndex = 1;
       while (byteWrap.hasRemaining()) {
-
-        /*
-        When chunk size is not a multiple of bytes.per.crc we get an offset.
-        For eg, RS-3-2-1524k is not a multiple of 1MB. So two checksums are
-        generated 1st checksum for 1024k bytes and 2nd checksum for 500k bytes.
-        When we reach the 2nd Checksum we need to modify the bytesPerCrc as in
-        this case 500k is the bytes for which the checksum is generated.
-        */
-        long currentChunkOffset = Long.MAX_VALUE;
-        if ((chunkOffsetIndex % numChecksumPerChunk == 0)
-            && (bytesPerCrcOffset > 0)) {
-          currentChunkOffset = bytesPerCrcOffset;
+        // Here Math.min in mainly required for last stripe's last chunk. The last chunk of the last stripe can be
+        // less than the chunkSize, chunkSize is only calculated from each stripe's first chunk. This would be fine
+        // for rest of the stripe because all the chunks are of the same size. But for the last stripe we don't know
+        // the exact size of the last chunk. So we calculate it with the of blockSize. If the block size is smaller
+        // than the chunk size, then we know it is the last stripe' last chunk.
+        long remainingChunkSize = Math.min(blockSize, chunkSize);
+        while (byteWrap.hasRemaining() && remainingChunkSize > 0) {
+          final int checksumData = byteWrap.getInt();
+          blockCrcComposer.update(checksumData, Math.min(bytesPerCrc, remainingChunkSize));
+          remainingChunkSize -= bytesPerCrc;
         }
-
-        final int checksumDataCrc = byteWrap.getInt();
-        //To handle last chunk when it size is lower than 1524K in the case
-        // of rs-3-2-1524k.
-        long chunkSizePerChecksum = Math.min(Math.min(keySize, bytesPerCrc),
-            currentChunkOffset);
-        chunkCrcComposer.update(checksumDataCrc, chunkSizePerChecksum);
-
-        int chunkChecksumCrc = CrcUtil.readInt(chunkCrcComposer.digest(), 0);
-        blockCrcComposer.update(chunkChecksumCrc, chunkSizePerChecksum);
-        keySize -= Math.min(bytesPerCrc, currentChunkOffset);
-        ++chunkOffsetIndex;
+        blockSize -= chunkSize;
       }
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECBlockChecksumComputer.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECBlockChecksumComputer.java
@@ -25,12 +25,13 @@ import org.apache.hadoop.io.MD5Hash;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.util.DataChecksum;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.security.MessageDigest;
 import java.util.List;
 
 
@@ -42,8 +43,8 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
   private static final Logger LOG =
       LoggerFactory.getLogger(ECBlockChecksumComputer.class);
 
-  private List<ContainerProtos.ChunkInfo> chunkInfoList;
-  private OmKeyInfo keyInfo;
+  private final List<ContainerProtos.ChunkInfo> chunkInfoList;
+  private final OmKeyInfo keyInfo;
 
 
   public ECBlockChecksumComputer(
@@ -68,7 +69,7 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
 
   }
 
-  private void computeMd5Crc() throws IOException {
+  private void computeMd5Crc() {
     Preconditions.checkArgument(chunkInfoList.size() > 0);
 
     final ContainerProtos.ChunkInfo firstChunkInfo = chunkInfoList.get(0);
@@ -77,32 +78,28 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
     // Total parity checksum bytes per stripe to remove
     int parityBytes = getParityBytes(chunkSize, bytesPerCrc);
 
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final MessageDigest digester = MD5Hash.getDigester();
 
     for (ContainerProtos.ChunkInfo chunkInfo : chunkInfoList) {
       ByteString stripeChecksum = chunkInfo.getStripeChecksum();
 
       Preconditions.checkNotNull(stripeChecksum);
-      byte[] checksumBytes = stripeChecksum.toByteArray();
-
-      Preconditions.checkArgument(checksumBytes.length % 4 == 0,
+      final int checksumSize = stripeChecksum.size();
+      Preconditions.checkArgument(checksumSize % 4 == 0,
           "Checksum Bytes size does not match");
 
-      ByteBuffer byteWrap = ByteBuffer
-          .wrap(checksumBytes, 0, checksumBytes.length - parityBytes);
-      byte[] currentChecksum = new byte[4];
-
-      while (byteWrap.hasRemaining()) {
-        byteWrap.get(currentChecksum);
-        out.write(currentChecksum);
-      }
+      final ByteBuffer byteWrap = stripeChecksum.asReadOnlyByteBuffer();
+      byteWrap.limit(checksumSize - parityBytes);
+      digester.update(byteWrap);
     }
 
-    MD5Hash fileMD5 = MD5Hash.digest(out.toByteArray());
-    setOutBytes(fileMD5.getDigest());
+    final byte[] fileMD5 = digester.digest();
+    setOutBytes(digester.digest());
 
-    LOG.debug("Number of chunks={}, md5hash={}",
-        chunkInfoList.size(), fileMD5);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Number of chunks={}, md5hash={}",
+          chunkInfoList.size(), StringUtils.bytes2HexString(fileMD5));
+    }
   }
 
   private void computeCompositeCrc() throws IOException {
@@ -149,17 +146,15 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
       ByteString stripeChecksum = chunkInfo.getStripeChecksum();
 
       Preconditions.checkNotNull(stripeChecksum);
-      byte[] checksumBytes = stripeChecksum.toByteArray();
-
-      Preconditions.checkArgument(checksumBytes.length % 4 == 0,
+      final int checksumSize = stripeChecksum.size();
+      Preconditions.checkArgument(checksumSize % 4 == 0,
           "Checksum Bytes size does not match");
       CrcComposer chunkCrcComposer =
           CrcComposer.newCrcComposer(dataChecksumType, bytesPerCrc);
 
       // Limit parity bytes as they do not contribute to fileChecksum
-      ByteBuffer byteWrap = ByteBuffer
-          .wrap(checksumBytes, 0, checksumBytes.length - parityBytes);
-      byte[] currentChecksum = new byte[4];
+      final ByteBuffer byteWrap = stripeChecksum.asReadOnlyByteBuffer();
+      byteWrap.limit(checksumSize - parityBytes);
 
       long chunkOffsetIndex = 1;
       while (byteWrap.hasRemaining()) {
@@ -177,8 +172,7 @@ public class ECBlockChecksumComputer extends AbstractBlockChecksumComputer {
           currentChunkOffset = bytesPerCrcOffset;
         }
 
-        byteWrap.get(currentChecksum);
-        int checksumDataCrc = CrcUtil.readInt(currentChecksum, 0);
+        final int checksumDataCrc = byteWrap.getInt();
         //To handle last chunk when it size is lower than 1524K in the case
         // of rs-3-2-1524k.
         long chunkSizePerChecksum = Math.min(Math.min(keySize, bytesPerCrc),

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ECFileChecksumHelper.java
@@ -102,7 +102,7 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
     setBytesPerCRC(bytesPerChecksum);
 
     ByteBuffer blockChecksumByteBuffer =
-        getBlockChecksumFromChunkChecksums(chunkInfos);
+        getBlockChecksumFromChunkChecksums(chunkInfos, keyLocationInfo.getLength());
     String blockChecksumForDebug =
         populateBlockChecksumBuf(blockChecksumByteBuffer);
 
@@ -140,10 +140,11 @@ public class ECFileChecksumHelper extends BaseFileChecksumHelper {
   }
 
   private ByteBuffer getBlockChecksumFromChunkChecksums(
-      List<ContainerProtos.ChunkInfo> chunkInfos) throws IOException {
+      List<ContainerProtos.ChunkInfo> chunkInfos,
+      long blockLength) throws IOException {
 
     AbstractBlockChecksumComputer blockChecksumComputer =
-        new ECBlockChecksumComputer(chunkInfos, getKeyInfo());
+        new ECBlockChecksumComputer(chunkInfos, getKeyInfo(), blockLength);
     blockChecksumComputer.compute(getCombineMode());
 
     return blockChecksumComputer.getOutByteBuffer();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedBlockChecksumComputer.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedBlockChecksumComputer.java
@@ -26,8 +26,9 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
 import java.util.List;
 
 /**
@@ -39,7 +40,13 @@ public class ReplicatedBlockChecksumComputer extends
   private static final Logger LOG =
       LoggerFactory.getLogger(ReplicatedBlockChecksumComputer.class);
 
-  private List<ContainerProtos.ChunkInfo> chunkInfoList;
+  static MD5Hash digest(ByteBuffer data) {
+    final MessageDigest digester = MD5Hash.getDigester();
+    digester.update(data);
+    return new MD5Hash(digester.digest());
+  }
+
+  private final List<ContainerProtos.ChunkInfo> chunkInfoList;
 
   public ReplicatedBlockChecksumComputer(
       List<ContainerProtos.ChunkInfo> chunkInfoList) {
@@ -62,20 +69,20 @@ public class ReplicatedBlockChecksumComputer extends
   }
 
   // compute the block checksum, which is the md5 of chunk checksums
-  private void computeMd5Crc() throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
+  private void computeMd5Crc() {
+    ByteString bytes = ByteString.EMPTY;
     for (ContainerProtos.ChunkInfo chunkInfo : chunkInfoList) {
       ContainerProtos.ChecksumData checksumData =
           chunkInfo.getChecksumData();
       List<ByteString> checksums = checksumData.getChecksumsList();
 
       for (ByteString checksum : checksums) {
-        baos.write(checksum.toByteArray());
+        bytes = bytes.concat(checksum);
       }
     }
 
-    MD5Hash fileMD5 = MD5Hash.digest(baos.toByteArray());
+    final MD5Hash fileMD5 = digest(bytes.asReadOnlyByteBuffer());
+
     setOutBytes(fileMD5.getDigest());
 
     LOG.debug("number of chunks={}, md5out={}",
@@ -121,7 +128,7 @@ public class ReplicatedBlockChecksumComputer extends
       Preconditions.checkArgument(remainingChunkSize <=
           checksums.size() * chunkSize);
       for (ByteString checksum : checksums) {
-        int checksumDataCrc = CrcUtil.readInt(checksum.toByteArray(), 0);
+        final int checksumDataCrc = checksum.asReadOnlyByteBuffer().getInt();
         chunkCrcComposer.update(checksumDataCrc,
             Math.min(bytesPerCrc, remainingChunkSize));
         remainingChunkSize -= bytesPerCrc;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -2162,9 +2162,11 @@ public class RpcClient implements ClientProtocol {
       String bucketName, String keyName, boolean recursive, String startKey,
       long numEntries, boolean allowPartialPrefixes) throws IOException {
     OmKeyArgs keyArgs = prepareOmKeyArgs(volumeName, bucketName, keyName);
-    return ozoneManagerClient
-        .listStatusLight(keyArgs, recursive, startKey, numEntries,
-            allowPartialPrefixes);
+    // Disable listStatusLight in Ozone-1.4.x due to compatibility issues with Ozone-1.4.x listStatusLight.
+    return ozoneManagerClient.listStatus(keyArgs, recursive, startKey, numEntries, allowPartialPrefixes)
+        .stream()
+        .map(OzoneFileStatusLight::fromOzoneFileStatus)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMNotLeaderException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMNotLeaderException.java
@@ -56,6 +56,13 @@ public class OMNotLeaderException extends IOException {
     this.leaderAddress = suggestedLeaderAddress;
   }
 
+  public OMNotLeaderException(String msg) {
+    super(msg);
+    this.currentPeerId = null;
+    this.leaderPeerId = null;
+    this.leaderAddress = null;
+  }
+
   public String getSuggestedLeaderNodeId() {
     return leaderPeerId;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAccessAuthorizer.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAccessAuthorizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.security.acl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 
 /**
- * Default implementation for {@link IAccessAuthorizer}.
+ * No-op implementation for {@link IAccessAuthorizer}, allows everything.
  * */
 public class OzoneAccessAuthorizer implements IAccessAuthorizer {
 
@@ -33,6 +33,11 @@ public class OzoneAccessAuthorizer implements IAccessAuthorizer {
   @Override
   public boolean checkAccess(IOzoneObj ozoneObject, RequestContext context)
       throws OMException {
+    return true;
+  }
+
+  @Override
+  public boolean isNative() {
     return true;
   }
 }

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -35,8 +35,9 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-export OZONE_CURRENT_VERSION=1.4.0
-run_test ha non-rolling-upgrade 1.3.0 "$OZONE_CURRENT_VERSION"
+export OZONE_CURRENT_VERSION=1.5.0
+run_test ha non-rolling-upgrade 1.4.0 "$OZONE_CURRENT_VERSION"
+# run_test ha non-rolling-upgrade 1.3.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.2.1 "$OZONE_CURRENT_VERSION"
 # run_test om-ha non-rolling-upgrade 1.1.0 "$OZONE_CURRENT_VERSION"
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -35,7 +35,7 @@ RESULT_DIR="$ALL_RESULT_DIR" create_results_dir
 
 # This is the version of Ozone that should use the runner image to run the
 # code that was built. Other versions will pull images from docker hub.
-export OZONE_CURRENT_VERSION=1.5.0
+export OZONE_CURRENT_VERSION="${ozone.version}"
 run_test ha non-rolling-upgrade 1.4.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.3.0 "$OZONE_CURRENT_VERSION"
 # run_test ha non-rolling-upgrade 1.2.1 "$OZONE_CURRENT_VERSION"

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -45,6 +45,13 @@ services:
     volumes:
       - ../..:/opt/ozone
     command: ["sleep","1000000"]
+  old_client_1_4_0:
+    image: apache/ozone:1.4.0
+    env_file:
+      - docker-config
+    volumes:
+      - ../..:/opt/ozone
+    command: ["sleep","1000000"]
   new_client:
     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     env_file:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -21,8 +21,8 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 basename=$(basename ${COMPOSE_DIR})
 
-current_version=1.4.0
-old_versions="1.0.0 1.1.0 1.2.1 1.3.0" # container is needed for each version in clients.yaml
+current_version=1.5.0
+old_versions="1.0.0 1.1.0 1.2.1 1.3.0 1.4.0" # container is needed for each version in clients.yaml
 
 # shellcheck source=hadoop-ozone/dist/src/main/compose/testlib.sh
 source "${COMPOSE_DIR}/../testlib.sh"
@@ -77,7 +77,7 @@ test_cross_compatibility() {
 
 test_ec_cross_compatibility() {
   echo "Running Erasure Coded storage backward compatibility tests."
-  local cluster_versions_with_ec="1.3.0"
+  local cluster_versions_with_ec="1.3.0 1.4.0"
   local non_ec_client_versions="1.0.0 1.1.0 1.2.1"
 
   for cluster_version in ${cluster_versions_with_ec}; do

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -21,7 +21,7 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 basename=$(basename ${COMPOSE_DIR})
 
-current_version=1.5.0
+current_version="${ozone.version}"
 old_versions="1.0.0 1.1.0 1.2.1 1.3.0 1.4.0" # container is needed for each version in clients.yaml
 
 # shellcheck source=hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -77,7 +77,8 @@ test_cross_compatibility() {
 
 test_ec_cross_compatibility() {
   echo "Running Erasure Coded storage backward compatibility tests."
-  local cluster_versions_with_ec="1.3.0 1.4.0"
+  # local cluster_versions_with_ec="1.3.0 1.4.0 ${current_version}"
+  local cluster_versions_with_ec="${current_version}" # until HDDS-11334
   local non_ec_client_versions="1.0.0 1.1.0 1.2.1"
 
   for cluster_version in ${cluster_versions_with_ec}; do

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
@@ -30,6 +30,10 @@ Key Can Be Read
 Dir Can Be Listed
     Execute    ozone fs -ls o3fs://bucket1.vol1/dir-${SUFFIX}
 
+Dir Can Be Listed Using Shell
+    ${result} =     Execute    ozone sh key list /vol1/bucket1
+                    Should Contain    ${result}    key-${SUFFIX}
+
 File Can Be Get
     Execute    ozone fs -get o3fs://bucket1.vol1/dir-${SUFFIX}/file-${SUFFIX} /tmp/
     Execute    diff -q ${TESTFILE} /tmp/file-${SUFFIX}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandling.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container;
+
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for container report handling.
+ */
+public class TestContainerReportHandling {
+  private static final String VOLUME = "vol1";
+  private static final String BUCKET = "bucket1";
+  private static final String KEY = "key1";
+
+  /**
+   * Tests that a DELETING container moves to the CLOSED state if a non-empty CLOSED replica is reported. To do this,
+   * the test first creates a key and closes its corresponding container. Then it moves that container to the
+   * DELETING state using ContainerManager. Then it restarts a Datanode hosting that container, making it send a full
+   * container report. Then the test waits for the container to move from DELETING to CLOSED.
+   */
+  @Test
+  void testDeletingContainerTransitionsToClosedWhenNonEmptyReplicaIsReported() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
+    conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
+
+    Path clusterPath = null;
+    try (MiniOzoneCluster cluster = newCluster(conf)) {
+      cluster.waitForClusterToBeReady();
+      clusterPath = Paths.get(cluster.getBaseDir());
+
+      try (OzoneClient client = cluster.newClient()) {
+        // create a container and close it
+        createTestData(client);
+        List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
+        assertThat(keyLocations).isNotEmpty();
+        OmKeyLocationInfo keyLocation = keyLocations.get(0);
+        ContainerID containerID = ContainerID.valueOf(keyLocation.getContainerID());
+        waitForContainerClose(cluster, containerID.getId());
+
+        // move the container to DELETING
+        ContainerManager containerManager = cluster.getStorageContainerManager().getContainerManager();
+        containerManager.updateContainerState(containerID, HddsProtos.LifeCycleEvent.DELETE);
+        assertEquals(HddsProtos.LifeCycleState.DELETING, containerManager.getContainer(containerID).getState());
+
+        // restart a DN and wait for the container to get CLOSED.
+        HddsDatanodeService dn = cluster.getHddsDatanode(keyLocation.getPipeline().getFirstNode());
+        cluster.restartHddsDatanode(dn.getDatanodeDetails(), false);
+        GenericTestUtils.waitFor(() -> {
+          try {
+            return containerManager.getContainer(containerID).getState() == HddsProtos.LifeCycleState.CLOSED;
+          } catch (ContainerNotFoundException e) {
+            fail(e);
+          }
+          return false;
+        }, 2000, 20000);
+
+        assertEquals(HddsProtos.LifeCycleState.CLOSED, containerManager.getContainer(containerID).getState());
+      }
+    } finally {
+      if (clusterPath != null) {
+        System.out.println("Deleting path " + clusterPath);
+        boolean deleted = FileUtil.fullyDelete(clusterPath.toFile());
+        assertTrue(deleted);
+      }
+    }
+  }
+
+  private static MiniOzoneCluster newCluster(OzoneConfiguration conf)
+      throws IOException {
+    return MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .build();
+  }
+
+  private static List<OmKeyLocationInfo> lookupKey(MiniOzoneCluster cluster)
+      throws IOException {
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(VOLUME)
+        .setBucketName(BUCKET)
+        .setKeyName(KEY)
+        .build();
+    OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
+    OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
+    assertNotNull(locations);
+    return locations.getLocationList();
+  }
+
+  private void createTestData(OzoneClient client) throws IOException {
+    ObjectStore objectStore = client.getObjectStore();
+    objectStore.createVolume(VOLUME);
+    OzoneVolume volume = objectStore.getVolume(VOLUME);
+    volume.createBucket(BUCKET);
+
+    OzoneBucket bucket = volume.getBucket(BUCKET);
+
+    try (OutputStream out = bucket.createKey(KEY, 0,
+        RatisReplicationConfig.getInstance(THREE), emptyMap())) {
+      out.write("Hello".getBytes(UTF_8));
+    }
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReportHandlingWithHA.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container;
+
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for container report handling with SCM High Availability.
+ */
+public class TestContainerReportHandlingWithHA {
+  private static final String VOLUME = "vol1";
+  private static final String BUCKET = "bucket1";
+  private static final String KEY = "key1";
+
+  /**
+   * Tests that a DELETING container moves to the CLOSED state if a non-empty CLOSED replica is reported. To do this,
+   * the test first creates a key and closes its corresponding container. Then it moves that container to the
+   * DELETING state using ContainerManager. Then it restarts a Datanode hosting that container, making it send a full
+   * container report. Then the test waits for the container to move from DELETING to CLOSED in all SCMs.
+   */
+  @Test
+  void testDeletingContainerTransitionsToClosedWhenNonEmptyReplicaIsReportedWithScmHA() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
+    conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
+
+    int numSCM = 3;
+    Path clusterPath = null;
+    try (MiniOzoneHAClusterImpl cluster = newHACluster(conf, numSCM)) {
+      cluster.waitForClusterToBeReady();
+      clusterPath = Paths.get(cluster.getBaseDir());
+
+      try (OzoneClient client = cluster.newClient()) {
+        // create a container and close it
+        createTestData(client);
+        List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
+        assertThat(keyLocations).isNotEmpty();
+        OmKeyLocationInfo keyLocation = keyLocations.get(0);
+        ContainerID containerID = ContainerID.valueOf(keyLocation.getContainerID());
+        waitForContainerClose(cluster, containerID.getId());
+
+        // move the container to DELETING
+        ContainerManager containerManager = cluster.getScmLeader().getContainerManager();
+        containerManager.updateContainerState(containerID, HddsProtos.LifeCycleEvent.DELETE);
+        assertEquals(HddsProtos.LifeCycleState.DELETING, containerManager.getContainer(containerID).getState());
+
+        // restart a DN and wait for the container to get CLOSED in all SCMs
+        HddsDatanodeService dn = cluster.getHddsDatanode(keyLocation.getPipeline().getFirstNode());
+        cluster.restartHddsDatanode(dn.getDatanodeDetails(), false);
+        ContainerManager[] array = new ContainerManager[numSCM];
+        for (int i = 0; i < numSCM; i++) {
+          array[i] = cluster.getStorageContainerManager(i).getContainerManager();
+        }
+        GenericTestUtils.waitFor(() -> {
+          try {
+            for (ContainerManager manager : array) {
+              if (manager.getContainer(containerID).getState() != HddsProtos.LifeCycleState.CLOSED) {
+                return false;
+              }
+            }
+            return true;
+          } catch (ContainerNotFoundException e) {
+            fail(e);
+          }
+          return false;
+        }, 2000, 20000);
+
+        assertEquals(HddsProtos.LifeCycleState.CLOSED, containerManager.getContainer(containerID).getState());
+      }
+    } finally {
+      if (clusterPath != null) {
+        boolean deleted = FileUtil.fullyDelete(clusterPath.toFile());
+        assertTrue(deleted);
+      }
+    }
+  }
+
+  private static MiniOzoneHAClusterImpl newHACluster(OzoneConfiguration conf, int numSCM) throws IOException {
+    return (MiniOzoneHAClusterImpl) MiniOzoneCluster.newHABuilder(conf)
+        .setOMServiceId("om-service")
+        .setSCMServiceId("scm-service")
+        .setNumOfOzoneManagers(1)
+        .setNumOfStorageContainerManagers(numSCM)
+        .build();
+  }
+
+  private static List<OmKeyLocationInfo> lookupKey(MiniOzoneCluster cluster)
+      throws IOException {
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(VOLUME)
+        .setBucketName(BUCKET)
+        .setKeyName(KEY)
+        .build();
+    OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
+    OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
+    assertNotNull(locations);
+    return locations.getLocationList();
+  }
+
+  private void createTestData(OzoneClient client) throws IOException {
+    ObjectStore objectStore = client.getObjectStore();
+    objectStore.createVolume(VOLUME);
+    OzoneVolume volume = objectStore.getVolume(VOLUME);
+    volume.createBucket(BUCKET);
+
+    OzoneBucket bucket = volume.getBucket(BUCKET);
+
+    try (OutputStream out = bucket.createKey(KEY, 0,
+        RatisReplicationConfig.getInstance(THREE), emptyMap())) {
+      out.write("Hello".getBytes(UTF_8));
+    }
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -42,8 +42,10 @@ import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.io.BlockDataStreamOutputEntry;
@@ -325,14 +327,17 @@ public final class TestHelper {
       Long... containerIdList)
       throws ContainerNotFoundException, PipelineNotFoundException,
       TimeoutException, InterruptedException {
+    StorageContainerManager scm;
+    if (cluster instanceof MiniOzoneHAClusterImpl) {
+      MiniOzoneHAClusterImpl haCluster = (MiniOzoneHAClusterImpl) cluster;
+      scm = haCluster.getScmLeader();
+    } else {
+      scm = cluster.getStorageContainerManager();
+    }
     List<Pipeline> pipelineList = new ArrayList<>();
     for (long containerID : containerIdList) {
-      ContainerInfo container =
-          cluster.getStorageContainerManager().getContainerManager()
-              .getContainer(ContainerID.valueOf(containerID));
-      Pipeline pipeline =
-          cluster.getStorageContainerManager().getPipelineManager()
-              .getPipeline(container.getPipelineID());
+      ContainerInfo container = scm.getContainerManager().getContainer(ContainerID.valueOf(containerID));
+      Pipeline pipeline = scm.getPipelineManager().getPipeline(container.getPipelineID());
       pipelineList.add(pipeline);
       List<DatanodeDetails> datanodes = pipeline.getNodes();
 
@@ -348,9 +353,7 @@ public final class TestHelper {
         // make sure the container gets created first
         Assert.assertFalse(isContainerClosed(cluster, containerID, details));
         // send the order to close the container
-        cluster.getStorageContainerManager().getEventQueue()
-            .fireEvent(SCMEvents.CLOSE_CONTAINER,
-                ContainerID.valueOf(containerID));
+        scm.getEventQueue().fireEvent(SCMEvents.CLOSE_CONTAINER, ContainerID.valueOf(containerID));
       }
     }
     int index = 0;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -845,7 +845,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     prefixManager = new PrefixManagerImpl(metadataManager, isRatisEnabled);
     keyManager = new KeyManagerImpl(this, scmClient, configuration,
         perfMetrics);
-    accessAuthorizer = OzoneAuthorizerFactory.forOM(this);
+    // If authorizer is not initialized or the authorizer is Native
+    // re-initialize the authorizer, else for non-native authorizer
+    // like ranger we can reuse previous value if it is initialized
+    if (null == accessAuthorizer || accessAuthorizer.isNative()) {
+      accessAuthorizer = OzoneAuthorizerFactory.forOM(this);
+    }
+
     omMetadataReader = new OmMetadataReader(keyManager, prefixManager,
         this, LOG, AUDIT, metrics, accessAuthorizer);
     // Active DB's OmMetadataReader instance does not need to be reference

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -72,6 +72,7 @@ import org.apache.ratis.netty.NettyConfigKeys;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.SetConfigurationRequest;
 import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
+import org.apache.ratis.protocol.exceptions.LeaderSteppingDownException;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.protocol.Message;
@@ -491,6 +492,11 @@ public final class OzoneManagerRatisServer {
       if (leaderNotReadyException != null) {
         throw new ServiceException(new OMLeaderNotReadyException(
             leaderNotReadyException.getMessage()));
+      }
+
+      LeaderSteppingDownException leaderSteppingDownException = reply.getLeaderSteppingDownException();
+      if (leaderSteppingDownException != null) {
+        throw new ServiceException(new OMNotLeaderException(leaderSteppingDownException.getMessage()));
       }
 
       StateMachineException stateMachineException =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/TriggerDBSyncEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/TriggerDBSyncEndpoint.java
@@ -32,6 +32,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/triggerdbsync")
 @Produces(MediaType.APPLICATION_JSON)
+@AdminOnly
 public class TriggerDBSyncEndpoint {
 
   private OzoneManagerServiceProvider ozoneManagerServiceProvider;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/filters/TestAdminFilter.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/filters/TestAdminFilter.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.ozone.recon.api.MetricsProxyEndpoint;
 import org.apache.hadoop.ozone.recon.api.NodeEndpoint;
 import org.apache.hadoop.ozone.recon.api.PipelineEndpoint;
 import org.apache.hadoop.ozone.recon.api.TaskStatusService;
-import org.apache.hadoop.ozone.recon.api.TriggerDBSyncEndpoint;
 import org.apache.hadoop.ozone.recon.api.UtilizationEndpoint;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.Assertions;
@@ -66,8 +65,14 @@ public class TestAdminFilter {
 
     Assertions.assertFalse(allEndpoints.isEmpty());
 
-    // If an endpoint is added, it must be explicitly added to this set or be
-    // marked with @AdminOnly for this test to pass.
+    // If an endpoint is added, it must either require admin privileges by being
+    // marked with the `@AdminOnly` annotation, or be added to this set to exclude it.
+    // - Any endpoint that displays information related to the filesystem namespace
+    //   (including aggregate counts), user information, or allows modification to the
+    //   cluster's state should be marked as `@AdminOnly`.
+    // - Read-only endpoints that only return information about node status or
+    //   cluster state do not require the `@AdminOnly` annotation and can be excluded
+    //   from admin requirements by adding them to this set.
     Set<Class<?>> nonAdminEndpoints = new HashSet<>();
     nonAdminEndpoints.add(UtilizationEndpoint.class);
     nonAdminEndpoints.add(ClusterStateEndpoint.class);
@@ -75,7 +80,6 @@ public class TestAdminFilter {
     nonAdminEndpoints.add(NodeEndpoint.class);
     nonAdminEndpoints.add(PipelineEndpoint.class);
     nonAdminEndpoints.add(TaskStatusService.class);
-    nonAdminEndpoints.add(TriggerDBSyncEndpoint.class);
 
     Assertions.assertTrue(allEndpoints.containsAll(nonAdminEndpoints));
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
@@ -44,14 +44,13 @@ public class CompleteMultipartUploadRequestUnmarshaller
     implements MessageBodyReader<CompleteMultipartUploadRequest> {
 
   private final JAXBContext context;
-  private final XMLReader xmlReader;
+  private final SAXParserFactory saxParserFactory;
 
   public CompleteMultipartUploadRequestUnmarshaller() {
     try {
       context = JAXBContext.newInstance(CompleteMultipartUploadRequest.class);
-      SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+      saxParserFactory = SAXParserFactory.newInstance();
       saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      xmlReader = saxParserFactory.newSAXParser().getXMLReader();
     } catch (Exception ex) {
       throw new AssertionError("Can not instantiate " +
           "CompleteMultipartUploadRequest parser", ex);
@@ -70,6 +69,7 @@ public class CompleteMultipartUploadRequestUnmarshaller
       MultivaluedMap<String, String> multivaluedMap,
       InputStream inputStream) throws IOException, WebApplicationException {
     try {
+      XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
       UnmarshallerHandler unmarshallerHandler =
           context.createUnmarshaller().getUnmarshallerHandler();
       XmlNamespaceFilter filter =

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequestUnmarshaller.java
@@ -43,14 +43,13 @@ public class MultiDeleteRequestUnmarshaller
     implements MessageBodyReader<MultiDeleteRequest> {
 
   private final JAXBContext context;
-  private final XMLReader xmlReader;
+  private final SAXParserFactory saxParserFactory;
 
   public MultiDeleteRequestUnmarshaller() {
     try {
       context = JAXBContext.newInstance(MultiDeleteRequest.class);
-      SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+      saxParserFactory = SAXParserFactory.newInstance();
       saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      xmlReader = saxParserFactory.newSAXParser().getXMLReader();
     } catch (Exception ex) {
       throw new AssertionError("Can't instantiate MultiDeleteRequest parser",
           ex);
@@ -68,6 +67,7 @@ public class MultiDeleteRequestUnmarshaller
       Type genericType, Annotation[] annotations, MediaType mediaType,
       MultivaluedMap<String, String> httpHeaders, InputStream entityStream) {
     try {
+      XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
       UnmarshallerHandler unmarshallerHandler =
           context.createUnmarshaller().getUnmarshallerHandler();
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/PutBucketAclRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/PutBucketAclRequestUnmarshaller.java
@@ -44,14 +44,13 @@ public class PutBucketAclRequestUnmarshaller
     implements MessageBodyReader<S3BucketAcl> {
 
   private final JAXBContext context;
-  private final XMLReader xmlReader;
+  private final SAXParserFactory saxParserFactory;
 
   public PutBucketAclRequestUnmarshaller() {
     try {
       context = JAXBContext.newInstance(S3BucketAcl.class);
-      SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+      saxParserFactory = SAXParserFactory.newInstance();
       saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      xmlReader = saxParserFactory.newSAXParser().getXMLReader();
     } catch (Exception ex) {
       throw new AssertionError("Can not instantiate " +
           "PutBucketAclRequest parser", ex);
@@ -70,6 +69,7 @@ public class PutBucketAclRequestUnmarshaller
       MultivaluedMap<String, String> multivaluedMap,
       InputStream inputStream) throws IOException, WebApplicationException {
     try {
+      XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
       UnmarshallerHandler unmarshallerHandler =
           context.createUnmarshaller().getUnmarshallerHandler();
       XmlNamespaceFilter filter =

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
@@ -193,7 +193,7 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
       throws OzoneChecksumException {
     ContainerProtos.ReadChunkResponseProto readChunk = response.getReadChunk();
     if (readChunk.hasData()) {
-      return checksum.computeChecksum(readChunk.getData().toByteArray());
+      return checksum.computeChecksum(readChunk.getData().asReadOnlyByteBuffer());
     } else {
       return checksum.computeChecksum(
           readChunk.getDataBuffers().getBuffersList());

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- HDDS Rocks Native dependency version-->
     <hdds.rocks.native.version>${hdds.version}</hdds.rocks.native.version>
     <!-- Apache Ratis version -->
-    <ratis.version>3.1.0</ratis.version>
+    <ratis.version>3.1.1</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>1.0.6</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport the following commit from master to ozone-1.4 for 1.4.1. Including some bug fixes and Ratis upgrade and necessary dependencies.

HDDS-11333. Avoid hard-coded current version in upgrade/xcompat tests (#7089)
HDDS-10168. Add Ozone 1.4.0 to compatibility acceptance tests (#6040)
HDDS-11414. Key listing for FSO buckets fails with forward client (#7161)
HDDS-11570. Fix HDDS Docs build failure with Hugo v0.135.0 (#7337)
HDDS-11498. Improve SCM deletion efficiency. (#7249)
HDDS-11482. EC Checksum throws IllegalArgumentException because the buffer limit is negative (#7230)
HDDS-10465. Change ozone.client.bytes.per.checksum default to 16KB (#6331)
HDDS-10480. Avoid proto2 ByteString.toByteArray() calls. (#6342)
HDDS-11536. Bump macOS runner version to macos-13 (#7279)
HDDS-11504. Update Ratis to 3.1.1. (#7257)
HDDS-11472. Avoid recreating external access authorizer on OM state reload (#7238)
HDDS-11436. Minor update in Recon API handling. (#7178)
HDDS-11223. Fix iteration over ChunkBufferImplWithByteBufferList (#6999)
HDDS-11136. Some containers affected by HDDS-8129 may still be in the DELETING state incorrectly (#6967)
HDDS-10918. NPE in OM when leader transfers (#6735)
HDDS-10777. S3 Gateway error when parsing XML concurrently (#6609)
HDDS-10780. NullPointerException in watchForCommit (#6627)

## How was this patch tested?
https://github.com/xichen01/ozone/actions/runs/11445199314