### PR TITLE
HDDS-11711. Add SCM metrics for delete commands sent and response received per datanode

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -445,8 +445,10 @@ public class DeletedBlockLogImpl
           getSCMDeletedBlockTransactionStatusManager()
               .commitTransactions(ackProto.getResultsList(), dnId);
           metrics.incrBlockDeletionCommandSuccess();
+          metrics.incrDNCommandsSuccess(dnId, 1);
         } else if (status == CommandStatus.Status.FAILED) {
           metrics.incrBlockDeletionCommandFailure();
+          metrics.incrDNCommandsFailure(dnId, 1);
         } else {
           LOG.debug("Delete Block Command {} is not executed on the Datanode" +
               " {}.", commandStatus.getCmdId(), dnId);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -192,6 +192,7 @@ public class SCMBlockDeletingService extends BackgroundService
                   new CommandForDatanode<>(dnId, command));
               metrics.incrBlockDeletionCommandSent();
               metrics.incrBlockDeletionTransactionSent(dnTXs.size());
+              metrics.incrDNCommandsSent(dnId, 1);
               if (LOG.isDebugEnabled()) {
                 LOG.debug(
                     "Added delete block command for datanode {} in the queue,"

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.hdds.scm.block;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
@@ -215,6 +216,31 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
 
   public Map<UUID, DatanodeCommandCounts> getNumCommandsDatanode() {
     return numCommandsDatanode;
+  }
+
+  @VisibleForTesting
+  public int getNumCommandsDatanodeSent() {
+    int sent = 0;
+    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+      sent += e.getValue().commandsSent;
+    }
+    return sent;
+  }
+  @VisibleForTesting
+  public int getNumCommandsDatanodeSuccess() {
+    int sent = 0;
+    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+      sent += e.getValue().commandsSuccess;
+    }
+    return sent;
+  }
+  @VisibleForTesting
+  public int getNumCommandsDatanodeFailed() {
+    int sent = 0;
+    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+      sent += e.getValue().commandsFailure;
+    }
+    return sent;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -99,7 +99,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
   @Metric(about = "The number of dataNodes of delete transactions.")
   private MutableGaugeLong numBlockDeletionTransactionDataNodes;
 
-  private Map<UUID, DatanodeCommandCounts> numCommandsDatanode;
+  private final Map<UUID, DatanodeCommandCounts> numCommandsDatanode;
 
   private ScmBlockDeletingServiceMetrics() {
     this.registry = new MetricsRegistry(SOURCE_NAME);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -261,6 +261,9 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     recordBuilder.endRecord();
   }
 
+  /**
+   *  Class contains metrics related to the ScmBlockDeletingService for each datanode.
+   */
   public static final class DatanodeCommandCounts {
     private long commandsSent;
     private long commandsSuccess;
@@ -315,7 +318,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
   @VisibleForTesting
   public int getNumCommandsDatanodeSent() {
     int sent = 0;
-    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+    for (Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
       sent += e.getValue().commandsSent;
     }
     return sent;
@@ -323,7 +326,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
   @VisibleForTesting
   public int getNumCommandsDatanodeSuccess() {
     int sent = 0;
-    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+    for (Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
       sent += e.getValue().commandsSuccess;
     }
     return sent;
@@ -331,7 +334,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
   @VisibleForTesting
   public int getNumCommandsDatanodeFailed() {
     int sent = 0;
-    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+    for (Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
       sent += e.getValue().commandsFailure;
     }
     return sent;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -170,6 +170,19 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     this.numBlockDeletionTransactionDataNodes.set(dataNodes);
   }
 
+  public void incrDNCommandsSent(UUID id, long delta) {
+    numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
+        .incrCommandsSent(delta);
+  }
+  public void incrDNCommandsSuccess(UUID id, long delta) {
+    numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
+        .incrCommandsSuccess(delta);
+  }
+  public void incrDNCommandsFailure(UUID id, long delta) {
+    numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
+        .incrCommandsFailure(delta);
+  }
+
   public long getNumBlockDeletionCommandSent() {
     return numBlockDeletionCommandSent.value();
   }
@@ -216,31 +229,6 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
 
   public Map<UUID, DatanodeCommandCounts> getNumCommandsDatanode() {
     return numCommandsDatanode;
-  }
-
-  @VisibleForTesting
-  public int getNumCommandsDatanodeSent() {
-    int sent = 0;
-    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
-      sent += e.getValue().commandsSent;
-    }
-    return sent;
-  }
-  @VisibleForTesting
-  public int getNumCommandsDatanodeSuccess() {
-    int sent = 0;
-    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
-      sent += e.getValue().commandsSuccess;
-    }
-    return sent;
-  }
-  @VisibleForTesting
-  public int getNumCommandsDatanodeFailed() {
-    int sent = 0;
-    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
-      sent += e.getValue().commandsFailure;
-    }
-    return sent;
   }
 
   @Override
@@ -324,17 +312,29 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     }
   }
 
-  public void incrDNCommandsSent(UUID id, long delta) {
-    numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
-        .incrCommandsSent(delta);
+  @VisibleForTesting
+  public int getNumCommandsDatanodeSent() {
+    int sent = 0;
+    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+      sent += e.getValue().commandsSent;
+    }
+    return sent;
   }
-  public void incrDNCommandsSuccess(UUID id, long delta) {
-    numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
-        .incrCommandsSuccess(delta);
+  @VisibleForTesting
+  public int getNumCommandsDatanodeSuccess() {
+    int sent = 0;
+    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+      sent += e.getValue().commandsSuccess;
+    }
+    return sent;
   }
-  public void incrDNCommandsFailure(UUID id, long delta) {
-    numCommandsDatanode.computeIfAbsent(id, k -> new DatanodeCommandCounts())
-        .incrCommandsFailure(delta);
+  @VisibleForTesting
+  public int getNumCommandsDatanodeFailed() {
+    int sent = 0;
+    for(Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
+      sent += e.getValue().commandsFailure;
+    }
+    return sent;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -19,7 +19,6 @@
 
 package org.apache.hadoop.hdds.scm.block;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
@@ -37,7 +36,7 @@ import org.apache.hadoop.metrics2.lib.Interns;
 
 import java.util.Map;
 import java.util.UUID;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Metrics related to Block Deleting Service running in SCM.
@@ -104,7 +103,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
 
   private ScmBlockDeletingServiceMetrics() {
     this.registry = new MetricsRegistry(SOURCE_NAME);
-    numCommandsDatanode = new HashMap<>();
+    numCommandsDatanode = new ConcurrentHashMap<>();
   }
 
   public static ScmBlockDeletingServiceMetrics create() {
@@ -315,27 +314,24 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     }
   }
 
-  @VisibleForTesting
-  public int getNumCommandsDatanodeSent() {
-    int sent = 0;
-    for (Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
-      sent += e.getValue().commandsSent;
+  public long getNumCommandsDatanodeSent() {
+    long sent = 0;
+    for (DatanodeCommandCounts v : numCommandsDatanode.values()) {
+      sent += v.commandsSent;
     }
     return sent;
   }
-  @VisibleForTesting
-  public int getNumCommandsDatanodeSuccess() {
-    int sent = 0;
-    for (Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
-      sent += e.getValue().commandsSuccess;
+  public long getNumCommandsDatanodeSuccess() {
+    long sent = 0;
+    for (DatanodeCommandCounts v : numCommandsDatanode.values()) {
+      sent += v.commandsSuccess;
     }
     return sent;
   }
-  @VisibleForTesting
-  public int getNumCommandsDatanodeFailed() {
-    int sent = 0;
-    for (Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
-      sent += e.getValue().commandsFailure;
+  public long getNumCommandsDatanodeFailed() {
+    long sent = 0;
+    for (DatanodeCommandCounts v : numCommandsDatanode.values()) {
+      sent += v.commandsFailure;
     }
     return sent;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -236,7 +236,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     for (Map.Entry<UUID, DatanodeCommandCounts> e : numCommandsDatanode.entrySet()) {
       recordBuilder = recordBuilder.endRecord().addRecord(SOURCE_NAME)
           .add(new MetricsTag(Interns.info("datanode",
-              "Commands sent/received for the datanode"), e.getKey().toString()))
+              "Datanode host for deletion commands"), e.getKey().toString()))
           .addGauge(DatanodeCommandCounts.COMMANDS_SENT_TO_DN,
               e.getValue().getCommandsSent())
           .addGauge(DatanodeCommandCounts.COMMANDS_SUCCESSFUL_EXECUTION_BY_DN,
@@ -247,14 +247,10 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     recordBuilder.endRecord();
   }
 
-  @Metrics(name = "DatanodeCommandCounts", about = "Metrics for deletion commands per Datanode", context = "datanode")
   public static final class DatanodeCommandCounts {
-    @Metric(about = "The number of delete commands sent to a DN.")
-    private MutableGaugeLong commandsSent;
-    @Metric(about = "The number of delete commands successful for a DN.")
-    private MutableGaugeLong commandsSuccess;
-    @Metric(about = "The number of delete commands failed for a DN.")
-    private MutableGaugeLong commandsFailure;
+    private long commandsSent;
+    private long commandsSuccess;
+    private long commandsFailure;
 
     private static final MetricsInfo COMMANDS_SENT_TO_DN = Interns.info(
         "CommandsSent",
@@ -267,33 +263,33 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
         "Number of commands sent from SCM to the datanode for deletion for which execution failed.");
 
     public DatanodeCommandCounts() {
-      this.commandsSent.set(0);
-      this.commandsSuccess.set(0);
-      this.commandsFailure.set(0);
+      this.commandsSent = 0;
+      this.commandsSuccess = 0;
+      this.commandsFailure = 0;
     }
 
     public void incrCommandsSent(long delta) {
-      this.commandsSent.incr(delta);
+      this.commandsSent += delta;
     }
 
     public void incrCommandsSuccess(long delta) {
-      this.commandsSuccess.incr(delta);
+      this.commandsSuccess += delta;
     }
 
     public void incrCommandsFailure(long delta) {
-      this.commandsFailure.incr(delta);
+      this.commandsFailure += delta;
     }
 
     public long getCommandsSent() {
-      return commandsSent.value();
+      return commandsSent;
     }
 
     public long getCommandsSuccess() {
-      return commandsSuccess.value();
+      return commandsSuccess;
     }
 
     public long getCommandsFailure() {
-      return commandsFailure.value();
+      return commandsFailure;
     }
 
     @Override
@@ -333,7 +329,9 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
         .append("numBlockDeletionTransactionSuccess = "
             + numBlockDeletionTransactionSuccess.value()).append("\t")
         .append("numBlockDeletionTransactionFailure = "
-            + numBlockDeletionTransactionFailure.value());
+            + numBlockDeletionTransactionFailure.value()).append("\t")
+        .append("numDeletionCommandsPerDatanode = "
+            + numCommandsDatanode);
     return buffer.toString();
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -99,11 +99,10 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
   @Metric(about = "The number of dataNodes of delete transactions.")
   private MutableGaugeLong numBlockDeletionTransactionDataNodes;
 
-  private final Map<UUID, DatanodeCommandCounts> numCommandsDatanode;
+  private final Map<UUID, DatanodeCommandCounts> numCommandsDatanode = new ConcurrentHashMap<>();
 
   private ScmBlockDeletingServiceMetrics() {
     this.registry = new MetricsRegistry(SOURCE_NAME);
-    numCommandsDatanode = new ConcurrentHashMap<>();
   }
 
   public static synchronized ScmBlockDeletingServiceMetrics create() {
@@ -226,10 +225,6 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     return numBlockDeletionTransactionDataNodes.value();
   }
 
-  public Map<UUID, DatanodeCommandCounts> getNumCommandsDatanode() {
-    return numCommandsDatanode;
-  }
-
   @Override
   public void getMetrics(MetricsCollector metricsCollector, boolean all) {
     MetricsRecordBuilder builder = metricsCollector.addRecord(SOURCE_NAME);
@@ -322,18 +317,18 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     return sent;
   }
   public long getNumCommandsDatanodeSuccess() {
-    long sent = 0;
+    long successCount = 0;
     for (DatanodeCommandCounts v : numCommandsDatanode.values()) {
-      sent += v.commandsSuccess;
+      successCount += v.commandsSuccess;
     }
-    return sent;
+    return successCount;
   }
   public long getNumCommandsDatanodeFailed() {
-    long sent = 0;
+    long failCount = 0;
     for (DatanodeCommandCounts v : numCommandsDatanode.values()) {
-      sent += v.commandsFailure;
+      failCount += v.commandsFailure;
     }
-    return sent;
+    return failCount;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/ScmBlockDeletingServiceMetrics.java
@@ -106,7 +106,7 @@ public final class ScmBlockDeletingServiceMetrics implements MetricsSource {
     numCommandsDatanode = new ConcurrentHashMap<>();
   }
 
-  public static ScmBlockDeletingServiceMetrics create() {
+  public static synchronized ScmBlockDeletingServiceMetrics create() {
     if (instance == null) {
       MetricsSystem ms = DefaultMetricsSystem.instance();
       instance = ms.register(SOURCE_NAME, "SCMBlockDeletingService",

--- a/hadoop-ozone/dist/src/main/compose/ozone/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone/.env
@@ -16,6 +16,7 @@
 
 HDDS_VERSION=${hdds.version}
 HADOOP_IMAGE=apache/hadoop
+COMPOSE_FILE=docker-compose.yaml:monitoring.yaml
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone/.env
@@ -16,7 +16,6 @@
 
 HDDS_VERSION=${hdds.version}
 HADOOP_IMAGE=apache/hadoop
-COMPOSE_FILE=docker-compose.yaml:monitoring.yaml
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -317,6 +317,9 @@ public class TestBlockDeletion {
 
     assertEquals(metrics.getNumBlockDeletionTransactionCreated(),
         metrics.getNumBlockDeletionTransactionCompleted());
+    LOG.info("tej1 : "+ " " + metrics.getNumBlockDeletionCommandSent() +" " + metrics.getNumBlockDeletionCommandSuccess()
+        + " " + metrics.getBNumBlockDeletionCommandFailure());
+    LOG.info("tej2 : "+ " " + metrics.getNumCommandsDatanode());
     assertThat(metrics.getNumBlockDeletionCommandSent())
         .isGreaterThanOrEqualTo(metrics.getNumBlockDeletionCommandSuccess() +
             metrics.getBNumBlockDeletionCommandFailure());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -317,9 +317,9 @@ public class TestBlockDeletion {
 
     assertEquals(metrics.getNumBlockDeletionTransactionCreated(),
         metrics.getNumBlockDeletionTransactionCompleted());
-    LOG.info("tej1 : "+ " " + metrics.getNumBlockDeletionCommandSent() +" " + metrics.getNumBlockDeletionCommandSuccess()
-        + " " + metrics.getBNumBlockDeletionCommandFailure());
-    LOG.info("tej2 : "+ " " + metrics.getNumCommandsDatanode());
+    assertEquals(metrics.getNumBlockDeletionCommandSent(), metrics.getNumCommandsDatanodeSent());
+    assertEquals(metrics.getNumBlockDeletionCommandSuccess(), metrics.getNumCommandsDatanodeSuccess());
+    assertEquals(metrics.getBNumBlockDeletionCommandFailure(), metrics.getNumCommandsDatanodeFailed());
     assertThat(metrics.getNumBlockDeletionCommandSent())
         .isGreaterThanOrEqualTo(metrics.getNumBlockDeletionCommandSuccess() +
             metrics.getBNumBlockDeletionCommandFailure());


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there are many DNs, and if any DN is slow in processing. It is difficult to identify which DN is having issue unless we check the log deeply and can take long time. For fast debug in this PR, metrics are added in SCM per datanode to show how many delete command sent to datanode and how many response received or timedout. This will help in understand which DN is slow or having problem in much efficient way.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11711

## How was this patch tested?

Updated test in TestBlockDeletion
