### PR TITLE
HDDS-11637. Compile failure is ignored in build check

### DIFF
--- a/hadoop-ozone/dev-support/checks/build.sh
+++ b/hadoop-ozone/dev-support/checks/build.sh
@@ -14,5 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -eu -o pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}"/_build.sh install "$@"

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/UpgradeActionRecon.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/UpgradeActionRecon.java
@@ -42,15 +42,12 @@ import java.lang.annotation.Target;
  * Example usage:
  *
  * <pre>
- * {@code
- *
- * @UpgradeActionRecon(feature = FEATURE_NAME, type = FINALIZE)
- *  public class FeatureNameUpgradeAction implements ReconUpgradeAction {
- *     @Override
- *     public void execute() throws Exception {
- *       // Custom upgrade logic for FEATURE_1
- *     }
- *  }
+ * &#64;UpgradeActionRecon(feature = FEATURE_NAME, type = FINALIZE)
+ * public class FeatureNameUpgradeAction implements ReconUpgradeAction {
+ *   &#64;Override
+ *   public void execute() throws Exception {
+ *     // Custom upgrade logic for FEATURE_1
+ *   }
  * }
  * </pre>
  */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exit code in `build.sh` (used by `build` check) was accidentally omitted in HDDS-11057.  This results in "successful" build check even in case of build failure.  (`dependency` or `acceptance` checks may still catch the problem due to missing artifacts.)

This PR makes `build.sh` exit with failure result if there are any errors.

Also fix a javadoc [failure](https://github.com/apache/ozone/actions/runs/11549582108/job/32143421325#step:8:15382), which was not caught by CI earlier due to the problem above.

https://issues.apache.org/jira/browse/HDDS-11637

## How was this patch tested?

Ran the script after introducing some syntax error:

```
$ echo "garbage" >> hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
$ ./hadoop-ozone/dev-support/checks/build.sh; echo $?
...
[ERROR] hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java:[405,1] reached end of file while parsing
...
[INFO] BUILD FAILURE
...
1
```