### PR TITLE
HDDS-11311. Added Compatibility test for HSync

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
@@ -46,3 +46,9 @@ FSO Bucket Can Be Read
     Execute    ozone fs -get ofs://om/vol1/fso-bucket-${SUFFIX}/dir/subdir/file ${TEMP_DIR}/
     Execute    diff -q ${TESTFILE} ${TEMP_DIR}/file
     [teardown]    Execute    rm -f ${TEMP_DIR}/file
+
+HSync Lease Recover Can Be Used
+    Pass Execution If    '${DATA_VERSION}' < '${HSYNC_VERSION}'      Skipped the test case
+    Pass Execution If    '${CLIENT_VERSION}' < '${HSYNC_VERSION}'    Client does not support HSYNC
+    Pass Execution If    '${CLUSTER_VERSION}' < '${HSYNC_VERSION}'   Cluster does not support HSYNC
+    Execute    ozone debug recover --path=ofs://om/vol1/fso-bucket-${SUFFIX}/dir/subdir/file

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/setup.robot
@@ -21,7 +21,7 @@ Resource            ../ozone-lib/shell.robot
 *** Variables ***
 ${SUFFIX}    ${EMPTY}
 ${FSO_VERSION}    1.3.0
-${HSYNC_VERSION}  1.5.0
+${HSYNC_VERSION}  2.0.0
 
 
 *** Keywords ***

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/setup.robot
@@ -21,6 +21,7 @@ Resource            ../ozone-lib/shell.robot
 *** Variables ***
 ${SUFFIX}    ${EMPTY}
 ${FSO_VERSION}    1.3.0
+${HSYNC_VERSION}  1.5.0
 
 
 *** Keywords ***

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -17,11 +17,15 @@
 Documentation       Write Compatibility
 Resource            ../ozone-lib/shell.robot
 Resource            setup.robot
+Resource            ../lib/fs.robot
+Resource            ../ozone-lib/freon.robot
 Test Timeout        5 minutes
 Suite Setup         Create Local Test File
 
 *** Variables ***
 ${SUFFIX}    ${EMPTY}
+${VOL}       comp-hsync-volume
+${BUCK}      comp-hsync-bucket
 
 
 *** Test Cases ***
@@ -40,3 +44,13 @@ FSO Bucket Can Be Created and Used
     Execute    ozone sh bucket create --layout FILE_SYSTEM_OPTIMIZED /vol1/fso-bucket-${SUFFIX}
     Execute    ozone fs -mkdir -p ofs://om/vol1/fso-bucket-${SUFFIX}/dir/subdir
     Execute    ozone fs -put ${TESTFILE} ofs://om/vol1/fso-bucket-${SUFFIX}/dir/subdir/file
+
+HSync Can Be Used To Create Keys
+    Pass Execution If    '${CLIENT_VERSION}' < '${HSYNC_VERSION}'    Client does not support HSYNC
+    Pass Execution If    '${CLUSTER_VERSION}' < '${HSYNC_VERSION}'   Cluster does not support HSYNC
+    Execute             ozone sh volume create /${VOL}
+    Execute             ozone sh bucket create /${VOL}/${BUCK}
+    ${o3fspath} =   Format FS URL         o3fs     ${VOL}    ${BUCK}
+    Freon DFSG      sync=HSYNC    path=${o3fspath}
+    ${pfspath} =    Format FS URL         ofs      ${VOL}    ${BUCK}
+    Freon DFSG      sync=HSYNC    path=${pfspath}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to add a compatibility test for HSync similar to FSO (jira: HDDS-11134).

## What is the link to the Apache JIRA
HDDS-11311

## How was this patch tested?
A successful run on the fork: https://github.com/hemantk-12/ozone/actions/runs/11699680411
