### PR TITLE
HDDS-11639. Upgrade ozone-runner to Rocky Linux 9.3

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20241022-jdk17-1</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20241104-jdk17-1</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>apache/ozone-testkrb5:20230318-1</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
   </properties>

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectcopys3a.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectcopys3a.robot
@@ -31,17 +31,17 @@ Put object s3a simulation
                         Execute                    echo "Randomtext" > /tmp/testfile
     ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt    255
     ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/word.txt/
-                        Should Not contain         ${result}   word.txt
+                        Should Not Match Regexp    ${result}   "Key".*word.txt
 
     ${result} =         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt._COPYING_    255
     ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/word.txt._COPYING_/
-                        Should Not contain         ${result}  word.txt._COPYING_
+                        Should Not Match Regexp    ${result}   "Key".*word.txt._COPYING_
 
     ${result} =         Execute AWSS3ApiCli        put-object --bucket ${BUCKET} --key ${PREFIX}/word.txt._COPYING_ --body /tmp/testfile
                         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt._COPYING_    0
                         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt    255
     ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/word.txt/
-                        Should Not contain         ${result}  word.txt._COPYING_
+                        Should Not Match Regexp    ${result}   "Key".*word.txt._COPYING_
 
     ${result} =         Execute AWSS3ApiCli        copy-object --bucket ${BUCKET} --key ${PREFIX}/word.txt --copy-source ${BUCKET}/${PREFIX}/word.txt._COPYING_
                         Execute AWSS3APICli and checkrc    head-object --bucket ${BUCKET} --key ${PREFIX}/word.txt    0


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade to `ozone-runner` image with Rocky Linux 9.3.

New `awscli` prints `Prefix` in the response for `list-objects`, e.g.:

```
{
    "RequestCharged": null,
    "Prefix": "ozone-test-6310816850/word.txt/"
}
```

So we have to tweak some assertions to look for given text only in key names, not just anywhere in the response.

https://issues.apache.org/jira/browse/HDDS-11639

## How was this patch tested?

Ran acceptance tests with pre-commit image:
https://github.com/adoroszlai/ozone/actions/runs/11662926001

Full CI with final image in progress:
https://github.com/adoroszlai/ozone/actions/runs/11665816501