### PR TITLE
HDDS-11758. Require successful quick checks for repro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
       needs-build: ${{ steps.selective-checks.outputs.needs-build }}
       needs-compile: ${{ steps.selective-checks.outputs.needs-compile }}
       needs-compose-tests: ${{ steps.selective-checks.outputs.needs-compose-tests }}
-      needs-dependency-check: ${{ steps.selective-checks.outputs.needs-dependency-check }}
       needs-integration-tests: ${{ steps.selective-checks.outputs.needs-integration-tests }}
       needs-kubernetes-tests: ${{ steps.selective-checks.outputs.needs-kubernetes-tests }}
       sha: ${{ steps.get-sha.outputs.sha }}
@@ -339,7 +338,6 @@ jobs:
       - build
     runs-on: ubuntu-20.04
     timeout-minutes: 5
-    if: needs.build-info.outputs.needs-dependency-check == 'true'
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -370,7 +368,6 @@ jobs:
       - build
     runs-on: ubuntu-20.04
     timeout-minutes: 15
-    if: needs.build-info.outputs.needs-dependency-check == 'true'
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -415,6 +412,9 @@ jobs:
     needs:
       - build-info
       - build
+      - basic
+      - dependency
+      - license
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:

--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -40,7 +40,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -52,7 +51,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -64,7 +62,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -76,7 +73,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=true
 }
@@ -88,7 +84,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=true
 }
@@ -100,7 +95,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=true
 }
@@ -112,7 +106,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -124,7 +117,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -136,7 +128,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -148,7 +139,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -160,7 +150,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -172,7 +161,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }
@@ -184,7 +172,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -196,7 +183,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -208,7 +194,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=true
 }
@@ -220,7 +205,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -232,7 +216,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -244,7 +227,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -256,7 +238,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -268,7 +249,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -280,7 +260,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -292,7 +271,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -304,7 +282,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -317,7 +294,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -329,7 +305,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=true
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=true
 }
@@ -341,7 +316,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -353,7 +327,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -365,7 +338,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -377,7 +349,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -389,7 +360,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -401,7 +371,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -413,7 +382,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -422,10 +390,9 @@ load bats-assert/load.bash
   run dev-support/ci/selective_ci_checks.sh 47a5671cc5
 
   assert_output -p 'basic-checks=["rat","bats"]'
-  assert_output -p needs-build=false
+  assert_output -p needs-build=true
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=true
   assert_output -p needs-integration-tests=false
   assert_output -p needs-kubernetes-tests=false
 }
@@ -437,7 +404,6 @@ load bats-assert/load.bash
   assert_output -p needs-build=false
   assert_output -p needs-compile=false
   assert_output -p needs-compose-tests=false
-  assert_output -p needs-dependency-check=false
   assert_output -p needs-integration-tests=true
   assert_output -p needs-kubernetes-tests=false
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Background:
- `basic` checks run in parallel with `build`
- `dependency` and `license` checks wait for `build`, but are fairly quick
- `repro` is repeats build and checks for differences

Wait for `basic`, `dependency` and `license` to succeed before starting `repro` check.  This way if trivial errors are found by any of the prerequisites (e.g. checkstyle violation), we save time by avoiding the lengthy rebuild process.

To simplify things, `needs-dependency-check` flag is removed, `dependency` and `license` are triggered after successful build in all runs.

https://issues.apache.org/jira/browse/HDDS-11758

## How was this patch tested?

Updated bats tests.

CI:
https://github.com/adoroszlai/ozone/actions/runs/11934931757