### PR TITLE
HDDS-11796. Update documentation to mention that container schemaV3 is default

### DIFF
--- a/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.md
+++ b/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.md
@@ -25,15 +25,15 @@ summary: Introduction to Ozone Datanode Container Schema V3
 
 In Ozone, user data are separated into blocks and stored in HDDS Containers. Containers are the fundamental replication unit of Ozone/HDDS. Each Container has its metadata and data. Data are saved as files on disk. Metadata is saved in RocksDB.
 
-Currently there will be one RocksDB for each Container on datanode. With user data continously grow, there will be hundreds of thousands of RocksDB instances on one datanode. It's a big challenge to manage this amount of RocksDB instances in one JVM. 
+Earlier, there was one RocksDB for each Container on datanode. With user data continously growing, there will be hundreds of thousands of RocksDB instances on one datanode. It's a big challenge to manage this amount of RocksDB instances in one JVM. 
 
-Unlike the current approach, this "Merge Container RocksDB in DN" feature will use only one RocksDB for each data volume, holding all metadata of Containers in this RocksDB. 
+Unlike the previous approach, this "Merge Container RocksDB in DN" feature will use only one RocksDB for each data volume, holding all metadata of Containers in this RocksDB. 
   
 ## Configuration
 
-This is mainly a DN feature, which doesn't require much configuration.
+This is mainly a DN feature, which doesn't require much configuration. By default, it is enabled.
 
-Here is a configuration which disable this feature if the current one RocksDB for each container mode is more preferred. Please be noted that once the feature is enabled, it's strongly suggested not to disable it in later. 
+Here is a configuration which disables this feature if the "one RocksDB for each container" mode is more preferred. Please be noted that once the feature is enabled, it's strongly suggested not to disable it in later. 
   
 ```XML
 <property>

--- a/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.zh.md
+++ b/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.zh.md
@@ -25,13 +25,13 @@ summary: Ozone DataNode Container模式简介V3
 
 在 Ozone 中，用户数据被分割成blocks并存储在 HDDS Container中。Container是 Ozone/HDDS 的基本复制单元。每个Container都有自己的元数据和数据, 数据以文件形式保存在磁盘上，元数据保存在RocksDB中。
 
-目前，数据节点上的每个Container都有一个RocksDB。随着用户数据的不断增长，一个DataNode上将会有成百上千个RocksDB实例。在一个JVM中管理如此多的RocksDB实例是一个巨大的挑战。
+之前，数据节点上每个Container都有一个RocksDB。随着用户数据的不断增长，一个DataNode上将会有成百上千个RocksDB实例。在一个JVM中管理如此多的RocksDB实例是一个巨大的挑战。
 
-与当前使用方法不同，"Merge Container RocksDB in DN"功能将为每个Volume只使用一个RocksDB，并在此RocksDB中保存所有Container的元数据。
+与以前的用法不同，"Merge Container RocksDB in DN"功能将为每个Volume只使用一个RocksDB，并在此RocksDB中保存所有Container的元数据。
   
 ## 配置
 
-这主要是DataNode的功能，不需要太多配置。
+这主要是DataNode的功能，不需要太多配置。默认情况下，它是启用的。
 
 如果更倾向于为每个Container使用一个RocksDB的模式，那么这下面的配置可以禁用上面所介绍的功能。请注意，一旦启用该功能，强烈建议以后不要再禁用。
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-7320](https://issues.apache.org/jira/browse/HDDS-7320) updated the default to be schemaV3. But it is not mentioned in the docs "Merge Container RocksDB in DN". It is updated in this PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11796

## How was this patch tested?

Tested manually with `hugo serve`
