### PR TITLE
HDDS-11600. Intermittent failure in repro due to ordering differences in builddef.lst

### DIFF
--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -474,12 +474,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>${aspectj-plugin.version}</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <argumentFileDirectory>${project.build.directory}/aspectj-build</argumentFileDirectory>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <sonar.java.binaries>${basedir}/target/classes</sonar.java.binaries>
 
     <aspectj.version>1.9.7</aspectj.version>
-    <aspectj-plugin.version>1.15.0</aspectj-plugin.version>
+    <aspectj-plugin.version>1.14</aspectj-plugin.version>
     <restrict-imports.enforcer.version>2.6.0</restrict-imports.enforcer.version>
     <jgrapht.version>1.4.0</jgrapht.version>
     <jgraphx.version>3.9.12</jgraphx.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent [failure](https://github.com/apache/ozone/actions/runs/11442330586/job/31839199387?pr=7340#step:10:35) in `repro` check:

```
--- /home/runner/.m2/repository/org/apache/ozone/ozone-manager/2.0.0-SNAPSHOT/ozone-manager-2.0.0-SNAPSHOT.jar
+++ hadoop-ozone/ozone-manager/target/ozone-manager-2.0.0-SNAPSHOT.jar
...
├── builddef.lst
│┄ ordering differences only
```

caused by:

> aspectj-maven-plugin generates a builddef.lst file with the detailed options passed to AspectJ and this file is embedded in the final jar. ([source](https://github.com/mojohaus/aspectj-maven-plugin/issues/52))

The contents of `builddef.lst` is non-reproducible due to:

- order of arguments may be different between runs (depends on filesystem iteration)
- arguments contain absolute paths

Since this file is not required at runtime, we should exclude it from the jar, which is made possible by https://github.com/dev-aspectj/aspectj-maven-plugin/commit/b4c9a8ce61eeafd2c2fe985a90eeedec61c80a59

https://issues.apache.org/jira/browse/HDDS-11600

## How was this patch tested?

Verified that `builddef.lst` is no longer part of the jar:

```
$ unzip -t hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/share/ozone/lib/ozone-manager-2.0.0-SNAPSHOT.jar | grep -c builddef.lst
0

$ find . -name builddef.lst
./hadoop-ozone/ozone-manager/target/aspectj-build/builddef.lst
```

Regular CI:
https://github.com/adoroszlai/ozone/actions/runs/11455208945