### PR TITLE
HDDS-11607. Improve compatibility of listStatusLight

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -44,13 +44,16 @@ public enum OzoneManagerVersion implements ComponentVersion {
 
   ATOMIC_REWRITE_KEY(6, "OzoneManager version that supports rewriting key as atomic operation"),
   HBASE_SUPPORT(7, "OzoneManager version that supports HBase integration"),
-  LIGHTWEIGHT_LIST_STATUS(8, "OzoneManager version that supports lightweight"
-      + " listStatus API."),
+  RESERVED8(8, "Originally added for HDDS-11414, no longer used, reserved"),
 
   FUTURE_VERSION(-1, "Used internally in the client when the server side is "
       + " newer and an unknown server version has arrived to the client.");
 
   public static final OzoneManagerVersion CURRENT = latest();
+
+  /** This version may or may not support listStatusLight.
+   * Previous versions do not support it, newer versions do. */
+  public static final OzoneManagerVersion MAYBE_LIGHTWEIGHT_LIST_STATUS = LIGHTWEIGHT_LIST_KEYS;
 
   private static final Map<Integer, OzoneManagerVersion> BY_PROTO_VALUE =
       Arrays.stream(values())

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
@@ -43,6 +43,8 @@ FSO Bucket Can Be Read
     Pass Execution If    '${DATA_VERSION}' < '${FSO_VERSION}'      Skipped write test case
     Pass Execution If    '${CLIENT_VERSION}' < '${FSO_VERSION}'    Client does not support FSO
     Pass Execution If    '${CLUSTER_VERSION}' < '${FSO_VERSION}'   Cluster does not support FSO
+    ${result} =     Execute    ozone sh key list /vol1/fso-bucket-${SUFFIX}
+                    Should Contain    ${result}    dir/subdir/file
     Execute    ozone fs -get ofs://om/vol1/fso-bucket-${SUFFIX}/dir/subdir/file ${TEMP_DIR}/
     Execute    diff -q ${TESTFILE} ${TEMP_DIR}/file
     [teardown]    Execute    rm -f ${TEMP_DIR}/file


### PR DESCRIPTION
## What changes were proposed in this pull request?

Background:

- HDDS-7715 in 1.4.0 introduced `listStatusLight` request, used when listing keys in FSO buckets.  Latest OM version was 4 at that time.  OM version is not checked by client.
- HDDS-11414 in 2.0.0 introduced new OM version 8, and added client-side check to send `listStatusLight` only if OM version is >= 8, otherwise use older `listStatus` request.
- OM version = 8 cannot be backported to 1.4.x without backporting features that introduced versions 5-7.  Therefore OM 1.4.x is stuck at version 4.
- OM version = 4 may or may not support `listStatusLight`, depending on whether it is 1.4.0 or some pre-release snapshot version.
- List keys fails with 1.4.0 client and 1.3.0 or earlier OM.
- Backport of HDDS-11414 to 1.4.x fixed this compatibility bug by completely disabling `listStatusLight` in client, regardless of whether OM supports it or not.

This PR changes 2.0.0+ client to use `listStatusLight` with OM versions that support it (1.4.0 and newer).  It can also be backported to 1.4.x, since it does not introduce a new OM version.

https://issues.apache.org/jira/browse/HDDS-11607

## How was this patch tested?

Tested with the commit preceding HDDS-7715. Implement a lightweight listStatus API:

- Built docker image with 68393452332a2d881c34eb2c21feee4b1a8e58e9.
- Set log level of client to DEBUG.
- Successfully ran `xcompat` with the custom docker image as old version.
- Verified FSO read compatibility test passes.
- Verified client log to confirm fallback to `listStatus`:

```
[main] DEBUG rpc.RpcClient: Failed listStatusLight, reverting to listStatus
```

Compatibility with other cluster versions are tested by CI:
https://github.com/adoroszlai/ozone/actions/runs/11550948011