### PR TITLE
HDDS-11729. Build fails with -DskipRecon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Compile Ozone using Java ${{ matrix.java }}
-        run: hadoop-ozone/dev-support/checks/build.sh -Pdist -Dskip.npx -Dskip.installnpx -Dmaven.javadoc.failOnWarnings=${{ matrix.java != 8 }} -Djavac.version=${{ matrix.java }} ${{ inputs.ratis_args }}
+        run: hadoop-ozone/dev-support/checks/build.sh -Pdist -Dskip.npx -Dskip.installnodenpm -Dmaven.javadoc.failOnWarnings=${{ matrix.java != 8 }} -Djavac.version=${{ matrix.java }} ${{ inputs.ratis_args }}
         env:
           OZONE_WITH_COVERAGE: false
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}

--- a/.github/workflows/intermittent-test-check.yml
+++ b/.github/workflows/intermittent-test-check.yml
@@ -115,7 +115,7 @@ jobs:
           java-version: 8
       - name: Build (most) of Ozone
         run: |
-          args="-Dskip.npx -Dskip.installnpx -DskipShade -Dmaven.javadoc.skip=true"
+          args="-Dskip.npx -Dskip.installnodenpm -DskipShade -Dmaven.javadoc.skip=true"
           if [[ "${{ github.event.inputs.ratis-ref }}" != "" ]]; then
             args="$args -Dratis.version=${{ needs.ratis.outputs.ratis-version }}"
             args="$args -Dratis.thirdparty.version=${{ needs.ratis.outputs.thirdparty-version }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ mvn clean verify -DskipTests
 ### Useful Maven build options
 
   * Use `-DskipShade` to skip shaded Ozone FS jar file creation. Saves time, but you can't test integration with other software that uses Ozone as a Hadoop-compatible file system.
-  * Use `-DskipRecon` to skip building Recon Web UI. It saves about 2 minutes.
+  * Use `-Dskip.installnodenpm -Dskip.npx` to skip building Recon Web UI. It saves about 2 minutes.
   * Use `-Pdist` to build the binary tarball, similar to the one that gets released
 
 ## Running Ozone in Docker

--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -24,7 +24,7 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/checkstyle"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-MAVEN_OPTIONS='-B -fae -Dskip.npx -Dskip.installnpx -Dcheckstyle.failOnViolation=false --no-transfer-progress'
+MAVEN_OPTIONS='-B -fae -Dskip.npx -Dskip.installnodenpm -Dcheckstyle.failOnViolation=false --no-transfer-progress'
 
 declare -i rc
 mvn ${MAVEN_OPTIONS} checkstyle:check > "${REPORT_DIR}/output.log"

--- a/hadoop-ozone/dev-support/checks/findbugs.sh
+++ b/hadoop-ozone/dev-support/checks/findbugs.sh
@@ -25,7 +25,7 @@ source "${DIR}/_lib.sh"
 
 install_spotbugs
 
-MAVEN_OPTIONS='-B -fae -Dskip.npx -Dskip.installnpx --no-transfer-progress'
+MAVEN_OPTIONS='-B -fae -Dskip.npx -Dskip.installnodenpm --no-transfer-progress'
 
 if [[ "${OZONE_WITH_COVERAGE}" != "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -31,7 +31,7 @@ if [[ ${ITERATIONS} -le 0 ]]; then
 fi
 
 export MAVEN_OPTS="-Xmx4096m ${MAVEN_OPTS:-}"
-MAVEN_OPTIONS="-B -V -Dskip.npx -Dskip.installnpx -Dnative.lib.tmp.dir=/tmp --no-transfer-progress"
+MAVEN_OPTIONS="-B -V -Dskip.npx -Dskip.installnodenpm -Dnative.lib.tmp.dir=/tmp --no-transfer-progress"
 
 if [[ "${OZONE_WITH_COVERAGE}" != "true" ]]; then
   MAVEN_OPTIONS="${MAVEN_OPTIONS} -Djacoco.skip"

--- a/hadoop-ozone/dev-support/checks/license.sh
+++ b/hadoop-ozone/dev-support/checks/license.sh
@@ -42,7 +42,7 @@ DEFAULT_SRC="target/generated-sources/license/THIRD-PARTY.txt"
 src="${1:-${DEFAULT_SRC}}"
 
 if [[ ! -e ${src} ]]; then
-  MAVEN_OPTIONS="-B -fae -Dskip.npx -Dskip.installnpx --no-transfer-progress ${MAVEN_OPTIONS:-}"
+  MAVEN_OPTIONS="-B -fae -Dskip.npx -Dskip.installnodenpm --no-transfer-progress ${MAVEN_OPTIONS:-}"
   mvn ${MAVEN_OPTIONS} license:aggregate-add-third-party | tee "${REPORT_DIR}/output.log"
   src="${DEFAULT_SRC}"
 fi

--- a/hadoop-ozone/dev-support/checks/sonar.sh
+++ b/hadoop-ozone/dev-support/checks/sonar.sh
@@ -24,7 +24,7 @@ if [ ! "$SONAR_TOKEN" ]; then
 fi
 
 
-mvn -V -B -DskipShade -DskipTests -Dskip.npx -Dskip.installnpx --no-transfer-progress \
+mvn -V -B -DskipShade -DskipTests -Dskip.npx -Dskip.installnodenpm --no-transfer-progress \
   -Dsonar.coverage.jacoco.xmlReportPaths="$(pwd)/target/coverage/all.xml" \
   -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=hadoop-ozone \
   verify org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -168,6 +168,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.ozone</groupId>
+      <artifactId>ozone-recon</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
       <artifactId>ozone-s3gateway</artifactId>
     </dependency>
     <dependency>
@@ -231,21 +235,6 @@
         <dependency>
           <groupId>org.apache.ozone</groupId>
           <artifactId>ozone-filesystem-hadoop3-client</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>build-with-recon</id>
-      <activation>
-        <property>
-          <name>!skipRecon</name>
-        </property>
-      </activation>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.ozone</groupId>
-          <artifactId>ozone-recon</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -38,6 +38,8 @@
     <module>ozonefs-common</module>
     <module>ozonefs</module>
     <module>datanode</module>
+    <module>recon</module>
+    <module>recon-codegen</module>
     <module>s3gateway</module>
     <module>dist</module>
     <module>csi</module>
@@ -394,18 +396,6 @@
       <modules>
         <module>ozonefs-shaded</module>
         <module>ozonefs-hadoop2</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>build-with-recon</id>
-      <activation>
-        <property>
-          <name>!skipRecon</name>
-        </property>
-      </activation>
-      <modules>
-        <module>recon</module>
-        <module>recon-codegen</module>
       </modules>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -2107,7 +2107,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <properties>
         <test>void</test>
         <skip.npx>true</skip.npx>
-        <skip.installnpx>true</skip.installnpx>
+        <skip.installnodenpm>true</skip.installnodenpm>
         <skipDocs>true</skipDocs>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.shade.skip>true</maven.shade.skip>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`mvn -DskipRecon` removes Recon from the build:

https://github.com/apache/ozone/blob/dd22dbef8958311c2ec5e99822269405d59f8eba/hadoop-ozone/pom.xml#L399-L410}

But it fails due to unconditional dependencies in `ozone-tools` and `ozone-integration-test`.

```
[INFO] --------------------< org.apache.ozone:ozone-tools >--------------------
[INFO] Building Apache Ozone Tools 2.0.0-SNAPSHOT                       [34/45]
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The POM for org.apache.ozone:ozone-recon:jar:2.0.0-SNAPSHOT is missing, no dependency information available
```

I propose to remove this profile.  It was introduced for developers to speed up compilation when not working on Recon (HDDS-2316).  We can achieve almost similar speedup by skipping just the frontend build.  Replaced instruction in CONTRIBUTING.md for that.

Also updated build scripts, replacing `skip.installnpx` with `skip.installnodenpm`.  The latter skips `install-node-and-npm` goal of `frontend-maven-plugin`:

https://github.com/eirslett/frontend-maven-plugin/blob/3f70757455b41c399baf742954a9285f93a0f774/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java#L63-L67

which we use:

https://github.com/apache/ozone/blob/2cef3935e0de763b479f5e3a1c8f72d7393974e3/hadoop-ozone/recon/pom.xml#L141

while `skip.installnpx` does nothing with the current 

https://issues.apache.org/jira/browse/HDDS-11729

## How was this patch tested?

Tested Maven options:

```
$ mvn -DskipTests -Dskip.installnodenpm -Dskip.npx clean package
...
[INFO] --- frontend-maven-plugin:1.15.1:install-node-and-npm (Install node and npm locally to the project) @ ozone-recon ---
[INFO] Skipping execution.
[INFO] 
[INFO] --- frontend-maven-plugin:1.15.1:npx (set pnpm@8.15.7 store path) @ ozone-recon ---
[INFO] Skipping execution.
[INFO] 
[INFO] --- frontend-maven-plugin:1.15.1:npx (install frontend dependencies) @ ozone-recon ---
[INFO] Skipping execution.
[INFO] 
[INFO] --- frontend-maven-plugin:1.15.1:npx (Build frontend) @ ozone-recon ---
[INFO] Skipping execution.
```

CI (includes Recon tests):
https://github.com/adoroszlai/ozone/actions/runs/11908206758