### PR TITLE
HDDS-11621. Fix missing HADOOP_ variables in MR acceptance test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/hadoop.conf
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop.conf
@@ -18,9 +18,6 @@ CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
 CORE-SITE.xml_fs.AbstractFileSystem.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzFs
 
 MAPRED-SITE.XML_mapreduce.framework.name=yarn
-MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
-MAPRED-SITE.XML_mapreduce.map.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
-MAPRED-SITE.XML_mapreduce.reduce.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
 MAPRED-SITE.XML_mapreduce.map.memory.mb=4096
 MAPRED-SITE.XML_mapreduce.reduce.memory.mb=4096
 MAPRED-SITE.XML_mapred.child.java.opts=-Xmx2g

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/.env
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
+HADOOP_IMAGE=apache/hadoop
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
+HADOOP_IMAGE=apache/hadoop
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_TESTKRB5_IMAGE=${docker.ozone-testkr5b.image}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Eliminate warning messages in _acceptance (MR)_:

```
time="2024-10-29T17:40:36Z" level=warning msg="The \"HADOOP_IMAGE\" variable is not set. Defaulting to a blank string."
time="2024-10-29T17:40:36Z" level=warning msg="The \"HADOOP_HOME\" variable is not set. Defaulting to a blank string."
```

Example:
https://github.com/apache/ozone/actions/runs/11579223435/job/32239674587#step:5:22

https://issues.apache.org/jira/browse/HDDS-11621

## How was this patch tested?

Ran MR acceptance test locally:

```
export OZONE_ACCEPTANCE_SUITE=MR
./hadoop-ozone/dev-support/checks/acceptance.sh
```

https://github.com/adoroszlai/ozone/actions/runs/11581423405/job/32242834663#step:5:20