### PR TITLE
HDDS-11773. Prevent frequent DataNode Ratis snapshotting.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -280,7 +280,7 @@
   <property>
     <name>hdds.ratis.snapshot.threshold</name>
     <value>100000</value>
-    <tag>OZONE, RATIS</tag>
+    <tag>OZONE, CONTAINER, RATIS</tag>
     <description>Number of transactions after which a ratis snapshot should be
       taken.
     </description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -279,7 +279,7 @@
   </property>
   <property>
     <name>hdds.ratis.snapshot.threshold</name>
-    <value>10000</value>
+    <value>100000</value>
     <tag>OZONE, RATIS</tag>
     <description>Number of transactions after which a ratis snapshot should be
       taken.
@@ -287,7 +287,7 @@
   </property>
   <property>
     <name>hdds.container.ratis.statemachine.max.pending.apply-transactions</name>
-    <value>10000</value>
+    <value>100000</value>
     <tag>OZONE, RATIS</tag>
     <description>Maximum number of pending apply transactions in a data
       pipeline. The default value is kept same as default snapshot threshold

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -288,7 +288,7 @@
   <property>
     <name>hdds.container.ratis.statemachine.max.pending.apply-transactions</name>
     <value>100000</value>
-    <tag>OZONE, RATIS</tag>
+    <tag>OZONE, CONTAINER, RATIS</tag>
     <description>Maximum number of pending apply transactions in a data
       pipeline. The default value is kept same as default snapshot threshold
       hdds.ratis.snapshot.threshold.


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11773. Bump hdds.ratis.snapshot.threshold and hdds.container.ratis.statemachine.max.pending.apply-transactions to 100k

Please describe your PR in detail:
* DataNode is configured to snapshot every 10k transactions, which is too frequent for HBase workloads where DataNode can do thousands and eventually 10s of thousands of transactions per second. 
* Bump hdds.ratis.snapshot.threshold to 100k for now. Update hdds.container.ratis.statemachine.max.pending.apply-transactions to make it consistent.
* We have to revisit and make it 1M eventually.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11773

## How was this patch tested?

Applied the change to a HBase cluster. Previously it was snapshotting every 4-5 seconds, and now it is doing it about every minute.