### PR TITLE
HDDS-11594. Update batchPut buffer log for rocksdb.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -306,7 +306,7 @@ public final class RocksDatabase implements Closeable {
         ByteBuffer value) throws IOException {
       if (LOG.isDebugEnabled()) {
         LOG.debug("batchPut buffer key {}", bytes2String(key.duplicate()));
-        LOG.debug("batchPut buffer value {}", bytes2String(value.duplicate()));
+        LOG.debug("batchPut buffer value size {}", value.remaining());
       }
 
       try (UncheckedAutoCloseable ignored = acquire()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update batch put buffer debug log to print value remaining size.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11594

## How was this patch tested?

Verified log in the local docker cluster
