### PR TITLE
HDDS-11619. Remove dependency on hadoop-shaded-guava

### DIFF
--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -52,10 +52,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <artifactId>snappy-java</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.hadoop.thirdparty</groupId>
-          <artifactId>hadoop-shaded-guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-annotations</artifactId>
         </exclusion>
@@ -211,10 +207,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop.thirdparty</groupId>
-      <artifactId>hadoop-shaded-guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
@@ -224,10 +216,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <version>${hadoop.version}</version>
       <scope>compile</scope>
       <exclusions>
-        <exclusion>
-          <groupId>org.apache.hadoop.thirdparty</groupId>
-          <artifactId>hadoop-shaded-guava</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>

--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -52,10 +52,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <artifactId>snappy-java</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.hadoop.thirdparty</groupId>
-          <artifactId>hadoop-shaded-guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.apache.curator</groupId>
           <artifactId>*</artifactId>
         </exclusion>
@@ -149,10 +145,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop.thirdparty</groupId>
-      <artifactId>hadoop-shaded-guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
@@ -170,10 +162,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <exclusion>
           <groupId>com.sun.jersey</groupId>
           <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.hadoop.thirdparty</groupId>
-          <artifactId>hadoop-shaded-guava</artifactId>
         </exclusion>
         <exclusion>
           <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <properties.maven.plugin.version>1.2.1</properties.maven.plugin.version>
     <maven.core.version>3.9.9</maven.core.version>
     <snappy-java.version>1.1.10.7</snappy-java.version>
-    <hadoop-shaded-guava.version>1.2.0</hadoop-shaded-guava.version>
     <com.nimbusds.nimbus-jose-jwt.version>9.40</com.nimbusds.nimbus-jose-jwt.version>
   </properties>
 
@@ -1312,11 +1311,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
         <version>${snappy-java.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hadoop.thirdparty</groupId>
-        <artifactId>hadoop-shaded-guava</artifactId>
-        <version>${hadoop-shaded-guava.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.vlsi.mxgraph</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove explicit dependency on `hadoop-shaded-guava`.  It is only for Hadoop, not used directly by Ozone.

https://issues.apache.org/jira/browse/HDDS-11619

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/11577173548