### PR TITLE
HDDS-11811. rocksdbjni deleted on exit could be used by other components

### DIFF
--- a/hadoop-hdds/rocks-native/src/test/java/org/apache/hadoop/hdds/utils/TestNativeLibraryLoader.java
+++ b/hadoop-hdds/rocks-native/src/test/java/org/apache/hadoop/hdds/utils/TestNativeLibraryLoader.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.utils;
 
 
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedRawSSTFileReader;
 import org.apache.ozone.test.tag.Native;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,15 +29,16 @@ import org.mockito.MockedStatic;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.utils.NativeConstants.ROCKS_TOOLS_NATIVE_LIBRARY_NAME;
 import static org.apache.hadoop.hdds.utils.NativeLibraryLoader.NATIVE_LIB_TMP_DIR;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.apache.hadoop.hdds.utils.NativeLibraryLoader.getJniLibraryFileName;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.anyString;
@@ -68,21 +70,45 @@ public class TestNativeLibraryLoader {
       mockedNativeLibraryLoader.when(() -> NativeLibraryLoader.getInstance()).thenReturn(loader);
       ManagedRawSSTFileReader.loadLibrary();
       assertTrue(NativeLibraryLoader.isLibraryLoaded(ROCKS_TOOLS_NATIVE_LIBRARY_NAME));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("nativeLibraryDirectoryLocations")
+  public void testDummyLibrary(String nativeLibraryDirectoryLocation) {
+    Map<String, Boolean> libraryLoadedMap = new HashMap<>();
+    NativeLibraryLoader loader = new NativeLibraryLoader(libraryLoadedMap);
+    try (MockedStatic<NativeLibraryLoader> mockedNativeLibraryLoader = mockStatic(NativeLibraryLoader.class,
+        CALLS_REAL_METHODS)) {
+      mockedNativeLibraryLoader.when(() -> NativeLibraryLoader.getSystemProperty(same(NATIVE_LIB_TMP_DIR)))
+          .thenReturn(nativeLibraryDirectoryLocation);
+      mockedNativeLibraryLoader.when(NativeLibraryLoader::getInstance).thenReturn(loader);
       // Mocking to force copy random bytes to create a lib file to
       // nativeLibraryDirectoryLocation. But load library will fail.
       mockedNativeLibraryLoader.when(() -> NativeLibraryLoader.getResourceStream(anyString()))
           .thenReturn(new ByteArrayInputStream(new byte[]{0, 1, 2, 3}));
       String dummyLibraryName = "dummy_lib";
-      NativeLibraryLoader.getInstance().loadLibrary(dummyLibraryName, Collections.emptyList());
-      NativeLibraryLoader.isLibraryLoaded(dummyLibraryName);
-      // Checking if the resource with random was copied to a temp file.
-      File[] libPath = new File(nativeLibraryDirectoryLocation == null ? "" : nativeLibraryDirectoryLocation)
-          .getAbsoluteFile().listFiles((dir, name) -> name.startsWith(dummyLibraryName) &&
-              name.endsWith(NativeLibraryLoader.getLibOsSuffix()));
-      assertNotNull(libPath);
-      assertEquals(1, libPath.length);
-      assertTrue(libPath[0].delete());
-    }
+      List<String> dependencies = Arrays.asList("dep1", "dep2");
+      File absDir = new File(nativeLibraryDirectoryLocation == null ? "" : nativeLibraryDirectoryLocation)
+          .getAbsoluteFile();
 
+      NativeLibraryLoader.getInstance().loadLibrary(dummyLibraryName, dependencies);
+
+      // Checking if the resource with random was copied to a temp file.
+      File[] libPath = absDir
+          .listFiles((dir, name) -> name.startsWith(dummyLibraryName));
+      assertThat(libPath)
+          .isNotNull()
+          .isNotEmpty();
+      assertThat(libPath[0])
+          .isDirectory();
+      try {
+        assertThat(new File(libPath[0], getJniLibraryFileName(dummyLibraryName)))
+            .isFile();
+        dependencies.forEach(dep -> assertThat(new File(libPath[0], dep)).isFile());
+      } finally {
+        FileUtil.fullyDelete(libPath[0]);
+      }
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`NativeLibraryLoader` copies the library being loaded to the directory defined by `native.lib.tmp.dir` property (e.g. `/tmp`). It uses a temporary file name as target to avoid conflicts.  It also copies some dependencies, whose names are preserved to ensure library links are not broken.  All libs are deleted when the process exits.

Multiple Ozone processes running on the same host all copy libs to the same path (`/tmp/librocksdbjni-linux64.so`).  Copying and deleting both introduce race conditions, causing other processes to see incomplete or no file at all.

https://issues.apache.org/jira/browse/HDDS-11811

## How was this patch tested?

Updated unit test case.

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.633 s - in org.apache.hadoop.hdds.utils.TestNativeLibraryLoader
```

Built locally with native libs.

```
$ mvn -DskipTests -DskipRecon -Drocks_tools_native clean package
```

```
$ cd hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT

$ bin/ozone checknative
Native library checking:
hadoop:  false 
ISA-L:   false 
rocks-tools: true libozone_rocksdb_tools.so

$ export OZONE_OPTS=-Dnative.lib.tmp.dir=/no-such-dir

$ bin/ozone checknative
Native library checking:
hadoop:  false 
ISA-L:   false 
rocks-tools: false 
```

CI:
https://github.com/adoroszlai/ozone/actions/runs/12039265661