### PR TITLE
HDDS-11770. Change default failed volume tolerated to 0

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -79,7 +79,7 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
 
   static final long PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT = 60;
 
-  static final int FAILED_VOLUMES_TOLERATED_DEFAULT = -1;
+  static final int FAILED_VOLUMES_TOLERATED_DEFAULT = 0;
 
   public static final int DISK_CHECK_IO_TEST_COUNT_DEFAULT = 3;
 
@@ -330,35 +330,38 @@ public class DatanodeConfiguration extends ReconfigurableConfig {
       PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
 
   @Config(key = "failed.data.volumes.tolerated",
-      defaultValue = "-1",
+      defaultValue = "0",
       type = ConfigType.INT,
       tags = { DATANODE },
       description = "The number of data volumes that are allowed to fail "
-          + "before a datanode stops offering service. "
-          + "Config this to -1 means unlimited, but we should have "
-          + "at least one good volume left."
+          + "before a datanode stops offering service. By default, "
+          + "any volume failure will cause a datanode to shutdown. "
+          + "The value should be greater than or equal to -1 , -1 represents minimum "
+          + "1 valid volume."
   )
   private int failedDataVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;
 
   @Config(key = "failed.metadata.volumes.tolerated",
-      defaultValue = "-1",
+      defaultValue = "0",
       type = ConfigType.INT,
       tags = { DATANODE },
       description = "The number of metadata volumes that are allowed to fail "
-          + "before a datanode stops offering service. "
-          + "Config this to -1 means unlimited, but we should have "
-          + "at least one good volume left."
+          + "before a datanode stops offering service. By default, "
+          + "any volume failure will cause a datanode to shutdown. "
+          + "The value should be greater than or equal to -1 , -1 represents minimum "
+          + "1 valid volume."
   )
   private int failedMetadataVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;
 
   @Config(key = "failed.db.volumes.tolerated",
-      defaultValue = "-1",
+      defaultValue = "0",
       type = ConfigType.INT,
       tags = { DATANODE },
       description = "The number of db volumes that are allowed to fail "
-          + "before a datanode stops offering service. "
-          + "Config this to -1 means unlimited, but we should have "
-          + "at least one good volume left."
+          + "before a datanode stops offering service. By default, "
+          + "any volume failure will cause a datanode to shutdown. "
+          + "The value should be greater than or equal to -1 , -1 represents minimum "
+          + "1 valid volume."
   )
   private int failedDbVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;
 

--- a/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.md
+++ b/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.md
@@ -55,9 +55,11 @@ For some advanced cluster admins who have the high performance requirement, he/s
 </property>
 <property>
    <name>hdds.datanode.failed.db.volumes.tolerated</name>
-   <value>-1</value>
+   <value>0</value>
    <description>The number of db volumes that are allowed to fail before a datanode stops offering service.
-   Default -1 means unlimited, but we should have at least one good volume left.</description>
+      By default, any volume failure will cause a datanode to shutdown.
+      The value should be greater than or equal to -1 , -1 represents minimum 1 valid volume.
+   </description>
 </property>
 ```
 

--- a/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.zh.md
+++ b/hadoop-hdds/docs/content/feature/dn-merge-rocksdb.zh.md
@@ -55,9 +55,11 @@ summary: Ozone DataNode Container模式简介V3
 </property>
 <property>
    <name>hdds.datanode.failed.db.volumes.tolerated</name>
-   <value>-1</value>
+   <value>0</value>
    <description>The number of db volumes that are allowed to fail before a datanode stops offering service.
-   Default -1 means unlimited, but we should have at least one good volume left.</description>
+      By default, any volume failure will cause a datanode to shutdown.
+      The value should be greater than or equal to -1 , -1 represents minimum 1 valid volume.
+   </description>
 </property>
 ```
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently "hdds.datanode.failed.data.volumes.tolerated", "hdds.datanode.failed.metadata.volumes.tolerated" and "hdds.datanode.failed.db.volumes.tolerated" all have default "-1" value, means unlimited, as long as there is a good volume left.

There is a corresponding property in HDFS "dfs.datanode.failed.volumes.tolerated", which default is 0, means any volume failure will cause a datanode to shutdown.

It's better to have a more conservative default value than this current unlimited value.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11770

## How was this patch tested?

existing unit tests.