### PR TITLE
HDDS-11656. Default native ACL limits to user and user's primary group

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -171,6 +171,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.ozone.OzoneAcl.LINK_BUCKET_DEFAULT_ACL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY;
@@ -657,6 +658,12 @@ public class RpcClient implements ClientProtocol {
 
     if (bucketArgs.getAcls() != null) {
       builder.setAcls(bucketArgs.getAcls());
+    }
+
+    // Link bucket default acl
+    if (bucketArgs.getSourceVolume() != null
+        && bucketArgs.getSourceBucket() != null) {
+      builder.addAcl(LINK_BUCKET_DEFAULT_ACL);
     }
 
     if (bek != null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
@@ -27,6 +27,7 @@ import net.jcip.annotations.Immutable;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo.OzoneAclScope;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo.OzoneAclType;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.ratis.util.MemoizedSupplier;
@@ -41,8 +42,11 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.ALL;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.NONE;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE;
 
 /**
  * OzoneACL classes define bucket ACLs used in OZONE.
@@ -58,6 +62,13 @@ import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.NON
 public class OzoneAcl {
 
   private static final String ACL_SCOPE_REGEX = ".*\\[(ACCESS|DEFAULT)\\]";
+  /**
+   * Link bucket default acl defined [world::rw]
+   * which is similar to Linux POSIX symbolic.
+   */
+  public static final OzoneAcl LINK_BUCKET_DEFAULT_ACL =
+      new OzoneAcl(IAccessAuthorizer.ACLIdentityType.WORLD, "", ACCESS, READ, WRITE);
+
   private final ACLIdentityType type;
   private final String name;
   @JsonIgnore

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -40,8 +40,6 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
-import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
-import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE;
 
 /**
  * Helper class for ozone acls operations.
@@ -78,16 +76,6 @@ public final class OzoneAclUtil {
       // do nothing, since user has the permission, user can add ACL for selected groups later.
     }
     return listOfAcls;
-  }
-
-  /**
-   * Link bucket default acl defined [world::rw]
-   * which is similar to Linux POSIX symbolic.
-   *
-   * @return OzoneAclInfo
-   */
-  public static OzoneAcl linkBucketDefaultAcl() {
-    return new OzoneAcl(IAccessAuthorizer.ACLIdentityType.WORLD, "", ACCESS, READ, WRITE);
   }
 
   public static List<OzoneAcl> getAclList(UserGroupInformation ugi, ACLType userPrivilege, ACLType groupPrivilege) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -35,6 +35,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
@@ -45,6 +47,7 @@ import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentity
  * Helper class for ozone acls operations.
  */
 public final class OzoneAclUtil {
+  static final Logger LOG = LoggerFactory.getLogger(OzoneAclUtil.class);
 
   private OzoneAclUtil() {
   }
@@ -74,6 +77,7 @@ public final class OzoneAclUtil {
       listOfAcls.add(new OzoneAcl(GROUP, groupName, ACCESS, groupRights));
     } catch (IOException e) {
       // do nothing, since user has the permission, user can add ACL for selected groups later.
+      LOG.warn("Failed to get primary group from user {}", ugi);
     }
     return listOfAcls;
   }
@@ -87,6 +91,7 @@ public final class OzoneAclUtil {
       listOfAcls.add(new OzoneAcl(GROUP, groupName, ACCESS, groupPrivilege));
     } catch (IOException e) {
       // do nothing, since user has the permission, user can add ACL for selected groups later.
+      LOG.warn("Failed to get primary group from user {}", ugi);
     }
     return listOfAcls;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1652,9 +1652,12 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setKeyName(omKeyArgs.getKeyName())
         .addAllMetadata(KeyValueUtil.toProtobuf(omKeyArgs.getMetadata()))
         .setOwnerName(omKeyArgs.getOwner())
-        .addAllAcls(omKeyArgs.getAcls().stream().map(a ->
-            OzoneAcl.toProtobuf(a)).collect(Collectors.toList()))
         .addAllTags(KeyValueUtil.toProtobuf(omKeyArgs.getTags()));
+
+    if (omKeyArgs.getAcls() != null) {
+      keyArgs.addAllAcls(omKeyArgs.getAcls().stream().map(a ->
+          OzoneAcl.toProtobuf(a)).collect(Collectors.toList()));
+    }
 
     setReplicationConfig(omKeyArgs.getReplicationConfig(), keyArgs);
 
@@ -1726,10 +1729,12 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setVolumeName(omKeyArgs.getVolumeName())
         .setBucketName(omKeyArgs.getBucketName())
         .setKeyName(omKeyArgs.getKeyName())
-        .addAllAcls(omKeyArgs.getAcls().stream().map(a ->
-            OzoneAcl.toProtobuf(a)).collect(Collectors.toList()))
         .setOwnerName(omKeyArgs.getOwner())
         .setMultipartUploadID(omKeyArgs.getMultipartUploadID());
+    if (omKeyArgs.getAcls() != null) {
+      keyArgs.addAllAcls(omKeyArgs.getAcls().stream().map(a ->
+          OzoneAcl.toProtobuf(a)).collect(Collectors.toList()));
+    }
 
     multipartUploadCompleteRequest.setKeyArgs(keyArgs.build());
     multipartUploadCompleteRequest.addAllPartsList(multipartUploadList
@@ -2125,16 +2130,17 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
   @Override
   public void createDirectory(OmKeyArgs args) throws IOException {
-    KeyArgs keyArgs = KeyArgs.newBuilder()
+    KeyArgs.Builder keyArgsBuilder = KeyArgs.newBuilder()
         .setVolumeName(args.getVolumeName())
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
-        .addAllAcls(args.getAcls().stream().map(a ->
-            OzoneAcl.toProtobuf(a)).collect(Collectors.toList()))
-        .setOwnerName(args.getOwner())
-        .build();
+        .setOwnerName(args.getOwner());
+    if (args.getAcls() != null) {
+      keyArgsBuilder.addAllAcls(args.getAcls().stream().map(a ->
+          OzoneAcl.toProtobuf(a)).collect(Collectors.toList()));
+    }
     CreateDirectoryRequest request = CreateDirectoryRequest.newBuilder()
-        .setKeyArgs(keyArgs)
+        .setKeyArgs(keyArgsBuilder.build())
         .build();
 
     OMRequest omRequest = createOMRequest(Type.CreateDirectory)
@@ -2296,9 +2302,11 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setDataSize(args.getDataSize())
-        .addAllAcls(args.getAcls().stream().map(a ->
-            OzoneAcl.toProtobuf(a)).collect(Collectors.toList()))
         .setOwnerName(args.getOwner());
+    if (args.getAcls() != null) {
+      keyArgsBuilder.addAllAcls(args.getAcls().stream().map(a ->
+          OzoneAcl.toProtobuf(a)).collect(Collectors.toList()));
+    }
     if (args.getReplicationConfig() != null) {
       if (args.getReplicationConfig() instanceof ECReplicationConfig) {
         keyArgsBuilder.setEcReplicationConfig(

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAclConfig.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneAclConfig.java
@@ -23,6 +23,10 @@ import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Ozone ACL config pojo.
  * */
@@ -40,7 +44,7 @@ public class OzoneAclConfig {
   private String userDefaultRights;
 
   @Config(key = "group.rights",
-      defaultValue = "ALL",
+      defaultValue = "READ, LIST",
       type = ConfigType.STRING,
       tags = {ConfigTag.OM, ConfigTag.SECURITY},
       description = "Default group permissions set for an object in " +
@@ -48,18 +52,26 @@ public class OzoneAclConfig {
   )
   private String groupDefaultRights;
 
-  public ACLType getUserDefaultRights() {
+  public ACLType[] getUserDefaultRights() {
+    List<ACLType> types = new ArrayList();
     if (userDefaultRights == null) {
-      return ACLType.ALL;
+      types.add(ACLType.ALL);
+    } else {
+      String[] array = userDefaultRights.trim().split(",");
+      Arrays.stream(array).forEach(t -> types.add(ACLType.valueOf(t.trim())));
     }
-    return ACLType.valueOf(userDefaultRights);
+    return types.toArray(new ACLType[0]);
   }
 
-  public ACLType getGroupDefaultRights() {
+  public ACLType[] getGroupDefaultRights() {
+    List<ACLType> types = new ArrayList();
     if (groupDefaultRights == null) {
-      return ACLType.ALL;
+      types.add(ACLType.READ);
+      types.add(ACLType.LIST);
+    } else {
+      String[] array = groupDefaultRights.trim().split(",");
+      Arrays.stream(array).forEach(t -> types.add(ACLType.valueOf(t.trim())));
     }
-    return ACLType.valueOf(groupDefaultRights);
+    return types.toArray(new ACLType[0]);
   }
-
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
@@ -186,8 +186,8 @@ public class TestOzoneAclUtil {
     }
 
     OzoneAclConfig aclConfig = newInstanceOf(OzoneAclConfig.class);
-    IAccessAuthorizer.ACLType userRights = aclConfig.getUserDefaultRights();
-    IAccessAuthorizer.ACLType groupRights = aclConfig.getGroupDefaultRights();
+    IAccessAuthorizer.ACLType[] userRights = aclConfig.getUserDefaultRights();
+    IAccessAuthorizer.ACLType[] groupRights = aclConfig.getGroupDefaultRights();
 
     OzoneAclUtil.addAcl(ozoneAcls, new OzoneAcl(USER,
         ugi.getUserName(), ACCESS, userRights));

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -42,7 +42,7 @@ Create bucket with invalid bucket name
     ${result} =         Execute AWSS3APICli and checkrc         create-bucket --bucket invalid_bucket_${randStr}   255
                         Should contain          ${result}           InvalidBucketName
 
-Create new bucket and check no group ACL
+Create new bucket and check default group ACL
     ${bucket} =         Create bucket
     ${acl} =            Execute     ozone sh bucket getacl s3v/${bucket}
     ${group} =          Get Regexp Matches   ${acl}     "GROUP"
@@ -50,5 +50,6 @@ Create new bucket and check no group ACL
         ${json} =           Evaluate    json.loads('''${acl}''')    json
         # make sure this check is for group acl
         Should contain      ${json}[1][type]       GROUP
-        Should contain      ${json}[1][aclList]    NONE
+        Should contain      ${json}[1][aclList]    READ
+        Should contain      ${json}[1][aclList]    LIST
     END

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/AbstractRootedOzoneFileSystemTest.java
@@ -1207,7 +1207,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     ClientProtocol proxy = objectStore.getClientProxy();
     // Get default acl rights for user
     OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
-    ACLType userRights = aclConfig.getUserDefaultRights();
+    ACLType[] userRights = aclConfig.getUserDefaultRights();
     // Construct ACL for world access
     // ACL admin owner, world read+write
     EnumSet<ACLType> aclRights = EnumSet.of(READ, WRITE);
@@ -1310,7 +1310,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
     ClientProtocol proxy = objectStore.getClientProxy();
     // Get default acl rights for user
     OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
-    ACLType userRights = aclConfig.getUserDefaultRights();
+    ACLType[] userRights = aclConfig.getUserDefaultRights();
     // Construct ACL for world access
     OzoneAcl aclWorldAccess = new OzoneAcl(ACLIdentityType.WORLD, "",
         ACCESS, userRights);
@@ -2311,7 +2311,7 @@ abstract class AbstractRootedOzoneFileSystemTest {
 
     // Get default acl rights for user
     OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
-    ACLType userRights = aclConfig.getUserDefaultRights();
+    ACLType[] userRights = aclConfig.getUserDefaultRights();
     // Construct ACL for world access
     OzoneAcl aclWorldAccess = new OzoneAcl(ACLIdentityType.WORLD, "",
         ACCESS, userRights);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -3980,14 +3980,12 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     //User ACL
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
-    ACLType userRights = aclConfig.getUserDefaultRights();
-    ACLType groupRights = aclConfig.getGroupDefaultRights();
+    ACLType[] userRights = aclConfig.getUserDefaultRights();
+    ACLType[] groupRights = aclConfig.getGroupDefaultRights();
 
-    listOfAcls.add(new OzoneAcl(USER, ugi.getUserName(), ACCESS, userRights));
-    //Group ACLs of the User
-    List<String> userGroups = Arrays.asList(ugi.getGroupNames());
-    userGroups.stream().forEach((group) -> listOfAcls.add(
-        new OzoneAcl(GROUP, group, ACCESS, groupRights)));
+    listOfAcls.add(new OzoneAcl(USER, ugi.getShortUserName(), ACCESS, userRights));
+    //Group ACL of the User
+    listOfAcls.add(new OzoneAcl(GROUP, ugi.getPrimaryGroupName(), ACCESS, groupRights));
     return listOfAcls;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/OzoneRpcClientTests.java
@@ -172,6 +172,8 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NO_S
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PARTIAL_RENAME;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.ALL;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.LIST;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
 
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE;
@@ -394,10 +396,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           .setVolumeName(volumeName).setBucketName(bucketName)
           .setStoreType(OzoneObj.StoreType.OZONE)
           .setResType(OzoneObj.ResourceType.BUCKET).build();
-      store.addAcl(volumeObj, new OzoneAcl(USER, "user1", ACCESS, ACLType.ALL));
-      store.addAcl(volumeObj, new OzoneAcl(USER, "user2", ACCESS, ACLType.ALL));
-      store.addAcl(bucketObj, new OzoneAcl(USER, "user1", ACCESS, ACLType.ALL));
-      store.addAcl(bucketObj, new OzoneAcl(USER, "user2", ACCESS, ACLType.ALL));
+      store.addAcl(volumeObj, new OzoneAcl(USER, "user1", ACCESS, ALL));
+      store.addAcl(volumeObj, new OzoneAcl(USER, "user2", ACCESS, ALL));
+      store.addAcl(bucketObj, new OzoneAcl(USER, "user1", ACCESS, ALL));
+      store.addAcl(bucketObj, new OzoneAcl(USER, "user2", ACCESS, ALL));
 
       createKeyForUser(volumeName, bucketName, key1, content, user1);
       createKeyForUser(volumeName, bucketName, key2, content, user2);
@@ -779,7 +781,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneAcl userAcl = new OzoneAcl(USER, "test",
-        ACCESS, ACLType.ALL);
+        ACCESS, ALL);
     ReplicationConfig repConfig = new ECReplicationConfig(3, 2);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
@@ -818,7 +820,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     List<OzoneAcl> acls = new ArrayList<>();
-    acls.add(new OzoneAcl(USER, "test", ACCESS, ACLType.ALL));
+    acls.add(new OzoneAcl(USER, "test", ACCESS, ALL));
     OzoneBucket bucket = volume.getBucket(bucketName);
     for (OzoneAcl acl : acls) {
       assertTrue(bucket.addAcl(acl));
@@ -834,7 +836,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneAcl userAcl = new OzoneAcl(USER, "test",
-        ACCESS, ACLType.ALL);
+        ACCESS, ALL);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     BucketArgs.Builder builder = BucketArgs.newBuilder()
@@ -853,9 +855,9 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneAcl userAcl = new OzoneAcl(USER, "test",
-        ACCESS, ACLType.ALL);
+        ACCESS, ALL);
     OzoneAcl acl2 = new OzoneAcl(USER, "test1",
-        ACCESS, ACLType.ALL);
+        ACCESS, ALL);
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     BucketArgs.Builder builder = BucketArgs.newBuilder()
@@ -911,6 +913,64 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     List<OzoneAcl> aclsAfterSet = newBucket.getAcls();
     assertEquals(currentAcls, aclsAfterSet);
 
+  }
+
+  @Test
+  public void testAclDeDuplication()
+      throws IOException {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneAcl userAcl1 = new OzoneAcl(USER, "test", DEFAULT, READ);
+    UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
+    OzoneAcl currentUserAcl = new OzoneAcl(USER, currentUser.getShortUserName(), ACCESS, ALL);
+    OzoneAcl currentUserPrimaryGroupAcl = new OzoneAcl(GROUP, currentUser.getPrimaryGroupName(), ACCESS, READ, LIST);
+    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
+        .setOwner(currentUser.getShortUserName())
+        .setAdmin(currentUser.getShortUserName())
+        .addAcl(userAcl1)
+        .addAcl(currentUserAcl)
+        .addAcl(currentUserPrimaryGroupAcl)
+        .build();
+
+    store.createVolume(volumeName, createVolumeArgs);
+    OzoneVolume volume = store.getVolume(volumeName);
+    List<OzoneAcl> volumeAcls = volume.getAcls();
+    assertEquals(3, volumeAcls.size());
+    assertTrue(volumeAcls.contains(userAcl1));
+    assertTrue(volumeAcls.contains(currentUserAcl));
+    assertTrue(volumeAcls.contains(currentUserPrimaryGroupAcl));
+
+    // normal bucket
+    BucketArgs.Builder builder = BucketArgs.newBuilder()
+        .addAcl(currentUserAcl).addAcl(currentUserPrimaryGroupAcl);
+    volume.createBucket(bucketName, builder.build());
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    List<OzoneAcl> bucketAcls = bucket.getAcls();
+    assertEquals(bucketName, bucket.getName());
+    assertEquals(3, bucketAcls.size());
+    assertTrue(bucketAcls.contains(currentUserAcl));
+    assertTrue(bucketAcls.contains(currentUserPrimaryGroupAcl));
+    assertTrue(bucketAcls.get(2).getName().equals(userAcl1.getName()));
+    assertTrue(bucketAcls.get(2).getAclList().equals(userAcl1.getAclList()));
+    assertTrue(bucketAcls.get(2).getAclScope().equals(ACCESS));
+
+    // link bucket
+    OzoneAcl userAcl2 = new OzoneAcl(USER, "test-link", DEFAULT, READ);
+    String linkBucketName =  "link-" + bucketName;
+    builder = BucketArgs.newBuilder().setSourceVolume(volumeName).setSourceBucket(bucketName)
+        .addAcl(currentUserAcl).addAcl(currentUserPrimaryGroupAcl).addAcl(userAcl2);
+    volume.createBucket(linkBucketName, builder.build());
+    OzoneBucket linkBucket = volume.getBucket(linkBucketName);
+    List<OzoneAcl> linkBucketAcls = linkBucket.getAcls();
+    assertEquals(linkBucketName, linkBucket.getName());
+    assertEquals(5, linkBucketAcls.size());
+    assertTrue(linkBucketAcls.contains(currentUserAcl));
+    assertTrue(linkBucketAcls.contains(currentUserPrimaryGroupAcl));
+    assertTrue(linkBucketAcls.contains(userAcl2));
+    assertTrue(linkBucketAcls.contains(OzoneAcl.LINK_BUCKET_DEFAULT_ACL));
+    assertTrue(linkBucketAcls.get(4).getName().equals(userAcl1.getName()));
+    assertTrue(linkBucketAcls.get(4).getAclList().equals(userAcl1.getAclList()));
+    assertTrue(linkBucketAcls.get(4).getAclScope().equals(ACCESS));
   }
 
   @Test
@@ -3029,10 +3089,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneBucket bucket = volume.getBucket(bucketName);
 
     // Add ACL on Bucket
-    OzoneAcl acl1 = new OzoneAcl(USER, "Monday", DEFAULT, ACLType.ALL);
-    OzoneAcl acl2 = new OzoneAcl(USER, "Friday", DEFAULT, ACLType.ALL);
-    OzoneAcl acl3 = new OzoneAcl(USER, "Jan", ACCESS, ACLType.ALL);
-    OzoneAcl acl4 = new OzoneAcl(USER, "Feb", ACCESS, ACLType.ALL);
+    OzoneAcl acl1 = new OzoneAcl(USER, "Monday", DEFAULT, ALL);
+    OzoneAcl acl2 = new OzoneAcl(USER, "Friday", DEFAULT, ALL);
+    OzoneAcl acl3 = new OzoneAcl(USER, "Jan", ACCESS, ALL);
+    OzoneAcl acl4 = new OzoneAcl(USER, "Feb", ACCESS, ALL);
     bucket.addAcl(acl1);
     bucket.addAcl(acl2);
     bucket.addAcl(acl3);
@@ -3203,10 +3263,10 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
           .setVolumeName(volumeName).setBucketName(bucketName)
           .setStoreType(OzoneObj.StoreType.OZONE)
           .setResType(OzoneObj.ResourceType.BUCKET).build();
-      store.addAcl(volumeObj, new OzoneAcl(USER, "user1", ACCESS, ACLType.ALL));
-      store.addAcl(volumeObj, new OzoneAcl(USER, "awsUser1", ACCESS, ACLType.ALL));
-      store.addAcl(bucketObj, new OzoneAcl(USER, "user1", ACCESS, ACLType.ALL));
-      store.addAcl(bucketObj, new OzoneAcl(USER, "awsUser1", ACCESS, ACLType.ALL));
+      store.addAcl(volumeObj, new OzoneAcl(USER, "user1", ACCESS, ALL));
+      store.addAcl(volumeObj, new OzoneAcl(USER, "awsUser1", ACCESS, ALL));
+      store.addAcl(bucketObj, new OzoneAcl(USER, "user1", ACCESS, ALL));
+      store.addAcl(bucketObj, new OzoneAcl(USER, "awsUser1", ACCESS, ALL));
 
       // user1 MultipartUpload a key
       UserGroupInformation.setLoginUser(user1);
@@ -3943,7 +4003,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     aclsGet = store.getAcl(prefixObj);
     assertEquals(0, aclsGet.size());
 
-    OzoneAcl group1Acl = new OzoneAcl(GROUP, "group1", ACCESS, ACLType.ALL);
+    OzoneAcl group1Acl = new OzoneAcl(GROUP, "group1", ACCESS, ALL);
     List<OzoneAcl> acls = new ArrayList<>();
     acls.add(user1Acl);
     acls.add(group1Acl);
@@ -4054,7 +4114,7 @@ abstract class OzoneRpcClientTests extends OzoneTestBase {
     OzoneAcl ua = new OzoneAcl(USER, "userx",
         ACCESS, ACLType.READ_ACL);
     OzoneAcl ug = new OzoneAcl(GROUP, "userx",
-        ACCESS, ACLType.ALL);
+        ACCESS, ALL);
     store.setAcl(ozObj, Arrays.asList(ua, ug));
     newAcls = store.getAcl(ozObj);
     assertEquals(2, newAcls.size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,9 @@ public class TestBucketLayoutWithOlderClient {
                             OzoneManagerProtocolProtos.StorageTypeProto.DISK)
                             .build())
                     .build()).build();
+    createBucketReq = createBucketReq.toBuilder()
+        .setUserInfo(OzoneManagerProtocolProtos.UserInfo.newBuilder()
+            .setUserName(UserGroupInformation.getCurrentUser().getShortUserName()).build()).build();
 
     OzoneManagerProtocolProtos.OMResponse
         omResponse = cluster.getOzoneManager().getOmServerProtocol()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -337,8 +337,7 @@ public class TestKeyManagerImpl {
         .setKeyName(KEY_NAME)
         .setDataSize(1000)
         .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
-        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
-            ALL, ALL))
+        .setAcls(OzoneAclUtil.getAclList(ugi, ALL, ALL))
         .build();
     OMException omException = assertThrows(OMException.class,
         () -> writeClient.openKey(keyArgs));
@@ -1695,8 +1694,7 @@ public class TestKeyManagerImpl {
         .setDataSize(0)
         .setReplicationConfig(
             StandaloneReplicationConfig.getInstance(ONE))
-        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
-            ALL, ALL))
+        .setAcls(OzoneAclUtil.getAclList(ugi, ALL, ALL))
         .setVolumeName(VOLUME_NAME)
         .setOwnerName(ugi.getShortUserName());
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -381,7 +381,6 @@ public abstract class OMClientRequest implements RequestAuditor {
    */
   @VisibleForTesting
   public UserGroupInformation createUGI() throws AuthenticationException {
-
     if (userGroupInformation != null) {
       return userGroupInformation;
     }
@@ -411,6 +410,11 @@ public abstract class OMClientRequest implements RequestAuditor {
       throw new OMException(e, UNAUTHORIZED);
     }
     return ugi;
+  }
+
+  @VisibleForTesting
+  public void setUGI(UserGroupInformation ugi) {
+    this.userGroupInformation = ugi;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -69,10 +69,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.apache.hadoop.ozone.OzoneAcl.LINK_BUCKET_DEFAULT_ACL;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.helpers.OzoneAclUtil.getDefaultAclList;
-import static org.apache.hadoop.ozone.om.helpers.OzoneAclUtil.linkBucketDefaultAcl;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 
@@ -335,7 +335,7 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
     // Link bucket default acl
     if (omBucketInfo.getSourceBucket() != null && omBucketInfo.getSourceVolume() != null) {
-      acls.add(linkBucketDefaultAcl());
+      acls.add(LINK_BUCKET_DEFAULT_ACL);
     }
 
     // Add default acls from volume.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -325,14 +325,14 @@ public class OMBucketCreateRequest extends OMClientRequest {
    */
   private void addDefaultAcls(OmBucketInfo omBucketInfo,
       OmVolumeArgs omVolumeArgs, OzoneManager ozoneManager) throws OMException {
-    // Add acls for bucket creator.
     List<OzoneAcl> acls = new ArrayList<>();
+    // Add default acls
+    acls.addAll(getDefaultAclList(createUGIForApi(), ozoneManager.getConfiguration()));
     if (omBucketInfo.getAcls() != null) {
+      // Add acls for bucket creator.
       acls.addAll(omBucketInfo.getAcls());
     }
 
-    // Add default acls
-    acls.addAll(getDefaultAclList(createUGIForApi(), ozoneManager.getConfiguration()));
     // Link bucket default acl
     if (omBucketInfo.getSourceBucket() != null && omBucketInfo.getSourceVolume() != null) {
       acls.add(linkBucketDefaultAcl());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -69,7 +69,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
-import static org.apache.hadoop.ozone.OzoneAcl.LINK_BUCKET_DEFAULT_ACL;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.helpers.OzoneAclUtil.getDefaultAclList;
@@ -331,11 +330,6 @@ public class OMBucketCreateRequest extends OMClientRequest {
     if (omBucketInfo.getAcls() != null) {
       // Add acls for bucket creator.
       acls.addAll(omBucketInfo.getAcls());
-    }
-
-    // Link bucket default acl
-    if (omBucketInfo.getSourceBucket() != null && omBucketInfo.getSourceVolume() != null) {
-      acls.add(LINK_BUCKET_DEFAULT_ACL);
     }
 
     // Add default acls from volume.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -188,7 +188,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
         OmBucketInfo omBucketInfo =
             getBucketInfo(omMetadataManager, volumeName, bucketName);
 
-        dirKeyInfo = createDirectoryKeyInfoWithNoACL(keyName, keyArgs, baseObjId,
+        dirKeyInfo = createDirectoryKeyInfoWithACL(keyName, keyArgs, baseObjId,
             omBucketInfo, omPathInfo, trxnLogIndex,
             ozoneManager.getDefaultReplicationConfig(), ozoneManager.getConfiguration());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -22,18 +22,11 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.ratis.server.protocol.TermIndex;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -73,7 +66,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
@@ -87,11 +79,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoryCreateRequest.class);
-
-  // The maximum number of directories which can be created through a single
-  // transaction (recursive directory creations) is 2^8 - 1 as only 8
-  // bits are set aside for this in ObjectID.
-  private static final long MAX_NUM_OF_RECURSIVE_DIRS = 255;
 
   /**
    * Stores the result of request execution in
@@ -201,9 +188,9 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
         OmBucketInfo omBucketInfo =
             getBucketInfo(omMetadataManager, volumeName, bucketName);
 
-        dirKeyInfo = createDirectoryKeyInfoWithACL(keyName, keyArgs, baseObjId,
+        dirKeyInfo = createDirectoryKeyInfoWithNoACL(keyName, keyArgs, baseObjId,
             omBucketInfo, omPathInfo, trxnLogIndex,
-            ozoneManager.getDefaultReplicationConfig());
+            ozoneManager.getDefaultReplicationConfig(), ozoneManager.getConfiguration());
 
         missingParentInfos = getAllParentInfo(ozoneManager, keyArgs,
             missingParents, omBucketInfo, omPathInfo, trxnLogIndex);
@@ -250,58 +237,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     return omClientResponse;
   }
 
-  /**
-   * Construct OmKeyInfo for every parent directory in missing list.
-   * @param ozoneManager
-   * @param keyArgs
-   * @param missingParents list of parent directories to be created
-   * @param bucketInfo
-   * @param omPathInfo
-   * @param trxnLogIndex
-   * @return {@code List<OmKeyInfo>}
-   * @throws IOException
-   */
-  public static List<OmKeyInfo> getAllParentInfo(OzoneManager ozoneManager,
-      KeyArgs keyArgs, List<String> missingParents, OmBucketInfo bucketInfo,
-      OMFileRequest.OMPathInfo omPathInfo, long trxnLogIndex)
-      throws IOException {
-    List<OmKeyInfo> missingParentInfos = new ArrayList<>();
-
-    // The base id is left shifted by 8 bits for creating space to
-    // create (2^8 - 1) object ids in every request.
-    // maxObjId represents the largest object id allocation possible inside
-    // the transaction.
-    long baseObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
-    long maxObjId = baseObjId + MAX_NUM_OF_RECURSIVE_DIRS;
-    long objectCount = 1; // baseObjID is used by the leaf directory
-
-    String volumeName = keyArgs.getVolumeName();
-    String bucketName = keyArgs.getBucketName();
-    String keyName = keyArgs.getKeyName();
-
-    for (String missingKey : missingParents) {
-      long nextObjId = baseObjId + objectCount;
-      if (nextObjId > maxObjId) {
-        throw new OMException("Too many directories in path. Exceeds limit of "
-            + MAX_NUM_OF_RECURSIVE_DIRS + ". Unable to create directory: "
-            + keyName + " in volume/bucket: " + volumeName + "/" + bucketName,
-            INVALID_KEY_NAME);
-      }
-
-      LOG.debug("missing parent {} getting added to KeyTable", missingKey);
-
-      OmKeyInfo parentKeyInfo =
-          createDirectoryKeyInfoWithACL(missingKey, keyArgs, nextObjId,
-              bucketInfo, omPathInfo, trxnLogIndex,
-              ozoneManager.getDefaultReplicationConfig());
-      objectCount++;
-
-      missingParentInfos.add(parentKeyInfo);
-    }
-
-    return missingParentInfos;
-  }
-
   private void logResult(CreateDirectoryRequest createDirectoryRequest,
       KeyArgs keyArgs, OMMetrics omMetrics, Result result,
       Exception exception, int numMissingParents) {
@@ -334,69 +269,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       LOG.error("Unrecognized Result for OMDirectoryCreateRequest: {}",
           createDirectoryRequest);
     }
-  }
-
-  /**
-   * fill in a KeyInfo for a new directory entry in OM database.
-   * without initializing ACLs from the KeyArgs - used for intermediate
-   * directories which get created internally/recursively during file
-   * and directory create.
-   * @param keyName
-   * @param keyArgs
-   * @param objectId
-   * @param bucketInfo
-   * @param omPathInfo
-   * @param transactionIndex
-   * @param serverDefaultReplConfig
-   * @return the OmKeyInfo structure
-   */
-  public static OmKeyInfo createDirectoryKeyInfoWithACL(String keyName,
-      KeyArgs keyArgs, long objectId, OmBucketInfo bucketInfo,
-      OMFileRequest.OMPathInfo omPathInfo, long transactionIndex,
-      ReplicationConfig serverDefaultReplConfig) {
-    return dirKeyInfoBuilderNoACL(keyName, keyArgs, objectId,
-        serverDefaultReplConfig)
-        .setAcls(getAclsForDir(keyArgs, bucketInfo, omPathInfo))
-        .setUpdateID(transactionIndex).build();
-  }
-
-  private static OmKeyInfo.Builder dirKeyInfoBuilderNoACL(String keyName,
-      KeyArgs keyArgs, long objectId,
-      ReplicationConfig serverDefaultReplConfig) {
-    String dirName = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
-
-    OmKeyInfo.Builder keyInfoBuilder =
-        new OmKeyInfo.Builder()
-            .setVolumeName(keyArgs.getVolumeName())
-            .setBucketName(keyArgs.getBucketName())
-            .setKeyName(dirName)
-            .setOwnerName(keyArgs.getOwnerName())
-            .setOmKeyLocationInfos(Collections.singletonList(
-                new OmKeyLocationInfoGroup(0, new ArrayList<>())))
-            .setCreationTime(keyArgs.getModificationTime())
-            .setModificationTime(keyArgs.getModificationTime())
-            .setDataSize(0);
-    if (keyArgs.getFactor() != null && keyArgs
-        .getFactor() != HddsProtos.ReplicationFactor.ZERO && keyArgs
-        .getType() != HddsProtos.ReplicationType.EC) {
-      // Factor available and not an EC replication config.
-      keyInfoBuilder.setReplicationConfig(ReplicationConfig
-          .fromProtoTypeAndFactor(keyArgs.getType(), keyArgs.getFactor()));
-    } else if (keyArgs.getType() == HddsProtos.ReplicationType.EC) {
-      // Found EC type
-      keyInfoBuilder.setReplicationConfig(
-          new ECReplicationConfig(keyArgs.getEcReplicationConfig()));
-    } else {
-      // default type
-      keyInfoBuilder.setReplicationConfig(serverDefaultReplConfig);
-    }
-
-    keyInfoBuilder.setObjectID(objectId);
-    return keyInfoBuilder;
-  }
-
-  static long getMaxNumOfRecursiveDirs() {
-    return MAX_NUM_OF_RECURSIVE_DIRS;
   }
 
   @RequestFeatureValidator(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -51,12 +51,10 @@ import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS;
@@ -145,8 +143,7 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
         OmBucketInfo omBucketInfo =
             getBucketInfo(omMetadataManager, volumeName, bucketName);
         // prepare all missing parents
-        missingParentInfos =
-            OMDirectoryCreateRequestWithFSO.getAllMissingParentDirInfo(
+        missingParentInfos = getAllMissingParentDirInfo(
                 ozoneManager, keyArgs, omBucketInfo, omPathInfo, trxnLogIndex);
 
         final long volumeId = omMetadataManager.getVolumeId(volumeName);
@@ -163,7 +160,7 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
             omPathInfo.getLeafNodeName(),
             keyArgs, omPathInfo.getLeafNodeObjectId(),
             omPathInfo.getLastKnownParentId(), trxnLogIndex,
-            omBucketInfo, omPathInfo);
+            omBucketInfo, omPathInfo, ozoneManager.getConfiguration());
         OMFileRequest.addDirectoryTableCacheEntries(omMetadataManager,
             volumeId, bucketId, trxnLogIndex,
             missingParentInfos, dirInfo);
@@ -234,87 +231,5 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
       LOG.error("Unrecognized Result for OMDirectoryCreateRequest: {}",
           createDirectoryRequest);
     }
-  }
-
-  /**
-   * Construct OmDirectoryInfo for every parent directory in missing list.
-   *
-   * @param keyArgs      key arguments
-   * @param pathInfo     list of parent directories to be created and its ACLs
-   * @param trxnLogIndex transaction log index id
-   * @return list of missing parent directories
-   * @throws IOException DB failure
-   */
-  public static List<OmDirectoryInfo> getAllMissingParentDirInfo(
-      OzoneManager ozoneManager, KeyArgs keyArgs, OmBucketInfo bucketInfo,
-      OMFileRequest.OMPathInfoWithFSO pathInfo, long trxnLogIndex)
-      throws IOException {
-    List<OmDirectoryInfo> missingParentInfos = new ArrayList<>();
-
-    // The base id is left shifted by 8 bits for creating space to
-    // create (2^8 - 1) object ids in every request.
-    // maxObjId represents the largest object id allocation possible inside
-    // the transaction.
-    long baseObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
-    long maxObjId = baseObjId + getMaxNumOfRecursiveDirs();
-    long objectCount = 1;
-
-    String volumeName = keyArgs.getVolumeName();
-    String bucketName = keyArgs.getBucketName();
-    String keyName = keyArgs.getKeyName();
-
-    long lastKnownParentId = pathInfo.getLastKnownParentId();
-    List<String> missingParents = pathInfo.getMissingParents();
-    for (String missingKey : missingParents) {
-      long nextObjId = baseObjId + objectCount;
-      if (nextObjId > maxObjId) {
-        throw new OMException("Too many directories in path. Exceeds limit of "
-            + getMaxNumOfRecursiveDirs() + ". Unable to create directory: "
-            + keyName + " in volume/bucket: " + volumeName + "/" + bucketName,
-            INVALID_KEY_NAME);
-      }
-
-      LOG.debug("missing parent {} getting added to DirectoryTable",
-              missingKey);
-      OmDirectoryInfo dirInfo = createDirectoryInfoWithACL(missingKey,
-          keyArgs, nextObjId, lastKnownParentId, trxnLogIndex,
-          bucketInfo, pathInfo);
-      objectCount++;
-
-      missingParentInfos.add(dirInfo);
-
-      // updating id for the next sub-dir
-      lastKnownParentId = nextObjId;
-    }
-    pathInfo.setLastKnownParentId(lastKnownParentId);
-    pathInfo.setLeafNodeObjectId(baseObjId + objectCount);
-    return missingParentInfos;
-  }
-
-  /**
-   * Fill in a DirectoryInfo for a new directory entry in OM database.
-   * @param dirName
-   * @param keyArgs
-   * @param objectId
-   * @param parentObjectId
-   * @param bucketInfo
-   * @param omPathInfo
-   * @return the OmDirectoryInfo structure
-   */
-  private static OmDirectoryInfo createDirectoryInfoWithACL(
-      String dirName, KeyArgs keyArgs, long objectId,
-      long parentObjectId, long transactionIndex,
-      OmBucketInfo bucketInfo, OMFileRequest.OMPathInfo omPathInfo) {
-
-    return OmDirectoryInfo.newBuilder()
-        .setName(dirName)
-        .setOwner(keyArgs.getOwnerName())
-        .setCreationTime(keyArgs.getModificationTime())
-        .setModificationTime(keyArgs.getModificationTime())
-        .setObjectID(objectId)
-        .setUpdateID(transactionIndex)
-        .setParentObjectID(parentObjectId)
-        .setAcls(getAclsForDir(keyArgs, bucketInfo, omPathInfo))
-        .build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -247,7 +247,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
           keyArgs.getDataSize(), locations, getFileEncryptionInfo(keyArgs),
           ozoneManager.getPrefixManager(), omBucketInfo, pathInfo, trxnLogIndex,
           ozoneManager.getObjectIdFromTxId(trxnLogIndex),
-          ozoneManager.isRatisEnabled(), repConfig);
+          ozoneManager.isRatisEnabled(), repConfig, ozoneManager.getConfiguration());
       validateEncryptionKeyInfo(omBucketInfo, keyArgs);
 
       long openVersion = omKeyInfo.getLatestVersionLocations().getVersion();
@@ -255,8 +255,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
       String dbOpenKeyName = omMetadataManager.getOpenKey(volumeName,
           bucketName, keyName, clientID);
 
-      missingParentInfos = OMDirectoryCreateRequest
-          .getAllParentInfo(ozoneManager, keyArgs,
+      missingParentInfos = getAllParentInfo(ozoneManager, keyArgs,
               pathInfo.getMissingParents(), omBucketInfo,
               pathInfo, trxnLogIndex);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -153,9 +153,8 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
           omMetadataManager.getBucketKey(volumeName, bucketName));
       // add all missing parents to dir table
 
-      missingParentInfos =
-          OMDirectoryCreateRequestWithFSO.getAllMissingParentDirInfo(
-              ozoneManager, keyArgs, bucketInfo, pathInfoFSO, trxnLogIndex);
+      missingParentInfos = getAllMissingParentDirInfo(
+          ozoneManager, keyArgs, bucketInfo, pathInfoFSO, trxnLogIndex);
 
       // total number of keys created.
       numKeysCreated = missingParentInfos.size();
@@ -171,7 +170,7 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
               getFileEncryptionInfo(keyArgs), ozoneManager.getPrefixManager(),
               bucketInfo, pathInfoFSO, trxnLogIndex,
               pathInfoFSO.getLeafNodeObjectId(),
-              ozoneManager.isRatisEnabled(), repConfig);
+              ozoneManager.isRatisEnabled(), repConfig, ozoneManager.getConfiguration());
       validateEncryptionKeyInfo(bucketInfo, keyArgs);
 
       long openVersion = omFileInfo.getLatestVersionLocations().getVersion();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.om.OzoneConfigUtil;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.lock.OzoneLockStrategy;
-import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequest;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
@@ -261,9 +260,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
                 " as there is already file in the given path", NOT_A_FILE);
           }
 
-        missingParentInfos = OMDirectoryCreateRequest
-            .getAllParentInfo(ozoneManager, keyArgs,
-                pathInfo.getMissingParents(), bucketInfo,
+        missingParentInfos = getAllParentInfo(ozoneManager, keyArgs,
+            pathInfo.getMissingParents(), bucketInfo,
                 pathInfo, trxnLogIndex);
 
         numMissingParents = missingParentInfos.size();
@@ -279,7 +277,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           keyArgs.getDataSize(), locations, getFileEncryptionInfo(keyArgs),
           ozoneManager.getPrefixManager(), bucketInfo, pathInfo, trxnLogIndex,
           ozoneManager.getObjectIdFromTxId(trxnLogIndex),
-          ozoneManager.isRatisEnabled(), replicationConfig);
+          ozoneManager.isRatisEnabled(), replicationConfig, ozoneManager.getConfiguration());
 
       validateEncryptionKeyInfo(bucketInfo, keyArgs);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -138,9 +137,8 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
               omMetadataManager.getBucketKey(volumeName, bucketName));
 
       // add all missing parents to dir table
-      missingParentInfos =
-          OMDirectoryCreateRequestWithFSO.getAllMissingParentDirInfo(
-              ozoneManager, keyArgs, bucketInfo, pathInfoFSO, trxnLogIndex);
+      missingParentInfos = getAllMissingParentDirInfo(
+          ozoneManager, keyArgs, bucketInfo, pathInfoFSO, trxnLogIndex);
 
       // total number of keys created.
       numKeysCreated = missingParentInfos.size();
@@ -156,7 +154,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
               getFileEncryptionInfo(keyArgs), ozoneManager.getPrefixManager(),
               bucketInfo, pathInfoFSO, trxnLogIndex,
               pathInfoFSO.getLeafNodeObjectId(),
-              ozoneManager.isRatisEnabled(), repConfig);
+              ozoneManager.isRatisEnabled(), repConfig, ozoneManager.getConfiguration());
 
       validateEncryptionKeyInfo(bucketInfo, keyArgs);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -416,11 +416,10 @@ public abstract class OMKeyRequest extends OMClientRequest {
       PrefixManager prefixManager, OzoneConfiguration config) throws OMException {
 
     List<OzoneAcl> acls = new ArrayList<>();
+    acls.addAll(getDefaultAclList(createUGIForApi(), config));
     if (keyArgs.getAclsList() != null) {
       acls.addAll(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()));
     }
-
-    acls.addAll(getDefaultAclList(createUGIForApi(), config));
 
     // Inherit DEFAULT acls from prefix.
     if (prefixManager != null) {
@@ -477,6 +476,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
       OMFileRequest.OMPathInfo omPathInfo, OzoneConfiguration config) throws OMException {
     // Acls inherited from parent or bucket will convert to DEFAULT scope
     List<OzoneAcl> acls = new ArrayList<>();
+    // add default ACLs
+    acls.addAll(getDefaultAclList(createUGIForApi(), config));
 
     // Inherit DEFAULT acls from parent-dir
     if (omPathInfo != null) {
@@ -491,7 +492,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
 
     // add acls from clients
     acls.addAll(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()));
-    acls.addAll(getDefaultAclList(createUGIForApi(), config));
     acls = acls.stream().distinct().collect(Collectors.toList());
     return acls;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -496,10 +496,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
     return acls;
   }
 
-  static long getMaxNumOfRecursiveDirs() {
-    return MAX_NUM_OF_RECURSIVE_DIRS;
-  }
-
   /**
    * Construct OmDirectoryInfo for every parent directory in missing list.
    *
@@ -520,7 +516,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // maxObjId represents the largest object id allocation possible inside
     // the transaction.
     long baseObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
-    long maxObjId = baseObjId + getMaxNumOfRecursiveDirs();
+    long maxObjId = baseObjId + MAX_NUM_OF_RECURSIVE_DIRS;
     long objectCount = 1;
 
     String volumeName = keyArgs.getVolumeName();
@@ -533,7 +529,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       long nextObjId = baseObjId + objectCount;
       if (nextObjId > maxObjId) {
         throw new OMException("Too many directories in path. Exceeds limit of "
-            + getMaxNumOfRecursiveDirs() + ". Unable to create directory: "
+            + MAX_NUM_OF_RECURSIVE_DIRS + ". Unable to create directory: "
             + keyName + " in volume/bucket: " + volumeName + "/" + bucketName,
             INVALID_KEY_NAME);
       }
@@ -596,7 +592,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       LOG.debug("missing parent {} getting added to KeyTable", missingKey);
 
       OmKeyInfo parentKeyInfo =
-          createDirectoryKeyInfoWithNoACL(missingKey, keyArgs, nextObjId,
+          createDirectoryKeyInfoWithACL(missingKey, keyArgs, nextObjId,
               bucketInfo, omPathInfo, trxnLogIndex,
               ozoneManager.getDefaultReplicationConfig(), ozoneManager.getConfiguration());
       objectCount++;
@@ -615,6 +611,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * @param parentObjectId
    * @param bucketInfo
    * @param omPathInfo
+   * @param config
    * @return the OmDirectoryInfo structure
    */
   @SuppressWarnings("parameternumber")
@@ -646,10 +643,11 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * @param omPathInfo
    * @param transactionIndex
    * @param serverDefaultReplConfig
+   * @param config
    * @return the OmKeyInfo structure
    */
   @SuppressWarnings("parameternumber")
-  protected OmKeyInfo createDirectoryKeyInfoWithNoACL(String keyName,
+  protected OmKeyInfo createDirectoryKeyInfoWithACL(String keyName,
       KeyArgs keyArgs, long objectId, OmBucketInfo bucketInfo,
       OMFileRequest.OMPathInfo omPathInfo, long transactionIndex,
       ReplicationConfig serverDefaultReplConfig, OzoneConfiguration config) throws OMException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -39,6 +39,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OmUtils;
@@ -52,12 +54,14 @@ import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.lock.OzoneLockStrategy;
@@ -99,9 +103,11 @@ import static org.apache.hadoop.ozone.OzoneConsts.OBJECT_ID_RECLAIM_BLOCKS;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
     .BUCKET_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
     .VOLUME_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.helpers.OzoneAclUtil.getDefaultAclList;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.util.Time.monotonicNow;
 
@@ -109,6 +115,11 @@ import static org.apache.hadoop.util.Time.monotonicNow;
  * Interface for key write requests.
  */
 public abstract class OMKeyRequest extends OMClientRequest {
+
+  // The maximum number of directories which can be created through a single
+  // transaction (recursive directory creations) is 2^8 - 1 as only 8
+  // bits are set aside for this in ObjectID.
+  private static final long MAX_NUM_OF_RECURSIVE_DIRS = 255;
 
   @VisibleForTesting
   public static final Logger LOG = LoggerFactory.getLogger(OMKeyRequest.class);
@@ -400,14 +411,16 @@ public abstract class OMKeyRequest extends OMClientRequest {
     return edek;
   }
 
-  protected List< OzoneAcl > getAclsForKey(KeyArgs keyArgs,
+  protected List<OzoneAcl> getAclsForKey(KeyArgs keyArgs,
       OmBucketInfo bucketInfo, OMFileRequest.OMPathInfo omPathInfo,
-      PrefixManager prefixManager) {
+      PrefixManager prefixManager, OzoneConfiguration config) throws OMException {
 
     List<OzoneAcl> acls = new ArrayList<>();
     if (keyArgs.getAclsList() != null) {
       acls.addAll(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()));
     }
+
+    acls.addAll(getDefaultAclList(createUGIForApi(), config));
 
     // Inherit DEFAULT acls from prefix.
     if (prefixManager != null) {
@@ -422,6 +435,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
         OmPrefixInfo prefixInfo = prefixList.get(prefixList.size() - 1);
         if (prefixInfo  != null) {
           if (OzoneAclUtil.inheritDefaultAcls(acls, prefixInfo.getAcls(), ACCESS)) {
+            // Remove the duplicates
+            acls = acls.stream().distinct().collect(Collectors.toList());
             return acls;
           }
         }
@@ -432,6 +447,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // prefix are not set
     if (omPathInfo != null) {
       if (OzoneAclUtil.inheritDefaultAcls(acls, omPathInfo.getAcls(), ACCESS)) {
+        acls = acls.stream().distinct().collect(Collectors.toList());
         return acls;
       }
     }
@@ -440,10 +456,12 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // parent-dir are not set.
     if (bucketInfo != null) {
       if (OzoneAclUtil.inheritDefaultAcls(acls, bucketInfo.getAcls(), ACCESS)) {
+        acls = acls.stream().distinct().collect(Collectors.toList());
         return acls;
       }
     }
 
+    acls = acls.stream().distinct().collect(Collectors.toList());
     return acls;
   }
 
@@ -452,10 +470,11 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * @param keyArgs
    * @param bucketInfo
    * @param omPathInfo
+   * @param config
    * @return Acls which inherited parent DEFAULT and keyArgs ACCESS acls.
    */
-  protected static List<OzoneAcl> getAclsForDir(KeyArgs keyArgs,
-      OmBucketInfo bucketInfo, OMFileRequest.OMPathInfo omPathInfo) {
+  protected List<OzoneAcl> getAclsForDir(KeyArgs keyArgs, OmBucketInfo bucketInfo,
+      OMFileRequest.OMPathInfo omPathInfo, OzoneConfiguration config) throws OMException {
     // Acls inherited from parent or bucket will convert to DEFAULT scope
     List<OzoneAcl> acls = new ArrayList<>();
 
@@ -470,10 +489,208 @@ public abstract class OMKeyRequest extends OMClientRequest {
       OzoneAclUtil.inheritDefaultAcls(acls, bucketInfo.getAcls(), DEFAULT);
     }
 
-    // add itself acls
+    // add acls from clients
     acls.addAll(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()));
-
+    acls.addAll(getDefaultAclList(createUGIForApi(), config));
+    acls = acls.stream().distinct().collect(Collectors.toList());
     return acls;
+  }
+
+  static long getMaxNumOfRecursiveDirs() {
+    return MAX_NUM_OF_RECURSIVE_DIRS;
+  }
+
+  /**
+   * Construct OmDirectoryInfo for every parent directory in missing list.
+   *
+   * @param keyArgs      key arguments
+   * @param pathInfo     list of parent directories to be created and its ACLs
+   * @param trxnLogIndex transaction log index id
+   * @return list of missing parent directories
+   * @throws IOException DB failure
+   */
+  protected List<OmDirectoryInfo> getAllMissingParentDirInfo(
+      OzoneManager ozoneManager, KeyArgs keyArgs, OmBucketInfo bucketInfo,
+      OMFileRequest.OMPathInfoWithFSO pathInfo, long trxnLogIndex)
+      throws IOException {
+    List<OmDirectoryInfo> missingParentInfos = new ArrayList<>();
+
+    // The base id is left shifted by 8 bits for creating space to
+    // create (2^8 - 1) object ids in every request.
+    // maxObjId represents the largest object id allocation possible inside
+    // the transaction.
+    long baseObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
+    long maxObjId = baseObjId + getMaxNumOfRecursiveDirs();
+    long objectCount = 1;
+
+    String volumeName = keyArgs.getVolumeName();
+    String bucketName = keyArgs.getBucketName();
+    String keyName = keyArgs.getKeyName();
+
+    long lastKnownParentId = pathInfo.getLastKnownParentId();
+    List<String> missingParents = pathInfo.getMissingParents();
+    for (String missingKey : missingParents) {
+      long nextObjId = baseObjId + objectCount;
+      if (nextObjId > maxObjId) {
+        throw new OMException("Too many directories in path. Exceeds limit of "
+            + getMaxNumOfRecursiveDirs() + ". Unable to create directory: "
+            + keyName + " in volume/bucket: " + volumeName + "/" + bucketName,
+            INVALID_KEY_NAME);
+      }
+
+      LOG.debug("missing parent {} getting added to DirectoryTable",
+          missingKey);
+      OmDirectoryInfo dirInfo = createDirectoryInfoWithACL(missingKey,
+          keyArgs, nextObjId, lastKnownParentId, trxnLogIndex,
+          bucketInfo, pathInfo, ozoneManager.getConfiguration());
+      objectCount++;
+
+      missingParentInfos.add(dirInfo);
+
+      // updating id for the next sub-dir
+      lastKnownParentId = nextObjId;
+    }
+    pathInfo.setLastKnownParentId(lastKnownParentId);
+    pathInfo.setLeafNodeObjectId(baseObjId + objectCount);
+    return missingParentInfos;
+  }
+
+  /**
+   * Construct OmKeyInfo for every parent directory in missing list.
+   * @param ozoneManager
+   * @param keyArgs
+   * @param missingParents list of parent directories to be created
+   * @param bucketInfo
+   * @param omPathInfo
+   * @param trxnLogIndex
+   * @return {@code List<OmKeyInfo>}
+   * @throws IOException
+   */
+  protected List<OmKeyInfo> getAllParentInfo(OzoneManager ozoneManager,
+      KeyArgs keyArgs, List<String> missingParents, OmBucketInfo bucketInfo,
+      OMFileRequest.OMPathInfo omPathInfo, long trxnLogIndex)
+      throws IOException {
+    List<OmKeyInfo> missingParentInfos = new ArrayList<>();
+
+    // The base id is left shifted by 8 bits for creating space to
+    // create (2^8 - 1) object ids in every request.
+    // maxObjId represents the largest object id allocation possible inside
+    // the transaction.
+    long baseObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
+    long maxObjId = baseObjId + MAX_NUM_OF_RECURSIVE_DIRS;
+    long objectCount = 1; // baseObjID is used by the leaf directory
+
+    String volumeName = keyArgs.getVolumeName();
+    String bucketName = keyArgs.getBucketName();
+    String keyName = keyArgs.getKeyName();
+
+    for (String missingKey : missingParents) {
+      long nextObjId = baseObjId + objectCount;
+      if (nextObjId > maxObjId) {
+        throw new OMException("Too many directories in path. Exceeds limit of "
+            + MAX_NUM_OF_RECURSIVE_DIRS + ". Unable to create directory: "
+            + keyName + " in volume/bucket: " + volumeName + "/" + bucketName,
+            INVALID_KEY_NAME);
+      }
+
+      LOG.debug("missing parent {} getting added to KeyTable", missingKey);
+
+      OmKeyInfo parentKeyInfo =
+          createDirectoryKeyInfoWithNoACL(missingKey, keyArgs, nextObjId,
+              bucketInfo, omPathInfo, trxnLogIndex,
+              ozoneManager.getDefaultReplicationConfig(), ozoneManager.getConfiguration());
+      objectCount++;
+
+      missingParentInfos.add(parentKeyInfo);
+    }
+
+    return missingParentInfos;
+  }
+
+  /**
+   * Fill in a DirectoryInfo for a new directory entry in OM database.
+   * @param dirName
+   * @param keyArgs
+   * @param objectId
+   * @param parentObjectId
+   * @param bucketInfo
+   * @param omPathInfo
+   * @return the OmDirectoryInfo structure
+   */
+  @SuppressWarnings("parameternumber")
+  protected OmDirectoryInfo createDirectoryInfoWithACL(
+      String dirName, KeyArgs keyArgs, long objectId,
+      long parentObjectId, long transactionIndex,
+      OmBucketInfo bucketInfo, OMFileRequest.OMPathInfo omPathInfo,
+      OzoneConfiguration config) throws OMException {
+    return OmDirectoryInfo.newBuilder()
+        .setName(dirName)
+        .setOwner(keyArgs.getOwnerName())
+        .setCreationTime(keyArgs.getModificationTime())
+        .setModificationTime(keyArgs.getModificationTime())
+        .setObjectID(objectId)
+        .setUpdateID(transactionIndex)
+        .setParentObjectID(parentObjectId).setAcls(getAclsForDir(keyArgs, bucketInfo, omPathInfo, config))
+        .build();
+  }
+
+  /**
+   * fill in a KeyInfo for a new directory entry in OM database.
+   * without initializing ACLs from the KeyArgs - used for intermediate
+   * directories which get created internally/recursively during file
+   * and directory create.
+   * @param keyName
+   * @param keyArgs
+   * @param objectId
+   * @param bucketInfo
+   * @param omPathInfo
+   * @param transactionIndex
+   * @param serverDefaultReplConfig
+   * @return the OmKeyInfo structure
+   */
+  @SuppressWarnings("parameternumber")
+  protected OmKeyInfo createDirectoryKeyInfoWithNoACL(String keyName,
+      KeyArgs keyArgs, long objectId, OmBucketInfo bucketInfo,
+      OMFileRequest.OMPathInfo omPathInfo, long transactionIndex,
+      ReplicationConfig serverDefaultReplConfig, OzoneConfiguration config) throws OMException {
+    return dirKeyInfoBuilderNoACL(keyName, keyArgs, objectId,
+        serverDefaultReplConfig)
+        .setAcls(getAclsForDir(keyArgs, bucketInfo, omPathInfo, config))
+        .setUpdateID(transactionIndex).build();
+  }
+
+  protected OmKeyInfo.Builder dirKeyInfoBuilderNoACL(String keyName, KeyArgs keyArgs, long objectId,
+      ReplicationConfig serverDefaultReplConfig) {
+    String dirName = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
+
+    OmKeyInfo.Builder keyInfoBuilder =
+        new OmKeyInfo.Builder()
+            .setVolumeName(keyArgs.getVolumeName())
+            .setBucketName(keyArgs.getBucketName())
+            .setKeyName(dirName)
+            .setOwnerName(keyArgs.getOwnerName())
+            .setOmKeyLocationInfos(Collections.singletonList(
+                new OmKeyLocationInfoGroup(0, new ArrayList<>())))
+            .setCreationTime(keyArgs.getModificationTime())
+            .setModificationTime(keyArgs.getModificationTime())
+            .setDataSize(0);
+    if (keyArgs.getFactor() != null && keyArgs
+        .getFactor() != HddsProtos.ReplicationFactor.ZERO && keyArgs
+        .getType() != HddsProtos.ReplicationType.EC) {
+      // Factor available and not an EC replication config.
+      keyInfoBuilder.setReplicationConfig(ReplicationConfig
+          .fromProtoTypeAndFactor(keyArgs.getType(), keyArgs.getFactor()));
+    } else if (keyArgs.getType() == HddsProtos.ReplicationType.EC) {
+      // Found EC type
+      keyInfoBuilder.setReplicationConfig(
+          new ECReplicationConfig(keyArgs.getEcReplicationConfig()));
+    } else {
+      // default type
+      keyInfoBuilder.setReplicationConfig(serverDefaultReplConfig);
+    }
+
+    keyInfoBuilder.setObjectID(objectId);
+    return keyInfoBuilder;
   }
 
   /**
@@ -801,12 +1018,12 @@ public abstract class OMKeyRequest extends OMClientRequest {
           @Nullable OmBucketInfo omBucketInfo,
           OMFileRequest.OMPathInfo omPathInfo,
           long transactionLogIndex, long objectID, boolean isRatisEnabled,
-          ReplicationConfig replicationConfig)
+          ReplicationConfig replicationConfig, OzoneConfiguration config)
           throws IOException {
 
     return prepareFileInfo(omMetadataManager, keyArgs, dbKeyInfo, size,
             locations, encInfo, prefixManager, omBucketInfo, omPathInfo,
-            transactionLogIndex, objectID, isRatisEnabled, replicationConfig);
+            transactionLogIndex, objectID, isRatisEnabled, replicationConfig, config);
   }
 
   /**
@@ -824,12 +1041,12 @@ public abstract class OMKeyRequest extends OMClientRequest {
           @Nullable OmBucketInfo omBucketInfo,
           OMFileRequest.OMPathInfo omPathInfo,
           long transactionLogIndex, long objectID,
-          boolean isRatisEnabled, ReplicationConfig replicationConfig)
-          throws IOException {
+          boolean isRatisEnabled, ReplicationConfig replicationConfig,
+          OzoneConfiguration config) throws IOException {
     if (keyArgs.getIsMultipartKey()) {
       return prepareMultipartFileInfo(omMetadataManager, keyArgs,
               size, locations, encInfo, prefixManager, omBucketInfo,
-              omPathInfo, transactionLogIndex, objectID);
+              omPathInfo, transactionLogIndex, objectID, config);
       //TODO args.getMetadata
     }
     if (dbKeyInfo != null) {
@@ -872,7 +1089,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // Blocks will be appended as version 0.
     return createFileInfo(keyArgs, locations, replicationConfig,
             keyArgs.getDataSize(), encInfo, prefixManager,
-            omBucketInfo, omPathInfo, transactionLogIndex, objectID);
+            omBucketInfo, omPathInfo, transactionLogIndex, objectID, config);
   }
 
   /**
@@ -889,7 +1106,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nonnull PrefixManager prefixManager,
       @Nullable OmBucketInfo omBucketInfo,
       OMFileRequest.OMPathInfo omPathInfo,
-      long transactionLogIndex, long objectID) {
+      long transactionLogIndex, long objectID,
+      OzoneConfiguration config) throws OMException {
     OmKeyInfo.Builder builder = new OmKeyInfo.Builder();
     builder.setVolumeName(keyArgs.getVolumeName())
             .setBucketName(keyArgs.getBucketName())
@@ -902,7 +1120,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
             .setReplicationConfig(replicationConfig)
             .setFileEncryptionInfo(encInfo)
             .setAcls(getAclsForKey(
-                keyArgs, omBucketInfo, omPathInfo, prefixManager))
+                keyArgs, omBucketInfo, omPathInfo, prefixManager, config))
             .addAllMetadata(KeyValueUtil.getFromProtobuf(
                     keyArgs.getMetadataList()))
             .addAllTags(KeyValueUtil.getFromProtobuf(
@@ -936,8 +1154,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
           FileEncryptionInfo encInfo,  @Nonnull PrefixManager prefixManager,
           @Nullable OmBucketInfo omBucketInfo,
           OMFileRequest.OMPathInfo omPathInfo,
-          @Nonnull long transactionLogIndex, long objectID)
-          throws IOException {
+          @Nonnull long transactionLogIndex, long objectID,
+          OzoneConfiguration configuration) throws IOException {
 
     Preconditions.checkArgument(args.getMultipartNumber() > 0,
             "PartNumber Should be greater than zero");
@@ -975,7 +1193,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // is not an actual key, it is a part of the key.
     return createFileInfo(args, locations, partKeyInfo.getReplicationConfig(),
             size, encInfo, prefixManager, omBucketInfo, omPathInfo,
-            transactionLogIndex, objectID);
+            transactionLogIndex, objectID, configuration);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -209,7 +209,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
           .setOmKeyLocationInfos(Collections.singletonList(
               new OmKeyLocationInfoGroup(0, new ArrayList<>(), true)))
           .setAcls(getAclsForKey(keyArgs, bucketInfo, pathInfo,
-              ozoneManager.getPrefixManager()))
+              ozoneManager.getPrefixManager(), ozoneManager.getConfiguration()))
           .setObjectID(objectID)
           .setUpdateID(transactionLogIndex)
           .setFileEncryptionInfo(keyArgs.hasFileEncryptionInfo() ?

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
-import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -121,8 +120,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
           volumeName, bucketName);
 
       // add all missing parents to dir table
-      missingParentInfos = OMDirectoryCreateRequestWithFSO
-          .getAllMissingParentDirInfo(ozoneManager, keyArgs, bucketInfo,
+      missingParentInfos = getAllMissingParentDirInfo(ozoneManager, keyArgs, bucketInfo,
               pathInfoFSO, transactionLogIndex);
 
       // We are adding uploadId to key, because if multiple users try to
@@ -185,7 +183,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
           .setOmKeyLocationInfos(Collections.singletonList(
               new OmKeyLocationInfoGroup(0, new ArrayList<>(), true)))
           .setAcls(getAclsForKey(keyArgs, bucketInfo, pathInfoFSO,
-              ozoneManager.getPrefixManager()))
+              ozoneManager.getPrefixManager(), ozoneManager.getConfiguration()))
           .setObjectID(pathInfoFSO.getLeafNodeObjectId())
           .setUpdateID(transactionLogIndex)
           .setFileEncryptionInfo(keyArgs.hasFileEncryptionInfo() ?

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -33,7 +33,6 @@ import java.util.function.BiFunction;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.om.OzoneConfigUtil;
-import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -187,8 +186,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       OMFileRequest.OMPathInfoWithFSO pathInfoFSO = OMFileRequest
           .verifyDirectoryKeysInPath(omMetadataManager, volumeName, bucketName,
               keyName, Paths.get(keyName));
-      missingParentInfos = OMDirectoryCreateRequestWithFSO
-          .getAllMissingParentDirInfo(ozoneManager, keyArgs, omBucketInfo,
+      missingParentInfos = getAllMissingParentDirInfo(ozoneManager, keyArgs, omBucketInfo,
               pathInfoFSO, trxnLogIndex);
 
       if (missingParentInfos != null) {
@@ -236,7 +234,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
               .setOmKeyLocationInfos(Collections.singletonList(
                   new OmKeyLocationInfoGroup(0, new ArrayList<>(), true)))
               .setAcls(getAclsForKey(keyArgs, omBucketInfo, pathInfoFSO,
-                  ozoneManager.getPrefixManager()))
+                  ozoneManager.getPrefixManager(), ozoneManager.getConfiguration()))
               .setObjectID(pathInfoFSO.getLeafNodeObjectId())
               .setUpdateID(trxnLogIndex)
               .setFileEncryptionInfo(keyArgs.hasFileEncryptionInfo() ?

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -20,11 +20,15 @@ package org.apache.hadoop.ozone.om.request.volume;
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -55,6 +59,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .VolumeInfo;
 import org.apache.hadoop.util.Time;
 
+import static org.apache.hadoop.ozone.om.helpers.OzoneAclUtil.getDefaultAclList;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.USER_LOCK;
 
@@ -160,6 +165,18 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
         volumeList = omMetadataManager.getUserTable().get(dbUserKey);
         volumeList = addVolumeToOwnerList(volumeList, volume, owner,
             ozoneManager.getMaxUserVolumeCount(), transactionLogIndex);
+
+        // Add default ACL for volume
+        List<OzoneAcl> listOfAcls = getDefaultAclList(UserGroupInformation.createRemoteUser(owner),
+            ozoneManager.getConfiguration());
+        // ACLs from VolumeArgs
+        if (omVolumeArgs.getAcls() != null) {
+          listOfAcls.addAll(omVolumeArgs.getAcls());
+        }
+        // Remove the duplicates
+        listOfAcls = listOfAcls.stream().distinct().collect(Collectors.toList());
+        omVolumeArgs.setAcls(listOfAcls);
+
         createVolume(omMetadataManager, omVolumeArgs, volumeList, dbVolumeKey,
             dbUserKey, transactionLogIndex);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -41,6 +42,7 @@ import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newCreateBucketRequest;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -336,7 +338,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     assertNull(omMetadataManager.getBucketTable().get(bucketKey));
     OMBucketCreateRequest omBucketCreateRequest =
         new OMBucketCreateRequest(modifiedRequest);
-
+    omBucketCreateRequest.setUGI(UserGroupInformation.getCurrentUser());
 
     OMClientResponse omClientResponse =
         omBucketCreateRequest.validateAndUpdateCache(ozoneManager, 1);
@@ -355,8 +357,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
         dbBucketInfo.getCreationTime());
     assertEquals(bucketInfoFromProto.getModificationTime(),
         dbBucketInfo.getModificationTime());
-    assertEquals(bucketInfoFromProto.getAcls(),
-        dbBucketInfo.getAcls());
+    assertTrue(dbBucketInfo.getAcls().containsAll(bucketInfoFromProto.getAcls()));
     assertEquals(bucketInfoFromProto.getIsVersionEnabled(),
         dbBucketInfo.getIsVersionEnabled());
     assertEquals(bucketInfoFromProto.getStorageType(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,7 @@ import java.util.UUID;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newBucketInfoBuilder;
 import static org.apache.hadoop.ozone.om.request.OMRequestTestUtils.newCreateBucketRequest;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketLayoutProto.FILE_SYSTEM_OPTIMIZED;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -143,7 +145,7 @@ public class TestOMBucketCreateRequestWithFSO
     assertNull(omMetadataManager.getBucketTable().get(bucketKey));
     OMBucketCreateRequest omBucketCreateRequest =
         new OMBucketCreateRequest(modifiedRequest);
-
+    omBucketCreateRequest.setUGI(UserGroupInformation.getCurrentUser());
 
     OMClientResponse omClientResponse =
         omBucketCreateRequest.validateAndUpdateCache(ozoneManager, 1);
@@ -166,8 +168,7 @@ public class TestOMBucketCreateRequestWithFSO
         dbBucketInfo.getCreationTime());
     assertEquals(bucketInfoFromProto.getModificationTime(),
         dbBucketInfo.getModificationTime());
-    assertEquals(bucketInfoFromProto.getAcls(),
-        dbBucketInfo.getAcls());
+    assertTrue(dbBucketInfo.getAcls().containsAll(bucketInfoFromProto.getAcls()));
     assertEquals(bucketInfoFromProto.getIsVersionEnabled(),
         dbBucketInfo.getIsVersionEnabled());
     assertEquals(bucketInfoFromProto.getStorageType(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -183,7 +185,7 @@ public class TestOMDirectoryCreateRequest {
 
     omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
-
+    omDirectoryCreateRequest.setUGI(UserGroupInformation.getCurrentUser());
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L);
 
@@ -222,6 +224,7 @@ public class TestOMDirectoryCreateRequest {
 
     omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
+    omDirectoryCreateRequest.setUGI(UserGroupInformation.getCurrentUser());
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L);
 
@@ -310,7 +313,7 @@ public class TestOMDirectoryCreateRequest {
 
     omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
-
+    omDirectoryCreateRequest.setUGI(UserGroupInformation.getCurrentUser());
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L);
 
@@ -430,6 +433,7 @@ public class TestOMDirectoryCreateRequest {
 
     omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
+    omDirectoryCreateRequest.setUGI(UserGroupInformation.getCurrentUser());
 
     assertEquals(0L, omMetrics.getNumKeys());
     OMClientResponse omClientResponse =
@@ -480,7 +484,7 @@ public class TestOMDirectoryCreateRequest {
 
     omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
-
+    omDirectoryCreateRequest.setUGI(UserGroupInformation.getCurrentUser());
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L);
 
@@ -510,7 +514,7 @@ public class TestOMDirectoryCreateRequest {
 
       List<OzoneAcl> omKeyAcls = omKeyInfo.getAcls();
 
-      assertEquals(expectedInheritAcls, omKeyAcls, "Failed to inherit parent acls!,");
+      assertTrue(omKeyAcls.containsAll(expectedInheritAcls), "Failed to inherit parent acls!,");
 
       prefix = dirName + OZONE_URI_DELIMITER;
       expectedInheritAcls = omKeyAcls;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateD
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import jakarta.annotation.Nonnull;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -169,7 +170,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     omDirCreateRequestFSO =
         new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
             BucketLayout.FILE_SYSTEM_OPTIMIZED);
-
+    omDirCreateRequestFSO.setUGI(UserGroupInformation.getCurrentUser());
     OMClientResponse omClientResponse =
         omDirCreateRequestFSO.validateAndUpdateCache(ozoneManager, 100L);
 
@@ -209,6 +210,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     omDirCreateRequestFSO =
         new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
             BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    omDirCreateRequestFSO.setUGI(UserGroupInformation.getCurrentUser());
     OMClientResponse omClientResponse =
         omDirCreateRequestFSO.validateAndUpdateCache(ozoneManager, 100L);
     assertSame(omClientResponse.getOMResponse().getStatus(),
@@ -317,7 +319,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
-
+    omDirCreateReqFSO.setUGI(UserGroupInformation.getCurrentUser());
     OMClientResponse omClientResponse =
         omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L);
 
@@ -570,6 +572,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    omDirCreateReqFSO.setUGI(UserGroupInformation.getCurrentUser());
 
     assertEquals(0L, omMetrics.getNumKeys());
     OMClientResponse omClientResponse =
@@ -604,7 +607,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
-
+    omDirCreateReqFSO.setUGI(UserGroupInformation.getCurrentUser());
     assertEquals(0L, omMetrics.getNumKeys());
     OMClientResponse omClientResponse =
         omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L);
@@ -643,6 +646,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    omDirCreateReqFSO.setUGI(UserGroupInformation.getCurrentUser());
 
     assertEquals(0L, omMetrics.getNumKeys());
     OMClientResponse omClientResponse =
@@ -695,7 +699,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
-
+    omDirCreateReqFSO.setUGI(UserGroupInformation.getCurrentUser());
     OMClientResponse omClientResponse =
         omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L);
     assertSame(omClientResponse.getOMResponse().getStatus(),
@@ -730,7 +734,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
       System.out.println(
           "  subdir acls : " + omDirInfo + " ==> " + omDirAcls);
 
-      assertEquals(expectedInheritAcls, omDirAcls,
+      assertTrue(omDirAcls.containsAll(expectedInheritAcls),
           "Failed to inherit parent DEFAULT acls!");
 
       parentID = omDirInfo.getObjectID();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
@@ -28,9 +28,11 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
@@ -236,9 +238,11 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
   }
 
   @Override
-  protected OMFileCreateRequest getOMFileCreateRequest(OMRequest omRequest) {
-    return new OMFileCreateRequestWithFSO(omRequest,
+  protected OMFileCreateRequest getOMFileCreateRequest(OMRequest omRequest) throws IOException {
+    OMFileCreateRequest request = new OMFileCreateRequestWithFSO(omRequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.om.lock.OzoneLockProvider;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -210,15 +211,19 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
   }
 
   @Override
-  protected OMKeyCreateRequest getOMKeyCreateRequest(OMRequest omRequest) {
-    return new OMKeyCreateRequestWithFSO(omRequest,
+  protected OMKeyCreateRequest getOMKeyCreateRequest(OMRequest omRequest) throws IOException {
+    OMKeyCreateRequest request = new OMKeyCreateRequestWithFSO(omRequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   @Override
   protected OMKeyCreateRequest getOMKeyCreateRequest(
-      OMRequest omRequest, BucketLayout layout) {
-    return new OMKeyCreateRequestWithFSO(omRequest, layout);
+      OMRequest omRequest, BucketLayout layout) throws IOException {
+    OMKeyCreateRequest request = new OMKeyCreateRequestWithFSO(omRequest, layout);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
   
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Expired
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExpiredMultipartUploadsBucket;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartUploadsExpiredAbortRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -447,6 +448,7 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
       S3InitiateMultipartUploadRequest s3InitiateMultipartUploadRequest =
           new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
               BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      s3InitiateMultipartUploadRequest.setUGI(UserGroupInformation.getLoginUser());
 
       OMClientResponse omClientResponse = s3InitiateMultipartUploadRequest
           .validateAndUpdateCache(ozoneManager, trxnLogIndex);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
@@ -250,7 +250,7 @@ public class TestS3InitiateMultipartUploadRequest
 
     // Should inherit parent DEFAULT Acls
     // [user:newUser:rw[DEFAULT], group:newGroup:rwl[DEFAULT]]
-    assertEquals(parentDefaultAcl, keyAcls,
+    assertTrue(keyAcls.containsAll(parentDefaultAcl),
         "Failed to inherit parent DEFAULT acls!");
 
     // Should not inherit parent ACCESS Acls

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -166,9 +167,11 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
 
   @Override
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
-      OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+      OMRequest initiateMPURequest) throws IOException {
+    S3InitiateMultipartUploadRequest request = new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getLoginUser());
+    return request;
   }
 
   @Test
@@ -256,7 +259,7 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
       List<OzoneAcl> omDirAcls = omDirInfo.getAcls();
 
       System.out.println("  subdir acls : " + omDirInfo + " ==> " + omDirAcls);
-      assertEquals(expectedInheritAcls, omDirAcls,
+      assertTrue(omDirAcls.containsAll(expectedInheritAcls),
           "Failed to inherit parent DEFAULT acls!");
 
       parentID = omDirInfo.getObjectID();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -114,6 +115,7 @@ public class TestS3MultipartRequest {
     when(lvm.getMetadataLayoutVersion()).thenReturn(0);
     when(ozoneManager.getVersionManager()).thenReturn(lvm);
     when(ozoneManager.isRatisEnabled()).thenReturn(true);
+    when(ozoneManager.getConfiguration()).thenReturn(ozoneConfiguration);
   }
 
 
@@ -353,21 +355,27 @@ public class TestS3MultipartRequest {
   }
 
   protected S3MultipartUploadCompleteRequest getS3MultipartUploadCompleteReq(
-      OMRequest omRequest) {
-    return new S3MultipartUploadCompleteRequest(omRequest,
+      OMRequest omRequest) throws IOException {
+    S3MultipartUploadCompleteRequest request = new S3MultipartUploadCompleteRequest(omRequest,
         BucketLayout.DEFAULT);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   protected S3MultipartUploadCommitPartRequest getS3MultipartUploadCommitReq(
-      OMRequest omRequest) {
-    return new S3MultipartUploadCommitPartRequest(omRequest,
+      OMRequest omRequest) throws IOException {
+    S3MultipartUploadCommitPartRequest request = new S3MultipartUploadCommitPartRequest(omRequest,
         BucketLayout.DEFAULT);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
-      OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequest(initiateMPURequest,
+      OMRequest initiateMPURequest) throws IOException {
+    S3InitiateMultipartUploadRequest request = new S3InitiateMultipartUploadRequest(initiateMPURequest,
         BucketLayout.DEFAULT);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   protected S3MultipartUploadAbortRequest getS3MultipartUploadAbortReq(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequestWithFSO.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -45,9 +46,11 @@ public class TestS3MultipartUploadAbortRequestWithFSO
 
   @Override
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
-      OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+      OMRequest initiateMPURequest) throws IOException {
+    S3InitiateMultipartUploadRequest request = new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -71,7 +71,7 @@ public class TestS3MultipartUploadCommitPartRequest
         bucketName, keyName);
 
     S3InitiateMultipartUploadRequest s3InitiateMultipartUploadRequest =
-            getS3InitiateMultipartUploadReq(initiateMPURequest);
+        getS3InitiateMultipartUploadReq(initiateMPURequest);
 
     OMClientResponse omClientResponse =
         s3InitiateMultipartUploadRequest.validateAndUpdateCache(ozoneManager, 1L);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,16 +50,20 @@ public class TestS3MultipartUploadCommitPartRequestWithFSO
 
   @Override
   protected S3MultipartUploadCommitPartRequest getS3MultipartUploadCommitReq(
-      OMRequest omRequest) {
-    return new S3MultipartUploadCommitPartRequestWithFSO(omRequest,
+      OMRequest omRequest) throws IOException {
+    S3MultipartUploadCommitPartRequest request = new S3MultipartUploadCommitPartRequestWithFSO(omRequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   @Override
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
-      OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+      OMRequest initiateMPURequest) throws IOException {
+    S3InitiateMultipartUploadRequest request = new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -113,23 +114,29 @@ public class TestS3MultipartUploadCompleteRequestWithFSO
 
   @Override
   protected S3MultipartUploadCompleteRequest getS3MultipartUploadCompleteReq(
-          OMRequest omRequest) {
-    return new S3MultipartUploadCompleteRequestWithFSO(omRequest,
+          OMRequest omRequest) throws IOException {
+    S3MultipartUploadCompleteRequest request = new S3MultipartUploadCompleteRequestWithFSO(omRequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   @Override
   protected S3MultipartUploadCommitPartRequest getS3MultipartUploadCommitReq(
-      OMRequest omRequest) {
-    return new S3MultipartUploadCommitPartRequestWithFSO(omRequest,
+      OMRequest omRequest) throws IOException {
+    S3MultipartUploadCommitPartRequest request = new S3MultipartUploadCommitPartRequestWithFSO(omRequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   @Override
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
-      OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+      OMRequest initiateMPURequest) throws IOException {
+    S3InitiateMultipartUploadRequest request = new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeRequest.java
@@ -81,6 +81,7 @@ public class TestOMVolumeRequest {
     auditLogger = mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
+    when(ozoneManager.getConfiguration()).thenReturn(ozoneConfiguration);
   }
 
   @AfterEach

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -169,8 +169,7 @@ public class TestOzoneNativeAuthorizer {
         .setReplicationConfig(StandaloneReplicationConfig
             .getInstance(HddsProtos.ReplicationFactor.ONE))
         .setDataSize(0)
-        .setAcls(OzoneAclUtil.getAclList(testUgi.getUserName(),
-            testUgi.getGroupNames(), ALL, ALL))
+        .setAcls(OzoneAclUtil.getAclList(testUgi, ALL, ALL))
         .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
         .build();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -344,8 +344,7 @@ public class TestParentAcl {
             HddsProtos.ReplicationFactor.ONE))
         .setDataSize(0)
         // here we give test ugi full access
-        .setAcls(OzoneAclUtil.getAclList(testUgi.getUserName(),
-            testUgi.getGroupNames(), ALL, ALL))
+        .setAcls(OzoneAclUtil.getAclList(testUgi, ALL, ALL))
         .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
         .build();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
@@ -142,11 +142,9 @@ public class TestVolumeOwner {
                   UserGroupInformation.getCurrentUser().getShortUserName())
               .setDataSize(0);
           if (k == 0) {
-            keyArgsBuilder.setAcls(OzoneAclUtil.getAclList(
-                testUgi.getUserName(), testUgi.getGroupNames(), ALL, ALL));
+            keyArgsBuilder.setAcls(OzoneAclUtil.getAclList(testUgi, ALL, ALL));
           } else {
-            keyArgsBuilder.setAcls(OzoneAclUtil.getAclList(
-                testUgi.getUserName(), testUgi.getGroupNames(), NONE, NONE));
+            keyArgsBuilder.setAcls(OzoneAclUtil.getAclList(testUgi, NONE, NONE));
           }
           OmKeyArgs keyArgs = keyArgsBuilder.build();
           OpenKeySession keySession = writeClient.createFile(keyArgs, true,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
@@ -109,8 +109,7 @@ public class OmKeyGenerator extends BaseFreonGenerator
         .setKeyName(generateObjectName(counter))
         .setReplicationConfig(replicationConfig)
         .setLocationInfoList(new ArrayList<>())
-        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
-            ALL, ALL))
+        .setAcls(OzoneAclUtil.getAclList(ugi, ALL, ALL))
         .setOwnerName(ownerName)
         .build();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmMetadataGenerator.java
@@ -272,8 +272,7 @@ public class OmMetadataGenerator extends BaseFreonGenerator
         .setVolumeName(volumeName)
         .setReplicationConfig(replicationConfig)
         .setLocationInfoList(new ArrayList<>())
-        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
-            ALL, ALL));
+        .setAcls(OzoneAclUtil.getAclList(ugi, ALL, ALL));
   }
 
   private String getPath(long counter) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Only create ACL for user's primary group, instead of create ACL for user's each group. 
2. change the default group ACL from "ALL" to "READ, LIST"
3.  use getShortUserName() instead of getUserName as ACL user name.  getShortUserName() is used in OM to verify ACLs long time ago. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-11656

## How was this patch tested?

Existing unit tests and new tests. 
