### PR TITLE
HDDS-11664. Hadoop download failure not reported as error

### DIFF
--- a/hadoop-ozone/dev-support/checks/_lib.sh
+++ b/hadoop-ozone/dev-support/checks/_lib.sh
@@ -160,7 +160,11 @@ download_hadoop_aws() {
 
   if [[ ! -e "${dir}" ]] || [[ ! -d "${dir}"/src/test/resources ]]; then
     mkdir -p "${dir}"
-    [[ -f "${dir}.tar.gz" ]] || curl -LSs -o "${dir}.tar.gz" https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}-src.tar.gz
+    if [[ ! -f "${dir}.tar.gz" ]]; then
+      local url="https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}-src.tar.gz"
+      echo "Downloading Hadoop from ${url}"
+      curl -LSs --fail -o "${dir}.tar.gz" "$url" || return 1
+    fi
     tar -x -z -C "${dir}" --strip-components=3 -f "${dir}.tar.gz" --wildcards 'hadoop-*-src/hadoop-tools/hadoop-aws' || return 1
   fi
 }

--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -49,7 +49,10 @@ if [[ "${OZONE_ACCEPTANCE_SUITE}" == "s3a" ]]; then
     export HADOOP_AWS_DIR=${OZONE_ROOT}/target/hadoop-src
   fi
 
-  download_hadoop_aws "${HADOOP_AWS_DIR}"
+  if ! download_hadoop_aws "${HADOOP_AWS_DIR}"; then
+    echo "Failed to download Hadoop ${HADOOP_VERSION}" > "${REPORT_DIR}/summary.txt"
+    exit 1
+  fi
 fi
 
 export OZONE_ACCEPTANCE_SUITE OZONE_ACCEPTANCE_TEST_TYPE


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid false negative ([failing](https://github.com/jojochuang/ozone/actions/runs/11388335221/job/31686275738#step:5:19), but reported as passing) _acceptance (s3a)_ check if Hadoop cannot be downloaded.

```
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

Abort the check in this case.

https://issues.apache.org/jira/browse/HDDS-11664

## How was this patch tested?

Temporarily changed Hadoop version to non-existent:

```diff
diff --git pom.xml pom.xml
index 9d48f929f6..1ad7cf2939 100644
--- pom.xml
+++ pom.xml
@@ -67,7 +67,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
 
     <hadoop2.version>2.10.2</hadoop2.version>
-    <hadoop.version>3.3.6</hadoop.version>
+    <hadoop.version>3.3.9</hadoop.version>
 
     <!-- version for hdds/ozone components -->
     <hdds.version>${ozone.version}</hdds.version>
```

And ran the check locally:

```bash
$ OZONE_ACCEPTANCE_SUITE=s3a ./hadoop-ozone/dev-support/checks/acceptance.sh
Downloading Hadoop from https://archive.apache.org/dist/hadoop/common/hadoop-3.3.9/hadoop-3.3.9-src.tar.gz
curl: (22) The requested URL returned error: 404

$ echo $?
1

$ cat target/acceptance/summary.txt 
Failed to download Hadoop 3.3.9
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/11783671867/job/32821950391