### PR TITLE
HDDS-11717. Require Java 17 for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,8 @@ jobs:
     strategy:
       matrix:
         check: ${{ fromJson(needs.build-info.outputs.basic-checks) }}
+        exclude:
+          - check: findbugs # HDDS-10150: Spotbugs 3 does not support Java 17
       fail-fast: false
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,10 +178,10 @@ jobs:
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 21 ]
         include:
           - os: ubuntu-20.04
-          - java: 8
+          - java: 17
             os: macos-13
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/hadoop-ozone/dev-support/checks/license.sh
+++ b/hadoop-ozone/dev-support/checks/license.sh
@@ -56,6 +56,7 @@ grep '(' ${src} \
     -e "Apache ${L}" -e "Apache Software ${L}" -e "Apache v2" -e "Apache.2" \
     -e "Bouncy Castle ${L}" \
     -e "(BSD)" -e "(The BSD ${L})" -e "\<BSD.[23]" -e "\<BSD ${L} [23]" -e "\<[23]\>.Clause.\<BSD\>" \
+    -e "(CC0)" \
     -e "(CDDL\>" -e ' CDDL '\
     -e "(EDL\>" -e "Eclipse Distribution ${L}" \
     -e "(EPL\>" -e "Eclipse Public ${L}" \

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -352,6 +352,7 @@ Apache License 2.0
    io.prometheus:simpleclient
    io.prometheus:simpleclient_common
    io.prometheus:simpleclient_dropwizard
+   io.r2dbc:r2dbc-spi
    joda-time:joda-time
    jakarta.inject:jakarta.inject-api
    jakarta.validation:jakarta.validation-api
@@ -465,6 +466,12 @@ Public Domain
 =====================
 
    aopalliance:aopalliance
+
+
+CC0
+=====================
+
+   org.reactivestreams:reactive-streams
 
 
 BSD 3-Clause

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -238,6 +238,7 @@ share/ozone/lib/protobuf-java.jar
 share/ozone/lib/protobuf-java.jar
 share/ozone/lib/protobuf-java-util.jar
 share/ozone/lib/proto-google-common-protos.jar
+share/ozone/lib/r2dbc-spi.RELEASE.jar
 share/ozone/lib/ranger-intg.jar
 share/ozone/lib/ranger-plugin-classloader.jar
 share/ozone/lib/ranger-plugins-audit.jar
@@ -256,6 +257,7 @@ share/ozone/lib/ratis-shell.jar
 share/ozone/lib/ratis-thirdparty-misc.jar
 share/ozone/lib/ratis-tools.jar
 share/ozone/lib/re2j.jar
+share/ozone/lib/reactive-streams.jar
 share/ozone/lib/reflections.jar
 share/ozone/lib/rocksdb-checkpoint-differ.jar
 share/ozone/lib/reload4j.jar

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -24,6 +24,7 @@
   <artifactId>ozone-reconcodegen</artifactId>
   <name>Apache Ozone Recon CodeGen</name>
   <properties>
+    <javac.version>17</javac.version>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
   </properties>
 

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -25,6 +25,7 @@
   <artifactId>ozone-recon</artifactId>
   <properties>
     <classpath.skip>false</classpath.skip>
+    <javac.version>17</javac.version>
     <pnpm.version>8.15.7</pnpm.version>
   </properties>
   <build>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -485,7 +485,7 @@ public class ReconUtils {
     Timestamp now =
         using(sqlConfiguration).fetchValue(select(currentTimestamp()));
     GlobalStats record = globalStatsDao.fetchOneByKey(key);
-    GlobalStats newRecord = new GlobalStats(key, count, now);
+    GlobalStats newRecord = new GlobalStats(key, count, now.toLocalDateTime());
 
     // Insert a new record for key if it does not exist
     if (record == null) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OmTableInsightTask.java
@@ -281,7 +281,7 @@ public class OmTableInsightTask implements ReconOmTask {
           using(sqlConfiguration).fetchValue(select(currentTimestamp()));
       GlobalStats record = globalStatsDao.fetchOneByKey(entry.getKey());
       GlobalStats newRecord
-          = new GlobalStats(entry.getKey(), entry.getValue(), now);
+          = new GlobalStats(entry.getKey(), entry.getValue(), now.toLocalDateTime());
 
       // Insert a new record for key if it does not exist
       if (record == null) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -1021,7 +1021,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   private void insertGlobalStatsRecords(GlobalStatsDao statsDao,
                                         Timestamp timestamp, String key,
                                         long value) {
-    GlobalStats newRecord = new GlobalStats(key, value, timestamp);
+    GlobalStats newRecord = new GlobalStats(key, value, timestamp.toLocalDateTime());
     statsDao.insert(newRecord);
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOmDBInsightEndPoint.java
@@ -65,7 +65,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -904,7 +904,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
   @Test
   public void testKeyCountsForValidAndInvalidKeyPrefix() {
-    Timestamp now = new Timestamp(System.currentTimeMillis());
+    LocalDateTime now = LocalDateTime.now();
     GlobalStatsDao statsDao = omdbInsightEndpoint.getDao();
 
     // Insert valid key count with valid key prefix
@@ -966,7 +966,7 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
 
   @Test
   public void testKeysSummaryAttribute() {
-    Timestamp now = new Timestamp(System.currentTimeMillis());
+    LocalDateTime now = LocalDateTime.now();
     GlobalStatsDao statsDao = omdbInsightEndpoint.getDao();
     // Insert records for replicated and unreplicated data sizes
     insertGlobalStatsRecords(statsDao, now, "openFileTableReplicatedDataSize",
@@ -1019,9 +1019,9 @@ public class TestOmDBInsightEndPoint extends AbstractReconSqlDBTest {
   }
 
   private void insertGlobalStatsRecords(GlobalStatsDao statsDao,
-                                        Timestamp timestamp, String key,
+                                        LocalDateTime timestamp, String key,
                                         long value) {
-    GlobalStats newRecord = new GlobalStats(key, value, timestamp.toLocalDateTime());
+    GlobalStats newRecord = new GlobalStats(key, value, timestamp);
     statsDao.insert(newRecord);
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestStatsSchemaDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestStatsSchemaDefinition.java
@@ -104,13 +104,13 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
 
     assertEquals("key1", dbRecord.getKey());
     assertEquals(Long.valueOf(500), dbRecord.getValue());
-    assertEquals(new Timestamp(now),
+    assertEquals(new Timestamp(now).toLocalDateTime(),
         dbRecord.getLastUpdatedTimestamp());
 
     dbRecord = dao.findById("key2");
     assertEquals("key2", dbRecord.getKey());
     assertEquals(Long.valueOf(10), dbRecord.getValue());
-    assertEquals(new Timestamp(now + 1000L),
+    assertEquals(new Timestamp(now + 1000L).toLocalDateTime(),
         dbRecord.getLastUpdatedTimestamp());
 
     // Update
@@ -121,7 +121,7 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
     // Read updated
     dbRecord = dao.findById("key2");
 
-    assertEquals(new Timestamp(now + 2000L),
+    assertEquals(new Timestamp(now + 2000L).toLocalDateTime(),
         dbRecord.getLastUpdatedTimestamp());
     assertEquals(Long.valueOf(100L), dbRecord.getValue());
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestStatsSchemaDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestStatsSchemaDefinition.java
@@ -87,14 +87,14 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
 
     long now = System.currentTimeMillis();
     GlobalStats newRecord = new GlobalStats();
-    newRecord.setLastUpdatedTimestamp(new Timestamp(now));
+    newRecord.setLastUpdatedTimestamp(new Timestamp(now).toLocalDateTime());
     newRecord.setKey("key1");
     newRecord.setValue(500L);
 
     // Create
     dao.insert(newRecord);
     GlobalStats newRecord2 = new GlobalStats();
-    newRecord2.setLastUpdatedTimestamp(new Timestamp(now + 1000L));
+    newRecord2.setLastUpdatedTimestamp(new Timestamp(now + 1000L).toLocalDateTime());
     newRecord2.setKey("key2");
     newRecord2.setValue(10L);
     dao.insert(newRecord2);
@@ -115,7 +115,7 @@ public class TestStatsSchemaDefinition extends AbstractReconSqlDBTest {
 
     // Update
     dbRecord.setValue(100L);
-    dbRecord.setLastUpdatedTimestamp(new Timestamp(now + 2000L));
+    dbRecord.setLastUpdatedTimestamp(new Timestamp(now + 2000L).toLocalDateTime());
     dao.update(dbRecord);
 
     // Read updated

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUtilizationSchemaDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUtilizationSchemaDefinition.java
@@ -29,8 +29,8 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -148,9 +148,9 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     }
 
     ClusterGrowthDailyDao dao = getDao(ClusterGrowthDailyDao.class);
-    long now = System.currentTimeMillis();
+    LocalDateTime now = LocalDateTime.now();
     ClusterGrowthDaily newRecord = new ClusterGrowthDaily();
-    newRecord.setTimestamp(new Timestamp(now).toLocalDateTime());
+    newRecord.setTimestamp(now);
     newRecord.setDatanodeId(10);
     newRecord.setDatanodeHost("host1");
     newRecord.setRackId("rack1");
@@ -166,7 +166,7 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     ClusterGrowthDaily dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now).toLocalDateTime()).value2(10));
+            .value1(now).value2(10));
 
     assertEquals("host1", dbRecord.getDatanodeHost());
     assertEquals("rack1", dbRecord.getRackId());
@@ -184,7 +184,7 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now).toLocalDateTime()).value2(10));
+            .value1(now).value2(10));
 
     assertEquals(Long.valueOf(700), dbRecord.getUsedSize());
     assertEquals(Integer.valueOf(30), dbRecord.getBlockCount());
@@ -192,13 +192,13 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     // Delete
     dao.deleteById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
         CLUSTER_GROWTH_DAILY.DATANODE_ID)
-        .value1(new Timestamp(now).toLocalDateTime()).value2(10));
+        .value1(now).value2(10));
 
     // Verify
     dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now).toLocalDateTime()).value2(10));
+            .value1(now).value2(10));
 
     assertNull(dbRecord);
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUtilizationSchemaDefinition.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/persistence/TestUtilizationSchemaDefinition.java
@@ -150,7 +150,7 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     ClusterGrowthDailyDao dao = getDao(ClusterGrowthDailyDao.class);
     long now = System.currentTimeMillis();
     ClusterGrowthDaily newRecord = new ClusterGrowthDaily();
-    newRecord.setTimestamp(new Timestamp(now));
+    newRecord.setTimestamp(new Timestamp(now).toLocalDateTime());
     newRecord.setDatanodeId(10);
     newRecord.setDatanodeHost("host1");
     newRecord.setRackId("rack1");
@@ -166,7 +166,7 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     ClusterGrowthDaily dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now)).value2(10));
+            .value1(new Timestamp(now).toLocalDateTime()).value2(10));
 
     assertEquals("host1", dbRecord.getDatanodeHost());
     assertEquals("rack1", dbRecord.getRackId());
@@ -184,7 +184,7 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now)).value2(10));
+            .value1(new Timestamp(now).toLocalDateTime()).value2(10));
 
     assertEquals(Long.valueOf(700), dbRecord.getUsedSize());
     assertEquals(Integer.valueOf(30), dbRecord.getBlockCount());
@@ -192,13 +192,13 @@ public class TestUtilizationSchemaDefinition extends AbstractReconSqlDBTest {
     // Delete
     dao.deleteById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
         CLUSTER_GROWTH_DAILY.DATANODE_ID)
-        .value1(new Timestamp(now)).value2(10));
+        .value1(new Timestamp(now).toLocalDateTime()).value2(10));
 
     // Verify
     dbRecord =
         dao.findById(getDslContext().newRecord(CLUSTER_GROWTH_DAILY.TIMESTAMP,
             CLUSTER_GROWTH_DAILY.DATANODE_ID)
-            .value1(new Timestamp(now)).value2(10));
+            .value1(new Timestamp(now).toLocalDateTime()).value2(10));
 
     assertNull(dbRecord);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jgrapht.version>1.4.0</jgrapht.version>
     <jgraphx.version>3.9.12</jgraphx.version>
 
-    <spring.version>5.3.39</spring.version>
+    <spring.version>6.2.0</spring.version>
     <jooq.version>3.11.10</jooq.version>
 
     <!-- Node.js version number (without the v prefix required by frontend-maven-plugin) -->

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jgraphx.version>3.9.12</jgraphx.version>
 
     <spring.version>6.2.0</spring.version>
-    <jooq.version>3.11.10</jooq.version>
+    <jooq.version>3.19.15</jooq.version>
 
     <!-- Node.js version number (without the v prefix required by frontend-maven-plugin) -->
     <nodejs.version>16.14.2</nodejs.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a breaking change that I would like to discuss.

The immediate goal is to upgrade Spring Framework to 6.2.0, the latest version, because Spring 5.x is EOL.

Spring 6.x requires Java 17.

Recon is the only component in Ozone that uses Spring.

Therefore with this change Ozone would require Java 17 at build time, and for Recon also at runtime.

Findbugs check needs to be disabled (temporarily), because Spotbugs 3 does not support Java 17 classes, and Spotbugs 4 emits ~2K failures for the same codebase.

https://issues.apache.org/jira/browse/HDDS-11717

## How was this patch tested?

Ozone is built in CI with Java 17, producing Java 8 jars.  Tests are run with Java 17.

_acceptance (MR)_ tests Ozone filesystem jars with Hadoop using Java 8.

https://github.com/adoroszlai/ozone/actions/runs/11858701453