### PR TITLE
HDDS-11507. Add error information to log while handling ServiceException

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/AbstractKeyDeletingService.java
@@ -252,7 +252,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     try {
       OzoneManagerRatisUtils.submitRequest(ozoneManager, omRequest, clientId, runCount.get());
     } catch (ServiceException e) {
-      LOG.error("PurgeKey request failed. Will retry at next run.");
+      LOG.error("PurgeKey request failed. Will retry at next run.", e);
       return 0;
     }
 
@@ -307,7 +307,7 @@ public abstract class AbstractKeyDeletingService extends BackgroundService
     try {
       OzoneManagerRatisUtils.submitRequest(ozoneManager, omRequest, clientId, runCount.get());
     } catch (ServiceException e) {
-      LOG.error("PurgePaths request failed. Will retry at next run.");
+      LOG.error("PurgePaths request failed. Will retry at next run.", e);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OMRangerBGSyncService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/OMRangerBGSyncService.java
@@ -390,7 +390,7 @@ public class OMRangerBGSyncService extends BackgroundService {
       OzoneManagerRatisUtils.submitRequest(ozoneManager, omRequest, CLIENT_ID, runCount.get());
     } catch (ServiceException e) {
       LOG.error("SetRangerServiceVersion request failed. "
-          + "Will retry at next run.");
+          + "Will retry at next run.", e);
       throw e;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-11507. Add error information to log while handling ServiceException

* Currently the log information provides a generic message with no error information when submitting purge request to Ratis fails.
* This PR adds the extra error information to the log


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11507

## How was this patch tested?
Patch was tested using unit tests