### PR TITLE
HDDS-11750. LegacyReplicationManager#notifyStatusChanged should submit Ratis request asynchronously

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -1896,9 +1896,6 @@ public class LegacyReplicationManager {
   }
 
   protected void notifyStatusChanged() {
-    //now, as the current scm is leader and it`s state is up-to-date,
-    //we need to take some action about replicated inflight move options.
-    onLeaderReadyAndOutOfSafeMode();
   }
 
   private InflightMap getInflightMap(InflightType type) {
@@ -2100,62 +2097,6 @@ public class LegacyReplicationManager {
             SCMHAInvocationHandler.class.getClassLoader(),
             new Class<?>[]{MoveScheduler.class},
             invocationHandler);
-      }
-    }
-  }
-
-  /**
-  * when scm become LeaderReady and out of safe mode, some actions
-  * should be taken. for now , it is only used for handle replicated
-  * infligtht move.
-  */
-  private void onLeaderReadyAndOutOfSafeMode() {
-    List<HddsProtos.ContainerID> needToRemove = new LinkedList<>();
-    moveScheduler.getInflightMove().forEach((k, v) -> {
-      Set<ContainerReplica> replicas;
-      ContainerInfo cif;
-      try {
-        replicas = containerManager.getContainerReplicas(k);
-        cif = containerManager.getContainer(k);
-      } catch (ContainerNotFoundException e) {
-        needToRemove.add(k.getProtobuf());
-        LOG.error("can not find container {} " +
-            "while processing replicated move", k);
-        return;
-      }
-      boolean isSrcExist = replicas.stream()
-          .anyMatch(r -> r.getDatanodeDetails().equals(v.getSrc()));
-      boolean isTgtExist = replicas.stream()
-          .anyMatch(r -> r.getDatanodeDetails().equals(v.getTgt()));
-
-      if (isSrcExist) {
-        if (isTgtExist) {
-          //the former scm leader may or may not send the deletion command
-          //before reelection.here, we just try to send the command again.
-          try {
-            deleteSrcDnForMove(cif, replicas);
-          } catch (Exception ex) {
-            LOG.error("Exception while cleaning up excess replicas.", ex);
-          }
-        } else {
-          // resenting replication command is ok , no matter whether there is an
-          // on-going replication
-          sendReplicateCommand(cif, v.getTgt(),
-              Collections.singletonList(v.getSrc()));
-        }
-      } else {
-        // if container does not exist in src datanode, no matter it exists
-        // in target datanode, we can not take more actions to this option,
-        // so just remove it through ratis
-        needToRemove.add(k.getProtobuf());
-      }
-    });
-
-    for (HddsProtos.ContainerID containerID : needToRemove) {
-      try {
-        moveScheduler.completeMove(containerID);
-      } catch (Exception ex) {
-        LOG.error("Exception while moving container.", ex);
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -2693,7 +2693,7 @@ public class TestLegacyReplicationManager {
           dn1.getDatanodeDetails()));
       //replica does not exist in target datanode, so a
       // replicateContainerCommand will be sent again at
-      // notifyStatusChanged#onLeaderReadyAndOutOfSafeMode
+      // notifyStatusChanged#handleInflightMoves
       assertEquals(2, datanodeCommandHandler.getInvocationCount(
               SCMCommandProto.Type.replicateContainerCommand));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -2691,11 +2691,6 @@ public class TestLegacyReplicationManager {
       assertFalse(datanodeCommandHandler.received(
           SCMCommandProto.Type.deleteContainerCommand,
           dn1.getDatanodeDetails()));
-      //replica does not exist in target datanode, so a
-      // replicateContainerCommand will be sent again at
-      // notifyStatusChanged#onLeaderReadyAndOutOfSafeMode
-      assertEquals(2, datanodeCommandHandler.getInvocationCount(
-              SCMCommandProto.Type.replicateContainerCommand));
 
 
       //replicate container to dn3, now, over-replicated
@@ -2730,17 +2725,6 @@ public class TestLegacyReplicationManager {
       containerStateManager.removeContainerReplica(id, dn1);
       replicationManager.processAll();
       eventQueue.processAll(1000);
-
-      //since the move is complete,so after scm crash and restart
-      //inflightMove should not contain the container again
-      resetReplicationManager();
-      replicationManager.getMoveScheduler()
-              .reinitialize(SCMDBDefinition.MOVE.getTable(dbStore));
-      assertThat(replicationManager.getMoveScheduler()
-              .getInflightMove()).doesNotContainKey(id);
-
-      //completeableFuture is not stored in DB, so after scm crash and
-      //restart ,completeableFuture is missing
     }
 
     /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestLegacyReplicationManagerWithSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestLegacyReplicationManagerWithSCMHA.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
+import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
+import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
+import org.apache.hadoop.hdds.scm.proxy.SCMContainerLocationFailoverProxyProvider;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.event.Level;
+
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test LegacyReplicationManager with SCM HA setup.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestLegacyReplicationManagerWithSCMHA {
+  private MiniOzoneHAClusterImpl cluster = null;
+  private OzoneConfiguration conf;
+  private String omServiceId;
+  private String scmServiceId;
+  private int numOfOMs = 1;
+  private int numOfSCMs = 3;
+
+  private static final long SNAPSHOT_THRESHOLD = 5;
+
+  /**
+   * Create a MiniOzoneCluster for testing.
+   *
+   * @throws IOException
+   */
+  @BeforeAll
+  public void init() throws Exception {
+    conf = new OzoneConfiguration();
+    omServiceId = "om-service-test1";
+    scmServiceId = "scm-service-test1";
+    conf.setLong(ScmConfigKeys.OZONE_SCM_HA_RATIS_SNAPSHOT_THRESHOLD,
+        SNAPSHOT_THRESHOLD);
+    conf.setBoolean("hdds.scm.replication.enable.legacy", true);
+
+    cluster = MiniOzoneCluster.newHABuilder(conf)
+        .setOMServiceId(omServiceId)
+        .setSCMServiceId(scmServiceId).setNumOfOzoneManagers(numOfOMs)
+        .setNumOfStorageContainerManagers(numOfSCMs).setNumOfActiveSCMs(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @Test
+  public void testLegacyReplicationManagerNotifyStatusChanged() throws Exception {
+    SCMClientConfig scmClientConfig =
+        conf.getObject(SCMClientConfig.class);
+    scmClientConfig.setRetryCount(1);
+    scmClientConfig.setRetryInterval(100);
+    scmClientConfig.setMaxRetryTimeout(1500);
+    assertEquals(15, scmClientConfig.getRetryCount());
+    conf.setFromObject(scmClientConfig);
+    StorageContainerManager leaderScm = getLeader(cluster);
+    assertNotNull(leaderScm);
+
+    // Setup SCM client
+    SCMContainerLocationFailoverProxyProvider proxyProvider =
+        new SCMContainerLocationFailoverProxyProvider(conf, null);
+    GenericTestUtils.setLogLevel(SCMContainerLocationFailoverProxyProvider.LOG,
+        Level.DEBUG);
+    GenericTestUtils.LogCapturer logCapture = GenericTestUtils.LogCapturer
+        .captureLogs(SCMContainerLocationFailoverProxyProvider.LOG);
+    proxyProvider.changeCurrentProxy(leaderScm.getSCMNodeId());
+    StorageContainerLocationProtocol scmContainerClient =
+        TracingUtil.createProxy(
+            new StorageContainerLocationProtocolClientSideTranslatorPB(
+                proxyProvider), StorageContainerLocationProtocol.class, conf);
+
+    // Steps to test the fix for HDDS-11750 in LegacyReplicationManager#notifyStatusChanged
+    // 1. Create a container with Replication.ONE having one replica in one DN that will be the source replica
+    // 2. Pick another datanode as the target replica and use LegacyReplicationManager.MoveScheduler#startMove
+    //    between the source and target replica
+    // 3. Do a transfer leadership to another SCM to trigger SCMStateMachine#notifyLeaderReady,
+    //    SCMServiceManager#notifyStatusChanged, and LegacyReplicationManager#notifyStatusChanged
+    // 4. Check the RM log capturer that there is no TimeoutException due to the deadlock
+    // 5. Create multiple containers and ensure that they are not blocked (no deadlock)
+    //    - each create container must be finished faster than ozone.scm.ha.ratis.request.timeout
+    //    - also keep checking whether there are TimeoutException exception
+
+    // Used to capture the TimeoutException in ReplicationManager (Step 4)
+    GenericTestUtils.LogCapturer rmLogCapture = GenericTestUtils.LogCapturer
+        .captureLogs(LegacyReplicationManager.LOG);
+
+    // Step 1
+    ContainerWithPipeline container = scmContainerClient.allocateContainer(HddsProtos.ReplicationType.RATIS,
+        HddsProtos.ReplicationFactor.ONE, "ozone");
+    assertThat(logCapture.getOutput())
+        .contains("Performing failover to suggested leader");
+    leaderScm = getLeader(cluster);
+    assertNotNull(leaderScm);
+    assertThat(container.getPipeline().getNodes()).hasSize(1);
+
+    // Step 2
+    final ContainerID id = container.getContainerInfo().containerID();
+    final DatanodeDetails sourceDN = container.getPipeline().getFirstNode();
+    DatanodeDetails targetDN = null;
+    for (HddsDatanodeService datanode: cluster.getHddsDatanodes()) {
+      if (!datanode.getDatanodeDetails().equals(sourceDN)) {
+        targetDN = datanode.getDatanodeDetails();
+      }
+    }
+    assertNotNull(targetDN);
+
+    leaderScm.getReplicationManager().getMoveScheduler().startMove(id.getProtobuf(),
+        (new MoveDataNodePair(sourceDN, targetDN))
+            .getProtobufMessage(ClientVersion.CURRENT_VERSION));
+
+    // Step 3
+    StorageContainerManager newLeaderScm = null;
+    for (StorageContainerManager s : cluster.getStorageContainerManagers()) {
+      if (s != leaderScm) {
+        newLeaderScm = s;
+        break;
+      }
+    }
+    assertNotNull(newLeaderScm);
+
+    // This should trigger the LegacyReplicationManager#notifyStatusChanged
+    scmContainerClient.transferLeadership(newLeaderScm.getScmId());
+    assertEquals(newLeaderScm, getLeader(cluster));
+
+    // Step 4
+    cluster.waitForClusterToBeReady();
+    assertThat(rmLogCapture.getOutput()).doesNotContain("TimeoutException");
+    assertThat(rmLogCapture.getOutput()).doesNotContain("Exception while moving container");
+
+    // Step 5
+    for (int i = 0; i < 5; i++) {
+      scmContainerClient.allocateContainer(HddsProtos.ReplicationType.RATIS,
+          HddsProtos.ReplicationFactor.ONE, "ozone");
+      assertThat(rmLogCapture.getOutput()).doesNotContain("TimeoutException");
+      assertThat(rmLogCapture.getOutput()).doesNotContain("Exception while moving container");
+    }
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @AfterAll
+  public void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  static StorageContainerManager getLeader(MiniOzoneHAClusterImpl impl) {
+    for (StorageContainerManager scm : impl.getStorageContainerManagers()) {
+      if (scm.checkLeader()) {
+        return scm;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

We encountered an issue where the SCM is stuck after transfer leadership, causing SCM leader to be stuck and all client requests to timeout (including OMs).

We saw that SCM is throwing TimeoutException in StateMachineUpdater (the thread in charge of applying Raft logs and completing user requests), causing the whole SCM request processing to be stuck.

```
2024-11-18 15:54:50,182 [daa4f362-f48d-4933-96b3-840a8739f1d9@group-C0BCE64451CF-StateMachineUpdater] ERROR org.apache.hadoop.hdds.scm.container.ReplicationManager: Exception while cleaning up excess replicas.
java.util.concurrent.TimeoutException
        at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1784)
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1928)
        at org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl.submitRequest(SCMRatisServerImpl.java:228)
        at org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler.invokeRatis(SCMHAInvocationHandler.java:110)
        at org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler.invoke(SCMHAInvocationHandler.java:67)
        at com.sun.proxy.$Proxy19.completeMove(Unknown Source)
        at org.apache.hadoop.hdds.scm.container.ReplicationManager.deleteSrcDnForMove(ReplicationManager.java:1610)
        at org.apache.hadoop.hdds.scm.container.ReplicationManager.lambda$onLeaderReadyAndOutOfSafeMode$36(ReplicationManager.java:2364)
        at java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1597)
        at org.apache.hadoop.hdds.scm.container.ReplicationManager.onLeaderReadyAndOutOfSafeMode(ReplicationManager.java:2342)
        at org.apache.hadoop.hdds.scm.container.ReplicationManager.notifyStatusChanged(ReplicationManager.java:2103)
        at org.apache.hadoop.hdds.scm.ha.SCMServiceManager.notifyStatusChanged(SCMServiceManager.java:53)
        at org.apache.hadoop.hdds.scm.ha.SCMStateMachine.notifyTermIndexUpdated(SCMStateMachine.java:338)
        at org.apache.ratis.server.impl.RaftServerImpl.applyLogToStateMachine(RaftServerImpl.java:1650)
        at org.apache.ratis.server.impl.StateMachineUpdater.applyLog(StateMachineUpdater.java:239)
        at org.apache.ratis.server.impl.StateMachineUpdater.run(StateMachineUpdater.java:182)
        at java.lang.Thread.run(Thread.java:748)
2024-11-18 15:54:50,183 [daa4f362-f48d-4933-96b3-840a8739f1d9@group-C0BCE64451CF-StateMachineUpdater] INFO org.apache.hadoop.hdds.scm.container.ReplicationManager: can not remove source replica after successfully replicated to target datanode
2024-11-18 15:54:50,745 [EventQueue-CloseContainerForCloseContainerEventHandler] ERROR org.apache.hadoop.hdds.server.events.SingleThreadExecutor: Error on execution message #8764007
java.lang.reflect.UndeclaredThrowableException
        at com.sun.proxy.$Proxy16.updateContainerState(Unknown Source)
        at org.apache.hadoop.hdds.scm.container.ContainerManagerImpl.updateContainerState(ContainerManagerImpl.java:332)
        at org.apache.hadoop.hdds.scm.container.CloseContainerEventHandler.onMessage(CloseContainerEventHandler.java:82)
        at org.apache.hadoop.hdds.scm.container.CloseContainerEventHandler.onMessage(CloseContainerEventHandler.java:51)
        at org.apache.hadoop.hdds.server.events.SingleThreadExecutor.lambda$onMessage$1(SingleThreadExecutor.java:85)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.util.concurrent.TimeoutException
        at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1784)
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1928)
        at org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl.submitRequest(SCMRatisServerImpl.java:228)
        at org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler.invokeRatis(SCMHAInvocationHandler.java:110)
        at org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler.invoke(SCMHAInvocationHandler.java:67)
        ... 8 more
2024-11-18 15:54:50,746 [EventQueue-DeleteBlockStatusForDeletedBlockLogImpl] WARN org.apache.hadoop.hdds.scm.block.SCMDeletedBlockTransactionStatusManager: Could not commit delete block transactions: []
java.util.concurrent.TimeoutException
        at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1784)
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1928)
        at org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl.submitRequest(SCMRatisServerImpl.java:228)
        at org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler.invokeRatis(SCMHAInvocationHandler.java:110)
        at org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler.invoke(SCMHAInvocationHandler.java:67)
        at com.sun.proxy.$Proxy17.removeTransactionsFromDB(Unknown Source)
        at org.apache.hadoop.hdds.scm.block.SCMDeletedBlockTransactionStatusManager.commitTransactions(SCMDeletedBlockTransactionStatusManager.java:527)
        at org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl.onMessage(DeletedBlockLogImpl.java:384)
        at org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl.onMessage(DeletedBlockLogImpl.java:73)
        at org.apache.hadoop.hdds.server.events.SingleThreadExecutor.lambda$onMessage$1(SingleThreadExecutor.java:85)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748) 
```
We found that the root cause this following call chains. 

- StateMachine#notifyTermIndexUpdated (due to the transfer leadership)
  - ReplicationManager#notifyStatusChanged
    - LegacyReplicationManager#notifyStatusChanged 
      - LegacyReplicationManager#onLeaderReadyAndOutofSafeMode
        - LegacyReplicationManager#deleteSrcDnForMove
          - LegacyReplicationManager.MoveScheduler#completeMove (replicated annotation means that it will submit Ratis request)
            - SCMHAInvocationHandler#invokeRatisServer
              - SCMRatiServerImpl#submitRequest
                - RaftServerImpl#submitClientRequestAsync

We should never send a Ratis request under the ReplicationManager#notifyStatusChanged since this will cause a deadlock with Ratis StateMachineUpdater. When ReplicationManager#notifyStatusChanged call the MoveScheduler#completeMove, it will send a Ratis request to the Raft server and wait until the log associated with it is applied by the StateMachineUpdater. However, since ReplicationManger#notifyStatusChanged is itself run under the StateMachineUpdater, it will block the StateMachineUpdater itself, meaning that the Raft log associated with request sent by MoveScheduler#completeMove will never be applied and there will be a deadlock. This will cause StateMachineUpdater to get stuck and most SCM client requests to timeout in the StateMachineUpdater.

Currently, one possible fix might be to just remove the onLeaderReadyAndOutOfSafeMode implementation altogether and hopefully the inflight move will be handled up by the main ReplicationManager thread.

Note: The issue should STILL happen after [HDDS-10690](https://issues.apache.org/jira/browse/HDDS-10690) since although StateMachine#notifyTermIndexUpdated will not trigger ReplicationManager#notifyStatusChanged, StateMachine#notifyLeaderReady will instead trigger the Replicationmanager#notifyStatusChanged. Since StateMachine#notifyLeaderReady is still called in the StateMachineUpdater through RaftServerImpl#applyLogToStateMachine.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11750

## How was this patch tested?

Integration test to reproduce the bug and verify the fix.

Failure before the fix: https://github.com/ivandika3/ozone/actions/runs/11965356725/job/33359496259

Success after fix: https://github.com/ivandika3/ozone/actions/runs/11965440504