### PR TITLE
HDDS-11660. Recon List Key API: Reduce object creation and buffering memory

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -291,11 +291,34 @@ public class ReconUtils {
    */
   public static String constructFullPath(OmKeyInfo omKeyInfo,
                                          ReconNamespaceSummaryManager reconNamespaceSummaryManager,
-                                         ReconOMMetadataManager omMetadataManager)
-      throws IOException {
+                                         ReconOMMetadataManager omMetadataManager)  throws IOException {
+    return constructFullPath(omKeyInfo.getKeyName(), omKeyInfo.getParentObjectID(), omKeyInfo.getVolumeName(),
+        omKeyInfo.getBucketName(), reconNamespaceSummaryManager, omMetadataManager);
+  }
 
-    StringBuilder fullPath = new StringBuilder(omKeyInfo.getKeyName());
-    long parentId = omKeyInfo.getParentObjectID();
+  /**
+   * Constructs the full path of a key from its key name and parent ID using a bottom-up approach, starting from the
+   * leaf node.
+   *
+   * The method begins with the leaf node (the key itself) and recursively prepends parent directory names, fetched
+   * via NSSummary objects, until reaching the parent bucket (parentId is -1). It effectively builds the path from
+   * bottom to top, finally prepending the volume and bucket names to complete the full path. If the directory structure
+   * is currently being rebuilt (indicated by the rebuildTriggered flag), this method returns an empty string to signify
+   * that path construction is temporarily unavailable.
+   *
+   * @param keyName The name of the key
+   * @param initialParentId The parent ID of the key
+   * @param volumeName The name of the volume
+   * @param bucketName The name of the bucket
+   * @return The constructed full path of the key as a String, or an empty string if a rebuild is in progress and
+   *         the path cannot be constructed at this time.
+   * @throws IOException
+   */
+  public static String constructFullPath(String keyName, long initialParentId, String volumeName, String bucketName,
+                                         ReconNamespaceSummaryManager reconNamespaceSummaryManager,
+                                         ReconOMMetadataManager omMetadataManager) throws IOException {
+    StringBuilder fullPath = new StringBuilder(keyName);
+    long parentId = initialParentId;
     boolean isDirectoryPresent = false;
 
     while (parentId != 0) {
@@ -320,8 +343,6 @@ public class ReconUtils {
     }
 
     // Prepend the volume and bucket to the constructed path
-    String volumeName = omKeyInfo.getVolumeName();
-    String bucketName = omKeyInfo.getBucketName();
     fullPath.insert(0, volumeName + OM_KEY_PREFIX + bucketName + OM_KEY_PREFIX);
     if (isDirectoryPresent) {
       return OmUtils.normalizeKey(fullPath.toString(), true);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfoProtoWrapper.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfoProtoWrapper.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.api.types;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
+import org.apache.hadoop.hdds.utils.db.Proto2Codec;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+
+/**
+ * POJO object wrapper for metadata of a given key/file. This class wraps a KeyInfo protobuf
+ * object and delegates most accessors to it.
+ */
+public final class KeyEntityInfoProtoWrapper {
+
+  public static Codec<KeyEntityInfoProtoWrapper> getCodec() {
+    return new DelegatedCodec<>(
+        Proto2Codec.get(OzoneManagerProtocolProtos.KeyInfo.getDefaultInstance()),
+        KeyEntityInfoProtoWrapper::getFromProtobuf,
+        KeyEntityInfoProtoWrapper::toProtobuf,
+        KeyEntityInfoProtoWrapper.class);
+  }
+
+  private final OzoneManagerProtocolProtos.KeyInfo keyInfoProto;
+
+  /** This is key table key of rocksDB and will help UI to implement pagination
+   * where UI will use the last record key to send in API as preKeyPrefix. */
+  @JsonProperty("key")
+  private String key;
+
+  /** Path of a key/file. */
+  @JsonProperty("path")
+  private String path;
+
+  @JsonProperty("replicatedSize")
+  private final long replicatedSize;
+
+  @JsonProperty("replicationInfo")
+  private final ReplicationConfig replicationConfig;
+
+  private KeyEntityInfoProtoWrapper(OzoneManagerProtocolProtos.KeyInfo proto) {
+    keyInfoProto = proto;
+    replicationConfig = ReplicationConfig.fromProto(proto.getType(), proto.getFactor(),
+        proto.getEcReplicationConfig());
+    this.replicatedSize = QuotaUtil.getReplicatedSize(getSize(), getReplicationConfig());
+  }
+
+  public static KeyEntityInfoProtoWrapper getFromProtobuf(OzoneManagerProtocolProtos.KeyInfo keyInfo) {
+    return new KeyEntityInfoProtoWrapper(keyInfo);
+  }
+
+  public OzoneManagerProtocolProtos.KeyInfo toProtobuf() {
+    throw new UnsupportedOperationException("This method is not supported.");
+  }
+
+  @JsonProperty("key")
+  public String getKey() {
+    if (key == null) {
+      throw new IllegalStateException("Key must be set to correctly serialize this object.");
+    }
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  @JsonProperty("path")
+  public String getPath() {
+    if (path == null) {
+      throw new IllegalStateException("Path must be set to correctly serialize this object.");
+    }
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  @JsonProperty("size")
+  public long getSize() {
+    return keyInfoProto.getDataSize();
+  }
+
+  @JsonProperty("replicatedSize")
+  public long getReplicatedSize() {
+    return replicatedSize;
+  }
+
+  @JsonProperty("replicationInfo")
+  public ReplicationConfig getReplicationConfig() {
+    return replicationConfig;
+  }
+
+  @JsonProperty("creationTime")
+  public long getCreationTime() {
+    return keyInfoProto.getCreationTime();
+  }
+
+  @JsonProperty("modificationTime")
+  public long getModificationTime() {
+    return keyInfoProto.getModificationTime();
+  }
+
+  @JsonProperty("isKey")
+  public boolean isKey() {
+    return keyInfoProto.getIsFile();
+  }
+
+  public long getParentId() {
+    return keyInfoProto.getParentID();
+  }
+
+  public String getVolumeName() {
+    return keyInfoProto.getVolumeName();
+  }
+
+  public String getBucketName() {
+    return keyInfoProto.getBucketName();
+  }
+
+  /** Returns the key name of the key stored in the OM Key Info object. */
+  public String getKeyName() {
+    return keyInfoProto.getKeyName();
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ListKeysResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ListKeysResponse.java
@@ -51,7 +51,7 @@ public class ListKeysResponse {
 
   /** list of keys. */
   @JsonProperty("keys")
-  private List<KeyEntityInfo> keys;
+  private List<KeyEntityInfoProtoWrapper> keys;
 
 
   public ListKeysResponse() {
@@ -95,11 +95,11 @@ public class ListKeysResponse {
     this.path = path;
   }
 
-  public List<KeyEntityInfo> getKeys() {
+  public List<KeyEntityInfoProtoWrapper> getKeys() {
     return keys;
   }
 
-  public void setKeys(List<KeyEntityInfo> keys) {
+  public void setKeys(List<KeyEntityInfoProtoWrapper> keys) {
     this.keys = keys;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOMMetadataManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOMMetadataManager.java
@@ -23,9 +23,12 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.recon.api.types.KeyEntityInfoProtoWrapper;
 
 /**
  * Interface for the OM Metadata Manager + DB store maintained by
@@ -112,5 +115,14 @@ public interface ReconOMMetadataManager extends OMMetadataManager {
    * @return OzoneConfiguration
    */
   OzoneConfiguration getOzoneConfiguration();
+
+  /**
+   * A lighter weight version of the getKeyTable method that only returns the KeyEntityInfo wrapper object. This
+   * avoids creating a full OMKeyInfo object for each key if it is not needed.
+   * @param bucketLayout The Bucket layout to use for the key table.
+   * @return A table of keys and their metadata.
+   * @throws IOException
+   */
+  Table<String, KeyEntityInfoProtoWrapper> getKeyTableLite(BucketLayout bucketLayout) throws IOException;
 
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -41,9 +41,11 @@ import org.apache.hadoop.hdds.utils.db.cache.TableCache;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.recon.ReconUtils;
+import org.apache.hadoop.ozone.recon.api.types.KeyEntityInfoProtoWrapper;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,6 +99,7 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
           .setName(dbFile.getName())
           .setPath(dbFile.toPath().getParent());
       addOMTablesAndCodecs(dbStoreBuilder);
+      dbStoreBuilder.addCodec(KeyEntityInfoProtoWrapper.class, KeyEntityInfoProtoWrapper.getCodec());
       setStore(dbStoreBuilder.build());
       LOG.info("Created OM DB handle from snapshot at {}.",
           dbFile.getAbsolutePath());
@@ -107,6 +110,12 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
       initializeOmTables(TableCache.CacheType.FULL_CACHE, true);
       omTablesInitialized = true;
     }
+  }
+
+  @Override
+  public Table<String, KeyEntityInfoProtoWrapper> getKeyTableLite(BucketLayout bucketLayout) throws IOException {
+    String tableName = bucketLayout.isFileSystemOptimized() ? FILE_TABLE : KEY_TABLE;
+    return getStore().getTable(tableName, String.class, KeyEntityInfoProtoWrapper.class);
   }
 
   @Override

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.recon.ReconTestInjector;
 import org.apache.hadoop.ozone.recon.ReconUtils;
-import org.apache.hadoop.ozone.recon.api.types.KeyEntityInfo;
+import org.apache.hadoop.ozone.recon.api.types.KeyEntityInfoProtoWrapper;
 import org.apache.hadoop.ozone.recon.api.types.KeyInsightInfoResponse;
 import org.apache.hadoop.ozone.recon.api.types.ListKeysResponse;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
@@ -1579,7 +1579,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "", 1000);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(6, listKeysResponse.getKeys().size());
-    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    KeyEntityInfoProtoWrapper keyEntityInfo = listKeysResponse.getKeys().get(0);
     assertEquals("volume1/fso-bucket/dir1/file1", keyEntityInfo.getPath());
     assertEquals("/1/10/11/file1", keyEntityInfo.getKey());
     assertEquals("/1/10/13/testfile", listKeysResponse.getLastKey());
@@ -1611,7 +1611,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "", 2);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(2, listKeysResponse.getKeys().size());
-    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    KeyEntityInfoProtoWrapper keyEntityInfo = listKeysResponse.getKeys().get(0);
     assertEquals("volume1/fso-bucket/dir1/file1", keyEntityInfo.getPath());
     assertEquals("/1/10/11/testfile", listKeysResponse.getLastKey());
     assertEquals("RATIS", keyEntityInfo.getReplicationConfig().getReplicationType().toString());
@@ -1653,7 +1653,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "", 2);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(2, listKeysResponse.getKeys().size());
-    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    KeyEntityInfoProtoWrapper keyEntityInfo = listKeysResponse.getKeys().get(0);
     assertEquals("volume1/fso-bucket/dir1/file1", keyEntityInfo.getPath());
     assertEquals("/1/10/11/testfile", listKeysResponse.getLastKey());
     assertEquals("RATIS", keyEntityInfo.getReplicationConfig().getReplicationType().toString());
@@ -1695,7 +1695,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "", 1);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(1, listKeysResponse.getKeys().size());
-    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    KeyEntityInfoProtoWrapper keyEntityInfo = listKeysResponse.getKeys().get(0);
     assertEquals("volume1/fso-bucket/dir1/file1", keyEntityInfo.getPath());
     assertEquals("/1/10/11/file1", listKeysResponse.getLastKey());
     assertEquals("RATIS", keyEntityInfo.getReplicationConfig().getReplicationType().toString());
@@ -1746,7 +1746,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "", 3);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(3, listKeysResponse.getKeys().size());
-    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    KeyEntityInfoProtoWrapper keyEntityInfo = listKeysResponse.getKeys().get(0);
     assertEquals("volume1/fso-bucket2/dir8/file1", keyEntityInfo.getPath());
     assertEquals("/1/30/32/file1", listKeysResponse.getLastKey());
     assertEquals("RATIS", keyEntityInfo.getReplicationConfig().getReplicationType().toString());
@@ -1779,7 +1779,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "", 2);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(2, listKeysResponse.getKeys().size());
-    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    KeyEntityInfoProtoWrapper keyEntityInfo = listKeysResponse.getKeys().get(0);
     assertEquals("volume1/fso-bucket/dir1/dir2/file1", keyEntityInfo.getPath());
     assertEquals("/1/10/12/testfile", listKeysResponse.getLastKey());
     assertEquals("RATIS", keyEntityInfo.getReplicationConfig().getReplicationType().toString());
@@ -1812,7 +1812,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "", 2);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(2, listKeysResponse.getKeys().size());
-    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    KeyEntityInfoProtoWrapper keyEntityInfo = listKeysResponse.getKeys().get(0);
     assertEquals("volume1/fso-bucket/dir1/dir2/dir3/file1", keyEntityInfo.getPath());
     assertEquals("/1/10/13/testfile", listKeysResponse.getLastKey());
     assertEquals("RATIS", keyEntityInfo.getReplicationConfig().getReplicationType().toString());
@@ -1899,7 +1899,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
         "", 2);
     ListKeysResponse listKeysResponse = (ListKeysResponse) bucketResponse.getEntity();
     assertEquals(2, listKeysResponse.getKeys().size());
-    KeyEntityInfo keyEntityInfo = listKeysResponse.getKeys().get(0);
+    KeyEntityInfoProtoWrapper keyEntityInfo = listKeysResponse.getKeys().get(0);
     assertEquals("volume1/obs-bucket/key1", keyEntityInfo.getPath());
     assertEquals("/volume1/obs-bucket/key1/key2", listKeysResponse.getLastKey());
     assertEquals("RATIS", keyEntityInfo.getReplicationConfig().getReplicationType().toString());


### PR DESCRIPTION
## What changes were proposed in this pull request?



The current ListKeysAPI implementation, pulls a batch of OMKeyInfo objects from the File / Key table and buffers them in an array.

Then it converts each item in that array to a KeyEntityInfo object, which has JSON annotations allowing the data to be serialized over HTTP.

This results in two copies of the objects buffered in memory at once.

Additionally, the OMKeyInfo object is a fairly heavyweight object, and creating it from protobuf also deserialized the block information, which is not needed for the ListKey purposes.

Further taking the protobuffer bytes from RocksDB creates a KeyInfo object (de-serialized proto) and then this object is copied into OmKeyInfo.

So for each key retrieved, we start with:

1. A deserialized proto object (KeyInfo)
2. A copy of the proto fields (OmKeyInfo)
3. A json annotated object (KeyEntityInfo).

By de-serializing into the 3rd object directly, and having it wrap a keyInfo object and delegate calls to it when appropriate, we avoid needing the heavyweight OmKeyInfo object, and make the KeyEntityInfo object "slimmer". We can also avoid the double buffering, creating only a single list of objects for the batch.

This PR introduces a KeyEntityInfoProtoWrapper object, rather than changing the existing KeyEntityInfo object. The reason, is that other APIs outside of ListKeys use it. I am not ready to change those APIs now, however after this change gets committed and we are happy with it, it should be possible to apply similar changes to those other APIs and eventually remove KeyEntityInfo from the system.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11660

## How was this patch tested?

Existing tests cover this, as the changes are internal to the API implementation