### PR TITLE
HDDS-11713. Use seek to reach the start transaction.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -137,6 +137,8 @@ public class DeletedBlockLogImpl
             }
           }
         } else {
+          iter.seek(startTxId);
+          iter.next();
           while (iter.hasNext() && failedTXs.size() < count) {
             DeletedBlocksTransaction delTX = iter.next().getValue();
             if (delTX.getCount() == -1 && delTX.getTxID() >= startTxId) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -138,7 +138,9 @@ public class DeletedBlockLogImpl
           }
         } else {
           iter.seek(startTxId);
-          iter.next();
+          if (iter.hasNext()) {
+            iter.next();
+          }
           while (iter.hasNext() && failedTXs.size() < count) {
             DeletedBlocksTransaction delTX = iter.next().getValue();
             if (delTX.getCount() == -1 && delTX.getTxID() >= startTxId) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -138,9 +138,6 @@ public class DeletedBlockLogImpl
           }
         } else {
           iter.seek(startTxId);
-          if (iter.hasNext()) {
-            iter.next();
-          }
           while (iter.hasNext() && failedTXs.size() < count) {
             DeletedBlocksTransaction delTX = iter.next().getValue();
             if (delTX.getCount() == -1 && delTX.getTxID() >= startTxId) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -144,7 +144,7 @@ public class DeletedBlockLogStateManagerImpl
       @Override
       public TypedTable.KeyValue<Long, DeletedBlocksTransaction> seek(
           Long key) throws IOException {
-        throw new UnsupportedOperationException("seek");
+        return iter.seek(key);
       }
 
       @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -144,7 +144,9 @@ public class DeletedBlockLogStateManagerImpl
       @Override
       public TypedTable.KeyValue<Long, DeletedBlocksTransaction> seek(
           Long key) throws IOException {
-        return iter.seek(key);
+        iter.seek(key);
+        findNext();
+        return nextTx;
       }
 
       @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestDeletedBlocksTxnShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestDeletedBlocksTxnShell.java
@@ -259,5 +259,27 @@ public class TestDeletedBlocksTxnShell {
     currentValidTxnNum = deletedBlockLog.getNumOfValidTransactions();
     LOG.info("Valid num of txns: {}", currentValidTxnNum);
     assertEquals(30, currentValidTxnNum);
+
+    // Fail first 20 txns be failed
+    // increment retry count than threshold, count will be set to -1
+    for (int i = 0; i < maxRetry + 1; i++) {
+      deletedBlockLog.incrementCount(txIds);
+    }
+    flush();
+
+    GetFailedDeletedBlocksTxnSubcommand getFailedBlockCommand =
+        new GetFailedDeletedBlocksTxnSubcommand();
+    outContent.reset();
+    cmd = new CommandLine(getFailedBlockCommand);
+    // set start transaction as 15
+    cmd.parseArgs("-c", "5", "-s", "15");
+    getFailedBlockCommand.execute(scmClient);
+    matchCount = 0;
+    p = Pattern.compile("\"txID\" : \\d+", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    while (m.find()) {
+      matchCount += 1;
+    }
+    assertEquals(5, matchCount);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

While getting failed transaction based on start value, in this case currently we are iterating table till we reach to the start of the input transaction and then do the business logic. Instead of iterating here we can use help of seek to reach the input start transaction.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11713

## How was this patch tested?

New integration test
