### PR TITLE
HDDS-11739. Extract generic unmarshaller for S3 requests

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -568,8 +568,7 @@ public class BucketEndpoint extends EndpointBase {
       if (grantReads == null && grantWrites == null && grantReadACP == null
           && grantWriteACP == null && grantFull == null) {
         S3BucketAcl putBucketAclRequest =
-            new PutBucketAclRequestUnmarshaller().readFrom(
-                null, null, null, null, null, body);
+            new PutBucketAclRequestUnmarshaller().readFrom(body);
         // Handle grants in body
         ozoneAclListOnBucket.addAll(
             S3Acl.s3AclToOzoneNativeAclOnBucket(putBucketAclRequest));

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
@@ -17,17 +17,9 @@
  */
 package org.apache.hadoop.ozone.s3.endpoint;
 
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
-
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.UnmarshallerHandler;
-import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -35,7 +27,6 @@ import java.lang.reflect.Type;
 import javax.ws.rs.ext.Provider;
 
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
-import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
 import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
 /**
@@ -43,25 +34,10 @@ import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
  */
 @Provider
 public class CompleteMultipartUploadRequestUnmarshaller
-    implements MessageBodyReader<CompleteMultipartUploadRequest> {
-
-  private final JAXBContext context;
-  private final SAXParserFactory saxParserFactory;
+    extends MessageUnmarshaller<CompleteMultipartUploadRequest> {
 
   public CompleteMultipartUploadRequestUnmarshaller() {
-    try {
-      context = JAXBContext.newInstance(CompleteMultipartUploadRequest.class);
-      saxParserFactory = SAXParserFactory.newInstance();
-      saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-    } catch (Exception ex) {
-      throw new AssertionError("Can not instantiate " +
-          "CompleteMultipartUploadRequest parser", ex);
-    }
-  }
-  @Override
-  public boolean isReadable(Class<?> aClass, Type type,
-      Annotation[] annotations, MediaType mediaType) {
-    return type.equals(CompleteMultipartUploadRequest.class);
+    super(CompleteMultipartUploadRequest.class);
   }
 
   @Override
@@ -69,24 +45,13 @@ public class CompleteMultipartUploadRequestUnmarshaller
       Class<CompleteMultipartUploadRequest> aClass, Type type,
       Annotation[] annotations, MediaType mediaType,
       MultivaluedMap<String, String> multivaluedMap,
-      InputStream inputStream) throws IOException, WebApplicationException {
+      InputStream inputStream) throws WebApplicationException {
     try {
       if (inputStream.available() == 0) {
         throw wrapOS3Exception(INVALID_REQUEST.withMessage("You must specify at least one part"));
       }
-
-      XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
-      UnmarshallerHandler unmarshallerHandler =
-          context.createUnmarshaller().getUnmarshallerHandler();
-      XmlNamespaceFilter filter =
-          new XmlNamespaceFilter(S3_XML_NAMESPACE);
-      filter.setContentHandler(unmarshallerHandler);
-      filter.setParent(xmlReader);
-      filter.parse(new InputSource(inputStream));
-      return (CompleteMultipartUploadRequest) unmarshallerHandler.getResult();
-    } catch (WebApplicationException e) {
-      throw e;
-    } catch (Exception e) {
+      return super.readFrom(aClass, type, annotations, mediaType, multivaluedMap, inputStream);
+    } catch (IOException e) {
       throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MessageUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MessageUnmarshaller.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.s3.endpoint;
+
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.UnmarshallerHandler;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
+import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
+import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
+
+/**
+ * Unmarshaller to create instances of type {@code T} from XML,
+ * which may or may not have namespace.
+ * @param <T> the object type to read from XML
+ */
+public class MessageUnmarshaller<T> implements MessageBodyReader<T> {
+
+  private final JAXBContext context;
+  private final SAXParserFactory saxParserFactory;
+  private final Class<T> cls;
+
+  public MessageUnmarshaller(Class<T> cls) {
+    this.cls = cls;
+
+    try {
+      context = JAXBContext.newInstance(cls);
+      saxParserFactory = SAXParserFactory.newInstance();
+      saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    } catch (Exception ex) {
+      throw new AssertionError("Can not instantiate XML parser for " + cls.getSimpleName(), ex);
+    }
+  }
+
+  @Override
+  public boolean isReadable(Class<?> aClass, Type type,
+      Annotation[] annotations, MediaType mediaType) {
+    return type.equals(cls);
+  }
+
+  @Override
+  public T readFrom(
+      Class<T> aClass, Type type,
+      Annotation[] annotations, MediaType mediaType,
+      MultivaluedMap<String, String> multivaluedMap,
+      InputStream inputStream
+  ) throws WebApplicationException {
+    try {
+      XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
+      UnmarshallerHandler unmarshallerHandler =
+          context.createUnmarshaller().getUnmarshallerHandler();
+      XmlNamespaceFilter filter =
+          new XmlNamespaceFilter(S3_XML_NAMESPACE);
+      filter.setContentHandler(unmarshallerHandler);
+      filter.setParent(xmlReader);
+      filter.parse(new InputSource(inputStream));
+      return cls.cast(unmarshallerHandler.getResult());
+    } catch (Exception e) {
+      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
+    }
+  }
+
+  /** Convenience method for programmatic invocation. */
+  public T readFrom(InputStream inputStream) throws WebApplicationException {
+    return readFrom(cls, cls, new Annotation[0], MediaType.APPLICATION_XML_TYPE, null, inputStream);
+  }
+
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/MultiDeleteRequestUnmarshaller.java
@@ -19,22 +19,7 @@ package org.apache.hadoop.ozone.s3.endpoint;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.UnmarshallerHandler;
-import javax.xml.parsers.SAXParserFactory;
-import java.io.InputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
-
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
-import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
 /**
  * Custom unmarshaller to read MultiDeleteRequest w/wo namespace.
@@ -42,45 +27,10 @@ import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 @Provider
 @Produces(MediaType.APPLICATION_XML)
 public class MultiDeleteRequestUnmarshaller
-    implements MessageBodyReader<MultiDeleteRequest> {
-
-  private final JAXBContext context;
-  private final SAXParserFactory saxParserFactory;
+    extends MessageUnmarshaller<MultiDeleteRequest> {
 
   public MultiDeleteRequestUnmarshaller() {
-    try {
-      context = JAXBContext.newInstance(MultiDeleteRequest.class);
-      saxParserFactory = SAXParserFactory.newInstance();
-      saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-    } catch (Exception ex) {
-      throw new AssertionError("Can't instantiate MultiDeleteRequest parser",
-          ex);
-    }
+    super(MultiDeleteRequest.class);
   }
 
-  @Override
-  public boolean isReadable(Class<?> type, Type genericType,
-      Annotation[] annotations, MediaType mediaType) {
-    return type.equals(MultiDeleteRequest.class);
-  }
-
-  @Override
-  public MultiDeleteRequest readFrom(Class<MultiDeleteRequest> type,
-      Type genericType, Annotation[] annotations, MediaType mediaType,
-      MultivaluedMap<String, String> httpHeaders, InputStream entityStream) {
-    try {
-      XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
-      UnmarshallerHandler unmarshallerHandler =
-          context.createUnmarshaller().getUnmarshallerHandler();
-
-      XmlNamespaceFilter filter =
-          new XmlNamespaceFilter("http://s3.amazonaws.com/doc/2006-03-01/");
-      filter.setContentHandler(unmarshallerHandler);
-      filter.setParent(xmlReader);
-      filter.parse(new InputSource(entityStream));
-      return (MultiDeleteRequest) unmarshallerHandler.getResult();
-    } catch (Exception e) {
-      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
-    }
-  }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/PutBucketAclRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/PutBucketAclRequestUnmarshaller.java
@@ -17,71 +17,16 @@
  */
 package org.apache.hadoop.ozone.s3.endpoint;
 
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
-
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.UnmarshallerHandler;
-import javax.xml.parsers.SAXParserFactory;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
-import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
-import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
 
 /**
  * Custom unmarshaller to read PutBucketAclRequest wo namespace.
  */
 @Provider
-public class PutBucketAclRequestUnmarshaller
-    implements MessageBodyReader<S3BucketAcl> {
-
-  private final JAXBContext context;
-  private final SAXParserFactory saxParserFactory;
+public class PutBucketAclRequestUnmarshaller extends MessageUnmarshaller<S3BucketAcl> {
 
   public PutBucketAclRequestUnmarshaller() {
-    try {
-      context = JAXBContext.newInstance(S3BucketAcl.class);
-      saxParserFactory = SAXParserFactory.newInstance();
-      saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-    } catch (Exception ex) {
-      throw new AssertionError("Can not instantiate " +
-          "PutBucketAclRequest parser", ex);
-    }
-  }
-  @Override
-  public boolean isReadable(Class<?> aClass, Type type,
-      Annotation[] annotations, MediaType mediaType) {
-    return type.equals(S3BucketAcl.class);
+    super(S3BucketAcl.class);
   }
 
-  @Override
-  public S3BucketAcl readFrom(
-      Class<S3BucketAcl> aClass, Type type,
-      Annotation[] annotations, MediaType mediaType,
-      MultivaluedMap<String, String> multivaluedMap,
-      InputStream inputStream) throws IOException, WebApplicationException {
-    try {
-      XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
-      UnmarshallerHandler unmarshallerHandler =
-          context.createUnmarshaller().getUnmarshallerHandler();
-      XmlNamespaceFilter filter =
-          new XmlNamespaceFilter(S3_XML_NAMESPACE);
-      filter.setContentHandler(unmarshallerHandler);
-      filter.setParent(xmlReader);
-      filter.parse(new InputSource(inputStream));
-      return (S3BucketAcl)(unmarshallerHandler.getResult());
-    } catch (Exception e) {
-      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
-    }
-  }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/PutTaggingUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/PutTaggingUnmarshaller.java
@@ -17,54 +17,13 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
-
-import javax.ws.rs.WebApplicationException;
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.UnmarshallerHandler;
-import javax.xml.parsers.SAXParserFactory;
-import java.io.InputStream;
-
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
-import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
-import static org.apache.hadoop.ozone.s3.util.S3Utils.wrapOS3Exception;
-
 /**
  * Custom unmarshaller to read Tagging request body.
  */
-public class PutTaggingUnmarshaller {
-
-  private JAXBContext context;
-  private SAXParserFactory saxParserFactory;
+public class PutTaggingUnmarshaller extends MessageUnmarshaller<S3Tagging> {
 
   public PutTaggingUnmarshaller() {
-    try {
-      context = JAXBContext.newInstance(S3Tagging.class);
-      saxParserFactory = SAXParserFactory.newInstance();
-      saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-    } catch (Exception ex) {
-      throw new AssertionError("Can not instantiate " +
-          "PutTaggingUnmarshaller parser", ex);
-    }
-  }
-
-  public S3Tagging readFrom(InputStream inputStream)
-        throws WebApplicationException {
-    try {
-      XMLReader xmlReader = saxParserFactory.newSAXParser().getXMLReader();
-      UnmarshallerHandler unmarshallerHandler =
-          context.createUnmarshaller().getUnmarshallerHandler();
-      XmlNamespaceFilter filter =
-          new XmlNamespaceFilter(S3_XML_NAMESPACE);
-      filter.setContentHandler(unmarshallerHandler);
-      filter.setParent(xmlReader);
-      filter.parse(new InputSource(inputStream));
-      return (S3Tagging) unmarshallerHandler.getResult();
-    } catch (Exception e) {
-      throw wrapOS3Exception(INVALID_REQUEST.withMessage(e.getMessage()));
-    }
+    super(S3Tagging.class);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce code duplication among:

- `CompleteMultipartUploadRequestUnmarshaller`
- `MultiDeleteRequestUnmarshaller`
- `PutBucketAclRequestUnmarshaller`
- `PutTaggingUnmarshaller`

by extracting generic parent class.

https://issues.apache.org/jira/browse/HDDS-11739

## How was this patch tested?

Refactoring, covered by existing tests.

CI:
https://github.com/adoroszlai/ozone/actions/runs/11880414364