### PR TITLE
HDDS-11644. Close OMLayoutVersionManager

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2329,6 +2329,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (bucketUtilizationMetrics != null) {
         bucketUtilizationMetrics.unRegister();
       }
+
+      if (versionManager != null) {
+        versionManager.close();
+      }
       return true;
     } catch (Exception e) {
       LOG.error("OzoneManager stop failed.", e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Seems OMLayoutVersionManager is never closed, unlike layout version manager in SCM and DN. This cause metrics to not be cleaned.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11644

## How was this patch tested?

Existing tests.

https://github.com/ivandika3/ozone/actions/runs/11867693678