### PR TITLE
HDDS-11640. Deletion services in SCM, OM and DN should have consistent metrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -225,12 +225,6 @@ public final class BlockDeletingServiceMetrics {
     this.containerChosenCountInLastIteration.set(containerChosenCountInLastIteration);
   }
 
-  public void resetLastIterationCounts() {
-    this.successCountInLastIteration.incr(-1L * this.successCountInLastIteration.value());
-    this.successBytesInLastIteration.incr(-1L * this.successBytesInLastIteration.value());
-    this.failureCountInLastIteration.incr(-1L * this.failureCountInLastIteration.value());
-  }
-
   public void incrSuccessCountInLastIteration(long delta) {
     this.successCountInLastIteration.incr(delta);
   }
@@ -239,8 +233,8 @@ public final class BlockDeletingServiceMetrics {
     this.successBytesInLastIteration.incr(delta);
   }
 
-  public void incrFailureCountInLastIteration() {
-    this.failureCountInLastIteration.incr();
+  public void incrFailureCountInLastIteration(long delta) {
+    this.failureCountInLastIteration.incr(delta);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -92,13 +92,13 @@ public final class BlockDeletingServiceMetrics {
   private MutableGaugeLong containerChosenCountInLastIteration;
 
   @Metric(about = "Total number of successful delete blocks in latest iteration.")
-  private MutableCounterLong successCountInLastIteration;
+  private MutableGaugeLong successCountInLastIteration;
 
   @Metric(about = "The total bytes for blocks successfully deleted in the latest iteration.")
-  private MutableCounterLong successBytesInLastIteration;
+  private MutableGaugeLong successBytesInLastIteration;
 
   @Metric(about = "The number of failed delete blocks in the latest iteration.")
-  private MutableCounterLong failureCountInLastIteration;
+  private MutableGaugeLong failureCountInLastIteration;
 
 
   private BlockDeletingServiceMetrics() {
@@ -131,8 +131,8 @@ public final class BlockDeletingServiceMetrics {
     this.successBytes.incr(bytes);
   }
 
-  public void incrFailureCount() {
-    this.failureCount.incr();
+  public void incrFailureCount(long delta) {
+    this.failureCount.incr(delta);
   }
 
   public void incrReceivedTransactionCount(long count) {
@@ -225,16 +225,24 @@ public final class BlockDeletingServiceMetrics {
     this.containerChosenCountInLastIteration.set(containerChosenCountInLastIteration);
   }
 
-  public void incrSuccessCountInLastIteration(long delta) {
-    this.successCountInLastIteration.incr(delta);
+  public void setSuccessCountInLastIteration(long delta) {
+    this.successCountInLastIteration.set(delta);
   }
 
-  public void incrSuccessBytesInLastIteration(long delta) {
-    this.successBytesInLastIteration.incr(delta);
+  public void setSuccessBytesInLastIteration(long delta) {
+    this.successBytesInLastIteration.set(delta);
   }
 
-  public void incrFailureCountInLastIteration(long delta) {
-    this.failureCountInLastIteration.incr(delta);
+  public void setFailureCountInLastIteration(long delta) {
+    this.failureCountInLastIteration.set(delta);
+  }
+
+  public long getBlockChosenCountInLastIteration() {
+    return blockChosenCountInLastIteration.value();
+  }
+
+  public long getContainerChosenCountInLastIteration() {
+    return containerChosenCountInLastIteration.value();
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -231,12 +231,12 @@ public final class BlockDeletingServiceMetrics {
     this.failureCountInLastIteration.incr(-1L * this.failureCountInLastIteration.value());
   }
 
-  public void incrSuccessCountInLastIteration(long successCountInLastIteration) {
-    this.successCountInLastIteration.incr(successCountInLastIteration);
+  public void incrSuccessCountInLastIteration(long delta) {
+    this.successCountInLastIteration.incr(delta);
   }
 
-  public void incrSuccessBytesInLastIteration(long successBytesInLastIteration) {
-    this.successBytesInLastIteration.incr(successBytesInLastIteration);
+  public void incrSuccessBytesInLastIteration(long delta) {
+    this.successBytesInLastIteration.incr(delta);
   }
 
   public void incrFailureCountInLastIteration() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/BlockDeletingServiceMetrics.java
@@ -78,6 +78,29 @@ public final class BlockDeletingServiceMetrics {
       " to container lock wait timeout.")
   private MutableGaugeLong totalLockTimeoutTransactionCount;
 
+  // Iteration specific metrics.
+  @Metric("Start time of last iteration of BlockDeletingService")
+  private MutableGaugeLong startTimeOfLastIteration;
+
+  @Metric("Total time taken by the last iteration of BlockDeletingService")
+  private MutableGaugeLong durationOfLastIteration;
+
+  @Metric(about = "Total number of blocks chosen to be deleted in latest iteration.")
+  private MutableGaugeLong blockChosenCountInLastIteration;
+
+  @Metric(about = "Total number of containers chosen to be deleted in the latest iteration.")
+  private MutableGaugeLong containerChosenCountInLastIteration;
+
+  @Metric(about = "Total number of successful delete blocks in latest iteration.")
+  private MutableCounterLong successCountInLastIteration;
+
+  @Metric(about = "The total bytes for blocks successfully deleted in the latest iteration.")
+  private MutableCounterLong successBytesInLastIteration;
+
+  @Metric(about = "The number of failed delete blocks in the latest iteration.")
+  private MutableCounterLong failureCountInLastIteration;
+
+
   private BlockDeletingServiceMetrics() {
   }
 
@@ -182,6 +205,42 @@ public final class BlockDeletingServiceMetrics {
 
   public long getTotalLockTimeoutTransactionCount() {
     return totalLockTimeoutTransactionCount.value();
+  }
+
+  public void setStartTimeOfLastIteration(long startTimeOfLastIteration) {
+    this.startTimeOfLastIteration.set(startTimeOfLastIteration);
+  }
+
+  public void setDurationOfLastIteration(long durationOfLastIteration) {
+    this.durationOfLastIteration.set(durationOfLastIteration);
+  }
+
+  public void setBlockChosenCountInLastIteration(
+      long blockChosenCountInLastIteration) {
+    this.blockChosenCountInLastIteration.set(blockChosenCountInLastIteration);
+  }
+
+  public void setContainerChosenCountInLastIteration(
+      long containerChosenCountInLastIteration) {
+    this.containerChosenCountInLastIteration.set(containerChosenCountInLastIteration);
+  }
+
+  public void resetLastIterationCounts() {
+    this.successCountInLastIteration.incr(-1L * this.successCountInLastIteration.value());
+    this.successBytesInLastIteration.incr(-1L * this.successBytesInLastIteration.value());
+    this.failureCountInLastIteration.incr(-1L * this.failureCountInLastIteration.value());
+  }
+
+  public void incrSuccessCountInLastIteration(long successCountInLastIteration) {
+    this.successCountInLastIteration.incr(successCountInLastIteration);
+  }
+
+  public void incrSuccessBytesInLastIteration(long successBytesInLastIteration) {
+    this.successBytesInLastIteration.incr(successBytesInLastIteration);
+  }
+
+  public void incrFailureCountInLastIteration() {
+    this.failureCountInLastIteration.incr();
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
@@ -128,7 +128,7 @@ public class BlockDeletingService extends BackgroundService {
   public BackgroundTaskQueue getTasks() {
     BackgroundTaskQueue queue = new BackgroundTaskQueue();
 
-    metrics.resetLastIterationCounts();
+    BlockDeletingTask.resetLastIterationCounts();
     try {
       // We at most list a number of containers a time,
       // in case there are too many containers and start too many workers.
@@ -159,6 +159,9 @@ public class BlockDeletingService extends BackgroundService {
       metrics.setContainerChosenCountInLastIteration(containers.size());
       metrics.incrTotalBlockChosenCount(totalBlocks);
       metrics.incrTotalContainerChosenCount(containers.size());
+      metrics.incrSuccessCountInLastIteration(BlockDeletingTask.getSuccessBlockDeleteInLastIteration());
+      metrics.incrSuccessBytesInLastIteration(BlockDeletingTask.getSuccessBytesDeletedInLastIteration());
+      metrics.incrFailureCountInLastIteration(BlockDeletingTask.getFailBlockDeleteInLastIteration());
       if (containers.size() > 0) {
         LOG.debug("Queued {} blocks from {} containers for deletion",
             totalBlocks, containers.size());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/BlockDeletingService.java
@@ -159,9 +159,9 @@ public class BlockDeletingService extends BackgroundService {
       metrics.setContainerChosenCountInLastIteration(containers.size());
       metrics.incrTotalBlockChosenCount(totalBlocks);
       metrics.incrTotalContainerChosenCount(containers.size());
-      metrics.incrSuccessCountInLastIteration(BlockDeletingTask.getSuccessBlockDeleteInLastIteration());
-      metrics.incrSuccessBytesInLastIteration(BlockDeletingTask.getSuccessBytesDeletedInLastIteration());
-      metrics.incrFailureCountInLastIteration(BlockDeletingTask.getFailBlockDeleteInLastIteration());
+      metrics.setSuccessCountInLastIteration(BlockDeletingTask.getSuccessBlockDeleteInLastIteration());
+      metrics.setSuccessBytesInLastIteration(BlockDeletingTask.getSuccessBytesDeletedInLastIteration());
+      metrics.setFailureCountInLastIteration(BlockDeletingTask.getFailBlockDeleteInLastIteration());
       if (containers.size() > 0) {
         LOG.debug("Queued {} blocks from {} containers for deletion",
             totalBlocks, containers.size());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
@@ -257,6 +257,8 @@ public class BlockDeletingTask implements BackgroundTask {
         containerData.getVolume().decrementUsedSpace(releasedBytes);
         metrics.incrSuccessCount(deletedBlocksCount);
         metrics.incrSuccessBytes(releasedBytes);
+        metrics.incrSuccessCountInLastIteration(deletedBlocksCount);
+        metrics.incrSuccessBytesInLastIteration(releasedBytes);
       }
 
       if (!succeedBlocks.isEmpty()) {
@@ -271,6 +273,7 @@ public class BlockDeletingTask implements BackgroundTask {
       LOG.warn("Deletion operation was not successful for container: " +
           container.getContainerData().getContainerID(), exception);
       metrics.incrFailureCount();
+      metrics.incrFailureCountInLastIteration();
       throw exception;
     }
   }
@@ -408,6 +411,8 @@ public class BlockDeletingTask implements BackgroundTask {
         containerData.getVolume().decrementUsedSpace(releasedBytes);
         metrics.incrSuccessCount(deletedBlocksCount);
         metrics.incrSuccessBytes(releasedBytes);
+        metrics.incrSuccessCountInLastIteration(deletedBlocksCount);
+        metrics.incrSuccessBytesInLastIteration(releasedBytes);
       }
 
       LOG.debug("Container: {}, deleted blocks: {}, space reclaimed: {}, " +
@@ -419,6 +424,7 @@ public class BlockDeletingTask implements BackgroundTask {
       LOG.warn("Deletion operation was not successful for container: " +
           container.getContainerData().getContainerID(), exception);
       metrics.incrFailureCount();
+      metrics.incrFailureCountInLastIteration();
       throw exception;
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingTask.java
@@ -260,8 +260,8 @@ public class BlockDeletingTask implements BackgroundTask {
         containerData.getVolume().decrementUsedSpace(releasedBytes);
         metrics.incrSuccessCount(deletedBlocksCount);
         metrics.incrSuccessBytes(releasedBytes);
-        successBlockDeleteInLastIteration += deletedBlocksCount;
-        successBytesDeletedInLastIteration += releasedBytes;
+        incrSuccessBlockDeleteInLastIteration(deletedBlocksCount);
+        incrSuccessBytesDeletedInLastIteration(releasedBytes);
       }
 
       if (!succeedBlocks.isEmpty()) {
@@ -276,7 +276,7 @@ public class BlockDeletingTask implements BackgroundTask {
       LOG.warn("Deletion operation was not successful for container: " +
           container.getContainerData().getContainerID(), exception);
       metrics.incrFailureCount();
-      failBlockDeleteInLastIteration += 1;
+      incrFailBlockDeleteInLastIteration(1);
       throw exception;
     }
   }
@@ -414,8 +414,8 @@ public class BlockDeletingTask implements BackgroundTask {
         containerData.getVolume().decrementUsedSpace(releasedBytes);
         metrics.incrSuccessCount(deletedBlocksCount);
         metrics.incrSuccessBytes(releasedBytes);
-        successBlockDeleteInLastIteration += deletedBlocksCount;
-        successBytesDeletedInLastIteration += releasedBytes;
+        incrSuccessBlockDeleteInLastIteration(deletedBlocksCount);
+        incrSuccessBytesDeletedInLastIteration(releasedBytes);
       }
 
       LOG.debug("Container: {}, deleted blocks: {}, space reclaimed: {}, " +
@@ -427,7 +427,7 @@ public class BlockDeletingTask implements BackgroundTask {
       LOG.warn("Deletion operation was not successful for container: " +
           container.getContainerData().getContainerID(), exception);
       metrics.incrFailureCount();
-      failBlockDeleteInLastIteration += 1;
+      incrFailBlockDeleteInLastIteration(1);
       throw exception;
     }
   }
@@ -542,6 +542,18 @@ public class BlockDeletingTask implements BackgroundTask {
 
   public static long getFailBlockDeleteInLastIteration() {
     return failBlockDeleteInLastIteration;
+  }
+
+  public static void incrSuccessBlockDeleteInLastIteration(long delta) {
+    BlockDeletingTask.successBlockDeleteInLastIteration += delta;
+  }
+
+  public static void incrSuccessBytesDeletedInLastIteration(long delta) {
+    BlockDeletingTask.successBytesDeletedInLastIteration += delta;
+  }
+
+  public static void incrFailBlockDeleteInLastIteration(long delta) {
+    BlockDeletingTask.failBlockDeleteInLastIteration += delta;
   }
 
   private interface Deleter {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -604,9 +604,11 @@ public class TestBlockDeletingService {
       assertEquals(2,
           deletingServiceMetrics.getTotalBlockChosenCount()
               - totalBlockChosenCount);
+      assertEquals(2, deletingServiceMetrics.getBlockChosenCountInLastIteration());
       assertEquals(1,
           deletingServiceMetrics.getTotalContainerChosenCount()
               - totalContainerChosenCount);
+      assertEquals(1, deletingServiceMetrics.getContainerChosenCountInLastIteration());
       // The value of the getTotalPendingBlockCount Metrics is obtained
       // before the deletion is processing
       // So the Pending Block count will be 3
@@ -633,9 +635,11 @@ public class TestBlockDeletingService {
       assertEquals(3,
           deletingServiceMetrics.getTotalBlockChosenCount()
               - totalBlockChosenCount);
+      assertEquals(1, deletingServiceMetrics.getBlockChosenCountInLastIteration());
       assertEquals(2,
           deletingServiceMetrics.getTotalContainerChosenCount()
               - totalContainerChosenCount);
+      assertEquals(1, deletingServiceMetrics.getContainerChosenCountInLastIteration());
 
       // check if blockData get deleted
       assertBlockDataTableRecordCount(0, meta, filter, data.getContainerID());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -196,20 +196,28 @@ public final class ScmBlockDeletingServiceMetrics {
     return numBlockDeletionTransactionDataNodes.value();
   }
 
-/*
+
+  @Metric(about = "Start time taken of last iteration of ScmBlockDeletingService")
+  private MutableGaugeLong startTimeOfLastIteration;
+
+  @Metric(about = "Total time taken by the last iteration of ScmBlockDeletingService.")
+  private MutableGaugeLong durationOfLastIteration;
+
   @Metric(about = "Total number of individual delete transaction commands sent " +
       "to all DN in last iteration.")
   private MutableGaugeLong numBlockDeletionCommandSentInLastIteration;
+
+  @Metric(about = "Total number of individual delete transactions sent to " +
+      "all DN in last iteration.")
+  private MutableGaugeLong numBlockDeletionTransactionSentInLastIteration;
+
+/*
 
   @Metric(about = "Total number of success ACK of delete transaction commands in last iteration.")
   private MutableGaugeLong numBlockDeletionCommandSuccessInLastIteration;
 
   @Metric(about = "Total number of failure ACK of delete transaction commands in last iteration.")
   private MutableGaugeLong numBlockDeletionCommandFailureInLastIteration;
-
-  @Metric(about = "Total number of individual delete transactions sent to " +
-      "all DN in last iteration.")
-  private MutableGaugeLong numBlockDeletionTransactionSentInLastIteration;
 
   @Metric(about = "Total number of success execution of delete transactions in last iteration.")
   private MutableGaugeLong numBlockDeletionTransactionSuccessInLastIteration;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -196,6 +196,90 @@ public final class ScmBlockDeletingServiceMetrics {
     return numBlockDeletionTransactionDataNodes.value();
   }
 
+/*
+  @Metric(about = "Total number of individual delete transaction commands sent " +
+      "to all DN in last iteration.")
+  private MutableGaugeLong numBlockDeletionCommandSentInLastIteration;
+
+  @Metric(about = "Total number of success ACK of delete transaction commands in last iteration.")
+  private MutableGaugeLong numBlockDeletionCommandSuccessInLastIteration;
+
+  @Metric(about = "Total number of failure ACK of delete transaction commands in last iteration.")
+  private MutableGaugeLong numBlockDeletionCommandFailureInLastIteration;
+
+  @Metric(about = "Total number of individual delete transactions sent to " +
+      "all DN in last iteration.")
+  private MutableGaugeLong numBlockDeletionTransactionSentInLastIteration;
+
+  @Metric(about = "Total number of success execution of delete transactions in last iteration.")
+  private MutableGaugeLong numBlockDeletionTransactionSuccessInLastIteration;
+
+  @Metric(about = "Total number of failure execution of delete transactions in last iteration.")
+  private MutableGaugeLong numBlockDeletionTransactionFailureInLastIteration;
+
+  @Metric(about = "Total number of completed txs which are removed from DB in last iteration.")
+  private MutableGaugeLong numBlockDeletionTransactionCompletedInLastIteration;
+
+  @Metric(about = "Total number of created txs which are added into DB in last iteration.")
+  private MutableGaugeLong numBlockDeletionTransactionCreatedInLastIteration;
+
+  @Metric(about = "Total number of skipped transactions in last iteration")
+  private MutableGaugeLong numSkippedTransactionsInLastIteration;
+
+  @Metric(about = "Total number of processed transactions in last iteration")
+  private MutableGaugeLong numProcessedTransactionsInLastIteration;
+
+  public void setNumBlockDeletionCommandSentInLastIteration(
+      long numBlockDeletionCommandSentInLastIteration) {
+    this.numBlockDeletionCommandSentInLastIteration.set(numBlockDeletionCommandSentInLastIteration);
+  }
+
+  public void setNumBlockDeletionCommandSuccessInLastIteration(
+      long numBlockDeletionCommandSuccessInLastIteration) {
+    this.numBlockDeletionCommandSuccessInLastIteration.set(numBlockDeletionCommandSuccessInLastIteration);
+  }
+
+  public void setNumBlockDeletionCommandFailureInLastIteration(
+      long numBlockDeletionCommandFailureInLastIteration) {
+    this.numBlockDeletionCommandFailureInLastIteration.set(numBlockDeletionCommandFailureInLastIteration);
+  }
+
+  public void setNumBlockDeletionTransactionSentInLastIteration(
+      long numBlockDeletionTransactionSentInLastIteration) {
+    this.numBlockDeletionTransactionSentInLastIteration.set(numBlockDeletionTransactionSentInLastIteration);
+  }
+
+  public void setNumBlockDeletionTransactionSuccessInLastIteration(
+      long numBlockDeletionTransactionSuccessInLastIteration) {
+    this.numBlockDeletionTransactionSuccessInLastIteration.set(numBlockDeletionTransactionSuccessInLastIteration);
+  }
+
+  public void setNumBlockDeletionTransactionFailureInLastIteration(
+      long numBlockDeletionTransactionFailureInLastIteration) {
+    this.numBlockDeletionTransactionFailureInLastIteration.set(numBlockDeletionTransactionFailureInLastIteration);
+  }
+
+  public void setNumBlockDeletionTransactionCompletedInLastIteration(
+      long numBlockDeletionTransactionCompletedInLastIteration) {
+    this.numBlockDeletionTransactionCompletedInLastIteration.set(numBlockDeletionTransactionCompletedInLastIteration);
+  }
+
+  public void setNumBlockDeletionTransactionCreatedInLastIteration(
+      long numBlockDeletionTransactionCreatedInLastIteration) {
+    this.numBlockDeletionTransactionCreatedInLastIteration.set(numBlockDeletionTransactionCreatedInLastIteration);
+  }
+
+  public void setNumSkippedTransactionsInLastIteration(
+      long numSkippedTransactionsInLastIteration) {
+    this.numSkippedTransactionsInLastIteration.set(numSkippedTransactionsInLastIteration);
+  }
+
+  public void setNumProcessedTransactionsInLastIteration(
+      long numProcessedTransactionsInLastIteration) {
+    this.numProcessedTransactionsInLastIteration.set(numProcessedTransactionsInLastIteration);
+  }
+*/
+
   @Override
   public String toString() {
     StringBuffer buffer = new StringBuffer();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -196,7 +196,6 @@ public final class ScmBlockDeletingServiceMetrics {
     return numBlockDeletionTransactionDataNodes.value();
   }
 
-
   @Metric(about = "Start time taken of last iteration of ScmBlockDeletingService")
   private MutableGaugeLong startTimeOfLastIteration;
 
@@ -211,14 +210,6 @@ public final class ScmBlockDeletingServiceMetrics {
       "all DN in last iteration.")
   private MutableGaugeLong numBlockDeletionTransactionSentInLastIteration;
 
-/*
-
-  @Metric(about = "Total number of success ACK of delete transaction commands in last iteration.")
-  private MutableGaugeLong numBlockDeletionCommandSuccessInLastIteration;
-
-  @Metric(about = "Total number of failure ACK of delete transaction commands in last iteration.")
-  private MutableGaugeLong numBlockDeletionCommandFailureInLastIteration;
-
   @Metric(about = "Total number of success execution of delete transactions in last iteration.")
   private MutableGaugeLong numBlockDeletionTransactionSuccessInLastIteration;
 
@@ -228,28 +219,17 @@ public final class ScmBlockDeletingServiceMetrics {
   @Metric(about = "Total number of completed txs which are removed from DB in last iteration.")
   private MutableGaugeLong numBlockDeletionTransactionCompletedInLastIteration;
 
-  @Metric(about = "Total number of created txs which are added into DB in last iteration.")
-  private MutableGaugeLong numBlockDeletionTransactionCreatedInLastIteration;
+  public void setStartTimeOfLastIteration(long startTimeOfLastIteration) {
+    this.startTimeOfLastIteration.set(startTimeOfLastIteration);
+  }
 
-  @Metric(about = "Total number of skipped transactions in last iteration")
-  private MutableGaugeLong numSkippedTransactionsInLastIteration;
-
-  @Metric(about = "Total number of processed transactions in last iteration")
-  private MutableGaugeLong numProcessedTransactionsInLastIteration;
+  public void setDurationOfLastIteration(long durationOfLastIteration) {
+    this.durationOfLastIteration.set(durationOfLastIteration);
+  }
 
   public void setNumBlockDeletionCommandSentInLastIteration(
       long numBlockDeletionCommandSentInLastIteration) {
     this.numBlockDeletionCommandSentInLastIteration.set(numBlockDeletionCommandSentInLastIteration);
-  }
-
-  public void setNumBlockDeletionCommandSuccessInLastIteration(
-      long numBlockDeletionCommandSuccessInLastIteration) {
-    this.numBlockDeletionCommandSuccessInLastIteration.set(numBlockDeletionCommandSuccessInLastIteration);
-  }
-
-  public void setNumBlockDeletionCommandFailureInLastIteration(
-      long numBlockDeletionCommandFailureInLastIteration) {
-    this.numBlockDeletionCommandFailureInLastIteration.set(numBlockDeletionCommandFailureInLastIteration);
   }
 
   public void setNumBlockDeletionTransactionSentInLastIteration(
@@ -271,22 +251,6 @@ public final class ScmBlockDeletingServiceMetrics {
       long numBlockDeletionTransactionCompletedInLastIteration) {
     this.numBlockDeletionTransactionCompletedInLastIteration.set(numBlockDeletionTransactionCompletedInLastIteration);
   }
-
-  public void setNumBlockDeletionTransactionCreatedInLastIteration(
-      long numBlockDeletionTransactionCreatedInLastIteration) {
-    this.numBlockDeletionTransactionCreatedInLastIteration.set(numBlockDeletionTransactionCreatedInLastIteration);
-  }
-
-  public void setNumSkippedTransactionsInLastIteration(
-      long numSkippedTransactionsInLastIteration) {
-    this.numSkippedTransactionsInLastIteration.set(numSkippedTransactionsInLastIteration);
-  }
-
-  public void setNumProcessedTransactionsInLastIteration(
-      long numProcessedTransactionsInLastIteration) {
-    this.numProcessedTransactionsInLastIteration.set(numProcessedTransactionsInLastIteration);
-  }
-*/
 
   @Override
   public String toString() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, SCM and DN have only total metrics, they don't track the numbers for each iteration of the deleting services. In order to view the progress of deletion using metrics, iteration specific metrics will useful.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11640

## How was this patch tested?

Tested Manually
