### PR TITLE
HDDS-11614. Speed up TestTransferLeadershipShell

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestTransferLeadershipShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestTransferLeadershipShell.java
@@ -26,9 +26,10 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.ratis.protocol.RaftPeer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 /**
  * Test transferLeadership with SCM HA setup.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestTransferLeadershipShell {
   private MiniOzoneHAClusterImpl cluster = null;
   private OzoneConfiguration conf;
@@ -58,7 +60,7 @@ public class TestTransferLeadershipShell {
    *
    * @throws IOException Exception
    */
-  @BeforeEach
+  @BeforeAll
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     omServiceId = "om-service-test1";
@@ -78,7 +80,7 @@ public class TestTransferLeadershipShell {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterEach
+  @AfterAll
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR modifies `TestTransferLeadershipShell` to create a cluster before executing all tests instead of creating a new cluster for each test execution. Since the tests in `TestTransferLeadershipShell` are validating `OM` and `SCM` independently, we can safely make this change to reduce integration test time.

## What is the link to the Apache JIRA

[HDDS-11614. Speed up TestTransferLeadershipShell](https://issues.apache.org/jira/browse/HDDS-11614)

## How was this patch tested?

Pass the tests.
