### PR TITLE
HDDS-11602. Update docker.ozone-runner.version in pom to 20241022-jdk17-1

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20240729-jdk17-1</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20241022-jdk17-1</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>apache/ozone-testkrb5:20230318-1</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
   </properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update the ozone-runner image version in the pom file to reflect the changes made in https://github.com/apache/ozone-docker-runner/pull/29

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11602

## How was this patch tested?
CI: https://github.com/ptlrs/hadoop-ozone/actions/runs/11465640926