### PR TITLE
HDDS-11687. Robot warning: replace "is not" with "!="

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -46,7 +46,7 @@ Create new bucket and check no group ACL
     ${bucket} =         Create bucket
     ${acl} =            Execute     ozone sh bucket getacl s3v/${bucket}
     ${group} =          Get Regexp Matches   ${acl}     "GROUP"
-    IF      '${group}' is not '[]'
+    IF      '${group}' != '[]'
         ${json} =           Evaluate    json.loads('''${acl}''')    json
         # make sure this check is for group acl
         Should contain      ${json}[1][type]       GROUP


### PR DESCRIPTION
## What changes were proposed in this pull request?
Robot warning: replace "is not" with "!=" for S3 bucket create test.

## What is the link to the Apache JIRA
HDDS-11687

## How was this patch tested?
Verified with local robot test run.