### PR TITLE
HDDS-11649. Recon ListKeys API: Simplify filter predicates

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ParamInfo.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ParamInfo.java
@@ -17,6 +17,10 @@
  */
 package org.apache.hadoop.ozone.recon.api.types;
 
+import org.apache.hadoop.ozone.recon.ReconUtils;
+
+import java.util.TimeZone;
+
 /**
  * Wrapper object for statistics of records of a page in API response.
  */
@@ -36,6 +40,8 @@ public class ParamInfo {
    * creation date filter for keys to filter.
    */
   private String creationDate;
+
+  private long creationDateEpoch = -1;
 
   /**
    *
@@ -85,6 +91,14 @@ public class ParamInfo {
 
   public String getCreationDate() {
     return creationDate;
+  }
+
+  public long getCreationDateEpoch() {
+    if (creationDateEpoch == -1) {
+      creationDateEpoch = ReconUtils.convertToEpochMillis(
+          getCreationDate(), "MM-dd-yyyy HH:mm:ss", TimeZone.getDefault());
+    }
+    return creationDateEpoch;
   }
 
   public String getReplicationType() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the Recon ListKeys API, a series of predicate lambdas are created to filter the returned keys. The filters create 3 new lambdas for each key to check and this api could iterate a lot of keys in parallel.

Benchmarking the original code against simple IF statements shows the IF statements to be about 3x faster. However the creation of all the lambda object resulted in about 4500MB/s of short lived objects.

This PR simplifies the code to IF statements. It should not change any functionality.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11649

## How was this patch tested?

Existing tests cover this.
