### PR TITLE
HDDS-11683. Skip shade in most integration checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,9 @@ jobs:
           if [[ "${{ matrix.profile }}" == "flaky" ]]; then
             args="$args -Dsurefire.rerunFailingTestsCount=5 -Dsurefire.fork.timeout=3600"
           fi
+          if [[ "${{ matrix.profile }}" != "filesystem" ]]; then
+            args="$args -DskipShade"
+          fi
 
           hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }} ${args}
         env:

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -183,7 +183,7 @@ jobs:
             export OZONE_REPO_CACHED=true
           fi
 
-          args="-DexcludedGroups=native|slow|unhealthy"
+          args="-DexcludedGroups=native|slow|unhealthy -DskipShade"
           if [[ "${{ github.event.inputs.ratis-ref }}" != "" ]]; then
             args="$args -Dratis.version=${{ needs.ratis.outputs.ratis-version }}"
             args="$args -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Significant amount of time is spent on building Ozone FS modules in integration
check.  Any tests in these modules (currently only one) are executed only in
_integration (filesystem)_.  Thus we can skip shading in other splits.  Also
can be skipped in `flaky-test-check`.

https://issues.apache.org/jira/browse/HDDS-11683

## How was this patch tested?

Shaded modules were included in _integration (filesystem)_:

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.333 s - in org.apache.hadoop.fs.TestOmKeyInfoWithHadoop2
...
[INFO] Apache Ozone FileSystem Shaded ..................... SUCCESS [03:09 min]
[INFO] Apache Ozone FS Hadoop 2.x compatibility ........... SUCCESS [ 18.842 s]
[INFO] Apache Ozone FS Hadoop 3.x compatibility ........... SUCCESS [ 13.471 s]
[INFO] Apache Ozone FS Hadoop shaded 3.x compatibility .... SUCCESS [ 46.457 s]
```

https://github.com/adoroszlai/ozone/actions/runs/11784838217/job/32825378804#step:6:3659

but excluded in other splits, e.g.:
https://github.com/adoroszlai/ozone/actions/runs/11784838217/job/32825378246#step:6:4429