### PR TITLE
HDDS-11641. Allow testing Hadoop with custom docker images

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -21,6 +21,8 @@ if [[ ${SECURITY_ENABLED} == "true" ]]; then
 fi
 export COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yaml}":../common/${extra_compose_file}
 
+: ${HADOOP_TEST_VERSIONS:="apache/hadoop:${hadoop2.version} flokkr/hadoop:3.1.2 apache/hadoop:${hadoop.version}"}
+
 export HADOOP_MAJOR_VERSION=3
 export HADOOP_VERSION=unused # will be set for each test version below
 export OZONE_REPLICATION_FACTOR=3
@@ -42,14 +44,10 @@ export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-for HADOOP_VERSION in ${hadoop2.version} 3.1.2 ${hadoop.version}; do
-  export HADOOP_VERSION
+for test_version in $HADOOP_TEST_VERSIONS; do
+  export HADOOP_IMAGE="${test_version%%:*}"
+  export HADOOP_VERSION="${test_version##*:}"
   export HADOOP_MAJOR_VERSION=${HADOOP_VERSION%%.*}
-  if [[ "${HADOOP_VERSION}" == "${hadoop2.version}" ]] || [[ "${HADOOP_VERSION}" == "${hadoop.version}" ]]; then
-    export HADOOP_IMAGE=apache/hadoop
-  else
-    export HADOOP_IMAGE=flokkr/hadoop
-  fi
 
   docker-compose --ansi never --profile hadoop up -d nm rm
 

--- a/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/hadoop-test.sh
@@ -21,7 +21,11 @@ if [[ ${SECURITY_ENABLED} == "true" ]]; then
 fi
 export COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yaml}":../common/${extra_compose_file}
 
-: ${HADOOP_TEST_VERSIONS:="apache/hadoop:${hadoop2.version} flokkr/hadoop:3.1.2 apache/hadoop:${hadoop.version}"}
+# need temp variables because maven filtering replaces only one item per line
+hadoop2_version="${hadoop2.version}"
+hadoop_version="${hadoop.version}"
+
+: ${HADOOP_TEST_VERSIONS:="apache/hadoop:${hadoop2_version} flokkr/hadoop:3.1.2 apache/hadoop:${hadoop_version}"}
 
 export HADOOP_MAJOR_VERSION=3
 export HADOOP_VERSION=unused # will be set for each test version below


### PR DESCRIPTION
## What changes were proposed in this pull request?

_acceptance (MR)_ test has some hard-coded information about Hadoop versions and corresponding Docker images.  The goal of this change is to allow overriding this information.  Possible use cases:

- build with Hadoop version X that does not (yet) have Docker image, and test with other Hadoop versions that do
- use custom Docker images with version of base software (Java, Robot Framework, etc.)

The implementation allows providing the list of Docker images by overriding `HADOOP_TEST_VERSIONS` environment variable.

https://issues.apache.org/jira/browse/HDDS-11641

## How was this patch tested?

Set custom `HADOOP_TEST_VERSIONS`:
https://github.com/adoroszlai/ozone/blob/b02daa3f62b61cd8cfe9005f53dd48875dbe02be/.github/workflows/ci.yml#L35

and verified that tests are executed for the specified versions:
https://github.com/adoroszlai/ozone/actions/runs/11667624818/job/32486234840#step:5:171
https://github.com/adoroszlai/ozone/actions/runs/11667624818/job/32486234840#step:5:239
https://github.com/adoroszlai/ozone/actions/runs/11667624818/job/32486234840#step:5:307