### PR TITLE
HDDS-11653. Bump Ratis to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- HDDS Rocks Native dependency version-->
     <hdds.rocks.native.version>${hdds.version}</hdds.rocks.native.version>
     <!-- Apache Ratis version -->
-    <ratis.version>3.1.1</ratis.version>
+    <ratis.version>3.1.2</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>1.0.6</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis 3.1.2 was just released, upgrade the version in Ozone.

https://issues.apache.org/jira/browse/HDDS-11653

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/11813605274