### PR TITLE
HDDS-11583. Use ozone-runner from GitHub in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ env:
   # Minimum required Java version for running Ozone is defined in pom.xml (javac.version).
   TEST_JAVA_VERSION: 17 # JDK version used by CI build and tests; should match the JDK version in apache/ozone-runner image
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+  OZONE_RUNNER_IMAGE: ghcr.io/apache/ozone-runner
+  OZONE_RUNNER_VERSION: 20241108-jdk17-1
   OZONE_WITH_COVERAGE: ${{ github.event_name == 'push' }}
 jobs:
   build-info:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change CI workflow to use `ozone-runner` from GitHub Container Registry to reduce rate of pull from Docker Hub.

(Ideally the version should be changed in `hadoop-ozone/dist/pom.xml`, but this image is not yet available in Docker Hub due to infra issues.)

https://issues.apache.org/jira/browse/HDDS-11583

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/11737132627

Verified that download activity for the [image](https://github.com/apache/ozone-docker-runner/pkgs/container/ozone-runner/302390217?tag=20241108-jdk17-1) in GitHub increased (from 5 to 101) due to the CI run.