### PR TITLE
HDDS-11702. Merge test_bucket_encryption into robot compatibility test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -50,6 +50,7 @@ _kinit() {
 }
 
 _init() {
+  container=scm
   _kinit
   execute_command_in_container ${container} ozone freon ockg -n1 -t1 -p warmup
 }
@@ -81,8 +82,8 @@ test_cross_compatibility() {
 
   execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
 
-  container=scm _kinit
-  execute_command_in_container scm ozone freon ockg -n1 -t1 -p warmup
+  _init
+
   new_client _write
   new_client _read ${current_version}
 

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -74,18 +74,12 @@ _read() {
     compatibility/read.robot
 }
 
-test_bucket_encryption() {
-  _kinit
-  execute_robot_test ${container} -N "xcompat-cluster-${cluster_version}-client-${client_version}" -v SUFFIX:${client_version} security/bucket-encryption.robot
-}
-
 test_cross_compatibility() {
   echo "Starting ${cluster_version} cluster with COMPOSE_FILE=${COMPOSE_FILE}"
 
   OZONE_KEEP_RESULTS=true start_docker_env
 
   execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
-  new_client test_bucket_encryption
 
   container=scm _kinit
   execute_command_in_container scm ozone freon ockg -n1 -t1 -p warmup
@@ -94,8 +88,6 @@ test_cross_compatibility() {
 
   for client_version in "$@"; do
     client="old_client_${client_version//./_}"
-
-    old_client test_bucket_encryption
 
     old_client _write
     old_client _read ${client_version}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
@@ -27,6 +27,9 @@ ${SUFFIX}    ${EMPTY}
 Key Can Be Read
     Key Should Match Local File    /vol1/bucket1/key-${SUFFIX}    ${TESTFILE}
 
+Encrypted Key Can Be Read
+    Key Should Match Local File    /vol1/encrypted-${SUFFIX}/key    ${TESTFILE}
+
 Dir Can Be Listed
     Execute    ozone fs -ls o3fs://bucket1.vol1/dir-${SUFFIX}
 

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -24,9 +24,16 @@ Suite Setup         Create Local Test File
 
 *** Variables ***
 ${SUFFIX}    ${EMPTY}
+${KEY_NAME}  key1
 
 
 *** Test Cases ***
+Create Encrypted Bucket
+    Execute    ozone sh bucket create -k ${KEY_NAME} /vol1/encrypted-${SUFFIX}
+
+Create Key in Encrypted Bucket
+    Execute    ozone sh key put /vol1/encrypted-${SUFFIX}/key ${TESTFILE}
+
 Key Can Be Written
     Create Key    /vol1/bucket1/key-${SUFFIX}    ${TESTFILE}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`test_bucket_encryption` was added to `xcompat/test.sh` as separate step, but it can be performed as part of the existing write/read test.

Benefits:

- fewer top-level elements in Robot test report
- increase coverage by testing read with all versions

Also, remove duplicated code related to `_init`.

https://issues.apache.org/jira/browse/HDDS-11702

## How was this patch tested?

```
xcompat-cluster-2.0.0-client-1.1.0-write :: Write Compatibility               
==============================================================================
Create Encrypted Bucket                                               | PASS |
------------------------------------------------------------------------------
Create Key in Encrypted Bucket                                        | PASS |
...
xcompat-cluster-2.0.0-client-2.0.0-read-1.1.0 :: Read Compatibility           
==============================================================================
Key Can Be Read                                                       | PASS |
------------------------------------------------------------------------------
Encrypted Key Can Be Read                                             | PASS |
...
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/11882211273