### PR TITLE
HDDS-11822. Register subcommands in OzoneShell

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
@@ -19,6 +19,13 @@ package org.apache.hadoop.ozone.shell;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.ozone.shell.bucket.BucketCommands;
+import org.apache.hadoop.ozone.shell.keys.KeyCommands;
+import org.apache.hadoop.ozone.shell.prefix.PrefixCommands;
+import org.apache.hadoop.ozone.shell.snapshot.SnapshotCommands;
+import org.apache.hadoop.ozone.shell.tenant.TenantUserCommands;
+import org.apache.hadoop.ozone.shell.token.TokenCommands;
+import org.apache.hadoop.ozone.shell.volume.VolumeCommands;
 
 import picocli.CommandLine.Command;
 
@@ -27,13 +34,18 @@ import picocli.CommandLine.Command;
  */
 @Command(name = "ozone sh",
     description = "Shell for Ozone object store",
+    subcommands = {
+        BucketCommands.class,
+        KeyCommands.class,
+        PrefixCommands.class,
+        SnapshotCommands.class,
+        TenantUserCommands.class,
+        TokenCommands.class,
+        VolumeCommands.class,
+    },
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 public class OzoneShell extends Shell {
-
-  public OzoneShell() {
-    super(OzoneShell.class);
-  }
 
   /**
    * Main for the ozShell Command handling.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
@@ -23,12 +23,9 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.shell.OzoneShell;
 import org.apache.hadoop.ozone.shell.Shell;
 
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -55,9 +52,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-@MetaInfServices(SubcommandWithParent.class)
-public class BucketCommands implements GenericParentCommand, Callable<Void>,
-    SubcommandWithParent {
+public class BucketCommands implements GenericParentCommand, Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -76,10 +71,5 @@ public class BucketCommands implements GenericParentCommand, Callable<Void>,
   @Override
   public OzoneConfiguration createOzoneConfiguration() {
     return shell.createOzoneConfiguration();
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneShell.class;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
@@ -23,12 +23,9 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.shell.OzoneShell;
 import org.apache.hadoop.ozone.shell.Shell;
 
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -55,9 +52,8 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-@MetaInfServices(SubcommandWithParent.class)
 public class KeyCommands
-    implements GenericParentCommand, Callable<Void>, SubcommandWithParent {
+    implements GenericParentCommand, Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -76,10 +72,5 @@ public class KeyCommands
   @Override
   public OzoneConfiguration createOzoneConfiguration() {
     return shell.createOzoneConfiguration();
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneShell.class;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/prefix/PrefixCommands.java
@@ -23,12 +23,9 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.shell.OzoneShell;
 import org.apache.hadoop.ozone.shell.Shell;
 
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -45,9 +42,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-@MetaInfServices(SubcommandWithParent.class)
-public class PrefixCommands implements GenericParentCommand, Callable<Void>,
-    SubcommandWithParent {
+public class PrefixCommands implements GenericParentCommand, Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -66,10 +61,5 @@ public class PrefixCommands implements GenericParentCommand, Callable<Void>,
   @Override
   public OzoneConfiguration createOzoneConfiguration() {
     return shell.createOzoneConfiguration();
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneShell.class;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/snapshot/SnapshotCommands.java
@@ -23,12 +23,9 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.shell.OzoneShell;
 import org.apache.hadoop.ozone.shell.Shell;
 
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -48,9 +45,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-@MetaInfServices(SubcommandWithParent.class)
-public class SnapshotCommands implements GenericParentCommand, Callable<Void>,
-    SubcommandWithParent {
+public class SnapshotCommands implements GenericParentCommand, Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -69,10 +64,5 @@ public class SnapshotCommands implements GenericParentCommand, Callable<Void>,
   @Override
   public OzoneConfiguration createOzoneConfiguration() {
     return shell.createOzoneConfiguration();
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneShell.class;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantUserCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantUserCommands.java
@@ -20,11 +20,8 @@ package org.apache.hadoop.ozone.shell.tenant;
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.shell.OzoneShell;
 import org.apache.hadoop.ozone.shell.Shell;
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
@@ -46,9 +43,8 @@ import java.util.concurrent.Callable;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-@MetaInfServices(SubcommandWithParent.class)
 public class TenantUserCommands implements
-    GenericParentCommand, Callable<Void>, SubcommandWithParent {
+    GenericParentCommand, Callable<Void> {
 
   @CommandLine.ParentCommand
   private Shell shell;
@@ -67,10 +63,5 @@ public class TenantUserCommands implements
   @Override
   public OzoneConfiguration createOzoneConfiguration() {
     return shell.createOzoneConfiguration();
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneShell.class;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenCommands.java
@@ -23,12 +23,9 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.shell.OzoneShell;
 import org.apache.hadoop.ozone.shell.Shell;
 
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -45,9 +42,8 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-@MetaInfServices(SubcommandWithParent.class)
 public class TokenCommands
-    implements GenericParentCommand, Callable<Void>, SubcommandWithParent {
+    implements GenericParentCommand, Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -66,10 +62,5 @@ public class TokenCommands
   @Override
   public OzoneConfiguration createOzoneConfiguration() {
     return shell.createOzoneConfiguration();
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneShell.class;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeCommands.java
@@ -23,12 +23,9 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.shell.OzoneShell;
 import org.apache.hadoop.ozone.shell.Shell;
 
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
 
@@ -53,9 +50,7 @@ import picocli.CommandLine.ParentCommand;
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-@MetaInfServices(SubcommandWithParent.class)
-public class VolumeCommands implements GenericParentCommand, Callable<Void>,
-    SubcommandWithParent {
+public class VolumeCommands implements GenericParentCommand, Callable<Void> {
 
   @ParentCommand
   private Shell shell;
@@ -74,10 +69,5 @@ public class VolumeCommands implements GenericParentCommand, Callable<Void>,
   @Override
   public OzoneConfiguration createOzoneConfiguration() {
     return shell.createOzoneConfiguration();
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneShell.class;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OzoneShell` subcommands are currently added via `ServiceLoader` (by implementing `SubcommandWithParent`).  Since this is a well-defined set of commands, we can register them in the parent command directly (`subcommands = { ... }`).

https://issues.apache.org/jira/browse/HDDS-11822

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12096565592