### PR TITLE
HDDS-11859. Remove mention of fuse from s3 interface docs page

### DIFF
--- a/hadoop-hdds/docs/content/interface/CSI.md
+++ b/hadoop-hdds/docs/content/interface/CSI.md
@@ -57,7 +57,7 @@ Now, create the CSI related resources by execute the follow command.
 kubectl create -f /ozone/kubernetes/examples/ozone/csi
 ```
 
-## Crete pv-test and visit the result.
+## Create pv-test and visit the result.
 
 Create pv-test related resources by execute the follow command.
 

--- a/hadoop-hdds/docs/content/interface/S3.md
+++ b/hadoop-hdds/docs/content/interface/S3.md
@@ -163,10 +163,3 @@ Or
 aws s3 ls --endpoint http://localhost:9878 s3://buckettest
 ```
 
-### S3 Fuse driver (goofys)
-
-[Goofys](https://github.com/kahing/goofys) is a S3 FUSE driver. As Ozone S3 gateway is AWS S3 compatible, it can be used to mount any Ozone buckets as an OS level mounted filesystem.
-
-```bash
-goofys --endpoint http://localhost:9878 bucket1 /mount/bucket1
-```

--- a/hadoop-hdds/docs/content/interface/S3.zh.md
+++ b/hadoop-hdds/docs/content/interface/S3.zh.md
@@ -142,10 +142,3 @@ aws s3api --endpoint http://localhost:9878 create-bucket --bucket buckettest
 aws s3 ls --endpoint http://localhost:9878 s3://buckettest
 ```
 
-### S3 Fuse 驱动（goofys）
-
-Goofys 是一个 S3 FUSE 驱动，可以将 Ozone 的桶挂载到 POSIX 文件系统。
-
-```bash
-goofys --endpoint http://localhost:9878 bucket1 /mount/bucket1
-```


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fuse support for Ozone via S3 is still experimental and not tested. This is explicitly called out in the CSI page, but not so in the S3 page. Remove the mention of fuse in the S3 page since it duplicates information from the CSI page.

## What is the link to the Apache JIRA

HDDS-11859

## How was this patch tested?

Checked locally with `hugo serve`
