### PR TITLE
HDDS-11737. UnsupportedOperationException in S3 setBucketAcl

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -20,12 +20,13 @@ package org.apache.hadoop.ozone.client;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import org.apache.commons.collections.ListUtils;
 import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
@@ -124,7 +125,7 @@ public class OzoneVolume extends WithMetadata {
             this.creationTime.getEpochSecond(), this.creationTime.getNano());
       }
     }
-    this.acls = builder.acls;
+    this.acls = new ArrayList<>(builder.acls);
     if (builder.conf != null) {
       this.listCacheSize = HddsClientUtils.getListCacheSize(builder.conf);
     }
@@ -203,7 +204,7 @@ public class OzoneVolume extends WithMetadata {
    * @return aclMap
    */
   public List<OzoneAcl> getAcls() {
-    return ListUtils.unmodifiableList(acls);
+    return Collections.unmodifiableList(acls);
   }
 
    /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/s3/awssdk/v1/AbstractS3SDKV1Tests.java
@@ -220,7 +220,7 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
 
   @Test
   public void testBucketACLOperations() {
-    // TODO: Uncomment assertions when bucket S3 ACL logic has been fixed
+    // TODO HDDS-11738: Uncomment assertions when bucket S3 ACL logic has been fixed
     final String bucketName = getBucketName();
 
     AccessControlList aclList = new AccessControlList();
@@ -235,15 +235,12 @@ public abstract class AbstractS3SDKV1Tests extends OzoneTestBase {
 
     s3Client.createBucket(createBucketRequest);
 
-//    AccessControlList retrievedAclList = s3.getBucketAcl(bucketName);
-//    assertEquals(aclList, retrievedAclList);
+    //assertEquals(aclList, s3Client.getBucketAcl(bucketName));
 
-//    aclList.grantPermission(grantee, Permission.Write);
-//    s3.setBucketAcl(bucketName, aclList);
+    aclList.grantPermission(grantee, Permission.Write);
+    s3Client.setBucketAcl(bucketName, aclList);
 
-//    retrievedAclList = s3.getBucketAcl(bucketName);
-//    assertEquals(aclList, retrievedAclList);
-
+    //assertEquals(aclList, s3Client.getBucketAcl(bucketName));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix:

```
java.lang.UnsupportedOperationException: null
	at com.google.common.collect.ImmutableCollection.add(ImmutableCollection.java:268) ~[guava-32.1.3-jre.jar:?]
	at org.apache.hadoop.ozone.client.OzoneVolume.addAcl(OzoneVolume.java:220) ~[classes/:?]
	at org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint.putAcl(BucketEndpoint.java:632) ~[classes/:?]
	at org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint.put(BucketEndpoint.java:304) ~[classes/:?]
```

which happens when trying to update bucket ACL via S3 Gateway.

https://issues.apache.org/jira/browse/HDDS-11737

## How was this patch tested?

Updated S3 integration test to exercise this code path.

CI:
https://github.com/adoroszlai/ozone/actions/runs/11878215107