### PR TITLE
HDDS-11475: Verify EC reconstruction correctness

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -225,6 +225,14 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private int ecReconstructStripeWritePoolLimit = 10 * 3;
 
+  @Config(key="ec.reconstruction.validation",
+      defaultValue = "false",
+      description = "Flag to enable validation for EC reconstruction tasks" +
+          " to reconstruct target containers correctly. Reconstruction tasks" +
+          " will fail if validation fails when enabled.",
+      tags = ConfigTag.CLIENT)
+  private boolean ecReconstructionValidation = false;
+
   @Config(key = "checksum.combine.mode",
       defaultValue = "COMPOSITE_CRC",
       description = "The combined checksum type [MD5MD5CRC / COMPOSITE_CRC] "
@@ -507,6 +515,14 @@ public class OzoneClientConfig {
 
   public int getEcReconstructStripeWritePoolLimit() {
     return ecReconstructStripeWritePoolLimit;
+  }
+
+  public void setEcReconstructionValidation(boolean validationEnabled) {
+    this.ecReconstructionValidation = validationEnabled;
+  }
+
+  public boolean getEcReconstructionValidation() {
+    return ecReconstructionValidation;
   }
 
   public void setFsDefaultBucketLayout(String bucketLayout) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -826,4 +826,8 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
         .boxed().collect(toCollection(TreeSet::new));
   }
 
+  public boolean validateChecksum(ByteBuffer[] buf) {
+
+  }
+
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -825,9 +825,4 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     return range(startInclusive, endExclusive)
         .boxed().collect(toCollection(TreeSet::new));
   }
-
-  public boolean validateChecksum(ByteBuffer[] buf) {
-
-  }
-
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -116,6 +116,7 @@ public class ECReconstructionCoordinator implements Closeable {
   private final ECReconstructionMetrics metrics;
   private final StateContext context;
   private final OzoneClientConfig ozoneClientConfig;
+  private final ECValidator ecValidator;
 
   public ECReconstructionCoordinator(
       ConfigurationSource conf, CertificateClient certificateClient,
@@ -141,6 +142,7 @@ public class ECReconstructionCoordinator implements Closeable {
     tokenHelper = new TokenHelper(new SecurityConfig(conf), secretKeyClient);
     this.clientMetrics = ContainerClientMetrics.acquire();
     this.metrics = metrics;
+    ecValidator = new ECValidator(ozoneClientConfig);
   }
 
   public void reconstructECContainerGroup(long containerID,
@@ -330,8 +332,7 @@ public class ECReconstructionCoordinator implements Closeable {
                     future = targetBlockStreams[i].write(bufs[i]);
                 checkFailures(targetBlockStreams[i], future);
               }
-              ECValidator validator = new ECValidator(ozoneClientConfig);
-              validator.validateBuffer(bufs[i], targetBlockStreams[i]);
+              ecValidator.validateBuffer(bufs[i], targetBlockStreams[i], i);
               bufs[i].clear();
             }
             length -= readLen;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -300,7 +300,6 @@ public class ECReconstructionCoordinator implements Closeable {
             try {
               readLen = sis.recoverChunks(bufs);
               Set<Integer> failedIndexes = sis.getFailedIndexes();
-              
               if (!failedIndexes.isEmpty()) {
                 // There was a problem reading some of the block indexes, but we
                 // did not get an exception as there must have been spare indexes
@@ -331,6 +330,8 @@ public class ECReconstructionCoordinator implements Closeable {
                     future = targetBlockStreams[i].write(bufs[i]);
                 checkFailures(targetBlockStreams[i], future);
               }
+              ECValidator validator = new ECValidator(ozoneClientConfig);
+              validator.validateBuffer(bufs[i], targetBlockStreams[i]);
               bufs[i].clear();
             }
             length -= readLen;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.security.token.Token;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.MemoizedSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -273,6 +274,8 @@ public class ECReconstructionCoordinator implements Closeable {
       ECBlockOutputStream[] emptyBlockStreams =
           new ECBlockOutputStream[notReconstructIndexes.size()];
       ByteBuffer[] bufs = new ByteBuffer[toReconstructIndexes.size()];
+      List<ByteString> checksums = new ArrayList<>(toReconstructIndexes.size());
+
       try {
         // Create streams and buffers for all indexes that need reconstructed
         for (int i = 0; i < toReconstructIndexes.size(); i++) {
@@ -328,6 +331,8 @@ public class ECReconstructionCoordinator implements Closeable {
                 CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
                     future = targetBlockStreams[i].write(bufs[i]);
                 checkFailures(targetBlockStreams[i], future);
+                // Store the recreated checksum
+
               }
               bufs[i].clear();
             }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECValidator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECValidator.java
@@ -4,8 +4,10 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.storage.ECBlockOutputStream;
 import org.apache.hadoop.ozone.common.Checksum;
+import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,19 +18,37 @@ public class ECValidator {
   private static final Logger LOG =
     LoggerFactory.getLogger(ECValidator.class);
   private Checksum checksum = null;
+  private final boolean isValidationEnabled;
 
   ECValidator(OzoneClientConfig config) {
     this.checksum = new Checksum(config.getChecksumType(), config.getBytesPerChecksum());
+    // We fetch the configuration value beforehand to avoid re-fetching on every validation call
+    isValidationEnabled = config.getEcReconstructionValidation();
   }
 
-  public boolean validateBuffer(ByteBuffer buf, ECBlockOutputStream ecBlockOutputStream)
+  /**
+   * Helper function to validate the checksum between recreated data and
+   * @param buf  A {@link ByteBuffer} instance that stores the chunk
+   * @param ecBlockOutputStream A {@link ECBlockOutputStream} instance that stores
+   *                            the reconstructed index ECBlockOutputStream
+   * @param idx Used to store the index at which data was recreated
+   * @throws OzoneChecksumException if the recreated checksum and the block checksum doesn't match
+   */
+  public void validateBuffer(ByteBuffer buf, ECBlockOutputStream ecBlockOutputStream, int idx)
       throws OzoneChecksumException{
-    try (ChunkBuffer chunk = ChunkBuffer.wrap(buf)) {
-      //Checksum will be stored in the 1st chunk and parity chunks
-      ContainerProtos.ChecksumData stripeChecksum = ecBlockOutputStream.getContainerBlockData()
-        .getChunks(0).getChecksumData();
-      ContainerProtos.ChecksumData chunkChecksum = checksum.computeChecksum(chunk).getProtoBufMessage();
-      LOG.info("Chunk Checksum: {}, Stripe Checksum: {}", chunkChecksum, stripeChecksum);
+    if (isValidationEnabled) {
+      try (ChunkBuffer chunk = ChunkBuffer.wrap(buf)) {
+        //Checksum will be stored in the 1st chunk and parity chunks
+        ContainerProtos.ChecksumData stripeChecksum = ecBlockOutputStream.getContainerBlockData()
+          .getChunks(0).getChecksumData();
+        ContainerProtos.ChecksumData chunkChecksum = checksum.computeChecksum(chunk).getProtoBufMessage();
+        if (stripeChecksum.getChecksums(idx) != chunkChecksum.getChecksums(0)) {
+          LOG.info("Checksum mismatched between recreated chunk and re-created chunk");
+          throw new OzoneChecksumException("Inconsistent checksum for re-created chunk and original chunk");
+        }
+      }
+    } else {
+      LOG.debug("Checksum validation was disabled, skipping check");
     }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECValidator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECValidator.java
@@ -1,0 +1,34 @@
+package org.apache.hadoop.ozone.container.ec.reconstruction;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.storage.ECBlockOutputStream;
+import org.apache.hadoop.ozone.common.Checksum;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
+import org.apache.hadoop.ozone.common.OzoneChecksumException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+
+public class ECValidator {
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(ECValidator.class);
+  private Checksum checksum = null;
+
+  ECValidator(OzoneClientConfig config) {
+    this.checksum = new Checksum(config.getChecksumType(), config.getBytesPerChecksum());
+  }
+
+  public boolean validateBuffer(ByteBuffer buf, ECBlockOutputStream ecBlockOutputStream)
+      throws OzoneChecksumException{
+    try (ChunkBuffer chunk = ChunkBuffer.wrap(buf)) {
+      //Checksum will be stored in the 1st chunk and parity chunks
+      ContainerProtos.ChecksumData stripeChecksum = ecBlockOutputStream.getContainerBlockData()
+        .getChunks(0).getChecksumData();
+      ContainerProtos.ChecksumData chunkChecksum = checksum.computeChecksum(chunk).getProtoBufMessage();
+      LOG.info("Chunk Checksum: {}, Stripe Checksum: {}", chunkChecksum, stripeChecksum);
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11475: Verify EC reconstruction correctness

Please describe your PR in detail:
* In current implementation the stripe checksum is formed in ECKeyOutputStream in `private StripeWriteStatus commitStripeWrite(ECChunkBuffers stripe)`
* To verify the recreated data we can use the stripe checksum - which is a concatenation of all the chunk checksums in the stripe and compare the recreated chunk checksum with the stripe checksum at recreated index to verify the correct data was recreated
```
Example, for EC 3-2 we will have chunks c1, c2, c3, c4, c5
(stripe checksum) s1 = add checksum of(c1 to c5)

Let recreated chunk be c2
Then:
checksum(c2) == 2nd checksum in s1 checksum sequence
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11475

## How was this patch tested?

Unit tests