### PR TITLE
HDDS-11689. Extract scheduled workflow for populate-cache

### DIFF
--- a/.github/workflows/populate-cache.yml
+++ b/.github/workflows/populate-cache.yml
@@ -26,8 +26,7 @@ on:
       - 'pom.xml'
       - '**/pom.xml'
       - '.github/workflows/populate-cache.yml'
-  schedule:
-    - cron: '20 3 * * *'
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/scheduled-cache-update.yml
+++ b/.github/workflows/scheduled-cache-update.yml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow periodically updates dependency cache.
+
+name: scheduled-cache-update
+
+on:
+  schedule:
+    - cron: '20 3 * * *'
+
+jobs:
+  update:
+    uses: ./.github/workflows/populate-cache.yml
+    secrets: inherit


### PR DESCRIPTION
## What changes were proposed in this pull request?

Workflows with schedules are disabled by GitHub in new forks.  `populate-cache` has a schedule, but is also triggered by commits changing POM files.  This PR extracts the scheduled part, so that new forks can start out with `populate-cache` enabled (only the schedule will be disabled by default).  Hopefully.

https://issues.apache.org/jira/browse/HDDS-11689

## How was this patch tested?

Pushed to `master` in my fork, `populate-cache` workflow was triggered correctly:
https://github.com/adoroszlai/ozone/actions/runs/11814012303

scheduled run was also triggered (with modified schedule, to avoid having to wait a day):
https://github.com/adoroszlai/ozone/actions/runs/11815697729