### PR TITLE
HDDS-11719. Remove dependency on server components from ozonefs-common

### DIFF
--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -59,10 +59,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>commons-cli</groupId>
-          <artifactId>commons-cli</artifactId>
-        </exclusion>
+        <!-- commons-cli is required by OzoneFsShell -->
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-math3</artifactId>

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -114,32 +114,12 @@
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.ozone</groupId>
-      <artifactId>hdds-container-service</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-hadoop-dependency-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
-      <artifactId>hdds-server-framework</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.ozone</groupId>
-      <artifactId>hdds-server-scm</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.ozone</groupId>
       <artifactId>hdds-test-utils</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.ozone</groupId>
-      <artifactId>ozone-manager</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -117,10 +117,5 @@
       <artifactId>hdds-hadoop-dependency-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.ozone</groupId>
-      <artifactId>hdds-test-utils</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsShell.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsShell.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.fs.shell.CommandFactory;
 import org.apache.hadoop.util.ToolRunner;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
 
@@ -32,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 
-
 /**
  * Tests the behavior of OzoneFsShell.
  */
@@ -40,7 +38,7 @@ public class TestOzoneFsShell {
 
   // tests command handler for FsShell bound to OzoneDelete class
   @Test
-  public void testOzoneFsShellRegisterDeleteCmd() throws IOException {
+  public void testOzoneFsShellRegisterDeleteCmd() throws Exception {
     final String rmCmdName = "rm";
     final String rmCmd = "-" + rmCmdName;
     final String arg = "arg1";
@@ -52,16 +50,17 @@ public class TestOzoneFsShell {
     System.setErr(bytesPrintStream);
     try {
       ToolRunner.run(shell, argv);
-    } catch (Exception e) {
-    } finally {
+
       // test command bindings for "rm" command handled by OzoneDelete class
       CommandFactory factory = shell.getCommandFactory();
+      assertNotNull(factory);
       assertEquals(1, Arrays.stream(factory.getNames())
           .filter(c -> c.equals(rmCmd)).count());
       Command instance = factory.getInstance(rmCmd);
       assertNotNull(instance);
       assertEquals(OzoneFsDelete.Rm.class, instance.getClass());
       assertEquals(rmCmdName, instance.getCommandName());
+    } finally {
       shell.close();
       System.setErr(oldErr);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozonefs-common` depends on some server-side components with `test` scope, but doesn't actually use any of those.  It shouldn't need them, since it's a client-side component.

`OzoneFsShell` requires `commons-cli` due to the parent class from Hadoop.  It gets the dependency accidentally, because `ozone fs` uses the `ozone-tools` classpath, which has it:

https://github.com/apache/ozone/blob/dd22dbef8958311c2ec5e99822269405d59f8eba/hadoop-ozone/dist/src/shell/ozone/ozone#L191-L194

Similarly, `TestOzoneFsShell` gets the dependency transitively via the server-side components.  It started failing after removing the test-scoped dependencies:

```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.153 s <<< FAILURE! - in org.apache.hadoop.fs.ozone.TestOzoneFsShell
org.apache.hadoop.fs.ozone.TestOzoneFsShell.testOzoneFsShellRegisterDeleteCmd  Time elapsed: 0.132 s  <<< ERROR!
java.lang.NullPointerException: Cannot invoke "org.apache.hadoop.fs.shell.CommandFactory.getNames()" because "factory" is null
	at org.apache.hadoop.fs.ozone.TestOzoneFsShell.testOzoneFsShellRegisterDeleteCmd(TestOzoneFsShell.java:59)
```

`factory` is initialized in `FsShell.init() <- FsShell.run() <- ToolRunner.run()` (which the test calls), but it fails due to classpath issue, and the test suppresses the exception, leaving `factory` as null.

Test is updated to let it fail with the original problem, if it happens.

Classpath issue is fixed by removing exclusion of `commons-cli` in client-side dependencies.

https://issues.apache.org/jira/browse/HDDS-11719

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/11859467136