### PR TITLE
HDDS-11658. Skip known tombstones when scanning rocksdb deletedtable in KeyDeletingService

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyPurging.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyPurging.java
@@ -140,7 +140,7 @@ public class TestKeyPurging {
     GenericTestUtils.waitFor(
         () -> {
           try {
-            return keyManager.getPendingDeletionKeys(Integer.MAX_VALUE)
+            return keyManager.getPendingDeletionKeys(Integer.MAX_VALUE, "")
                 .getKeyBlocksList().size() == 0;
           } catch (IOException e) {
             return false;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingServiceIntegrationTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingServiceIntegrationTest.java
@@ -514,7 +514,7 @@ public class TestSnapshotDeletingServiceIntegrationTest {
     keyDeletingService.shutdown();
     GenericTestUtils.waitFor(() -> keyDeletingService.getThreadCount() == 0, 1000,
         100000);
-    when(keyManager.getPendingDeletionKeys(anyInt())).thenAnswer(i -> {
+    when(keyManager.getPendingDeletionKeys(anyInt(), "")).thenAnswer(i -> {
       // wait for SDS to reach the KDS wait block before processing any key.
       GenericTestUtils.waitFor(keyDeletionWaitStarted::get, 1000, 100000);
       keyDeletionStarted.set(true);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -119,7 +119,8 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    * and a hashmap for key-value pair to be updated in the deletedTable.
    * @throws IOException
    */
-  PendingKeysDeletion getPendingDeletionKeys(int count) throws IOException;
+  PendingKeysDeletion getPendingDeletionKeys(int count, String startKey)
+      throws IOException;
 
   /**
    * Returns a list rename entries from the snapshotRenamedTable.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -658,12 +658,13 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public PendingKeysDeletion getPendingDeletionKeys(final int count)
+  public PendingKeysDeletion getPendingDeletionKeys(final int count,
+      final String startKey)
       throws IOException {
     OmMetadataManagerImpl omMetadataManager =
         (OmMetadataManagerImpl) metadataManager;
-    return omMetadataManager
-        .getPendingDeletionKeys(count, ozoneManager.getOmSnapshotManager());
+    return omMetadataManager.getPendingDeletionKeys(count, startKey,
+        ozoneManager.getOmSnapshotManager());
   }
 
   private <V, R> List<Table.KeyValue<String, R>> getTableEntries(String startKey,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PendingKeysDeletion.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PendingKeysDeletion.java
@@ -31,11 +31,18 @@ public class PendingKeysDeletion {
 
   private HashMap<String, RepeatedOmKeyInfo> keysToModify;
   private List<BlockGroup> keyBlocksList;
+  private String lastKey;
 
   public PendingKeysDeletion(List<BlockGroup> keyBlocksList,
-       HashMap<String, RepeatedOmKeyInfo> keysToModify) {
+       HashMap<String, RepeatedOmKeyInfo> keysToModify,
+       String lastKey) {
     this.keysToModify = keysToModify;
     this.keyBlocksList = keyBlocksList;
+    this.lastKey = lastKey;
+  }
+
+  public String getLastKey() {
+    return lastKey;
   }
 
   public HashMap<String, RepeatedOmKeyInfo> getKeysToModify() {


### PR DESCRIPTION

## What changes were proposed in this pull request?

KeyDeletingService, iterate several records from scratch each time, send deletion requests, and then delete these records.

If each iteration starts from scratch, Rocksdb will also include the recently deleted tombstone data in the scan.
 
The optimization is to optimize the iteration strategy, record breakpoints for each iteration, skip known tombstones, and reset breakpoints if errors occur during the iteration or if the endpoint is reached.




## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11658

## How was this patch tested?

TestKeyDeletingService set OZONE_KEY_DELETING_LIMIT_PER_TASK is 10
