### PR TITLE
HDDS-11769. Add tools folder into ozone src package.

### DIFF
--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -32,28 +32,22 @@
       <source>NOTICE.txt</source>
       <outputDirectory>/</outputDirectory>
     </file>
-    <file>
-      <source>hadoop-ozone/dist/src/main/license/src/licenses/LICENSE-angular-nvd3.txt</source>
-      <outputDirectory>/licenses</outputDirectory>
-    </file>
-    <file>
-      <source>hadoop-ozone/dist/src/main/license/src/licenses/LICENSE-angular.txt</source>
-      <outputDirectory>/licenses</outputDirectory>
-    </file>
-    <file>
-      <source>hadoop-ozone/dist/src/main/license/src/licenses/LICENSE-d3.txt</source>
-      <outputDirectory>/licenses</outputDirectory>
-    </file>
-    <file>
-      <source>hadoop-ozone/dist/src/main/license/src/licenses/LICENSE-nvd3.txt</source>
-      <outputDirectory>/licenses</outputDirectory>
-    </file>
-    <file>
-      <source>hadoop-ozone/dist/src/main/license/src/licenses/LICENSE-jquery.txt</source>
-      <outputDirectory>/licenses</outputDirectory>
-    </file>
   </files>
   <fileSets>
+    <fileSet>
+      <directory>hadoop-ozone/dist/src/main/license/src/licenses</directory>
+      <outputDirectory>/licenses</outputDirectory>
+      <includes>
+        <include>*.txt</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>tools</directory>
+      <outputDirectory>/tools</outputDirectory>
+      <includes>
+        <include>**/*</include>
+      </includes>
+    </fileSet>
     <fileSet>
       <directory>.</directory>
       <includes>

--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -38,7 +38,7 @@
       <directory>hadoop-ozone/dist/src/main/license/src/licenses</directory>
       <outputDirectory>/licenses</outputDirectory>
       <includes>
-        <include>*.txt</include>
+        <include>LICENSE-*.txt</include>
       </includes>
     </fileSet>
     <fileSet>
@@ -47,6 +47,14 @@
       <includes>
         <include>**/*</include>
       </includes>
+      <useDefaultExcludes>true</useDefaultExcludes>
+      <excludes>
+        <exclude>**/.classpath</exclude>
+        <exclude>**/.project</exclude>
+        <exclude>**/.settings</exclude>
+        <exclude>**/*.iml</exclude>
+        <exclude>**/target/**</exclude>
+      </excludes>
     </fileSet>
     <fileSet>
       <directory>.</directory>

--- a/hadoop-ozone/dist/src/main/license/src/licenses/IMPORTANT.md
+++ b/hadoop-ozone/dist/src/main/license/src/licenses/IMPORTANT.md
@@ -14,5 +14,8 @@
 
 # Important
 
+The files from this directory are copied automatically to the source distribution package
+via the `hadoop-ozone/dist/src/main/assemblies/ozone-src.xml` file.
+
 If you add any of the files to here,
- * and copy the dependency to ../../bin/licenses (if it's included in the bin tar)
+ * copy the dependency to ../../bin/licenses (if it's included in the bin tar)

--- a/hadoop-ozone/dist/src/main/license/src/licenses/IMPORTANT.md
+++ b/hadoop-ozone/dist/src/main/license/src/licenses/IMPORTANT.md
@@ -14,8 +14,5 @@
 
 # Important
 
-The files from this directory are not copied by automatically to the source distribution package.
-
 If you add any of the files to here,
- * please also adjust `hadoop-ozone/dist/src/main/assemblies/ozone-src.xml` file.
  * and copy the dependency to ../../bin/licenses (if it's included in the bin tar)


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. add tools folder into ozone src package
2. copy all license txt file under hadoop-ozone/dist/src/main/license/src/licenses to licenses folder. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11769


## How was this patch tested?

Tested locally with command "mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Psrc -Dtar", then checked the generated ozone-2.0.0-SNAPSHOT-src.tar.gz.  
