### PR TITLE
HDDS-11606. Implement a server-side configuration to limit maxKeys for listing

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -705,6 +705,9 @@ public final class OzoneConfigKeys {
       "ozone.security.crypto.compliance.mode";
   public static final String OZONE_SECURITY_CRYPTO_COMPLIANCE_MODE_UNRESTRICTED = "unrestricted";
 
+  public static final String OZONE_OM_LIST_KEYS_MAX_SIZE = "ozone.om.list.keys.max.size";
+  public static final int OZONE_OM_LIST_KEYS_MAX_SIZE_DEFAULT = 500;
+
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4182,6 +4182,16 @@
   </property>
 
   <property>
+    <name>ozone.om.list.keys.max.size</name>
+    <value>500</value>
+    <tag>OZONE, OM</tag>
+    <description>
+      Limits the maximum number of keys to be returned as part of the listKeys call. The actual size of the result
+      would be minimum of the two settings: ozone.client.list.cache and ozone.om.list.keys.max.size.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.recon.nssummary.flush.db.max.threshold</name>
     <value>150000</value>
     <tag>OZONE, RECON, PERFORMANCE</tag>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataReader.java
@@ -55,6 +55,8 @@ import static org.apache.hadoop.hdds.utils.HddsServerUtil.getRemoteUser;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_LISTING_PAGE_SIZE_MAX;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_LIST_KEYS_MAX_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_LIST_KEYS_MAX_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.om.OzoneManager.getS3Auth;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -329,6 +331,9 @@ public class OmMetadataReader implements IOmMetadataReader, Auditor {
         perfMetrics.getListKeysResolveBucketLatencyNs(),
         () -> ozoneManager.resolveBucketLink(
             Pair.of(volumeName, bucketName)));
+
+    maxKeys = Math.min(maxKeys, ozoneManager.getConfiguration()
+        .getInt(OZONE_OM_LIST_KEYS_MAX_SIZE, OZONE_OM_LIST_KEYS_MAX_SIZE_DEFAULT));
 
     boolean auditSuccess = true;
     Map<String, String> auditMap = bucket.audit();


### PR DESCRIPTION
## What changes were proposed in this pull request?

- As of today, the cap on the maxKeys to be listed is governed by the client-side property:  `ozone.client.list.cache` (default = 1000).
- We should instead update the logic in OM for setting the maxKeys to be listed as the min (existing client-side property, new server-side max).
- New server-side configuration that has been introduced: `ozone.om.list.keys.max.size`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11606

## How was this patch tested?

Tested manually
