### PR TITLE
HDDS-11755. mktemp --suffix does not work on Mac

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -398,7 +398,7 @@ run_rebot() {
 
   shift 2
 
-  local tempdir="$(mktemp -d --suffix rebot -p "${output_dir}")"
+  local tempdir="$(mktemp -d "${output_dir}"/rebot-XXXXXX)"
   #Should be writeable from the docker containers where user is different.
   chmod a+wx "${tempdir}"
   if docker run --rm -v "${input_dir}":/rebot-input -v "${tempdir}":/rebot-output -w /rebot-input \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance test fails on Mac while generating Rebot report.

```
mktemp: unrecognized option `--suffix'
usage: mktemp [-d] [-p tmpdir] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-p tmpdir] [-q] [-u] -t prefix 
```

On even older version:

```
mktemp: illegal option -- -
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix 
```

https://issues.apache.org/jira/browse/HDDS-11755

## How was this patch tested?

Tested the `mktemp` command on both Mac and Linux.

CI:
https://github.com/adoroszlai/ozone/actions/runs/11921031854

Excerpt from log where the temp dir is used (`rebot-71Ma3M`):

```
renamed '/home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/rebot-71Ma3M/log.html' -> '/home/runner/work/ozone/ozone/hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/result/log.html'
```