### PR TITLE
HDDS-11831. Finer-grained interface for dynamically registered subcommands

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/ExtensibleParentCommand.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/ExtensibleParentCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.cli;
+
+import picocli.CommandLine;
+
+import java.util.ServiceLoader;
+
+/**
+ * Interface for parent commands that accept subcommands to be dynamically registered.
+ * Subcommands should:
+ * <li>implement the interface returned by {@link #subcommandType()}</li>
+ * <li>be annotated with {@code MetaInfServices} parameterized with the same type</li>
+ */
+public interface ExtensibleParentCommand {
+
+  /** @return The class of the marker interface for subcommands. */
+  Class<?> subcommandType();
+
+  /** Recursively find and add subcommands to {@code cli}. */
+  static void addSubcommands(CommandLine cli) {
+    Object command = cli.getCommand();
+
+    // find and add subcommands
+    if (command instanceof ExtensibleParentCommand) {
+      ExtensibleParentCommand parentCommand = (ExtensibleParentCommand) command;
+      ServiceLoader<?> subcommands = ServiceLoader.load(parentCommand.subcommandType());
+      for (Object subcommand : subcommands) {
+        final CommandLine.Command commandAnnotation = subcommand.getClass().getAnnotation(CommandLine.Command.class);
+        CommandLine subcommandCommandLine = new CommandLine(subcommand);
+        cli.addSubcommand(commandAnnotation.name(), subcommandCommandLine);
+      }
+    }
+
+    // process subcommands recursively
+    for (CommandLine subcommand : cli.getSubcommands().values()) {
+      addSubcommands(subcommand);
+    }
+  }
+
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -52,16 +52,20 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
   private final CommandLine cmd;
 
   public GenericCli() {
+    this(null);
+  }
+
+  public GenericCli(Class<?> type) {
     cmd = new CommandLine(this);
     cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
       printError(ex);
       return EXECUTION_ERROR_EXIT_CODE;
     });
-  }
 
-  public GenericCli(Class<?> type) {
-    this();
-    addSubcommands(getCmd(), type);
+    if (type != null) {
+      addSubcommands(getCmd(), type);
+    }
+    ExtensibleParentCommand.addSubcommands(cmd);
   }
 
   private void addSubcommands(CommandLine cli, Class<?> type) {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AdminSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/AdminSubcommand.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.cli;
+
+/** Marker interface for subcommands to be added to {@code OzoneAdmin}. */
+public interface AdminSubcommand {
+  // marker
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
@@ -33,19 +33,18 @@ import picocli.CommandLine;
     description = "Developer tools for Ozone Admin operations",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
-public class OzoneAdmin extends GenericCli {
+public class OzoneAdmin extends GenericCli implements ExtensibleParentCommand {
 
   private OzoneConfiguration ozoneConf;
 
   private UserGroupInformation user;
 
   public OzoneAdmin() {
-    super(OzoneAdmin.class);
+    super();
   }
 
   @VisibleForTesting
   public OzoneAdmin(OzoneConfiguration conf) {
-    super(OzoneAdmin.class);
     ozoneConf = conf;
   }
 
@@ -78,5 +77,10 @@ public class OzoneAdmin extends GenericCli {
     String spanName = "ozone admin " + String.join(" ", argv);
     return TracingUtil.executeInNewSpan(spanName,
         () -> super.execute(argv));
+  }
+
+  @Override
+  public Class<? extends AdminSubcommand> subcommandType() {
+    return AdminSubcommand.class;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerBalancerCommands.java
@@ -17,10 +17,9 @@
  */
 package org.apache.hadoop.hdds.scm.cli;
 
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
@@ -90,9 +89,8 @@ import java.util.concurrent.Callable;
         ContainerBalancerStopSubcommand.class,
         ContainerBalancerStatusSubcommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class ContainerBalancerCommands implements Callable<Void>,
-    SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class ContainerBalancerCommands implements Callable<Void>, AdminSubcommand {
 
   @Spec
   private CommandSpec spec;
@@ -101,10 +99,5 @@ public class ContainerBalancerCommands implements Callable<Void>,
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ReplicationManagerCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ReplicationManagerCommands.java
@@ -19,10 +19,9 @@ package org.apache.hadoop.hdds.scm.cli;
 
 import java.util.concurrent.Callable;
 
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
@@ -42,9 +41,8 @@ import picocli.CommandLine.Spec;
         ReplicationManagerStopSubcommand.class,
         ReplicationManagerStatusSubcommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class ReplicationManagerCommands implements Callable<Void>,
-    SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class ReplicationManagerCommands implements Callable<Void>, AdminSubcommand {
 
   @Spec
   private CommandSpec spec;
@@ -53,10 +51,5 @@ public class ReplicationManagerCommands implements Callable<Void>,
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCommands.java
@@ -19,10 +19,9 @@ package org.apache.hadoop.hdds.scm.cli;
 
 import java.util.concurrent.Callable;
 
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
@@ -42,8 +41,8 @@ import picocli.CommandLine.Spec;
         SafeModeExitSubcommand.class,
         SafeModeWaitSubcommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class SafeModeCommands implements Callable<Void>, SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class SafeModeCommands implements Callable<Void>, AdminSubcommand {
 
   @Spec
   private CommandSpec spec;
@@ -52,10 +51,5 @@ public class SafeModeCommands implements Callable<Void>, SubcommandWithParent {
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
@@ -33,9 +33,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
@@ -56,9 +55,9 @@ import picocli.CommandLine;
     description = "Print a tree of the network topology as reported by SCM",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
-@MetaInfServices(SubcommandWithParent.class)
+@MetaInfServices(AdminSubcommand.class)
 public class TopologySubcommand extends ScmSubcommand
-    implements SubcommandWithParent {
+    implements AdminSubcommand {
 
   private static final List<HddsProtos.NodeState> STATES = new ArrayList<>();
 
@@ -135,11 +134,6 @@ public class TopologySubcommand extends ScmSubcommand
         }
       }
     }
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 
   // Format

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/CertCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/CertCommands.java
@@ -19,10 +19,9 @@ package org.apache.hadoop.hdds.scm.cli.cert;
 
 import java.util.concurrent.Callable;
 
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
@@ -43,8 +42,8 @@ import picocli.CommandLine.Spec;
         CleanExpiredCertsSubcommand.class,
     })
 
-@MetaInfServices(SubcommandWithParent.class)
-public class CertCommands implements Callable<Void>, SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class CertCommands implements Callable<Void>, AdminSubcommand {
 
   @Spec
   private CommandSpec spec;
@@ -53,10 +52,5 @@ public class CertCommands implements Callable<Void>, SubcommandWithParent {
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ContainerCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ContainerCommands.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdds.scm.cli.container;
 
 import java.util.concurrent.Callable;
 
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
@@ -46,8 +46,8 @@ import picocli.CommandLine.Spec;
         ReportSubcommand.class,
         UpgradeSubcommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class ContainerCommands implements Callable<Void>, SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class ContainerCommands implements Callable<Void>, AdminSubcommand {
 
   @Spec
   private CommandSpec spec;
@@ -59,11 +59,6 @@ public class ContainerCommands implements Callable<Void>, SubcommandWithParent {
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 
   public OzoneAdmin getParent() {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DatanodeCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DatanodeCommands.java
@@ -17,10 +17,9 @@
  */
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
@@ -41,10 +40,11 @@ import java.util.concurrent.Callable;
         DecommissionSubCommand.class,
         MaintenanceSubCommand.class,
         RecommissionSubCommand.class,
+        StatusSubCommand.class,
         UsageInfoSubcommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class DatanodeCommands implements Callable<Void>, SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class DatanodeCommands implements Callable<Void>, AdminSubcommand {
 
   @Spec
   private CommandSpec spec;
@@ -53,10 +53,5 @@ public class DatanodeCommands implements Callable<Void>, SubcommandWithParent {
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/StatusSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/StatusSubCommand.java
@@ -19,8 +19,6 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
-import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import java.util.concurrent.Callable;
@@ -37,8 +35,7 @@ import java.util.concurrent.Callable;
         DecommissionStatusSubCommand.class
     })
 
-@MetaInfServices(SubcommandWithParent.class)
-public class StatusSubCommand implements Callable<Void>, SubcommandWithParent {
+public class StatusSubCommand implements Callable<Void> {
 
   @CommandLine.Spec
   private CommandLine.Model.CommandSpec spec;
@@ -47,10 +44,5 @@ public class StatusSubCommand implements Callable<Void>, SubcommandWithParent {
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return DatanodeCommands.class;
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/PipelineCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/PipelineCommands.java
@@ -19,10 +19,9 @@ package org.apache.hadoop.hdds.scm.cli.pipeline;
 
 import java.util.concurrent.Callable;
 
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
@@ -44,8 +43,8 @@ import picocli.CommandLine.Spec;
         CreatePipelineSubcommand.class,
         ClosePipelineSubcommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class PipelineCommands implements Callable<Void>, SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class PipelineCommands implements Callable<Void>, AdminSubcommand {
 
   @Spec
   private CommandSpec spec;
@@ -54,10 +53,5 @@ public class PipelineCommands implements Callable<Void>, SubcommandWithParent {
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.ozone.OzoneClientUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
@@ -62,8 +62,8 @@ import static org.apache.hadoop.hdds.server.http.HttpServer2.HTTP_SCHEME;
         QuotaUsageSubCommand.class,
         FileSizeDistSubCommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class NSSummaryAdmin extends GenericCli implements AdminSubcommand {
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
 
@@ -78,11 +78,6 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
   public Void call() throws Exception {
     GenericCli.missingSubcommand(spec);
     return null;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 
   private boolean isObjectStoreBucket(OzoneBucket bucket, ObjectStore objectStore) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.admin.om;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
@@ -63,8 +63,8 @@ import java.util.Collection;
         TransferOmLeaderSubCommand.class,
         FetchKeySubCommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class OMAdmin extends GenericCli implements SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class OMAdmin extends GenericCli implements AdminSubcommand {
 
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
@@ -145,10 +145,5 @@ public class OMAdmin extends GenericCli implements SubcommandWithParent {
     Collection<String> omServiceIds =
         conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
     return omServiceIds;
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/reconfig/ReconfigureCommands.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.ozone.admin.reconfig;
 
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
@@ -47,9 +47,8 @@ import java.util.concurrent.Callable;
         ReconfigureStatusSubcommand.class,
         ReconfigurePropertiesSubcommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class ReconfigureCommands implements Callable<Void>,
-    SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class ReconfigureCommands implements Callable<Void>, AdminSubcommand {
 
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
@@ -85,11 +84,6 @@ public class ReconfigureCommands implements Callable<Void>,
 
   public HddsProtos.NodeType getService() {
     return HddsProtos.NodeType.valueOf(service);
-  }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
   }
 
   public boolean isBatchReconfigDatanodes() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ScmAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/ScmAdmin.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.admin.scm;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
-import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.cli.AdminSubcommand;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
@@ -43,8 +43,8 @@ import picocli.CommandLine.Spec;
         DecommissionScmSubcommand.class,
         RotateKeySubCommand.class
     })
-@MetaInfServices(SubcommandWithParent.class)
-public class ScmAdmin extends GenericCli implements SubcommandWithParent {
+@MetaInfServices(AdminSubcommand.class)
+public class ScmAdmin extends GenericCli implements AdminSubcommand {
 
   @CommandLine.ParentCommand
   private OzoneAdmin parent;
@@ -61,10 +61,4 @@ public class ScmAdmin extends GenericCli implements SubcommandWithParent {
     GenericCli.missingSubcommand(spec);
     return null;
   }
-
-  @Override
-  public Class<?> getParentType() {
-    return OzoneAdmin.class;
-  }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dynamically registered subcommands all implement `SubcommandWithParent`.  The parent command is identified by `getParentType()`.
- Each top-level command (`OzoneAdmin`, `OzoneDebug`, etc.) has to load all implementors of `SubcommandWithParent`, only to discard most of them.  This increases command startup latency, which is a minor problem for short-lived commands, e.g. `ozone sh`.
- Finding children of a parent command is also a bit harder.

This change introduces a way to limit the search scope of subcommands:
- parent commands can implement `ExtensibleParentCommand` to indicate they support dynamically registered subcommands
- subcommands implement the marker interface returned by the parent command's `subcommandType()`

As an example, `OzoneAdmin` and its subcommands are converted to this new model.

Benefits:
- Slightly less startup time for `ozone admin` (240 ms vs. 500 ms for me locally)
- Easier to find subcommands (implementors of `AdminSubcommand` in this case)
- The same subcommand may be added to multiple parents, just like with `subcommands = { ... }` declaration, but unlike `SubcommandWithParent`, which allows only one parent.
- Subcommands only need to access the marker interface.  The actual parent command can be in another module (`hdds-tools` vs. `ozone-tools`).

https://issues.apache.org/jira/browse/HDDS-11831

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone/actions/runs/12107950425