### PR TITLE
HDDS-11740. Add debug command to show internal component versions

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -49,3 +49,8 @@ Test ozone debug read-replicas
     FOR    ${replica}    IN RANGE    3
         Verify Healthy Replica   ${json}    ${replica}    ${md5sum}
     END
+
+
+Test ozone debug version
+    ${output} =    Execute    ozone debug version
+                   Execute    echo '${output}' | jq -r '.' # validate JSON

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/VersionDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/VersionDebug.java
@@ -67,8 +67,10 @@ public class VersionDebug implements Callable<Void>, SubcommandWithParent {
 
   private static <T extends Enum<T> & ComponentVersion> Map<String, Object> asMap(T version) {
     return ImmutableSortedMap.of(
-        "name", version.name(),
-        "protoValue", version.toProtoValue()
+        "componentVersion", ImmutableSortedMap.of(
+            "name", version.name(),
+            "protoValue", version.toProtoValue()
+        )
     );
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/VersionDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/VersionDebug.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.debug;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.apache.hadoop.hdds.ComponentVersion;
+import org.apache.hadoop.hdds.DatanodeVersion;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.server.JsonUtils;
+import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.OzoneManagerVersion;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/** Show internal component version information as JSON. */
+@CommandLine.Command(
+    name = "version",
+    description = "Show internal version of Ozone components.")
+@MetaInfServices(SubcommandWithParent.class)
+public class VersionDebug implements Callable<Void>, SubcommandWithParent {
+
+  @Override
+  public Class<?> getParentType() {
+    return OzoneDebug.class;
+  }
+
+  @Override
+  public Void call() throws IOException {
+    Map<String, Map<String, Object>> versions = ImmutableSortedMap.of(
+        "client", asMap(ClientVersion.CURRENT),
+        "datanode", asMap(DatanodeVersion.CURRENT),
+        "om", asMap(OzoneManagerVersion.CURRENT)
+    );
+    System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(versions));
+    return null;
+  }
+
+  private static <T extends Enum<T> & ComponentVersion> Map<String, Object> asMap(T version) {
+    return ImmutableSortedMap.of(
+        "name", version.name(),
+        "protoValue", version.toProtoValue()
+    );
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/VersionDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/VersionDebug.java
@@ -35,7 +35,11 @@ import java.util.concurrent.Callable;
 /** Show internal component version information as JSON. */
 @CommandLine.Command(
     name = "version",
-    description = "Show internal version of Ozone components.")
+    description = "Show internal version of Ozone components, as defined in the artifacts where this command is " +
+        "executed.  It does not communicate with any Ozone services.  Run the same command on different nodes to " +
+        "get a cross-component view of versions.  The goal of this command is to help quickly get a glance of the " +
+        "latest features supported by Ozone on the current node."
+)
 @MetaInfServices(SubcommandWithParent.class)
 public class VersionDebug implements Callable<Void>, SubcommandWithParent {
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/VersionDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/VersionDebug.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneManagerVersion;
+import org.apache.hadoop.ozone.util.OzoneVersionInfo;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 
@@ -45,12 +46,18 @@ public class VersionDebug implements Callable<Void>, SubcommandWithParent {
 
   @Override
   public Void call() throws IOException {
-    Map<String, Map<String, Object>> versions = ImmutableSortedMap.of(
-        "client", asMap(ClientVersion.CURRENT),
-        "datanode", asMap(DatanodeVersion.CURRENT),
-        "om", asMap(OzoneManagerVersion.CURRENT)
-    );
-    System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(versions));
+    System.out.println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(ImmutableSortedMap.of(
+        "ozone", ImmutableSortedMap.of(
+            "revision", OzoneVersionInfo.OZONE_VERSION_INFO.getRevision(),
+            "url", OzoneVersionInfo.OZONE_VERSION_INFO.getUrl(),
+            "version", OzoneVersionInfo.OZONE_VERSION_INFO.getVersion()
+        ),
+        "components", ImmutableSortedMap.of(
+            "client", asMap(ClientVersion.CURRENT),
+            "datanode", asMap(DatanodeVersion.CURRENT),
+            "om", asMap(OzoneManagerVersion.CURRENT)
+        )
+    )));
     return null;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement debug subcommand to show Ozone internal component versions like:

```
$ ozone debug version
{
  "client" : {
    "name" : "BUCKET_LAYOUT_SUPPORT",
    "protoValue" : 3
  },
  "datanode" : {
    "name" : "COMBINED_PUTBLOCK_WRITECHUNK_RPC",
    "protoValue" : 2
  },
  "om" : {
    "name" : "S3_OBJECT_TAGGING_API",
    "protoValue" : 9
  }
}
```

It can be used in compatibility tests to help validate not only releases, but any specific commit.  (Of course this will require further changes in the tests.)

https://issues.apache.org/jira/browse/HDDS-11740

## How was this patch tested?

Added basic test case to exercise the command in acceptance tests.

CI:
https://github.com/adoroszlai/ozone/actions/runs/11881652506