### PR TITLE
HDDS-11764. Fix initiating DocumentBuilderFactory performance problem.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/DocumentBuilderFactoryWrapper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/DocumentBuilderFactoryWrapper.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdds.scm.net;
 
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/DocumentBuilderFactoryWrapper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/DocumentBuilderFactoryWrapper.java
@@ -1,0 +1,20 @@
+package org.apache.hadoop.hdds.scm.net;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+/**
+ * Wrapper for DocumentBuilderFactory reduces the initialization amount.
+ */
+public final class DocumentBuilderFactoryWrapper {
+  private static DocumentBuilderFactory factory;
+
+  private DocumentBuilderFactoryWrapper() {
+  }
+
+  public static DocumentBuilderFactory getInstance() {
+    if (factory == null) {
+      factory = DocumentBuilderFactory.newInstance();
+    }
+    return factory;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -77,8 +77,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
   }
 
   public NetworkTopologyImpl(String schemaFile, InnerNode clusterTree) {
-    schemaManager = NodeSchemaManager.getInstance();
-    schemaManager.init(schemaFile);
+    schemaManager = NodeSchemaManager.getInitiatedInstance(schemaFile);
     maxLevel = schemaManager.getMaxLevel();
     shuffleOperation = Collections::shuffle;
     factory = InnerNodeImpl.FACTORY;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaLoader.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaLoader.java
@@ -175,7 +175,7 @@ public final class NodeSchemaLoader {
       ParserConfigurationException, SAXException, IOException {
     LOG.info("Loading network topology layer schema file");
     // Read and parse the schema file.
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    DocumentBuilderFactory dbf = DocumentBuilderFactoryWrapper.getInstance();
     dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
     dbf.setIgnoringComments(true);
     DocumentBuilder builder = dbf.newDocumentBuilder();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /** The class manages all network topology schemas. */
 
@@ -45,6 +46,8 @@ public final class NodeSchemaManager {
 
   private static volatile NodeSchemaManager instance = null;
 
+  private static final ConcurrentHashMap<String, NodeSchemaManager> cache = new ConcurrentHashMap<>();
+
   private NodeSchemaManager() {
   }
 
@@ -53,6 +56,18 @@ public final class NodeSchemaManager {
       instance = new NodeSchemaManager();
     }
     return instance;
+  }
+
+  public static NodeSchemaManager getInitiatedInstance(String schemaFile) {
+    NodeSchemaManager cachedInstance = cache.get(schemaFile);
+    if (cachedInstance == null) {
+      instance = new NodeSchemaManager();
+      instance.init(schemaFile);
+      cache.put(schemaFile, instance);
+      return instance;
+    } else {
+      return cachedInstance;
+    }
   }
 
   public void init(ConfigurationSource conf) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaManager.java
@@ -46,7 +46,7 @@ public final class NodeSchemaManager {
 
   private static volatile NodeSchemaManager instance = null;
 
-  private static final ConcurrentHashMap<String, NodeSchemaManager> cache = new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<String, NodeSchemaManager> CACHE = new ConcurrentHashMap<>();
 
   private NodeSchemaManager() {
   }
@@ -59,11 +59,11 @@ public final class NodeSchemaManager {
   }
 
   public static NodeSchemaManager getInitiatedInstance(String schemaFile) {
-    NodeSchemaManager cachedInstance = cache.get(schemaFile);
+    NodeSchemaManager cachedInstance = CACHE.get(schemaFile);
     if (cachedInstance == null) {
       instance = new NodeSchemaManager();
       instance.init(schemaFile);
-      cache.put(schemaFile, instance);
+      CACHE.computeIfAbsent(schemaFile, k -> instance);
       return instance;
     } else {
       return cachedInstance;


### PR DESCRIPTION
HDDS-11764. Fix initiating DocumentBuilderFactory performance problem.

Cache initiating DocumentBuilderFactory and NodeSchemaManager to ip

[Link to Jira task: HDDS-11764](https://issues.apache.org/jira/browse/HDDS-11764)

Patch tested only by performance tests.
