### PR TITLE
HDDS-11848. Serialisation bug in Recon's listKeys API

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
@@ -61,18 +61,12 @@ Check http return code
 
 Check if the listKeys api responds OK
     [Arguments]     ${volume}    ${bucket}
-    ${result} =     Curl    "${API_ENDPOINT_URL}/keys/listKeys?startPrefix=/${volume}/${bucket}&limit=1000"
+    Run Keyword if     '${SECURITY_ENABLED}' == 'true'     Kinit as ozone admin
+    ${result} =        Execute         curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/keys/listKeys?startPrefix=/${volume}/${bucket}&limit=1000
     Should contain  ${result}   "OK"
     Should contain  ${result}   "keys"
     Should contain  ${result}   "${volume}"
     Should contain  ${result}   "${bucket}"
-
-Curl
-    [Arguments]     ${url}
-    ${curl_command} =    Set Variable    curl -LSs ${url}
-    Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Set Variable    ${curl_command}    curl --negotiate -u : -LSs ${url}
-    ${result} =     Execute     ${curl_command}
-    [Return]        ${result}
 
 *** Test Cases ***
 Check if Recon picks up OM data

--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
@@ -84,6 +84,7 @@ Check if Recon picks up OM data
     Execute    ozone sh bucket create recon/api --layout=LEGACY
     Freon OCKG    n=10    args=-s 1025 -v recon -b api
     Wait Until Keyword Succeeds     90sec      10sec        Check if Recon picks up container from OM
+    Wait Until Keyword Succeeds     90sec      10sec        Check if the listKeys api responds OK       recon   api
 
 Check if Recon picks up DN heartbeats
     ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/datanodes
@@ -153,13 +154,3 @@ Check normal api access
 
     kinit as non admin
     Check http return code      ${NON_ADMIN_API_ENDPOINT_URL}   200
-
-Check listKeys api works
-   kinit as ozone admin
-   # Create volume and bucket
-   Execute    ozone sh volume create ${VOLUME}
-   Execute    ozone sh bucket create ${VOLUME}/${BUCKET}
-   Freon OCKG    n=2    args=-s 10 -v ${VOLUME} -b ${BUCKET}
-
-   # Wait until Recon picks up the keys
-   Wait Until Keyword Succeeds     90sec      10sec        Check if the listKeys api responds OK   ${VOLUME}     ${BUCKET}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfoProtoWrapper.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyEntityInfoProtoWrapper.java
@@ -122,7 +122,7 @@ public final class KeyEntityInfoProtoWrapper {
   }
 
   @JsonProperty("isKey")
-  public boolean isKey() {
+  public boolean getIsKey() {
     return keyInfoProto.getIsFile();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Please check the jira for a description of the problem. The solution proposed here is to change `isKey()` to `getIsKey()` in `KeyEntityInfoProtoWrapper`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11848

## How was this patch tested?

Tested manually. 

Before the fix, calling the listKeys endpoint resulted in the described bug:
```
http://localhost:9888/api/v1/keys/listKeys?startPrefix=/vol1/bucket2&limit=1000

Conflicting/ambiguous property name definitions (implicit name 'key'): found multiple explicit names: [key, isKey], but also implicit accessor: [method org.apache.hadoop.ozone.recon.api.types.KeyEntityInfoProtoWrapper#setKey(java.lang.String)][visible=true,ignore=false,explicitName=false] (through reference chain: org.apache.hadoop.ozone.recon.api.types.ListKeysResponse["keys"])
```

After the fix, it works as expected:
```
http://localhost:9888/api/v1/keys/listKeys?startPrefix=/vol1/bucket2&limit=1000

{
  "status": "OK",
  "path": "/vol1/bucket2",
  "replicatedDataSize": 4068,
  "unReplicatedDataSize": 4068,
  "lastKey": "/-9223372036854775552/-9223372036854775040/-9223372036854775040/key",
  "keys": [
    {
      "parentId": -9.223372036854775e+18,
      "volumeName": "vol1",
      "bucketName": "bucket2",
      "keyName": "key",
      "key": "/-9223372036854775552/-9223372036854775040/-9223372036854775040/key",
      "path": "vol1/bucket2/key",
      "replicatedSize": 4068,
      "replicationInfo": {
        "replicationFactor": "ONE",
        "requiredNodes": 1,
        "minimumNodes": 1,
        "replicationType": "RATIS"
      },
      "creationTime": 1733221329416,
      "size": 4068,
      "isKey": true,
      "modificationTime": 1733221330013
    }
  ]
}
```