### PR TITLE
HDDS-11669. In OmUtils.normalizeKey isDebugEnabled should be evaluated first

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -767,7 +767,7 @@ public final class OmUtils {
         normalizedKeyName = new Path(OM_KEY_PREFIX + keyName)
             .toUri().getPath();
       }
-      if (!keyName.equals(normalizedKeyName) && LOG.isDebugEnabled()) {
+      if (LOG.isDebugEnabled() && !keyName.equals(normalizedKeyName)) {
         LOG.debug("Normalized key {} to {} ", keyName,
             normalizedKeyName.substring(1));
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `OmUtils.normalizeKey()`, the code:

```
      if (!keyName.equals(normalizedKeyName) && LOG.isDebugEnabled()) {
        LOG.debug("Normalized key {} to {} ", keyName,
            normalizedKeyName.substring(1));
      }
```

Always executes the `String.equals()`, but it does not do anything unless debug is enabled.

Debug should be first in the if statement as predicates are evaluated left to right and if isDebugEnabled returns false, the more expensive string compare will not execute.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11669

## How was this patch tested?

Existing tests.