### PR TITLE
HDDS-11132. Revert client version bump done as part of HDDS-10983

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -42,10 +42,6 @@ public enum ClientVersion implements ComponentVersion {
       "This client version has support for Object Store and File " +
           "System Optimized Bucket Layouts."),
 
-  EC_REPLICA_INDEX_REQUIRED_IN_BLOCK_REQUEST(4,
-      "This client version enforces replica index is set for fixing read corruption that could occur when " +
-          "replicaIndex parameter is not validated before EC block reads."),
-
   FUTURE_VERSION(-1, "Used internally when the server side is older and an"
       + " unknown client version has arrived from the client.");
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -121,7 +121,6 @@ import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuil
 import static org.apache.hadoop.hdds.scm.utils.ClientCommandsUtils.getReadChunkVersion;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ContainerDataProto.State.RECOVERING;
-import static org.apache.hadoop.ozone.ClientVersion.EC_REPLICA_INDEX_REQUIRED_IN_BLOCK_REQUEST;
 import static org.apache.hadoop.ozone.OzoneConsts.INCREMENTAL_CHUNK_LIST;
 import static org.apache.hadoop.ozone.container.common.interfaces.Container.ScanResult;
 
@@ -635,15 +634,6 @@ public class KeyValueHandler extends Handler {
   }
 
   /**
-   * Checks if a replicaIndex needs to be checked based on the client version for a request.
-   * @param request ContainerCommandRequest object.
-   * @return true if the validation is required for the client version else false.
-   */
-  private boolean replicaIndexCheckRequired(ContainerCommandRequestProto request) {
-    return request.hasVersion() && request.getVersion() >= EC_REPLICA_INDEX_REQUIRED_IN_BLOCK_REQUEST.toProtoValue();
-  }
-
-  /**
    * Handle Get Block operation. Calls BlockManager to process the request.
    */
   ContainerCommandResponseProto handleGetBlock(
@@ -661,9 +651,7 @@ public class KeyValueHandler extends Handler {
     try {
       BlockID blockID = BlockID.getFromProtobuf(
           request.getGetBlock().getBlockID());
-      if (replicaIndexCheckRequired(request)) {
-        BlockUtils.verifyReplicaIdx(kvContainer, blockID);
-      }
+      BlockUtils.verifyReplicaIdx(kvContainer, blockID);
       responseData = blockManager.getBlock(kvContainer, blockID).getProtoBufMessage();
       final long numBytes = responseData.getSerializedSize();
       metrics.incContainerBytesStats(Type.GetBlock, numBytes);
@@ -786,9 +774,7 @@ public class KeyValueHandler extends Handler {
       ChunkInfo chunkInfo = ChunkInfo.getFromProtoBuf(request.getReadChunk()
           .getChunkData());
       Preconditions.checkNotNull(chunkInfo);
-      if (replicaIndexCheckRequired(request)) {
-        BlockUtils.verifyReplicaIdx(kvContainer, blockID);
-      }
+      BlockUtils.verifyReplicaIdx(kvContainer, blockID);
       BlockUtils.verifyBCSId(kvContainer, blockID);
 
       if (dispatcherContext == null) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -247,7 +247,9 @@ public final class BlockUtils {
   public static void verifyReplicaIdx(Container container, BlockID blockID)
       throws IOException {
     Integer containerReplicaIndex = container.getContainerData().getReplicaIndex();
-    if (containerReplicaIndex > 0 && !containerReplicaIndex.equals(blockID.getReplicaIndex())) {
+    Integer blockReplicaIndex = blockID.getReplicaIndex();
+    if (containerReplicaIndex > 0 && blockReplicaIndex != null && blockReplicaIndex != 0 &&
+        !containerReplicaIndex.equals(blockReplicaIndex)) {
       throw new StorageContainerException(
           "Unable to find the Container with replicaIdx " + blockID.getReplicaIndex() + ". Container "
               + container.getContainerData().getContainerID() + " replicaIdx is "

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
@@ -124,8 +124,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
           handler.handleGetBlock(
               getDummyCommandRequestProto(clientVersion, ContainerProtos.Type.GetBlock, rid),
               container);
-      assertEquals((replicaIndex > 0 && rid != replicaIndex && clientVersion.toProtoValue() >=
-              ClientVersion.EC_REPLICA_INDEX_REQUIRED_IN_BLOCK_REQUEST.toProtoValue()) ?
+      assertEquals((replicaIndex > 0 && rid != 0 && rid != replicaIndex) ?
               ContainerProtos.Result.CONTAINER_NOT_FOUND : UNKNOWN_BCSID,
           response.getResult());
     }
@@ -167,8 +166,7 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
       ContainerProtos.ContainerCommandResponseProto response =
           handler.handleReadChunk(getDummyCommandRequestProto(clientVersion, ContainerProtos.Type.ReadChunk, rid),
               container, null);
-      assertEquals((replicaIndex > 0 && rid != replicaIndex &&
-              clientVersion.toProtoValue() >= ClientVersion.EC_REPLICA_INDEX_REQUIRED_IN_BLOCK_REQUEST.toProtoValue()) ?
+      assertEquals((replicaIndex > 0 && rid != 0 && rid != replicaIndex) ?
               ContainerProtos.Result.CONTAINER_NOT_FOUND : UNKNOWN_BCSID,
           response.getResult());
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/storage/TestContainerCommandsEC.java
@@ -460,7 +460,7 @@ public class TestContainerCommandsEC {
       int replicaIndex = 4;
       XceiverClientSpi dnClient = xceiverClientManager.acquireClient(
           createSingleNodePipeline(newPipeline, newPipeline.getNodes().get(0),
-              replicaIndex));
+              2));
       try {
         // To create the actual situation, container would have been in closed
         // state at SCM.


### PR DESCRIPTION
Change-Id: Ib8b9fb743492eacde1f11436eb3116e6a221ac9b

## What changes were proposed in this pull request?
Currently backward client version compatability of Ozone RequestFeatureValidator in OM is broken, after a client version bump done as part of HDDS-10983. https://github.com/apache/ozone/pull/6932 fixes the issue on the RequestFeatureValidator side. 
This patch is a stop gap arrangement done in the interim which reverts the client version bump done in HDDS-10983.
 
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11132

## How was this patch tested?
Existing IT & unit tests
