### PR TITLE
HDDS-10568. When the ldb command is executed, it is output by line

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -435,22 +435,7 @@ public class TestLDBCli {
 
     switch (tableName) {
     case KEY_TABLE:
-      // Dummy om.db with only keyTable
-      dbStore = DBStoreBuilder.newBuilder(conf).setName("om.db")
-          .setPath(tempDir.toPath()).addTable(KEY_TABLE).build();
-
-      Table<byte[], byte[]> keyTable = dbStore.getTable(KEY_TABLE);
-      // Insert 5 keys
-      for (int i = 1; i <= 5; i++) {
-        String key = "key" + i;
-        OmKeyInfo value = OMRequestTestUtils.createOmKeyInfo("vol1", "buck1",
-            key, ReplicationConfig.fromProtoTypeAndFactor(STAND_ALONE, HddsProtos.ReplicationFactor.ONE)).build();
-        keyTable.put(key.getBytes(UTF_8),
-            value.getProtobuf(ClientVersion.CURRENT_VERSION).toByteArray());
-
-        // Populate map
-        dbMap.put(key, toMap(value));
-      }
+      prepareKeyTable(5);
       break;
 
     case BLOCK_DATA:
@@ -506,6 +491,7 @@ public class TestLDBCli {
     if (recordsCount < 1) {
       throw new IllegalArgumentException("recordsCount must be greater than 1.");
     }
+    // Dummy om.db with only keyTable
     dbStore = DBStoreBuilder.newBuilder(conf).setName("om.db")
         .setPath(tempDir.toPath()).addTable(KEY_TABLE).build();
     Table<byte[], byte[]> keyTable = dbStore.getTable(KEY_TABLE);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -54,7 +54,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -369,8 +370,10 @@ public class TestLDBCli {
     assertNotNull(subFiles);
     assertEquals(Math.ceil(recordsCount / (maxRecordsPerFile * 1.0)), subFiles.length);
     for (File subFile : subFiles) {
-      JsonElement jsonElement = JsonParser.parseReader(new FileReader(subFile));
-      assertTrue(jsonElement.isJsonArray() || jsonElement.isJsonObject());
+      try(FileInputStream inputStream =new FileInputStream(subFile)) {
+        JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream, "UTF-8"));
+        assertTrue(jsonElement.isJsonArray() || jsonElement.isJsonObject());
+      }
     }
 
     String scanDir2 = tempDir.getAbsolutePath() + "/scandir2";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -17,10 +17,9 @@
 package org.apache.hadoop.ozone.debug;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -54,8 +53,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -370,10 +367,8 @@ public class TestLDBCli {
     assertNotNull(subFiles);
     assertEquals(Math.ceil(recordsCount / (maxRecordsPerFile * 1.0)), subFiles.length);
     for (File subFile : subFiles) {
-      try (FileInputStream inputStream = new FileInputStream(subFile)) {
-        JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream, "UTF-8"));
-        assertTrue(jsonElement.isJsonArray() || jsonElement.isJsonObject());
-      }
+      JsonNode jsonNode = MAPPER.readTree(subFile);
+      assertNotNull(jsonNode);
     }
 
     String scanDir2 = tempDir.getAbsolutePath() + "/scandir2";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -370,7 +370,7 @@ public class TestLDBCli {
     assertNotNull(subFiles);
     assertEquals(Math.ceil(recordsCount / (maxRecordsPerFile * 1.0)), subFiles.length);
     for (File subFile : subFiles) {
-      try(FileInputStream inputStream =new FileInputStream(subFile)) {
+      try (FileInputStream inputStream = new FileInputStream(subFile)) {
         JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream, "UTF-8"));
         assertTrue(jsonElement.isJsonArray() || jsonElement.isJsonObject());
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -342,6 +342,43 @@ public class TestLDBCli {
   }
 
   @Test
+  void testScanWithRecordsPerFile() throws IOException {
+    // Prepare dummy table
+    prepareTable(KEY_TABLE, false);
+
+    String scanDir1 = tempDir.getAbsolutePath() + "/scandir1";
+    // Prepare scan args
+    List<String> completeScanArgs1 = new ArrayList<>(Arrays.asList(
+        "--db", dbStore.getDbLocation().getAbsolutePath(),
+        "scan",
+        "--column-family", KEY_TABLE, "--out", scanDir1,
+        "--max-records-per-file", "2"));
+
+    File tmpDir1 = new File(scanDir1);
+    tmpDir1.deleteOnExit();
+
+    int exitCode1 = cmd.execute(completeScanArgs1.toArray(new String[0]));
+    assertEquals(0, exitCode1);
+    assertTrue(tmpDir1.isDirectory());
+    assertEquals(3, tmpDir1.listFiles().length);
+
+    String scanDir2 = tempDir.getAbsolutePath() + "/scandir2";
+    // Used with parameter '-l'
+    List<String> completeScanArgs2 = new ArrayList<>(Arrays.asList(
+        "--db", dbStore.getDbLocation().getAbsolutePath(),
+        "scan",
+        "--column-family", KEY_TABLE, "--out", scanDir2,
+        "--max-records-per-file", "3", "-l", "2"));
+    File tmpDir2 = new File(scanDir2);
+    tmpDir2.deleteOnExit();
+
+    int exitCode2 = cmd.execute(completeScanArgs2.toArray(new String[0]));
+    assertEquals(0, exitCode2);
+    assertTrue(tmpDir2.isDirectory());
+    assertEquals(1, tmpDir2.listFiles().length);
+  }
+
+  @Test
   void testSchemaCommand() throws IOException {
     // Prepare dummy table
     prepareTable(KEY_TABLE, false);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/debug/TestLDBCli.java
@@ -71,6 +71,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.S
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * This class tests `ozone debug ldb` CLI that reads from a RocksDB directory.
@@ -365,6 +366,7 @@ public class TestLDBCli {
     assertEquals(0, exitCode1);
     assertTrue(tmpDir1.isDirectory());
     File[] subFiles = tmpDir1.listFiles();
+    assertNotNull(subFiles);
     assertEquals(Math.ceil(recordsCount / (maxRecordsPerFile * 1.0)), subFiles.length);
     for (File subFile : subFiles) {
       JsonElement jsonElement = JsonParser.parseReader(new FileReader(subFile));
@@ -441,7 +443,11 @@ public class TestLDBCli {
 
       Table<byte[], byte[]> keyTable = dbStore.getTable(KEY_TABLE);
       // Insert the number of keys specified by recordsCount[0]
-      for (int i = 1; i <= recordsCount[0]; i++) {
+      int count = 5;
+      if (recordsCount.length > 0) {
+        count = recordsCount[0];
+      }
+      for (int i = 1; i <= count; i++) {
         String key = "key" + i;
         OmKeyInfo value = OMRequestTestUtils.createOmKeyInfo("vol1", "buck1",
             key, ReplicationConfig.fromProtoTypeAndFactor(STAND_ALONE, HddsProtos.ReplicationFactor.ONE)).build();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -251,15 +251,13 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     }
 
     // If there are no parent directories, create them
-    if (recordsPerFile > 0) {
-      File file = new File(fileName);
-      File parentFile = file.getParentFile();
-      if (!parentFile.exists()) {
-        boolean flg = parentFile.mkdirs();
-        if (!flg) {
-          throw new IOException("An exception occurred while creating " +
-              "the directory. Directorys: " + parentFile.getAbsolutePath());
-        }
+    File file = new File(fileName);
+    File parentFile = file.getParentFile();
+    if (!parentFile.exists()) {
+      boolean flg = parentFile.mkdirs();
+      if (!flg) {
+        throw new IOException("An exception occurred while creating " +
+            "the directory. Directorys: " + parentFile.getAbsolutePath());
       }
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -251,18 +251,21 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     }
 
     // If there are no parent directories, create them
-    File dirFile = new File(fileName);
-    if (!dirFile.exists()) {
-      boolean flg = dirFile.mkdirs();
-      if (!flg) {
-        throw new IOException("An exception occurred while creating " +
-                "the directory. Directorys: " + dirFile.getAbsolutePath());
+    if (recordsPerFile > 0) {
+      File file = new File(fileName);
+      File parentFile = file.getParentFile();
+      if (!parentFile.exists()) {
+        boolean flg = parentFile.mkdirs();
+        if (!flg) {
+          throw new IOException("An exception occurred while creating " +
+              "the directory. Directorys: " + parentFile.getAbsolutePath());
+        }
       }
     }
 
     // Write to file output
     while (iterator.get().isValid() && withinLimit(globalCount)) {
-      String fileNameTarget = recordsPerFile > 0 ? fileName + File.separator + fileSuffix++ :
+      String fileNameTarget = recordsPerFile > 0 ? fileName + "." + fileSuffix++ :
           fileName;
       try (PrintWriter out = new PrintWriter(new BufferedWriter(
           new PrintWriter(fileNameTarget, UTF_8.name())))) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
@@ -172,6 +173,14 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       defaultValue = "10")
   private int threadCount;
 
+  @CommandLine.Option(names = {"--max-records-per-file"},
+      description = "The number of records to print per file.",
+      defaultValue = "0")
+  private long recordsPerFile;
+
+  private int fileSuffix = 0;
+  private long globalCount = 0;
+
   private static final String KEY_SEPARATOR_SCHEMA_V3 =
       new OzoneConfiguration().getObject(DatanodeConfiguration.class)
           .getContainerSchemaV3KeySeparator();
@@ -180,7 +189,8 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
 
   @Override
   public Void call() throws Exception {
-
+    fileSuffix = 0;
+    globalCount = 0;
     List<ColumnFamilyDescriptor> cfDescList =
         RocksDBUtils.getColumnFamilyDescriptors(parent.getDbPath());
     final List<ColumnFamilyHandle> cfHandleList = new ArrayList<>();
@@ -240,11 +250,28 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       return displayTable(iterator, dbColumnFamilyDef, out(), schemaV3);
     }
 
-    // Write to file output
-    try (PrintWriter out = new PrintWriter(new BufferedWriter(
-        new PrintWriter(fileName, UTF_8.name())))) {
-      return displayTable(iterator, dbColumnFamilyDef, out, schemaV3);
+    // If there are no parent directories, create them
+    File dirFile = new File(fileName);
+    if (!dirFile.exists()) {
+      boolean flg = dirFile.mkdirs();
+      if (!flg) {
+        throw new IOException("An exception occurred while creating " +
+                "the directory. Directorys: " + dirFile.getAbsolutePath());
+      }
     }
+
+    // Write to file output
+    while (iterator.get().isValid() && withinLimit(globalCount)) {
+      String fileNameTarget = recordsPerFile > 0 ? fileName + File.separator + fileSuffix++ :
+          fileName;
+      try (PrintWriter out = new PrintWriter(new BufferedWriter(
+          new PrintWriter(fileNameTarget, UTF_8.name())))) {
+        if (!displayTable(iterator, dbColumnFamilyDef, out, schemaV3)) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   private boolean displayTable(ManagedRocksIterator iterator,
@@ -314,7 +341,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       }
     }
 
-    while (withinLimit(count) && iterator.get().isValid() && !exception && !reachedEnd) {
+    while (withinLimit(globalCount) && iterator.get().isValid() && !exception && !reachedEnd) {
       // if invalid endKey is given, it is ignored
       if (null != endKey && Arrays.equals(iterator.get().key(), getValueObject(dbColumnFamilyDef, endKey))) {
         reachedEnd = true;
@@ -326,6 +353,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         // the record passes the filter
         batch.add(new ByteArrayKeyValue(
             iterator.get().key(), iterator.get().value()));
+        globalCount++;
         count++;
         if (batch.size() >= batchSize) {
           while (logWriter.getInflightLogCount() > threadCount * 10L
@@ -343,6 +371,9 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
         }
       }
       iterator.get().next();
+      if ((recordsPerFile > 0) && (count >= recordsPerFile)) {
+        break;
+      }
     }
     if (!batch.isEmpty()) {
       Future<Void> future = threadPool.submit(new Task(dbColumnFamilyDef,


### PR DESCRIPTION
## What changes were proposed in this pull request?
When executing the ldb command, specify the maximum number of records to print for each file.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-10568

## How was this patch tested?
ci : 
https://github.com/jianghuazhu/ozone/actions/runs/11955271018
Test command:
`
./bin/ozone debug ldb --db=/home/hadoop/jhz/test/om.db scan --column_family=bucketTable --out=/data12/test/tmp_file1 --max-records-per-file=300
`
`--max-records-per-file` specifies the maximum number of records to print per file. It is used together with `--out`.
result:
```
-rw-rw-r-- 1 hadoop hadoop 140538 Nov 21 22:02 0
-rw-rw-r-- 1 hadoop hadoop 136737 Nov 21 22:02 1
-rw-rw-r-- 1 hadoop hadoop 136741 Nov 21 22:02 2
-rw-rw-r-- 1 hadoop hadoop 139301 Nov 21 22:02 3
-rw-rw-r-- 1 hadoop hadoop 130741 Nov 21 22:02 4
-rw-rw-r-- 1 hadoop hadoop 130737 Nov 21 22:02 5
-rw-rw-r-- 1 hadoop hadoop 114272 Nov 21 22:02 6
```
or
`
/bin/ozone debug ldb --db=/home/hadoop/jhz/test/om.db scan --column_family=bucketTable --limit=3 --out=/data12/test/tmp_file2 --max-records-per-file=300
`
`--max-records-per-file` can also be used with `--limit` .
result:
```
-rw-rw-r-- 1 hadoop hadoop 614 Nov 21 22:03 0
```
