### PR TITLE
HDDS-11692. Skip spotbugs for modules with only generated code

### DIFF
--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -31,6 +31,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
+    <spotbugs.skip>true</spotbugs.skip> <!-- only generated code in this module -->
   </properties>
 
   <dependencies>
@@ -80,14 +81,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 </project>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -31,6 +31,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
+    <spotbugs.skip>true</spotbugs.skip> <!-- only generated code in this module -->
   </properties>
 
   <dependencies>
@@ -175,13 +176,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -31,6 +31,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no testable code in this module -->
+    <spotbugs.skip>true</spotbugs.skip> <!-- only generated code in this module -->
   </properties>
 
   <dependencies>
@@ -141,13 +142,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -30,6 +30,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <properties>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
+    <spotbugs.skip>true</spotbugs.skip> <!-- only generated code in this module -->
   </properties>
 
   <dependencies>
@@ -186,13 +187,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

SpotBugs spends quite some time (~2.5 minutes) analyzing protobuf generated classes in _basic (findbugs)_ check ([example](https://github.com/apache/ozone/actions/runs/11812304304/job/32907294585#step:7:494)):

```
2024-11-13T07:07:13.4457877Z [INFO] --- spotbugs-maven-plugin:3.1.12.2:spotbugs (default-cli) @ hdds-interface-client ---
2024-11-13T07:07:14.2753914Z [INFO] Fork Value is true
2024-11-13T07:07:44.5920143Z [INFO] Done SpotBugs Analysis....
...
2024-11-13T07:07:48.7132408Z [INFO] --- spotbugs-maven-plugin:3.1.12.2:spotbugs (default-cli) @ hdds-interface-admin ---
2024-11-13T07:07:48.7224599Z [INFO] Fork Value is true
2024-11-13T07:08:07.8785130Z [INFO] Done SpotBugs Analysis....
...
2024-11-13T07:08:11.9305598Z [INFO] --- spotbugs-maven-plugin:3.1.12.2:spotbugs (default-cli) @ hdds-interface-server ---
2024-11-13T07:08:11.9403330Z [INFO] Fork Value is true
2024-11-13T07:08:33.4146294Z [INFO] Done SpotBugs Analysis....
...
2024-11-13T07:12:25.4418247Z [INFO] --- spotbugs-maven-plugin:3.1.12.2:spotbugs (default-cli) @ ozone-interface-client ---
2024-11-13T07:12:26.0084460Z [INFO] Fork Value is true
2024-11-13T07:13:39.6522625Z [INFO] Done SpotBugs Analysis....
...
2024-11-13T07:19:28.6163995Z [INFO] Total time:  12:46 min
```

Since these modules do not have any Java sources, only code generated from protobuf files, we can skip SpotBugs analysis.

https://issues.apache.org/jira/browse/HDDS-11692

## How was this patch tested?

Verified that SpotBugs indeed skips these modules:

```
$ ./hadoop-ozone/dev-support/checks/findbugs.sh
...
[INFO] --- spotbugs-maven-plugin:3.1.12.2:spotbugs (default-cli) @ hdds-interface-client ---
[INFO]
...
[INFO] --- spotbugs-maven-plugin:3.1.12.2:spotbugs (default-cli) @ hdds-interface-admin ---
[INFO]
...
[INFO] --- spotbugs-maven-plugin:3.1.12.2:spotbugs (default-cli) @ hdds-interface-server ---
[INFO]
...
[INFO] --- spotbugs-maven-plugin:3.1.12.2:spotbugs (default-cli) @ ozone-interface-client ---
[INFO]
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/11815271941/job/32916101846