### PR TITLE
HDDS-11820. Create test principals at test run time

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -31,7 +31,7 @@
     <docker.ozone.image>apache/ozone</docker.ozone.image>
     <docker.ozone.image.flavor>-rocky</docker.ozone.image.flavor> <!-- suffix appended to Ozone version to get Docker image version -->
     <docker.ozone-runner.version>20241108-jdk17-1</docker.ozone-runner.version>
-    <docker.ozone-testkr5b.image>ghcr.io/apache/ozone-testkrb5:20241112-1</docker.ozone-testkr5b.image>
+    <docker.ozone-testkr5b.image>ghcr.io/apache/ozone-testkrb5:20241129-1</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
   </properties>
 

--- a/hadoop-ozone/dist/src/main/compose/common/init-kdc.sh
+++ b/hadoop-ozone/dist/src/main/compose/common/init-kdc.sh
@@ -20,7 +20,8 @@ set -eux -o pipefail
 # This script exports keytabs and starts KDC server.
 
 export_keytab() {
-   kadmin.local -q "ktadd -norandkey -k /etc/security/keytabs/$2.keytab $1@EXAMPLE.COM"
+  kadmin.local -q "addprinc -randkey $1@EXAMPLE.COM"
+  kadmin.local -q "ktadd -norandkey -k /etc/security/keytabs/$2.keytab $1@EXAMPLE.COM"
 }
 
 rm -f /etc/security/keytabs/*.keytab


### PR DESCRIPTION
## What changes were proposed in this pull request?

Test user principals are currently defined in the `apache/ozone-docker-testkrb5` repository.  Whenever a new principal is needed for tests, we need to:
- commit updated `init.sh` in `apache/ozone-docker-testkrb5`
- bump `ozone-testkrb5` image version in `apache/ozone`
- update keytabs in `apache/ozone` (this steps is removed in HDDS-11810)

This can be improved by creating principals just-in-time, right before exporting keytabs.

Benefits:
- simplifies the process of adding new principals
- avoid mismatch in list of principals added and exported

This PR updates `ozone-testkrb5` image to the latest version, which does not include any test principals.  It also adds logic to create the principals at test run time.

After this change we can simply add new principals in `init-kdc.sh` without having to update the `ozone-testkrb5` image.

https://issues.apache.org/jira/browse/HDDS-11820

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12079220909