### PR TITLE
HDDS-11704. Hadoop test leaves running containers in case of failure

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -138,7 +138,7 @@ start_docker_env(){
   create_results_dir
   export OZONE_SAFEMODE_MIN_DATANODES="${datanode_count}"
 
-  docker-compose --ansi never down
+  docker-compose --ansi never down --remove-orphans
 
   trap stop_docker_env EXIT HUP INT TERM
 
@@ -367,7 +367,7 @@ stop_docker_env(){
     down_repeats=3
     for i in $(seq 1 $down_repeats)
     do
-      if docker-compose --ansi never down; then
+      if docker-compose --ansi never --profile "*" down --remove-orphans; then
         return
       fi
       if [[ ${i} -eq 1 ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hadoop's containers are left running if Hadoop test fails.

Steps to reproduce (by simulating failure):

```bash
cd hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose
sed -i -e 's/execute_command_in_container rm hadoop version/exit 1/' common/hadoop-test.sh
cd ozone
./test-hadoop.sh
docker ps
```

Result:

```
CONTAINER ID   IMAGE                  COMMAND                  CREATED         STATUS         PORTS                                                                      NAMES
983d0cd0fe79   apache/hadoop:2.10.2   "/usr/local/bin/dumb…"   8 seconds ago   Up 7 seconds   0.0.0.0:8088->8088/tcp, :::8088->8088/tcp                                  ozone-rm-1
89b8ddc1c331   apache/hadoop:2.10.2   "/usr/local/bin/dumb…"   8 seconds ago   Up 7 seconds                                                                              ozone-nm-1
```

https://issues.apache.org/jira/browse/HDDS-11704

## How was this patch tested?

Same steps as described in repro.  Verified that no containers are left running.

CI:
https://github.com/adoroszlai/ozone/actions/runs/11843661370