### PR TITLE
HDDS-11668. Recon List Keys API: Reuse key prefix if parentID is the same

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -319,6 +319,9 @@ public class ReconUtils {
                                          ReconOMMetadataManager omMetadataManager) throws IOException {
     StringBuilder fullPath = constructFullPathPrefix(initialParentId, volumeName, bucketName,
         reconNamespaceSummaryManager, omMetadataManager);
+    if (fullPath.length() == 0) {
+      return "";
+    }
     fullPath.append(keyName);
     return fullPath.toString();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -356,6 +356,7 @@ public class ReconUtils {
       if (nsSummary == null) {
         log.warn("NSSummary tree is currently being rebuilt or the directory could be in the progress of " +
             "deletion, returning empty string for path construction.");
+        fullPath.setLength(0);
         return fullPath;
       }
       if (nsSummary.getParentId() == -1) {
@@ -363,6 +364,7 @@ public class ReconUtils {
           triggerRebuild(reconNamespaceSummaryManager, omMetadataManager);
         }
         log.warn("NSSummary tree is currently being rebuilt, returning empty string for path construction.");
+        fullPath.setLength(0);
         return fullPath;
       }
       // On the last pass, dir-name will be empty and parent will be zero, indicating the loop should end.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -317,7 +317,34 @@ public class ReconUtils {
   public static String constructFullPath(String keyName, long initialParentId, String volumeName, String bucketName,
                                          ReconNamespaceSummaryManager reconNamespaceSummaryManager,
                                          ReconOMMetadataManager omMetadataManager) throws IOException {
-    StringBuilder fullPath = new StringBuilder(keyName);
+    StringBuilder fullPath = constructFullPathPrefix(initialParentId, volumeName, bucketName,
+        reconNamespaceSummaryManager, omMetadataManager);
+    fullPath.append(keyName);
+    return fullPath.toString();
+  }
+
+
+  /**
+   * Constructs the prefix path to a key from its key name and parent ID using a bottom-up approach, starting from the
+   * leaf node.
+   *
+   * The method begins with the leaf node (the key itself) and recursively prepends parent directory names, fetched
+   * via NSSummary objects, until reaching the parent bucket (parentId is -1). It effectively builds the path from
+   * bottom to top, finally prepending the volume and bucket names to complete the full path. If the directory structure
+   * is currently being rebuilt (indicated by the rebuildTriggered flag), this method returns an empty string to signify
+   * that path construction is temporarily unavailable.
+   *
+   * @param initialParentId The parent ID of the key
+   * @param volumeName The name of the volume
+   * @param bucketName The name of the bucket
+   * @return A StringBuilder containing the constructed prefix path of the key, or an empty string builder if a rebuild
+   *         is in progress.
+   * @throws IOException
+   */
+  public static StringBuilder constructFullPathPrefix(long initialParentId, String volumeName,
+      String bucketName, ReconNamespaceSummaryManager reconNamespaceSummaryManager,
+      ReconOMMetadataManager omMetadataManager) throws IOException {
+    StringBuilder fullPath = new StringBuilder();
     long parentId = initialParentId;
     boolean isDirectoryPresent = false;
 
@@ -326,16 +353,19 @@ public class ReconUtils {
       if (nsSummary == null) {
         log.warn("NSSummary tree is currently being rebuilt or the directory could be in the progress of " +
             "deletion, returning empty string for path construction.");
-        return "";
+        return fullPath;
       }
       if (nsSummary.getParentId() == -1) {
         if (rebuildTriggered.compareAndSet(false, true)) {
           triggerRebuild(reconNamespaceSummaryManager, omMetadataManager);
         }
         log.warn("NSSummary tree is currently being rebuilt, returning empty string for path construction.");
-        return "";
+        return fullPath;
       }
-      fullPath.insert(0, nsSummary.getDirName() + OM_KEY_PREFIX);
+      // On the last pass, dir-name will be empty and parent will be zero, indicating the loop should end.
+      if (!nsSummary.getDirName().isEmpty()) {
+        fullPath.insert(0, nsSummary.getDirName() + OM_KEY_PREFIX);
+      }
 
       // Move to the parent ID of the current directory
       parentId = nsSummary.getParentId();
@@ -344,10 +374,18 @@ public class ReconUtils {
 
     // Prepend the volume and bucket to the constructed path
     fullPath.insert(0, volumeName + OM_KEY_PREFIX + bucketName + OM_KEY_PREFIX);
+    // TODO - why is this needed? It seems lke it should handle double slashes in the path name,
+    //        but its not clear how they get there. This normalize call is quite expensive as it
+    //        creates several objects (URI, PATH, back to string). There was a bug fixed above
+    //        where the last parent dirName was empty, which always caused a double // after the
+    //        bucket name, but with that fixed, it seems like this should not be needed. All tests
+    //        pass without it for key listing.
     if (isDirectoryPresent) {
-      return OmUtils.normalizeKey(fullPath.toString(), true);
+      String path = fullPath.toString();
+      fullPath.setLength(0);
+      fullPath.append(OmUtils.normalizeKey(path, true));
     }
-    return fullPath.toString();
+    return fullPath;
   }
 
   private static void triggerRebuild(ReconNamespaceSummaryManager reconNamespaceSummaryManager,


### PR DESCRIPTION
## What changes were proposed in this pull request?

As we iterate keys in the listKeys API there is logic to resolve the FSO path to the key which is quite expensive in aggregate over many keys.

As we iterate the keys in order, it is highly likely there will be consecutive keys with the same parent folder and hence prefix.

Therefore, we should save the prefix prefix and if the current parentID is equal to the previous one, simple reuse it, avoiding all the path construction work.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11668

## How was this patch tested?

Existing tests