### PR TITLE
HDDS-11684. Remove suppression of HiddenField

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
@@ -134,7 +134,6 @@ public final class CertInfo implements Comparable<CertInfo>, Serializable {
   /**
    * Builder class for CertInfo.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static class Builder {
     private X509Certificate x509Certificate;
     private long timestamp;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/FinalizationManagerImpl.java
@@ -183,7 +183,6 @@ public class FinalizationManagerImpl implements FinalizationManager {
   /**
    * Builds a {@link FinalizationManagerImpl}.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static class Builder {
     private OzoneConfiguration conf;
     private HDDSLayoutVersionManager versionManager;
@@ -196,14 +195,14 @@ public class FinalizationManagerImpl implements FinalizationManager {
       executor = new DefaultUpgradeFinalizationExecutor<>();
     }
 
-    public Builder setConfiguration(OzoneConfiguration conf) {
-      this.conf = conf;
+    public Builder setConfiguration(OzoneConfiguration configuration) {
+      this.conf = configuration;
       return this;
     }
 
     public Builder setLayoutVersionManager(
-        HDDSLayoutVersionManager versionManager) {
-      this.versionManager = versionManager;
+        HDDSLayoutVersionManager layoutVersionManager) {
+      this.versionManager = layoutVersionManager;
       return this;
     }
 
@@ -212,8 +211,8 @@ public class FinalizationManagerImpl implements FinalizationManager {
       return this;
     }
 
-    public Builder setHAManager(SCMHAManager scmHAManager) {
-      this.scmHAManager = scmHAManager;
+    public Builder setHAManager(SCMHAManager haManager) {
+      this.scmHAManager = haManager;
       return this;
     }
 
@@ -224,8 +223,8 @@ public class FinalizationManagerImpl implements FinalizationManager {
     }
 
     public Builder setFinalizationExecutor(
-        UpgradeFinalizationExecutor<SCMUpgradeFinalizationContext> executor) {
-      this.executor = executor;
+        UpgradeFinalizationExecutor<SCMUpgradeFinalizationContext> finalizationExecutor) {
+      this.executor = finalizationExecutor;
       return this;
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizationContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizationContext.java
@@ -80,7 +80,6 @@ public final class SCMUpgradeFinalizationContext {
   /**
    * Builds an {@link SCMUpgradeFinalizationContext}.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private PipelineManager pipelineManager;
     private NodeManager nodeManager;
@@ -120,13 +119,13 @@ public final class SCMUpgradeFinalizationContext {
     }
 
     public Builder setLayoutVersionManager(
-        HDDSLayoutVersionManager versionManager) {
-      this.versionManager = versionManager;
+        HDDSLayoutVersionManager layoutVersionManager) {
+      this.versionManager = layoutVersionManager;
       return this;
     }
 
-    public Builder setConfiguration(OzoneConfiguration conf) {
-      this.conf = conf;
+    public Builder setConfiguration(OzoneConfiguration configuration) {
+      this.conf = configuration;
       return this;
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/TenantArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/TenantArgs.java
@@ -59,14 +59,13 @@ public final class TenantArgs {
    *
    * @return Builder
    */
-  public static TenantArgs.Builder newBuilder() {
-    return new TenantArgs.Builder();
+  public static Builder newBuilder() {
+    return new Builder();
   }
 
   /**
    * Builder for TenantArgs.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static class Builder {
     private String volumeName;
     private boolean forceCreationWhenVolumeExists;
@@ -77,12 +76,12 @@ public final class TenantArgs {
     public Builder() {
     }
 
-    public TenantArgs.Builder setVolumeName(String volumeName) {
+    public Builder setVolumeName(String volumeName) {
       this.volumeName = volumeName;
       return this;
     }
 
-    public TenantArgs.Builder setForceCreationWhenVolumeExists(
+    public Builder setForceCreationWhenVolumeExists(
         boolean forceCreationWhenVolumeExists) {
       this.forceCreationWhenVolumeExists = forceCreationWhenVolumeExists;
       return this;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/DeleteTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/DeleteTenantState.java
@@ -66,7 +66,6 @@ public class DeleteTenantState {
   /**
    * Builder for TenantDeleted.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private String volumeName;
     private long volRefCount;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -112,7 +112,6 @@ public final class OmDBAccessIdInfo {
   /**
    * Builder for OmDBAccessIdInfo.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private String tenantId;
     private String userPrincipal;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -168,7 +168,6 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   /**
    * Builder for OmDBTenantState.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private String tenantId;
     private String bucketNamespaceName;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
@@ -90,7 +90,6 @@ public final class OmDBUserPrincipalInfo {
   /**
    * Builder for OmDBUserPrincipalInfo.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private Set<String> accessIds;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmRangerSyncArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmRangerSyncArgs.java
@@ -45,7 +45,6 @@ public class OmRangerSyncArgs {
   /**
    * Builder for OmRangerSyncArgs.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static class Builder {
     private long newServiceVersion;
     /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmTenantArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmTenantArgs.java
@@ -77,7 +77,6 @@ public class OmTenantArgs {
   /**
    * Builder for OmTenantArgs.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static class Builder {
     private String tenantId;
     private String volumeName;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3VolumeContext.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3VolumeContext.java
@@ -69,7 +69,6 @@ public class S3VolumeContext {
   /**
    * Builder for S3VolumeContext.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private OmVolumeArgs omVolumeArgs;
     private String userPrincipal;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
@@ -152,28 +152,28 @@ public class NodeEndpoint {
         }
       });
       try {
-        builder.withContainers(nodeManager.getContainerCount(datanode));
-        builder.withOpenContainers(openContainers.get());
+        builder.setContainers(nodeManager.getContainerCount(datanode));
+        builder.setOpenContainers(openContainers.get());
       } catch (NodeNotFoundException ex) {
         LOG.warn("Cannot get containers, datanode {} not found.",
             datanode.getUuid(), ex);
       }
 
       DatanodeInfo dnInfo = (DatanodeInfo) datanode;
-      datanodes.add(builder.withHostname(nodeManager.getHostName(datanode))
-          .withDatanodeStorageReport(storageReport)
-          .withLastHeartbeat(nodeManager.getLastHeartbeat(datanode))
-          .withState(nodeState)
-          .withOperationalState(nodeOpState)
-          .withPipelines(pipelines)
-          .withLeaderCount(leaderCount.get())
-          .withUUid(datanode.getUuidString())
-          .withVersion(nodeManager.getVersion(datanode))
-          .withSetupTime(nodeManager.getSetupTime(datanode))
-          .withRevision(nodeManager.getRevision(datanode))
-          .withLayoutVersion(
+      datanodes.add(builder.setHostname(nodeManager.getHostName(datanode))
+          .setDatanodeStorageReport(storageReport)
+          .setLastHeartbeat(nodeManager.getLastHeartbeat(datanode))
+          .setState(nodeState)
+          .setOperationalState(nodeOpState)
+          .setPipelines(pipelines)
+          .setLeaderCount(leaderCount.get())
+          .setUuid(datanode.getUuidString())
+          .setVersion(nodeManager.getVersion(datanode))
+          .setSetupTime(nodeManager.getSetupTime(datanode))
+          .setRevision(nodeManager.getRevision(datanode))
+          .setLayoutVersion(
               dnInfo.getLastKnownLayoutVersion().getMetadataLayoutVersion())
-          .withNetworkLocation(datanode.getNetworkLocation())
+          .setNetworkLocation(datanode.getNetworkLocation())
           .build());
     });
 
@@ -220,26 +220,26 @@ public class NodeEndpoint {
         try {
           if (preChecksSuccess(nodeByUuid, failedNodeErrorResponseMap)) {
             removedDatanodes.add(DatanodeMetadata.newBuilder()
-                .withHostname(nodeManager.getHostName(nodeByUuid))
-                .withUUid(uuid)
-                .withState(nodeManager.getNodeStatus(nodeByUuid).getHealth())
+                .setHostname(nodeManager.getHostName(nodeByUuid))
+                .setUuid(uuid)
+                .setState(nodeManager.getNodeStatus(nodeByUuid).getHealth())
                 .build());
             nodeManager.removeNode(nodeByUuid);
             LOG.info("Node {} removed successfully !!!", uuid);
           } else {
             failedDatanodes.add(DatanodeMetadata.newBuilder()
-                .withHostname(nodeManager.getHostName(nodeByUuid))
-                .withUUid(uuid)
-                .withOperationalState(nodeByUuid.getPersistedOpState())
-                .withState(nodeManager.getNodeStatus(nodeByUuid).getHealth())
+                .setHostname(nodeManager.getHostName(nodeByUuid))
+                .setUuid(uuid)
+                .setOperationalState(nodeByUuid.getPersistedOpState())
+                .setState(nodeManager.getNodeStatus(nodeByUuid).getHealth())
                 .build());
           }
         } catch (NodeNotFoundException nnfe) {
           LOG.error("Selected node {} not found : {} ", uuid, nnfe);
           notFoundDatanodes.add(DatanodeMetadata.newBuilder()
-                  .withHostname("")
-                  .withState(NodeState.DEAD)
-              .withUUid(uuid).build());
+                  .setHostname("")
+                  .setState(NodeState.DEAD)
+              .setUuid(uuid).build());
         }
       }
     } catch (Exception exp) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/AclMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/AclMetadata.java
@@ -73,7 +73,6 @@ public final class AclMetadata {
   /**
    * Builder for AclMetadata.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private String type;
     private String name;
@@ -84,23 +83,23 @@ public final class AclMetadata {
 
     }
 
-    public Builder withType(String type) {
+    public Builder setType(String type) {
       this.type = type;
       return this;
     }
 
-    public Builder withName(String name) {
+    public Builder setName(String name) {
       this.name = name;
       return this;
     }
 
-    public Builder withScope(String scope) {
+    public Builder setScope(String scope) {
       this.scope = scope;
       return this;
 
     }
 
-    public Builder withAclList(List<String> aclList) {
+    public Builder setAclList(List<String> aclList) {
       this.aclList = aclList;
       return this;
     }
@@ -127,10 +126,10 @@ public final class AclMetadata {
 
     AclMetadata.Builder builder = AclMetadata.newBuilder();
 
-    return builder.withType(ozoneAcl.getType().toString().toUpperCase())
-        .withName(ozoneAcl.getName())
-        .withScope(ozoneAcl.getAclScope().toString().toUpperCase())
-        .withAclList(ozoneAcl.getAclStringList())
+    return builder.setType(ozoneAcl.getType().toString().toUpperCase())
+        .setName(ozoneAcl.getName())
+        .setScope(ozoneAcl.getAclScope().toString().toUpperCase())
+        .setAclList(ozoneAcl.getAclStringList())
         .build();
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/ClusterStateResponse.java
@@ -138,7 +138,6 @@ public final class ClusterStateResponse {
   /**
    * Builder for ClusterStateResponse.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private int pipelines;
     private int totalDatanodes;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
@@ -182,7 +182,6 @@ public final class DatanodeMetadata {
   /**
    * Builder for DatanodeMetadata.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private String hostname;
     private String uuid;
@@ -206,78 +205,78 @@ public final class DatanodeMetadata {
       this.leaderCount = 0;
     }
 
-    public Builder withHostname(String hostname) {
+    public Builder setHostname(String hostname) {
       this.hostname = hostname;
       return this;
     }
 
-    public Builder withState(NodeState state) {
+    public Builder setState(NodeState state) {
       this.state = state;
       return this;
     }
 
-    public Builder withOperationalState(NodeOperationalState opState) {
-      this.opState = opState;
+    public Builder setOperationalState(NodeOperationalState operationalState) {
+      this.opState = operationalState;
       return this;
     }
 
-    public Builder withLastHeartbeat(long lastHeartbeat) {
+    public Builder setLastHeartbeat(long lastHeartbeat) {
       this.lastHeartbeat = lastHeartbeat;
       return this;
     }
 
-    public Builder withDatanodeStorageReport(DatanodeStorageReport 
+    public Builder setDatanodeStorageReport(DatanodeStorageReport 
                                                  datanodeStorageReport) {
       this.datanodeStorageReport = datanodeStorageReport;
       return this;
     }
 
-    public Builder withPipelines(List<DatanodePipeline> pipelines) {
+    public Builder setPipelines(List<DatanodePipeline> pipelines) {
       this.pipelines = pipelines;
       return this;
     }
 
-    public Builder withContainers(int containers) {
+    public Builder setContainers(int containers) {
       this.containers = containers;
       return this;
     }
 
-    public Builder withOpenContainers(int openContainers) {
+    public Builder setOpenContainers(int openContainers) {
       this.openContainers = openContainers;
       return this;
     }
 
-    public Builder withLeaderCount(int leaderCount) {
+    public Builder setLeaderCount(int leaderCount) {
       this.leaderCount = leaderCount;
       return this;
     }
 
-    public Builder withUUid(String uuid) {
+    public Builder setUuid(String uuid) {
       this.uuid = uuid;
       return this;
     }
 
-    public Builder withVersion(String version) {
+    public Builder setVersion(String version) {
       this.version = version;
       return this;
     }
 
-    public Builder withSetupTime(long setupTime) {
+    public Builder setSetupTime(long setupTime) {
       this.setupTime = setupTime;
       return this;
     }
 
-    public Builder withRevision(String revision) {
+    public Builder setRevision(String revision) {
       this.revision = revision;
       return this;
     }
 
-    public Builder withLayoutVersion(int layoutVersion) {
+    public Builder setLayoutVersion(int layoutVersion) {
       this.layoutVersion = layoutVersion;
       return this;
     }
 
-    public Builder withNetworkLocation(String networkLocation) {
+    public Builder setNetworkLocation(String networkLocation) {
       this.networkLocation = networkLocation;
       return this;
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NamespaceSummaryResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NamespaceSummaryResponse.java
@@ -49,8 +49,8 @@ public class NamespaceSummaryResponse {
    *
    * @return Builder
    */
-  public static NamespaceSummaryResponse.Builder newBuilder() {
-    return new NamespaceSummaryResponse.Builder();
+  public static Builder newBuilder() {
+    return new Builder();
   }
 
   public NamespaceSummaryResponse(Builder b) {
@@ -104,7 +104,6 @@ public class NamespaceSummaryResponse {
   /**
    * Builder for NamespaceSummaryResponse.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private String path;
     private EntityType entityType;
@@ -119,30 +118,30 @@ public class NamespaceSummaryResponse {
       this.entityType = EntityType.ROOT;
     }
 
-    public NamespaceSummaryResponse.Builder setPath(String path) {
+    public Builder setPath(String path) {
       this.path = path;
       return this;
     }
 
-    public NamespaceSummaryResponse.Builder setEntityType(
+    public Builder setEntityType(
         EntityType entityType) {
       this.entityType = entityType;
       return this;
     }
 
-    public NamespaceSummaryResponse.Builder setCountStats(
+    public Builder setCountStats(
         CountStats countStats) {
       this.countStats = countStats;
       return this;
     }
 
-    public NamespaceSummaryResponse.Builder setObjectDBInfo(
+    public Builder setObjectDBInfo(
         ObjectDBInfo objectDBInfo) {
       this.objectDBInfo = objectDBInfo;
       return this;
     }
 
-    public NamespaceSummaryResponse.Builder setStatus(
+    public Builder setStatus(
         ResponseStatus status) {
       this.status = status;
       return this;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/PipelineMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/PipelineMetadata.java
@@ -133,7 +133,6 @@ public final class PipelineMetadata {
   /**
    * Builder for PipelineMetadata.
    */
-  @SuppressWarnings("checkstyle:hiddenfield")
   public static class Builder {
     private UUID pipelineId;
     private PipelineState status;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove suppression of `HiddenField` checkstyle rule, currently only used for `Builder` classes.

Checkstyle is already configured to ignore `HiddenField` for "setter" methods.  However,

> [a] method is recognized as a setter if it is in the following form
> ```
> ${returnType} set${Name}(${anyType} ${name})
> ```
> where ... `${name}` is name of the variable that is being set and `${Name}` its capitalized form that appears in the method name.
> https://checkstyle.org/checks/coding/hiddenfield.html

So we need to make sure to follow naming conventions:

- parameter name must match method name
- method name must be `set...`, not `with...`

(We could also avoid the violation by renaming parameters to something like `newValue`.)

In some classes suppression was completely unnecessary.

https://issues.apache.org/jira/browse/HDDS-11684

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/11793288532