### PR TITLE
HDDS-11785. DataNode aborts ContainerStateMachine if it does not know any follower next index

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -1006,7 +1006,7 @@ public class ContainerStateMachine extends BaseStateMachine {
         RaftServer.Division division = ratisServer.getServer().getDivision(getGroupId());
         if (division.getInfo().isLeader()) {
           long minIndex = Arrays.stream(division.getInfo()
-              .getFollowerNextIndices()).min().getAsLong();
+              .getFollowerNextIndices()).min().orElse(0);
           LOG.debug("Removing data corresponding to log index {} min index {} "
                   + "from cache", index, minIndex);
           removeCacheDataUpTo(Math.min(minIndex, index));

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -1005,12 +1005,15 @@ public class ContainerStateMachine extends BaseStateMachine {
       try {
         RaftServer.Division division = ratisServer.getServer().getDivision(getGroupId());
         if (division.getInfo().isLeader()) {
-          long minIndex = Arrays.stream(division.getInfo()
-              .getFollowerNextIndices()).min().orElse(0);
-          LOG.debug("Removing data corresponding to log index {} min index {} "
-                  + "from cache", index, minIndex);
-          removeCacheDataUpTo(Math.min(minIndex, index));
+          Arrays.stream(division.getInfo()
+              .getFollowerNextIndices()).min().ifPresent(minIndex -> {
+                removeCacheDataUpTo(Math.min(minIndex, index));
+                LOG.debug("Removing data corresponding to log index {} min index {} "
+                    + "from cache", index, minIndex);
+              });
         }
+      } catch (RuntimeException e) {
+        throw e;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11785. DataNode aborts state machine because ContainerStateMachine does not know follower's next index

Please describe your PR in detail:
* When waitOnAllFollowers is enabled (hdds.datanode.wait.on.all.followers), the leader may not have the follower's information, and will throw a RuntimeException that closes the state machine.
* Add a fix to return 0 in that case.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11785

## How was this patch tested?
