### PR TITLE
HDDS-11806. Add HttpFS and Recon in getting-started k8s example

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/config-configmap.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/config-configmap.yaml
@@ -31,6 +31,7 @@ data:
   OZONE-SITE.XML_ozone.om.address: om-0.om
   OZONE-SITE.XML_ozone.scm.client.address: scm-0.scm
   OZONE-SITE.XML_ozone.scm.names: scm-0.scm
+  OZONE-SITE.XML_ozone.recon.address: recon-0.recon
   OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "3"
   OZONE-SITE.XML_ozone.datanode.pipeline.limit: "1"
   OZONE-SITE.XML_dfs.datanode.use.datanode.hostname: "true"

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/config-configmap.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/config-configmap.yaml
@@ -19,6 +19,11 @@ kind: ConfigMap
 metadata:
   name: config
 data:
+  HTTPFS-SITE.XML_httpfs.hadoop.config.dir: /opt/hadoop/etc/config
+  CORE-SITE.XML_fs.defaultFS: ofs://om/
+  CORE-SITE.XML_fs.trash.interval: "1"
+  HTTPFS-SITE.XML_httpfs.proxyuser.hadoop.hosts: "*"
+  HTTPFS-SITE.XML_httpfs.proxyuser.hadoop.groups: "*"
   OZONE-SITE.XML_hdds.datanode.dir: /data/storage
   OZONE-SITE.XML_ozone.scm.datanode.id.dir: /data
   OZONE-SITE.XML_ozone.metadata.dirs: /data/metadata

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/httpfs-public-service.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/httpfs-public-service.yaml
@@ -14,20 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resources:
-- config-configmap.yaml
-- datanode-service.yaml
-- datanode-statefulset.yaml
-- om-service.yaml
-- om-statefulset.yaml
-- s3g-service.yaml
-- s3g-statefulset.yaml
-- scm-service.yaml
-- scm-statefulset.yaml
-- httpfs-service.yaml
-- httpfs-statefulset.yaml
-- datanode-public-service.yaml
-- om-public-service.yaml
-- s3g-public-service.yaml
-- scm-public-service.yaml
-- httpfs-public-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpfs-public
+spec:
+  ports:
+  - port: 14000
+    name: rest
+  selector:
+    app: ozone
+    component: httpfs
+  type: NodePort

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/httpfs-service.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/httpfs-service.yaml
@@ -14,20 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resources:
-- config-configmap.yaml
-- datanode-service.yaml
-- datanode-statefulset.yaml
-- om-service.yaml
-- om-statefulset.yaml
-- s3g-service.yaml
-- s3g-statefulset.yaml
-- scm-service.yaml
-- scm-statefulset.yaml
-- httpfs-service.yaml
-- httpfs-statefulset.yaml
-- datanode-public-service.yaml
-- om-public-service.yaml
-- s3g-public-service.yaml
-- scm-public-service.yaml
-- httpfs-public-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpfs
+spec:
+  ports:
+  - port: 14000
+    name: rest
+  clusterIP: None
+  selector:
+    app: ozone
+    component: httpfs

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/httpfs-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/httpfs-statefulset.yaml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: httpfs
+  labels:
+    app.kubernetes.io/component: ozone
+spec:
+  selector:
+    matchLabels:
+      app: ozone
+      component: httpfs
+  serviceName: httpfs
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ozone
+        component: httpfs
+    spec:
+      containers:
+      - name: httpfs
+        image: '@docker.image@'
+        args:
+        - ozone
+        - httpfs
+        livenessProbe:
+          httpGet:
+            path: /webhdfs/v1/?op=LISTSTATUS&user.name=hadoop
+            port: 14000
+          initialDelaySeconds: 30
+        envFrom:
+        - configMapRef:
+            name: config
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/recon-public-service.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/recon-public-service.yaml
@@ -14,23 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resources:
-- config-configmap.yaml
-- datanode-service.yaml
-- datanode-statefulset.yaml
-- om-service.yaml
-- om-statefulset.yaml
-- s3g-service.yaml
-- s3g-statefulset.yaml
-- scm-service.yaml
-- scm-statefulset.yaml
-- httpfs-service.yaml
-- httpfs-statefulset.yaml
-- recon-service.yaml
-- recon-statefulset.yaml
-- datanode-public-service.yaml
-- om-public-service.yaml
-- s3g-public-service.yaml
-- scm-public-service.yaml
-- httpfs-public-service.yaml
-- recon-public-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: recon-public
+spec:
+  ports:
+  - port: 9888
+    name: ui
+  selector:
+    app: ozone
+    component: recon
+  type: NodePort

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/recon-service.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/recon-service.yaml
@@ -14,23 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resources:
-- config-configmap.yaml
-- datanode-service.yaml
-- datanode-statefulset.yaml
-- om-service.yaml
-- om-statefulset.yaml
-- s3g-service.yaml
-- s3g-statefulset.yaml
-- scm-service.yaml
-- scm-statefulset.yaml
-- httpfs-service.yaml
-- httpfs-statefulset.yaml
-- recon-service.yaml
-- recon-statefulset.yaml
-- datanode-public-service.yaml
-- om-public-service.yaml
-- s3g-public-service.yaml
-- scm-public-service.yaml
-- httpfs-public-service.yaml
-- recon-public-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: recon
+spec:
+  ports:
+  - port: 9888
+    name: ui
+  clusterIP: None
+  selector:
+    app: ozone
+    component: recon

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/recon-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/recon-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: recon
-        image: 'apache/ozone:1.4.0'
+        image: '@docker.image@'
         args:
         - ozone
         - recon

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/recon-statefulset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/recon-statefulset.yaml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: recon
+  labels:
+    app.kubernetes.io/component: ozone
+spec:
+  selector:
+    matchLabels:
+      app: ozone
+      component: recon
+  serviceName: recon
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ozone
+        component: recon
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9888"
+        prometheus.io/path: /prom
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+      - name: recon
+        image: 'apache/ozone:1.4.0'
+        args:
+        - ozone
+        - recon
+        env:
+        - name: WAITFOR
+          value: scm-0.scm:9876
+        livenessProbe:
+          tcpSocket:
+            port: 9891
+          initialDelaySeconds: 30
+        envFrom:
+        - configMapRef:
+            name: config
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        emptyDir: {}


### PR DESCRIPTION
## What changes were proposed in this pull request?
HttpFS k8s example files are added in the getting-started directory

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11806

## How was this patch tested?
By manual test, I have deployed getting-started in my own k8s cluster. It has been successfully deployed and I have checked the functionalities by integrating hue with httpfs gw.