### PR TITLE
HDDS-11635. Memory leak while using OFS connector via FileContext Hadoop API

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzFs.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzFs.java
@@ -46,4 +46,13 @@ public class BasicOzFs extends DelegateToFileSystem {
   public int getUriDefaultPort() {
     return -1;
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/OzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/OzFs.java
@@ -45,4 +45,13 @@ public class OzFs extends DelegateToFileSystem {
   public int getUriDefaultPort() {
     return -1;
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -46,4 +46,13 @@ public class RootedOzFs extends DelegateToFileSystem {
   public int getUriDefaultPort() {
     return -1;
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzFs.java
@@ -40,4 +40,13 @@ public class OzFs extends DelegateToFileSystem {
     super(theUri, new OzoneFileSystem(), conf,
         OzoneConsts.OZONE_URI_SCHEME, false);
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -41,4 +41,13 @@ public class RootedOzFs extends DelegateToFileSystem {
     super(theUri, new RootedOzoneFileSystem(), conf,
         OzoneConsts.OZONE_OFS_URI_SCHEME, false);
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzFs.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzFs.java
@@ -41,4 +41,13 @@ public class OzFs extends DelegateToFileSystem {
     super(theUri, new OzoneFileSystem(), conf,
         OzoneConsts.OZONE_URI_SCHEME, false);
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -41,4 +41,13 @@ public class RootedOzFs extends DelegateToFileSystem {
     super(theUri, new RootedOzoneFileSystem(), conf,
         OzoneConsts.OZONE_OFS_URI_SCHEME, false);
   }
+
+  /**
+   * Close the file system; the FileContext API doesn't have an explicit close.
+   */
+  @Override
+  protected void finalize() throws Throwable {
+    fsImpl.close();
+    super.finalize();
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11635. Fix memory leak while using OFS connector via FileContext Hadoop API

Please describe your PR in detail:
* Leak occurs while using OFS connector via **Hadoop FileContext API**
  * FileContext API does not have an explicit close interface
  * ozone-filesystem client library implements FileContext API by means of **org.apache.hadoop.fs.ozone.RootedOzFs** which spawns new **RootedOzoneFileSystem** every time FileContext is used
  * this internal FS object is never closed
* Propsed solution:
  * close internal FS object in finalize()

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11635


## How was this patch tested?

Manual testing (accessing and manipulating data in Ozone over FileContext API) while monitoring memory consumption via JMX metrics. With the fix, consumption is stable