### PR TITLE
HDDS-11636. Cache ozone key details

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -702,6 +702,11 @@ public final class OzoneConfigKeys {
       "ozone.security.crypto.compliance.mode";
   public static final String OZONE_SECURITY_CRYPTO_COMPLIANCE_MODE_UNRESTRICTED = "unrestricted";
 
+  public static final String OZONE_S3G_KEY_INFO_CACHE_IDLE_LIFETIME =
+      "ozone.s3g.key.info.cache.idle.lifetime";
+
+  public static final String OZONE_S3G_KEY_INFO_CACHE_IDLE_LIFETIME_DEFAULT = "10s";
+
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -4555,5 +4555,14 @@
       allowing for better identification and analysis of performance issues.
     </description>
   </property>
-
+  <property>
+    <name>ozone.s3g.key.info.cache.idle.lifetime</name>
+    <value>10s</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>
+      Cache lifetime of the ozone key details after the last request.
+      By the default a cache entry will be removed if it has been idle for 10s.
+      A key of the cache entry is a pair of bucket and the requested key path.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMultipartObjectGet.java
@@ -45,6 +45,7 @@ import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Base64;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -166,7 +167,7 @@ public class TestMultipartObjectGet {
   }
 
   private void getObjectMultipart(int partNumber, long bytes)
-      throws IOException, OS3Exception {
+      throws IOException, OS3Exception, ExecutionException {
     Response response =
         REST.get(BUCKET, KEY, partNumber, null, 100, null);
     assertEquals(200, response.getStatus());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneClientStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneClientStub.java
@@ -22,6 +22,8 @@ package org.apache.hadoop.ozone.client;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.s3.metrics.S3GatewayMetrics;
 
+import static org.mockito.Mockito.spy;
+
 /**
  * In-memory OzoneClient for testing.
  */
@@ -31,7 +33,7 @@ public class OzoneClientStub extends OzoneClient {
   }
 
   public OzoneClientStub(ObjectStoreStub objectStoreStub) {
-    super(objectStoreStub, new ClientProtocolStub(objectStoreStub));
+    super(objectStoreStub, spy(new ClientProtocolStub(objectStoreStub)));
     S3GatewayMetrics.create(new OzoneConfiguration());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Cache ozone key details for a tiny period to avoid OM spamming with equal consequent requests

If you read a huge file through s3g, requests for the same ozone key details will be sent to OM. But the response to the requests will be the same. Hence, the result of the first request could be cached, and the following requests for the key would be redirected to the cache

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11636

## How was this patch tested?
A new unit-test is implemented to check that the key details will be retrieved from the cache if consequent requests are called in a short period. Existing robot tests check that the cache will be invalidated if the key/key_metadata/key_tags are updated.
