### PR TITLE
HDDS-11846. Set the schema version for Recon for fresh install

### DIFF
--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/SqlDbUtils.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/SqlDbUtils.java
@@ -19,15 +19,19 @@
 package org.hadoop.ozone.recon.codegen;
 
 import static org.jooq.impl.DSL.count;
+import static org.jooq.impl.DSL.name;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.function.BiPredicate;
 
 import org.apache.commons.lang3.function.TriFunction;
+import org.jooq.Record;
+import org.jooq.Result;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
@@ -97,17 +101,15 @@ public final class SqlDbUtils {
         return true;
       };
 
-  public static final TriFunction<Connection, String, String, Boolean> COLUMN_EXISTS_CHECK =
+  public static final TriFunction<Connection, String, String, Boolean> CHECK_COLUMN_HAS_VALUE =
     (conn, tableName, columnName) -> {
       try {
-        DSL.using(conn).select(DSL.field(DSL.name(columnName)))
-          .from(DSL.table(DSL.name(tableName)))
-          .fetch();
+        return DSL.using(conn).select(DSL.field(DSL.name(columnName)))
+            .from(DSL.table(DSL.name(tableName)))
+            .fetch().isNotEmpty();
       } catch (DataAccessException ex) {
         LOG.debug(ex.getMessage());
         return false;
       }
-      LOG.info("Column: {} in Table: {} has value present", columnName, tableName);
-      return true;
     };
 }

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/SqlDbUtils.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/SqlDbUtils.java
@@ -27,6 +27,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.function.BiPredicate;
 
+import org.apache.commons.lang3.function.TriFunction;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
@@ -95,4 +96,18 @@ public final class SqlDbUtils {
         LOG.info("{} table already exists, skipping creation.", tableName);
         return true;
       };
+
+  public static final TriFunction<Connection, String, String, Boolean> COLUMN_EXISTS_CHECK =
+    (conn, tableName, columnName) -> {
+      try {
+        DSL.using(conn).select(DSL.field(DSL.name(columnName)))
+          .from(DSL.table(DSL.name(tableName)))
+          .fetch();
+      } catch (DataAccessException ex) {
+        LOG.debug(ex.getMessage());
+        return false;
+      }
+      LOG.info("Column: {} in Table: {} has value present", columnName, tableName);
+      return true;
+    };
 }

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/SqlDbUtils.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/SqlDbUtils.java
@@ -19,19 +19,15 @@
 package org.hadoop.ozone.recon.codegen;
 
 import static org.jooq.impl.DSL.count;
-import static org.jooq.impl.DSL.name;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.function.BiPredicate;
 
 import org.apache.commons.lang3.function.TriFunction;
-import org.jooq.Record;
-import org.jooq.Result;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
@@ -102,14 +98,14 @@ public final class SqlDbUtils {
       };
 
   public static final TriFunction<Connection, String, String, Boolean> CHECK_COLUMN_HAS_VALUE =
-    (conn, tableName, columnName) -> {
-      try {
-        return DSL.using(conn).select(DSL.field(DSL.name(columnName)))
-            .from(DSL.table(DSL.name(tableName)))
-            .fetch().isNotEmpty();
-      } catch (DataAccessException ex) {
-        LOG.debug(ex.getMessage());
-        return false;
-      }
-    };
+      (conn, tableName, columnName) -> {
+        try {
+          return DSL.using(conn).select(DSL.field(DSL.name(columnName)))
+              .from(DSL.table(DSL.name(tableName)))
+              .fetch().isNotEmpty();
+        } catch (DataAccessException ex) {
+          LOG.debug(ex.getMessage());
+          return false;
+        }
+      };
 }

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/SchemaVersionTableDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/SchemaVersionTableDefinition.java
@@ -31,8 +31,6 @@ import java.sql.SQLException;
 
 import static org.hadoop.ozone.recon.codegen.SqlDbUtils.COLUMN_EXISTS_CHECK;
 import static org.hadoop.ozone.recon.codegen.SqlDbUtils.TABLE_EXISTS_CHECK;
-import static org.jooq.impl.DSL.name;
-import static org.jooq.impl.DSL.table;
 
 /**
  * Class for managing the schema of the SchemaVersion table.

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/SchemaVersionTableDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/SchemaVersionTableDefinition.java
@@ -29,8 +29,8 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import static org.hadoop.ozone.recon.codegen.SqlDbUtils.COLUMN_EXISTS_CHECK;
 import static org.hadoop.ozone.recon.codegen.SqlDbUtils.TABLE_EXISTS_CHECK;
+import static org.hadoop.ozone.recon.codegen.SqlDbUtils.CHECK_COLUMN_HAS_VALUE;
 
 /**
  * Class for managing the schema of the SchemaVersion table.
@@ -69,12 +69,12 @@ public class SchemaVersionTableDefinition implements ReconSchemaDefinition {
   }
 
   /**
-   * Insert the version of the MLV for the table if it doesn't already exist
+   * Insert the version of the MLV for the table if it doesn't already exist.
    * @param version The version value to be inserted
    * @throws SQLException If the insert operation failed
    */
   public void insertCurrentVersion(int version) throws SQLException {
-    if (!COLUMN_EXISTS_CHECK.apply(conn, SCHEMA_VERSION_TABLE_NAME, "version_number")) {
+    if (!CHECK_COLUMN_HAS_VALUE.apply(conn, SCHEMA_VERSION_TABLE_NAME, "version_number")) {
       dslContext.insertInto(DSL.table(DSL.name(SCHEMA_VERSION_TABLE_NAME)))
           .set(DSL.field(DSL.name("version_number")), version)
           .execute();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -130,11 +130,9 @@ public class ReconServer extends GenericCli {
         }
         if (OzoneSecurityUtil.isSecurityEnabled(configuration)) {
           LOG.info("ReconStorageConfig initialized." +
-              "Initializing certificate.");
+            "Initializing certificate.");
           initializeCertificateClient();
         }
-      } catch (SQLException se) {
-        LOG.error("Failed to set the MLV version, defaulting to -1");
       } catch (Exception e) {
         LOG.error("Error during initializing Recon certificate", e);
       }
@@ -175,9 +173,13 @@ public class ReconServer extends GenericCli {
       ReconStorageContainerManagerFacade reconStorageContainerManagerFacade =
           (ReconStorageContainerManagerFacade) this.getReconStorageContainerManager();
 
-      // If the version information is not already set, this is the first time the version
-      // will be added, hence update it to the current code SLV
-      reconVersionSchemaInstance.insertCurrentVersion(ReconLayoutVersionManager.determineSLV());
+      try {
+        // If the version information is not already set, this is the first time the version
+        // will be added, hence update it to the current code SLV
+        reconVersionSchemaInstance.insertCurrentVersion(ReconLayoutVersionManager.determineSLV());
+      } catch (SQLException se) {
+        LOG.error("Failed to update version_number, defaulting to -1.");
+      }
       layoutVersionManager.finalizeLayoutFeatures(reconStorageContainerManagerFacade);
 
       LOG.info("Initializing support of Recon Features...");

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -127,9 +127,6 @@ public class ReconServer extends GenericCli {
       try {
         if (reconStorage.getState() != INITIALIZED) {
           reconStorage.initialize();
-          // If the version information is not already set, this is the first time the version
-          // will be added, hence update it to the current code SLV
-          reconVersionSchemaInstance.insertCurrentVersion(ReconLayoutVersionManager.determineSLV());
         }
         if (OzoneSecurityUtil.isSecurityEnabled(configuration)) {
           LOG.info("ReconStorageConfig initialized." +
@@ -177,6 +174,10 @@ public class ReconServer extends GenericCli {
       // Run the upgrade framework to finalize layout features if needed
       ReconStorageContainerManagerFacade reconStorageContainerManagerFacade =
           (ReconStorageContainerManagerFacade) this.getReconStorageContainerManager();
+
+      // If the version information is not already set, this is the first time the version
+      // will be added, hence update it to the current code SLV
+      reconVersionSchemaInstance.insertCurrentVersion(ReconLayoutVersionManager.determineSLV());
       layoutVersionManager.finalizeLayoutFeatures(reconStorageContainerManagerFacade);
 
       LOG.info("Initializing support of Recon Features...");

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -150,7 +150,7 @@ public class ReconServer extends GenericCli {
       LOG.debug("Recon schema creation done.");
 
       SchemaVersionTableDefinition reconVersionSchemaInstance =
-        injector.getInstance(SchemaVersionTableDefinition.class);
+          injector.getInstance(SchemaVersionTableDefinition.class);
       try {
         // If the version information is not already set, this is the first time the version
         // will be added, hence update it to the current code SLV

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutVersionManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/upgrade/ReconLayoutVersionManager.java
@@ -69,7 +69,7 @@ public class ReconLayoutVersionManager {
    * Determines the Software Layout Version (SLV) based on the latest feature version.
    * @return The Software Layout Version (SLV).
    */
-  private int determineSLV() {
+  public static int determineSLV() {
     return Arrays.stream(ReconLayoutFeature.values())
         .mapToInt(ReconLayoutFeature::getVersion)
         .max()


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11846. Set the schema version for Recon for fresh install

Please describe your PR in detail:
* In the current Recon Schema version table, we do not set the version_number value to the table, this causes the version information to default to -1, causing upgrade handler to run even in case of fresh install
* In case the version number is not already set for the schema version table - it indicates that this is a fresh install for Ozone.
* In case of a fresh install, we need to set the `version_number` in the table to have a record of the MLV for later upgrade.
* This PR adds the insertion of the version to the Schema version table in this scenario

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11846

## How was this patch tested?
Patch was verified using unit tests, and manually tested to ensure the fix works